### PR TITLE
Fix restoring archiver state after restart in case it wasn't interrupted exactly on last archived block boundary

### DIFF
--- a/crates/pallet-spartan/src/lib.rs
+++ b/crates/pallet-spartan/src/lib.rs
@@ -928,7 +928,6 @@ where
     }
 }
 
-// TODO: Tests for root block
 /// Methods for the `ValidateUnsigned` implementation:
 /// It restricts calls to `store_root_block` to local calls (i.e. extrinsics generated on this
 /// node) or that already in a block. This guarantees that only block authors can include root

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -597,6 +597,15 @@ impl BlockArchiver {
         Ok(archiver)
     }
 
+    /// Get last archived block if there was any
+    pub fn last_archived_block_number(&self) -> Option<u32> {
+        if self.last_archived_block != INITIAL_LAST_ARCHIVED_BLOCK {
+            Some(self.last_archived_block.number)
+        } else {
+            None
+        }
+    }
+
     /// Adds new block to internal buffer, potentially producing pieces and root block headers
     pub fn add_block<B: Encode>(&mut self, block: &B) -> Vec<ArchivedSegment> {
         // Append new block to the buffer


### PR DESCRIPTION
Found this bug when analyzing code in my head