### PR TITLE
Farmer MockRPC revisited

### DIFF
--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use jsonrpsee::types::{Error, Subscription};
 use serde::Deserialize;
 use subspace_rpc_primitives::{
     EncodedBlockWithObjectMapping, FarmerMetadata, SlotInfo, SolutionResponse,
 };
+use tokio::sync::mpsc::Receiver;
 
 // There are more fields in this struct, but we only care about one
 #[derive(Debug, Deserialize)]
@@ -11,20 +11,27 @@ pub struct NewHead {
     pub number: String,
 }
 
+/// To become error type agnostic
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+
 #[async_trait]
 pub trait RpcClient {
     /// Get farmer metadata.
     async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error>;
 
+    /// Get a block by number.
     async fn block_by_number(
         &self,
         block_number: u32,
     ) -> Result<Option<EncodedBlockWithObjectMapping>, Error>;
 
-    async fn subscribe_new_head(&self) -> Result<Subscription<NewHead>, Error>;
+    /// Subscribe to chain head.
+    async fn subscribe_new_head(&self) -> Result<Receiver<NewHead>, Error>;
 
-    async fn subscribe_slot_info(&self) -> Result<Subscription<SlotInfo>, Error>;
+    /// Subscribe to slot.
+    async fn subscribe_slot_info(&self) -> Result<Receiver<SlotInfo>, Error>;
 
+    /// Submit a slot solution.
     async fn submit_solution_response(
         &self,
         solution_response: SolutionResponse,


### PR DESCRIPTION
Now, `subcription` is also abstracted from the RPC. So that, we won't have to create/mimic an instance of **jsonrpsee Subscription** for mocking the RPC