### PR TITLE
Fix `.git` inclusion based on upstream feedback

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -18,6 +18,9 @@ jobs:
           - farmer
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Log into registry
         uses: docker/login-action@v1
         with:
@@ -40,6 +43,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: Dockerfile-${{ matrix.image }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -20,11 +20,9 @@ COPY Cargo.toml /code/Cargo.toml
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 # Just enough files for `git rev-parse --short HEAD` to work (used in Substrate node build)
-# TODO: Restore once https://github.com/docker/build-push-action/issues/513 is resolved
-#COPY .git /code/.git
+COPY .git /code/.git
 # Just an empty directory for Git to recognize it is indeed a Git repository
-# TODO: Restore once https://github.com/docker/build-push-action/issues/513 is resolved
-#RUN mkdir /code/.git/objects
+RUN mkdir /code/.git/objects
 COPY crates /code/crates
 COPY substrate /code/substrate
 


### PR DESCRIPTION
See https://github.com/docker/build-push-action/issues/513 for context