### PR TITLE
Eliminate common.rs in farmer

### DIFF
--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests;
 
-use crate::common::BATCH_SIZE;
 use crate::plot::Plot;
 use async_lock::Mutex;
 use async_std::io;
@@ -16,6 +15,7 @@ use std::sync::Arc;
 use subspace_core_primitives::{Piece, Salt, Tag, PIECE_SIZE};
 use thiserror::Error;
 
+const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;
 const COMMITMENTS_CACHE_SIZE: usize = 2;
 const COMMITMENTS_KEY: &[u8] = b"commitments";
 

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::common::{Salt, Tag, BATCH_SIZE};
+use crate::common::BATCH_SIZE;
 use crate::plot::Plot;
 use async_lock::Mutex;
 use async_std::io;
@@ -13,7 +13,7 @@ use rocksdb::{Options, DB};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use subspace_core_primitives::{Piece, PIECE_SIZE};
+use subspace_core_primitives::{Piece, Salt, Tag, PIECE_SIZE};
 use thiserror::Error;
 
 const COMMITMENTS_CACHE_SIZE: usize = 2;

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -1,10 +1,9 @@
 use crate::commitments::Commitments;
-use crate::common::{Salt, Tag};
 use crate::plot::Plot;
 use rand::prelude::*;
 use rand::rngs::StdRng;
 use std::sync::Arc;
-use subspace_core_primitives::Piece;
+use subspace_core_primitives::{Piece, Salt, Tag};
 use tempfile::TempDir;
 
 fn init() {

--- a/crates/subspace-farmer/src/common.rs
+++ b/crates/subspace-farmer/src/common.rs
@@ -1,5 +1,3 @@
 use subspace_core_primitives::PIECE_SIZE;
 
-pub(crate) type Tag = [u8; 8];
-pub(crate) type Salt = [u8; 8];
 pub(crate) const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;

--- a/crates/subspace-farmer/src/common.rs
+++ b/crates/subspace-farmer/src/common.rs
@@ -1,3 +1,0 @@
-use subspace_core_primitives::PIECE_SIZE;
-
-pub(crate) const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -1,5 +1,4 @@
 use crate::commitments::Commitments;
-use crate::common::Salt;
 use crate::identity::Identity;
 use crate::plot::Plot;
 use crate::rpc::{ProposedProofOfReplicationResponse, RpcClient, SlotInfo, Solution};
@@ -7,7 +6,7 @@ use anyhow::Result;
 use futures::{future, future::Either};
 use log::{debug, error, info, trace};
 use std::time::Instant;
-use subspace_core_primitives::crypto;
+use subspace_core_primitives::{crypto, Salt};
 
 /// Farming Instance to store the necessary information for the farming operations,
 /// and also a channel to stop/pause the background farming task

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -18,7 +18,6 @@
 
 pub(crate) mod commands; // TODO: remove this again (temporarily inserted)
 pub(crate) mod commitments;
-pub(crate) mod common;
 pub(crate) mod farming;
 pub(crate) mod identity;
 pub(crate) mod object_mappings;

--- a/crates/subspace-farmer/src/main.rs
+++ b/crates/subspace-farmer/src/main.rs
@@ -18,7 +18,6 @@
 
 mod commands;
 mod commitments;
-mod common;
 mod farming;
 mod identity;
 mod object_mappings;

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -1,4 +1,3 @@
-use crate::common::{Salt, Tag};
 use hex_buffer_serde::{Hex, HexForm};
 use jsonrpsee::types::traits::{Client, SubscriptionClient};
 use jsonrpsee::types::v2::params::JsonRpcParams;
@@ -7,6 +6,7 @@ use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subspace_core_primitives::objects::BlockObjectMapping;
+use subspace_core_primitives::{Salt, Tag};
 
 type SlotNumber = u64;
 


### PR DESCRIPTION
Seemingly `common.rs` is not neccessary.