### PR TITLE
sloth256-189 integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6564,6 +6564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sloth256-189"
+version = "0.1.0"
+source = "git+https://github.com/subspace/sloth256-189.git#f3135cfcab7ed65adb361dcaae1a8ad518d8cac6"
+dependencies = [
+ "cc",
+ "glob",
+ "thiserror",
+ "which",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7345,7 +7356,7 @@ dependencies = [
  "schnorrkel 0.10.1",
  "serde",
  "serde_json",
- "spartan-codec",
+ "sloth256-189",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byte-slice-cast"
@@ -4390,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad6f1acec69b95caf435bbd158d486e5a0a44fcf51531e84922c59ff09e8457"
+checksum = "9f7adaf50e545c285006d384d50588e98c405c49b55c0aa05660aca081f6ee5e"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
@@ -5031,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
+checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
 dependencies = [
  "num-traits",
  "rand 0.8.4",
@@ -6566,8 +6566,9 @@ dependencies = [
 
 [[package]]
 name = "sloth256-189"
-version = "0.2.0"
-source = "git+https://github.com/subspace/sloth256-189?branch=unresolved_symbol_test#ed2032734db71044bf7a1ed037fd2041d794ce21"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6743712655581c231c30fe94e554b8a3f3c4bb7b845289eab22f89315fa5b736"
 dependencies = [
  "cc",
  "glob",
@@ -7904,9 +7905,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.7",
@@ -7967,9 +7968,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "approx"
@@ -1368,7 +1368,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -1559,9 +1559,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2909,7 +2909,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -2980,7 +2980,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "smallvec",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -3020,7 +3020,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.0",
@@ -3082,7 +3082,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.4",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3305,7 +3305,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "typenum",
 ]
 
@@ -3324,7 +3324,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "typenum",
 ]
 
@@ -3740,7 +3740,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "unsigned-varint 0.7.0",
 ]
 
@@ -4344,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "e11263a97373b43da4b426edbb52ef99a7b51e2d9752ef56a7f8b356f48495a5"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec 0.20.4",
@@ -4358,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "b157dc92b3db2bae522afb31b3843e91ae097eb01d66c72dda66a2e86bc3ca14"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -4874,9 +4874,9 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c1a2f10b47d446372a4f397c58b329aaea72b2daf9395a623a411cb8ccb54f"
+checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
 dependencies = [
  "byteorder 1.4.3",
  "log",
@@ -6301,7 +6301,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "merlin 3.0.0",
  "rand_core 0.6.3",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "subtle-ng",
  "zeroize",
 ]
@@ -6425,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -6473,9 +6473,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -6565,8 +6565,8 @@ dependencies = [
 
 [[package]]
 name = "sloth256-189"
-version = "0.1.0"
-source = "git+https://github.com/subspace/sloth256-189.git#f3135cfcab7ed65adb361dcaae1a8ad518d8cac6"
+version = "0.2.0"
+source = "git+https://github.com/subspace/sloth256-189.git#09485267e86cc531eb618b0ab4a3cdbb50adcd6d"
 dependencies = [
  "cc",
  "glob",
@@ -6599,7 +6599,7 @@ dependencies = [
  "rand_core 0.6.3",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "subtle",
  "x25519-dalek",
 ]
@@ -6889,7 +6889,7 @@ dependencies = [
  "schnorrkel 0.9.1",
  "secrecy",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -7458,7 +7458,7 @@ dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
  "schnorrkel 0.9.1",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -7798,7 +7798,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "thiserror",
  "unicode-normalization",
  "zeroize",
@@ -7815,9 +7815,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7900,9 +7900,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.7",
@@ -7912,9 +7912,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7923,9 +7923,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
 dependencies = [
  "lazy_static",
 ]
@@ -7963,9 +7963,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "62af966210b88ad5776ee3ba12d5f35b8d6a2b2a12168f3080cf02b814d7376b"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -8275,9 +8275,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -8285,9 +8285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -8300,9 +8300,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
+checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8312,9 +8312,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8322,9 +8322,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8335,9 +8335,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
 
 [[package]]
 name = "wasm-gc-api"
@@ -8441,7 +8441,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "toml",
  "winapi 0.3.9",
  "zstd",
@@ -8586,9 +8586,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8709,9 +8709,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.1",
+ "socket2 0.4.2",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -642,9 +642,9 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "ca0796d76a983651b4a0ddda16203032759f2fd9103d9181f7c65c06ee8872e6"
 
 [[package]]
 name = "byte-tools"
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek-ng"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574d8b2cd0bae5434fd50d53280f8299d95557a978686555880aaf5b8f4f81e9"
+checksum = "b2d05dbe571a5f832174d536b65101025c33693189830372032c005af68cbaec"
 dependencies = [
  "byteorder 1.4.3",
  "digest 0.9.0",
@@ -1722,7 +1722,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2278,9 +2278,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -2293,7 +2293,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.7",
- "socket2 0.4.1",
+ "socket2 0.4.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2814,9 +2814,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "libloading"
@@ -3045,7 +3045,7 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "smallvec",
- "socket2 0.4.1",
+ "socket2 0.4.2",
  "void",
 ]
 
@@ -3218,7 +3218,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "log",
- "socket2 0.4.1",
+ "socket2 0.4.2",
 ]
 
 [[package]]
@@ -3764,7 +3764,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4243,7 +4243,7 @@ name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4362,7 +4362,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b157dc92b3db2bae522afb31b3843e91ae097eb01d66c72dda66a2e86bc3ca14"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4745,9 +4745,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
@@ -5479,7 +5479,7 @@ name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6180,7 +6180,7 @@ name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6257,7 +6257,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sloth256-189"
 version = "0.2.0"
-source = "git+https://github.com/subspace/sloth256-189.git#09485267e86cc531eb618b0ab4a3cdbb50adcd6d"
+source = "git+https://github.com/subspace/sloth256-189?branch=unresolved_symbol_test#ed2032734db71044bf7a1ed037fd2041d794ce21"
 dependencies = [
  "cc",
  "glob",
@@ -6618,9 +6618,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -6680,7 +6680,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
  "blake2-rfc",
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7049,7 +7049,7 @@ name = "sp-npos-elections-solution-type"
 version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7127,7 +7127,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=fa635c968e831110b13f7ff997c4cd3f5e9a3798#fa635c968e831110b13f7ff997c4cd3f5e9a3798"
 dependencies = [
  "Inflector",
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7641,9 +7641,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subtle-ng"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8049cf85f0e715d6af38dde439cb0ccb91f67fb9f5f63c80f8b43e48356e1a3f"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -7967,9 +7967,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62af966210b88ad5776ee3ba12d5f35b8d6a2b2a12168f3080cf02b814d7376b"
+checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -8125,9 +8125,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -8279,9 +8279,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -8289,9 +8289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -8304,9 +8304,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8316,9 +8316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8326,9 +8326,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8339,9 +8339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasm-gc-api"
@@ -8590,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.14"
 rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
-sloth256-189 = { git = "https://github.com/subspace/sloth256-189", branch = "unresolved_symbol_test", features = ["cuda"]}
+#sloth256-189 = { git = "https://github.com/subspace/sloth256-189", features = ["cuda"]}
 schnorrkel = "0.10.1"
 thiserror = "1.0.24"
 tokio = "1.11.0"
@@ -36,9 +36,9 @@ tokio = "1.11.0"
 features = ["client"]
 version = "0.2.0"
 
-#[dependencies.sloth256-189]
-#features = ["cuda"]
-#version = "0.2.0"
+[dependencies.sloth256-189]
+features = ["cuda"]
+version = "0.2.2"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -28,7 +28,7 @@ rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
 schnorrkel = "0.10.1"
-sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git" }
+sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git", features = ["cuda"]}
 thiserror = "1.0.24"
 tokio = "1.11.0"
 

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -27,14 +27,18 @@ log = "0.4.14"
 rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
+sloth256-189 = { git = "https://github.com/subspace/sloth256-189", branch = "unresolved_symbol_test", features = ["cuda"]}
 schnorrkel = "0.10.1"
-sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git", features = ["cuda"]}
 thiserror = "1.0.24"
 tokio = "1.11.0"
 
 [dependencies.jsonrpsee]
 features = ["client"]
 version = "0.2.0"
+
+#[dependencies.sloth256-189]
+#features = ["cuda"]
+#version = "0.2.0"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -28,7 +28,7 @@ rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
 schnorrkel = "0.10.1"
-spartan-codec = "0.1.0"
+sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git" }
 thiserror = "1.0.24"
 tokio = "1.11.0"
 

--- a/crates/spartan-farmer/src/commands/plot.rs
+++ b/crates/spartan-farmer/src/commands/plot.rs
@@ -1,12 +1,12 @@
 use crate::plot::Plot;
-use crate::{crypto, Piece, BATCH_SIZE, ENCODE_ROUNDS, PIECE_SIZE, PRIME_SIZE_BYTES};
+use crate::spartan::Spartan;
+use crate::{crypto, Piece, BATCH_SIZE, ENCODE_ROUNDS, PIECE_SIZE};
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
 use indicatif::ProgressBar;
 use log::{info, warn};
 use rayon::prelude::*;
 use schnorrkel::Keypair;
-use spartan_codec::Spartan;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -31,8 +31,7 @@ pub(crate) async fn plot(
 
     let plot = Plot::open_or_create(&path.into()).await?;
     let public_key_hash = crypto::hash_public_key(&keypair.public);
-    let spartan: Arc<Spartan<PRIME_SIZE_BYTES, PIECE_SIZE>> =
-        Arc::new(Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(genesis_piece));
+    let spartan: Arc<Spartan> = Arc::new(Spartan::new(genesis_piece));
 
     if plot.is_empty().await {
         let plotting_fut = {

--- a/crates/spartan-farmer/src/main.rs
+++ b/crates/spartan-farmer/src/main.rs
@@ -18,6 +18,7 @@
 mod commands;
 mod crypto;
 mod plot;
+mod spartan;
 mod utils;
 
 use async_std::task;
@@ -29,10 +30,10 @@ use std::path::PathBuf;
 use tokio::runtime::Runtime;
 
 type Piece = [u8; PIECE_SIZE];
-type Tag = [u8; PRIME_SIZE_BYTES];
-type Salt = [u8; PRIME_SIZE_BYTES];
+type Tag = [u8; 8];
+type Salt = [u8; 8];
 
-const PRIME_SIZE_BYTES: usize = 8;
+const PRIME_SIZE_BYTES: usize = 32;
 const PIECE_SIZE: usize = 4096;
 const ENCODE_ROUNDS: usize = 1;
 const SIGNING_CONTEXT: &[u8] = b"FARMER";

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -58,34 +58,19 @@ impl Spartan {
         // should consume [u8; 32 * piece_amount] space.
         let piece_amount = pieces.len() / PIECE_SIZE;
         let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * HASH_SIZE);
-        let mut nonce_iter = nonce_array.iter();
         let mut expanded_iv;
-        for _ in 0..piece_amount {
+        for nonce in nonce_array {
             // same encoding_key_hash will be used for each expanded_iv
             expanded_iv = encoding_key_hash;
 
             // select the nonce from nonce_array, xor it with the encoding_key_hash
-            for (i, &byte) in nonce_iter
-                .next()
-                .unwrap()
+            nonce
                 .to_le_bytes()
                 .iter()
                 .rev()
-                .enumerate()
-            {
-                expanded_iv[HASH_SIZE - i - 1] ^= byte;
-            }
-
-            /* can replace the upper for loop
-            nonce_iter
-                .next()
-                .unwrap()
-                .to_le_bytes()
-                .iter()
-                .rev()
-                .enumerate()
-                .map(|(i, &byte)| expanded_iv[32 - i - 1] ^= byte);
-            */
+                .zip(expanded_iv.iter_mut().rev())
+                .for_each(|(nonce_byte, expanded_iv_byte)| *expanded_iv_byte ^= nonce_byte);
+            //*/
             expanded_iv_vector.extend(expanded_iv);
         }
 

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -1,29 +1,43 @@
 #![warn(missing_debug_implementations, missing_docs)]
 //! This is an adaptation of [SLOTH](https://eprint.iacr.org/2015/366) (slow-timed hash function) into a time-asymmetric permutation using a standard CBC block cipher. This code is largely based on the C implementation used in [PySloth](https://github.com/randomchain/pysloth/blob/master/sloth.c) which is the same as used in the paper.
 
-use sloth256_189::cpu;
-use sloth256_189::cuda;
+use ::sloth256_189::cpu;
+use ::sloth256_189::cuda;
+
+const PIECE_SIZE: usize = 4096; // length of a single piece
+const HASH_SIZE: usize = 32; // length of public_key_hash
+const GPU_PIECE_BLOCK: usize = 1024; // piece amount should be multiples of 1024 for GPU
 
 /// Spartan struct used to encode and validate
 #[derive(Debug, Clone)]
 pub struct Spartan {
-    genesis_piece: [u8; 4096],
+    genesis_piece: [u8; PIECE_SIZE],
+    cuda_available: bool,
 }
 
 impl Spartan {
     /// New instance with 256-bit prime and 4096-byte genesis piece size
-    pub fn new(genesis_piece: [u8; 4096]) -> Self {
-        Spartan { genesis_piece }
+    pub fn new(genesis_piece: [u8; PIECE_SIZE]) -> Self {
+        let cuda_available = cuda::is_cuda_available();
+        Spartan {
+            genesis_piece,
+            cuda_available,
+        }
     }
 }
 
 impl Spartan {
     /// Create an encoding based on genesis piece using provided encoding key hash, nonce and
     /// desired number of rounds
-    pub fn encode(&self, encoding_key_hash: [u8; 32], nonce: u64, rounds: usize) -> [u8; 4096] {
+    pub fn encode(
+        &self,
+        encoding_key_hash: [u8; HASH_SIZE],
+        nonce: u64,
+        rounds: usize,
+    ) -> [u8; PIECE_SIZE] {
         let mut expanded_iv = encoding_key_hash;
         for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
-            expanded_iv[32 - i - 1] ^= byte;
+            expanded_iv[HASH_SIZE - i - 1] ^= byte;
         }
 
         let mut encoding = self.genesis_piece;
@@ -32,39 +46,59 @@ impl Spartan {
 
         encoding
     }
-
+    /// encodes given batch of pieces using GPU (if available) and CPU
     pub fn batch_encode(
         &self,
-        piece_amount: usize,
         pieces: &mut [u8],
-        encoding_key_hash: [u8; 32],
+        encoding_key_hash: [u8; HASH_SIZE],
         nonce_array: &[u64],
         rounds: usize,
     ) {
         // each expanded_iv will be in format [u8; 32], so `piece_amount` expanded_iv's
         // should consume [u8; 32 * piece_amount] space.
-        let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * 32);
-        for x in 0..piece_amount {
+        let piece_amount = pieces.len() / PIECE_SIZE;
+        let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * HASH_SIZE);
+        let mut nonce_iter = nonce_array.iter();
+        let mut expanded_iv;
+        for _ in 0..piece_amount {
             // same encoding_key_hash will be used for each expanded_iv
-            let mut expanded_iv = encoding_key_hash.clone();
+            expanded_iv = encoding_key_hash;
 
             // select the nonce from nonce_array, xor it with the encoding_key_hash
-            for (i, &byte) in nonce_array[x].to_le_bytes().iter().rev().enumerate() {
-                expanded_iv[32 - i - 1] ^= byte;
+            for (i, &byte) in nonce_iter
+                .next()
+                .unwrap()
+                .to_le_bytes()
+                .iter()
+                .rev()
+                .enumerate()
+            {
+                expanded_iv[HASH_SIZE - i - 1] ^= byte;
             }
+
+            /* can replace the upper for loop
+            nonce_iter
+                .next()
+                .unwrap()
+                .to_le_bytes()
+                .iter()
+                .rev()
+                .enumerate()
+                .map(|(i, &byte)| expanded_iv[32 - i - 1] ^= byte);
+            */
             expanded_iv_vector.extend(expanded_iv);
         }
 
         // if we have access to CUDA, we will utilize GPU and CPU together
-        if cuda::is_cuda_available() {
-            // GPU can handle multiples of 1024 pieces. If there any leftovers, cpu will handle them
-            let cpu_encode_end_index = piece_amount % 1024;
+        if self.cuda_available {
+            // If there any leftovers from 1024x pieces, cpu will handle them
+            let cpu_encode_end_index = piece_amount % GPU_PIECE_BLOCK;
 
             // CPU encoding:
             for x in 0..cpu_encode_end_index {
                 cpu::encode(
-                    &mut pieces[x * 4096..(x + 1) * 4096],
-                    &expanded_iv_vector[x * 32..(x + 1) * 32],
+                    &mut pieces[x * PIECE_SIZE..(x + 1) * PIECE_SIZE],
+                    &expanded_iv_vector[x * HASH_SIZE..(x + 1) * HASH_SIZE],
                     rounds,
                 )
                 .unwrap();
@@ -72,19 +106,17 @@ impl Spartan {
 
             // GPU encoding:
             cuda::encode(
-                &mut pieces[cpu_encode_end_index * 4096..],
-                &expanded_iv_vector[cpu_encode_end_index * 32..],
+                &mut pieces[cpu_encode_end_index * PIECE_SIZE..],
+                &expanded_iv_vector[cpu_encode_end_index * HASH_SIZE..],
                 rounds,
             )
             .unwrap();
-        }
-        // if there is no CUDA in this device
-        else {
+        } else {
             // do all the pieces in CPU
             for x in 0..piece_amount {
                 cpu::encode(
-                    &mut pieces[x * 4096..(x + 1) * 4096],
-                    &expanded_iv_vector[x * 32..(x + 1) * 32],
+                    &mut pieces[x * PIECE_SIZE..(x + 1) * PIECE_SIZE],
+                    &expanded_iv_vector[x * HASH_SIZE..(x + 1) * HASH_SIZE],
                     rounds,
                 )
                 .unwrap();
@@ -96,13 +128,13 @@ impl Spartan {
     pub fn is_valid(
         &self,
         encoding: &mut [u8],
-        encoding_key_hash: [u8; 32],
+        encoding_key_hash: [u8; HASH_SIZE],
         nonce: u64,
         rounds: usize,
     ) -> bool {
         let mut expanded_iv = encoding_key_hash;
         for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
-            expanded_iv[32 - i - 1] ^= byte;
+            expanded_iv[HASH_SIZE - i - 1] ^= byte;
         }
 
         cpu::decode(encoding, &expanded_iv, rounds).unwrap();
@@ -137,7 +169,7 @@ mod tests {
     #[test]
     fn test_1026_piece() {
         let genesis_piece = random_bytes();
-        let mut piece_array: Vec<u8> = Vec::with_capacity(4096 * 1026);
+        let mut piece_array: Vec<u8> = Vec::with_capacity(PIECE_SIZE * 1026);
         let encoding_key_hash = random_bytes();
         let nonce: u64 = rand::random();
         let nonce_array = vec![nonce; 1026];
@@ -149,7 +181,6 @@ mod tests {
         }
 
         spartan.batch_encode(
-            1026,
             &mut piece_array,
             encoding_key_hash,
             nonce_array.as_slice(),
@@ -158,7 +189,7 @@ mod tests {
 
         for x in 0..1026 {
             assert!(spartan.is_valid(
-                &mut piece_array[x * 4096..(x + 1) * 4096],
+                &mut piece_array[x * PIECE_SIZE..(x + 1) * PIECE_SIZE],
                 encoding_key_hash,
                 nonce_array[x],
                 1

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -1,0 +1,75 @@
+#![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
+//! This is an adaptation of [SLOTH](https://eprint.iacr.org/2015/366) (slow-timed hash function) into a time-asymmetric permutation using a standard CBC block cipher. This code is largely based on the C implementation used in [PySloth](https://github.com/randomchain/pysloth/blob/master/sloth.c) which is the same as used in the paper.
+
+use sloth256_189::cpu;
+
+/// Spartan struct used to encode and validate
+#[derive(Debug, Clone)]
+pub struct Spartan {
+    genesis_piece: [u8; 4096],
+}
+
+impl Spartan {
+    /// New instance with 256-bit prime and 4096-byte genesis piece size
+    pub fn new(genesis_piece: [u8; 4096]) -> Self {
+        Spartan { genesis_piece }
+    }
+}
+
+impl Spartan {
+    /// Create an encoding based on genesis piece using provided encoding key hash, nonce and
+    /// desired number of rounds
+    pub fn encode(&self, encoding_key_hash: [u8; 32], nonce: u64, rounds: usize) -> [u8; 4096] {
+        let mut expanded_iv = encoding_key_hash;
+        for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
+            expanded_iv[32 - i - 1] ^= byte;
+        }
+
+        let mut encoding = self.genesis_piece;
+        cpu::encode(&mut encoding, expanded_iv, rounds).unwrap();
+
+        encoding
+    }
+
+    /// Check if previously created encoding is valid
+    pub fn is_valid(
+        &self,
+        mut encoding: [u8; 4096],
+        encoding_key_hash: [u8; 32],
+        nonce: u64,
+        rounds: usize,
+    ) -> bool {
+        let mut expanded_iv = encoding_key_hash;
+        for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
+            expanded_iv[32 - i - 1] ^= byte;
+        }
+
+        cpu::decode(&mut encoding, expanded_iv, rounds);
+
+        encoding == self.genesis_piece
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::prelude::*;
+
+    fn random_bytes<const BYTES: usize>() -> [u8; BYTES] {
+        let mut bytes = [0u8; BYTES];
+        rand::thread_rng().fill(&mut bytes[..]);
+        bytes
+    }
+
+    #[test]
+    fn test_random_piece() {
+        let genesis_piece = random_bytes();
+        let encoding_key = random_bytes();
+        let nonce = rand::random();
+
+        let spartan = Spartan::new(genesis_piece);
+        let encoding = spartan.encode(encoding_key, nonce, 1);
+
+        assert!(spartan.is_valid(encoding, encoding_key, nonce, 1));
+    }
+}


### PR DESCRIPTION
1. For big arrays (containing multiple pieces), I thought creating a vector with `with_capacity` would be a good idea. Then I use `.extend` method. Do you have any suggestions on that?
2. `Spartan.encode()` uses only CPU, since its parameter is a single piece
3. `Spartan.batch_encode()` uses CPU with GPU (if there is CUDA available, of course). Please check this thoroughly. 
4. After your suggestions (if there will be any), `spartan.rs` should be completed. The next step would be identifying where do we call `encode` in plotting, and replace its structure to `batch_encode` I guess.