### PR TITLE
Eliminate wildcard imports (except prelude) to make it clearer what is imported where

### DIFF
--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -21,7 +21,6 @@
 
 use core::mem;
 pub use pallet::*;
-use sp_std::vec::Vec;
 use subspace_core_primitives::{crypto, Sha256Hash};
 
 #[cfg(all(feature = "std", test))]
@@ -31,11 +30,10 @@ mod tests;
 
 #[frame_support::pallet]
 mod pallet {
-    use super::*;
-    use frame_support::dispatch::DispatchResult;
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
     use scale_info::TypeInfo;
+    use sp_std::prelude::*;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -1,4 +1,5 @@
-use crate::{mock::*, Error, FeedId, ObjectMetadata, PutDataObject, TotalObjectsAndSize};
+use crate::mock::{new_test_ext, Event, Feeds, Origin, System, Test};
+use crate::{Error, FeedId, ObjectMetadata, PutDataObject, TotalObjectsAndSize};
 use frame_support::{assert_noop, assert_ok};
 
 const FEED_ID: FeedId = 0;

--- a/crates/pallet-offences-subspace/src/lib.rs
+++ b/crates/pallet-offences-subspace/src/lib.rs
@@ -25,14 +25,13 @@ mod mock;
 mod tests;
 
 use codec::{Decode, Encode};
+pub use pallet::*;
 use sp_consensus_subspace::{
-    offence::{Kind, Offence, OffenceDetails, OffenceError, OnOffenceHandler, ReportOffence},
+    offence::{Offence, OffenceDetails, OffenceError, OnOffenceHandler, ReportOffence},
     FarmerPublicKey,
 };
 use sp_runtime::traits::Hash;
 use sp_std::prelude::*;
-
-pub use pallet::*;
 
 /// A binary blob which represents a SCALE codec-encoded `O::TimeSlot`.
 type OpaqueTimeSlot = Vec<u8>;
@@ -41,9 +40,12 @@ type OpaqueTimeSlot = Vec<u8>;
 type ReportIdOf<T> = <T as frame_system::Config>::Hash;
 
 #[frame_support::pallet]
-pub mod pallet {
-    use super::*;
+mod pallet {
+    use super::{OpaqueTimeSlot, ReportIdOf};
     use frame_support::pallet_prelude::*;
+    use sp_consensus_subspace::offence::{Kind, OffenceDetails, OnOffenceHandler};
+    use sp_consensus_subspace::FarmerPublicKey;
+    use sp_std::prelude::*;
 
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]

--- a/crates/pallet-offences-subspace/src/tests.rs
+++ b/crates/pallet-offences-subspace/src/tests.rs
@@ -18,13 +18,15 @@
 
 #![cfg(test)]
 
-use super::*;
 use crate::mock::{
     new_test_ext, offence_reports, report_id, with_on_offence_fractions, Event, Offence,
     OffencesSubspace, System, KIND,
 };
+use codec::{Decode, Encode};
 use frame_system::{EventRecord, Phase};
 use schnorrkel::Keypair;
+use sp_consensus_subspace::offence::{OffenceDetails, OffenceError, ReportOffence};
+use sp_consensus_subspace::FarmerPublicKey;
 use sp_core::Public;
 use sp_runtime::Perbill;
 

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -28,18 +28,19 @@ pub use pallet::*;
 use sp_consensus_subspace::digests::PreDigest;
 use sp_consensus_subspace::SUBSPACE_ENGINE_ID;
 
-type BalanceOf<T> =
-    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-
 pub trait WeightInfo {
     fn on_initialize() -> Weight;
 }
 
 #[frame_support::pallet]
 mod pallet {
-    use super::*;
+    use super::WeightInfo;
     use frame_support::pallet_prelude::*;
+    use frame_support::traits::Currency;
     use frame_system::pallet_prelude::*;
+
+    type BalanceOf<T> =
+        <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -16,22 +16,35 @@
 
 //! Consensus extension module tests for Subspace consensus.
 
-use super::{Call, *};
+use crate::mock::{
+    create_root_block, generate_equivocation_proof, go_to_block, make_pre_digest, new_test_ext,
+    progress_to_block, Event, Origin, ReportLongevity, Subspace, System, Test,
+    INITIAL_SOLUTION_RANGE, SLOT_PROBABILITY,
+};
+use crate::{
+    compute_randomness, Call, Config, CurrentSlot, EpochConfig, EpochStart, Error, NextEpochConfig,
+    NextRandomness, SegmentIndex, UnderConstruction, WeightInfo,
+};
+use codec::Encode;
+use frame_support::weights::Pays;
 use frame_support::{
     assert_err, assert_noop, assert_ok, traits::OnFinalize, weights::GetDispatchInfo,
 };
 use frame_system::{EventRecord, Phase};
-use mock::{Event, *};
 use schnorrkel::Keypair;
 use sp_consensus_slots::Slot;
-use sp_consensus_subspace::{digests::Solution, SubspaceEpochConfiguration};
+use sp_consensus_subspace::digests::NextConfigDescriptor;
+use sp_consensus_subspace::{
+    digests::Solution, FarmerPublicKey, SubspaceEpochConfiguration, SUBSPACE_ENGINE_ID,
+};
 use sp_core::Public;
 use sp_runtime::traits::Header;
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
     ValidTransaction,
 };
-use sp_runtime::DispatchError;
+use sp_runtime::{DigestItem, DispatchError};
+use subspace_core_primitives::RANDOMNESS_LENGTH;
 
 const EMPTY_RANDOMNESS: [u8; 32] = [
     74, 25, 49, 128, 53, 97, 244, 49, 222, 202, 176, 2, 231, 66, 95, 10, 133, 49, 213, 228, 86,

--- a/crates/sc-consensus-subspace/src/authorship.rs
+++ b/crates/sc-consensus-subspace/src/authorship.rs
@@ -14,7 +14,28 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::*;
+use crate::slot_worker::SubspaceSlotWorker;
+use crate::{subspace_err, verification, Epoch, Error, NewSlotInfo, NewSlotNotification};
+use futures::StreamExt;
+use log::{debug, trace, warn};
+use sc_consensus::block_import::BlockImport;
+use sc_consensus_epochs::ViableEpochDescriptor;
+use sc_consensus_slots::BackoffAuthoringBlocksStrategy;
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
+use schnorrkel::SecretKey;
+use sp_api::{NumberFor, ProvideRuntimeApi};
+use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata, ProvideCache};
+use sp_consensus::{Environment, Error as ConsensusError, Proposer, SyncOracle};
+use sp_consensus_slots::Slot;
+use sp_consensus_subspace::digests::{
+    CompatibleDigestItem, NextSaltDescriptor, NextSolutionRangeDescriptor, PreDigest, Solution,
+};
+use sp_consensus_subspace::{ConsensusLog, SubspaceApi, SUBSPACE_ENGINE_ID};
+use sp_core::sr25519::Pair;
+use sp_runtime::generic::{BlockId, OpaqueDigestItemId};
+use sp_runtime::traits::{Block as BlockT, DigestItemFor, Header, Zero};
+pub use subspace_archiving::archiver::ArchivedSegment;
+use subspace_core_primitives::{Randomness, Salt};
 
 type EpochData<B> = ViableEpochDescriptor<<B as BlockT>::Hash, NumberFor<B>, Epoch>;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -38,7 +38,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, Verify};
 use sp_runtime::{
-    create_runtime_str, generic, impl_opaque_keys,
+    create_runtime_str, generic,
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult, MultiSignature, Perbill,
 };
@@ -76,14 +76,15 @@ pub type Moment = u64;
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
 /// to even the core data structures.
 pub mod opaque {
-    use super::*;
-
-    use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
+    use super::{BlockNumber, Subspace};
+    use sp_runtime::traits::BlakeTwo256;
+    use sp_runtime::{generic, impl_opaque_keys, OpaqueExtrinsic};
+    use sp_std::vec::Vec;
 
     /// Opaque block header type.
     pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
     /// Opaque block type.
-    pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+    pub type Block = generic::Block<Header, OpaqueExtrinsic>;
     /// Opaque block identifier type.
     pub type BlockId = generic::BlockId<Block>;
 


### PR DESCRIPTION
No real logic changes, but it is now easier to deal with codebase