### PR TITLE
Simple `pallet-object-store` for no frills object storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4094,6 +4094,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-object-store"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "hex",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "subspace-core-primitives",
+]
+
+[[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
 dependencies = [
@@ -7365,6 +7383,7 @@ dependencies = [
  "orml-vesting",
  "pallet-balances",
  "pallet-feeds",
+ "pallet-object-store",
  "pallet-offences-subspace",
  "pallet-rewards",
  "pallet-subspace",

--- a/crates/pallet-object-store/Cargo.toml
+++ b/crates/pallet-object-store/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "pallet-object-store"
+version = "0.1.0"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace"
+description = "Subspace node pallet for simple objects storage"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = ["derive"] }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+log = { version = "0.4.14", default-features = false }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
+subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
+
+[dev-dependencies]
+serde = "1.0.127"
+sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
+sp-io = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
+sp-runtime = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "frame-support/std",
+  "frame-system/std",
+  "hex/std",
+  "log/std",
+  "scale-info/std",
+  "sp-std/std",
+  "subspace-core-primitives/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-object-store/README.md
+++ b/crates/pallet-object-store/README.md
@@ -1,0 +1,5 @@
+# Pallet Object Store
+
+Subspace node pallet for simple objects storage
+
+License: Apache-2.0

--- a/crates/pallet-object-store/src/lib.rs
+++ b/crates/pallet-object-store/src/lib.rs
@@ -1,0 +1,107 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pallet object store, used for simple object storage on the network.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, missing_debug_implementations)]
+
+#[cfg(all(feature = "std", test))]
+mod mock;
+#[cfg(all(feature = "std", test))]
+mod tests;
+
+pub use pallet::*;
+use subspace_core_primitives::{crypto, Sha256Hash};
+
+#[frame_support::pallet]
+mod pallet {
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+    use log::debug;
+    use sp_std::prelude::*;
+    use subspace_core_primitives::{crypto, Sha256Hash};
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// `pallet-object-store` events
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+    }
+
+    /// Pallet object-store, used for storing arbitrary user-provided data combined into object-store.
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+    /// `pallet-object-store` events
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// New object is added \[who, object_id, object_size\]
+        DataSubmitted(T::AccountId, Sha256Hash, u32),
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        // TODO: add proper weights
+        // TODO: For now we don't have fees, but we will have them in the future
+        /// Put a new object into a feed
+        #[pallet::weight((10_000, Pays::No))]
+        pub fn put(origin: OriginFor<T>, data: Vec<u8>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            let object_size = data.len() as u32;
+
+            let object_id = crypto::sha256_hash(&data);
+
+            debug!(
+                target: "runtime:object-store",
+                "New object {}, size {} bytes",
+                hex::encode(&object_id),
+                object_size
+            );
+
+            Self::deposit_event(Event::DataSubmitted(who, object_id, object_size));
+
+            Ok(())
+        }
+    }
+}
+
+/// Mapping to the object offset and size within an extrinsic
+#[derive(Debug)]
+pub struct CallObjectLocation {
+    /// Object hash
+    pub hash: Sha256Hash,
+    /// Offset
+    pub offset: u32,
+}
+
+impl<T: Config> Call<T> {
+    /// Extract object location if an extrinsic corresponds to `put` call
+    pub fn extract_object_location(&self) -> Option<CallObjectLocation> {
+        match self {
+            Self::put { data } => {
+                // `1` corresponds to `Call::put {}` enum variant encoding.
+                Some(CallObjectLocation {
+                    hash: crypto::sha256_hash(data),
+                    offset: 1,
+                })
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/pallet-object-store/src/mock.rs
+++ b/crates/pallet-object-store/src/mock.rs
@@ -1,0 +1,71 @@
+use frame_support::parameter_types;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        ObjectStore: crate::{Pallet, Call, Event<T>}
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const SS58Prefix: u8 = 42;
+}
+
+impl frame_system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: u64 = 1;
+}
+
+impl crate::Config for Test {
+    type Event = Event;
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    let mut t: sp_io::TestExternalities = t.into();
+
+    t.execute_with(|| System::set_block_number(1));
+
+    t
+}

--- a/crates/pallet-object-store/src/tests.rs
+++ b/crates/pallet-object-store/src/tests.rs
@@ -1,0 +1,22 @@
+use crate::mock::{new_test_ext, Event, ObjectStore, Origin, System, Test};
+use frame_support::assert_ok;
+use subspace_core_primitives::crypto;
+
+const ACCOUNT_ID: u64 = 100;
+
+#[test]
+fn can_do_put() {
+    new_test_ext().execute_with(|| {
+        let object = vec![1, 2, 3, 4, 5];
+        let object_id = crypto::sha256_hash(&object);
+        let object_size = object.len() as u32;
+
+        assert_ok!(ObjectStore::put(Origin::signed(ACCOUNT_ID), object));
+
+        System::assert_last_event(Event::ObjectStore(crate::Event::<Test>::DataSubmitted(
+            ACCOUNT_ID,
+            object_id,
+            object_size,
+        )));
+    });
+}

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -24,6 +24,7 @@ hex-literal = { version = "0.3.3", optional = true }
 orml-vesting = { version = "0.4.1-dev", default-features = false, git = "https://github.com/subspace/open-runtime-module-library", branch = "substrate-monthly-2021-11" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "26d69bcbe26f6b463e9374e1b1c54c3067fb6131" }
 pallet-feeds = { version = "0.1.0", default-features = false, path = "../pallet-feeds" }
+pallet-object-store = { version = "0.1.0", default-features = false, path = "../pallet-object-store" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../pallet-offences-subspace" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../pallet-rewards" }
 pallet-subspace = { version = "0.1.0", default-features = false, features = ["no-early-solution-range-updates"], path = "../pallet-subspace" }
@@ -68,6 +69,7 @@ std = [
 	"orml-vesting/std",
 	"pallet-balances/std",
 	"pallet-feeds/std",
+	"pallet-object-store/std",
 	"pallet-offences-subspace/std",
 	"pallet-rewards/std",
 	"pallet-subspace/std",

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -397,6 +397,10 @@ impl pallet_feeds::Config for Runtime {
     type Event = Event;
 }
 
+impl pallet_object_store::Config for Runtime {
+    type Event = Event;
+}
+
 parameter_types! {
     // This value doesn't matter, we don't use it (`VestedTransferOrigin = EnsureNever` below).
     pub const MinVestedTransfer: Balance = 0;
@@ -433,6 +437,7 @@ construct_runtime!(
         Utility: pallet_utility::{Pallet, Call, Event} = 8,
 
         Feeds: pallet_feeds::{Pallet, Call, Storage, Event<T>} = 6,
+        ObjectStore: pallet_object_store::{Pallet, Call, Event<T>} = 10,
 
         Vesting: orml_vesting::{Pallet, Call, Config<T>, Storage, Event<T>} = 7,
 
@@ -490,6 +495,19 @@ fn extract_feeds_block_object_mapping(
     }
 }
 
+fn extract_object_store_block_object_mapping(
+    base_offset: u32,
+    objects: &mut Vec<BlockObject>,
+    call: &pallet_object_store::Call<Runtime>,
+) {
+    if let Some(call_object_location) = call.extract_object_location() {
+        objects.push(BlockObject::V0 {
+            hash: call_object_location.hash,
+            offset: base_offset + call_object_location.offset,
+        });
+    }
+}
+
 fn extract_utility_block_object_mapping(
     base_offset: u32,
     objects: &mut Vec<BlockObject>,
@@ -503,9 +521,24 @@ fn extract_utility_block_object_mapping(
             base_nested_call_offset += Compact::compact_len(&(calls.len() as u32)) as u32;
 
             for call in calls {
-                if let Call::Feeds(call) = call {
-                    // `+1` for enum variant offset
-                    extract_feeds_block_object_mapping(base_nested_call_offset + 1, objects, call);
+                match call {
+                    Call::Feeds(call) => {
+                        // `+1` for enum variant offset
+                        extract_feeds_block_object_mapping(
+                            base_nested_call_offset + 1,
+                            objects,
+                            call,
+                        );
+                    }
+                    Call::ObjectStore(call) => {
+                        // `+1` for enum variant offset
+                        extract_object_store_block_object_mapping(
+                            base_nested_call_offset + 1,
+                            objects,
+                            call,
+                        );
+                    }
+                    _ => {}
                 }
 
                 base_nested_call_offset += call.encoded_size() as u32;
@@ -514,9 +547,20 @@ fn extract_utility_block_object_mapping(
         pallet_utility::Call::as_derivative { index, call } => {
             base_nested_call_offset += index.encoded_size() as u32;
 
-            if let Call::Feeds(call) = call.as_ref() {
-                // `+1` for enum variant offset
-                extract_feeds_block_object_mapping(base_nested_call_offset + 1, objects, call);
+            match call.as_ref() {
+                Call::Feeds(call) => {
+                    // `+1` for enum variant offset
+                    extract_feeds_block_object_mapping(base_nested_call_offset + 1, objects, call);
+                }
+                Call::ObjectStore(call) => {
+                    // `+1` for enum variant offset
+                    extract_object_store_block_object_mapping(
+                        base_nested_call_offset + 1,
+                        objects,
+                        call,
+                    );
+                }
+                _ => {}
             }
         }
         pallet_utility::Call::__Ignore(_, _) => {
@@ -549,6 +593,13 @@ fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
         match &extrinsic.function {
             Call::Feeds(call) => {
                 extract_feeds_block_object_mapping(
+                    base_extrinsic_offset as u32,
+                    &mut block_object_mapping.objects,
+                    call,
+                );
+            }
+            Call::ObjectStore(call) => {
+                extract_object_store_block_object_mapping(
                     base_extrinsic_offset as u32,
                     &mut block_object_mapping.objects,
                     call,


### PR DESCRIPTION
Basically a much simpler version of `pallet-feeds` with some tweaks, will be used as the first simple API for `subspace.js` library.

Closes #137