### PR TITLE
sloth256-189 library integration

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -62,6 +62,15 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: CUDA toolchain
+        run: sudo apt-get install --no-install-recommends -y nvidia-cuda-toolkit
+
+      # CUDA toolchain above doesn't like GCC newer than 8
+      - name: Select GCC 8
+        run: |
+          echo "CC=gcc-8" >> $GITHUB_ENV
+          echo "CXX=g++-8" >> $GITHUB_ENV
+
       - name: Configure cache
         uses: actions/cache@v2
         with:
@@ -96,6 +105,15 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy
+
+      - name: CUDA toolchain
+        run: sudo apt-get install --no-install-recommends -y nvidia-cuda-toolkit
+
+      # CUDA toolchain above doesn't like GCC newer than 8
+      - name: Select GCC 8
+        run: |
+          echo "CC=gcc-8" >> $GITHUB_ENV
+          echo "CXX=g++-8" >> $GITHUB_ENV
 
       - name: Configure cache
         uses: actions/cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6538,8 +6538,8 @@ dependencies = [
 
 [[package]]
 name = "sloth256-189"
-version = "0.1.0"
-source = "git+https://github.com/subspace/sloth256-189.git#f3135cfcab7ed65adb361dcaae1a8ad518d8cac6"
+version = "0.2.0"
+source = "git+https://github.com/subspace/sloth256-189.git#09485267e86cc531eb618b0ab4a3cdbb50adcd6d"
 dependencies = [
  "cc",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad6f1acec69b95caf435bbd158d486e5a0a44fcf51531e84922c59ff09e8457"
+checksum = "9f7adaf50e545c285006d384d50588e98c405c49b55c0aa05660aca081f6ee5e"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
@@ -6538,8 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "sloth256-189"
-version = "0.2.0"
-source = "git+https://github.com/subspace/sloth256-189?branch=unresolved_symbol_test#ed2032734db71044bf7a1ed037fd2041d794ce21"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6743712655581c231c30fe94e554b8a3f3c4bb7b845289eab22f89315fa5b736"
 dependencies = [
  "cc",
  "glob",
@@ -7953,9 +7954,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6539,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "sloth256-189"
 version = "0.2.0"
-source = "git+https://github.com/subspace/sloth256-189.git#09485267e86cc531eb618b0ab4a3cdbb50adcd6d"
+source = "git+https://github.com/subspace/sloth256-189?branch=unresolved_symbol_test#ed2032734db71044bf7a1ed037fd2041d794ce21"
 dependencies = [
  "cc",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "az"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6dff4a1892b54d70af377bf7a17064192e822865791d812957f21e3108c325"
-
-[[package]]
 name = "backtrace"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,16 +2075,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c909eb55443867ff73a36c7c28784f02496e657c9618cdfed0c70a8379b911a"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4235,7 +4219,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "spartan-codec",
  "subspace-core-primitives",
 ]
 
@@ -5257,17 +5240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rug"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0c6e98de59509e62e09f3456b23cebb75dad21928882016f169bb628843459"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5618,7 +5590,6 @@ dependencies = [
  "sp-timestamp",
  "sp-tracing",
  "sp-version",
- "spartan-codec",
  "subspace-archiving",
  "subspace-core-primitives",
  "substrate-prometheus-endpoint",
@@ -7290,16 +7261,6 @@ dependencies = [
  "parity-scale-codec",
  "sp-std",
  "wasmi",
-]
-
-[[package]]
-name = "spartan-codec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c9ee58de0a3f898393546ee74c909d3b87ba285248db142e1d1ef03519ad19"
-dependencies = [
- "rayon",
- "rug",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
@@ -2230,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -2431,11 +2431,14 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4315,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241f9c5d25063080f2c02846221f13e1d0e5e18fa00c32c234aad585b744ee55"
+checksum = "91b679c6acc14fac74382942e2b73bea441686a33430b951ea03b5aeb6a7f254"
 dependencies = [
  "blake2-rfc",
  "crc32fast",
@@ -4380,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7adaf50e545c285006d384d50588e98c405c49b55c0aa05660aca081f6ee5e"
+checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
@@ -6826,7 +6829,8 @@ name = "sp-consensus-spartan"
 version = "0.1.0"
 dependencies = [
  "ring",
- "spartan-codec",
+ "sloth256-189",
+ "subspace-core-primitives",
 ]
 
 [[package]]
@@ -7779,13 +7783,14 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
+checksum = "524daa5624d9d4ffb5a0625971d35205b882111daa6b6338a7a6c578a3c36928"
 dependencies = [
  "anyhow",
  "hmac 0.8.1",
  "once_cell",
+ "parking_lot 0.11.2",
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
@@ -7821,9 +7826,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes 1.1.0",
@@ -8725,18 +8730,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6537,6 +6537,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sloth256-189"
+version = "0.1.0"
+source = "git+https://github.com/subspace/sloth256-189.git#f3135cfcab7ed65adb361dcaae1a8ad518d8cac6"
+dependencies = [
+ "cc",
+ "glob",
+ "thiserror",
+ "which",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7308,7 +7319,7 @@ dependencies = [
  "schnorrkel 0.10.1",
  "serde",
  "serde_json",
- "spartan-codec",
+ "sloth256-189",
  "subspace-core-primitives",
  "thiserror",
  "tokio",

--- a/crates/pallet-spartan/Cargo.toml
+++ b/crates/pallet-spartan/Cargo.toml
@@ -32,7 +32,6 @@ pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/
 pallet-offences-poc = { version = "0.1.0", path = "../pallet-offences-poc" }
 sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 schnorrkel = { version = "0.9.1" }
-spartan-codec = "0.1.0"
 ring = "0.16"
 
 [features]

--- a/crates/pallet-spartan/src/mock.rs
+++ b/crates/pallet-spartan/src/mock.rs
@@ -181,9 +181,8 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
         System::parent_hash()
     };
 
-    let spartan = spartan_codec::Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(
-        genesis_piece_from_seed(GENESIS_PIECE_SEED),
-    );
+    let spartan =
+        sp_consensus_spartan::spartan::Spartan::new(genesis_piece_from_seed(GENESIS_PIECE_SEED));
     let public_key_hash = hash_public_key(&keypair.public);
     let ctx = schnorrkel::context::signing_context(SIGNING_CONTEXT);
     let nonce = 0;

--- a/crates/sc-consensus-poc/Cargo.toml
+++ b/crates/sc-consensus-poc/Cargo.toml
@@ -58,4 +58,3 @@ sc-network-test = { version = "0.8.0", path = "../../substrate/sc-network-test" 
 substrate-test-runtime = { version = "2.0.0", path = "../../substrate/substrate-test-runtime" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../substrate/substrate-test-runtime-client" }
 sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
-spartan-codec = "0.1.0"

--- a/crates/sc-consensus-poc/src/tests.rs
+++ b/crates/sc-consensus-poc/src/tests.rs
@@ -506,9 +506,9 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 
         let mut new_slot_notification_stream = data.link.new_slot_notification_stream().subscribe();
         let poc_farmer = async move {
-            let spartan = spartan_codec::Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(
-                genesis_piece_from_seed(GENESIS_PIECE_SEED),
-            );
+            let spartan = sp_consensus_spartan::spartan::Spartan::new(genesis_piece_from_seed(
+                GENESIS_PIECE_SEED,
+            ));
             let keypair = Keypair::generate();
             let public_key_hash = hash_public_key(&keypair.public);
             let ctx = schnorrkel::context::signing_context(SIGNING_CONTEXT);

--- a/crates/sc-consensus-poc/src/verification.rs
+++ b/crates/sc-consensus-poc/src/verification.rs
@@ -24,7 +24,7 @@ use schnorrkel::context::SigningContext;
 use sp_consensus_poc::digests::{CompatibleDigestItem, PreDigest, Solution};
 use sp_consensus_poc::Randomness;
 use sp_consensus_slots::Slot;
-use sp_consensus_spartan::spartan::{self, Piece, Salt, Spartan, PRIME_SIZE_BYTES};
+use sp_consensus_spartan::spartan::{self, Piece, Salt, Spartan, ENCODE_ROUNDS, PRIME_SIZE_BYTES};
 use sp_core::Public;
 use sp_runtime::{traits::DigestItemFor, traits::Header, RuntimeAppPublic};
 use std::convert::TryInto;
@@ -150,7 +150,7 @@ pub(crate) fn verify_solution<B: BlockT + Sized>(
         return Err(Error::OutsideOfSolutionRange(slot));
     }
 
-    let mut piece: Piece = solution
+    let piece: Piece = solution
         .encoding
         .as_slice()
         .try_into()
@@ -164,7 +164,12 @@ pub(crate) fn verify_solution<B: BlockT + Sized>(
         return Err(Error::BadSolutionSignature(slot));
     }
 
-    if !spartan.is_encoding_valid(&mut piece, solution.public_key.as_ref(), solution.nonce) {
+    if !spartan.is_encoding_valid(
+        piece,
+        solution.public_key.as_ref(),
+        solution.nonce,
+        ENCODE_ROUNDS,
+    ) {
         return Err(Error::InvalidEncoding(slot));
     }
 

--- a/crates/sp-consensus-spartan/Cargo.toml
+++ b/crates/sp-consensus-spartan/Cargo.toml
@@ -12,13 +12,16 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[dependencies.subspace-core-primitives]
+version = "0.1.0"
+path = "../subspace-core-primitives"
+
 [dependencies]
 ring = { version = "0.16.20", optional = true }
-spartan-codec = { version = "0.1.0", default-features = false, optional = true }
+sloth256-189 = "0.2.2"
 
 [features]
 default = ["std"]
 std = [
     "ring/std",
-    "spartan-codec"
 ]

--- a/crates/sp-consensus-spartan/Cargo.toml
+++ b/crates/sp-consensus-spartan/Cargo.toml
@@ -12,16 +12,16 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[dependencies.subspace-core-primitives]
-version = "0.1.0"
-path = "../subspace-core-primitives"
 
 [dependencies]
 ring = { version = "0.16.20", optional = true }
-sloth256-189 = "0.2.2"
+sloth256-189 = { version = "0.2.2", optional = true}
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", optional = true}
 
 [features]
 default = ["std"]
 std = [
     "ring/std",
+    "sloth256-189",
+    "subspace-core-primitives"
 ]

--- a/crates/sp-consensus-spartan/src/spartan.rs
+++ b/crates/sp-consensus-spartan/src/spartan.rs
@@ -50,6 +50,26 @@ impl Default for Spartan {
 }
 
 impl Spartan {
+    /// Create an encoding based on genesis piece using provided encoding key hash, nonce and
+    /// desired number of rounds
+    pub fn encode(
+        &self,
+        encoding_key_hash: [u8; PRIME_SIZE_BYTES],
+        nonce: u64,
+        rounds: usize,
+    ) -> [u8; PIECE_SIZE] {
+        let mut expanded_iv = encoding_key_hash;
+        for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
+            expanded_iv[PRIME_SIZE_BYTES - i - 1] ^= byte;
+        }
+
+        let mut encoding = self.genesis_piece;
+
+        cpu::encode(&mut encoding, &expanded_iv, rounds).unwrap();
+
+        encoding
+    }
+
     /// Check if previously created encoding is valid
     pub fn is_encoding_valid(
         &self,

--- a/crates/sp-consensus-spartan/src/spartan.rs
+++ b/crates/sp-consensus-spartan/src/spartan.rs
@@ -19,13 +19,12 @@ use ring::{digest, hmac};
 use sloth256_189::cpu;
 use std::convert::TryInto;
 use std::io::Write;
-use subspace_core_primitives::{Piece, PIECE_SIZE};
+pub use subspace_core_primitives::{Piece, PIECE_SIZE};
 
 pub const PRIME_SIZE_BYTES: usize = 32;
 pub const GENESIS_PIECE_SEED: &str = "spartan";
 pub const ENCODE_ROUNDS: usize = 1;
 pub const SIGNING_CONTEXT: &[u8] = b"FARMER";
-const HASH_SIZE: usize = 32; // length of public_key_hash
 
 pub type Tag = [u8; 8];
 pub type Salt = [u8; 8];
@@ -47,13 +46,13 @@ impl Spartan {
     pub fn is_valid(
         &self,
         encoding: &mut [u8],
-        encoding_key_hash: [u8; HASH_SIZE],
+        encoding_key_hash: [u8; PRIME_SIZE_BYTES],
         nonce: u64,
         rounds: usize,
     ) -> bool {
         let mut expanded_iv = encoding_key_hash;
         for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
-            expanded_iv[HASH_SIZE - i - 1] ^= byte;
+            expanded_iv[PRIME_SIZE_BYTES - i - 1] ^= byte;
         }
 
         cpu::decode(encoding, &expanded_iv, rounds).unwrap();
@@ -71,7 +70,7 @@ impl Default for Spartan {
 }
 
 impl Spartan {
-    pub fn is_encoding_valid(&self, encoding: &mut [u8], public_key: &[u8], nonce: u64) -> bool {
+    pub fn is_encoding_valid(&self, encoding: &mut Piece, public_key: &[u8], nonce: u64) -> bool {
         self.is_valid(encoding, hash_public_key(public_key), nonce, ENCODE_ROUNDS)
     }
 }

--- a/crates/sp-consensus-spartan/src/spartan.rs
+++ b/crates/sp-consensus-spartan/src/spartan.rs
@@ -16,38 +16,63 @@
 //! Spartan-based PoR.
 
 use ring::{digest, hmac};
+use sloth256_189::cpu;
 use std::convert::TryInto;
 use std::io::Write;
+use subspace_core_primitives::{Piece, PIECE_SIZE};
 
-pub const PRIME_SIZE_BYTES: usize = 8;
-pub const PIECE_SIZE: usize = 4096;
+pub const PRIME_SIZE_BYTES: usize = 32;
 pub const GENESIS_PIECE_SEED: &str = "spartan";
 pub const ENCODE_ROUNDS: usize = 1;
 pub const SIGNING_CONTEXT: &[u8] = b"FARMER";
+const HASH_SIZE: usize = 32; // length of public_key_hash
 
-pub type Piece = [u8; PIECE_SIZE];
-pub type Tag = [u8; PRIME_SIZE_BYTES];
+pub type Tag = [u8; 8];
 pub type Salt = [u8; 8];
 
 #[derive(Clone)]
 pub struct Spartan {
-    instance: spartan_codec::Spartan<PRIME_SIZE_BYTES, PIECE_SIZE>,
+    genesis_piece: [u8; PIECE_SIZE],
+}
+
+impl Spartan {
+    /// New instance with 256-bit prime and 4096-byte genesis piece size
+    pub fn new(genesis_piece: [u8; PIECE_SIZE]) -> Self {
+        Spartan { genesis_piece }
+    }
+}
+
+impl Spartan {
+    /// Check if previously created encoding is valid
+    pub fn is_valid(
+        &self,
+        encoding: &mut [u8],
+        encoding_key_hash: [u8; HASH_SIZE],
+        nonce: u64,
+        rounds: usize,
+    ) -> bool {
+        let mut expanded_iv = encoding_key_hash;
+        for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
+            expanded_iv[HASH_SIZE - i - 1] ^= byte;
+        }
+
+        cpu::decode(encoding, &expanded_iv, rounds).unwrap();
+
+        encoding == self.genesis_piece
+    }
 }
 
 impl Default for Spartan {
     fn default() -> Self {
         Self {
-            instance: spartan_codec::Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(
-                genesis_piece_from_seed(GENESIS_PIECE_SEED),
-            ),
+            genesis_piece: genesis_piece_from_seed(GENESIS_PIECE_SEED),
         }
     }
 }
 
 impl Spartan {
-    pub fn is_encoding_valid(&self, encoding: Piece, public_key: &[u8], nonce: u64) -> bool {
-        self.instance
-            .is_valid(encoding, hash_public_key(public_key), nonce, ENCODE_ROUNDS)
+    pub fn is_encoding_valid(&self, encoding: &mut [u8], public_key: &[u8], nonce: u64) -> bool {
+        self.is_valid(encoding, hash_public_key(public_key), nonce, ENCODE_ROUNDS)
     }
 }
 

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.14"
 rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
-sloth256-189 = { git = "https://github.com/subspace/sloth256-189", branch = "unresolved_symbol_test", features = ["cuda"]}
+#sloth256-189 = { git = "https://github.com/subspace/sloth256-189", features = ["cuda"]}
 schnorrkel = "0.10.1"
 thiserror = "1.0.24"
 tokio = "1.11.0"
@@ -36,9 +36,9 @@ tokio = "1.11.0"
 features = ["client"]
 version = "0.2.0"
 
-#[dependencies.sloth256-189]
-#features = ["cuda"]
-#version = "0.2.0"
+[dependencies.sloth256-189]
+features = ["cuda"]
+version = "0.2.2"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -28,7 +28,7 @@ rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
 schnorrkel = "0.10.1"
-sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git" }
+sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git", features = ["cuda"]}
 thiserror = "1.0.24"
 tokio = "1.11.0"
 

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -27,7 +27,6 @@ log = "0.4.14"
 rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
-#sloth256-189 = { git = "https://github.com/subspace/sloth256-189", features = ["cuda"]}
 schnorrkel = "0.10.1"
 thiserror = "1.0.24"
 tokio = "1.11.0"

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -27,14 +27,18 @@ log = "0.4.14"
 rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
+sloth256-189 = { git = "https://github.com/subspace/sloth256-189", branch = "unresolved_symbol_test", features = ["cuda"]}
 schnorrkel = "0.10.1"
-sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git", features = ["cuda"]}
 thiserror = "1.0.24"
 tokio = "1.11.0"
 
 [dependencies.jsonrpsee]
 features = ["client"]
 version = "0.2.0"
+
+#[dependencies.sloth256-189]
+#features = ["cuda"]
+#version = "0.2.0"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -28,7 +28,7 @@ rayon = "1.5.0"
 ring = "0.16.20"
 serde_json = "1.0.64"
 schnorrkel = "0.10.1"
-spartan-codec = "0.1.0"
+sloth256-189 = { git = "https://github.com/subspace/sloth256-189.git" }
 thiserror = "1.0.24"
 tokio = "1.11.0"
 

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -26,18 +26,15 @@ indicatif = "0.16.2"
 log = "0.4.14"
 rayon = "1.5.0"
 ring = "0.16.20"
-serde_json = "1.0.64"
 schnorrkel = "0.10.1"
+serde_json = "1.0.64"
+sloth256-189 = "0.2.2"
 thiserror = "1.0.24"
 tokio = "1.11.0"
 
 [dependencies.jsonrpsee]
 features = ["client"]
 version = "0.2.0"
-
-[dependencies.sloth256-189]
-features = ["cuda"]
-version = "0.2.2"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to
@@ -61,3 +58,12 @@ rand = "0.8.4"
 [dev-dependencies.async-std]
 features = ["attributes"]
 version = "1.9.0"
+
+[features]
+default = ["cuda"]
+# Compile with CUDA support and use it if compatible GPU is available
+cuda = [
+    "sloth256-189/cuda",
+]
+# Special feature to test CUDA support
+test-cuda = []

--- a/crates/spartan-farmer/README.md
+++ b/crates/spartan-farmer/README.md
@@ -38,10 +38,6 @@ docker run --rm -it --mount source=spartan-farmer,target=/var/spartan subspacela
 ## Install and Run Manually
 Instead of Docker you can also install spartan-farmer natively by compiling it using cargo.
 
-**Notes:** This will currently only work on Mac and Linux, not Windows.
-
-If you have not previously installed the `gmp_mpfr_sys` crate, follow these [instructions](https://docs.rs/gmp-mpfr-sys/1.3.0/gmp_mpfr_sys/index.html#building-on-gnulinux). 
-
 RocksDB on Linux needs LLVM/Clang:
 ```bash
 sudo apt-get install llvm clang

--- a/crates/spartan-farmer/src/commands/farm.rs
+++ b/crates/spartan-farmer/src/commands/farm.rs
@@ -1,5 +1,5 @@
 use crate::plot::Plot;
-use crate::{crypto, Salt, Tag, PRIME_SIZE_BYTES, SIGNING_CONTEXT};
+use crate::{crypto, Salt, Tag, SIGNING_CONTEXT};
 use async_std::task;
 use futures::channel::oneshot;
 use jsonrpsee::ws_client::traits::{Client, SubscriptionClient};
@@ -42,7 +42,7 @@ struct SlotInfo {
     /// Slot number
     slot_number: SlotNumber,
     /// Slot challenge
-    challenge: [u8; PRIME_SIZE_BYTES],
+    challenge: [u8; 8],
     /// Salt
     salt: Salt,
     /// Salt for the next eon

--- a/crates/spartan-farmer/src/commands/plot.rs
+++ b/crates/spartan-farmer/src/commands/plot.rs
@@ -64,7 +64,7 @@ pub(crate) async fn plot(
                                 &nonce_array[(batch_start as usize)..batch_end],
                                 1,
                             );
-                            bar.inc(1 * CUDA_BATCH_SIZE);
+                            bar.inc(CUDA_BATCH_SIZE);
 
                             let encoded_piece = piece_array
                                 [(batch_start as usize) * PIECE_SIZE..batch_end * PIECE_SIZE]

--- a/crates/spartan-farmer/src/commands/plot.rs
+++ b/crates/spartan-farmer/src/commands/plot.rs
@@ -1,12 +1,12 @@
 use crate::plot::Plot;
-use crate::{crypto, Piece, BATCH_SIZE, ENCODE_ROUNDS, PIECE_SIZE, PRIME_SIZE_BYTES};
+use crate::spartan::Spartan;
+use crate::{crypto, Piece, BATCH_SIZE, ENCODE_ROUNDS, PIECE_SIZE};
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
 use indicatif::ProgressBar;
 use log::{info, warn};
 use rayon::prelude::*;
 use schnorrkel::Keypair;
-use spartan_codec::Spartan;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -31,8 +31,7 @@ pub(crate) async fn plot(
 
     let plot = Plot::open_or_create(&path.into()).await?;
     let public_key_hash = crypto::hash_public_key(&keypair.public);
-    let spartan: Arc<Spartan<PRIME_SIZE_BYTES, PIECE_SIZE>> =
-        Arc::new(Spartan::<PRIME_SIZE_BYTES, PIECE_SIZE>::new(genesis_piece));
+    let spartan: Arc<Spartan> = Arc::new(Spartan::new(genesis_piece));
 
     if plot.is_empty().await {
         let plotting_fut = {

--- a/crates/spartan-farmer/src/commands/plot.rs
+++ b/crates/spartan-farmer/src/commands/plot.rs
@@ -64,6 +64,18 @@ pub(crate) async fn plot(
                                 1,
                             );
                             bar.inc(1 * CUDA_BATCH_SIZE);
+
+                            /*
+                            if futures::executor::block_on(batch_sender.send((
+                                batch_start,
+                                piece_array
+                                    [(batch_start as usize) * PIECE_SIZE..batch_end * PIECE_SIZE],
+                            )))
+                            .is_err()
+                            {
+                                return;
+                            }
+                            */
                         }
                     } else {
                         info!("Using only CPU for plotting!");

--- a/crates/spartan-farmer/src/main.rs
+++ b/crates/spartan-farmer/src/main.rs
@@ -39,6 +39,7 @@ const PIECE_SIZE: usize = 4096;
 const ENCODE_ROUNDS: usize = 1;
 const SIGNING_CONTEXT: &[u8] = b"FARMER";
 const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;
+const CUDA_BATCH_SIZE: u64 = (32 * 1024) as u64;
 
 #[derive(Debug, Clap)]
 #[clap(about, version)]

--- a/crates/spartan-farmer/src/main.rs
+++ b/crates/spartan-farmer/src/main.rs
@@ -30,12 +30,10 @@ use std::path::PathBuf;
 use subspace_core_primitives::{Piece, PIECE_SIZE};
 use tokio::runtime::Runtime;
 
-type Piece = [u8; PIECE_SIZE];
 type Tag = [u8; 8];
 type Salt = [u8; 8];
 
 const PRIME_SIZE_BYTES: usize = 32;
-const PIECE_SIZE: usize = 4096;
 const ENCODE_ROUNDS: usize = 1;
 const SIGNING_CONTEXT: &[u8] = b"FARMER";
 const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;

--- a/crates/spartan-farmer/src/main.rs
+++ b/crates/spartan-farmer/src/main.rs
@@ -18,6 +18,7 @@
 mod commands;
 mod crypto;
 mod plot;
+mod spartan;
 mod utils;
 
 use async_std::task;
@@ -29,10 +30,12 @@ use std::path::PathBuf;
 use subspace_core_primitives::{Piece, PIECE_SIZE};
 use tokio::runtime::Runtime;
 
-type Tag = [u8; PRIME_SIZE_BYTES];
-type Salt = [u8; PRIME_SIZE_BYTES];
+type Piece = [u8; PIECE_SIZE];
+type Tag = [u8; 8];
+type Salt = [u8; 8];
 
-const PRIME_SIZE_BYTES: usize = 8;
+const PRIME_SIZE_BYTES: usize = 32;
+const PIECE_SIZE: usize = 4096;
 const ENCODE_ROUNDS: usize = 1;
 const SIGNING_CONTEXT: &[u8] = b"FARMER";
 const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -58,34 +58,19 @@ impl Spartan {
         // should consume [u8; 32 * piece_amount] space.
         let piece_amount = pieces.len() / PIECE_SIZE;
         let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * HASH_SIZE);
-        let mut nonce_iter = nonce_array.iter();
         let mut expanded_iv;
-        for _ in 0..piece_amount {
+        for nonce in nonce_array {
             // same encoding_key_hash will be used for each expanded_iv
             expanded_iv = encoding_key_hash;
 
             // select the nonce from nonce_array, xor it with the encoding_key_hash
-            for (i, &byte) in nonce_iter
-                .next()
-                .unwrap()
+            nonce
                 .to_le_bytes()
                 .iter()
                 .rev()
-                .enumerate()
-            {
-                expanded_iv[HASH_SIZE - i - 1] ^= byte;
-            }
-
-            /* can replace the upper for loop
-            nonce_iter
-                .next()
-                .unwrap()
-                .to_le_bytes()
-                .iter()
-                .rev()
-                .enumerate()
-                .map(|(i, &byte)| expanded_iv[32 - i - 1] ^= byte);
-            */
+                .zip(expanded_iv.iter_mut().rev())
+                .for_each(|(nonce_byte, expanded_iv_byte)| *expanded_iv_byte ^= nonce_byte);
+            //*/
             expanded_iv_vector.extend(expanded_iv);
         }
 

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -61,8 +61,8 @@ impl Spartan {
     ) {
         // each expanded_iv will be in format [u8; 32], so `piece_amount` expanded_iv's
         // should consume [u8; 32 * piece_amount] space.
-        let piece_amount = pieces.len() / PIECE_SIZE;
-        let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * HASH_SIZE);
+        let piece_count = pieces.len() / PIECE_SIZE;
+        let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_count * HASH_SIZE);
         let mut expanded_iv;
         for nonce in nonce_array {
             // same encoding_key_hash will be used for each expanded_iv
@@ -80,7 +80,7 @@ impl Spartan {
         }
 
         // If there any leftovers from 1024x pieces, cpu will handle them
-        let cpu_encode_end_index = piece_amount % GPU_PIECE_BLOCK;
+        let cpu_encode_end_index = piece_count % GPU_PIECE_BLOCK;
 
         // CPU encoding:
         for x in 0..cpu_encode_end_index {

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -145,6 +145,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cuda")]
     // CUDA accepts multiples of 1024 pieces, and any remainder piece will be handled on CPU
     // this test aims to process 1024 pieces in GPU, and 2 pieces in CPU, hence 1026 pieces.
     fn test_1026_piece() {

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "cuda")]
+    #[cfg(feature = "test-cuda")]
     // CUDA accepts multiples of 1024 pieces, and any remainder piece will be handled on CPU
     // this test aims to process 1024 pieces in GPU, and 2 pieces in CPU, hence 1026 pieces.
     fn test_1026_piece() {

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -1,29 +1,43 @@
 #![warn(missing_debug_implementations, missing_docs)]
 //! This is an adaptation of [SLOTH](https://eprint.iacr.org/2015/366) (slow-timed hash function) into a time-asymmetric permutation using a standard CBC block cipher. This code is largely based on the C implementation used in [PySloth](https://github.com/randomchain/pysloth/blob/master/sloth.c) which is the same as used in the paper.
 
-use sloth256_189::cpu;
-use sloth256_189::cuda;
+use ::sloth256_189::cpu;
+use ::sloth256_189::cuda;
+
+const PIECE_SIZE: usize = 4096; // length of a single piece
+const HASH_SIZE: usize = 32; // length of public_key_hash
+const GPU_PIECE_BLOCK: usize = 1024; // piece amount should be multiples of 1024 for GPU
 
 /// Spartan struct used to encode and validate
 #[derive(Debug, Clone)]
 pub struct Spartan {
-    genesis_piece: [u8; 4096],
+    genesis_piece: [u8; PIECE_SIZE],
+    cuda_available: bool,
 }
 
 impl Spartan {
     /// New instance with 256-bit prime and 4096-byte genesis piece size
-    pub fn new(genesis_piece: [u8; 4096]) -> Self {
-        Spartan { genesis_piece }
+    pub fn new(genesis_piece: [u8; PIECE_SIZE]) -> Self {
+        let cuda_available = cuda::is_cuda_available();
+        Spartan {
+            genesis_piece,
+            cuda_available,
+        }
     }
 }
 
 impl Spartan {
     /// Create an encoding based on genesis piece using provided encoding key hash, nonce and
     /// desired number of rounds
-    pub fn encode(&self, encoding_key_hash: [u8; 32], nonce: u64, rounds: usize) -> [u8; 4096] {
+    pub fn encode(
+        &self,
+        encoding_key_hash: [u8; HASH_SIZE],
+        nonce: u64,
+        rounds: usize,
+    ) -> [u8; PIECE_SIZE] {
         let mut expanded_iv = encoding_key_hash;
         for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
-            expanded_iv[32 - i - 1] ^= byte;
+            expanded_iv[HASH_SIZE - i - 1] ^= byte;
         }
 
         let mut encoding = self.genesis_piece;
@@ -32,39 +46,59 @@ impl Spartan {
 
         encoding
     }
-
+    /// encodes given batch of pieces using GPU (if available) and CPU
     pub fn batch_encode(
         &self,
-        piece_amount: usize,
         pieces: &mut [u8],
-        encoding_key_hash: [u8; 32],
+        encoding_key_hash: [u8; HASH_SIZE],
         nonce_array: &[u64],
         rounds: usize,
     ) {
         // each expanded_iv will be in format [u8; 32], so `piece_amount` expanded_iv's
         // should consume [u8; 32 * piece_amount] space.
-        let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * 32);
-        for x in 0..piece_amount {
+        let piece_amount = pieces.len() / PIECE_SIZE;
+        let mut expanded_iv_vector: Vec<u8> = Vec::with_capacity(piece_amount * HASH_SIZE);
+        let mut nonce_iter = nonce_array.iter();
+        let mut expanded_iv;
+        for _ in 0..piece_amount {
             // same encoding_key_hash will be used for each expanded_iv
-            let mut expanded_iv = encoding_key_hash.clone();
+            expanded_iv = encoding_key_hash;
 
             // select the nonce from nonce_array, xor it with the encoding_key_hash
-            for (i, &byte) in nonce_array[x].to_le_bytes().iter().rev().enumerate() {
-                expanded_iv[32 - i - 1] ^= byte;
+            for (i, &byte) in nonce_iter
+                .next()
+                .unwrap()
+                .to_le_bytes()
+                .iter()
+                .rev()
+                .enumerate()
+            {
+                expanded_iv[HASH_SIZE - i - 1] ^= byte;
             }
+
+            /* can replace the upper for loop
+            nonce_iter
+                .next()
+                .unwrap()
+                .to_le_bytes()
+                .iter()
+                .rev()
+                .enumerate()
+                .map(|(i, &byte)| expanded_iv[32 - i - 1] ^= byte);
+            */
             expanded_iv_vector.extend(expanded_iv);
         }
 
         // if we have access to CUDA, we will utilize GPU and CPU together
-        if cuda::is_cuda_available() {
-            // GPU can handle multiples of 1024 pieces. If there any leftovers, cpu will handle them
-            let cpu_encode_end_index = piece_amount % 1024;
+        if self.cuda_available {
+            // If there any leftovers from 1024x pieces, cpu will handle them
+            let cpu_encode_end_index = piece_amount % GPU_PIECE_BLOCK;
 
             // CPU encoding:
             for x in 0..cpu_encode_end_index {
                 cpu::encode(
-                    &mut pieces[x * 4096..(x + 1) * 4096],
-                    &expanded_iv_vector[x * 32..(x + 1) * 32],
+                    &mut pieces[x * PIECE_SIZE..(x + 1) * PIECE_SIZE],
+                    &expanded_iv_vector[x * HASH_SIZE..(x + 1) * HASH_SIZE],
                     rounds,
                 )
                 .unwrap();
@@ -72,19 +106,17 @@ impl Spartan {
 
             // GPU encoding:
             cuda::encode(
-                &mut pieces[cpu_encode_end_index * 4096..],
-                &expanded_iv_vector[cpu_encode_end_index * 32..],
+                &mut pieces[cpu_encode_end_index * PIECE_SIZE..],
+                &expanded_iv_vector[cpu_encode_end_index * HASH_SIZE..],
                 rounds,
             )
             .unwrap();
-        }
-        // if there is no CUDA in this device
-        else {
+        } else {
             // do all the pieces in CPU
             for x in 0..piece_amount {
                 cpu::encode(
-                    &mut pieces[x * 4096..(x + 1) * 4096],
-                    &expanded_iv_vector[x * 32..(x + 1) * 32],
+                    &mut pieces[x * PIECE_SIZE..(x + 1) * PIECE_SIZE],
+                    &expanded_iv_vector[x * HASH_SIZE..(x + 1) * HASH_SIZE],
                     rounds,
                 )
                 .unwrap();
@@ -96,13 +128,13 @@ impl Spartan {
     pub fn is_valid(
         &self,
         encoding: &mut [u8],
-        encoding_key_hash: [u8; 32],
+        encoding_key_hash: [u8; HASH_SIZE],
         nonce: u64,
         rounds: usize,
     ) -> bool {
         let mut expanded_iv = encoding_key_hash;
         for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
-            expanded_iv[32 - i - 1] ^= byte;
+            expanded_iv[HASH_SIZE - i - 1] ^= byte;
         }
 
         cpu::decode(encoding, &expanded_iv, rounds).unwrap();
@@ -137,7 +169,7 @@ mod tests {
     #[test]
     fn test_1026_piece() {
         let genesis_piece = random_bytes();
-        let mut piece_array: Vec<u8> = Vec::with_capacity(4096 * 1026);
+        let mut piece_array: Vec<u8> = Vec::with_capacity(PIECE_SIZE * 1026);
         let encoding_key_hash = random_bytes();
         let nonce: u64 = rand::random();
         let nonce_array = vec![nonce; 1026];
@@ -149,7 +181,6 @@ mod tests {
         }
 
         spartan.batch_encode(
-            1026,
             &mut piece_array,
             encoding_key_hash,
             nonce_array.as_slice(),
@@ -158,7 +189,7 @@ mod tests {
 
         for x in 0..1026 {
             assert!(spartan.is_valid(
-                &mut piece_array[x * 4096..(x + 1) * 4096],
+                &mut piece_array[x * PIECE_SIZE..(x + 1) * PIECE_SIZE],
                 encoding_key_hash,
                 nonce_array[x],
                 1

--- a/crates/spartan-farmer/src/spartan.rs
+++ b/crates/spartan-farmer/src/spartan.rs
@@ -1,0 +1,75 @@
+#![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
+//! This is an adaptation of [SLOTH](https://eprint.iacr.org/2015/366) (slow-timed hash function) into a time-asymmetric permutation using a standard CBC block cipher. This code is largely based on the C implementation used in [PySloth](https://github.com/randomchain/pysloth/blob/master/sloth.c) which is the same as used in the paper.
+
+use sloth256_189::cpu;
+
+/// Spartan struct used to encode and validate
+#[derive(Debug, Clone)]
+pub struct Spartan {
+    genesis_piece: [u8; 4096],
+}
+
+impl Spartan {
+    /// New instance with 256-bit prime and 4096-byte genesis piece size
+    pub fn new(genesis_piece: [u8; 4096]) -> Self {
+        Spartan { genesis_piece }
+    }
+}
+
+impl Spartan {
+    /// Create an encoding based on genesis piece using provided encoding key hash, nonce and
+    /// desired number of rounds
+    pub fn encode(&self, encoding_key_hash: [u8; 32], nonce: u64, rounds: usize) -> [u8; 4096] {
+        let mut expanded_iv = encoding_key_hash;
+        for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
+            expanded_iv[32 - i - 1] ^= byte;
+        }
+
+        let mut encoding = self.genesis_piece;
+        cpu::encode(&mut encoding, expanded_iv, rounds).unwrap();
+
+        encoding
+    }
+
+    /// Check if previously created encoding is valid
+    pub fn is_valid(
+        &self,
+        mut encoding: [u8; 4096],
+        encoding_key_hash: [u8; 32],
+        nonce: u64,
+        rounds: usize,
+    ) -> bool {
+        let mut expanded_iv = encoding_key_hash;
+        for (i, &byte) in nonce.to_le_bytes().iter().rev().enumerate() {
+            expanded_iv[32 - i - 1] ^= byte;
+        }
+
+        cpu::decode(&mut encoding, expanded_iv, rounds);
+
+        encoding == self.genesis_piece
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::prelude::*;
+
+    fn random_bytes<const BYTES: usize>() -> [u8; BYTES] {
+        let mut bytes = [0u8; BYTES];
+        rand::thread_rng().fill(&mut bytes[..]);
+        bytes
+    }
+
+    #[test]
+    fn test_random_piece() {
+        let genesis_piece = random_bytes();
+        let encoding_key = random_bytes();
+        let nonce = rand::random();
+
+        let spartan = Spartan::new(genesis_piece);
+        let encoding = spartan.encode(encoding_key, nonce, 1);
+
+        assert!(spartan.is_valid(encoding, encoding_key, nonce, 1));
+    }
+}

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -38,6 +38,6 @@ std = [
     "scale-info/std",
     "serde/std",
     # Can't enable this in platform-specific way, see https://github.com/rust-lang/cargo/issues/1197
-    "sha2/asm",
+    #"sha2/asm",
     "sha2/std",
 ]

--- a/node-template-spartan/README.md
+++ b/node-template-spartan/README.md
@@ -142,8 +142,6 @@ Use `Ctrl+C` to stop the pair, everything will be stopped and cleaned up automat
 First, complete the [basic Rust setup instructions](docs/rust-setup.md).
 
 #### Install Dependencies
-If you have not previously installed the `gmp_mpfr_sys` crate, follow these [instructions](https://docs.rs/gmp-mpfr-sys/1.3.0/gmp_mpfr_sys/index.html#building-on-gnulinux).
-
 On Linux, RocksDB requires Clang
 
 ```bash


### PR DESCRIPTION
sloth256-189 CUDA/CPU sloth encoding library is now can be used in plotting. `Verification` and `farmer` are changed accordingly.
CI job is updated to be able to compile CUDA code, now it passes tests on GitHub Workflow