### PR TITLE
Farmer bin to lib - Phase 2

### DIFF
--- a/crates/subspace-farmer/src/commands.rs
+++ b/crates/subspace-farmer/src/commands.rs
@@ -1,3 +1,3 @@
 mod farm;
 
-pub(crate) use farm::farm;
+pub use farm::farm; // TODO: revert this to pub(crate) again (temporarily modified)

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -23,7 +23,8 @@ use subspace_solving::SubspaceCodec;
 
 /// Start farming by using plot in specified path and connecting to WebSocket server at specified
 /// address.
-pub(crate) async fn farm(base_directory: PathBuf, ws_server: &str) -> Result<()> {
+pub async fn farm(base_directory: PathBuf, ws_server: &str) -> Result<()> {
+    // TODO: revert this to pub(crate) again (temporarily modified)
     // TODO: This doesn't account for the fact that node can
     // have a completely different history to what farmer expects
     info!("Opening plot");

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -20,7 +20,7 @@ const COMMITMENTS_CACHE_SIZE: usize = 2;
 const COMMITMENTS_KEY: &[u8] = b"commitments";
 
 #[derive(Debug, Error)]
-pub(crate) enum CommitmentError {
+pub enum CommitmentError {
     #[error("Metadata DB error: {0}")]
     MetadataDb(rocksdb::Error),
     #[error("Commitment DB error: {0}")]
@@ -94,7 +94,7 @@ pub struct Commitments {
 
 impl Commitments {
     /// Creates new commitments database
-    pub(super) async fn new(base_directory: PathBuf) -> Result<Self, CommitmentError> {
+    pub async fn new(base_directory: PathBuf) -> Result<Self, CommitmentError> {
         // Cache size is just enough for last 2 salts to be stored
         let commitment_databases_fut = tokio::task::spawn_blocking({
             let base_directory = base_directory.clone();

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -88,7 +88,7 @@ struct Inner {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct Commitments {
+pub struct Commitments {
     inner: Arc<Inner>,
 }
 

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -25,6 +25,7 @@ pub(crate) mod plot;
 pub(crate) mod rpc;
 
 pub use commands::farm;
+pub use commitments::CommitmentError;
 pub use commitments::Commitments;
 pub use identity::Identity;
 pub use object_mappings::ObjectMappings;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -25,10 +25,8 @@ pub(crate) mod plot;
 pub(crate) mod rpc;
 
 pub use commands::farm;
-pub use commitments::CommitmentError;
-pub use commitments::Commitments;
+pub use commitments::{CommitmentError, Commitments};
 pub use identity::Identity;
-pub use object_mappings::ObjectMappings;
-pub use plot::Plot;
-pub use plot::PlotError;
+pub use object_mappings::{ObjectMappingError, ObjectMappings};
+pub use plot::{Plot, PlotError};
 pub use rpc::RpcClient;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -16,6 +16,17 @@
 #![feature(try_blocks)]
 #![feature(hash_drain_filter)]
 
+pub(crate) mod commands; // TODO: remove this again (temporarily inserted)
+pub(crate) mod commitments;
+pub(crate) mod common;
 pub(crate) mod identity;
+pub(crate) mod object_mappings;
+pub(crate) mod plot;
+pub(crate) mod rpc;
 
+pub use commands::farm;
+pub use commitments::Commitments;
 pub use identity::Identity;
+pub use object_mappings::ObjectMappings;
+pub use plot::Plot;
+pub use rpc::RpcClient;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -29,4 +29,5 @@ pub use commitments::Commitments;
 pub use identity::Identity;
 pub use object_mappings::ObjectMappings;
 pub use plot::Plot;
+pub use plot::PlotError;
 pub use rpc::RpcClient;

--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -16,7 +16,7 @@ pub(crate) enum ObjectMappingError {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct ObjectMappings {
+pub struct ObjectMappings {
     db: Arc<DB>,
 }
 

--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -10,7 +10,7 @@ use subspace_core_primitives::Sha256Hash;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub(crate) enum ObjectMappingError {
+pub enum ObjectMappingError {
     #[error("DB error: {0}")]
     Db(rocksdb::Error),
 }
@@ -22,7 +22,7 @@ pub struct ObjectMappings {
 
 impl ObjectMappings {
     /// Creates a new object mappings database
-    pub(super) fn new(path: &Path) -> Result<Self, ObjectMappingError> {
+    pub fn new(path: &Path) -> Result<Self, ObjectMappingError> {
         let db = DB::open_default(path).map_err(ObjectMappingError::Db)?;
 
         Ok(Self { db: Arc::new(db) })

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -64,7 +64,7 @@ struct Inner {
 /// cycle repeats. This allows finding solution with as little delay as possible while introducing
 /// changes to the plot at the same time (re-plotting on salt changes or extending plot size).
 #[derive(Clone)]
-pub(crate) struct Plot {
+pub struct Plot {
     inner: Arc<Inner>,
 }
 

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 const LAST_ROOT_BLOCK_KEY: &[u8] = b"last_root_block";
 
 #[derive(Debug, Error)]
-pub(crate) enum PlotError {
+pub enum PlotError {
     #[error("Plot open error: {0}")]
     PlotOpen(io::Error),
     #[error("Metadata DB open error: {0}")]
@@ -70,7 +70,7 @@ pub struct Plot {
 
 impl Plot {
     /// Creates a new plot for persisting encoded pieces to disk
-    pub(crate) async fn open_or_create(base_directory: &PathBuf) -> Result<Plot, PlotError> {
+    pub async fn open_or_create(base_directory: &PathBuf) -> Result<Plot, PlotError> {
         let mut plot_file = OpenOptions::new()
             .read(true)
             .write(true)

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -105,7 +105,7 @@ pub struct RpcClient {
 
 impl RpcClient {
     /// Create a new instance of [`RpcClient`].
-    pub(super) async fn new(url: &str) -> Result<Self, Error> {
+    pub async fn new(url: &str) -> Result<Self, Error> {
         let client = Arc::new(WsClientBuilder::default().build(url).await?);
         Ok(Self { client })
     }


### PR DESCRIPTION
This is the draft of the upcoming PR:

Summary:
1. Following structs are exposed in the lib.rs:
- commitments (along with its `new` method and Error enum)
- object_mappings (along with its `new` method and Error enum)
- plot (along with its `open_or_create` method and Error enum)
- rpc (along with its `new` method)

2. To not get massive unused warnings all the time, `farm` function is also made public. Although, it is to be reverted in the upcoming changes (TODO's are present in the code for that). I believe, when `farm` and `plot` processes are abstracted into structs, this problem will go away on its own :)