### PR TITLE
Get chain parameters from best block instead of genesis block to fix sync for non-archival nodes

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -185,15 +185,15 @@ where
     fn get_farmer_metadata(&self) -> FutureResult<FarmerMetadata> {
         let client = Arc::clone(&self.client);
         Box::pin(async move {
-            let best_block_hash = BlockId::Hash(client.info().best_hash);
+            let best_block_id = BlockId::Hash(client.info().best_hash);
             let runtime_api = client.runtime_api();
 
             let farmer_metadata: Result<FarmerMetadata, ApiError> = try {
                 FarmerMetadata {
-                    confirmation_depth_k: runtime_api.confirmation_depth_k(&best_block_hash)?,
-                    record_size: runtime_api.record_size(&best_block_hash)?,
+                    confirmation_depth_k: runtime_api.confirmation_depth_k(&best_block_id)?,
+                    record_size: runtime_api.record_size(&best_block_id)?,
                     recorded_history_segment_size: runtime_api
-                        .recorded_history_segment_size(&best_block_hash)?,
+                        .recorded_history_segment_size(&best_block_id)?,
                 }
             };
 

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -85,19 +85,19 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
         + 'static,
     Client::Api: SubspaceApi<Block>,
 {
-    let genesis_block_id = BlockId::Number(Zero::zero());
+    let best_block_id = BlockId::Hash(client.info().best_hash);
 
     let confirmation_depth_k = client
         .runtime_api()
-        .confirmation_depth_k(&genesis_block_id)
+        .confirmation_depth_k(&best_block_id)
         .expect("Failed to get `confirmation_depth_k` from runtime API");
     let record_size = client
         .runtime_api()
-        .record_size(&genesis_block_id)
+        .record_size(&best_block_id)
         .expect("Failed to get `record_size` from runtime API");
     let recorded_history_segment_size = client
         .runtime_api()
-        .recorded_history_segment_size(&genesis_block_id)
+        .recorded_history_segment_size(&best_block_id)
         .expect("Failed to get `recorded_history_segment_size` from runtime API");
 
     let maybe_last_root_block = find_last_root_block(client.as_ref());

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -1644,9 +1644,11 @@ where
     let (imported_block_notification_sender, imported_block_notification_stream) =
         notification::channel("subspace_imported_block_notification_stream");
 
+    let best_block_id = BlockId::Hash(client.info().best_hash);
+
     let confirmation_depth_k = client
         .runtime_api()
-        .confirmation_depth_k(&BlockId::Number(Zero::zero()))
+        .confirmation_depth_k(&best_block_id)
         .expect("Failed to get `confirmation_depth_k` from runtime API");
 
     let link = SubspaceLink {


### PR DESCRIPTION
Fixes #149