### PR TITLE
Remove unnecessary check in rustdoc workflow

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
 
 jobs:


### PR DESCRIPTION
These are already checked in regular Rust workflow (and unreachable pub is unstable, it has a bunch of false-positives from what I have read and tried), so no need to check in rustdoc too