### PR TITLE
Reduce unwraps in spartan-farmer CLI

### DIFF
--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -35,7 +35,7 @@ subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-codec = { version = "0.1.0", path = "../subspace-codec" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 thiserror = "1.0.24"
-tokio = "1.11.0"
+tokio = { version = "1.11.0", features = ["rt", "macros"] }
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -35,7 +35,7 @@ subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-codec = { version = "0.1.0", path = "../subspace-codec" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 thiserror = "1.0.24"
-tokio = { version = "1.11.0", features = ["rt", "macros"] }
+tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to
@@ -49,7 +49,6 @@ version = "0.17.0"
 async-std = { version = "1.9.0", features = ["attributes"] }
 rand = "0.8.4"
 tempfile = "3.2.0"
-tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []

--- a/crates/spartan-farmer/src/main.rs
+++ b/crates/spartan-farmer/src/main.rs
@@ -70,38 +70,30 @@ fn try_remove<P: AsRef<Path>>(
     Ok(())
 }
 
-impl Command {
-    async fn run(self) -> Result<()> {
-        match self {
-            Self::ErasePlot { custom_path } => {
-                let path = utils::get_path(custom_path);
-                info!("Erasing the plot");
-                try_remove(path.join("plot.bin"), fs::remove_file)?;
-                info!("Erasing plot metadata");
-                try_remove(path.join("plot-metadata"), fs::remove_dir_all)?;
-                info!("Erasing plot commitments");
-                try_remove(path.join("commitments"), fs::remove_dir_all)?;
-                info!("Erasing identity");
-                try_remove(path.join("identity.bin"), fs::remove_file)?;
-                info!("Done");
-            }
-            Self::Farm {
-                custom_path,
-                ws_server,
-            } => {
-                let path = utils::get_path(custom_path);
-                commands::farm(path, &ws_server).await?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init_from_env(Env::new().default_filter_or("info"));
     let command: Command = Command::parse();
-    command.run().await?;
+    match command {
+        Command::ErasePlot { custom_path } => {
+            let path = utils::get_path(custom_path);
+            info!("Erasing the plot");
+            try_remove(path.join("plot.bin"), fs::remove_file)?;
+            info!("Erasing plot metadata");
+            try_remove(path.join("plot-metadata"), fs::remove_dir_all)?;
+            info!("Erasing plot commitments");
+            try_remove(path.join("commitments"), fs::remove_dir_all)?;
+            info!("Erasing identity");
+            try_remove(path.join("identity.bin"), fs::remove_file)?;
+            info!("Done");
+        }
+        Command::Farm {
+            custom_path,
+            ws_server,
+        } => {
+            let path = utils::get_path(custom_path);
+            commands::farm(path, &ws_server).await?;
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
This PR is mostly about refactoring the farmer `Command` with some
unwraps fixed. This is the first step of ultimately eliminating the
unwrap or replacing them with `expect()`, I'll try sending some small PRs
when reading the code.