### PR TITLE
Specify edition in rustfmt.yml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 ignore = [
     # This is where Substrate sources with custom formatting are, don't touch them
     "/substrate",


### PR DESCRIPTION
This change is to fix the error `[E0670]: async fn is not permitted in the 2015 edition` when using Vim with rust-analyzer.

Ref: https://github.com/rust-analyzer/rust-analyzer/issues/1959