### PR TITLE
Subspace upgrade (step 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -2909,7 +2909,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -2980,7 +2980,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "smallvec",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -3020,7 +3020,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.0",
@@ -3082,7 +3082,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.4",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3305,7 +3305,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "typenum",
 ]
 
@@ -3324,7 +3324,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "typenum",
 ]
 
@@ -3740,7 +3740,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "unsigned-varint 0.7.0",
 ]
 
@@ -6302,7 +6302,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "merlin 3.0.0",
  "rand_core 0.6.3",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "subtle-ng",
  "zeroize",
 ]
@@ -6474,9 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -6589,7 +6589,7 @@ dependencies = [
  "rand_core 0.6.3",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "subtle",
  "x25519-dalek",
 ]
@@ -6834,7 +6834,10 @@ dependencies = [
 name = "sp-consensus-spartan"
 version = "0.1.0"
 dependencies = [
+ "parity-scale-codec",
  "ring",
+ "sha2 0.9.8",
+ "sp-debug-derive",
  "spartan-codec",
 ]
 
@@ -6879,7 +6882,7 @@ dependencies = [
  "schnorrkel 0.9.1",
  "secrecy",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -7448,7 +7451,7 @@ dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
  "schnorrkel 0.9.1",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -7788,7 +7791,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "thiserror",
  "unicode-normalization",
  "zeroize",
@@ -8431,7 +8434,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "toml",
  "winapi 0.3.9",
  "zstd",

--- a/crates/pallet-offences-poc/src/lib.rs
+++ b/crates/pallet-offences-poc/src/lib.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/pallet-offences-poc/src/mock.rs
+++ b/crates/pallet-offences-poc/src/mock.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2018-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/pallet-offences-poc/src/tests.rs
+++ b/crates/pallet-offences-poc/src/tests.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/pallet-spartan/src/default_weights.rs
+++ b/crates/pallet-spartan/src/default_weights.rs
@@ -1,4 +1,3 @@
-// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -25,6 +24,11 @@ impl crate::WeightInfo for () {
     }
 
     fn report_equivocation() -> Weight {
+        // TODO: Proper value
+        1
+    }
+
+    fn submit_root_block() -> Weight {
         // TODO: Proper value
         1
     }

--- a/crates/pallet-spartan/src/default_weights.rs
+++ b/crates/pallet-spartan/src/default_weights.rs
@@ -28,7 +28,7 @@ impl crate::WeightInfo for () {
         1
     }
 
-    fn submit_root_block() -> Weight {
+    fn store_root_block() -> Weight {
         // TODO: Proper value
         1
     }

--- a/crates/pallet-spartan/src/equivocation.rs
+++ b/crates/pallet-spartan/src/equivocation.rs
@@ -127,7 +127,7 @@ where
     ) -> DispatchResult {
         use frame_system::offchain::SubmitTransaction;
 
-        let call = Call::report_equivocation_unsigned(Box::new(equivocation_proof));
+        let call = Call::report_equivocation(Box::new(equivocation_proof));
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
             Ok(()) => log::info!(
@@ -146,23 +146,26 @@ where
 }
 
 /// Methods for the `ValidateUnsigned` implementation:
-/// It restricts calls to `report_equivocation_unsigned` to local calls (i.e. extrinsics generated
-/// on this node) or that already in a block. This guarantees that only block authors can include
-/// unsigned equivocation reports.
+/// It restricts calls to `report_equivocation`` to local calls (i.e. extrinsics generated on this
+/// node) or that already in a block. This guarantees that only block authors can include
+/// equivocation reports.
 impl<T: Config> Pallet<T> {
-    pub fn validate_unsigned(source: TransactionSource, call: &Call<T>) -> TransactionValidity {
-        if let Call::report_equivocation_unsigned(equivocation_proof) = call {
-            // discard equivocation report not coming from the local node
-            match source {
-                TransactionSource::Local | TransactionSource::InBlock => { /* allowed */ }
-                _ => {
-                    log::warn!(
-                        target: "runtime::poc",
-                        "rejecting unsigned report equivocation transaction because it is not local/in-block.",
-                    );
+    pub fn validate_equivocation_report(
+        source: TransactionSource,
+        call: &Call<T>,
+    ) -> TransactionValidity {
+        if let Call::report_equivocation(equivocation_proof) = call {
+            // Discard equivocation report not coming from the local node
+            if !matches!(
+                source,
+                TransactionSource::Local | TransactionSource::InBlock
+            ) {
+                log::warn!(
+                    target: "runtime::poc",
+                    "Rejecting report equivocation extrinsic because it is not local/in-block.",
+                );
 
-                    return InvalidTransaction::Call.into();
-                }
+                return InvalidTransaction::Call.into();
             }
 
             // check report staleness
@@ -172,8 +175,10 @@ impl<T: Config> Pallet<T> {
                 <T::HandleEquivocation as HandleEquivocation<T>>::ReportLongevity::get();
 
             ValidTransaction::with_tag_prefix("PoCEquivocation")
-                // We assign the maximum priority for any equivocation report.
-                .priority(TransactionPriority::max_value())
+                // We assign the `(maximum - 1)` priority for any equivocation report (`-1` is
+                // to make sure potential root block transactions are always included no matter
+                // what).
+                .priority(TransactionPriority::MAX - 1)
                 // Only one equivocation report for the same offender at the same slot.
                 .and_provides((
                     equivocation_proof.offender.clone(),
@@ -188,8 +193,10 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    pub fn pre_dispatch(call: &Call<T>) -> Result<(), TransactionValidityError> {
-        if let Call::report_equivocation_unsigned(equivocation_proof) = call {
+    pub fn pre_dispatch_equivocation_report(
+        call: &Call<T>,
+    ) -> Result<(), TransactionValidityError> {
+        if let Call::report_equivocation(equivocation_proof) = call {
             is_known_offence::<T>(equivocation_proof)
         } else {
             Err(InvalidTransaction::Call.into())

--- a/crates/pallet-spartan/src/equivocation.rs
+++ b/crates/pallet-spartan/src/equivocation.rs
@@ -63,7 +63,7 @@ pub trait HandleEquivocation<T: Config> {
     fn is_known_offence(offenders: &[FarmerId], time_slot: &Slot) -> bool;
 
     /// Create and dispatch an equivocation report extrinsic.
-    fn submit_unsigned_equivocation_report(
+    fn submit_equivocation_report(
         equivocation_proof: EquivocationProof<T::Header>,
     ) -> DispatchResult;
 }
@@ -79,7 +79,7 @@ impl<T: Config> HandleEquivocation<T> for () {
         true
     }
 
-    fn submit_unsigned_equivocation_report(
+    fn submit_equivocation_report(
         _equivocation_proof: EquivocationProof<T::Header>,
     ) -> DispatchResult {
         Ok(())
@@ -122,7 +122,7 @@ where
         R::is_known_offence(offenders, time_slot)
     }
 
-    fn submit_unsigned_equivocation_report(
+    fn submit_equivocation_report(
         equivocation_proof: EquivocationProof<T::Header>,
     ) -> DispatchResult {
         use frame_system::offchain::SubmitTransaction;

--- a/crates/pallet-spartan/src/lib.rs
+++ b/crates/pallet-spartan/src/lib.rs
@@ -21,7 +21,16 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unused_must_use, unsafe_code, unused_variables, unused_must_use)]
 
+mod default_weights;
+mod equivocation;
+
+#[cfg(all(feature = "std", test))]
+mod mock;
+#[cfg(all(feature = "std", test))]
+mod tests;
+
 use codec::{Decode, Encode};
+pub use equivocation::{EquivocationHandler, HandleEquivocation, PoCEquivocationOffence};
 use frame_support::{
     dispatch::DispatchResultWithPostInfo,
     traits::{Get, OnTimestampSet},
@@ -29,6 +38,7 @@ use frame_support::{
 };
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
+pub use pallet::*;
 use sp_consensus_poc::{
     digests::{
         NextConfigDescriptor, NextEpochDescriptor, NextSaltDescriptor, NextSolutionRangeDescriptor,
@@ -38,27 +48,21 @@ use sp_consensus_poc::{
     ConsensusLog, Epoch, EquivocationProof, PoCEpochConfiguration, Slot, POC_ENGINE_ID,
 };
 pub use sp_consensus_poc::{FarmerId, RANDOMNESS_LENGTH};
+use sp_consensus_spartan::{RootBlock, Sha256Hash};
+use sp_runtime::transaction_validity::{
+    InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
+    TransactionValidityError, ValidTransaction,
+};
 use sp_runtime::{
     generic::DigestItem,
     traits::{One, SaturatedConversion, Saturating, Zero},
 };
 use sp_std::prelude::*;
 
-mod default_weights;
-mod equivocation;
-
-#[cfg(all(feature = "std", test))]
-mod mock;
-#[cfg(all(feature = "std", test))]
-mod tests;
-
-pub use equivocation::{EquivocationHandler, HandleEquivocation, PoCEquivocationOffence};
-
-pub use pallet::*;
-
 pub trait WeightInfo {
     fn plan_config_change() -> Weight;
     fn report_equivocation() -> Weight;
+    fn submit_root_block() -> Weight;
 }
 
 /// Trigger an epoch change, if any should take place.
@@ -194,6 +198,7 @@ pub mod pallet {
         /// definition.
         type HandleEquivocation: HandleEquivocation<Self>;
 
+        /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
     }
 
@@ -328,6 +333,10 @@ pub mod pallet {
     #[pallet::storage]
     pub(super) type BlockList<T> = StorageMap<_, Twox64Concat, FarmerId, ()>;
 
+    /// Mapping from segment index to corresponding Merkle Root.
+    #[pallet::storage]
+    pub(super) type MerkleRootsBySegmentIndex<T> = StorageMap<_, Twox64Concat, u64, Sha256Hash>;
+
     #[pallet::genesis_config]
     pub struct GenesisConfig {
         pub epoch_config: Option<PoCEpochConfiguration>,
@@ -380,16 +389,15 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        /// Report authority equivocation/misbehavior. This method will verify
-        /// the equivocation proof and validate the given key ownership proof
-        /// against the extracted offender. If both are valid, the offence will
-        /// be reported.
-        /// This extrinsic must be called unsigned and it is expected that only
-        /// block authors will call it (validated in `ValidateUnsigned`), as such
-        /// if the block author is defined it will be defined as the equivocation
-        /// reporter.
+        /// Report authority equivocation/misbehavior. This method will verify the equivocation
+        /// proof and validate the given key ownership proof against the extracted offender. If both
+        /// are valid, the offence will be reported.
+        ///
+        /// This extrinsic must be called unsigned and it is expected that only block authors will
+        /// call it (validated in `ValidateUnsigned`), as such if the block author is defined it
+        /// will be defined as the equivocation reporter.
         #[pallet::weight(<T as Config>::WeightInfo::report_equivocation())]
-        pub fn report_equivocation_unsigned(
+        pub fn report_equivocation(
             origin: OriginFor<T>,
             equivocation_proof: Box<EquivocationProof<T::Header>>,
         ) -> DispatchResultWithPostInfo {
@@ -411,17 +419,40 @@ pub mod pallet {
             PendingEpochConfigChange::<T>::put(config);
             Ok(())
         }
+
+        /// Submit new root block to the blockchain. Contents of this extrinsic can't be verified in
+        /// the runtime at the moment, so that is done in block import pipeline instead.
+        ///
+        /// This extrinsic must be called unsigned and it is expected that only block authors will
+        /// call it (validated in `ValidateUnsigned`).
+        #[pallet::weight(<T as Config>::WeightInfo::report_equivocation())]
+        pub fn submit_root_block(
+            origin: OriginFor<T>,
+            root_block: RootBlock,
+        ) -> DispatchResultWithPostInfo {
+            ensure_none(origin)?;
+
+            Self::do_submit_root_block(root_block)
+        }
     }
 
     #[pallet::validate_unsigned]
     impl<T: Config> ValidateUnsigned for Pallet<T> {
         type Call = Call<T>;
         fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
-            Self::validate_unsigned(source, call)
+            match call {
+                Call::report_equivocation(_) => Self::validate_equivocation_report(source, call),
+                Call::submit_root_block(_) => Self::validate_root_block(source, call),
+                _ => InvalidTransaction::Call.into(),
+            }
         }
 
         fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
-            Self::pre_dispatch(call)
+            match call {
+                Call::report_equivocation(_) => Self::pre_dispatch_equivocation_report(call),
+                Call::submit_root_block(_) => Self::pre_dispatch_root_block(call),
+                _ => Err(InvalidTransaction::Call.into()),
+            }
         }
     }
 }
@@ -818,8 +849,18 @@ impl<T: Config> Pallet<T> {
         Ok(Pays::No.into())
     }
 
+    fn do_submit_root_block(root_block: RootBlock) -> DispatchResultWithPostInfo {
+        MerkleRootsBySegmentIndex::<T>::insert(
+            root_block.segment_index(),
+            root_block.merkle_tree_root(),
+        );
+
+        // Waive the fee since the root block is required by the protocol and beneficial
+        Ok(Pays::No.into())
+    }
+
     /// Submits an extrinsic to report an equivocation. This method will create
-    /// an unsigned extrinsic with a call to `report_equivocation_unsigned` and
+    /// an unsigned extrinsic with a call to `report_equivocation` and
     /// will push the transaction to the pool. Only useful in an offchain
     /// context.
     pub fn submit_unsigned_equivocation_report(
@@ -839,6 +880,72 @@ impl<T: Config> Pallet<T> {
     /// Check if `farmer_id` is in block list (due to equivocation)
     pub fn is_in_block_list(farmer_id: &FarmerId) -> bool {
         BlockList::<T>::contains_key(farmer_id)
+    }
+}
+
+// TODO: Tests for root block
+/// Methods for the `ValidateUnsigned` implementation:
+/// It restricts calls to `submit_root_block` to local calls (i.e. extrinsics generated on this
+/// node) or that already in a block. This guarantees that only block authors can include root
+/// blocks.
+impl<T: Config> Pallet<T> {
+    pub fn validate_root_block(source: TransactionSource, call: &Call<T>) -> TransactionValidity {
+        if let Call::submit_root_block(root_block) = call {
+            // Discard root block not coming from the local node
+            if !matches!(
+                source,
+                TransactionSource::Local | TransactionSource::InBlock,
+            ) {
+                log::warn!(
+                    target: "runtime::poc",
+                    "Rejecting root block extrinsic because it is not local/in-block.",
+                );
+
+                return InvalidTransaction::Call.into();
+            }
+
+            // Check if root block for this segment index already exists
+            check_root_block_for_segment_index::<T>(root_block.segment_index())?;
+
+            ValidTransaction::with_tag_prefix("SubspaceRootBlock")
+                // We assign the maximum priority for any equivocation report.
+                .priority(TransactionPriority::MAX)
+                // Only one root block for every segment index.
+                .and_provides(root_block.segment_index())
+                // TODO: Should this be `0` or `1`?
+                // Should be included immediately with no exceptions
+                .longevity(1)
+                // We don't propagate this. This can never be included on a remote node.
+                .propagate(false)
+                .build()
+        } else {
+            InvalidTransaction::Call.into()
+        }
+    }
+
+    pub fn pre_dispatch_root_block(call: &Call<T>) -> Result<(), TransactionValidityError> {
+        if let Call::submit_root_block(root_block) = call {
+            check_root_block_for_segment_index::<T>(root_block.segment_index())
+        } else {
+            Err(InvalidTransaction::Call.into())
+        }
+    }
+}
+
+fn check_root_block_for_segment_index<T: Config>(
+    segment_index: u64,
+) -> Result<(), TransactionValidityError> {
+    // Check if the root block was already set for this segment index
+    if MerkleRootsBySegmentIndex::<T>::contains_key(segment_index) {
+        return Err(InvalidTransaction::Stale.into());
+    }
+
+    // TODO: Check if order can be guaranteed for transactions with the same weight and type though
+    // Check if the root block for previous segment is already added, it must be at this point
+    if !MerkleRootsBySegmentIndex::<T>::contains_key(segment_index - 1) {
+        Err(InvalidTransaction::Stale.into())
+    } else {
+        Ok(())
     }
 }
 

--- a/crates/pallet-spartan/src/lib.rs
+++ b/crates/pallet-spartan/src/lib.rs
@@ -380,18 +380,6 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        /// Report farmer equivocation/misbehavior. This method will verify
-        /// the equivocation proof and validate the given key ownership proof
-        /// against the extracted offender. If both are valid, the offence will
-        /// be reported.
-        #[pallet::weight(<T as Config>::WeightInfo::report_equivocation())]
-        pub fn report_equivocation(
-            _origin: OriginFor<T>,
-            equivocation_proof: Box<EquivocationProof<T::Header>>,
-        ) -> DispatchResultWithPostInfo {
-            Self::do_report_equivocation(*equivocation_proof)
-        }
-
         /// Report authority equivocation/misbehavior. This method will verify
         /// the equivocation proof and validate the given key ownership proof
         /// against the extracted offender. If both are valid, the offence will

--- a/crates/pallet-spartan/src/lib.rs
+++ b/crates/pallet-spartan/src/lib.rs
@@ -972,12 +972,16 @@ fn check_root_block_for_segment_index<T: Config>(
         return Err(InvalidTransaction::Stale.into());
     }
 
-    // TODO: Check if order can be guaranteed for transactions with the same weight and type though
-    // Check if the root block for previous segment is already added, it must be at this point
-    if !MerkleRootsBySegmentIndex::<T>::contains_key(segment_index - 1) {
-        Err(InvalidTransaction::Stale.into())
-    } else {
+    // TODO: Check if order can be guaranteed for transactions with the same weight and type though,
+    //  that is in case we have a blockchain block that causes two root blocks to be created and
+    //  submitted for inclusion in the same blockchain block
+    // Check if the root block for previous segment is already added, it must be at this point.
+    //
+    // NOTE: The very first segment will not have predecessor, we check for that as well.
+    if segment_index == 0 || MerkleRootsBySegmentIndex::<T>::contains_key(segment_index - 1) {
         Ok(())
+    } else {
+        Err(InvalidTransaction::Stale.into())
     }
 }
 

--- a/crates/pallet-spartan/src/mock.rs
+++ b/crates/pallet-spartan/src/mock.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/pallet-spartan/src/tests.rs
+++ b/crates/pallet-spartan/src/tests.rs
@@ -334,8 +334,7 @@ fn report_equivocation_current_session_works() {
         assert_eq!(Spartan::is_in_block_list(&farmer_id), false);
 
         // report the equivocation
-        Spartan::report_equivocation_unsigned(Origin::none(), Box::new(equivocation_proof))
-            .unwrap();
+        Spartan::report_equivocation(Origin::none(), Box::new(equivocation_proof)).unwrap();
 
         progress_to_block(&keypair, 2);
 
@@ -364,8 +363,7 @@ fn report_equivocation_old_session_works() {
         assert_eq!(Spartan::is_in_block_list(&farmer_id), false);
 
         // report the equivocation
-        Spartan::report_equivocation_unsigned(Origin::none(), Box::new(equivocation_proof))
-            .unwrap();
+        Spartan::report_equivocation(Origin::none(), Box::new(equivocation_proof)).unwrap();
 
         progress_to_block(&keypair, 3);
 
@@ -385,7 +383,7 @@ fn report_equivocation_invalid_equivocation_proof() {
 
         let assert_invalid_equivocation = |equivocation_proof| {
             assert_err!(
-                Spartan::report_equivocation_unsigned(Origin::none(), Box::new(equivocation_proof),),
+                Spartan::report_equivocation(Origin::none(), Box::new(equivocation_proof),),
                 Error::<Test>::InvalidEquivocationProof,
             )
         };
@@ -458,7 +456,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 
         let equivocation_proof = generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
 
-        let inner = Call::report_equivocation_unsigned(Box::new(equivocation_proof.clone()));
+        let inner = Call::report_equivocation(Box::new(equivocation_proof.clone()));
 
         // only local/inblock reports are allowed
         assert_eq!(
@@ -477,7 +475,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
                 &inner,
             ),
             TransactionValidity::Ok(ValidTransaction {
-                priority: TransactionPriority::max_value(),
+                priority: TransactionPriority::MAX - 1,
                 requires: vec![],
                 provides: vec![("PoCEquivocation", tx_tag).encode()],
                 longevity: ReportLongevity::get(),
@@ -489,8 +487,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
         assert_ok!(<Spartan as sp_runtime::traits::ValidateUnsigned>::pre_dispatch(&inner));
 
         // we submit the report
-        Spartan::report_equivocation_unsigned(Origin::none(), Box::new(equivocation_proof))
-            .unwrap();
+        Spartan::report_equivocation(Origin::none(), Box::new(equivocation_proof)).unwrap();
 
         // the report should now be considered stale and the transaction is invalid.
         // the check for staleness should be done on both `validate_unsigned` and on `pre_dispatch`
@@ -530,7 +527,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
         let equivocation_proof = generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
 
         // check the dispatch info for the call.
-        let info = Call::<Test>::report_equivocation_unsigned(Box::new(equivocation_proof.clone()))
+        let info = Call::<Test>::report_equivocation(Box::new(equivocation_proof.clone()))
             .get_dispatch_info();
 
         // it should have non-zero weight and the fee has to be paid.
@@ -538,11 +535,9 @@ fn valid_equivocation_reports_dont_pay_fees() {
         assert_eq!(info.pays_fee, Pays::Yes);
 
         // report the equivocation.
-        let post_info = Spartan::report_equivocation_unsigned(
-            Origin::none(),
-            Box::new(equivocation_proof.clone()),
-        )
-        .unwrap();
+        let post_info =
+            Spartan::report_equivocation(Origin::none(), Box::new(equivocation_proof.clone()))
+                .unwrap();
 
         // the original weight should be kept, but given that the report
         // is valid the fee is waived.
@@ -551,11 +546,10 @@ fn valid_equivocation_reports_dont_pay_fees() {
 
         // report the equivocation again which is invalid now since it is
         // duplicate.
-        let post_info =
-            Spartan::report_equivocation_unsigned(Origin::none(), Box::new(equivocation_proof))
-                .err()
-                .unwrap()
-                .post_info;
+        let post_info = Spartan::report_equivocation(Origin::none(), Box::new(equivocation_proof))
+            .err()
+            .unwrap()
+            .post_info;
 
         // the fee is not waived and the original weight is kept.
         assert!(post_info.actual_weight.is_none());

--- a/crates/pallet-spartan/src/tests.rs
+++ b/crates/pallet-spartan/src/tests.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/sc-consensus-poc/src/archiver.rs
+++ b/crates/sc-consensus-poc/src/archiver.rs
@@ -18,8 +18,8 @@
 use crate::merkle_tree::MerkleTree;
 use codec::Encode;
 use reed_solomon_erasure::galois_16::ReedSolomon;
-use ring::digest;
 use sp_consensus_spartan::spartan::{Piece, PIECE_SIZE};
+use sp_consensus_spartan::RootBlock;
 use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::io::Write;
@@ -36,47 +36,6 @@ enum Segment {
         /// Segment items
         items: Vec<SegmentItem>,
     },
-}
-
-/// Root block for a specific segment
-#[derive(Debug, Encode, Copy, Clone)]
-pub enum RootBlock {
-    // V0 of the root block data structure
-    #[codec(index = 0)]
-    V0 {
-        /// Segment index
-        segment_index: u64,
-        /// Merkle tree root of all pieces within segment
-        merkle_tree_root: Sha256Hash,
-        /// Hash of the root block of the previous segment
-        prev_root_block_hash: Sha256Hash,
-    },
-}
-
-impl RootBlock {
-    /// Hash of the whole root block
-    pub fn hash(&self) -> Sha256Hash {
-        digest::digest(&digest::SHA256, &self.encode())
-            .as_ref()
-            .try_into()
-            .expect("Sha256 output is always 32 bytes; qed")
-    }
-
-    /// Segment index
-    pub fn segment_index(&self) -> u64 {
-        match self {
-            RootBlock::V0 { segment_index, .. } => *segment_index,
-        }
-    }
-
-    /// Merkle tree root of all pieces within segment
-    pub fn merkle_tree_root(&self) -> Sha256Hash {
-        match self {
-            RootBlock::V0 {
-                merkle_tree_root, ..
-            } => *merkle_tree_root,
-        }
-    }
 }
 
 /// Kinds of items that are contained within a segment

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -1984,6 +1984,7 @@ where
             let client = Arc::clone(&client);
 
             async move {
+                let mut last_archived_block = None;
                 let mut archiver =
                     Archiver::new(RECORD_SIZE, WITNESS_SIZE, RECORDED_HISTORY_SEGMENT_SIZE);
 
@@ -1997,6 +1998,18 @@ where
                                 continue;
                             }
                         };
+
+                    if let Some(last_archived_block) = &mut last_archived_block {
+                        if *last_archived_block >= block_to_archive {
+                            // This block was already archived, skip
+                            continue;
+                        }
+
+                        *last_archived_block = block_to_archive;
+                    } else {
+                        last_archived_block.replace(block_to_archive);
+                    }
+
                     debug!(target: "poc", "Archiving block {:?}", block_to_archive);
 
                     let id = BlockId::number(block_to_archive);

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -1271,7 +1271,7 @@ where
         // submit equivocation report at best block.
         self.client
             .runtime_api()
-            .submit_report_equivocation_unsigned_extrinsic(&best_id, equivocation_proof)
+            .submit_report_equivocation_extrinsic(&best_id, equivocation_proof)
             .map_err(Error::RuntimeApi)?;
 
         info!(target: "poc", "Submitted equivocation report for author {:?}", author);

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -49,7 +49,7 @@
 #![feature(int_log)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
-use crate::archiver::{ArchivedSegment, Archiver, RootBlock};
+use crate::archiver::{ArchivedSegment, Archiver};
 use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream};
 use codec::{Decode, Encode};
 use futures::channel::{mpsc, oneshot};
@@ -101,6 +101,7 @@ pub use sp_consensus_poc::{
 };
 use sp_consensus_slots::Slot;
 use sp_consensus_spartan::spartan::{Piece, Salt, Spartan, PIECE_SIZE, SIGNING_CONTEXT};
+use sp_consensus_spartan::RootBlock;
 use sp_core::sr25519::Pair;
 use sp_core::{ExecutionContext, Pair as PairTrait};
 use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};

--- a/crates/sc-consensus-poc/src/merkle_tree.rs
+++ b/crates/sc-consensus-poc/src/merkle_tree.rs
@@ -171,7 +171,7 @@ impl MerkleTree {
         }))
     }
 
-    /// Get Merkle root
+    /// Get Merkle Root
     pub fn root(&self) -> Sha256Hash {
         self.merkle_tree.root()
     }

--- a/crates/sc-consensus-poc/src/tests.rs
+++ b/crates/sc-consensus-poc/src/tests.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0

--- a/crates/sp-consensus-poc/src/lib.rs
+++ b/crates/sp-consensus-poc/src/lib.rs
@@ -275,7 +275,7 @@ sp_api::decl_runtime_apis! {
         /// `None` when creation of the extrinsic fails, e.g. if equivocation
         /// reporting is disabled for the given runtime (i.e. this method is
         /// hardcoded to return `None`). Only useful in an offchain context.
-        fn submit_report_equivocation_unsigned_extrinsic(
+        fn submit_report_equivocation_extrinsic(
             equivocation_proof: EquivocationProof<Block::Header>,
         ) -> Option<()>;
 

--- a/crates/sp-consensus-poc/src/lib.rs
+++ b/crates/sp-consensus-poc/src/lib.rs
@@ -23,7 +23,7 @@ pub mod digests;
 pub mod inherents;
 pub mod offence;
 
-pub use sp_consensus_spartan::{Randomness, RANDOMNESS_LENGTH};
+pub use sp_consensus_spartan::{Randomness, RootBlock, RANDOMNESS_LENGTH};
 
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
@@ -267,17 +267,20 @@ sp_api::decl_runtime_apis! {
         /// previously announced).
         fn next_epoch() -> Epoch;
 
-        /// Submits an unsigned extrinsic to report an equivocation. The caller
-        /// must provide the equivocation proof and a key ownership proof
-        /// (should be obtained using `generate_key_ownership_proof`). The
-        /// extrinsic will be unsigned and should only be accepted for local
-        /// authorship (not to be broadcast to the network). This method returns
-        /// `None` when creation of the extrinsic fails, e.g. if equivocation
-        /// reporting is disabled for the given runtime (i.e. this method is
-        /// hardcoded to return `None`). Only useful in an offchain context.
+        /// Submits an unsigned extrinsic to report an equivocation. The caller must provide the
+        /// equivocation proof. The extrinsic will be unsigned and should only be accepted for local
+        /// authorship (not to be broadcast to the network). This method returns `None` when
+        /// creation of the extrinsic fails, e.g. if equivocation reporting is disabled for the
+        /// given runtime (i.e. this method is hardcoded to return `None`). Only useful in an
+        /// offchain context.
         fn submit_report_equivocation_extrinsic(
             equivocation_proof: EquivocationProof<Block::Header>,
         ) -> Option<()>;
+
+        /// Submits an unsigned extrinsic to store root block. The extrinsic will be unsigned and
+        /// should only be accepted for local authorship (not to be broadcast to the network). Only
+        /// useful in an offchain context.
+        fn submit_store_root_block_extrinsic(root_block: RootBlock);
 
         /// Check if `farmer_id` is in block list (due to equivocation)
         fn is_in_block_list(farmer_id: &FarmerId) -> bool;

--- a/crates/sp-consensus-poc/src/offence.rs
+++ b/crates/sp-consensus-poc/src/offence.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/sp-consensus-spartan/Cargo.toml
+++ b/crates/sp-consensus-spartan/Cargo.toml
@@ -13,8 +13,17 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+parity-scale-codec = { version = "2.0.0", default-features = false }
+ring = { version = "0.16.20", optional = true }
+sha2 = { version = "0.9.8", default-features = false }
+sp-debug-derive = { version = "3.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fa635c968e831110b13f7ff997c4cd3f5e9a3798" }
 spartan-codec = { version = "0.1.0", default-features = false, optional = true }
-ring = { version = "0.16", optional = true }
 
 [features]
-std = ["spartan-codec", "ring"]
+std = [
+    "parity-scale-codec/std",
+    "ring",
+    "sha2/std",
+    "sp-debug-derive/std",
+    "spartan-codec"
+]

--- a/crates/sp-consensus-spartan/src/lib.rs
+++ b/crates/sp-consensus-spartan/src/lib.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/crates/sp-consensus-spartan/src/lib.rs
+++ b/crates/sp-consensus-spartan/src/lib.rs
@@ -19,8 +19,57 @@
 #[cfg(feature = "std")]
 pub mod spartan;
 
+use core::convert::TryInto;
+use parity_scale_codec::Encode;
+use sha2::{Digest, Sha256};
+use sp_debug_derive::RuntimeDebug;
+
 /// The length of the Randomness.
 pub const RANDOMNESS_LENGTH: usize = 32;
 
 /// Randomness value.
 pub type Randomness = [u8; RANDOMNESS_LENGTH];
+
+pub type Sha256Hash = [u8; 32];
+
+/// Root block for a specific segment
+#[derive(Encode, Copy, Clone, RuntimeDebug)]
+pub enum RootBlock {
+    // V0 of the root block data structure
+    #[codec(index = 0)]
+    V0 {
+        /// Segment index
+        segment_index: u64,
+        /// Merkle tree root of all pieces within segment
+        merkle_tree_root: Sha256Hash,
+        /// Hash of the root block of the previous segment
+        prev_root_block_hash: Sha256Hash,
+    },
+}
+
+impl RootBlock {
+    /// Hash of the whole root block
+    pub fn hash(&self) -> Sha256Hash {
+        let mut hasher = Sha256::new();
+        hasher.update(&self.encode());
+        hasher.finalize()[..]
+            .try_into()
+            .expect("Sha256 output is always 32 bytes; qed")
+    }
+
+    /// Segment index
+    pub fn segment_index(&self) -> u64 {
+        match self {
+            RootBlock::V0 { segment_index, .. } => *segment_index,
+        }
+    }
+
+    /// Merkle tree root of all pieces within segment
+    pub fn merkle_tree_root(&self) -> Sha256Hash {
+        match self {
+            RootBlock::V0 {
+                merkle_tree_root, ..
+            } => *merkle_tree_root,
+        }
+    }
+}

--- a/crates/sp-consensus-spartan/src/lib.rs
+++ b/crates/sp-consensus-spartan/src/lib.rs
@@ -20,7 +20,7 @@
 pub mod spartan;
 
 use core::convert::TryInto;
-use parity_scale_codec::Encode;
+use parity_scale_codec::{Decode, Encode};
 use sha2::{Digest, Sha256};
 use sp_debug_derive::RuntimeDebug;
 
@@ -33,7 +33,7 @@ pub type Randomness = [u8; RANDOMNESS_LENGTH];
 pub type Sha256Hash = [u8; 32];
 
 /// Root block for a specific segment
-#[derive(Encode, Copy, Clone, RuntimeDebug)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
 pub enum RootBlock {
     // V0 of the root block data structure
     #[codec(index = 0)]

--- a/crates/sp-consensus-spartan/src/spartan.rs
+++ b/crates/sp-consensus-spartan/src/spartan.rs
@@ -1,5 +1,3 @@
-// This file is part of Substrate.
-
 // Copyright (C) 2021 Subspace Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/node-template-spartan/runtime/src/lib.rs
+++ b/node-template-spartan/runtime/src/lib.rs
@@ -456,9 +456,11 @@ impl_runtime_apis! {
         fn submit_report_equivocation_extrinsic(
             equivocation_proof: sp_consensus_poc::EquivocationProof<<Block as BlockT>::Header>,
         ) -> Option<()> {
-            PoC::submit_unsigned_equivocation_report(
-                equivocation_proof,
-            )
+            PoC::submit_equivocation_report(equivocation_proof)
+        }
+
+        fn submit_store_root_block_extrinsic(root_block: sp_consensus_poc::RootBlock) {
+            PoC::submit_store_root_block(root_block)
         }
 
         fn is_in_block_list(farmer_id: &sp_consensus_poc::FarmerId) -> bool {

--- a/node-template-spartan/runtime/src/lib.rs
+++ b/node-template-spartan/runtime/src/lib.rs
@@ -453,7 +453,7 @@ impl_runtime_apis! {
             PoC::next_epoch()
         }
 
-        fn submit_report_equivocation_unsigned_extrinsic(
+        fn submit_report_equivocation_extrinsic(
             equivocation_proof: sp_consensus_poc::EquivocationProof<<Block as BlockT>::Header>,
         ) -> Option<()> {
             PoC::submit_unsigned_equivocation_report(

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -917,7 +917,7 @@ cfg_if! {
 					<pallet_spartan::Pallet<Runtime>>::next_epoch()
 				}
 
-				fn submit_report_equivocation_unsigned_extrinsic(
+				fn submit_report_equivocation_extrinsic(
 					equivocation_proof: sp_consensus_poc::EquivocationProof<
 						<Block as BlockT>::Header,
 					>,
@@ -1221,7 +1221,7 @@ cfg_if! {
 					<pallet_spartan::Pallet<Runtime>>::next_epoch()
 				}
 
-				fn submit_report_equivocation_unsigned_extrinsic(
+				fn submit_report_equivocation_extrinsic(
 					equivocation_proof: sp_consensus_poc::EquivocationProof<
 						<Block as BlockT>::Header,
 					>,

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -927,6 +927,10 @@ cfg_if! {
 					)
 				}
 
+				fn submit_store_root_block_extrinsic(root_block: sp_consensus_poc::RootBlock) {
+					<pallet_spartan::Pallet<Runtime>>::submit_test_store_root_block(root_block);
+				}
+
 				fn is_in_block_list(farmer_id: &sp_consensus_poc::FarmerId) -> bool {
 					<pallet_spartan::Pallet<Runtime>>::is_in_block_list(farmer_id)
 				}
@@ -1229,6 +1233,10 @@ cfg_if! {
 					<pallet_spartan::Pallet<Runtime>>::submit_test_equivocation_report(
 						equivocation_proof,
 					)
+				}
+
+				fn submit_store_root_block_extrinsic(root_block: sp_consensus_poc::RootBlock) {
+					<pallet_spartan::Pallet<Runtime>>::submit_test_store_root_block(root_block);
 				}
 
 				fn is_in_block_list(farmer_id: &sp_consensus_poc::FarmerId) -> bool {


### PR DESCRIPTION
This PR introduces an unsigned extrinsic containing root block. It is used to persist in the history the state of the archiving process and to set mapping between segment index and Merkle Root in the runtime storage that can later be queried.

This PR also introduces runtime API for submitting root blocks and it is used in block import pipeline, but no validation is currently happening.

There are some minor cleanups I did when I was adding new things using existing code as an example.

The validation and tests are the things for the upcoming PRs.