### PR TITLE
CODEOWNERS file added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Order matters
+# below ones takes precedence over the upper ones
+
+# Nazar & Jeremiah - global owners
+*                       @nazar-pc @rg3l3dr
+
+# Justin - scripts
+/scripts/               @ImmaZoni
+
+# Liu-Cheng Xu - Protocol
+/crates/                @liuchengxu
+
+# Ozgun & Liu-Cheng Xu - farmer
+/crates/subspace-farmer @ozgunozerk @liuchengxu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,10 +5,10 @@
 *                       @nazar-pc @rg3l3dr
 
 # Scripts
-/scripts/               @ImmaZoni
+/scripts/               @ImmaZoni @nazar-pc @rg3l3dr
 
 # Protocol
-/crates/                @liuchengxu
+/crates/                @liuchengxu @nazar-pc @rg3l3dr
 
 # Farmer
-/crates/subspace-farmer/ @ozgunozerk @liuchengxu
+/crates/subspace-farmer/ @ozgunozerk @liuchengxu @nazar-pc @rg3l3dr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # Order matters
 # below ones takes precedence over the upper ones
 
-# Nazar & Jeremiah - global owners
+# Global owners
 *                       @nazar-pc @rg3l3dr
 
-# Justin - scripts
+# Scripts
 /scripts/               @ImmaZoni
 
-# Liu-Cheng Xu - Protocol
+# Protocol
 /crates/                @liuchengxu
 
-# Ozgun & Liu-Cheng Xu - farmer
+# Farmer
 /crates/subspace-farmer/ @ozgunozerk @liuchengxu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 /crates/                @liuchengxu
 
 # Ozgun & Liu-Cheng Xu - farmer
-/crates/subspace-farmer @ozgunozerk @liuchengxu
+/crates/subspace-farmer/ @ozgunozerk @liuchengxu


### PR DESCRIPTION
This is by no means finished. 

If you are unfamiliar with how Codeowners file works, please read the below explanations:

1- codeowners file is per repository (will add one to the relayer repo as the next step)
2- we are matching files or folders to the people, and the below matches take precedence over the upper ones. In other words, if I match Nazar with everything, and myself with `farmer` folder, Nazar will not get assigned to the pull requests related to `farmer`. 
3- To my knowledge, Jeremiah and Nazar are subscribed to all the pull-requests in this repo, so no need to include them in every match statement.
4- Liu Cheng Xu will be responsible from the overall core-protocol as I recall. So I assigned him to /crates/. But I also had to include him in the /crates/subspace-farmer/, because otherwise, only I would be assigned to the farmer (see item 2 in this list). 
5- Currently, no specific person is assigned to /substrate/ folder. So Jeremiah and Nazar being the global owners, they will be assigned to there (because they are matching with every file).

Please review this small file. If any change is required, do let me know :)