### PR TITLE
Introduce RpcClient for abstracting all rpc related functions

### DIFF
--- a/crates/sc-consensus-subspace/src/verification.rs
+++ b/crates/sc-consensus-subspace/src/verification.rs
@@ -178,12 +178,11 @@ pub(crate) fn verify_solution<B: BlockT + Sized>(
     let subspace_solving = SubspaceCodec::new(&solution.public_key);
 
     let mut piece = solution.encoding.clone();
-    if subspace_solving
+
+    // Ensure piece is decodable.
+    subspace_solving
         .decode(solution.piece_index, &mut piece)
-        .is_err()
-    {
-        return Err(Error::InvalidEncoding(slot));
-    }
+        .map_err(|_| Error::InvalidEncoding(slot))?;
 
     if !archiver::is_piece_valid(
         &piece,

--- a/crates/subspace-farmer/src/commands.rs
+++ b/crates/subspace-farmer/src/commands.rs
@@ -1,6 +1,3 @@
 mod farm;
 
-pub(crate) use farm::{
-    start_farm, EncodedBlockWithObjectMapping, FarmerMetadata, NewHead,
-    ProposedProofOfReplicationResponse, SlotInfo,
-};
+pub(crate) use farm::start_farm;

--- a/crates/subspace-farmer/src/commands.rs
+++ b/crates/subspace-farmer/src/commands.rs
@@ -1,3 +1,6 @@
-pub mod farm;
+mod farm;
 
-pub(crate) use farm::start_farm;
+pub(crate) use farm::{
+    start_farm, EncodedBlockWithObjectMapping, FarmerMetadata, NewHead,
+    ProposedProofOfReplicationResponse, SlotInfo,
+};

--- a/crates/subspace-farmer/src/commands.rs
+++ b/crates/subspace-farmer/src/commands.rs
@@ -1,3 +1,3 @@
 mod farm;
 
-pub(crate) use farm::start_farm;
+pub(crate) use farm::farm;

--- a/crates/subspace-farmer/src/commands.rs
+++ b/crates/subspace-farmer/src/commands.rs
@@ -1,3 +1,3 @@
-mod farm;
+pub mod farm;
 
-pub(crate) use farm::farm;
+pub(crate) use farm::start_farm;

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -26,7 +26,7 @@ use subspace_solving::{SubspaceCodec, SOLUTION_SIGNING_CONTEXT};
 
 /// Start farming by using plot in specified path and connecting to WebSocket server at specified
 /// address.
-pub(crate) async fn start_farm(base_directory: PathBuf, ws_server: &str) -> Result<()> {
+pub(crate) async fn farm(base_directory: PathBuf, ws_server: &str) -> Result<()> {
     info!("Connecting to RPC server");
     let client = RpcClient::new(ws_server).await?;
 

--- a/crates/subspace-farmer/src/main.rs
+++ b/crates/subspace-farmer/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
             ws_server,
         } => {
             let path = utils::get_path(custom_path);
-            commands::start_farm(path, &ws_server).await?;
+            commands::farm(path, &ws_server).await?;
         }
     }
     Ok(())

--- a/crates/subspace-farmer/src/main.rs
+++ b/crates/subspace-farmer/src/main.rs
@@ -20,6 +20,7 @@ mod commands;
 mod commitments;
 mod object_mappings;
 mod plot;
+mod rpc;
 mod utils;
 
 use anyhow::Result;
@@ -94,7 +95,7 @@ async fn main() -> Result<()> {
             ws_server,
         } => {
             let path = utils::get_path(custom_path);
-            commands::farm(path, &ws_server).await?;
+            commands::start_farm(path, &ws_server).await?;
         }
     }
     Ok(())

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -1,0 +1,92 @@
+use crate::commands::farm::{
+    EncodedBlockWithObjectMapping, FarmerMetadata, NewHead, ProposedProofOfReplicationResponse,
+    SlotInfo,
+};
+use anyhow::Result;
+use jsonrpsee::types::traits::{Client, SubscriptionClient};
+use jsonrpsee::types::v2::params::JsonRpcParams;
+use jsonrpsee::types::Subscription;
+use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+use std::sync::Arc;
+
+/// `WsClient` wrapper.
+#[derive(Clone, Debug)]
+pub struct RpcClient {
+    client: Arc<WsClient>,
+}
+
+impl From<WsClient> for RpcClient {
+    fn from(client: WsClient) -> Self {
+        Self {
+            client: Arc::new(client),
+        }
+    }
+}
+
+impl RpcClient {
+    /// Create a new instance of [`RpcClient`].
+    pub async fn new(url: &str) -> Result<Self> {
+        let client = Arc::new(WsClientBuilder::default().build(url).await?);
+        Ok(Self { client })
+    }
+
+    /// Get farmer metadata.
+    pub async fn farmer_metadata(&self) -> Result<FarmerMetadata> {
+        self.client
+            .request("subspace_getFarmerMetadata", JsonRpcParams::NoParams)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Get a block by number.
+    pub async fn block_by_number(
+        &self,
+        block_number: u32,
+    ) -> Result<Option<EncodedBlockWithObjectMapping>> {
+        self.client
+            .request(
+                "subspace_getBlockByNumber",
+                JsonRpcParams::Array(vec![serde_json::to_value(block_number)?]),
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Subscribe to chain head.
+    pub async fn subscribe_new_head(&self) -> Result<Subscription<NewHead>> {
+        self.client
+            .subscribe(
+                "chain_subscribeNewHead",
+                JsonRpcParams::NoParams,
+                "chain_unsubscribeNewHead",
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Subscribe to slot.
+    pub async fn subscribe_slot_info(&self) -> Result<Subscription<SlotInfo>> {
+        self.client
+            .subscribe(
+                "subspace_subscribeSlotInfo",
+                JsonRpcParams::NoParams,
+                "subspace_unsubscribeSlotInfo",
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Propose PoR.
+    pub async fn propose_proof_of_replication(
+        &self,
+        por: ProposedProofOfReplicationResponse,
+    ) -> Result<()> {
+        self.client
+            .request(
+                "subspace_proposeProofOfReplication",
+                JsonRpcParams::Array(vec![serde_json::to_value(&por)?]),
+            )
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -1,4 +1,4 @@
-use crate::commands::farm::{
+use crate::commands::{
     EncodedBlockWithObjectMapping, FarmerMetadata, NewHead, ProposedProofOfReplicationResponse,
     SlotInfo,
 };

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -1,12 +1,101 @@
-use crate::commands::{
-    EncodedBlockWithObjectMapping, FarmerMetadata, NewHead, ProposedProofOfReplicationResponse,
-    SlotInfo,
-};
+use crate::{Salt, Tag};
 use jsonrpsee::types::traits::{Client, SubscriptionClient};
 use jsonrpsee::types::v2::params::JsonRpcParams;
 use jsonrpsee::types::{Error, Subscription};
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use subspace_core_primitives::objects::BlockObjectMapping;
+
+type SlotNumber = u64;
+
+/// Metadata necessary for farmer operation
+#[derive(Debug, Deserialize)]
+pub(super) struct FarmerMetadata {
+    /// Depth `K` after which a block enters the recorded history (a global constant, as opposed
+    /// to the client-dependent transaction confirmation depth `k`).
+    pub confirmation_depth_k: u32,
+    /// The size of data in one piece (in bytes).
+    pub record_size: u32,
+    /// Recorded history is encoded and plotted in segments of this size (in bytes).
+    pub recorded_history_segment_size: u32,
+    /// This constant defines the size (in bytes) of one pre-genesis object.
+    pub pre_genesis_object_size: u32,
+    /// This constant defines the number of a pre-genesis objects that will bootstrap the
+    /// history.
+    pub pre_genesis_object_count: u32,
+    /// This constant defines the seed used for deriving pre-genesis objects that will bootstrap
+    /// the history.
+    pub pre_genesis_object_seed: Vec<u8>,
+}
+
+/// Encoded block with mapping of objects that it contains
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct EncodedBlockWithObjectMapping {
+    /// Encoded block
+    pub block: Vec<u8>,
+    /// Mapping of objects inside of the block
+    pub object_mapping: BlockObjectMapping,
+}
+
+// There are more fields in this struct, but we only care about one
+#[derive(Debug, Deserialize)]
+pub(super) struct NewHead {
+    pub number: String,
+}
+
+/// Proposed proof of space consisting of solution and farmer's secret key for block signing
+#[derive(Debug, Serialize)]
+pub(super) struct ProposedProofOfReplicationResponse {
+    /// Slot number
+    pub slot_number: SlotNumber,
+    /// Solution (if present) from farmer's plot corresponding to slot number above
+    pub solution: Option<Solution>,
+    /// Secret key, used for signing blocks on the client node
+    pub secret_key: Vec<u8>,
+}
+
+/// Information about new slot that just arrived
+#[derive(Debug, Deserialize)]
+pub(super) struct SlotInfo {
+    /// Slot number
+    pub slot_number: SlotNumber,
+    /// Slot challenge
+    pub challenge: [u8; 8],
+    /// Salt
+    pub salt: Salt,
+    /// Salt for the next eon
+    pub next_salt: Option<Salt>,
+    /// Acceptable solution range
+    pub solution_range: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct Solution {
+    public_key: [u8; 32],
+    piece_index: u64,
+    encoding: Vec<u8>,
+    signature: Vec<u8>,
+    tag: Tag,
+}
+
+impl Solution {
+    pub(super) fn new(
+        public_key: [u8; 32],
+        piece_index: u64,
+        encoding: Vec<u8>,
+        signature: Vec<u8>,
+        tag: Tag,
+    ) -> Self {
+        Self {
+            public_key,
+            piece_index,
+            encoding,
+            signature,
+            tag,
+        }
+    }
+}
 
 /// `WsClient` wrapper.
 #[derive(Clone, Debug)]
@@ -16,20 +105,20 @@ pub struct RpcClient {
 
 impl RpcClient {
     /// Create a new instance of [`RpcClient`].
-    pub async fn new(url: &str) -> Result<Self, Error> {
+    pub(super) async fn new(url: &str) -> Result<Self, Error> {
         let client = Arc::new(WsClientBuilder::default().build(url).await?);
         Ok(Self { client })
     }
 
     /// Get farmer metadata.
-    pub async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error> {
+    pub(super) async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error> {
         self.client
             .request("subspace_getFarmerMetadata", JsonRpcParams::NoParams)
             .await
     }
 
     /// Get a block by number.
-    pub async fn block_by_number(
+    pub(super) async fn block_by_number(
         &self,
         block_number: u32,
     ) -> Result<Option<EncodedBlockWithObjectMapping>, Error> {
@@ -42,7 +131,7 @@ impl RpcClient {
     }
 
     /// Subscribe to chain head.
-    pub async fn subscribe_new_head(&self) -> Result<Subscription<NewHead>, Error> {
+    pub(super) async fn subscribe_new_head(&self) -> Result<Subscription<NewHead>, Error> {
         self.client
             .subscribe(
                 "chain_subscribeNewHead",
@@ -53,7 +142,7 @@ impl RpcClient {
     }
 
     /// Subscribe to slot.
-    pub async fn subscribe_slot_info(&self) -> Result<Subscription<SlotInfo>, Error> {
+    pub(super) async fn subscribe_slot_info(&self) -> Result<Subscription<SlotInfo>, Error> {
         self.client
             .subscribe(
                 "subspace_subscribeSlotInfo",
@@ -64,7 +153,7 @@ impl RpcClient {
     }
 
     /// Propose PoR.
-    pub async fn propose_proof_of_replication(
+    pub(super) async fn propose_proof_of_replication(
         &self,
         por: ProposedProofOfReplicationResponse,
     ) -> Result<(), Error> {

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -14,14 +14,6 @@ pub struct RpcClient {
     client: Arc<WsClient>,
 }
 
-impl From<WsClient> for RpcClient {
-    fn from(client: WsClient) -> Self {
-        Self {
-            client: Arc::new(client),
-        }
-    }
-}
-
 impl RpcClient {
     /// Create a new instance of [`RpcClient`].
     pub async fn new(url: &str) -> Result<Self, Error> {


### PR DESCRIPTION
This PR extracts all the RPC related functions to `rpc.rs` to allow understanding
the farmer more easily(at least for me). I think `rpc.rs` will be
extended further in the future, e.g., `subspace_subscribeArchivedSegment`.