### PR TITLE
Farmer lib phase3b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,6 +4188,7 @@ name = "pallet-utility"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?rev=26d69bcbe26f6b463e9374e1b1c54c3067fb6131#26d69bcbe26f6b463e9374e1b1c54c3067fb6131"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -7229,6 +7230,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-lock",
+ "async-oneshot",
  "async-std",
  "clap 3.0.0-beta.5",
  "dirs",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 [dependencies]
 anyhow = "1.0.44"
 async-lock = "2.4.0"
+async-oneshot = "0.5.0"
 async-std = "1.9.0"
 clap = { version = "3.0.0-beta.5", features = ["color", "derive"] }
 dirs = "4.0.0"

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -1,24 +1,19 @@
 use crate::commitments::Commitments;
-use crate::common::Salt;
 use crate::identity::Identity;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
-use crate::rpc::{
-    EncodedBlockWithObjectMapping, FarmerMetadata, ProposedProofOfReplicationResponse, RpcClient,
-    SlotInfo, Solution,
-};
+use crate::rpc::{EncodedBlockWithObjectMapping, FarmerMetadata, RpcClient};
 use anyhow::{anyhow, Result};
 use futures::future;
 use futures::future::Either;
-use log::{debug, error, info, trace};
+use log::{debug, error, info};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
 use subspace_archiving::archiver::{ArchivedSegment, BlockArchiver, ObjectArchiver};
 use subspace_archiving::pre_genesis_data;
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
-use subspace_core_primitives::{crypto, Sha256Hash};
+use subspace_core_primitives::Sha256Hash;
 use subspace_solving::SubspaceCodec;
 
 /// Start farming by using plot in specified path and connecting to WebSocket server at specified
@@ -56,15 +51,15 @@ pub async fn farm(base_directory: PathBuf, ws_server: &str) -> Result<()> {
                 background_plotting(client, plot, commitments, object_mappings, &public_key).await
             })
         },
-        Box::pin(
-            async move { subscribe_to_slot_info(&client, &plot, &commitments, &identity).await },
-        ),
+        Box::pin(async move {
+            crate::farming::subscribe_to_slot_info(&client, &plot, &commitments, &identity).await
+        }),
     )
     .await
     {
         Either::Left((result, _)) => match result {
             Ok(()) => {
-                info!("Background plotting finished successfully");
+                info!("Background plotting shutdown gracefully");
 
                 Ok(())
             }
@@ -382,145 +377,4 @@ fn create_global_object_mapping(
             })
         })
         .collect()
-}
-
-async fn subscribe_to_slot_info(
-    client: &RpcClient,
-    plot: &Plot,
-    commitments: &Commitments,
-    identity: &Identity,
-) -> Result<()> {
-    let farmer_public_key_hash = crypto::sha256_hash(&identity.public_key());
-
-    info!("Subscribing to slot info");
-    let mut new_slots = client.subscribe_slot_info().await?;
-
-    let mut salts = Salts::default();
-
-    while let Some(slot_info) = new_slots.next().await? {
-        debug!("New slot: {:?}", slot_info);
-
-        update_commitments(plot, commitments, &mut salts, &slot_info);
-
-        let local_challenge =
-            subspace_solving::derive_local_challenge(slot_info.challenge, &farmer_public_key_hash);
-
-        let solution = match commitments
-            .find_by_range(local_challenge, slot_info.solution_range, slot_info.salt)
-            .await
-        {
-            Some((tag, piece_index)) => {
-                let encoding = plot.read(piece_index).await?;
-                let solution = Solution::new(
-                    identity.public_key().to_bytes(),
-                    piece_index,
-                    encoding.to_vec(),
-                    identity.sign(&tag).to_bytes().to_vec(),
-                    tag,
-                );
-                debug!("Solution found");
-                trace!("Solution found: {:?}", solution);
-
-                Some(solution)
-            }
-            None => {
-                debug!("Solution not found");
-                None
-            }
-        };
-
-        client
-            .propose_proof_of_replication(ProposedProofOfReplicationResponse {
-                slot_number: slot_info.slot_number,
-                solution,
-                secret_key: identity.secret_key().to_bytes().into(),
-            })
-            .await?;
-    }
-
-    Ok(())
-}
-
-#[derive(Default)]
-struct Salts {
-    current: Option<Salt>,
-    next: Option<Salt>,
-}
-
-/// Compare salts in `slot_info` to those known from `salts` and start update plot commitments
-/// accordingly if necessary (in background)
-fn update_commitments(
-    plot: &Plot,
-    commitments: &Commitments,
-    salts: &mut Salts,
-    slot_info: &SlotInfo,
-) {
-    // Check if current salt has changed
-    if salts.current != Some(slot_info.salt) {
-        salts.current.replace(slot_info.salt);
-
-        if salts.next != Some(slot_info.salt) {
-            // If previous `salts.next` is the same as current (expected behavior), need to re-commit
-
-            tokio::spawn({
-                let salt = slot_info.salt;
-                let plot = plot.clone();
-                let commitments = commitments.clone();
-
-                async move {
-                    let started = Instant::now();
-                    info!(
-                        "Salt updated to {}, recommitting in background",
-                        hex::encode(salt)
-                    );
-
-                    if let Err(error) = commitments.create(salt, plot).await {
-                        error!(
-                            "Failed to create commitment for {}: {}",
-                            hex::encode(salt),
-                            error
-                        );
-                    } else {
-                        info!(
-                            "Finished recommitment for {} in {} seconds",
-                            hex::encode(salt),
-                            started.elapsed().as_secs_f32()
-                        );
-                    }
-                }
-            });
-        }
-    }
-
-    if let Some(new_next_salt) = slot_info.next_salt {
-        if salts.next != Some(new_next_salt) {
-            salts.next.replace(new_next_salt);
-
-            tokio::spawn({
-                let plot = plot.clone();
-                let commitments = commitments.clone();
-
-                async move {
-                    let started = Instant::now();
-                    info!(
-                        "Salt will update to {} soon, recommitting in background",
-                        hex::encode(new_next_salt)
-                    );
-                    if let Err(error) = commitments.create(new_next_salt, plot).await {
-                        error!(
-                            "Recommitting salt in background failed for {}: {}",
-                            hex::encode(new_next_salt),
-                            error
-                        );
-                        return;
-                    }
-                    info!(
-                        "Finished recommitment in background for {} in {} seconds",
-                        hex::encode(new_next_salt),
-                        started.elapsed().as_secs_f32()
-                    );
-                }
-            });
-        }
-    }
 }

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -1,0 +1,150 @@
+use crate::commitments::Commitments;
+use crate::common::Salt;
+use crate::identity::Identity;
+use crate::plot::Plot;
+use crate::rpc::{ProposedProofOfReplicationResponse, RpcClient, SlotInfo, Solution};
+use anyhow::Result;
+use log::{debug, error, info, trace};
+use std::time::Instant;
+use subspace_core_primitives::crypto;
+
+#[derive(Default)]
+struct Salts {
+    current: Option<Salt>,
+    next: Option<Salt>,
+}
+
+pub(crate) async fn subscribe_to_slot_info(
+    client: &RpcClient,
+    plot: &Plot,
+    commitments: &Commitments,
+    identity: &Identity,
+) -> Result<()> {
+    let farmer_public_key_hash = crypto::sha256_hash(&identity.public_key());
+
+    info!("Subscribing to slot info");
+    let mut new_slots = client.subscribe_slot_info().await?;
+
+    let mut salts = Salts::default();
+
+    while let Some(slot_info) = new_slots.next().await? {
+        debug!("New slot: {:?}", slot_info);
+
+        update_commitments(plot, commitments, &mut salts, &slot_info);
+
+        let local_challenge =
+            subspace_solving::derive_local_challenge(slot_info.challenge, &farmer_public_key_hash);
+
+        let solution = match commitments
+            .find_by_range(local_challenge, slot_info.solution_range, slot_info.salt)
+            .await
+        {
+            Some((tag, piece_index)) => {
+                let encoding = plot.read(piece_index).await?;
+                let solution = Solution::new(
+                    identity.public_key().to_bytes(),
+                    piece_index,
+                    encoding.to_vec(),
+                    identity.sign(&tag).to_bytes().to_vec(),
+                    tag,
+                );
+                debug!("Solution found");
+                trace!("Solution found: {:?}", solution);
+
+                Some(solution)
+            }
+            None => {
+                debug!("Solution not found");
+                None
+            }
+        };
+
+        client
+            .propose_proof_of_replication(ProposedProofOfReplicationResponse {
+                slot_number: slot_info.slot_number,
+                solution,
+                secret_key: identity.secret_key().to_bytes().into(),
+            })
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Compare salts in `slot_info` to those known from `salts` and start update plot commitments
+/// accordingly if necessary (in background)
+fn update_commitments(
+    plot: &Plot,
+    commitments: &Commitments,
+    salts: &mut Salts,
+    slot_info: &SlotInfo,
+) {
+    // Check if current salt has changed
+    if salts.current != Some(slot_info.salt) {
+        salts.current.replace(slot_info.salt);
+
+        if salts.next != Some(slot_info.salt) {
+            // If previous `salts.next` is the same as current (expected behavior), need to re-commit
+
+            tokio::spawn({
+                let salt = slot_info.salt;
+                let plot = plot.clone();
+                let commitments = commitments.clone();
+
+                async move {
+                    let started = Instant::now();
+                    info!(
+                        "Salt updated to {}, recommitting in background",
+                        hex::encode(salt)
+                    );
+
+                    if let Err(error) = commitments.create(salt, plot).await {
+                        error!(
+                            "Failed to create commitment for {}: {}",
+                            hex::encode(salt),
+                            error
+                        );
+                    } else {
+                        info!(
+                            "Finished recommitment for {} in {} seconds",
+                            hex::encode(salt),
+                            started.elapsed().as_secs_f32()
+                        );
+                    }
+                }
+            });
+        }
+    }
+
+    if let Some(new_next_salt) = slot_info.next_salt {
+        if salts.next != Some(new_next_salt) {
+            salts.next.replace(new_next_salt);
+
+            tokio::spawn({
+                let plot = plot.clone();
+                let commitments = commitments.clone();
+
+                async move {
+                    let started = Instant::now();
+                    info!(
+                        "Salt will update to {} soon, recommitting in background",
+                        hex::encode(new_next_salt)
+                    );
+                    if let Err(error) = commitments.create(new_next_salt, plot).await {
+                        error!(
+                            "Recommitting salt in background failed for {}: {}",
+                            hex::encode(new_next_salt),
+                            error
+                        );
+                        return;
+                    }
+                    info!(
+                        "Finished recommitment in background for {} in {} seconds",
+                        hex::encode(new_next_salt),
+                        started.elapsed().as_secs_f32()
+                    );
+                }
+            });
+        }
+    }
+}

--- a/crates/subspace-farmer/src/identity.rs
+++ b/crates/subspace-farmer/src/identity.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::Path;
 use subspace_solving::SOLUTION_SIGNING_CONTEXT;
 
+#[derive(Clone)]
 pub struct Identity {
     keypair: Keypair,
     ctx: SigningContext,

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod rpc;
 
 pub use commands::farm;
 pub use commitments::{CommitmentError, Commitments};
+pub use farming::Farming;
 pub use identity::Identity;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
 pub use plot::{Plot, PlotError};

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -19,6 +19,7 @@
 pub(crate) mod commands; // TODO: remove this again (temporarily inserted)
 pub(crate) mod commitments;
 pub(crate) mod common;
+pub(crate) mod farming;
 pub(crate) mod identity;
 pub(crate) mod object_mappings;
 pub(crate) mod plot;

--- a/crates/subspace-farmer/src/main.rs
+++ b/crates/subspace-farmer/src/main.rs
@@ -19,6 +19,7 @@
 mod commands;
 mod commitments;
 mod common;
+mod farming;
 mod identity;
 mod object_mappings;
 mod plot;


### PR DESCRIPTION
## Summary: abstraction of farmer process. 
Now, `farmer` is an interruptible process, and callable from public API.

I suggest reviewing all changes at once instead of *commit by commit* (early commits were not that meaningful, since I was learning the concepts).

### Important note:
- I'm aware of this abstracted farmer is not being used directly in the main. It is still in the `farm.rs`. It will move out of it, but currently `farm.rs` contains also plotting, and the **initialization of the arguments** required for both `farming` and `plotting`, and when this function is removed from there, it will be `plot.rs` instead of `farm.rs`. 
- I could have done these initializations in the new abstracted farming process, but then, the same would have to be done for the plotting -> inefficiency and code duplication

### My plan:
- I'm show-casing the abstracted struct can be called anywhere with this PR. 
- And after the *plot abstraction PR* (the upcoming one), I'm planning to have another PR, which introduces an `initializer` function, providing the common arguments for both `plotting` and `farming` tasks (in order to reduce duplication). With that PR, `farm.rs` will be changed significantly (maybe erased), and we will have an `initializer`, along with abstracted `plotting` and `farming` tasks, that can be callable from anywhere, and present in the Public API.