### PR TITLE
Optimize the extraction of root block from Extrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6587,6 +6587,7 @@ source = "git+https://github.com/paritytech/substrate?rev=26d69bcbe26f6b463e9374
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-arithmetic",
  "sp-runtime",
 ]

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -32,7 +32,7 @@ where
         for extrinsic in block.block.extrinsics() {
             match client
                 .runtime_api()
-                .extract_root_block(&block_to_check, extrinsic.encode())
+                .extract_root_block(&block_to_check, extrinsic)
             {
                 Ok(Some(root_block)) => match &mut latest_root_block {
                     Some(latest_root_block) => {

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -1495,7 +1495,7 @@ where
                     match self
                         .client
                         .runtime_api()
-                        .extract_root_block(&BlockId::Hash(parent_hash), extrinsic.encode())
+                        .extract_root_block(&BlockId::Hash(parent_hash), extrinsic)
                     {
                         Ok(Some(root_block)) => {
                             if !root_blocks_set.remove(&root_block) {

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -306,8 +306,8 @@ sp_api::decl_runtime_apis! {
         /// Get the merkle tree root of records for specified segment index
         fn records_root(segment_index: u64) -> Option<Sha256Hash>;
 
-        /// Try to decode an extrinsic as `store_root_block` extrinsic and get root block out of it
-        fn extract_root_block(encoded_extrinsic: Vec<u8>) -> Option<RootBlock>;
+        /// Returns `RootBlock` if the given extrinsic has one.
+        fn extract_root_block(ext: &Block::Extrinsic) -> Option<RootBlock>;
 
         /// Extract block object mapping for a given block
         fn extract_block_object_mapping(block: Block) -> BlockObjectMapping;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -23,7 +23,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use codec::{Compact, CompactLen, Decode, Encode};
+use codec::{Compact, CompactLen, Encode};
 use frame_support::{
     construct_runtime, parameter_types,
     weights::{
@@ -453,16 +453,11 @@ pub type Executive = frame_executive::Executive<
     AllPallets,
 >;
 
-fn extract_root_block(encoded_extrinsic: Vec<u8>) -> Option<RootBlock> {
-    if let Ok(extrinsic) = UncheckedExtrinsic::decode(&mut encoded_extrinsic.as_slice()) {
-        if let Call::Subspace(pallet_subspace::Call::store_root_block { root_block }) =
-            extrinsic.function
-        {
-            return Some(root_block);
-        }
+fn extract_root_block(ext: &UncheckedExtrinsic) -> Option<RootBlock> {
+    match ext.function {
+        Call::Subspace(pallet_subspace::Call::store_root_block { root_block }) => Some(root_block),
+        _ => None,
     }
-
-    None
 }
 
 fn extract_feeds_block_object_mapping(
@@ -697,8 +692,8 @@ impl_runtime_apis! {
             Subspace::records_root(segment_index)
         }
 
-        fn extract_root_block(encoded_extrinsic: Vec<u8>) -> Option<RootBlock> {
-            extract_root_block(encoded_extrinsic)
+        fn extract_root_block(ext: &<Block as BlockT>::Extrinsic) -> Option<RootBlock> {
+            extract_root_block(ext)
         }
 
         fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -1010,7 +1010,7 @@ cfg_if! {
                 }
 
                 fn extract_root_block(
-                    _encoded_extrinsic: Vec<u8>,
+                    _ext: &<Block as BlockT>::Extrinsic
                 ) -> Option<subspace_core_primitives::RootBlock> {
                     panic!("Not needed in tests")
                 }
@@ -1352,7 +1352,7 @@ cfg_if! {
                 }
 
                 fn extract_root_block(
-                    _encoded_extrinsic: Vec<u8>,
+                    _ext: &<Block as BlockT>::Extrinsic
                 ) -> Option<subspace_core_primitives::RootBlock> {
                     panic!("Not needed in tests")
                 }


### PR DESCRIPTION
Now we don't have to extract the `RootBlock` from an extrinsic by encoding/decoding it.