### PR TITLE
Do not submit unsigned root block extrinsic on nodes that do not produce blocks themselves

### DIFF
--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -345,8 +345,9 @@ impl TestNetFactory for SubspaceTestNet {
         let client = client.as_full().expect("only full clients are tested");
 
         let config = Config::get_or_compute(&*client).expect("config available");
-        let (block_import, link) = crate::block_import(config, client.clone(), client.clone())
-            .expect("can initialize block-import");
+        let (block_import, link) =
+            crate::block_import(false, config, client.clone(), client.clone())
+                .expect("can initialize block-import");
 
         let block_import = PanickingBlockImport {
             block_import,

--- a/crates/subspace-node/src/service.rs
+++ b/crates/subspace-node/src/service.rs
@@ -104,6 +104,7 @@ pub fn new_partial(
     );
 
     let (block_import, subspace_link) = sc_consensus_subspace::block_import(
+        config.role.is_authority(),
         sc_consensus_subspace::Config::get_or_compute(&*client)?,
         client.clone(),
         client.clone(),
@@ -333,6 +334,7 @@ pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
     ));
 
     let (subspace_block_import, subspace_link) = sc_consensus_subspace::block_import(
+        config.role.is_authority(),
         sc_consensus_subspace::Config::get_or_compute(&*client)?,
         client.clone(),
         client.clone(),


### PR DESCRIPTION
This should allow non-validator nodes to validate blocks properly as well as serve as public RPC node