### PR TITLE
Refactor `claim_slot` in authorship

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -76,7 +76,7 @@ use sc_consensus_slots::{
     SimpleSlotWorker, SlotInfo, SlotProportion, StorageChanges,
 };
 use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_TRACE};
-use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 use schnorrkel::context::SigningContext;
 use schnorrkel::SecretKey;
 use sp_api::{ApiExt, NumberFor, ProvideRuntimeApi};

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -91,7 +91,8 @@ where
         slot: Slot,
         epoch_descriptor: &Self::EpochData,
     ) -> Option<Self::Claim> {
-        self.claim_slot_impl(parent_header, slot, epoch_descriptor).await
+        self.claim_slot_impl(parent_header, slot, epoch_descriptor)
+            .await
     }
 
     fn pre_digest_data(

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -91,7 +91,7 @@ where
         slot: Slot,
         epoch_descriptor: &Self::EpochData,
     ) -> Option<Self::Claim> {
-        authorship::claim_slot(self, parent_header, slot, epoch_descriptor).await
+        self.claim_slot_impl(parent_header, slot, epoch_descriptor).await
     }
 
     fn pre_digest_data(


### PR DESCRIPTION
Part of #80 

This PR mainly refactors `claim_slot` into 3 steps:

1. Prepare the neccessary data for the next slot.
2. Notify the subscribers(framers) about the new slot.
3. Await for a slot solution.

Should be reviewed by each commit.