### PR TITLE
Refine documentation for subspace-core-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7243,6 +7243,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sha2 0.9.8",
+ "sp-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7243,8 +7243,6 @@ dependencies = [
  "scale-info",
  "serde",
  "sha2 0.9.8",
- "sp-core",
- "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7244,6 +7244,7 @@ dependencies = [
  "serde",
  "sha2 0.9.8",
  "sp-core",
+ "sp-std",
 ]
 
 [[package]]

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -917,7 +917,7 @@ impl<T: Config> Pallet<T> {
     fn do_store_root_block(root_block: RootBlock) -> DispatchResultWithPostInfo {
         MerkleRootsBySegmentIndex::<T>::insert(
             root_block.segment_index(),
-            root_block.merkle_tree_root(),
+            root_block.record_root(),
         );
 
         Self::deposit_event(Event::RootBlockStored(root_block));
@@ -947,7 +947,7 @@ impl<T: Config> Pallet<T> {
     pub fn submit_test_store_root_block(root_block: RootBlock) {
         MerkleRootsBySegmentIndex::<T>::insert(
             root_block.segment_index(),
-            root_block.merkle_tree_root(),
+            root_block.record_root(),
         );
     }
 

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -917,7 +917,7 @@ impl<T: Config> Pallet<T> {
     fn do_store_root_block(root_block: RootBlock) -> DispatchResultWithPostInfo {
         MerkleRootsBySegmentIndex::<T>::insert(
             root_block.segment_index(),
-            root_block.record_root(),
+            root_block.records_root(),
         );
 
         Self::deposit_event(Event::RootBlockStored(root_block));
@@ -947,7 +947,7 @@ impl<T: Config> Pallet<T> {
     pub fn submit_test_store_root_block(root_block: RootBlock) {
         MerkleRootsBySegmentIndex::<T>::insert(
             root_block.segment_index(),
-            root_block.record_root(),
+            root_block.records_root(),
         );
     }
 

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
     traits::{Header as _, IdentityLookup},
     Perbill,
 };
-use subspace_core_primitives::{LastArchivedBlock, Piece, RootBlock, Sha256Hash, Tag};
+use subspace_core_primitives::{LastArchivedBlock, Piece, RootBlock, Tag};
 use subspace_solving::{SubspaceCodec, SOLUTION_SIGNING_CONTEXT};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -302,11 +302,11 @@ pub fn generate_equivocation_proof(
 pub fn create_root_block(segment_index: u64) -> RootBlock {
     RootBlock::V0 {
         segment_index,
-        records_root: Sha256Hash::default(),
-        prev_root_block_hash: Sha256Hash::default(),
+        records_root: Default::default(),
+        prev_root_block_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,
-            partial_archived: None,
+            archived_progress: Default::default(),
         },
     }
 }

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -302,7 +302,7 @@ pub fn generate_equivocation_proof(
 pub fn create_root_block(segment_index: u64) -> RootBlock {
     RootBlock::V0 {
         segment_index,
-        merkle_tree_root: Sha256Hash::default(),
+        record_root: Sha256Hash::default(),
         prev_root_block_hash: Sha256Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -302,7 +302,7 @@ pub fn generate_equivocation_proof(
 pub fn create_root_block(segment_index: u64) -> RootBlock {
     RootBlock::V0 {
         segment_index,
-        record_root: Sha256Hash::default(),
+        records_root: Sha256Hash::default(),
         prev_root_block_hash: Sha256Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -306,7 +306,7 @@ pub fn create_root_block(segment_index: u64) -> RootBlock {
         prev_root_block_hash: Sha256Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,
-            bytes: None,
+            partial_archived: None,
         },
     }
 }

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -34,7 +34,9 @@ use sp_runtime::{
     traits::{Header as _, IdentityLookup},
     Perbill,
 };
-use subspace_core_primitives::{LastArchivedBlock, Piece, RootBlock, Tag};
+use subspace_core_primitives::{
+    ArchivedBlockProgress, LastArchivedBlock, Piece, RootBlock, Sha256Hash, Tag,
+};
 use subspace_solving::{SubspaceCodec, SOLUTION_SIGNING_CONTEXT};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -302,11 +304,11 @@ pub fn generate_equivocation_proof(
 pub fn create_root_block(segment_index: u64) -> RootBlock {
     RootBlock::V0 {
         segment_index,
-        records_root: Default::default(),
-        prev_root_block_hash: Default::default(),
+        records_root: Sha256Hash::default(),
+        prev_root_block_hash: Sha256Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,
-            archived_progress: Default::default(),
+            archived_progress: ArchivedBlockProgress::Complete,
         },
     }
 }

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -844,7 +844,7 @@ where
                     |(_block_number, root_blocks)| {
                         root_blocks.iter().find_map(|root_block| {
                             if root_block.segment_index() == segment_index {
-                                Some(root_block.merkle_tree_root())
+                                Some(root_block.record_root())
                             } else {
                                 None
                             }
@@ -1457,7 +1457,7 @@ where
                         .find_map(|(_block_number, root_blocks)| {
                             root_blocks.iter().find_map(|root_block| {
                                 if root_block.segment_index() == segment_index {
-                                    Some(root_block.merkle_tree_root())
+                                    Some(root_block.record_root())
                                 } else {
                                     None
                                 }

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -844,7 +844,7 @@ where
                     |(_block_number, root_blocks)| {
                         root_blocks.iter().find_map(|root_block| {
                             if root_block.segment_index() == segment_index {
-                                Some(root_block.record_root())
+                                Some(root_block.records_root())
                             } else {
                                 None
                             }
@@ -1457,7 +1457,7 @@ where
                         .find_map(|(_block_number, root_blocks)| {
                             root_blocks.iter().find_map(|root_block| {
                                 if root_block.segment_index() == segment_index {
-                                    Some(root_block.record_root())
+                                    Some(root_block.records_root())
                                 } else {
                                     None
                                 }

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -670,7 +670,7 @@ impl<State: private::ArchiverState> Archiver<State> {
         // Now produce root block
         let root_block = RootBlock::V0 {
             segment_index: self.segment_index,
-            record_root: merkle_tree.root(),
+            records_root: merkle_tree.root(),
             prev_root_block_hash: self.prev_root_block_hash,
             last_archived_block: self.last_archived_block,
         };

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -667,22 +667,17 @@ impl<State: private::ArchiverState> Archiver<State> {
             })
             .collect();
 
-        let segment_index = self.segment_index;
-        let merkle_tree_root = merkle_tree.root();
-
         // Now produce root block
         let root_block = RootBlock::V0 {
-            segment_index,
-            merkle_tree_root,
+            segment_index: self.segment_index,
+            record_root: merkle_tree.root(),
             prev_root_block_hash: self.prev_root_block_hash,
             last_archived_block: self.last_archived_block,
         };
 
-        let root_block_hash = root_block.hash();
-
         // Update state
-        self.segment_index = segment_index + 1;
-        self.prev_root_block_hash = root_block_hash;
+        self.segment_index += 1;
+        self.prev_root_block_hash = root_block.hash();
 
         // Add root block to the beginning of the buffer to be the first thing included in the next
         // segment

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -32,7 +32,7 @@ use thiserror::Error;
 
 const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
     number: 0,
-    bytes: Some(0),
+    partial_archived: Some(0),
 };
 
 /// Segment represents a collection of items stored in archival history of the Subspace blockchain
@@ -346,7 +346,7 @@ impl<State: private::ArchiverState> Archiver<State> {
                         // archived
                         last_archived_block.number += 1;
                     }
-                    last_archived_block.bytes = None;
+                    last_archived_block.partial_archived = None;
                 }
                 SegmentItem::BlockStart { .. } => {
                     unreachable!("Buffer never contains SegmentItem::BlockStart; qed");
@@ -355,11 +355,11 @@ impl<State: private::ArchiverState> Archiver<State> {
                     // Same block, but assume for now that the whole block was archived, but
                     // also store the number of bytes as opposed to `None`, we'll transform
                     // it into `None` if needed later
-                    let archived_bytes = last_archived_block.bytes.expect(
+                    let archived_bytes = last_archived_block.partial_archived.expect(
                         "Block continuation implies that there are some bytes \
                                 archived already; qed",
                     );
-                    last_archived_block.bytes.replace(
+                    last_archived_block.partial_archived.replace(
                         archived_bytes
                             + u32::try_from(bytes.len())
                                 .expect("Blocks length is never bigger than u32; qed"),
@@ -443,7 +443,7 @@ impl<State: private::ArchiverState> Archiver<State> {
                     };
 
                     // Update last archived block to include partial archiving info
-                    last_archived_block.bytes.replace(
+                    last_archived_block.partial_archived.replace(
                         u32::try_from(bytes.len())
                             .expect("Blocks length is never bigger than u32; qed"),
                     );
@@ -493,11 +493,11 @@ impl<State: private::ArchiverState> Archiver<State> {
 
                     // Above code assumed that block was archived fully, now remove spilled-over
                     // bytes from the size
-                    let archived_bytes = last_archived_block.bytes.expect(
+                    let archived_bytes = last_archived_block.partial_archived.expect(
                         "Block continuation implies that there are some bytes archived \
                         already; qed",
                     );
-                    last_archived_block.bytes.replace(
+                    last_archived_block.partial_archived.replace(
                         archived_bytes
                             - u32::try_from(spill_over)
                                 .expect("Blocks length is never bigger than u32; qed"),
@@ -527,7 +527,7 @@ impl<State: private::ArchiverState> Archiver<State> {
         } else {
             // Above code added bytes length even though it was assumed that all continuation bytes
             // fit into the segment, now we need to tweak that
-            last_archived_block.bytes.take();
+            last_archived_block.partial_archived.take();
         }
 
         self.last_archived_block = last_archived_block;
@@ -757,7 +757,7 @@ impl BlockArchiver {
             .buffer
             .push_back(SegmentItem::RootBlock(root_block));
 
-        if let Some(archived_block_bytes) = archiver.last_archived_block.bytes {
+        if let Some(archived_block_bytes) = archiver.last_archived_block.partial_archived {
             let encoded_block = encoded_block.as_ref();
             let encoded_block_bytes = u32::try_from(encoded_block.len())
                 .expect("Blocks length is never bigger than u32; qed");

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -34,6 +34,11 @@ use thiserror::Error;
 const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
     number: 0,
     // Special case for the genesis block.
+    //
+    // When we start archiving process with pre-genesis objects, we do not yet have any blocks
+    // archived, but `LastArchivedBlock` is required for `RootBlock`s to be produced, so
+    // `ArchivedBlockProgress::Partial(0)` indicates that we have archived 0 bytes of block `0` (see
+    // field above), meaning we did not in fact archive actual blocks yet.
     archived_progress: ArchivedBlockProgress::Partial(0),
 };
 

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -149,7 +149,7 @@ fn archiver() {
     for (position, piece) in first_archived_segment.pieces.iter().enumerate() {
         assert!(archiver::is_piece_valid(
             piece,
-            first_archived_segment.root_block.record_root(),
+            first_archived_segment.root_block.records_root(),
             position,
             RECORD_SIZE,
         ));
@@ -236,7 +236,7 @@ fn archiver() {
         for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 piece,
-                archived_segment.root_block.record_root(),
+                archived_segment.root_block.records_root(),
                 position,
                 RECORD_SIZE,
             ));
@@ -279,7 +279,7 @@ fn archiver() {
         for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 piece,
-                archived_segment.root_block.record_root(),
+                archived_segment.root_block.records_root(),
                 position,
                 RECORD_SIZE,
             ));
@@ -363,7 +363,7 @@ fn archiver_invalid_usage() {
             SEGMENT_SIZE,
             RootBlock::V0 {
                 segment_index: 0,
-                record_root: Sha256Hash::default(),
+                records_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -390,7 +390,7 @@ fn archiver_invalid_usage() {
             SEGMENT_SIZE,
             RootBlock::V0 {
                 segment_index: 0,
-                record_root: Sha256Hash::default(),
+                records_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -422,7 +422,7 @@ fn archiver_invalid_usage() {
             SEGMENT_SIZE,
             RootBlock::V0 {
                 segment_index: 0,
-                record_root: Sha256Hash::default(),
+                records_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -7,7 +7,7 @@ use subspace_archiving::archiver;
 use subspace_archiving::archiver::{ArchiverInstantiationError, BlockArchiver, ObjectArchiver};
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, PieceObject};
 use subspace_core_primitives::{
-    LastArchivedBlock, RootBlock, Sha256Hash, PIECE_SIZE, SHA256_HASH_SIZE,
+    ArchivedBlockProgress, LastArchivedBlock, RootBlock, Sha256Hash, PIECE_SIZE, SHA256_HASH_SIZE,
 };
 
 const MERKLE_NUM_LEAVES: usize = 8_usize;
@@ -121,7 +121,7 @@ fn archiver() {
     {
         let last_archived_block = first_archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 1);
-        assert_eq!(last_archived_block.partial_archived, Some(7992));
+        assert_eq!(last_archived_block.partial_archived(), Some(7992));
     }
 
     // 4 objects fit into the first segment
@@ -209,13 +209,13 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived, Some(13233));
+        assert_eq!(last_archived_block.partial_archived(), Some(13233));
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived, Some(29143));
+        assert_eq!(last_archived_block.partial_archived(), Some(29143));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -274,7 +274,7 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 3);
-        assert_eq!(last_archived_block.partial_archived, None);
+        assert_eq!(last_archived_block.partial_archived(), None);
 
         for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
@@ -367,7 +367,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    partial_archived: Some(10),
+                    archived_progress: ArchivedBlockProgress::Partial(10),
                 },
             },
             &vec![0u8; 10],
@@ -394,7 +394,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    partial_archived: Some(10),
+                    archived_progress: ArchivedBlockProgress::Partial(10),
                 },
             },
             &vec![0u8; 6],
@@ -426,7 +426,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    partial_archived: Some(0),
+                    archived_progress: ArchivedBlockProgress::Partial(0),
                 },
             },
             &vec![0u8; 5],

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -121,7 +121,7 @@ fn archiver() {
     {
         let last_archived_block = first_archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 1);
-        assert_eq!(last_archived_block.bytes, Some(7992));
+        assert_eq!(last_archived_block.partial_archived, Some(7992));
     }
 
     // 4 objects fit into the first segment
@@ -209,13 +209,13 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.bytes, Some(13233));
+        assert_eq!(last_archived_block.partial_archived, Some(13233));
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.bytes, Some(29143));
+        assert_eq!(last_archived_block.partial_archived, Some(29143));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -274,7 +274,7 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 3);
-        assert_eq!(last_archived_block.bytes, None);
+        assert_eq!(last_archived_block.partial_archived, None);
 
         for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
@@ -367,7 +367,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    bytes: Some(10),
+                    partial_archived: Some(10),
                 },
             },
             &vec![0u8; 10],
@@ -394,7 +394,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    bytes: Some(10),
+                    partial_archived: Some(10),
                 },
             },
             &vec![0u8; 6],
@@ -426,7 +426,7 @@ fn archiver_invalid_usage() {
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
-                    bytes: Some(0),
+                    partial_archived: Some(0),
                 },
             },
             &vec![0u8; 5],

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -149,7 +149,7 @@ fn archiver() {
     for (position, piece) in first_archived_segment.pieces.iter().enumerate() {
         assert!(archiver::is_piece_valid(
             piece,
-            first_archived_segment.root_block.merkle_tree_root(),
+            first_archived_segment.root_block.record_root(),
             position,
             RECORD_SIZE,
         ));
@@ -236,7 +236,7 @@ fn archiver() {
         for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 piece,
-                archived_segment.root_block.merkle_tree_root(),
+                archived_segment.root_block.record_root(),
                 position,
                 RECORD_SIZE,
             ));
@@ -279,7 +279,7 @@ fn archiver() {
         for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 piece,
-                archived_segment.root_block.merkle_tree_root(),
+                archived_segment.root_block.record_root(),
                 position,
                 RECORD_SIZE,
             ));
@@ -363,7 +363,7 @@ fn archiver_invalid_usage() {
             SEGMENT_SIZE,
             RootBlock::V0 {
                 segment_index: 0,
-                merkle_tree_root: Sha256Hash::default(),
+                record_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -390,7 +390,7 @@ fn archiver_invalid_usage() {
             SEGMENT_SIZE,
             RootBlock::V0 {
                 segment_index: 0,
-                merkle_tree_root: Sha256Hash::default(),
+                record_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -422,7 +422,7 @@ fn archiver_invalid_usage() {
             SEGMENT_SIZE,
             RootBlock::V0 {
                 segment_index: 0,
-                merkle_tree_root: Sha256Hash::default(),
+                record_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,6 +17,7 @@ hmac = { version  = "0.11.0", default-features = false }
 parity-scale-codec = { version = "2.3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.130", default-features = false, features = ["alloc", "derive"] }
+sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -37,4 +38,5 @@ std = [
     "scale-info/std",
     "serde/std",
     "sha2/std",
+    "sp-core/std",
 ]

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,8 +17,6 @@ hmac = { version  = "0.11.0", default-features = false }
 parity-scale-codec = { version = "2.3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
-sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
-sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -39,6 +37,4 @@ std = [
     "scale-info/std",
     "serde/std",
     "sha2/std",
-    "sp-core/std",
-    "sp-std/std",
 ]

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -18,6 +18,7 @@ parity-scale-codec = { version = "2.3.0", default-features = false, features = [
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.130", default-features = false, features = ["alloc", "derive"] }
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
+sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -39,4 +40,5 @@ std = [
     "serde/std",
     "sha2/std",
     "sp-core/std",
+    "sp-std/std",
 ]

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 hmac = { version  = "0.11.0", default-features = false }
 parity-scale-codec = { version = "2.3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.130", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.130", optional = true, features = ["derive"] }
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "91b386ff07a85b3dd50ff3ed29c97e6b29d15f05" }
 

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Various cryptographic utilities used across Subspace Network implementation.
+//! Various cryptographic utilities used across Subspace Network.
 
 use crate::Sha256Hash;
 use hmac::{Hmac, Mac, NewMac};

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -43,9 +43,11 @@ pub const RANDOMNESS_LENGTH: usize = 32;
 /// Sha2-256 hash output
 pub type Sha256Hash = [u8; SHA256_HASH_SIZE];
 
-/// Type of a piece in Subspace Network.
+/// A piece of archival history in Subspace Network.
 ///
-/// TODO: explain the content of a piece somewhere?
+/// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
+/// the segment this piece belongs to can be used to verify that a piece belongs to the actual
+/// archival history of the blockchain.
 pub type Piece = [u8; PIECE_SIZE];
 
 /// Type of randomness.

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -27,22 +27,33 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
 
-/// Size of Sha2-256 hash output (in bytes)
+/// Byte size of `sha2::Sha256Hash` output.
 pub const SHA256_HASH_SIZE: usize = 32;
-/// Piece size in Subspace Network (in bytes)
+
+/// Byte size of a piece in Subspace Network, 4KiB.
+///
+/// This can not changed after the network is launched.
 pub const PIECE_SIZE: usize = 4096;
-/// The length of the Randomness.
+
+/// Byte length of a randomness type.
 pub const RANDOMNESS_LENGTH: usize = 32;
 
-// TODO: Create new types out of these
-/// Sha2-256 hash output
+/// Type of the output of `sha2::Sha256Hash`.
 pub type Sha256Hash = [u8; SHA256_HASH_SIZE];
-/// Piece size in Subspace Network
+
+/// Type of a piece in Subspace Network.
+///
+/// TODO: explain the content of a piece somewhere?
 pub type Piece = [u8; PIECE_SIZE];
-/// Randomness value.
+
+/// Type of randomness.
 pub type Randomness = [u8; RANDOMNESS_LENGTH];
-/// Commitment tag for a particular piece.
+
+/// Type of the commitment for a particular piece.
+///
+/// TODO: why not use `Commitment` directly?
 pub type Tag = [u8; 8];
+
 /// Salt used for creating commitment tags for pieces.
 pub type Salt = [u8; 8];
 
@@ -63,13 +74,17 @@ pub type Salt = [u8; 8];
     RuntimeDebug,
 )]
 pub struct LastArchivedBlock {
-    /// Block number
+    /// Number of this block.
     pub number: u32,
     /// `None` if the block was archived fully or number of bytes otherwise
     pub bytes: Option<u32>,
 }
 
-/// Root block for a specific segment
+/// This type represents the digest of a segment.
+///
+/// Each segment will contain a [`RootBlock`].
+///
+/// TODO: explain why `RootBlock` is more appropriate than `SegmentDigest`?
 #[derive(
     Copy,
     Clone,
@@ -111,14 +126,14 @@ impl RootBlock {
     /// Segment index
     pub fn segment_index(&self) -> u64 {
         match self {
-            RootBlock::V0 { segment_index, .. } => *segment_index,
+            Self::V0 { segment_index, .. } => *segment_index,
         }
     }
 
     /// Merkle tree root of all pieces within segment
     pub fn merkle_tree_root(&self) -> Sha256Hash {
         match self {
-            RootBlock::V0 {
+            Self::V0 {
                 merkle_tree_root, ..
             } => *merkle_tree_root,
         }
@@ -127,7 +142,7 @@ impl RootBlock {
     /// Hash of the root block of the previous segment
     pub fn prev_root_block_hash(&self) -> Sha256Hash {
         match self {
-            RootBlock::V0 {
+            Self::V0 {
                 prev_root_block_hash,
                 ..
             } => *prev_root_block_hash,
@@ -137,7 +152,7 @@ impl RootBlock {
     /// Last archived block
     pub fn last_archived_block(&self) -> LastArchivedBlock {
         match self {
-            RootBlock::V0 {
+            Self::V0 {
                 last_archived_block,
                 ..
             } => *last_archived_block,

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -25,6 +25,7 @@ pub mod objects;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
+use sp_core::RuntimeDebug;
 
 /// Size of Sha2-256 hash output (in bytes)
 pub const SHA256_HASH_SIZE: usize = 32;
@@ -59,8 +60,8 @@ pub type Salt = [u8; 8];
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct LastArchivedBlock {
     /// Block number
     pub number: u32,
@@ -82,8 +83,8 @@ pub struct LastArchivedBlock {
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum RootBlock {
     /// V0 of the root block data structure

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -87,6 +87,7 @@ pub struct LastArchivedBlock {
 pub enum RootBlock {
     /// V0 of the root block data structure
     #[codec(index = 0)]
+    #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
     V0 {
         /// Segment index
         segment_index: u64,

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -25,6 +25,7 @@ pub mod objects;
 
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
 
@@ -60,20 +61,10 @@ pub type Salt = [u8; 8];
 
 /// Last archived block
 #[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct LastArchivedBlock {
     /// Number of this block.
     pub number: u32,
@@ -89,25 +80,13 @@ pub struct LastArchivedBlock {
 ///
 /// TODO: explain why `RootBlock` is more appropriate than `SegmentDigest`?
 #[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum RootBlock {
     /// V0 of the root block data structure
     #[codec(index = 0)]
-    #[serde(rename_all = "camelCase")]
     V0 {
         /// Segment index
         segment_index: u64,

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -126,11 +126,12 @@ impl LastArchivedBlock {
     }
 }
 
-/// This type represents the digest of a segment.
+/// Root block for a specific segment.
 ///
-/// Each segment will contain a [`RootBlock`].
-///
-/// TODO: explain why `RootBlock` is more appropriate than `SegmentDigest`?
+/// Each segment will have corresponding [`RootBlock`] included as the first item in the next
+/// segment. Each `RootBlock` includes hash of the previous one and all together form a chain of
+/// root blocks that is used for quick and efficient verification that some [`Piece`] corresponds to
+/// the actual archival history of the blockchain.
 #[derive(
     Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -27,7 +27,6 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_core::RuntimeDebug;
 
 /// Size of Sha2-256 hash output (in bytes)
 pub const SHA256_HASH_SIZE: usize = 32;
@@ -62,9 +61,8 @@ pub type Tag = [u8; 8];
 pub type Salt = [u8; 8];
 
 /// Progress of an archived block.
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum ArchivedBlockProgress {
@@ -99,9 +97,8 @@ impl ArchivedBlockProgress {
 }
 
 /// Last archived block
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct LastArchivedBlock {
@@ -134,9 +131,8 @@ impl LastArchivedBlock {
 /// segment. Each `RootBlock` includes hash of the previous one and all together form a chain of
 /// root blocks that is used for quick and efficient verification that some [`Piece`] corresponds to
 /// the actual archival history of the blockchain.
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum RootBlock {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -29,7 +29,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
 
-/// Byte size of `sha2::Sha256Hash` output.
+/// Size of Sha2-256 hash output (in bytes)
 pub const SHA256_HASH_SIZE: usize = 32;
 
 /// Byte size of a piece in Subspace Network, 4KiB.
@@ -40,7 +40,7 @@ pub const PIECE_SIZE: usize = 4096;
 /// Byte length of a randomness type.
 pub const RANDOMNESS_LENGTH: usize = 32;
 
-/// Type of the output of `sha2::Sha256Hash`.
+/// Sha2-256 hash output
 pub type Sha256Hash = [u8; SHA256_HASH_SIZE];
 
 /// Type of a piece in Subspace Network.
@@ -66,7 +66,7 @@ pub type Salt = [u8; 8];
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct LastArchivedBlock {
-    /// Number of this block.
+    /// Block number
     pub number: u32,
     /// Number of paritally archived bytes of a block.
     ///
@@ -113,7 +113,7 @@ impl RootBlock {
         }
     }
 
-    /// Merkle root of the records of a segment.
+    /// Merkle root of the records in a segment.
     pub fn records_root(&self) -> Sha256Hash {
         match self {
             Self::V0 { records_root, .. } => *records_root,

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -108,8 +108,8 @@ pub enum RootBlock {
     V0 {
         /// Segment index
         segment_index: u64,
-        /// Merkle tree root of all pieces within segment
-        merkle_tree_root: Sha256Hash,
+        /// Merkle root of the records in a segment.
+        record_root: Sha256Hash,
         /// Hash of the root block of the previous segment
         prev_root_block_hash: Sha256Hash,
         /// Last archived block
@@ -131,11 +131,9 @@ impl RootBlock {
     }
 
     /// Merkle tree root of all pieces within segment
-    pub fn merkle_tree_root(&self) -> Sha256Hash {
+    pub fn record_root(&self) -> Sha256Hash {
         match self {
-            Self::V0 {
-                merkle_tree_root, ..
-            } => *merkle_tree_root,
+            Self::V0 { record_root, .. } => *record_root,
         }
     }
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 //! Core primitives for Subspace Network.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_docs)]
@@ -76,8 +77,10 @@ pub type Salt = [u8; 8];
 pub struct LastArchivedBlock {
     /// Number of this block.
     pub number: u32,
-    /// `None` if the block was archived fully or number of bytes otherwise
-    pub bytes: Option<u32>,
+    /// Number of paritally archived bytes of a block.
+    ///
+    /// `None` if the block has been fully archived fully.
+    pub partial_archived: Option<u32>,
 }
 
 /// This type represents the digest of a segment.
@@ -130,7 +133,7 @@ impl RootBlock {
         }
     }
 
-    /// Merkle tree root of all pieces within segment
+    /// Merkle root of the records of a segment.
     pub fn record_root(&self) -> Sha256Hash {
         match self {
             Self::V0 { record_root, .. } => *record_root,

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -91,7 +91,7 @@ pub enum RootBlock {
         /// Segment index
         segment_index: u64,
         /// Merkle root of the records in a segment.
-        record_root: Sha256Hash,
+        records_root: Sha256Hash,
         /// Hash of the root block of the previous segment
         prev_root_block_hash: Sha256Hash,
         /// Last archived block
@@ -113,9 +113,9 @@ impl RootBlock {
     }
 
     /// Merkle root of the records of a segment.
-    pub fn record_root(&self) -> Sha256Hash {
+    pub fn records_root(&self) -> Sha256Hash {
         match self {
-            Self::V0 { record_root, .. } => *record_root,
+            Self::V0 { records_root, .. } => *records_root,
         }
     }
 

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -28,6 +28,7 @@ use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
+use sp_core::RuntimeDebug;
 
 /// Object stored inside of the block
 #[derive(
@@ -43,8 +44,8 @@ use serde::{Deserialize, Serialize};
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum BlockObject {
     /// V0 of object mapping data structure
@@ -89,8 +90,8 @@ impl BlockObject {
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct BlockObjectMapping {
     /// Objects stored inside of the block
     pub objects: Vec<BlockObject>,
@@ -110,8 +111,8 @@ pub struct BlockObjectMapping {
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum PieceObject {
     /// V0 of object mapping data structure
@@ -154,8 +155,8 @@ impl PieceObject {
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 pub struct PieceObjectMapping {
     /// Objects stored inside of the block
     pub objects: Vec<PieceObject>,
@@ -175,8 +176,8 @@ pub struct PieceObjectMapping {
     TypeInfo,
     Serialize,
     Deserialize,
+    RuntimeDebug,
 )]
-#[cfg_attr(feature = "std", derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum GlobalObject {
     /// V0 of object mapping data structure

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -59,16 +59,14 @@ impl BlockObject {
     /// Object hash
     pub fn hash(&self) -> Sha256Hash {
         match self {
-            BlockObject::V0 { hash, .. } => *hash,
+            Self::V0 { hash, .. } => *hash,
         }
     }
 
     /// Offset of the object (limited to 24-bit size internally)
     pub fn offset(&self) -> u32 {
         match self {
-            BlockObject::V0 { offset, .. } => {
-                u32::from_le_bytes([offset[0], offset[1], offset[2], 0])
-            }
+            Self::V0 { offset, .. } => u32::from_le_bytes([offset[0], offset[1], offset[2], 0]),
         }
     }
 }
@@ -126,14 +124,14 @@ impl PieceObject {
     /// Object hash
     pub fn hash(&self) -> Sha256Hash {
         match self {
-            PieceObject::V0 { hash, .. } => *hash,
+            Self::V0 { hash, .. } => *hash,
         }
     }
 
     /// Offset of the object
     pub fn offset(&self) -> u16 {
         match self {
-            PieceObject::V0 { offset, .. } => *offset,
+            Self::V0 { offset, .. } => *offset,
         }
     }
 }
@@ -191,14 +189,14 @@ impl GlobalObject {
     /// Piece index where object is contained (at least its beginning, might not fit fully)
     pub fn piece_index(&self) -> u64 {
         match self {
-            GlobalObject::V0 { piece_index, .. } => *piece_index,
+            Self::V0 { piece_index, .. } => *piece_index,
         }
     }
 
     /// Offset of the object
     pub fn offset(&self) -> u16 {
         match self {
-            GlobalObject::V0 { offset, .. } => *offset,
+            Self::V0 { offset, .. } => *offset,
         }
     }
 }

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -20,15 +20,12 @@
 //! * for objects within a piece
 //! * for global objects in the global history of the blockchain
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
 use crate::Sha256Hash;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
+use sp_std::vec::Vec;
 
 /// Object stored inside of the block
 #[derive(

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -20,18 +20,19 @@
 //! * for objects within a piece
 //! * for global objects in the global history of the blockchain
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 use crate::Sha256Hash;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_core::RuntimeDebug;
-use sp_std::vec::Vec;
 
 /// Object stored inside of the block
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum BlockObject {
@@ -62,9 +63,8 @@ impl BlockObject {
 }
 
 /// Mapping of objects stored inside of the block
-#[derive(
-    Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BlockObjectMapping {
@@ -73,9 +73,8 @@ pub struct BlockObjectMapping {
 }
 
 /// Object stored inside of the block
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum PieceObject {
@@ -106,9 +105,8 @@ impl PieceObject {
 }
 
 /// Mapping of objects stored inside of the piece
-#[derive(
-    Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct PieceObjectMapping {
@@ -117,9 +115,8 @@ pub struct PieceObjectMapping {
 }
 
 /// Object stored inside in the history of the blockchain
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum GlobalObject {

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -23,27 +23,17 @@
 use crate::Sha256Hash;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
 use sp_std::vec::Vec;
 
 /// Object stored inside of the block
 #[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum BlockObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
@@ -73,20 +63,10 @@ impl BlockObject {
 
 /// Mapping of objects stored inside of the block
 #[derive(
-    Default,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BlockObjectMapping {
     /// Objects stored inside of the block
     pub objects: Vec<BlockObject>,
@@ -94,21 +74,10 @@ pub struct BlockObjectMapping {
 
 /// Object stored inside of the block
 #[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum PieceObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
@@ -138,20 +107,10 @@ impl PieceObject {
 
 /// Mapping of objects stored inside of the piece
 #[derive(
-    Default,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct PieceObjectMapping {
     /// Objects stored inside of the block
     pub objects: Vec<PieceObject>,
@@ -159,21 +118,10 @@ pub struct PieceObjectMapping {
 
 /// Object stored inside in the history of the blockchain
 #[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    RuntimeDebug,
+    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, RuntimeDebug,
 )]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum GlobalObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -58,7 +58,7 @@ async fn last_root_block() {
         prev_root_block_hash: rand::random(),
         last_archived_block: LastArchivedBlock {
             number: rand::random(),
-            bytes: Some(rand::random()),
+            partial_archived: Some(rand::random()),
         },
     };
 

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -54,7 +54,7 @@ async fn last_root_block() {
 
     let root_block = RootBlock::V0 {
         segment_index: rand::random(),
-        merkle_tree_root: rand::random(),
+        record_root: rand::random(),
         prev_root_block_hash: rand::random(),
         last_archived_block: LastArchivedBlock {
             number: rand::random(),

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -1,7 +1,9 @@
 use crate::plot::Plot;
 use rand::prelude::*;
 use std::sync::Arc;
-use subspace_core_primitives::{LastArchivedBlock, Piece, RootBlock, PIECE_SIZE};
+use subspace_core_primitives::{
+    ArchivedBlockProgress, LastArchivedBlock, Piece, RootBlock, PIECE_SIZE,
+};
 use tempfile::TempDir;
 
 fn init() {
@@ -58,7 +60,7 @@ async fn last_root_block() {
         prev_root_block_hash: rand::random(),
         last_archived_block: LastArchivedBlock {
             number: rand::random(),
-            partial_archived: Some(rand::random()),
+            archived_progress: ArchivedBlockProgress::Partial(rand::random()),
         },
     };
 

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -54,7 +54,7 @@ async fn last_root_block() {
 
     let root_block = RootBlock::V0 {
         segment_index: rand::random(),
-        record_root: rand::random(),
+        records_root: rand::random(),
         prev_root_block_hash: rand::random(),
         last_archived_block: LastArchivedBlock {
             number: rand::random(),


### PR DESCRIPTION
Part of #80 

This PR mainly takes care of `subspace-core-primitives`, reviewing by each commit should make more sense, I'm open to all suggestions as my current understanding of the big picture can be limited. The Object related concepts will be revisited later.

