### PR TITLE
Farmer lib phase4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7202,6 +7202,7 @@ dependencies = [
  "async-lock",
  "async-oneshot",
  "async-std",
+ "async-trait",
  "clap 3.0.0-beta.5",
  "dirs",
  "env_logger 0.9.0",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0.44"
 async-lock = "2.4.0"
 async-oneshot = "0.5.0"
 async-std = "1.9.0"
+async-trait = "0.1.51"
 clap = { version = "3.0.0-beta.5", features = ["color", "derive"] }
 dirs = "4.0.0"
 env_logger = "0.9.0"

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -4,7 +4,7 @@ use crate::identity::Identity;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::plotting::Plotting;
-use crate::rpc::RpcClient;
+use crate::web_socket_rpc::WebSocketRpc;
 use anyhow::{anyhow, Result};
 use log::info;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub(crate) async fn farm(base_directory: PathBuf, ws_server: &str) -> Result<(),
     .await??;
 
     info!("Connecting to RPC server: {}", ws_server);
-    let client = RpcClient::new(ws_server).await?;
+    let client = WebSocketRpc::new(ws_server).await?;
 
     let identity = Identity::open_or_create(&base_directory)?;
 

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -4,7 +4,7 @@ use crate::identity::Identity;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::plotting::Plotting;
-use crate::web_socket_rpc::WebSocketRpc;
+use crate::ws_rpc::WsRpc;
 use anyhow::{anyhow, Result};
 use log::info;
 use std::path::PathBuf;
@@ -28,7 +28,7 @@ pub(crate) async fn farm(base_directory: PathBuf, ws_server: &str) -> Result<(),
     .await??;
 
     info!("Connecting to RPC server: {}", ws_server);
-    let client = WebSocketRpc::new(ws_server).await?;
+    let client = WsRpc::new(ws_server).await?;
 
     let identity = Identity::open_or_create(&base_directory)?;
 

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -1,7 +1,7 @@
 use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::plot::Plot;
-use crate::rpc::RpcClient;
+use crate::web_socket_rpc::WebSocketRpc;
 use futures::{future, future::Either};
 use log::{debug, error, info, trace};
 use std::time::Instant;
@@ -32,7 +32,7 @@ impl Farming {
     pub fn start(
         plot: Plot,
         commitments: Commitments,
-        client: RpcClient,
+        client: WebSocketRpc,
         identity: Identity,
     ) -> Self {
         let (sender, receiver) = async_oneshot::oneshot();
@@ -69,7 +69,7 @@ impl Drop for Farming {
 }
 
 async fn background_farming(
-    client: RpcClient,
+    client: WebSocketRpc,
     plot: Plot,
     commitments: Commitments,
     identity: Identity,
@@ -104,7 +104,7 @@ struct Salts {
 }
 
 async fn subscribe_to_slot_info(
-    client: &RpcClient,
+    client: &WebSocketRpc,
     plot: &Plot,
     commitments: &Commitments,
     identity: &Identity,

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -1,7 +1,7 @@
 use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::plot::Plot;
-use crate::web_socket_rpc::WebSocketRpc;
+use crate::rpc::RpcClient;
 use futures::{future, future::Either};
 use log::{debug, error, info, trace};
 use std::time::Instant;
@@ -29,10 +29,10 @@ pub struct Farming {
 
 impl Farming {
     /// returns an instance of farming, and also starts a concurrent background farming task
-    pub fn start(
+    pub fn start<T: RpcClient + Sync + Send + 'static>(
         plot: Plot,
         commitments: Commitments,
-        client: WebSocketRpc,
+        client: T,
         identity: Identity,
     ) -> Self {
         let (sender, receiver) = async_oneshot::oneshot();
@@ -68,8 +68,8 @@ impl Drop for Farming {
     }
 }
 
-async fn background_farming(
-    client: WebSocketRpc,
+async fn background_farming<T: RpcClient + Send>(
+    client: T,
     plot: Plot,
     commitments: Commitments,
     identity: Identity,
@@ -103,8 +103,8 @@ struct Salts {
     next: Option<Salt>,
 }
 
-async fn subscribe_to_slot_info(
-    client: &WebSocketRpc,
+async fn subscribe_to_slot_info<T: RpcClient>(
+    client: &T,
     plot: &Plot,
     commitments: &Commitments,
     identity: &Identity,

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) mod identity;
 pub(crate) mod object_mappings;
 pub(crate) mod plot;
 pub(crate) mod plotting;
-pub(crate) mod rpc;
+pub(crate) mod web_socket_rpc;
 
 pub use commitments::{CommitmentError, Commitments};
 pub use farming::Farming;
@@ -30,4 +30,3 @@ pub use identity::Identity;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
 pub use plot::{Plot, PlotError};
 pub use plotting::Plotting;
-pub use rpc::RpcClient;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -22,7 +22,8 @@ pub(crate) mod identity;
 pub(crate) mod object_mappings;
 pub(crate) mod plot;
 pub(crate) mod plotting;
-pub(crate) mod web_socket_rpc;
+pub(crate) mod rpc;
+pub(crate) mod ws_rpc;
 
 pub use commitments::{CommitmentError, Commitments};
 pub use farming::Farming;
@@ -30,3 +31,5 @@ pub use identity::Identity;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
 pub use plot::{Plot, PlotError};
 pub use plotting::Plotting;
+pub use rpc::RpcClient;
+pub use ws_rpc::WsRpc;

--- a/crates/subspace-farmer/src/main.rs
+++ b/crates/subspace-farmer/src/main.rs
@@ -23,8 +23,9 @@ mod identity;
 mod object_mappings;
 mod plot;
 mod plotting;
+mod rpc;
 mod utils;
-mod web_socket_rpc;
+mod ws_rpc;
 
 use anyhow::Result;
 use clap::{Parser, ValueHint};

--- a/crates/subspace-farmer/src/main.rs
+++ b/crates/subspace-farmer/src/main.rs
@@ -23,8 +23,8 @@ mod identity;
 mod object_mappings;
 mod plot;
 mod plotting;
-mod rpc;
 mod utils;
+mod web_socket_rpc;
 
 use anyhow::Result;
 use clap::{Parser, ValueHint};

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -2,7 +2,7 @@ use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
-use crate::rpc::RpcClient;
+use crate::web_socket_rpc::WebSocketRpc;
 use log::{debug, error, info};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -48,7 +48,7 @@ impl Plotting {
         plot: Plot,
         commitments: Commitments,
         object_mappings: ObjectMappings,
-        client: RpcClient,
+        client: WebSocketRpc,
         identity: Identity,
     ) -> Self {
         let (sender, receiver) = oneshot::channel();
@@ -93,7 +93,7 @@ impl Drop for Plotting {
 //  don't want eventually
 /// Maintains plot in up to date state plotting new pieces as they are produced on the network.
 async fn background_plotting<P: AsRef<[u8]>>(
-    client: RpcClient,
+    client: WebSocketRpc,
     plot: Plot,
     commitments: Commitments,
     object_mappings: ObjectMappings,

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -2,7 +2,7 @@ use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
-use crate::web_socket_rpc::WebSocketRpc;
+use crate::rpc::RpcClient;
 use log::{debug, error, info};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -44,11 +44,11 @@ pub struct Plotting {
 }
 
 impl Plotting {
-    pub fn start(
+    pub fn start<T: RpcClient + Clone + Send + Sync + 'static>(
         plot: Plot,
         commitments: Commitments,
         object_mappings: ObjectMappings,
-        client: WebSocketRpc,
+        client: T,
         identity: Identity,
     ) -> Self {
         let (sender, receiver) = oneshot::channel();
@@ -92,8 +92,8 @@ impl Drop for Plotting {
 // TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
 //  don't want eventually
 /// Maintains plot in up to date state plotting new pieces as they are produced on the network.
-async fn background_plotting<P: AsRef<[u8]>>(
-    client: WebSocketRpc,
+async fn background_plotting<P: AsRef<[u8]>, T: RpcClient + Clone + Send + 'static>(
+    client: T,
     plot: Plot,
     commitments: Commitments,
     object_mappings: ObjectMappings,

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use jsonrpsee::types::{Error, Subscription};
+use serde::Deserialize;
+use subspace_rpc_primitives::{
+    EncodedBlockWithObjectMapping, FarmerMetadata, SlotInfo, SolutionResponse,
+};
+
+// There are more fields in this struct, but we only care about one
+#[derive(Debug, Deserialize)]
+pub struct NewHead {
+    pub number: String,
+}
+
+#[async_trait]
+pub trait RpcClient {
+    /// Get farmer metadata.
+    async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error>;
+
+    async fn block_by_number(
+        &self,
+        block_number: u32,
+    ) -> Result<Option<EncodedBlockWithObjectMapping>, Error>;
+
+    async fn subscribe_new_head(&self) -> Result<Subscription<NewHead>, Error>;
+
+    async fn subscribe_slot_info(&self) -> Result<Subscription<SlotInfo>, Error>;
+
+    async fn submit_solution_response(
+        &self,
+        solution_response: SolutionResponse,
+    ) -> Result<(), Error>;
+}

--- a/crates/subspace-farmer/src/web_socket_rpc.rs
+++ b/crates/subspace-farmer/src/web_socket_rpc.rs
@@ -16,11 +16,11 @@ pub(super) struct NewHead {
 
 /// `WsClient` wrapper.
 #[derive(Clone, Debug)]
-pub struct RpcClient {
+pub struct WebSocketRpc {
     client: Arc<WsClient>,
 }
 
-impl RpcClient {
+impl WebSocketRpc {
     /// Create a new instance of [`RpcClient`].
     pub async fn new(url: &str) -> Result<Self, Error> {
         let client = Arc::new(WsClientBuilder::default().build(url).await?);


### PR DESCRIPTION
This PR abstracts the RPC, to be able to mock it in the upcoming phase (adding integration tests).

Current `RpcClient` is renamed as `WebSocketRpc`, and a new trait is defined with the old name `RpcClient`.

`WebSocketRpc` is **no longer** public in the *library*, but the abstraction of it, the trait `RpcClient`, is public.

Any further suggestion is welcome!


Edit: WebSocketRpc is now public as suggested
