### PR TITLE
Fix skip block authoring

### DIFF
--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -224,6 +224,9 @@ where
     }
 
     fn authorities_len(&self, _epoch_data: &Self::EpochData) -> Option<usize> {
-        None
+        // This function is used in `sc-consensus-slots` in order to determine whether it is
+        // possible to skip block production under certain circumstances, returning `None` or any
+        // number smaller than `1` disables that functionality and we don't want it
+        Some(2)
     }
 }

--- a/crates/subspace-node/README.md
+++ b/crates/subspace-node/README.md
@@ -55,7 +55,7 @@ docker run --rm --init -it \
   --mount source=subspace-farmer,target=/var/subspace \
   subspacelabs/subspace-farmer \
     farm \
-    --ws-server ws://subspace-node:9944
+    --node-rpc-url ws://subspace-node:9944
 ```
 
 Now you should see block production in the first terminal where node is running.
@@ -184,7 +184,7 @@ cargo run --bin subspace-farmer -- farm
         --mount source=subspace-farmer-1,target=/var/subspace \
         subspacelabs/subspace-farmer \
           farm \
-          --ws-server ws://subspace-node-full-1:9944
+          --node-rpc-url ws://subspace-node-full-1:9944
       ```
 3. Repeat 2. with `-1` replaced with `-2` everywhere in order to obtain one more pair of client and farmer
 4. Observe following messages in logs similar to these, also block production will stop:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -10,11 +10,12 @@ services:
         target: /var/subspace
         type: volume
     command: [
-        "--validator",
-        "--chain", "testnet",
-        "--base-path", "/var/subspace",
-        "--ws-external",
-        "--bootnodes", "/ip4/${BOOTSTRAP_CLIENT_IP}/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
+      "--validator",
+      "--force-authoring",
+      "--chain", "testnet",
+      "--base-path", "/var/subspace",
+      "--ws-external",
+      "--bootnodes", "/ip4/${BOOTSTRAP_CLIENT_IP}/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
     ]
   farmer:
     image: subspacelabs/subspace-farmer
@@ -26,8 +27,8 @@ services:
         type: volume
     restart: always
     command: [
-        "farm",
-        "--ws-server", "ws://node:9944"
+      "farm",
+      "--node-rpc-url", "ws://node:9944"
     ]
 
 networks:

--- a/scripts/start-farmer.sh
+++ b/scripts/start-farmer.sh
@@ -18,7 +18,7 @@ run-farm() {
     --mount source=subspace-farmer,target=/var/subspace \
     subspacelabs/subspace-farmer \
         farm \
-        --ws-server ws://subspace-node-full:9944
+        --node-rpc-url ws://subspace-node-full:9944
 }
 
 wipe() {

--- a/scripts/start-node.sh
+++ b/scripts/start-node.sh
@@ -17,14 +17,14 @@ run-full() {
     --name subspace-node-full \
     --mount source=subspace-node,target=/var/subspace \
     --publish 0.0.0.0:30333:30333 \
-        --publish 127.0.0.1:9944:9944 \
-        --publish 127.0.0.1:9933:9933 \
+    --publish 127.0.0.1:9944:9944 \
+    --publish 127.0.0.1:9933:9933 \
     subspacelabs/subspace-node \
         --validator \
         --chain testnet \
         --base-path /var/subspace \
         --ws-external \
-        --bootnodes /ip4/165.232.157.230/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
+        --bootnodes /dns/test-rpc.subspace.network/tcp/30333/p2p/12D3KooWAbeaefPbU9brfEUKZPeqptT5uxcsEQxQacPFhE1Z5nbs \
         --telemetry-url 'wss://telemetry.polkadot.io/submit/ 1'
 }
 
@@ -50,10 +50,10 @@ clear='\e[0m'
 ##
 
 ColorGreen(){
-echo -ne $green$1$clear
+    echo -ne $green$1$clear
 }
 ColorBlue(){
-echo -ne $blue$1$clear
+    echo -ne $blue$1$clear
 }
 
 menu(){


### PR DESCRIPTION
Essentially our check for skipping of block production when node is offline was broken almost since very beginning.

Context: https://github.com/paritytech/substrate/blob/b5defce4bd25066a5d0b571398874f048a864a68/client/consensus/slots/src/lib.rs#L248-L263

Fixes #146 and one more ticket in Notion board.