### PR TITLE
subspace-archiving with no-std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,13 +5587,16 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+checksum = "91ef274f3adb7fd0266c926c9b0434043eb7f8181541e0ab730e9dbd110c7db2"
 dependencies = [
  "cc",
  "libc",
+ "libm",
+ "parking_lot 0.11.2",
  "smallvec",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -5699,7 +5702,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
@@ -7789,6 +7792,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "ss58-registry"

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -53,8 +53,7 @@ mod pallet {
     pub(super) type ObjectMetadata = Vec<u8>;
 
     /// Total amount of data and number of objects stored in a feed
-    #[derive(Decode, Encode, TypeInfo, Default, PartialEq, Eq)]
-    #[cfg_attr(feature = "std", derive(Debug))]
+    #[derive(Debug, Decode, Encode, TypeInfo, Default, PartialEq, Eq)]
     pub struct TotalObjectsAndSize {
         /// Total size of objects in bytes
         pub size: u64,

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -14,20 +14,11 @@ include = [
 [dependencies]
 merkletree = "0.21.0"
 parity-scale-codec = { version = "2.3.0", features = ["derive"], default-features = false }
+reed-solomon-erasure = { version = "5.0.0", default-features = true }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 thiserror = "1.0.29"
 typenum = "1.14.0"
-
-# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
-[target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.dependencies.reed-solomon-erasure]
-features = ["simd-accel"]
-version = "4.0.2"
-
-# Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
-# See https://github.com/darrenldl/reed-solomon-erasure/issues/86 for why `simd-accel` is disabled
-[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies.reed-solomon-erasure]
-version = "4.0.2"
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -48,6 +39,7 @@ rand = { version = "0.8.4", features = ["min_const_gen"] }
 default = ["std"]
 std = [
     "parity-scale-codec/std",
+    "reed-solomon-erasure/simd-accel",
     "serde",
     "sha2/std",
     "subspace-core-primitives/std",

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -17,7 +17,7 @@ parity-scale-codec = { version = "2.3.0", features = ["derive"], default-feature
 reed-solomon-erasure = { version = "5.0.0", default-features = true }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
-thiserror = "1.0.29"
+thiserror = { version = "1.0.29", optional = true }
 typenum = "1.14.0"
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
@@ -34,7 +34,6 @@ version = "0.9.8"
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["min_const_gen"] }
 
-# TODO: Nothing is exposed in no-std environment at the moment :(
 [features]
 default = ["std"]
 std = [
@@ -43,4 +42,5 @@ std = [
     "serde",
     "sha2/std",
     "subspace-core-primitives/std",
+    "thiserror",
 ]

--- a/crates/subspace-archiving/src/lib.rs
+++ b/crates/subspace-archiving/src/lib.rs
@@ -18,11 +18,7 @@
 #![feature(drain_filter)]
 #![feature(int_log)]
 
-#[cfg(feature = "std")]
 pub mod archiver;
-#[cfg(feature = "std")]
 pub mod merkle_tree;
-#[cfg(feature = "std")]
 pub mod reconstructor;
-#[cfg(feature = "std")]
 mod utils;

--- a/crates/subspace-archiving/src/merkle_tree.rs
+++ b/crates/subspace-archiving/src/merkle_tree.rs
@@ -14,14 +14,15 @@
 // limitations under the License.
 
 //! This module includes Merkle Tree implementation used in Subspace
+extern crate alloc;
 
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use core::hash::Hasher;
+use core::iter;
+use core::ops::Deref;
 use sha2::{Digest, Sha256};
-use std::borrow::Cow;
-use std::hash::Hasher;
-use std::iter;
-use std::ops::Deref;
 use subspace_core_primitives::{crypto, Sha256Hash, SHA256_HASH_SIZE};
-use thiserror::Error;
 use typenum::{U0, U2};
 
 #[derive(Default, Clone)]
@@ -154,10 +155,14 @@ impl<'a> From<Witness<'a>> for Cow<'a, [u8]> {
 }
 
 /// Errors that can happen when creating a witness
-#[derive(Debug, Error, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum MerkleTreeWitnessError {
     /// Wrong position
-    #[error("Wrong position, there is just {0} leaves available")]
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Wrong position, there is just {0} leaves available")
+    )]
     WrongPosition(usize),
 }
 

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -1,38 +1,57 @@
+extern crate alloc;
+
 use crate::archiver::{Segment, SegmentItem};
 use crate::utils;
+use alloc::vec::Vec;
+use core::mem;
 use parity_scale_codec::Decode;
 use reed_solomon_erasure::galois_16::ReedSolomon;
-use std::mem;
 use subspace_core_primitives::{
     ArchivedBlockProgress, LastArchivedBlock, Piece, RootBlock, PIECE_SIZE, SHA256_HASH_SIZE,
 };
-use thiserror::Error;
 
 /// Reconstructor-related instantiation error.
-#[derive(Debug, Error, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum ReconstructorInstantiationError {
     /// Segment size is not bigger than record size
-    #[error("Segment size is not bigger than record size")]
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Segment size is not bigger than record size")
+    )]
     SegmentSizeTooSmall,
     /// Segment size is not a multiple of record size
-    #[error("Segment size is not a multiple of record size")]
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Segment size is not a multiple of record size")
+    )]
     SegmentSizesNotMultipleOfRecordSize,
     /// Wrong record and segment size, it will not be possible to produce pieces
-    #[error("Wrong record and segment size, it will not be possible to produce pieces")]
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Wrong record and segment size, it will not be possible to produce pieces")
+    )]
     WrongRecordAndSegmentCombination,
 }
 
 /// Reconstructor-related instantiation error
-#[derive(Debug, Error, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum ReconstructorError {
     /// Segment size is not bigger than record size
-    #[error("Error during data shards reconstruction: {0}")]
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Error during data shards reconstruction: {0}")
+    )]
     DataShardsReconstruction(reed_solomon_erasure::Error),
     /// Segment size is not bigger than record size
-    #[error("Error during segment decoding: {0}")]
+    #[cfg_attr(feature = "thiserror", error("Error during segment decoding: {0}"))]
     SegmentDecoding(parity_scale_codec::Error),
     /// Incorrect segment order, each next segment must have monotonically increasing segment index
-    #[error("Incorrect segment order, expected index {expected_segment_index}, actual {actual_segment_index}")]
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Incorrect segment order, expected index {expected_segment_index}, actual {actual_segment_index}")
+    )]
     IncorrectSegmentOrder {
         expected_segment_index: u64,
         actual_segment_index: u64,

--- a/crates/subspace-archiving/src/utils.rs
+++ b/crates/subspace-archiving/src/utils.rs
@@ -1,6 +1,9 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::mem;
 use reed_solomon_erasure::galois_16::Field as Galois16Field;
 use reed_solomon_erasure::Field;
-use std::mem;
 
 pub(crate) type Gf16Element = <Galois16Field as Field>::Elem;
 pub(crate) const GF_16_ELEMENT_BYTES: usize = mem::size_of::<Gf16Element>();

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -65,8 +65,9 @@ pub type Salt = [u8; SALT_SIZE];
 const PUBLIC_KEY_LENGTH: usize = 32;
 
 /// A Ristretto Schnorr public key as bytes produced by `schnorrkel` crate.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(
+    Debug, Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo,
+)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct PublicKey([u8; PUBLIC_KEY_LENGTH]);
 
@@ -99,8 +100,7 @@ impl AsRef<[u8]> for PublicKey {
 const SIGNATURE_LENGTH: usize = 64;
 
 /// A Ristretto Schnorr signature as bytes produced by `schnorrkel` crate.
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct Signature(
     #[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; SIGNATURE_LENGTH],
@@ -139,8 +139,7 @@ impl AsRef<[u8]> for Signature {
 }
 
 /// A Ristretto Schnorr signature as bytes produced by `schnorrkel` crate.
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct LocalChallenge(
     #[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; SIGNATURE_LENGTH],
@@ -192,8 +191,7 @@ impl LocalChallenge {
 /// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
 /// the segment this piece belongs to can be used to verify that a piece belongs to the actual
 /// archival history of the blockchain.
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Piece(#[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; PIECE_SIZE]);
@@ -252,8 +250,7 @@ impl AsMut<[u8]> for Piece {
 }
 
 /// Flat representation of multiple pieces concatenated for higher efficient for processing.
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct FlatPieces(Vec<u8>);
@@ -314,8 +311,7 @@ impl AsMut<[u8]> for FlatPieces {
 }
 
 /// Progress of an archived block.
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum ArchivedBlockProgress {
@@ -350,8 +346,7 @@ impl ArchivedBlockProgress {
 }
 
 /// Last archived block
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct LastArchivedBlock {
@@ -384,8 +379,7 @@ impl LastArchivedBlock {
 /// segment. Each `RootBlock` includes hash of the previous one and all together form a chain of
 /// root blocks that is used for quick and efficient verification that some [`Piece`] corresponds to
 /// the actual archival history of the blockchain.
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum RootBlock {

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -31,8 +31,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 
 /// Object stored inside of the block
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum BlockObject {
@@ -72,8 +71,7 @@ impl BlockObject {
 }
 
 /// Mapping of objects stored inside of the block
-#[derive(Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct BlockObjectMapping {
@@ -82,8 +80,7 @@ pub struct BlockObjectMapping {
 }
 
 /// Object stored inside of the block
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum PieceObject {
@@ -114,8 +111,7 @@ impl PieceObject {
 }
 
 /// Mapping of objects stored inside of the piece
-#[derive(Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct PieceObjectMapping {
@@ -124,8 +120,7 @@ pub struct PieceObjectMapping {
 }
 
 /// Object stored inside in the history of the blockchain
-#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum GlobalObject {


### PR DESCRIPTION
Adds `no_std` support and removes workaround for M1 that was already applied upstream.

I also made `Debug` impl derived unconditionally since it doesn't affect WASM size anyway.