### PR TITLE
Cross platform fixes

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -44,11 +44,16 @@ jobs:
           args: --all -- --check
 
   cargo-clippy:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
+        os:
+          - ubuntu-20.04
+          - macos-11
+          - windows-2019
         rust:
           - nightly-2021-09-15
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -62,14 +67,17 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: CUDA toolchain
-        run: sudo apt-get install --no-install-recommends -y nvidia-cuda-toolkit
+      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
+      - name: Remove msys64
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
+        if: runner.os == 'Windows'
 
-      # CUDA toolchain above doesn't like GCC newer than 8
-      - name: Select GCC 8
-        run: |
-          echo "CC=gcc-8" >> $GITHUB_ENV
-          echo "CXX=g++-8" >> $GITHUB_ENV
+      - name: CUDA toolchain
+        uses: Jimver/cuda-toolkit@v0.2.4
+        id: cuda-toolkit
+        with:
+          cuda: '11.2.2'
+        if: runner.os != 'macOS'
 
       - name: Configure cache
         uses: actions/cache@v2
@@ -77,22 +85,35 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ matrix.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.os }}-cargo-
 
-      - name: cargo clippy
+      - name: cargo clippy (Linux or Windows with CUDA)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features=spartan-farmer/cuda -- -D warnings
+        if: runner.os != 'macOS'
+
+      - name: cargo clippy (macOS)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
+        if: runner.os == 'macOS'
 
   cargo-test:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
+        os:
+          - ubuntu-20.04
+          - macos-11
+          - windows-2019
         rust:
           - nightly-2021-09-15
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -106,14 +127,17 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: CUDA toolchain
-        run: sudo apt-get install --no-install-recommends -y nvidia-cuda-toolkit
+      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
+      - name: Remove msys64
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
+        if: runner.os == 'Windows'
 
-      # CUDA toolchain above doesn't like GCC newer than 8
-      - name: Select GCC 8
-        run: |
-          echo "CC=gcc-8" >> $GITHUB_ENV
-          echo "CXX=g++-8" >> $GITHUB_ENV
+      - name: CUDA toolchain
+        uses: Jimver/cuda-toolkit@v0.2.4
+        id: cuda-toolkit
+        with:
+          cuda: '11.2.2'
+        if: runner.os != 'macOS'
 
       - name: Configure cache
         uses: actions/cache@v2
@@ -121,11 +145,19 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ matrix.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.os }}-cargo-
 
-      - name: cargo test
+      - name: cargo test (Linux or Windows with CUDA)
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --features=spartan-farmer/cuda
+        if: runner.os != 'macOS'
+
+      - name: cargo test (macOS)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        if: runner.os == 'macOS'

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -67,7 +67,7 @@ features = ["macros"]
 version = "1.11.0"
 
 [features]
-default = ["cuda"]
+default = []
 # Compile with CUDA support and use it if compatible GPU is available
 cuda = [
     "subspace-codec/cuda",

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -22,11 +22,24 @@ default-features = false
 features = ["derive"]
 version = "2.3.0"
 
-[dependencies.reed-solomon-erasure]
+# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
+[target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.dependencies.reed-solomon-erasure]
 features = ["simd-accel"]
 version = "4.0.2"
 
-[dependencies.sha2]
+# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
+# See https://github.com/darrenldl/reed-solomon-erasure/issues/86 for why `simd-accel` is disabled
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies.reed-solomon-erasure]
+version = "4.0.2"
+
+# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
+[target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
+features = ["asm"]
+version = "0.9.8"
+
+# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
+# `asm` feature is not supported on Windows except with GNU toolchain
+[target.'cfg(not(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu"))))'.dependencies.sha2]
 default-features = false
 version = "0.9.8"
 
@@ -44,8 +57,6 @@ version = "0.8.4"
 default = ["std"]
 std = [
     "parity-scale-codec/std",
-    # Can't enable this in platform-specific way, see https://github.com/rust-lang/cargo/issues/1197
-    "sha2/asm",
     "sha2/std",
     "subspace-core-primitives/std",
 ]

--- a/crates/subspace-codec/src/lib.rs
+++ b/crates/subspace-codec/src/lib.rs
@@ -81,6 +81,12 @@ impl Spartan {
         encoding
     }
 
+    // TODO: Remove when CUDA support is properly integrated
+    #[cfg(not(feature = "cuda"))]
+    #[doc(hidden)]
+    /// Encode given batch of pieces using GPU, and CPU for the leftovers
+    pub fn cuda_batch_encode(&self, _pieces: &mut [u8], _nonce_array: &[u64]) {}
+
     // TODO: Refactor from being CUDA-specific to be batch-oriented
     /// Encode given batch of pieces using GPU, and CPU for the leftovers
     #[cfg(feature = "cuda")]

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -27,7 +27,14 @@ default-features = false
 features = ["derive"]
 version = "1.0.130"
 
-[dependencies.sha2]
+# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
+[target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
+features = ["asm"]
+version = "0.9.8"
+
+# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
+# `asm` feature is not supported on Windows except with GNU toolchain
+[target.'cfg(not(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu"))))'.dependencies.sha2]
 default-features = false
 version = "0.9.8"
 
@@ -37,7 +44,5 @@ std = [
     "parity-scale-codec/std",
     "scale-info/std",
     "serde/std",
-    # Can't enable this in platform-specific way, see https://github.com/rust-lang/cargo/issues/1197
-    #"sha2/asm",
     "sha2/std",
 ]


### PR DESCRIPTION
Fixes compilation on Windows MSVC target, supposedly fixes M1 compilation as well, all while preserving optimizations where they are supported.

Also CUDA support is disabled in farmer by default and actually compiles when disabled (can still be enabled with a feature flag and is tested in CI).

And last, but not least, this adds CI for Windows (with CUDA) and macOS (without CUDA) targets, so we don't regress there.