### PR TITLE
Pallet vesting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7314,6 +7314,7 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
+ "serde_json",
  "sp-api",
  "sp-authorship",
  "sp-block-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "orml-vesting"
+version = "0.4.1-dev"
+source = "git+https://github.com/subspace/open-runtime-module-library?branch=substrate-monthly-2021-10#facfee924f3c49f3400c64a36c5d8884744ddb33"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11263a97373b43da4b426edbb52ef99a7b51e2d9752ef56a7f8b356f48495a5"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec 0.20.4",
@@ -4217,9 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b157dc92b3db2bae522afb31b3843e91ae097eb01d66c72dda66a2e86bc3ca14"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7325,6 +7340,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "hex-literal",
+ "orml-vesting",
  "pallet-balances",
  "pallet-feeds",
  "pallet-offences-subspace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3960,7 +3960,7 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/open-runtime-module-library?branch=substrate-monthly-2021-10#facfee924f3c49f3400c64a36c5d8884744ddb33"
+source = "git+https://github.com/subspace/open-runtime-module-library?branch=multiple-genesis-schedules-substrate-monthly-2021-10#9a46de0955238bcbc8a8d3584279a29640bf89bb"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -32,6 +32,7 @@ sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/subs
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
+serde_json = "1.0.68"
 sp-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 sp-authorship = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -19,8 +19,8 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subspace_runtime::{
-    AccountId, BalancesConfig, GenesisConfig, Signature, SubspaceConfig, SudoConfig, SystemConfig,
-    WASM_BINARY,
+    AccountId, Balance, BalancesConfig, BlockNumber, GenesisConfig, Signature, SubspaceConfig,
+    SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -66,6 +66,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                 ],
+                vec![],
             )
         },
         // Bootnodes
@@ -106,6 +107,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                 ],
+                vec![],
             )
         },
         // Bootnodes
@@ -150,6 +152,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
+                vec![],
             )
         },
         // Bootnodes
@@ -170,6 +173,7 @@ fn testnet_genesis(
     wasm_binary: &[u8],
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
+    vesting: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -192,5 +196,6 @@ fn testnet_genesis(
             // Assign network admin rights.
             key: root_key,
         },
+        vesting: VestingConfig { vesting },
     }
 }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -20,7 +20,7 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subspace_runtime::{
     AccountId, Balance, BalancesConfig, BlockNumber, GenesisConfig, Signature, SubspaceConfig,
-    SudoConfig, SystemConfig, VestingConfig, WASM_BINARY,
+    SudoConfig, SystemConfig, VestingConfig, SSC, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -60,17 +60,21 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
                 "0x14682f9dea76a4dd47172a118eb29b9cf9976df7ade12f95709a7cd2e3d81d6c"
                     .parse()
                     .expect("Wrong root account ID");
-            testnet_genesis(
+            create_genesis_config(
                 WASM_BINARY.expect("Wasm binary must be built for testnet"),
                 // Sudo account
                 root_account.clone(),
                 // Pre-funded accounts
                 vec![
-                    root_account,
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                    (root_account, 1_000 * SSC),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Alice"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Bob"),
+                        1_000 * SSC,
+                    ),
                 ],
                 vec![],
             )
@@ -111,16 +115,28 @@ pub fn development_config() -> Result<ChainSpec, String> {
         ChainType::Development,
         // TODO: Provide a way for farmer to start with these accounts
         || {
-            testnet_genesis(
+            create_genesis_config(
                 wasm_binary,
                 // Sudo account
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 // Pre-funded accounts
                 vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Alice"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Bob"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                        1_000 * SSC,
+                    ),
                 ],
                 vec![],
             )
@@ -148,24 +164,60 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
         "local_testnet",
         ChainType::Local,
         || {
-            testnet_genesis(
+            create_genesis_config(
                 wasm_binary,
                 // Sudo account
                 get_account_id_from_seed::<sr25519::Public>("Alice"),
                 // Pre-funded accounts
                 vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Alice"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Bob"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Charlie"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Dave"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Eve"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+                        1_000 * SSC,
+                    ),
+                    (
+                        get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                        1_000 * SSC,
+                    ),
                 ],
                 vec![],
             )
@@ -184,10 +236,10 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 }
 
 /// Configure initial storage state for FRAME modules.
-fn testnet_genesis(
+fn create_genesis_config(
     wasm_binary: &[u8],
     root_key: AccountId,
-    endowed_accounts: Vec<AccountId>,
+    balances: Vec<(AccountId, Balance)>,
     vesting: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 ) -> GenesisConfig {
     GenesisConfig {
@@ -196,14 +248,7 @@ fn testnet_genesis(
             code: wasm_binary.to_vec(),
             changes_trie_config: Default::default(),
         },
-        balances: BalancesConfig {
-            // Configure endowed accounts with initial balance of 1 << 60.
-            balances: endowed_accounts
-                .iter()
-                .cloned()
-                .map(|k| (k, 1 << 60))
-                .collect(),
-        },
+        balances: BalancesConfig { balances },
         subspace: SubspaceConfig {
             epoch_config: Some(subspace_runtime::SUBSPACE_GENESIS_EPOCH_CONFIG),
         },

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -16,15 +16,43 @@
 
 use sc_service::{ChainType, Properties};
 use sc_telemetry::TelemetryEndpoints;
+use sp_core::crypto::Ss58Codec;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subspace_runtime::{
     AccountId, Balance, BalancesConfig, BlockNumber, GenesisConfig, Signature, SubspaceConfig,
-    SudoConfig, SystemConfig, VestingConfig, SSC, WASM_BINARY,
+    SudoConfig, SystemConfig, VestingConfig, MILLISECS_PER_BLOCK, SSC, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
 const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
+
+/// List of accounts which should receive token grants, amounts are specified in SSC.
+const TOKEN_GRANTS: &[(&str, u128)] = &[
+    (
+        "5Dns1SVEeDqnbSm2fVUqHJPCvQFXHVsgiw28uMBwmuaoKFYi",
+        3_000_000,
+    ),
+    (
+        "5DxtHHQL9JGapWCQARYUAWj4yDcwuhg9Hsk5AjhEzuzonVyE",
+        1_500_000,
+    ),
+    ("5EHhw9xuQNdwieUkNoucq2YcateoMVJQdN8EZtmRy3roQkVK", 133_333),
+    ("5C5qYYCQBnanGNPGwgmv6jiR2MxNPrGnWYLPFEyV1Xdy2P3x", 178_889),
+    ("5GBWVfJ253YWVPHzWDTos1nzYZpa9TemP7FpQT9RnxaFN6Sz", 350_000),
+    ("5F9tEPid88uAuGbjpyegwkrGdkXXtaQ9sGSWEnYrfVCUCsen", 111_111),
+    ("5DkJFCv3cTBsH5y1eFT94DXMxQ3EmVzYojEA88o56mmTKnMp", 244_444),
+    ("5G23o1yxWgVNQJuL4Y9UaCftAFvLuMPCRe7BCARxCohjoHc9", 311_111),
+    ("5GhHwuJoK1b7uUg5oi8qUXxWHdfgzv6P5CQSdJ3ffrnPRgKM", 317_378),
+    ("5EqBwtqrCV427xCtTsxnb9X2Qay39pYmKNk9wD9Kd62jLS97", 300_000),
+    ("5D9pNnGCiZ9UqhBQn5n71WFVaRLvZ7znsMvcZ7PHno4zsiYa", 600_000),
+    ("5DXfPcXUcP4BG8LBSkJDrfFNApxjWySR6ARfgh3v27hdYr5S", 430_000),
+    ("5CXSdDJgzRTj54f9raHN2Z5BNPSMa2ETjqCTUmpaw3ECmwm4", 330_000),
+    ("5DqKxL7bQregQmUfFgzTMfRKY4DSvA1KgHuurZWYmxYSCmjY", 200_000),
+    ("5CfixiS93yTwHQbzzfn8P2tMxhKXdTx7Jam9htsD7XtiMFtn", 27_800),
+    ("5FZe9YzXeEXe7sK5xLR8yCmbU8bPJDTZpNpNbToKvSJBUiEo", 18_067),
+    ("5FZwEgsvZz1vpeH7UsskmNmTpbfXvAcojjgVfShgbRqgC1nx", 27_800),
+];
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
@@ -39,11 +67,8 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 type AccountPublic = <Signature as Verify>::Signer;
 
 /// Generate an account ID from seed.
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
-where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
-{
-    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+pub fn get_account_id_from_seed(seed: &str) -> AccountId {
+    AccountPublic::from(get_from_seed::<sr25519::Public>(seed)).into_account()
 }
 
 pub fn testnet_config() -> Result<ChainSpec, String> {
@@ -53,30 +78,59 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         // ID
         "subspace_test",
         ChainType::Custom("Subspace testnet".to_string()),
-        // TODO: Provide a way for farmer to start with these accounts
         || {
-            // st6iwqnxNab6JUawtmqUmftG2oSsKoTaWzbg9PxdWrWw5C6Th
-            let root_account: AccountId =
-                "0x14682f9dea76a4dd47172a118eb29b9cf9976df7ade12f95709a7cd2e3d81d6c"
-                    .parse()
-                    .expect("Wrong root account ID");
+            let sudo_account =
+                AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
+                    .expect("Wrong root account address");
+
+            // Pre-funded accounts
+            // TODO: Remove these later, this is just for testing
+            let mut balances = vec![
+                (sudo_account.clone(), 1_000 * SSC),
+                (get_account_id_from_seed("Alice"), 1_000 * SSC),
+                (get_account_id_from_seed("Bob"), 1_000 * SSC),
+            ];
+            let vesting_schedules = TOKEN_GRANTS
+                .iter()
+                .flat_map(|&(account_address, amount)| {
+                    let account_id = AccountId::from_ss58check(account_address)
+                        .expect("Wrong vesting account address");
+                    let amount: Balance = amount * SSC;
+
+                    // TODO: Adjust start block to real value before mainnet launch
+                    let start_block = 100_000_000;
+                    let one_month_in_blocks =
+                        u32::try_from(3600 * 24 * 30 * MILLISECS_PER_BLOCK / 1000)
+                            .expect("One month of blocks always fits in u32; qed");
+
+                    // Add balance so it can be locked
+                    balances.push((account_id.clone(), amount));
+
+                    [
+                        // 1/4 of tokens are released after 1 year.
+                        (
+                            account_id.clone(),
+                            start_block,
+                            one_month_in_blocks * 12,
+                            1,
+                            amount / 4,
+                        ),
+                        // 1/48 of tokens are released every month after that for 3 more years.
+                        (
+                            account_id,
+                            start_block + one_month_in_blocks * 12,
+                            one_month_in_blocks,
+                            36,
+                            amount / 48,
+                        ),
+                    ]
+                })
+                .collect::<Vec<_>>();
             create_genesis_config(
                 WASM_BINARY.expect("Wasm binary must be built for testnet"),
-                // Sudo account
-                root_account.clone(),
-                // Pre-funded accounts
-                vec![
-                    (root_account, 1_000 * SSC),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Alice"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Bob"),
-                        1_000 * SSC,
-                    ),
-                ],
-                vec![],
+                sudo_account,
+                balances,
+                vesting_schedules,
             )
         },
         // Bootnodes
@@ -118,25 +172,13 @@ pub fn development_config() -> Result<ChainSpec, String> {
             create_genesis_config(
                 wasm_binary,
                 // Sudo account
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
+                get_account_id_from_seed("Alice"),
                 // Pre-funded accounts
                 vec![
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Alice"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Bob"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                        1_000 * SSC,
-                    ),
+                    (get_account_id_from_seed("Alice"), 1_000 * SSC),
+                    (get_account_id_from_seed("Bob"), 1_000 * SSC),
+                    (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
                 ],
                 vec![],
             )
@@ -167,57 +209,21 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
             create_genesis_config(
                 wasm_binary,
                 // Sudo account
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
+                get_account_id_from_seed("Alice"),
                 // Pre-funded accounts
                 vec![
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Alice"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Bob"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Dave"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Eve"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                        1_000 * SSC,
-                    ),
-                    (
-                        get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-                        1_000 * SSC,
-                    ),
+                    (get_account_id_from_seed("Alice"), 1_000 * SSC),
+                    (get_account_id_from_seed("Bob"), 1_000 * SSC),
+                    (get_account_id_from_seed("Charlie"), 1_000 * SSC),
+                    (get_account_id_from_seed("Dave"), 1_000 * SSC),
+                    (get_account_id_from_seed("Eve"), 1_000 * SSC),
+                    (get_account_id_from_seed("Ferdie"), 1_000 * SSC),
+                    (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Charlie//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Dave//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Eve//stash"), 1_000 * SSC),
+                    (get_account_id_from_seed("Ferdie//stash"), 1_000 * SSC),
                 ],
                 vec![],
             )
@@ -238,8 +244,9 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 /// Configure initial storage state for FRAME modules.
 fn create_genesis_config(
     wasm_binary: &[u8],
-    root_key: AccountId,
+    sudo_account: AccountId,
     balances: Vec<(AccountId, Balance)>,
+    // who, start, period, period_count, per_period
     vesting: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 ) -> GenesisConfig {
     GenesisConfig {
@@ -254,7 +261,7 @@ fn create_genesis_config(
         },
         sudo: SudoConfig {
             // Assign network admin rights.
-            key: root_key,
+            key: sudo_account,
         },
         vesting: VestingConfig { vesting },
     }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use sc_service::ChainType;
+use sc_service::{ChainType, Properties};
 use sc_telemetry::TelemetryEndpoints;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
@@ -79,7 +79,16 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         // Protocol ID
         Some("subspace"),
         // Properties
-        None,
+        Some(Properties::from_iter([
+            (
+                "tokenDecimals".to_string(),
+                serde_json::to_value(18_u8).expect("u8 is always serializable; qed"),
+            ),
+            (
+                "tokenSymbol".to_string(),
+                serde_json::to_value("tSSC").expect("&str is always serializable; qed"),
+            ),
+        ])),
         // Extensions
         None,
     ))

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -55,12 +55,18 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         ChainType::Custom("Subspace testnet".to_string()),
         // TODO: Provide a way for farmer to start with these accounts
         || {
+            // st6iwqnxNab6JUawtmqUmftG2oSsKoTaWzbg9PxdWrWw5C6Th
+            let root_account: AccountId =
+                "0x14682f9dea76a4dd47172a118eb29b9cf9976df7ade12f95709a7cd2e3d81d6c"
+                    .parse()
+                    .expect("Wrong root account ID");
             testnet_genesis(
                 WASM_BINARY.expect("Wasm binary must be built for testnet"),
                 // Sudo account
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
+                root_account.clone(),
                 // Pre-funded accounts
                 vec![
+                    root_account,
                     get_account_id_from_seed::<sr25519::Public>("Alice"),
                     get_account_id_from_seed::<sr25519::Public>("Bob"),
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -16,6 +16,7 @@ frame-executive = { version = "4.0.0-dev", default-features = false, git = "http
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 hex-literal = { version = "0.3.3", optional = true }
+orml-vesting = { version = "0.4.1-dev", default-features = false, git = "https://github.com/subspace/open-runtime-module-library", branch = "substrate-monthly-2021-10" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 pallet-feeds = { version = "0.1.0", default-features = false, path = "../pallet-feeds" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../pallet-offences-subspace" }
@@ -57,6 +58,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"frame-system-rpc-runtime-api/std",
+	"orml-vesting/std",
 	"pallet-balances/std",
 	"pallet-feeds/std",
 	"pallet-offences-subspace/std",
@@ -86,6 +88,7 @@ runtime-benchmarks = [
 	"frame-system-benchmarking",
 	"frame-system/runtime-benchmarks",
 	"hex-literal",
+	"orml-vesting/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -16,7 +16,7 @@ frame-executive = { version = "4.0.0-dev", default-features = false, git = "http
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 hex-literal = { version = "0.3.3", optional = true }
-orml-vesting = { version = "0.4.1-dev", default-features = false, git = "https://github.com/subspace/open-runtime-module-library", branch = "substrate-monthly-2021-10" }
+orml-vesting = { version = "0.4.1-dev", default-features = false, git = "https://github.com/subspace/open-runtime-module-library", branch = "multiple-genesis-schedules-substrate-monthly-2021-10" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "bf9683eee40f82cc4e01a05cd375b0e8bba3c8ef" }
 pallet-feeds = { version = "0.1.0", default-features = false, path = "../pallet-feeds" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../pallet-offences-subspace" }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -121,6 +121,11 @@ pub fn native_version() -> NativeVersion {
     }
 }
 
+/// The smallest unit of the token is called Shannon.
+pub const SHANNON: Balance = 1;
+/// One Subspace Credit has 18 decimal places.
+pub const SSC: Balance = (10 * SHANNON).pow(18);
+
 // TODO: Many of below constants should probably be updatable but currently they are not
 
 /// Since Subspace is probabilistic this is the average expected block time that
@@ -319,7 +324,7 @@ impl pallet_timestamp::Config for Runtime {
 
 parameter_types! {
     // TODO: this depends on the value of our native token?
-    pub const ExistentialDeposit: Balance = 500;
+    pub const ExistentialDeposit: Balance = 500 * SHANNON;
     pub const MaxLocks: u32 = 50;
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const SSC: Balance = (10 * SHANNON).pow(18);
 ///
 /// Based on:
 /// <https://research.web3.foundation/en/latest/polkadot/block-production/Babe.html#-6.-practical-results>
-const MILLISECS_PER_BLOCK: u64 = 6000;
+pub const MILLISECS_PER_BLOCK: u64 = 6000;
 
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.


### PR DESCRIPTION
Integration of `orml-vesting` pallet and some related tweaks/refactoring.

I had to use fork of the orml repo for 2 reasons:
* to make it depend on the same Substrate snapshot as we use otherwise
* to add support for multiple vesting schedules for the same account (see https://github.com/open-web3-stack/open-runtime-module-library/pull/644)

Draft because one address is still missing