### PR TITLE
replace sleep with a better solution

### DIFF
--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -29,7 +29,7 @@ pub enum FarmingError {
 /// Farming Instance that stores a channel to stop/pause the background farming task
 /// and a handle to make it possible to wait on this background task
 pub struct Farming {
-    stop_sender: Option<async_oneshot::Sender<()>>,
+    stop_sender: async_oneshot::Sender<()>,
     handle: Option<JoinHandle<Result<(), FarmingError>>>,
 }
 
@@ -70,7 +70,7 @@ impl Farming {
         });
 
         Farming {
-            stop_sender: Some(stop_sender),
+            stop_sender,
             handle: Some(farming_handle),
         }
     }
@@ -87,7 +87,7 @@ impl Farming {
 
 impl Drop for Farming {
     fn drop(&mut self) {
-        let _ = self.stop_sender.take().unwrap().send(());
+        let _ = self.stop_sender.send(());
     }
 }
 

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -44,13 +44,28 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
         identity.clone(),
     );
 
+    let mut counter = 0;
+    let mut latest_salt = slots.first().unwrap().salt;
     for (slot, tag) in slots.into_iter().zip(tags) {
         let client_copy = client.clone();
-        async move {
-            // commitment in the background cannot keep up with the speed, so putting a little delay in here
-            // commitment usually takes around 0.002-0.003 second on my machine (M1 iMac), putting 100 microseconds here to be safe
-            sleep(Duration::from_millis(100)).await;
+        counter += 1;
+        async {
             client_copy.send_slot(slot.clone()).await;
+
+            // if salt will change, wait for background recommitment to finish first
+            if slot.next_salt.unwrap() != latest_salt {
+                latest_salt = slot.next_salt.unwrap();
+                let mut current_commitment_notifier = commitments.clone().on_recommitment(slot.salt).await;
+                let mut upcoming_commitment_notifier = commitments.clone().on_recommitment(latest_salt).await;
+                tokio::select! {
+                    _ = current_commitment_notifier.recv() => {
+                        // also wait for the recommitment for the upcoming salt
+                        // it locks the commitment database, and causing racy behavior
+                        upcoming_commitment_notifier.recv().await;
+                    },
+                    _ = sleep(Duration::from_secs(3)) => { panic!("Cannot finish recommitments......"); }
+                }
+            }
 
             tokio::select! {
                 Some(solution) = client_copy.receive_solution() => {
@@ -59,10 +74,10 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
                             panic!("Wrong Tag! The expected value was: {:?}", tag);
                         }
                     } else {
-                        panic!("Solution was None!")
+                        panic!("Solution was None! For challenge #: {}", counter);
                     }
                 },
-                _ = sleep(Duration::from_secs(1)) => {},
+                _ = sleep(Duration::from_secs(1)) => { panic!("Something is taking too much time!"); },
             }
         }
         .await;
@@ -83,7 +98,7 @@ async fn farming_happy_path() {
         slot_number: 3,
         global_challenge: [1; TAG_SIZE],
         salt: [1, 1, 1, 1, 1, 1, 1, 1],
-        next_salt: None,
+        next_salt: Some([1, 1, 1, 1, 1, 1, 1, 2]),
         solution_range: u64::MAX,
     };
     let slots = vec![slot_info];
@@ -114,7 +129,7 @@ async fn farming_salt_change() {
         slot_number: 3,
         global_challenge: [1; TAG_SIZE],
         salt: [1, 1, 1, 1, 1, 1, 1, 2],
-        next_salt: None,
+        next_salt: Some([1, 1, 1, 1, 1, 1, 1, 2]),
         solution_range: u64::MAX,
     };
     let slots = vec![first_slot, second_slot, third_slot];


### PR DESCRIPTION
## Replacing sleeps with a better solution
**Before:** I put sleep before sending each solution. On my machine, it was working fine :) In Github CI, however, it was occasionally failing the tests.

**Now:** There is a new function in `Commitments`, that checks the status of the commitment, and notifies the test environment. This function is only compiled under *test* condition.

Unlike the previous PR #182 , no API has changed this time (thanks to Nazar's suggestion)! Source code is completely the same as before :)

Note: also a bit clean-up on the `farming.rs` file, but nothing serious.

If there are more room for improvement, please let me know
