### PR TITLE
Tweak weights on extrinsics

### DIFF
--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -109,14 +109,15 @@ mod pallet {
         }
 
         // TODO: add proper weights
+        // TODO: For now we don't have fees, but we will have them in the future
         /// Put a new object into a feed
-        #[pallet::weight(10_000)]
+        #[pallet::weight((10_000, Pays::No))]
         pub fn put(
             origin: OriginFor<T>,
             feed_id: FeedId,
             data: PutDataObject,
             metadata: ObjectMetadata,
-        ) -> DispatchResultWithPostInfo {
+        ) -> DispatchResult {
             let who = ensure_signed(origin)?;
 
             let object_size = data.len() as u64;
@@ -137,8 +138,7 @@ mod pallet {
 
             Self::deposit_event(Event::DataSubmitted(metadata, who, object_size));
 
-            // TODO: For now we don't have fees, but we will have them in the future
-            Ok(Pays::No.into())
+            Ok(())
         }
     }
 }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -442,7 +442,7 @@ pub mod pallet {
         /// This extrinsic must be called unsigned and it is expected that only block authors will
         /// call it (validated in `ValidateUnsigned`), as such if the block author is defined it
         /// will be defined as the equivocation reporter.
-        #[pallet::weight(<T as Config>::WeightInfo::report_equivocation())]
+        #[pallet::weight((<T as Config>::WeightInfo::report_equivocation(), DispatchClass::Operational))]
         // Suppression because the custom syntax will also generate an enum and we need enum to have
         // boxed value.
         #[allow(clippy::boxed_local)]
@@ -474,7 +474,7 @@ pub mod pallet {
         ///
         /// This extrinsic must be called unsigned and it is expected that only block authors will
         /// call it (validated in `ValidateUnsigned`).
-        #[pallet::weight(<T as Config>::WeightInfo::store_root_block())]
+        #[pallet::weight((<T as Config>::WeightInfo::store_root_block(), DispatchClass::Mandatory, Pays::No))]
         pub fn store_root_block(
             origin: OriginFor<T>,
             root_block: RootBlock,


### PR DESCRIPTION
Having `Pays::No` in the attribute allows to reduce number of events generated for `put` call (otherwise it charges account first and then does refund, generating a pair of events for every call).