### PR TITLE
Subspace upgrade (step 9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,59 @@ members = [
     "substrate/*",
 ]
 
+# The list of dependencies below (which can be both direct and indirect dependencies) are crates
+# that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of
+# their debug info might be missing) or to require to be frequently recompiled. We compile these
+# dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more usable.
+# The majority of these crates are cryptographic libraries.
+#
+# This list is ordered alphabetically.
+[profile.dev.package]
+blake2 = { opt-level = 3 }
+blake2-rfc = { opt-level = 3 }
+blake2b_simd = { opt-level = 3 }
+chacha20poly1305 = { opt-level = 3 }
+cranelift-codegen = { opt-level = 3 }
+cranelift-wasm = { opt-level = 3 }
+crc32fast = { opt-level = 3 }
+crossbeam-deque = { opt-level = 3 }
+crypto-mac = { opt-level = 3 }
+curve25519-dalek = { opt-level = 3 }
+ed25519-dalek = { opt-level = 3 }
+flate2 = { opt-level = 3 }
+futures-channel = { opt-level = 3 }
+hashbrown = { opt-level = 3 }
+hash-db = { opt-level = 3 }
+hmac = { opt-level = 3 }
+httparse = { opt-level = 3 }
+integer-sqrt = { opt-level = 3 }
+keccak = { opt-level = 3 }
+libm = { opt-level = 3 }
+librocksdb-sys = { opt-level = 3 }
+libsecp256k1 = { opt-level = 3 }
+libz-sys = { opt-level = 3 }
+mio = { opt-level = 3 }
+nalgebra = { opt-level = 3 }
+num-bigint = { opt-level = 3 }
+parking_lot = { opt-level = 3 }
+parking_lot_core = { opt-level = 3 }
+percent-encoding = { opt-level = 3 }
+primitive-types = { opt-level = 3 }
+reed-solomon-erasure = { opt-level = 3 }
+ring = { opt-level = 3 }
+rustls = { opt-level = 3 }
+sha2 = { opt-level = 3 }
+sha3 = { opt-level = 3 }
+sloth256-189 = { opt-level = 3 }
+smallvec = { opt-level = 3 }
+snow = { opt-level = 3 }
+twox-hash = { opt-level = 3 }
+uint = { opt-level = 3 }
+wasmi = { opt-level = 3 }
+x25519-dalek = { opt-level = 3 }
+yamux = { opt-level = 3 }
+zeroize = { opt-level = 3 }
+
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"

--- a/crates/pallet-spartan/src/lib.rs
+++ b/crates/pallet-spartan/src/lib.rs
@@ -178,6 +178,40 @@ pub mod pallet {
         #[pallet::constant]
         type ExpectedBlockTime: Get<Self::Moment>;
 
+        /// Depth `K` after which a block enters the recorded history (a global constant, as opposed
+        /// to the client-dependent transaction confirmation depth `k`).
+        #[pallet::constant]
+        type ConfirmationDepthK: Get<u32>;
+
+        /// The size of data in one piece (in bytes).
+        #[pallet::constant]
+        type RecordSize: Get<u32>;
+
+        // TODO: This will probably become configurable later
+        /// Recorded history is encoded and plotted in segments of this size (in bytes).
+        #[pallet::constant]
+        type RecordedHistorySegmentSize: Get<u32>;
+
+        // TODO: This is not the only way to bootstrap the network, we might want to use multiple
+        //  objects from file system instead (like Bitcoin history)
+        /// This constant defines the size (in bytes) of one pre-genesis object.
+        ///
+        /// Pre-genesis objects are needed to solve chicken-and-egg problem where in order to
+        /// produce a solution (and farm a block) a plot is needed, but plot is supposed to contain
+        /// some archived blocks. Pre-genesis history allows network bootstrapping.
+        #[pallet::constant]
+        type PreGenesisObjectSize: Get<u32>;
+
+        /// This constant defines the number of a pre-genesis objects that will bootstrap the
+        /// history.
+        #[pallet::constant]
+        type PreGenesisObjectCount: Get<u32>;
+
+        /// This constant defines the seed used for deriving pre-genesis objects that will bootstrap
+        /// the history.
+        #[pallet::constant]
+        type PreGenesisObjectSeed: Get<&'static [u8]>;
+
         /// Spartan requires some logic to be triggered on every block to query for whether an epoch
         /// has ended and to perform the transition to the next epoch.
         ///

--- a/crates/pallet-spartan/src/mock.rs
+++ b/crates/pallet-spartan/src/mock.rs
@@ -146,6 +146,12 @@ parameter_types! {
     pub const InitialSolutionRange: u64 = INITIAL_SOLUTION_RANGE;
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ExpectedBlockTime: u64 = 1;
+    pub const ConfirmationDepthK: u32 = 10;
+    pub const RecordSize: u32 = 3840;
+    pub const RecordedHistorySegmentSize: u32 = 3840 * 256 / 2;
+    pub const PreGenesisObjectSize: u32 = 3840 * 256 / 2;
+    pub const PreGenesisObjectCount: u32 = 5;
+    pub const PreGenesisObjectSeed: &'static [u8] = b"subspace";
     pub const ReportLongevity: u64 = 34;
 }
 
@@ -157,6 +163,12 @@ impl Config for Test {
     type InitialSolutionRange = InitialSolutionRange;
     type SlotProbability = SlotProbability;
     type ExpectedBlockTime = ExpectedBlockTime;
+    type ConfirmationDepthK = ConfirmationDepthK;
+    type RecordSize = RecordSize;
+    type RecordedHistorySegmentSize = RecordedHistorySegmentSize;
+    type PreGenesisObjectSize = PreGenesisObjectSize;
+    type PreGenesisObjectCount = PreGenesisObjectCount;
+    type PreGenesisObjectSeed = PreGenesisObjectSeed;
     type EpochChangeTrigger = NormalEpochChange;
     type EraChangeTrigger = NormalEraChange;
     type EonChangeTrigger = NormalEonChange;

--- a/crates/sp-consensus-poc/src/lib.rs
+++ b/crates/sp-consensus-poc/src/lib.rs
@@ -248,6 +248,27 @@ pub struct Epoch {
 sp_api::decl_runtime_apis! {
     /// API necessary for block authorship with PoC.
     pub trait PoCApi {
+        /// Depth `K` after which a block enters the recorded history (a global constant, as opposed
+        /// to the client-dependent transaction confirmation depth `k`).
+        fn confirmation_depth_k() -> u32;
+
+        /// The size of data in one piece (in bytes).
+        fn record_size() -> u32;
+
+        /// Recorded history is encoded and plotted in segments of this size (in bytes).
+        fn recorded_history_segment_size() -> u32;
+
+        /// This constant defines the size (in bytes) of one pre-genesis object.
+        fn pre_genesis_object_size() -> u32;
+
+        /// This constant defines the number of a pre-genesis objects that will bootstrap the
+        /// history.
+        fn pre_genesis_object_count() -> u32;
+
+        /// This constant defines the seed used for deriving pre-genesis objects that will bootstrap
+        /// the history.
+        fn pre_genesis_object_seed() -> Vec<u8>;
+
         /// Return the genesis configuration for PoC. The configuration is only read on genesis.
         fn configuration() -> PoCGenesisConfiguration;
 

--- a/crates/subspace-archiving/src/pre_genesis_data.rs
+++ b/crates/subspace-archiving/src/pre_genesis_data.rs
@@ -1,10 +1,21 @@
-use subspace_core_primitives::{crypto, SHA256_HASH_SIZE};
+use core::convert::TryInto;
+use sha2::{Digest, Sha256};
+use subspace_core_primitives::{crypto, Sha256Hash, SHA256_HASH_SIZE};
 
-/// Derives a single object blob of a given size from given seed, which is intended to be used as
-/// pre-genesis blockchain seed data
-pub fn from_seed(seed: &[u8], size: usize) -> Vec<u8> {
+/// Derives a single object blob of a given size from given seed and index, which is intended to be
+/// used as pre-genesis object (blockchain seed data)
+pub fn from_seed<S: AsRef<[u8]>>(seed: S, index: u32, size: u32) -> Vec<u8> {
+    let size = size as usize;
     let mut object = Vec::with_capacity(size);
-    let mut acc = crypto::sha256_hash(seed);
+    let mut acc: Sha256Hash = {
+        let mut hasher = Sha256::new();
+        hasher.update(seed.as_ref());
+        hasher.update(index.to_le_bytes().as_ref());
+
+        hasher.finalize()[..]
+            .try_into()
+            .expect("Sha256 output is always 32 bytes; qed")
+    };
     for _ in 0..size / SHA256_HASH_SIZE {
         object.extend_from_slice(&acc);
         acc = crypto::sha256_hash(&acc);

--- a/crates/subspace-archiving/tests/integration/pre_genesis_data.rs
+++ b/crates/subspace-archiving/tests/integration/pre_genesis_data.rs
@@ -4,19 +4,19 @@ use subspace_archiving::pre_genesis_data;
 fn pre_genesis_data() {
     {
         // Below 1 Sha256 block
-        let object = pre_genesis_data::from_seed(b"subspace", 10);
+        let object = pre_genesis_data::from_seed(b"subspace", 0, 10);
         assert_eq!(object.len(), 10);
         assert!(object.iter().find(|byte| **byte != 0).is_some());
     }
     {
         // Exactly 1 Sha256 block
-        let object = pre_genesis_data::from_seed(b"subspace", 32);
+        let object = pre_genesis_data::from_seed(b"subspace", 0, 32);
         assert_eq!(object.len(), 32);
         assert!(object.iter().find(|byte| **byte != 0).is_some());
     }
     {
         // Over 1 Sha256 block
-        let object = pre_genesis_data::from_seed(b"subspace", 40);
+        let object = pre_genesis_data::from_seed(b"subspace", 0, 40);
         assert_eq!(object.len(), 40);
         assert!(object.iter().find(|byte| **byte != 0).is_some());
     }

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -20,9 +20,9 @@ use core::convert::TryInto;
 use sha2::{Digest, Sha256};
 
 /// Simple Sha2-256 hashing.
-pub fn sha256_hash(data: &[u8]) -> Sha256Hash {
+pub fn sha256_hash<D: AsRef<[u8]>>(data: D) -> Sha256Hash {
     let mut hasher = Sha256::new();
-    hasher.update(data);
+    hasher.update(data.as_ref());
     hasher.finalize()[..]
         .try_into()
         .expect("Sha256 output is always 32 bytes; qed")

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -594,6 +594,12 @@ parameter_types! {
 	pub const EonDuration: u64 = 11;
 	pub const InitialSolutionRange: u64 = u64::MAX;
 	pub const SlotProbability: (u64, u64) = (3, 10);
+	pub const ConfirmationDepthK: u32 = 10;
+	pub const RecordSize: u32 = 3840;
+	pub const RecordedHistorySegmentSize: u32 = 3840 * 256 / 2;
+	pub const PreGenesisObjectSize: u32 = 3840 * 256 / 2;
+	pub const PreGenesisObjectCount: u32 = 5;
+	pub const PreGenesisObjectSeed: &'static [u8] = b"subspace";
 }
 
 impl pallet_spartan::Config for Runtime {
@@ -604,6 +610,12 @@ impl pallet_spartan::Config for Runtime {
 	type InitialSolutionRange = InitialSolutionRange;
 	type SlotProbability = SlotProbability;
 	type ExpectedBlockTime = ExpectedBlockTime;
+	type ConfirmationDepthK = ConfirmationDepthK;
+	type RecordSize = RecordSize;
+	type RecordedHistorySegmentSize = RecordedHistorySegmentSize;
+	type PreGenesisObjectSize = PreGenesisObjectSize;
+	type PreGenesisObjectCount = PreGenesisObjectCount;
+	type PreGenesisObjectSeed = PreGenesisObjectSeed;
 	type EpochChangeTrigger = pallet_spartan::NormalEpochChange;
 	type EraChangeTrigger = pallet_spartan::NormalEraChange;
 	type EonChangeTrigger = pallet_spartan::NormalEonChange;
@@ -866,6 +878,30 @@ cfg_if! {
 			}
 
 			impl sp_consensus_poc::PoCApi<Block> for Runtime {
+				fn confirmation_depth_k() -> u32 {
+					ConfirmationDepthK::get()
+				}
+
+				fn record_size() -> u32 {
+					RecordSize::get()
+				}
+
+				fn recorded_history_segment_size() -> u32 {
+					RecordedHistorySegmentSize::get()
+				}
+
+				fn pre_genesis_object_size() -> u32 {
+					PreGenesisObjectSize::get()
+				}
+
+				fn pre_genesis_object_count() -> u32 {
+					PreGenesisObjectCount::get()
+				}
+
+				fn pre_genesis_object_seed() -> Vec<u8> {
+					Vec::from(PreGenesisObjectSeed::get())
+				}
+
 				fn configuration() -> sp_consensus_poc::PoCGenesisConfiguration {
 					sp_consensus_poc::PoCGenesisConfiguration {
 						slot_duration: 1000,
@@ -1174,6 +1210,30 @@ cfg_if! {
 			}
 
 			impl sp_consensus_poc::PoCApi<Block> for Runtime {
+				fn confirmation_depth_k() -> u32 {
+					ConfirmationDepthK::get()
+				}
+
+				fn record_size() -> u32 {
+					RecordSize::get()
+				}
+
+				fn recorded_history_segment_size() -> u32 {
+					RecordedHistorySegmentSize::get()
+				}
+
+				fn pre_genesis_object_size() -> u32 {
+					PreGenesisObjectSize::get()
+				}
+
+				fn pre_genesis_object_count() -> u32 {
+					PreGenesisObjectCount::get()
+				}
+
+				fn pre_genesis_object_seed() -> Vec<u8> {
+					Vec::from(PreGenesisObjectSeed::get())
+				}
+
 				fn configuration() -> sp_consensus_poc::PoCGenesisConfiguration {
 					sp_consensus_poc::PoCGenesisConfiguration {
 						slot_duration: 1000,


### PR DESCRIPTION
This is a simple PR: it moves some of the constants to runtime constants such that farmer and others will be able to query them later, it also enables optimizations for a bunch of crates similarly to upstream Substrate to improve development experience.