### PR TITLE
Set SS58 prefix in testnet chain spec properties and runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6598,7 +6598,6 @@ source = "git+https://github.com/paritytech/substrate?rev=26d69bcbe26f6b463e9374
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-arithmetic",
  "sp-runtime",
 ]
@@ -7085,9 +7084,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ss58-registry"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb102b328df61c67f8ccf8471b29c31c7d6da646a867aff95fe8bff386fe7c4d"
+checksum = "dd3280d191d0d8f29c426b85cf6a3778bea71aef8ccd94034c6effac809b8b9b"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -20,8 +20,9 @@ use sp_core::crypto::Ss58Codec;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subspace_runtime::{
-    AccountId, Balance, BalancesConfig, BlockNumber, GenesisConfig, Signature, SubspaceConfig,
-    SudoConfig, SystemConfig, VestingConfig, MILLISECS_PER_BLOCK, SSC, WASM_BINARY,
+    AccountId, Balance, BalancesConfig, BlockNumber, GenesisConfig, SS58Prefix, Signature,
+    SubspaceConfig, SudoConfig, SystemConfig, VestingConfig, DECIMAL_PLACES, MILLISECS_PER_BLOCK,
+    SSC, WASM_BINARY,
 };
 
 // The URL for the telemetry server.
@@ -145,8 +146,12 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
         // Properties
         Some(Properties::from_iter([
             (
+                "ss58Format".to_string(),
+                serde_json::to_value(SS58Prefix::get()).expect("u16 is always serializable; qed"),
+            ),
+            (
                 "tokenDecimals".to_string(),
-                serde_json::to_value(18_u8).expect("u8 is always serializable; qed"),
+                serde_json::to_value(DECIMAL_PLACES).expect("u8 is always serializable; qed"),
             ),
             (
                 "tokenSymbol".to_string(),

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -123,8 +123,10 @@ pub fn native_version() -> NativeVersion {
 
 /// The smallest unit of the token is called Shannon.
 pub const SHANNON: Balance = 1;
-/// One Subspace Credit has 18 decimal places.
-pub const SSC: Balance = (10 * SHANNON).pow(18);
+/// Subspace Credits have 18 decimal places.
+pub const DECIMAL_PLACES: u8 = 18;
+/// One Subspace Credit.
+pub const SSC: Balance = (10 * SHANNON).pow(DECIMAL_PLACES as u32);
 
 // TODO: Many of below constants should probably be updatable but currently they are not
 
@@ -214,7 +216,7 @@ parameter_types! {
     pub SubspaceBlockWeights: BlockWeights = BlockWeights::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
     /// We allow for 3.75 MiB for `Normal` extrinsic with 5 MiB maximum block length.
     pub SubspaceBlockLength: BlockLength = BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO);
-    pub const SS58Prefix: u8 = 42;
+    pub const SS58Prefix: u16 = 2254;
 }
 
 // Configure FRAME pallets to include in runtime.
@@ -264,7 +266,7 @@ impl frame_system::Config for Runtime {
     type AccountData = pallet_balances::AccountData<Balance>;
     /// Weight information for the extrinsics of this pallet.
     type SystemWeightInfo = ();
-    /// This is used as an identifier of the chain. 42 is the generic substrate prefix.
+    /// This is used as an identifier of the chain.
     type SS58Prefix = SS58Prefix;
     /// The set code logic, just the default since we're not a parachain.
     type OnSetCode = ();


### PR DESCRIPTION
Also updates ss58-registry package to the version with our prefixes included in it