### PR TITLE
version compatibility across all monorepo

### DIFF
--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -16,7 +16,7 @@ merkletree = "0.21.0"
 parity-scale-codec = { version = "2.3.0", features = ["derive"], default-features = false }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
-thiserror = "1.0.29"
+thiserror = "1.0.30"
 typenum = "1.14.0"
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197


### PR DESCRIPTION
`thiserror` package was creating conflict when I tried to include `subspace-farmer` as a git repo in `subspace-desktop` project. It complained about `subspace-archiver` requires `thiserror` version being 1.0.29, whereas subspace-solving and subspace-farmer requires thiserror to be 1.0.30. 