### PR TITLE
Fix root block extrinsic longevity to make sure it gets included into the next block

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1018,7 +1018,7 @@ impl<T: Config> Pallet<T> {
                 // Only one root block for every segment index.
                 .and_provides(root_block.segment_index())
                 // Should be included immediately into the upcoming block with no exceptions.
-                .longevity(0)
+                .longevity(1)
                 // We don't propagate this. This can never be included on a remote node.
                 .propagate(false)
                 .build()

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -613,7 +613,7 @@ fn store_root_block_validate_unsigned_prevents_duplicates() {
                 priority: TransactionPriority::MAX,
                 requires: vec![],
                 provides: vec![("SubspaceRootBlock", segment_index).encode()],
-                longevity: 0,
+                longevity: 1,
                 propagate: false,
             })
         );


### PR DESCRIPTION
I wasn't able to figure it out 100% precisely, but for some reason, sometimes root block extrinsic was considered invalid and dropped from tx pool that was breaking consensus.

It only happened under specific situation where there was no block production for a brief period of time, but a lot of extrinsics were accumulated in the meantime.

I though it might be caused by revalidation of extrinsics after every slot, but that wasn't the reason because the same situation with a few slots skipped didn't cause issues when there wasn't a large number of extrinsics in tx pool.

All in all, I don't see the clear logic behind it, but with `1` block longevity (which seems to be correct after reading of the substrate code) it works. Not sure why it also mostly worked with value `0` :man_shrugging: 