### PR TITLE
Subspace upgrade (step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5621,7 +5621,6 @@ dependencies = [
  "derive_more",
  "fork-tree",
  "futures 0.3.17",
- "itertools",
  "log",
  "merkletree",
  "merlin 2.0.1",
@@ -5663,6 +5662,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
+ "typenum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5622,6 +5622,7 @@ dependencies = [
  "fork-tree",
  "futures 0.3.17",
  "log",
+ "lru",
  "merkletree",
  "merlin 2.0.1",
  "num-bigint",

--- a/crates/sc-consensus-poc/Cargo.toml
+++ b/crates/sc-consensus-poc/Cargo.toml
@@ -48,6 +48,7 @@ rand = "0.7.2"
 merlin = "2.0"
 derive_more = "0.99.16"
 async-trait = "0.1.51"
+lru = { version = "0.6.6", default-features = false }
 merkletree = "0.21.0"
 reed-solomon-erasure = { version = "4.0.2", features = ["simd-accel"] }
 ring = "0.16"

--- a/crates/sc-consensus-poc/Cargo.toml
+++ b/crates/sc-consensus-poc/Cargo.toml
@@ -48,10 +48,10 @@ rand = "0.7.2"
 merlin = "2.0"
 derive_more = "0.99.16"
 async-trait = "0.1.51"
-itertools = "0.10.1"
 merkletree = "0.21.0"
 reed-solomon-erasure = { version = "4.0.2", features = ["simd-accel"] }
 ring = "0.16"
+typenum = "1.14.0"
 
 [dev-dependencies]
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fa635c968e831110b13f7ff997c4cd3f5e9a3798" }

--- a/crates/sc-consensus-poc/src/archiver.rs
+++ b/crates/sc-consensus-poc/src/archiver.rs
@@ -125,11 +125,7 @@ impl Archiver {
     /// * record size it smaller that needed to hold any information
     /// * segment size is not bigger than record size
     /// * segment size is not a multiple of record size
-    pub(super) fn new(record_size: u32, witness_size: u32, segment_size: u32) -> Self {
-        let record_size = record_size as usize;
-        let witness_size = witness_size as usize;
-        let segment_size = segment_size as usize;
-
+    pub(super) fn new(record_size: usize, witness_size: usize, segment_size: usize) -> Self {
         let empty_segment = Segment::V0 { items: Vec::new() };
         assert!(
             record_size > empty_segment.encoded_size(),
@@ -320,8 +316,6 @@ impl Archiver {
                 );
                 drop(record);
 
-                // The first lemma element is root and the last is the item itself, we skip
-                // both here
                 (&mut piece[self.record_size..]).write_all(&witness).expect(
                     "With correct archiver parameters there should be just enough space to write \
                     a witness; qed",

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -128,7 +128,7 @@ const CONFIRMATION_DEPTH_K: u32 = 10;
 const HASH_OUTPUT_BYTES: usize = 32;
 // This is a nice power of 2 for Merkle Tree
 const MERKLE_NUM_LEAVES: usize = 256;
-const WITNESS_SIZE: usize = HASH_OUTPUT_BYTES * MERKLE_NUM_LEAVES.log2();
+const WITNESS_SIZE: usize = HASH_OUTPUT_BYTES * MERKLE_NUM_LEAVES.log2() as usize;
 const RECORD_SIZE: usize = PIECE_SIZE - WITNESS_SIZE;
 const RECORDED_HISTORY_SEGMENT_SIZE: usize = RECORD_SIZE * MERKLE_NUM_LEAVES / 2;
 

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -120,6 +120,15 @@ pub mod notification;
 mod tests;
 mod verification;
 
+// TODO: Move these constants somewhere more appropriate and adjust if necessary
+const CONFIRMATION_DEPTH_K: u32 = 10;
+const HASH_OUTPUT_BYTES: usize = 32;
+// This is a nice power of 2 for Merkle Tree
+const MERKLE_NUM_LEAVES: usize = 256;
+const WITNESS_SIZE: usize = HASH_OUTPUT_BYTES * MERKLE_NUM_LEAVES.log2();
+const RECORD_SIZE: usize = PIECE_SIZE - WITNESS_SIZE;
+const RECORDED_HISTORY_SEGMENT_SIZE: usize = RECORD_SIZE * MERKLE_NUM_LEAVES / 2;
+
 /// Information about new slot that just arrived
 #[derive(Debug, Copy, Clone)]
 pub struct NewSlotInfo {
@@ -1928,16 +1937,6 @@ where
     spawner.spawn_essential_blocking(
         "poc-archiver",
         Box::pin({
-            // TODO: Move these constants somewhere more appropriate and adjust if necessary
-            const CONFIRMATION_DEPTH_K: u32 = 10;
-            const HASH_OUTPUT_BYTES: u32 = 32;
-            // This is a nice power of 2 for Merkle Tree
-            const MERKLE_NUM_LEAVES: u32 = 256;
-            // `+1` corresponds to the path boolean for every hash
-            const WITNESS_SIZE: u32 = (1 + HASH_OUTPUT_BYTES) * MERKLE_NUM_LEAVES.log2();
-            const RECORD_SIZE: u32 = PIECE_SIZE as u32 - WITNESS_SIZE;
-            const RECORDED_HISTORY_SEGMENT_SIZE: u32 = RECORD_SIZE * MERKLE_NUM_LEAVES / 2;
-
             let mut imported_block_notification_stream =
                 poc_link.imported_block_notification_stream.subscribe();
             let archived_segment_notification_sender =

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -1793,7 +1793,7 @@ where
         match import_result {
             Ok(import_result) => {
                 self.imported_block_notification_sender
-                    .notify(|| (number, root_block_sender.clone()));
+                    .notify(move || (number, root_block_sender.clone()));
 
                 let next_block_number = number + One::one();
                 while let Some(root_block) = root_block_receiver.next().await {

--- a/crates/sc-consensus-poc/src/tests.rs
+++ b/crates/sc-consensus-poc/src/tests.rs
@@ -520,13 +520,13 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 
             while let Some(NewSlotNotification {
                 new_slot_info,
-                mut response_sender,
+                mut solution_sender,
             }) = new_slot_notification_stream.next().await
             {
                 if Into::<u64>::into(new_slot_info.slot) % 3 == (*peer_id) as u64 {
                     let tag: Tag = create_tag(&encoding, &new_slot_info.salt);
 
-                    let _ = response_sender
+                    let _ = solution_sender
                         .send((
                             Solution {
                                 public_key: FarmerId::from_slice(&keypair.public.to_bytes()),


### PR DESCRIPTION
This changes witness to be of correct size and adds `Witness` struct that implements abstracts away witness internals allowing to, for instance, verify whole pieces.

Also root blocks are now sent to block import pipeline and are stored in a special cache that will later be used to verify imported blocks to make sure we see an extrinsic (that doesn't yet exist) only precisely when we expect it to see.

More work in coming PRs, trying to make these more digestible.