### PR TITLE
Object mappings updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,6 +4062,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "subspace-core-primitives",
 ]
 
 [[package]]

--- a/crates/pallet-feeds/Cargo.toml
+++ b/crates/pallet-feeds/Cargo.toml
@@ -20,6 +20,7 @@ log = { version = "0.4.14", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
+subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [dev-dependencies]
 serde = "1.0.127"
@@ -36,5 +37,6 @@ std = [
   "scale-info/std",
   "sp-core/std",
   "sp-std/std",
+  "subspace-core-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -19,7 +19,6 @@
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_debug_implementations)]
 
-use codec::{Compact, CompactLen};
 use core::mem;
 pub use pallet::*;
 use sp_std::vec::Vec;
@@ -147,23 +146,17 @@ mod pallet {
 pub struct CallObjectLocation {
     /// Offset
     pub offset: usize,
-    /// Size
-    pub size: usize,
 }
 
 impl<T: Config> Call<T> {
     /// Extract object location if an extrinsic corresponds to `put` call
     pub fn extract_object_location(&self) -> Option<CallObjectLocation> {
         match self {
-            Self::put { data, .. } => {
-                // FeedId is the first field in the extrinsic followed by compact length prefix of
-                // the actual data and data itself.
-                // `+1` corresponds to `Call::put {}` enum variant encoding.
+            Self::put { .. } => {
+                // `FeedId` is the first field in the extrinsic. `1+` corresponds to `Call::put {}`
+                // enum variant encoding.
                 Some(CallObjectLocation {
-                    offset: mem::size_of::<FeedId>()
-                        + Compact::compact_len(&(data.len() as u32))
-                        + 1,
-                    size: data.len(),
+                    offset: 1 + mem::size_of::<FeedId>(),
                 })
             }
             _ => None,

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -22,6 +22,7 @@
 use core::mem;
 pub use pallet::*;
 use sp_std::vec::Vec;
+use subspace_core_primitives::{crypto, Sha256Hash};
 
 #[frame_support::pallet]
 mod pallet {
@@ -144,6 +145,8 @@ mod pallet {
 /// Mapping to the object offset and size within an extrinsic
 #[derive(Debug)]
 pub struct CallObjectLocation {
+    /// Object hash
+    pub hash: Sha256Hash,
     /// Offset
     pub offset: usize,
 }
@@ -152,10 +155,11 @@ impl<T: Config> Call<T> {
     /// Extract object location if an extrinsic corresponds to `put` call
     pub fn extract_object_location(&self) -> Option<CallObjectLocation> {
         match self {
-            Self::put { .. } => {
+            Self::put { data, .. } => {
                 // `FeedId` is the first field in the extrinsic. `1+` corresponds to `Call::put {}`
                 // enum variant encoding.
                 Some(CallObjectLocation {
+                    hash: crypto::sha256_hash(data),
                     offset: 1 + mem::size_of::<FeedId>(),
                 })
             }

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -575,7 +575,10 @@ impl<State: private::ArchiverState> Archiver<State> {
 
                             corrected_object_mapping[offset_in_segment / self.record_size]
                                 .objects
-                                .push(PieceObject::V0 { offset })
+                                .push(PieceObject::V0 {
+                                    hash: block_object.hash(),
+                                    offset,
+                                })
                         }
                     }
                     SegmentItem::RootBlock(_) => {

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -569,17 +569,13 @@ impl<State: private::ArchiverState> Archiver<State> {
                                 + block_object.offset() as usize
                                 + 1
                                 + Compact::compact_len(&(bytes.len() as u32));
-                            let BlockObject::V0 { size, .. } = block_object;
                             let offset = (offset_in_segment % self.record_size).try_into().expect(
                                 "Offset within piece should always fit in 16-bit integer; qed",
                             );
 
                             corrected_object_mapping[offset_in_segment / self.record_size]
                                 .objects
-                                .push(PieceObject::V0 {
-                                    offset,
-                                    size: *size,
-                                })
+                                .push(PieceObject::V0 { offset })
                         }
                     }
                     SegmentItem::RootBlock(_) => {

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -58,9 +58,11 @@ fn archiver() {
         let object_mapping = BlockObjectMapping {
             objects: vec![
                 BlockObject::V0 {
+                    hash: Sha256Hash::default(),
                     offset: size_to_u24(0),
                 },
                 BlockObject::V0 {
+                    hash: Sha256Hash::default(),
                     offset: size_to_u24(7000),
                 },
             ],
@@ -90,12 +92,15 @@ fn archiver() {
         let object_mapping = BlockObjectMapping {
             objects: vec![
                 BlockObject::V0 {
+                    hash: Sha256Hash::default(),
                     offset: size_to_u24(100),
                 },
                 BlockObject::V0 {
+                    hash: Sha256Hash::default(),
                     offset: size_to_u24(1000),
                 },
                 BlockObject::V0 {
+                    hash: Sha256Hash::default(),
                     offset: size_to_u24(10000),
                 },
             ],

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -51,8 +51,6 @@ pub enum BlockObject {
     V0 {
         /// 24-bit little-endian offset of the object
         offset: [u8; 3],
-        /// 24-bit little-endian size of the object
-        size: [u8; 3],
     },
 }
 
@@ -63,13 +61,6 @@ impl BlockObject {
             BlockObject::V0 { offset, .. } => {
                 u32::from_le_bytes([offset[0], offset[1], offset[2], 0])
             }
-        }
-    }
-
-    /// Offset of the object (limited to 24-bit size internally)
-    pub fn size(&self) -> u32 {
-        match self {
-            BlockObject::V0 { size, .. } => u32::from_le_bytes([size[0], size[1], size[2], 0]),
         }
     }
 }
@@ -118,8 +109,6 @@ pub enum PieceObject {
     V0 {
         /// Offset of the object
         offset: u16,
-        /// 24-bit little-endian size of the object
-        size: [u8; 3],
     },
 }
 
@@ -128,13 +117,6 @@ impl PieceObject {
     pub fn offset(&self) -> u16 {
         match self {
             PieceObject::V0 { offset, .. } => *offset,
-        }
-    }
-
-    /// Offset of the object (limited to 24-bit size internally)
-    pub fn size(&self) -> u32 {
-        match self {
-            PieceObject::V0 { size, .. } => u32::from_le_bytes([size[0], size[1], size[2], 0]),
         }
     }
 }
@@ -185,8 +167,6 @@ pub enum GlobalObject {
         piece_index: u64,
         /// Offset of the object
         offset: u16,
-        /// 24-bit little-endian size of the object
-        size: [u8; 3],
     },
 }
 
@@ -202,13 +182,6 @@ impl GlobalObject {
     pub fn offset(&self) -> u16 {
         match self {
             GlobalObject::V0 { offset, .. } => *offset,
-        }
-    }
-
-    /// Offset of the object (limited to 24-bit size internally)
-    pub fn size(&self) -> u32 {
-        match self {
-            GlobalObject::V0 { size, .. } => u32::from_le_bytes([size[0], size[1], size[2], 0]),
         }
     }
 }

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -22,6 +22,7 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+use crate::Sha256Hash;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
@@ -49,12 +50,21 @@ pub enum BlockObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
     V0 {
+        /// Object hash
+        hash: Sha256Hash,
         /// 24-bit little-endian offset of the object
         offset: [u8; 3],
     },
 }
 
 impl BlockObject {
+    /// Object hash
+    pub fn hash(&self) -> Sha256Hash {
+        match self {
+            BlockObject::V0 { hash, .. } => *hash,
+        }
+    }
+
     /// Offset of the object (limited to 24-bit size internally)
     pub fn offset(&self) -> u32 {
         match self {
@@ -107,12 +117,21 @@ pub enum PieceObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
     V0 {
+        /// Object hash
+        hash: Sha256Hash,
         /// Offset of the object
         offset: u16,
     },
 }
 
 impl PieceObject {
+    /// Object hash
+    pub fn hash(&self) -> Sha256Hash {
+        match self {
+            PieceObject::V0 { hash, .. } => *hash,
+        }
+    }
+
     /// Offset of the object
     pub fn offset(&self) -> u16 {
         match self {

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -10,7 +10,6 @@ use jsonrpsee::types::v2::params::JsonRpcParams;
 use jsonrpsee::types::Subscription;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use log::{debug, error, info, trace};
-use parity_scale_codec::{Compact, Decode};
 use schnorrkel::context::SigningContext;
 use schnorrkel::{Keypair, PublicKey};
 use serde::{Deserialize, Serialize};
@@ -24,7 +23,7 @@ use subspace_archiving::pre_genesis_data;
 use subspace_core_primitives::objects::{
     BlockObjectMapping, GlobalObject, PieceObject, PieceObjectMapping,
 };
-use subspace_core_primitives::{crypto, Piece, Sha256Hash};
+use subspace_core_primitives::{crypto, Sha256Hash};
 use subspace_solving::{SubspaceCodec, SOLUTION_SIGNING_CONTEXT};
 
 type SlotNumber = u64;
@@ -264,11 +263,8 @@ async fn background_plotting(
                         } = archived_segment;
                         let piece_index_offset = merkle_num_leaves * root_block.segment_index();
 
-                        let object_mapping = create_global_object_mapping(
-                            piece_index_offset,
-                            &pieces,
-                            object_mapping,
-                        );
+                        let object_mapping =
+                            create_global_object_mapping(piece_index_offset, object_mapping);
 
                         // TODO: Batch encoding
                         for (position, piece) in pieces.iter_mut().enumerate() {
@@ -386,11 +382,8 @@ async fn background_plotting(
                         } = archived_segment;
                         let piece_index_offset = merkle_num_leaves * root_block.segment_index();
 
-                        let object_mapping = create_global_object_mapping(
-                            piece_index_offset,
-                            &pieces,
-                            object_mapping,
-                        );
+                        let object_mapping =
+                            create_global_object_mapping(piece_index_offset, object_mapping);
 
                         // TODO: Batch encoding
                         for (position, piece) in pieces.iter_mut().enumerate() {
@@ -477,31 +470,22 @@ async fn background_plotting(
 
 fn create_global_object_mapping(
     piece_index_offset: u64,
-    pieces: &[Piece],
     object_mapping: Vec<PieceObjectMapping>,
 ) -> Vec<(Sha256Hash, GlobalObject)> {
-    pieces
+    object_mapping
         .iter()
         .enumerate()
-        .zip(object_mapping.iter())
-        .flat_map(move |((position, piece), object_mapping)| {
-            object_mapping
-                .objects
-                .iter()
-                .filter_map(move |piece_object| {
-                    let PieceObject::V0 { offset } = piece_object;
-                    let Compact(size) =
-                        Compact::<u64>::decode(&mut &piece[*offset as usize..]).ok()?;
-                    Some((
-                        crypto::sha256_hash(
-                            &piece[piece_object.offset() as usize..][..size as usize],
-                        ),
-                        GlobalObject::V0 {
-                            piece_index: piece_index_offset + position as u64,
-                            offset: *offset,
-                        },
-                    ))
-                })
+        .flat_map(move |(position, object_mapping)| {
+            object_mapping.objects.iter().map(move |piece_object| {
+                let PieceObject::V0 { hash, offset } = piece_object;
+                (
+                    *hash,
+                    GlobalObject::V0 {
+                        piece_index: piece_index_offset + position as u64,
+                        offset: *offset,
+                    },
+                )
+            })
         })
         .collect()
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -442,6 +442,7 @@ fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
 
                 // Block is known to never exceed 16MiB, hence 24-bit addressing
                 block_object_mapping.objects.push(BlockObject::V0 {
+                    hash: call_object_location.hash,
                     offset: [offset[0], offset[1], offset[2]],
                 });
             }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -439,12 +439,10 @@ fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
         if let Call::Feeds(call) = &extrinsic.function {
             if let Some(call_object_location) = call.extract_object_location() {
                 let offset = (base_extrinsic_offset + call_object_location.offset).to_le_bytes();
-                let size = call_object_location.size.to_le_bytes();
 
                 // Block is known to never exceed 16MiB, hence 24-bit addressing
                 block_object_mapping.objects.push(BlockObject::V0 {
                     offset: [offset[0], offset[1], offset[2]],
-                    size: [size[0], size[1], size[2]],
                 });
             }
         }


### PR DESCRIPTION
2 Changes:
* first of all, object mappings no longer include size, it can be read from scale encoding
* hash of the object is carried all the way through, since objects can be scattered between pieces and it will be harder to recover hash later without full object retrieval