### PR TITLE
Subspace upgrade (step 4)

### DIFF
--- a/crates/pallet-spartan/src/lib.rs
+++ b/crates/pallet-spartan/src/lib.rs
@@ -941,9 +941,8 @@ impl<T: Config> Pallet<T> {
                 .priority(TransactionPriority::MAX)
                 // Only one root block for every segment index.
                 .and_provides(root_block.segment_index())
-                // TODO: Should this be `0` or `1`?
-                // Should be included immediately with no exceptions
-                .longevity(1)
+                // Should be included immediately into the upcoming block with no exceptions.
+                .longevity(0)
                 // We don't propagate this. This can never be included on a remote node.
                 .propagate(false)
                 .build()

--- a/crates/sp-consensus-spartan/src/lib.rs
+++ b/crates/sp-consensus-spartan/src/lib.rs
@@ -34,7 +34,7 @@ pub type Randomness = [u8; RANDOMNESS_LENGTH];
 pub type Sha256Hash = [u8; 32];
 
 /// Root block for a specific segment
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub enum RootBlock {
     // V0 of the root block data structure
     #[codec(index = 0)]


### PR DESCRIPTION
This implements validation of the root block extrinsics.

I'm not proud of the way it is implemented, but it should do the job for now. I'm not sure it is even a supported use case to decode extrinsics on the client side, will try to ask folks on Matrix about a better approach.