### PR TITLE
`block.body` definitly exists unless it's a light client or using fast sync in storage chain mode

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -1489,9 +1489,12 @@ where
             let root_blocks = self.root_blocks.lock();
             // If there are root blocks expected to be included in this block, check them
             if let Some(correct_root_blocks) = root_blocks.peek(&block_number) {
-                // TODO: Why there could be no body? Light client?
                 let mut found = false;
-                for extrinsic in block.body.as_ref().unwrap() {
+                for extrinsic in block
+                    .body
+                    .as_ref()
+                    .expect("Light client or fast sync is unsupported; qed")
+                {
                     match self
                         .client
                         .runtime_api()


### PR DESCRIPTION
From what I see, there are two cases that `block.body` can be omitted otherwise it should always exist:

-  light client
https://github.com/paritytech/substrate/blob/3f657a56b3c9bfe14613d213efc6570292ffaf86/client/network/src/protocol/sync.rs#L572

- fast sync in storage chain mode
https://github.com/paritytech/substrate/blob/3f657a56b3c9bfe14613d213efc6570292ffaf86/client/network/src/protocol/sync.rs#L575