### PR TITLE
plot-tag folder is created by plotter

### DIFF
--- a/crates/spartan-farmer/src/commands/plot.rs
+++ b/crates/spartan-farmer/src/commands/plot.rs
@@ -29,6 +29,11 @@ pub(crate) async fn plot(
         keypair
     };
 
+    let plot_tags = path.join("plot-tags");
+    if !plot_tags.exists() {
+        fs::create_dir(plot_tags)?;
+    }
+
     let plot = Plot::open_or_create(&path.into()).await?;
     let spartan = Spartan::new(keypair.public.as_ref());
 


### PR DESCRIPTION
This is a very small fix.

Here is how to reproduce the run-time error:
1. plot
2. don't run farmer
3. erase-plot
4. error occurred on trying to delete a non-existing folder

This is happening, because, `plot-tags` folder is not created by the plotter. Instead, this folder is created when farmer is run.

This fix creates the `plot-tags` empty folder in the plotter. So in the above scenario, no errors are generated.

*Things to consider*:
1. to my testing, creating this empty directory beforehand has no harm.
2. when `erase-plot` is called a second time in a succession, there will still be an error (now, this error will be caused by all 3 files to be deleted). However, `erase-plot` button can be disabled in the GUI application after the first time, so it cannot be clicked in a row. It can be re-enabled after the `plot` command.