### PR TITLE
Subspace upgrade (step 8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,6 +5641,7 @@ dependencies = [
  "serde",
  "sp-consensus-poc",
  "sp-core",
+ "subspace-core-primitives",
 ]
 
 [[package]]
@@ -7421,6 +7422,7 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sha2 0.9.8",
 ]
 

--- a/crates/sc-consensus-poc-rpc/Cargo.toml
+++ b/crates/sc-consensus-poc-rpc/Cargo.toml
@@ -27,5 +27,6 @@ futures-timer = "3.0.2"
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 log = "0.4.14"
 parking_lot = "0.11.1"
+subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [dev-dependencies]

--- a/crates/sc-consensus-poc-rpc/src/lib.rs
+++ b/crates/sc-consensus-poc-rpc/src/lib.rs
@@ -32,6 +32,7 @@ use sp_consensus_poc::{FarmerId, Slot};
 use sp_core::crypto::Public;
 use std::sync::Arc;
 use std::time::Duration;
+use subspace_core_primitives::RootBlock;
 
 const SOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -56,21 +57,18 @@ pub struct RpcNewSlotInfo {
 /// Information about new slot that just arrived
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcArchivedSegment {
-    /// Segment index
-    pub segment_index: u64,
-    /// Pieces that correspond to this segment
+    /// Root block
+    pub root_block: RootBlock,
+    /// Pieces that correspond to the segment in root block
     pub pieces: Vec<Vec<u8>>,
 }
 
 impl From<ArchivedSegmentNotification> for RpcArchivedSegment {
     fn from(archived_segment_notification: ArchivedSegmentNotification) -> Self {
-        let ArchivedSegmentNotification {
-            segment_index,
-            pieces,
-        } = archived_segment_notification;
+        let ArchivedSegmentNotification { root_block, pieces } = archived_segment_notification;
 
         Self {
-            segment_index,
+            root_block,
             pieces: pieces.into_iter().map(|piece| piece.to_vec()).collect(),
         }
     }

--- a/crates/sc-consensus-poc/src/lib.rs
+++ b/crates/sc-consensus-poc/src/lib.rs
@@ -2043,7 +2043,7 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
             RECORD_SIZE,
             RECORDED_HISTORY_SEGMENT_SIZE,
             latest_root_block,
-            client
+            &client
                 .block(&BlockId::Number(
                     latest_root_block.last_archived_block().number.into(),
                 ))

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -549,7 +549,7 @@ impl BlockArchiver {
         record_size: usize,
         segment_size: usize,
         root_block: RootBlock,
-        block: B,
+        block: &B,
     ) -> Result<Self, ArchiverInstantiationError> {
         if root_block.last_archived_block() == INITIAL_LAST_ARCHIVED_BLOCK {
             return Err(ArchiverInstantiationError::NoBlocksInvalidInitialState);

--- a/crates/subspace-archiving/src/lib.rs
+++ b/crates/subspace-archiving/src/lib.rs
@@ -15,9 +15,7 @@
 
 //! Collection of modules used for dealing with archived state of Subspace Network.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(const_option)]
 #![feature(int_log)]
-#![feature(nonzero_ops)]
 
 #[cfg(feature = "std")]
 pub mod archiver;

--- a/crates/subspace-archiving/src/lib.rs
+++ b/crates/subspace-archiving/src/lib.rs
@@ -21,3 +21,5 @@
 pub mod archiver;
 #[cfg(feature = "std")]
 pub mod merkle_tree;
+#[cfg(feature = "std")]
+pub mod pre_genesis_data;

--- a/crates/subspace-archiving/src/pre_genesis_data.rs
+++ b/crates/subspace-archiving/src/pre_genesis_data.rs
@@ -1,0 +1,21 @@
+use subspace_core_primitives::{crypto, SHA256_HASH_SIZE};
+
+/// Derives a single object blob of a given size from given seed, which is intended to be used as
+/// pre-genesis blockchain seed data
+pub fn from_seed(seed: &[u8], size: usize) -> Vec<u8> {
+    let mut object = Vec::with_capacity(size);
+    let mut acc = crypto::sha256_hash(seed);
+    for _ in 0..size / SHA256_HASH_SIZE {
+        object.extend_from_slice(&acc);
+        acc = crypto::sha256_hash(&acc);
+    }
+
+    let remainder = size % SHA256_HASH_SIZE;
+    if remainder > 0 {
+        object.extend_from_slice(&acc[..remainder]);
+    }
+
+    assert_eq!(object.len(), size);
+
+    object
+}

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -1,5 +1,4 @@
 use std::assert_matches::assert_matches;
-use std::num::NonZeroU32;
 use subspace_archiving::archiver;
 use subspace_archiving::archiver::{Archiver, ArchiverInstantiationError};
 use subspace_core_primitives::{
@@ -34,10 +33,7 @@ fn archiver() {
     {
         let last_archived_block = first_archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 1);
-        assert_eq!(
-            last_archived_block.bytes,
-            Some(NonZeroU32::new(7992).unwrap()),
-        );
+        assert_eq!(last_archived_block.bytes, Some(7992),);
     }
 
     // Check that all pieces are valid
@@ -77,19 +73,13 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(
-            last_archived_block.bytes,
-            Some(NonZeroU32::new(13233).unwrap()),
-        );
+        assert_eq!(last_archived_block.bytes, Some(13233),);
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(
-            last_archived_block.bytes,
-            Some(NonZeroU32::new(29143).unwrap()),
-        );
+        assert_eq!(last_archived_block.bytes, Some(29143),);
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -192,7 +182,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    bytes: Some(NonZeroU32::new(10).unwrap()),
+                    bytes: Some(10),
                 },
             },
             vec![0u8; 9],
@@ -204,7 +194,7 @@ fn archiver_invalid_usage() {
         );
 
         if let Err(ArchiverInstantiationError::InvalidLastArchivedBlock(size)) = result {
-            assert_eq!(size, NonZeroU32::new(10).unwrap());
+            assert_eq!(size, 10);
         }
     }
 
@@ -218,7 +208,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    bytes: Some(NonZeroU32::new(10).unwrap()),
+                    bytes: Some(10),
                 },
             },
             vec![0u8; 5],
@@ -234,8 +224,8 @@ fn archiver_invalid_usage() {
             archived_block_bytes,
         }) = result
         {
-            assert_eq!(block_bytes, NonZeroU32::new(6).unwrap());
-            assert_eq!(archived_block_bytes, NonZeroU32::new(10).unwrap());
+            assert_eq!(block_bytes, 6);
+            assert_eq!(archived_block_bytes, 10);
         }
     }
 }

--- a/crates/subspace-archiving/tests/integration/main.rs
+++ b/crates/subspace-archiving/tests/integration/main.rs
@@ -3,3 +3,4 @@
 
 mod archiver;
 mod merkle_tree;
+mod pre_genesis_data;

--- a/crates/subspace-archiving/tests/integration/pre_genesis_data.rs
+++ b/crates/subspace-archiving/tests/integration/pre_genesis_data.rs
@@ -1,0 +1,23 @@
+use subspace_archiving::pre_genesis_data;
+
+#[test]
+fn pre_genesis_data() {
+    {
+        // Below 1 Sha256 block
+        let object = pre_genesis_data::from_seed(b"subspace", 10);
+        assert_eq!(object.len(), 10);
+        assert!(object.iter().find(|byte| **byte != 0).is_some());
+    }
+    {
+        // Exactly 1 Sha256 block
+        let object = pre_genesis_data::from_seed(b"subspace", 32);
+        assert_eq!(object.len(), 32);
+        assert!(object.iter().find(|byte| **byte != 0).is_some());
+    }
+    {
+        // Over 1 Sha256 block
+        let object = pre_genesis_data::from_seed(b"subspace", 40);
+        assert_eq!(object.len(), 40);
+        assert!(object.iter().find(|byte| **byte != 0).is_some());
+    }
+}

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -22,6 +22,11 @@ default-features = false
 features = ["derive"]
 version = "1.0"
 
+[dependencies.serde]
+default-features = false
+features = ["derive"]
+version = "1.0.130"
+
 [dependencies.sha2]
 default-features = false
 version = "0.9.8"
@@ -31,6 +36,7 @@ default = ["std"]
 std = [
     "parity-scale-codec/std",
     "scale-info/std",
+    "serde/std",
     # Can't enable this in platform-specific way, see https://github.com/rust-lang/cargo/issues/1197
     "sha2/asm",
     "sha2/std",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -19,7 +19,6 @@
 
 pub mod crypto;
 
-use core::num::NonZeroU32;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
@@ -41,7 +40,7 @@ pub struct LastArchivedBlock {
     /// Block number
     pub number: u32,
     /// `None` if the block was archived fully or number of bytes otherwise
-    pub bytes: Option<NonZeroU32>,
+    pub bytes: Option<u32>,
 }
 
 /// Root block for a specific segment

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -21,6 +21,7 @@ pub mod crypto;
 
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
 
 /// Size of Sha2-256 hash output (in bytes)
 pub const SHA256_HASH_SIZE: usize = 32;
@@ -34,7 +35,20 @@ pub type Sha256Hash = [u8; SHA256_HASH_SIZE];
 pub type Piece = [u8; PIECE_SIZE];
 
 /// Last archived block
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Encode,
+    Decode,
+    TypeInfo,
+    Serialize,
+    Deserialize,
+)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct LastArchivedBlock {
     /// Block number
@@ -44,7 +58,20 @@ pub struct LastArchivedBlock {
 }
 
 /// Root block for a specific segment
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Encode,
+    Decode,
+    TypeInfo,
+    Serialize,
+    Deserialize,
+)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum RootBlock {
     /// V0 of the root block data structure


### PR DESCRIPTION
Changes:
* Archiver is split into effective `ObjectArchiver` and `BlockArchiver`
  * `ObjectArchier` can be used to fill archived history with pre-genesis objects and then converted into `BlockArchiver` for the rest of history
* Farmer's RPC with archived segments now contains the whole root block instead of just segment ID
* Object archiving caveats:
  * No restart support, it is assumed that everyone will be able to finish archiving objects without interruption (which is true with small pre-genesis data of 10 segments)
  * In future when we have bigger data payload we might want to split root blocks among more than one block or else it will overload single block quite soon

Going commit by commit would make the most sense here.