### PR TITLE
Migrate pallet event from tuple to struct

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -46,7 +46,10 @@ mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// A new candidate receipt was backed.
-        CandidateReceiptStored(T::BlockNumber, T::Hash),
+        CandidateReceiptStored {
+            head_number: T::BlockNumber,
+            head_hash: T::Hash,
+        },
     }
 
     #[pallet::call]
@@ -78,7 +81,10 @@ mod pallet {
             LastHeadNumber::<T>::put(head_number);
             Heads::<T>::insert(head_number, head_hash);
 
-            Self::deposit_event(Event::CandidateReceiptStored(head_number, head_hash));
+            Self::deposit_event(Event::CandidateReceiptStored {
+                head_number,
+                head_hash,
+            });
 
             Ok(())
         }

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -80,10 +80,14 @@ mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        /// New object is added \[object_metadata, account_id, object_size\]
-        DataSubmitted(ObjectMetadata, T::AccountId, u64),
-        /// New feed is created \[feed_id, account_id\]
-        FeedCreated(FeedId, T::AccountId),
+        /// New object was added.
+        DataSubmitted {
+            metadata: ObjectMetadata,
+            who: T::AccountId,
+            object_size: u64,
+        },
+        /// New feed was created.
+        FeedCreated { feed_id: FeedId, who: T::AccountId },
     }
 
     /// `pallet-feeds` errors
@@ -107,7 +111,7 @@ mod pallet {
 
             Totals::<T>::insert(feed_id, TotalObjectsAndSize::default());
 
-            Self::deposit_event(Event::FeedCreated(feed_id, who));
+            Self::deposit_event(Event::FeedCreated { feed_id, who });
 
             Ok(())
         }
@@ -140,7 +144,11 @@ mod pallet {
                 feed_totals.count += 1;
             });
 
-            Self::deposit_event(Event::DataSubmitted(metadata, who, object_size));
+            Self::deposit_event(Event::DataSubmitted {
+                metadata,
+                who,
+                object_size,
+            });
 
             Ok(())
         }

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -16,9 +16,10 @@ fn can_create_feed() {
 
         assert_eq!(Feeds::totals(0), TotalObjectsAndSize::default());
 
-        System::assert_last_event(Event::Feeds(crate::Event::<Test>::FeedCreated(
-            FEED_ID, ACCOUNT_ID,
-        )));
+        System::assert_last_event(Event::Feeds(crate::Event::<Test>::FeedCreated {
+            feed_id: FEED_ID,
+            who: ACCOUNT_ID,
+        }));
     });
 }
 
@@ -50,11 +51,11 @@ fn can_do_put() {
             }
         );
 
-        System::assert_last_event(Event::Feeds(crate::Event::<Test>::DataSubmitted(
-            object_metadata,
-            ACCOUNT_ID,
+        System::assert_last_event(Event::Feeds(crate::Event::<Test>::DataSubmitted {
+            metadata: object_metadata,
+            who: ACCOUNT_ID,
             object_size,
-        )));
+        }));
     });
 }
 

--- a/crates/pallet-object-store/src/lib.rs
+++ b/crates/pallet-object-store/src/lib.rs
@@ -50,8 +50,12 @@ mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        /// New object is added \[who, object_id, object_size\]
-        DataSubmitted(T::AccountId, Sha256Hash, u32),
+        /// New object was added.
+        DataSubmitted {
+            who: T::AccountId,
+            object_id: Sha256Hash,
+            object_size: u32,
+        },
     }
 
     #[pallet::call]
@@ -74,7 +78,11 @@ mod pallet {
                 object_size
             );
 
-            Self::deposit_event(Event::DataSubmitted(who, object_id, object_size));
+            Self::deposit_event(Event::DataSubmitted {
+                who,
+                object_id,
+                object_size,
+            });
 
             Ok(())
         }

--- a/crates/pallet-object-store/src/tests.rs
+++ b/crates/pallet-object-store/src/tests.rs
@@ -13,10 +13,10 @@ fn can_do_put() {
 
         assert_ok!(ObjectStore::put(Origin::signed(ACCOUNT_ID), object));
 
-        System::assert_last_event(Event::ObjectStore(crate::Event::<Test>::DataSubmitted(
-            ACCOUNT_ID,
+        System::assert_last_event(Event::ObjectStore(crate::Event::<Test>::DataSubmitted {
+            who: ACCOUNT_ID,
             object_id,
             object_size,
-        )));
+        }));
     });
 }

--- a/crates/pallet-offences-subspace/src/lib.rs
+++ b/crates/pallet-offences-subspace/src/lib.rs
@@ -101,7 +101,10 @@ mod pallet {
         /// There is an offence reported of the given `kind` happened at the `session_index` and
         /// (kind-specific) time slot. This event is not deposited for duplicate slashes.
         /// \[kind, timeslot\].
-        Offence(Kind, OpaqueTimeSlot),
+        Offence {
+            kind: Kind,
+            timeslot: OpaqueTimeSlot,
+        },
     }
 }
 
@@ -123,7 +126,10 @@ impl<T: Config, O: Offence<FarmerPublicKey>> ReportOffence<FarmerPublicKey, O> f
         T::OnOffenceHandler::on_offence(&concurrent_offenders);
 
         // Deposit the event.
-        Self::deposit_event(Event::Offence(O::ID, time_slot.encode()));
+        Self::deposit_event(Event::Offence {
+            kind: O::ID,
+            timeslot: time_slot.encode(),
+        });
 
         Ok(())
     }

--- a/crates/pallet-offences-subspace/src/tests.rs
+++ b/crates/pallet-offences-subspace/src/tests.rs
@@ -137,7 +137,10 @@ fn should_deposit_event() {
             System::events(),
             vec![EventRecord {
                 phase: Phase::Initialization,
-                event: Event::OffencesSubspace(crate::Event::Offence(KIND, time_slot.encode())),
+                event: Event::OffencesSubspace(crate::Event::Offence {
+                    kind: KIND,
+                    timeslot: time_slot.encode()
+                }),
                 topics: vec![],
             }]
         );
@@ -174,7 +177,10 @@ fn doesnt_deposit_event_for_dups() {
             System::events(),
             vec![EventRecord {
                 phase: Phase::Initialization,
-                event: Event::OffencesSubspace(crate::Event::Offence(KIND, time_slot.encode())),
+                event: Event::OffencesSubspace(crate::Event::Offence {
+                    kind: KIND,
+                    timeslot: time_slot.encode()
+                }),
                 topics: vec![],
             }]
         );

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -63,8 +63,11 @@ mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        /// Issued reward for the block author. \[block_author, reward\]
-        BlockReward(T::AccountId, BalanceOf<T>),
+        /// Issued reward for the block author.
+        BlockReward {
+            block_author: T::AccountId,
+            reward: BalanceOf<T>,
+        },
     }
 
     #[pallet::hooks]
@@ -87,7 +90,10 @@ impl<T: Config> Pallet<T> {
             let reward = T::BlockReward::get();
             T::Currency::deposit_creating(&block_author, reward);
 
-            Self::deposit_event(Event::BlockReward(block_author, reward));
+            Self::deposit_event(Event::BlockReward {
+                block_author,
+                reward,
+            });
         }
     }
 }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -237,8 +237,7 @@ mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event {
         /// Root block was stored in blockchain history.
-        /// \[root_block\].
-        RootBlockStored(RootBlock),
+        RootBlockStored { root_block: RootBlock },
     }
 
     #[pallet::error]
@@ -962,7 +961,7 @@ impl<T: Config> Pallet<T> {
     fn do_store_root_blocks(root_blocks: Vec<RootBlock>) -> DispatchResult {
         for root_block in root_blocks {
             RecordsRoot::<T>::insert(root_block.segment_index(), root_block.records_root());
-            Self::deposit_event(Event::RootBlockStored(root_block));
+            Self::deposit_event(Event::RootBlockStored { root_block });
         }
         Ok(())
     }

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -592,7 +592,7 @@ fn store_root_block_works() {
             System::events(),
             vec![EventRecord {
                 phase: Phase::Initialization,
-                event: Event::Subspace(crate::Event::RootBlockStored(root_block)),
+                event: Event::Subspace(crate::Event::RootBlockStored { root_block }),
                 topics: vec![],
             }]
         );


### PR DESCRIPTION
Now it's recommended to use a struct for the event.