### PR TITLE
Use an unit type wrapper for Piece

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6198,6 +6198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrays"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7220,6 +7229,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "serde_arrays",
  "sha2 0.9.8",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,6 +4188,7 @@ name = "pallet-utility"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?rev=26d69bcbe26f6b463e9374e1b1c54c3067fb6131#26d69bcbe26f6b463e9374e1b1c54c3067fb6131"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -194,7 +194,7 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
     let subspace_solving = SubspaceCodec::new(&keypair.public);
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let piece_index = 0;
-    let mut piece: Piece = [0u8; 4096];
+    let mut piece: Piece = [0u8; 4096].into();
     subspace_solving.encode(piece_index, &mut piece).unwrap();
     let tag: Tag = subspace_solving::create_tag(&piece, Subspace::salt().to_le_bytes());
 
@@ -250,7 +250,7 @@ pub fn generate_equivocation_proof(
     let current_slot = CurrentSlot::<Test>::get();
 
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
-    let encoding: Piece = [0u8; 4096];
+    let encoding: Piece = [0u8; 4096].into();
     let tag: Tag = [(current_block % 8) as u8; 8];
 
     let public_key = FarmerPublicKey::from_slice(&keypair.public.to_bytes());

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -194,7 +194,7 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
     let subspace_solving = SubspaceCodec::new(&keypair.public);
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let piece_index = 0;
-    let mut piece: Piece = [0u8; 4096].into();
+    let mut piece = Piece::default();
     subspace_solving.encode(piece_index, &mut piece).unwrap();
     let tag: Tag = subspace_solving::create_tag(&piece, Subspace::salt().to_le_bytes());
 
@@ -250,7 +250,7 @@ pub fn generate_equivocation_proof(
     let current_slot = CurrentSlot::<Test>::get();
 
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
-    let encoding: Piece = [0u8; 4096].into();
+    let encoding = Piece::default();
     let tag: Tag = [(current_block % 8) as u8; 8];
 
     let public_key = FarmerPublicKey::from_slice(&keypair.public.to_bytes());

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -781,7 +781,7 @@ fn propose_and_import_block<Transaction: Send + 'static>(
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
 
     let (pre_digest, signature) = {
-        let encoding: Piece = [0u8; 4096].into();
+        let encoding = Piece::default();
         let tag: Tag = [0u8; 8];
 
         let signature = keypair.sign(ctx.bytes(&tag)).to_bytes().to_vec();

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -781,7 +781,7 @@ fn propose_and_import_block<Transaction: Send + 'static>(
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
 
     let (pre_digest, signature) = {
-        let encoding: Piece = [0u8; 4096];
+        let encoding: Piece = [0u8; 4096].into();
         let tag: Tag = [0u8; 8];
 
         let signature = keypair.sign(ctx.bytes(&tag)).to_bytes().to_vec();

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -647,7 +647,7 @@ impl<State: private::ArchiverState> Archiver<State> {
                 let witness = merkle_tree
                     .get_witness(position)
                     .expect("We use the same indexes as during Merkle tree creation; qed");
-                let mut piece = [0u8; PIECE_SIZE];
+                let mut piece = Piece::default();
 
                 piece.as_mut().write_all(&record).expect(
                     "With correct archiver parameters record is always smaller than \
@@ -660,7 +660,7 @@ impl<State: private::ArchiverState> Archiver<State> {
                     never happens; qed",
                 );
 
-                piece.into()
+                piece
             })
             .collect();
 

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -647,7 +647,7 @@ impl<State: private::ArchiverState> Archiver<State> {
                 let witness = merkle_tree
                     .get_witness(position)
                     .expect("We use the same indexes as during Merkle tree creation; qed");
-                let mut piece: Piece = [0u8; PIECE_SIZE];
+                let mut piece = [0u8; PIECE_SIZE];
 
                 piece.as_mut().write_all(&record).expect(
                     "With correct archiver parameters record is always smaller than \
@@ -660,7 +660,7 @@ impl<State: private::ArchiverState> Archiver<State> {
                     never happens; qed",
                 );
 
-                piece
+                piece.into()
             })
             .collect();
 

--- a/crates/subspace-archiving/tests/integration/merkle_tree.rs
+++ b/crates/subspace-archiving/tests/integration/merkle_tree.rs
@@ -1,11 +1,12 @@
+use std::iter;
 use subspace_archiving::merkle_tree::{MerkleTree, MerkleTreeWitnessError};
 use subspace_core_primitives::{crypto, Piece, Sha256Hash, PIECE_SIZE};
 
 #[test]
 fn merkle_tree() {
     let number_of_pieces = 16_usize;
-    let pieces: Vec<Piece> = (0..number_of_pieces)
-        .map(|_| [rand::random(); PIECE_SIZE].into())
+    let pieces: Vec<Piece> = iter::repeat_with(|| rand::random::<[u8; PIECE_SIZE]>().into())
+        .take(number_of_pieces)
         .collect();
     let hashes: Vec<Sha256Hash> = pieces.iter().map(crypto::sha256_hash).collect();
 

--- a/crates/subspace-archiving/tests/integration/merkle_tree.rs
+++ b/crates/subspace-archiving/tests/integration/merkle_tree.rs
@@ -1,12 +1,11 @@
-use std::iter;
 use subspace_archiving::merkle_tree::{MerkleTree, MerkleTreeWitnessError};
-use subspace_core_primitives::{crypto, Piece, Sha256Hash};
+use subspace_core_primitives::{crypto, Piece, Sha256Hash, PIECE_SIZE};
 
 #[test]
 fn merkle_tree() {
     let number_of_pieces = 16_usize;
-    let pieces: Vec<Piece> = iter::repeat_with(rand::random)
-        .take(number_of_pieces)
+    let pieces: Vec<Piece> = (0..number_of_pieces)
+        .map(|_| [rand::random(); PIECE_SIZE].into())
         .collect();
     let hashes: Vec<Sha256Hash> = pieces.iter().map(crypto::sha256_hash).collect();
 

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,6 +17,7 @@ hmac = { version  = "0.11.0", default-features = false }
 parity-scale-codec = { version = "2.3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
+serde_arrays = { version = "0.1", optional = true }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -36,5 +37,6 @@ std = [
     "parity-scale-codec/std",
     "scale-info/std",
     "serde/std",
+    "serde_arrays",
     "sha2/std",
 ]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -23,6 +23,8 @@
 pub mod crypto;
 pub mod objects;
 
+use core::convert::AsRef;
+use core::ops::{Deref, DerefMut};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
@@ -42,13 +44,6 @@ pub const RANDOMNESS_LENGTH: usize = 32;
 /// Sha2-256 hash output
 pub type Sha256Hash = [u8; SHA256_HASH_SIZE];
 
-/// A piece of archival history in Subspace Network.
-///
-/// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
-/// the segment this piece belongs to can be used to verify that a piece belongs to the actual
-/// archival history of the blockchain.
-pub type Piece = [u8; PIECE_SIZE];
-
 /// Type of randomness.
 pub type Randomness = [u8; RANDOMNESS_LENGTH];
 
@@ -59,6 +54,52 @@ pub type Tag = [u8; 8];
 
 /// Salt used for creating commitment tags for pieces.
 pub type Salt = [u8; 8];
+
+/// A piece of archival history in Subspace Network.
+///
+/// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
+/// the segment this piece belongs to can be used to verify that a piece belongs to the actual
+/// archival history of the blockchain.
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct Piece(#[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; PIECE_SIZE]);
+
+impl From<[u8; PIECE_SIZE]> for Piece {
+    fn from(inner: [u8; PIECE_SIZE]) -> Self {
+        Self(inner)
+    }
+}
+
+impl TryFrom<&[u8]> for Piece {
+    type Error = &'static str;
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        slice
+            .try_into()
+            .map(Self)
+            .map_err(|_| "Wrong piece size, expected: 4096")
+    }
+}
+
+impl Deref for Piece {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Piece {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Piece {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
 
 /// Progress of an archived block.
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -66,6 +66,12 @@ pub type Salt = [u8; 8];
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Piece(#[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; PIECE_SIZE]);
 
+impl Default for Piece {
+    fn default() -> Self {
+        Self([0u8; PIECE_SIZE])
+    }
+}
+
 impl From<[u8; PIECE_SIZE]> for Piece {
     fn from(inner: [u8; PIECE_SIZE]) -> Self {
         Self(inner)
@@ -98,6 +104,12 @@ impl DerefMut for Piece {
 impl AsRef<[u8]> for Piece {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl AsMut<[u8]> for Piece {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
     }
 }
 

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -4,7 +4,7 @@ use crate::plot::Plot;
 use rand::prelude::*;
 use rand::rngs::StdRng;
 use std::sync::Arc;
-use subspace_core_primitives::{Piece, PIECE_SIZE};
+use subspace_core_primitives::Piece;
 use tempfile::TempDir;
 
 fn init() {
@@ -59,9 +59,9 @@ async fn find_by_tag() {
         Arc::new(
             (0..1024_usize)
                 .map(|_| {
-                    let mut bytes = [0u8; PIECE_SIZE];
-                    rng.fill(&mut bytes[..]);
-                    bytes.into()
+                    let mut piece = Piece::default();
+                    rng.fill(&mut piece[..]);
+                    piece
                 })
                 .collect(),
         ),

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -16,7 +16,7 @@ async fn create() {
     init();
     let base_directory = TempDir::new().unwrap();
 
-    let piece: Piece = [9u8; 4096];
+    let piece: Piece = [9u8; 4096].into();
     let salt: Salt = [1u8; 8];
     let correct_tag: Tag = [23, 245, 162, 52, 107, 135, 192, 210];
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
@@ -61,7 +61,7 @@ async fn find_by_tag() {
                 .map(|_| {
                     let mut bytes = [0u8; PIECE_SIZE];
                     rng.fill(&mut bytes[..]);
-                    bytes
+                    bytes.into()
                 })
                 .collect(),
         ),

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -134,7 +134,7 @@ impl Plot {
                                             .await?;
                                         let mut buffer = [0u8; PIECE_SIZE];
                                         plot_file.read_exact(&mut buffer).await?;
-                                        buffer
+                                        buffer.into()
                                     },
                                 );
                             }

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -132,9 +132,9 @@ impl Plot {
                                         plot_file
                                             .seek(SeekFrom::Start(index * PIECE_SIZE as u64))
                                             .await?;
-                                        let mut buffer = [0u8; PIECE_SIZE];
+                                        let mut buffer = Piece::default();
                                         plot_file.read_exact(&mut buffer).await?;
-                                        buffer.into()
+                                        buffer
                                     },
                                 );
                             }

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -1,9 +1,7 @@
 use crate::plot::Plot;
 use rand::prelude::*;
 use std::sync::Arc;
-use subspace_core_primitives::{
-    ArchivedBlockProgress, LastArchivedBlock, Piece, RootBlock, PIECE_SIZE,
-};
+use subspace_core_primitives::{ArchivedBlockProgress, LastArchivedBlock, Piece, RootBlock};
 use tempfile::TempDir;
 
 fn init() {
@@ -11,9 +9,9 @@ fn init() {
 }
 
 fn generate_random_piece() -> Piece {
-    let mut bytes = [0u8; PIECE_SIZE];
-    rand::thread_rng().fill(&mut bytes[..]);
-    bytes.into()
+    let mut piece = Piece::default();
+    rand::thread_rng().fill(&mut piece[..]);
+    piece
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -13,7 +13,7 @@ fn init() {
 fn generate_random_piece() -> Piece {
     let mut bytes = [0u8; PIECE_SIZE];
     rand::thread_rng().fill(&mut bytes[..]);
-    bytes
+    bytes.into()
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
The motivation is when I'm working on the issue of deduplicating the RPC types,
I found that `RpcArchivedSegment` can be improved, while it can't be simply replaced
with `ArchivedSegment` because currently serde only supports the arrays up to 32
elements by default, therefore a type wrapper for the big array is necessary.

There are two crates for implementing the serde feature on the big array at the moment:

- https://github.com/est31/serde-big-array
- https://github.com/Kromey/serde_arrays

No particular reason, I choose `serde_arrays` just because it supports
nested array already while `serde-big-array` does not yet.