### PR TITLE
Farmer RPC server (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7283,6 +7283,7 @@ dependencies = [
  "env_logger 0.9.0",
  "futures 0.3.17",
  "hex",
+ "hex-buffer-serde",
  "indicatif",
  "jsonrpsee",
  "log",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -204,6 +204,12 @@ impl From<[u8; PIECE_SIZE]> for Piece {
     }
 }
 
+impl From<Piece> for [u8; PIECE_SIZE] {
+    fn from(piece: Piece) -> Self {
+        piece.0
+    }
+}
+
 impl TryFrom<&[u8]> for Piece {
     type Error = &'static str;
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -22,6 +22,7 @@ dirs = "4.0.0"
 env_logger = "0.9.0"
 futures = "0.3.13"
 hex = "0.4.3"
+hex-buffer-serde = "0.3.0"
 indicatif = "0.16.2"
 jsonrpsee = { version = "0.4.1", features = ["client", "macros", "server"] }
 log = "0.4.14"

--- a/crates/subspace-farmer/src/commands/farm.rs
+++ b/crates/subspace-farmer/src/commands/farm.rs
@@ -4,6 +4,7 @@ use crate::identity::Identity;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::plotting::Plotting;
+use crate::rpc::RpcClient;
 use crate::ws_rpc::WsRpc;
 use crate::ws_rpc_server::{RpcServer, RpcServerImpl};
 use anyhow::{anyhow, Result};
@@ -39,6 +40,11 @@ pub(crate) async fn farm(
     info!("Connecting to node at {}", node_rpc_url);
     let client = WsRpc::new(node_rpc_url).await?;
 
+    let farmer_metadata = client
+        .farmer_metadata()
+        .await
+        .map_err(|error| anyhow::Error::msg(error.to_string()))?;
+
     let identity = Identity::open_or_create(&base_directory)?;
 
     let subspace_codec = SubspaceCodec::new(&identity.public_key());
@@ -48,7 +54,13 @@ pub(crate) async fn farm(
         .build(ws_server_listen_addr)
         .await?;
     let ws_server_addr = ws_server.local_addr()?;
-    let rpc_server = RpcServerImpl::new(plot.clone(), object_mappings.clone(), subspace_codec);
+    let rpc_server = RpcServerImpl::new(
+        farmer_metadata.record_size,
+        farmer_metadata.recorded_history_segment_size,
+        plot.clone(),
+        object_mappings.clone(),
+        subspace_codec,
+    );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;
 
     info!("WS RPC server listening on {}", ws_server_addr);
@@ -58,8 +70,14 @@ pub(crate) async fn farm(
         Farming::start(plot.clone(), commitments.clone(), client.clone(), identity);
 
     // start the background plotting
-    let plotting_instance =
-        Plotting::start(plot, commitments, object_mappings, client, subspace_codec);
+    let plotting_instance = Plotting::start(
+        plot,
+        commitments,
+        object_mappings,
+        client,
+        farmer_metadata,
+        subspace_codec,
+    );
 
     tokio::select! {
         res = plotting_instance.wait() => if let Err(error) = res {

--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -21,9 +21,10 @@ pub struct ObjectMappings {
 }
 
 impl ObjectMappings {
-    /// Creates a new object mappings database
-    pub fn new(path: &Path) -> Result<Self, ObjectMappingError> {
-        let db = DB::open_default(path).map_err(ObjectMappingError::Db)?;
+    /// Opens or creates a new object mappings database
+    pub fn open_or_create<B: AsRef<Path>>(base_directory: B) -> Result<Self, ObjectMappingError> {
+        let db = DB::open_default(base_directory.as_ref().join("object-mappings"))
+            .map_err(ObjectMappingError::Db)?;
 
         Ok(Self { db: Arc::new(db) })
     }

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -48,6 +48,7 @@ impl Plotting {
         commitments: Commitments,
         object_mappings: ObjectMappings,
         client: T,
+        farmer_metadata: FarmerMetadata,
         subspace_codec: SubspaceCodec,
     ) -> Self {
         let (sender, receiver) = oneshot::channel();
@@ -58,6 +59,7 @@ impl Plotting {
                 plot,
                 commitments,
                 object_mappings,
+                farmer_metadata,
                 subspace_codec,
                 receiver,
             )
@@ -95,6 +97,7 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
     plot: Plot,
     commitments: Commitments,
     object_mappings: ObjectMappings,
+    farmer_metadata: FarmerMetadata,
     subspace_codec: SubspaceCodec,
     mut receiver: Receiver<()>,
 ) -> Result<(), PlottingError> {
@@ -106,10 +109,7 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
         pre_genesis_object_size,
         pre_genesis_object_count,
         pre_genesis_object_seed,
-    } = client
-        .farmer_metadata()
-        .await
-        .map_err(PlottingError::RpcError)?;
+    } = farmer_metadata;
 
     // TODO: This assumes fixed size segments, which might not be the case
     let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);

--- a/crates/subspace-farmer/src/rpc.rs
+++ b/crates/subspace-farmer/src/rpc.rs
@@ -12,7 +12,7 @@ pub struct NewHead {
 }
 
 /// To become error type agnostic
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[async_trait]
 pub trait RpcClient {

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -1,16 +1,119 @@
+use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use async_trait::async_trait;
+use hex_buffer_serde::{Hex, HexForm};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::error::Error;
-use log::debug;
-use subspace_core_primitives::Piece;
+use log::{debug, error};
+use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
+use subspace_core_primitives::{Piece, Sha256Hash, PIECE_SIZE};
 use subspace_solving::SubspaceCodec;
+
+/// Same as [`Piece`], but serializes/deserialized to/from hex string
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HexPiece(#[serde(with = "HexForm")] [u8; PIECE_SIZE]);
+
+impl From<Piece> for HexPiece {
+    fn from(piece: Piece) -> Self {
+        HexPiece(piece.into())
+    }
+}
+
+impl From<HexPiece> for Piece {
+    fn from(piece: HexPiece) -> Self {
+        piece.0.into()
+    }
+}
+
+impl Deref for HexPiece {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for HexPiece {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for HexPiece {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for HexPiece {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+/// Similar to [`Sha256Hash`], but serializes/deserialized to/from hex string
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HexSha256Hash(#[serde(with = "HexForm")] Sha256Hash);
+
+impl From<Sha256Hash> for HexSha256Hash {
+    fn from(hash: Sha256Hash) -> Self {
+        HexSha256Hash(hash)
+    }
+}
+
+impl From<HexSha256Hash> for Sha256Hash {
+    fn from(piece: HexSha256Hash) -> Self {
+        piece.0
+    }
+}
+
+impl Deref for HexSha256Hash {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for HexSha256Hash {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for HexSha256Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for HexSha256Hash {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+/// Object stored inside in the history of the blockchain
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Object {
+    /// Piece index where object is contained (at least its beginning, might not fit fully)
+    piece_index: u64,
+    /// Offset of the object
+    offset: u16,
+    /// The data object contains for convenience
+    #[serde(with = "HexForm")]
+    data: Vec<u8>,
+}
 
 #[rpc(server, client)]
 pub trait Rpc {
     /// Get single piece by its index
     #[method(name = "getPiece")]
-    async fn get_piece(&self, piece_index: u64) -> Result<Option<Piece>, Error>;
+    async fn get_piece(&self, piece_index: u64) -> Result<Option<HexPiece>, Error>;
+
+    /// Find object by its ID
+    #[method(name = "findObject")]
+    async fn find_object(&self, object_id: HexSha256Hash) -> Result<Option<Object>, Error>;
 }
 
 /// Farmer RPC server implementation.
@@ -19,7 +122,7 @@ pub trait Rpc {
 /// ```rust
 /// # async fn f() -> anyhow::Result<()> {
 /// use jsonrpsee::ws_server::WsServerBuilder;
-/// use subspace_farmer::{Identity, Plot};
+/// use subspace_farmer::{Identity, ObjectMappings, Plot};
 /// use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 /// use subspace_solving::SubspaceCodec;
 ///
@@ -28,8 +131,9 @@ pub trait Rpc {
 ///
 /// let identity = Identity::open_or_create(base_directory)?;
 /// let plot = Plot::open_or_create(base_directory).await?;
+/// let object_mappings = ObjectMappings::open_or_create(base_directory)?;
 /// let ws_server = WsServerBuilder::default().build(ws_server_listen_addr).await?;
-/// let rpc_server = RpcServerImpl::new(plot, SubspaceCodec::new(&[0]));
+/// let rpc_server = RpcServerImpl::new(plot, object_mappings, SubspaceCodec::new(&[0]));
 /// let stop_handle = ws_server.start(rpc_server.into_rpc())?;
 ///
 /// // Keep server running
@@ -39,13 +143,15 @@ pub trait Rpc {
 /// ```
 pub struct RpcServerImpl {
     plot: Plot,
+    object_mappings: ObjectMappings,
     subspace_codec: SubspaceCodec,
 }
 
 impl RpcServerImpl {
-    pub fn new(plot: Plot, subspace_codec: SubspaceCodec) -> Self {
+    pub fn new(plot: Plot, object_mappings: ObjectMappings, subspace_codec: SubspaceCodec) -> Self {
         Self {
             plot,
+            object_mappings,
             subspace_codec,
         }
     }
@@ -53,7 +159,7 @@ impl RpcServerImpl {
 
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-    async fn get_piece(&self, piece_index: u64) -> Result<Option<Piece>, Error> {
+    async fn get_piece(&self, piece_index: u64) -> Result<Option<HexPiece>, Error> {
         let mut piece = match self.plot.read(piece_index).await {
             Ok(encoding) => encoding,
             Err(error) => {
@@ -74,6 +180,61 @@ impl RpcServer for RpcServerImpl {
                 Error::Custom("Failed to decode piece".to_string())
             })?;
 
-        Ok(Some(piece))
+        Ok(Some(piece.into()))
+    }
+
+    /// Find object by its ID
+    async fn find_object(&self, object_id: HexSha256Hash) -> Result<Option<Object>, Error> {
+        let global_object_handle = tokio::task::spawn_blocking({
+            let object_mappings = self.object_mappings.clone();
+
+            move || object_mappings.retrieve(&object_id.into())
+        });
+        let global_object = global_object_handle
+            .await
+            .map_err(|error| {
+                error!("Object mapping retrieving panicked: {}", error);
+
+                Error::Custom("Failed to find an object due to internal error".to_string())
+            })?
+            .map_err(|error| {
+                error!("Object mapping retrieving failed: {}", error);
+
+                Error::Custom("Failed to find an object due to internal error".to_string())
+            })?;
+
+        let global_object = match global_object {
+            Some(global_object) => global_object,
+            None => {
+                return Ok(None);
+            }
+        };
+
+        let piece_index = global_object.piece_index();
+        let offset = global_object.offset();
+
+        let mut piece = self.plot.read(piece_index).await.map_err(|error| {
+            debug!("Failed to read piece with index {}: {}", piece_index, error);
+
+            Error::Custom("Object mapping found, but reading piece failed".to_string())
+        })?;
+
+        self.subspace_codec
+            .decode(piece_index, &mut piece)
+            .map_err(|error| {
+                debug!(
+                    "Failed to decode piece with index {}: {}",
+                    piece_index, error
+                );
+
+                Error::Custom("Failed to decode piece".to_string())
+            })?;
+
+        Ok(Some(Object {
+            piece_index,
+            offset,
+            // TODO: Just offset is not enough, need to read and handle length properly too
+            data: piece[offset as usize..].to_vec(),
+        }))
     }
 }

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -5,13 +5,14 @@ use hex_buffer_serde::{Hex, HexForm};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::error::Error;
 use log::{debug, error};
+use parity_scale_codec::{Compact, Decode};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 use subspace_core_primitives::{Piece, Sha256Hash, PIECE_SIZE};
 use subspace_solving::SubspaceCodec;
 
 /// Same as [`Piece`], but serializes/deserialized to/from hex string
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct HexPiece(#[serde(with = "HexForm")] [u8; PIECE_SIZE]);
 
 impl From<Piece> for HexPiece {
@@ -52,7 +53,7 @@ impl AsMut<[u8]> for HexPiece {
 }
 
 /// Similar to [`Sha256Hash`], but serializes/deserialized to/from hex string
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct HexSha256Hash(#[serde(with = "HexForm")] Sha256Hash);
 
 impl From<Sha256Hash> for HexSha256Hash {
@@ -133,27 +134,187 @@ pub trait Rpc {
 /// let plot = Plot::open_or_create(base_directory).await?;
 /// let object_mappings = ObjectMappings::open_or_create(base_directory)?;
 /// let ws_server = WsServerBuilder::default().build(ws_server_listen_addr).await?;
-/// let rpc_server = RpcServerImpl::new(plot, object_mappings, SubspaceCodec::new(&[0]));
+/// let rpc_server = RpcServerImpl::new(
+///     3840,
+///     3480 * 128,
+///     plot,
+///     object_mappings,
+///     SubspaceCodec::new(&[0]),
+/// );
 /// let stop_handle = ws_server.start(rpc_server.into_rpc())?;
 ///
-/// // Keep server running
-///
-/// Ok(())
+/// # Ok(())
 /// # }
 /// ```
 pub struct RpcServerImpl {
+    record_size: u32,
+    merkle_num_leaves: u32,
     plot: Plot,
     object_mappings: ObjectMappings,
     subspace_codec: SubspaceCodec,
 }
 
 impl RpcServerImpl {
-    pub fn new(plot: Plot, object_mappings: ObjectMappings, subspace_codec: SubspaceCodec) -> Self {
+    pub fn new(
+        record_size: u32,
+        recorded_history_segment_size: u32,
+        plot: Plot,
+        object_mappings: ObjectMappings,
+        subspace_codec: SubspaceCodec,
+    ) -> Self {
         Self {
+            record_size,
+            merkle_num_leaves: recorded_history_segment_size / (record_size * 2),
             plot,
             object_mappings,
             subspace_codec,
         }
+    }
+
+    async fn assemble_object(&self, piece_index: u64, offset: u16) -> Result<Vec<u8>, Error> {
+        // Try fast object assembling
+        if let Some(data) = self.assemble_object_fast(piece_index, offset).await? {
+            return Ok(data);
+        }
+
+        // TODO: Regular object retrieval
+
+        todo!()
+    }
+
+    /// Fast object assembling in case object doesn't cross piece (super fast) or segment (just
+    /// fast) boundary, returns `Ok(None)` if fast retrieval possibility is not guaranteed.
+    async fn assemble_object_fast(
+        &self,
+        piece_index: u64,
+        offset: u16,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        // We care if the offset is before the last 2 bytes of a piece because if not we might be
+        // able to do very fast object retrieval without assembling and processing the whole
+        // segment. Last 2 bytes is because those 2 bytes might contain padding if a piece is the
+        // last piece in the segment.
+        let before_last_two_bytes = u32::from(offset) <= self.record_size - 1 - 2;
+
+        // We care about whether piece index points to the last data piece in the segment because
+        // if not we might be able to do very fast object retrieval without assembling and
+        // processing the whole segment.
+        let last_data_piece_in_segment = {
+            let piece_position_in_segment = piece_index % u64::from(self.merkle_num_leaves);
+            let last_piece_position_in_segment = u64::from(self.merkle_num_leaves) / 2 - 1;
+
+            piece_position_in_segment >= last_piece_position_in_segment
+        };
+
+        // How much bytes are definitely available starting at `piece_index` and `offset` without
+        // crossing segment boundary
+        let bytes_available_in_segment = (u64::from(self.merkle_num_leaves)
+            - piece_index % u64::from(self.merkle_num_leaves))
+            * self.record_size as u64
+            - offset as u64
+            - 2;
+
+        if last_data_piece_in_segment && !before_last_two_bytes {
+            // Fast retrieval possibility is not guaranteed
+            return Ok(None);
+        }
+
+        // Cache of read pieces that were already read, starting with piece at index `piece_index`
+        let mut read_records_data = Vec::<u8>::new();
+        let mut next_piece_index = piece_index;
+
+        let piece = self.read_and_decode_piece(next_piece_index).await?;
+        next_piece_index += 1;
+        read_records_data.extend_from_slice(&piece[..self.record_size as usize]);
+
+        // Let's see how many bytes encode compact length encoding of the data, see
+        // https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers for
+        // details.
+        let data_length_bytes_length: u32 = match read_records_data[offset as usize] % 4 {
+            0 => 1,
+            1 => 2,
+            2 => 4,
+            _ => {
+                let error_string = format!(
+                    "Invalid data length prefix found: 0x{:02x}",
+                    read_records_data[offset as usize]
+                );
+                error!("{}", error_string);
+
+                return Err(Error::Custom(error_string));
+            }
+        };
+
+        // Same as `before_last_two_bytes`, but accounts for compact encoding of data length
+        let length_before_last_two_bytes =
+            u32::from(offset) + data_length_bytes_length < self.record_size - 1 - 2;
+        // Similar to `length_before_last_two_bytes`, but uses the whole recordif needed
+        let length_before_record_end =
+            u32::from(offset) + data_length_bytes_length < self.record_size - 1;
+
+        let data_length_result = if length_before_last_two_bytes {
+            Compact::<u32>::decode(&mut &read_records_data[offset as usize..])
+        } else if !last_data_piece_in_segment {
+            if !length_before_record_end {
+                // Need the next piece to read the length of data
+                let piece = self.read_and_decode_piece(next_piece_index).await?;
+                next_piece_index += 1;
+                read_records_data.extend_from_slice(&piece[..self.record_size as usize]);
+            }
+
+            Compact::<u32>::decode(&mut &read_records_data[offset as usize..])
+        } else {
+            // Super fast read is not possible
+            return Ok(None);
+        };
+
+        let Compact(data_length) = data_length_result.map_err(|error| {
+            let error_string = format!("Failed to read object data length: {}", error);
+            error!("{}", error_string);
+
+            Error::Custom(error_string)
+        })?;
+
+        if (data_length_bytes_length + data_length) as u64 > bytes_available_in_segment {
+            // Not enough data without crossing segment boundary
+            return Ok(None);
+        }
+
+        let mut data =
+            read_records_data[offset as usize + data_length_bytes_length as usize..].to_vec();
+        drop(read_records_data);
+
+        // Read more pieces until we have enough data
+        while data.len() < data_length as usize {
+            let piece = self.read_and_decode_piece(next_piece_index).await?;
+            next_piece_index += 1;
+            data.extend_from_slice(&piece[..self.record_size as usize]);
+        }
+
+        // Trim the excess
+        data.truncate(data_length as usize);
+
+        Ok(Some(data))
+    }
+
+    async fn read_and_decode_piece(&self, piece_index: u64) -> Result<Piece, Error> {
+        let mut piece = self.plot.read(piece_index).await.map_err(|error| {
+            debug!("Failed to read piece with index {}: {}", piece_index, error);
+
+            Error::Custom("Object mapping found, but reading piece failed".to_string())
+        })?;
+
+        self.subspace_codec
+            .decode(piece_index, &mut piece)
+            .map_err(|error| {
+                debug!(
+                    "Failed to decode piece with index {}: {}",
+                    piece_index, error
+                );
+
+                Error::Custom("Failed to decode piece".to_string())
+            })?;
+
+        Ok(piece)
     }
 }
 
@@ -206,6 +367,8 @@ impl RpcServer for RpcServerImpl {
         let global_object = match global_object {
             Some(global_object) => global_object,
             None => {
+                debug!("Object {} not found", hex::encode(object_id));
+
                 return Ok(None);
             }
         };
@@ -213,28 +376,11 @@ impl RpcServer for RpcServerImpl {
         let piece_index = global_object.piece_index();
         let offset = global_object.offset();
 
-        let mut piece = self.plot.read(piece_index).await.map_err(|error| {
-            debug!("Failed to read piece with index {}: {}", piece_index, error);
-
-            Error::Custom("Object mapping found, but reading piece failed".to_string())
-        })?;
-
-        self.subspace_codec
-            .decode(piece_index, &mut piece)
-            .map_err(|error| {
-                debug!(
-                    "Failed to decode piece with index {}: {}",
-                    piece_index, error
-                );
-
-                Error::Custom("Failed to decode piece".to_string())
-            })?;
-
+        let data = self.assemble_object(piece_index, offset).await?;
         Ok(Some(Object {
             piece_index,
             offset,
-            // TODO: Just offset is not enough, need to read and handle length properly too
-            data: piece[offset as usize..].to_vec(),
+            data,
         }))
     }
 }

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -89,7 +89,7 @@ fn object_mapping() {
     // Expect all 7 objects to be mapped.
     assert_eq!(objects.len(), 7);
 
-    // Hashes shoudl be computed correctly.
+    // Hashes should be computed correctly.
     assert_eq!(objects[0].hash(), crypto::sha256_hash(&data0));
     assert_eq!(objects[1].hash(), crypto::sha256_hash(&data1));
     assert_eq!(objects[2].hash(), crypto::sha256_hash(&data2));


### PR DESCRIPTION
This implements object retrieval from the farmer.

There are 2 modes actually:
* fast mode for objects that definitely don't cross segment boundary, in which case we don't need to deal with segment structure, which allows to avoid fetching extra pieces and assembling segments
  * subset of this is super fast mode where object definitely doesn't cross piece boundary, in which case we only need to read a single piece from the plot
* regular mode for objects that potentially cross segment boundary, in which case we need to assemble complete segments and process their structured content one after another until we read the whole object

In the future all of the logic of assembling of objects will be moved to the clients, but for now we have full archival farmers and can return objects for convenience. Also backend code can be used as a reference implementation for client-side libraries.

No tests at the moment, but I did manual testing for both fast and regular modes and it seems to work correctly.