### PR TITLE
Subspace upgrade (step 6)

### DIFF
--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -53,7 +53,7 @@ use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream
 use codec::{Decode, Encode};
 use futures::channel::{mpsc, oneshot};
 use futures::{future, FutureExt, SinkExt, StreamExt, TryFutureExt};
-use log::{debug, info, log, trace, warn};
+use log::{debug, error, info, log, trace, warn};
 use lru::LruCache;
 use parking_lot::Mutex;
 use prometheus_endpoint::Registry;
@@ -2017,9 +2017,77 @@ where
             let client = Arc::clone(&client);
 
             async move {
-                let mut last_archived_block = None;
-                let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE)
-                    .expect("Incorrect parameters for archiver");
+                let latest_root_block: Option<RootBlock> = {
+                    let mut block_to_check = BlockId::Hash(client.info().best_hash);
+                    loop {
+                        let block = client
+                            .block(&block_to_check)
+                            .expect("Older blocks should always exist")
+                            .expect("Older blocks should always exist");
+                        let mut latest_root_block: Option<RootBlock> = None;
+
+                        for extrinsic in block.block.extrinsics() {
+                            match client
+                                .runtime_api()
+                                .extract_root_block(&block_to_check, extrinsic.encode())
+                            {
+                                Ok(Some(root_block)) => match &mut latest_root_block {
+                                    Some(latest_root_block) => {
+                                        if latest_root_block.segment_index()
+                                            < root_block.segment_index()
+                                        {
+                                            *latest_root_block = root_block;
+                                        }
+                                    }
+                                    None => {
+                                        latest_root_block.replace(root_block);
+                                    }
+                                },
+                                Ok(None) => {
+                                    // Some other extrinsic, ignore
+                                }
+                                Err(error) => {
+                                    // TODO: Probably light client, can this even happen?
+                                    error!(
+                                        target: "poc",
+                                        "Failed to make runtime API call: {:?}",
+                                        error,
+                                    );
+                                }
+                            }
+                        }
+
+                        if latest_root_block.is_some() {
+                            break latest_root_block;
+                        }
+
+                        let parent_block_hash = *block.block.header().parent_hash();
+
+                        if parent_block_hash == Block::Hash::default() {
+                            // Genesis block, nothig else to check
+                            break None;
+                        }
+
+                        block_to_check = BlockId::Hash(parent_block_hash);
+                    }
+                };
+                let mut last_archived_block_number = None;
+                let mut archiver = match latest_root_block {
+                    Some(latest_root_block) => Archiver::with_initial_state(
+                        RECORD_SIZE,
+                        RECORDED_HISTORY_SEGMENT_SIZE,
+                        latest_root_block,
+                        client
+                            .block(&BlockId::Number(
+                                latest_root_block.last_archived_block().number.into(),
+                            ))
+                            .expect("Older blocks should always exist")
+                            .expect("Older blocks should always exist"),
+                    )
+                    .expect("Incorrect parameters for archiver"),
+                    None => Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE)
+                        .expect("Incorrect parameters for archiver"),
+                };
 
                 while let Some((block_number, mut root_block_sender)) =
                     imported_block_notification_stream.next().await
@@ -2032,7 +2100,7 @@ where
                             }
                         };
 
-                    if let Some(last_archived_block) = &mut last_archived_block {
+                    if let Some(last_archived_block) = &mut last_archived_block_number {
                         if *last_archived_block >= block_to_archive {
                             // This block was already archived, skip
                             continue;
@@ -2040,7 +2108,7 @@ where
 
                         *last_archived_block = block_to_archive;
                     } else {
-                        last_archived_block.replace(block_to_archive);
+                        last_archived_block_number.replace(block_to_archive);
                     }
 
                     debug!(target: "poc", "Archiving block {:?}", block_to_archive);

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -1977,7 +1977,8 @@ pub fn import_queue<Block: BlockT, Client, SelectChain, Inner, CAW, CIDP>(
     client: Arc<Client>,
     select_chain: SelectChain,
     create_inherent_data_providers: CIDP,
-    spawner: &impl sp_core::traits::SpawnEssentialNamed,
+    essential_spawner: &impl sp_core::traits::SpawnEssentialNamed,
+    spawner: &impl sp_core::traits::SpawnNamed,
     registry: Option<&Registry>,
     can_author_with: CAW,
     telemetry: Option<TelemetryHandle>,
@@ -2005,7 +2006,8 @@ where
     CIDP: CreateInherentDataProviders<Block, ()> + Send + Sync + 'static,
     CIDP::InherentDataProviders: InherentDataProviderExt + Send + Sync,
 {
-    spawner.spawn_essential_blocking(
+    // TODO: This task should probably be in a separate function altogether
+    spawner.spawn_blocking(
         "poc-archiver",
         Box::pin({
             let mut imported_block_notification_stream =
@@ -2083,7 +2085,7 @@ where
         verifier,
         Box::new(block_import),
         justification_import,
-        spawner,
+        essential_spawner,
         registry,
     ))
 }

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -62,7 +62,7 @@ pub enum SegmentItem {
     RootBlock(RootBlock),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 /// Archived segment as a combination of root block hash, segment index and corresponding pieces
 pub struct ArchivedSegment {
     /// Root block of the segment
@@ -185,8 +185,8 @@ impl Archiver {
     ) -> Result<Self, ArchiverInstantiationError> {
         let mut archiver = Self::new(record_size, segment_size)?;
 
-        archiver.segment_index = root_block.segment_index();
-        archiver.prev_root_block_hash = root_block.prev_root_block_hash();
+        archiver.segment_index = root_block.segment_index() + 1;
+        archiver.prev_root_block_hash = root_block.hash();
         archiver.last_archived_block = root_block.last_archived_block();
 
         // The first thing in the buffer should be root block

--- a/crates/subspace-archiving/src/lib.rs
+++ b/crates/subspace-archiving/src/lib.rs
@@ -15,7 +15,9 @@
 
 //! Collection of modules used for dealing with archived state of Subspace Network.
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(const_option)]
 #![feature(int_log)]
+#![feature(nonzero_ops)]
 
 #[cfg(feature = "std")]
 pub mod archiver;

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -43,6 +43,16 @@ pub struct LastArchivedBlock {
     pub bytes: Option<u32>,
 }
 
+impl LastArchivedBlock {
+    /// Initial state at genesis before block `0`
+    pub fn initial() -> Self {
+        Self {
+            number: 0,
+            bytes: Some(0),
+        }
+    }
+}
+
 /// Root block for a specific segment
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Debug))]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -33,6 +33,16 @@ pub type Sha256Hash = [u8; SHA256_HASH_SIZE];
 /// Piece size in Subspace Network
 pub type Piece = [u8; PIECE_SIZE];
 
+/// Last archived block
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct LastArchivedBlock {
+    /// Block number
+    pub number: u64,
+    /// `None` if the block was archived fully or number of bytes otherwise
+    pub bytes: Option<u32>,
+}
+
 /// Root block for a specific segment
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Debug))]
@@ -46,6 +56,8 @@ pub enum RootBlock {
         merkle_tree_root: Sha256Hash,
         /// Hash of the root block of the previous segment
         prev_root_block_hash: Sha256Hash,
+        /// Last archived block
+        last_archived_block: LastArchivedBlock,
     },
 }
 
@@ -78,6 +90,16 @@ impl RootBlock {
                 prev_root_block_hash,
                 ..
             } => *prev_root_block_hash,
+        }
+    }
+
+    /// Last archived block
+    pub fn last_archived_block(&self) -> LastArchivedBlock {
+        match self {
+            RootBlock::V0 {
+                last_archived_block,
+                ..
+            } => *last_archived_block,
         }
     }
 }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod crypto;
 
+use core::num::NonZeroU32;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
@@ -40,17 +41,7 @@ pub struct LastArchivedBlock {
     /// Block number
     pub number: u32,
     /// `None` if the block was archived fully or number of bytes otherwise
-    pub bytes: Option<u32>,
-}
-
-impl LastArchivedBlock {
-    /// Initial state at genesis before block `0`
-    pub fn initial() -> Self {
-        Self {
-            number: 0,
-            bytes: Some(0),
-        }
-    }
+    pub bytes: Option<NonZeroU32>,
 }
 
 /// Root block for a specific segment

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -38,7 +38,7 @@ pub type Piece = [u8; PIECE_SIZE];
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct LastArchivedBlock {
     /// Block number
-    pub number: u64,
+    pub number: u32,
     /// `None` if the block was archived fully or number of bytes otherwise
     pub bytes: Option<u32>,
 }

--- a/node-template-spartan/node/src/service.rs
+++ b/node-template-spartan/node/src/service.rs
@@ -115,6 +115,7 @@ pub fn new_partial(
             Ok((timestamp, slot, uncles))
         },
         &task_manager.spawn_essential_handle(),
+        &task_manager.spawn_handle(),
         config.prometheus_registry(),
         sp_consensus::CanAuthorWithNativeVersion::new(client.executor().clone()),
         telemetry.as_ref().map(|x| x.handle()),
@@ -338,6 +339,7 @@ pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
             Ok((timestamp, slot, uncles))
         },
         &task_manager.spawn_essential_handle(),
+        &task_manager.spawn_handle(),
         config.prometheus_registry(),
         sp_consensus::NeverCanAuthor,
         telemetry.as_ref().map(|x| x.handle()),


### PR DESCRIPTION
This introduces additional fields to root block with information about last archived block. Such information enabled node restart support, which is also implemented as part of this PR.