### PR TITLE
Farmer identity management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7926,12 +7926,15 @@ dependencies = [
  "schnorrkel",
  "serde",
  "serde_json",
+ "sp-core",
+ "ss58-registry",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-rpc-primitives",
  "subspace-solving",
  "tempfile",
  "thiserror",
+ "tiny-bip39",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7936,6 +7936,7 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -40,6 +40,7 @@ subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitive
 thiserror = "1.0.24"
 tiny-bip39 = "0.8.2"
 tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread"] }
+zeroize = "1.4.3"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -31,11 +31,14 @@ rayon = "1.5.1"
 schnorrkel = "0.9.1"
 serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.73"
+sp-core = { version = "4.1.0-dev", git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
+ss58-registry = "1.10.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
 thiserror = "1.0.24"
+tiny-bip39 = "0.8.2"
 tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.rocksdb]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -3,9 +3,8 @@ mod farm;
 use bip39::{Language, Mnemonic};
 pub(crate) use farm::farm;
 use log::info;
-use sp_core::crypto::{Ss58AddressFormatRegistry, Ss58Codec};
-use sp_core::sr25519::Pair;
-use sp_core::Pair as _;
+use sp_core::crypto::{Ss58AddressFormatRegistry, Ss58Codec, UncheckedFrom};
+use sp_core::sr25519::Public;
 use std::path::Path;
 use std::{fs, io};
 use subspace_farmer::Identity;
@@ -23,14 +22,14 @@ pub(crate) fn identity<P: AsRef<Path>>(
         }
     };
 
-    let keypair = Pair::from(identity.secret_key());
+    let public = Public::unchecked_from(identity.public_key().to_bytes());
 
     if (false, false, false) == (address, public_key, mnemonic) || address {
         eprint!("Address:\n  ");
 
         println!(
             "{}",
-            keypair.public().to_ss58check_with_version(
+            public.to_ss58check_with_version(
                 Ss58AddressFormatRegistry::SubspaceTestnetAccount.into()
             )
         );
@@ -39,7 +38,7 @@ pub(crate) fn identity<P: AsRef<Path>>(
     if public_key {
         eprint!("PublicKey:\n  ");
 
-        println!("0x{}", hex::encode(keypair.public()));
+        println!("0x{}", hex::encode(public));
     }
 
     if mnemonic {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,3 +1,88 @@
 mod farm;
 
+use bip39::{Language, Mnemonic};
 pub(crate) use farm::farm;
+use log::info;
+use sp_core::crypto::{Ss58AddressFormatRegistry, Ss58Codec};
+use sp_core::sr25519::Pair;
+use sp_core::Pair as _;
+use std::path::Path;
+use std::{fs, io};
+use subspace_farmer::Identity;
+
+pub(crate) fn identity<P: AsRef<Path>>(
+    path: P,
+    address: bool,
+    public_key: bool,
+    mnemonic: bool,
+) -> anyhow::Result<()> {
+    let identity = match Identity::open(&path)? {
+        Some(identity) => identity,
+        None => {
+            anyhow::bail!("Identity doesn't exist");
+        }
+    };
+
+    let keypair = Pair::from(identity.secret_key());
+
+    if (false, false, false) == (address, public_key, mnemonic) || address {
+        eprint!("Address:\n  ");
+
+        println!(
+            "{}",
+            keypair.public().to_ss58check_with_version(
+                Ss58AddressFormatRegistry::SubspaceTestnetAccount.into()
+            )
+        );
+    }
+
+    if public_key {
+        eprint!("PublicKey:\n  ");
+
+        println!("0x{}", hex::encode(keypair.public()));
+    }
+
+    if mnemonic {
+        eprint!("Mnemonic (NOTE: never share this with anyone!):\n  ");
+
+        println!(
+            "{}",
+            Mnemonic::from_entropy(identity.entropy(), Language::English).unwrap()
+        );
+    }
+
+    Ok(())
+}
+
+/// Helper function for ignoring the error that given file/directory does not exist.
+fn try_remove<P: AsRef<Path>>(
+    path: P,
+    remove: impl FnOnce(P) -> std::io::Result<()>,
+) -> io::Result<()> {
+    if path.as_ref().exists() {
+        remove(path)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn erase_plot<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    info!("Erasing the plot");
+    try_remove(path.as_ref().join("plot.bin"), fs::remove_file)?;
+    info!("Erasing plot metadata");
+    try_remove(path.as_ref().join("plot-metadata"), fs::remove_dir_all)?;
+    info!("Erasing plot commitments");
+    try_remove(path.as_ref().join("commitments"), fs::remove_dir_all)?;
+    info!("Erasing object mappings");
+    try_remove(path.as_ref().join("object-mappings"), fs::remove_dir_all)?;
+
+    Ok(())
+}
+
+pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    erase_plot(path.as_ref())?;
+
+    info!("Erasing identity");
+    try_remove(path.as_ref().join("identity.bin"), fs::remove_file)?;
+
+    Ok(())
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,57 +1,11 @@
 mod farm;
+mod identity;
 
-use bip39::{Language, Mnemonic};
 pub(crate) use farm::farm;
+pub(crate) use identity::identity;
 use log::info;
-use sp_core::crypto::{Ss58AddressFormatRegistry, Ss58Codec, UncheckedFrom};
-use sp_core::sr25519::Public;
 use std::path::Path;
 use std::{fs, io};
-use subspace_farmer::Identity;
-
-pub(crate) fn identity<P: AsRef<Path>>(
-    path: P,
-    address: bool,
-    public_key: bool,
-    mnemonic: bool,
-) -> anyhow::Result<()> {
-    let identity = match Identity::open(&path)? {
-        Some(identity) => identity,
-        None => {
-            anyhow::bail!("Identity doesn't exist");
-        }
-    };
-
-    let public = Public::unchecked_from(identity.public_key().to_bytes());
-
-    if (false, false, false) == (address, public_key, mnemonic) || address {
-        eprint!("Address:\n  ");
-
-        println!(
-            "{}",
-            public.to_ss58check_with_version(
-                Ss58AddressFormatRegistry::SubspaceTestnetAccount.into()
-            )
-        );
-    }
-
-    if public_key {
-        eprint!("PublicKey:\n  ");
-
-        println!("0x{}", hex::encode(public));
-    }
-
-    if mnemonic {
-        eprint!("Mnemonic (NOTE: never share this with anyone!):\n  ");
-
-        println!(
-            "{}",
-            Mnemonic::from_entropy(identity.entropy(), Language::English).unwrap()
-        );
-    }
-
-    Ok(())
-}
 
 /// Helper function for ignoring the error that given file/directory does not exist.
 fn try_remove<P: AsRef<Path>>(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -52,7 +52,7 @@ pub(crate) async fn farm(
 
     let identity = Identity::open_or_create(&base_directory)?;
 
-    let subspace_codec = SubspaceCodec::new(&identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key());
 
     // Start RPC server
     let ws_server = WsServerBuilder::default()

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/identity.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/identity.rs
@@ -1,0 +1,64 @@
+use crate::{utils, IdentityCommand};
+use bip39::{Language, Mnemonic};
+use sp_core::crypto::{Ss58AddressFormatRegistry, Ss58Codec, UncheckedFrom};
+use sp_core::sr25519::Public;
+use std::path::Path;
+use subspace_farmer::Identity;
+
+pub(crate) fn identity(identity_command: IdentityCommand) -> anyhow::Result<()> {
+    match identity_command {
+        IdentityCommand::View {
+            address,
+            public_key,
+            mnemonic,
+            custom_path,
+        } => {
+            let path = utils::get_path(custom_path);
+            view(&path, address, public_key, mnemonic)
+        }
+    }
+}
+
+fn view<P: AsRef<Path>>(
+    path: P,
+    address: bool,
+    public_key: bool,
+    mnemonic: bool,
+) -> anyhow::Result<()> {
+    let identity = match Identity::open(&path)? {
+        Some(identity) => identity,
+        None => {
+            anyhow::bail!("Identity doesn't exist");
+        }
+    };
+
+    let public = Public::unchecked_from(identity.public_key().to_bytes());
+
+    if (false, false, false) == (address, public_key, mnemonic) || address {
+        eprint!("Address (SS58 format):\n  ");
+
+        println!(
+            "{}",
+            public.to_ss58check_with_version(
+                Ss58AddressFormatRegistry::SubspaceTestnetAccount.into()
+            )
+        );
+    }
+
+    if public_key {
+        eprint!("Public key (hex format):\n  ");
+
+        println!("0x{}", hex::encode(public));
+    }
+
+    if mnemonic {
+        eprint!("Mnemonic (NOTE: never share this with anyone!):\n  ");
+
+        println!(
+            "{}",
+            Mnemonic::from_entropy(identity.entropy(), Language::English).unwrap()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -25,6 +25,14 @@ enum IdentityCommand {
         #[clap(long, short, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
     },
+    /// Import identity from BIP39 mnemonic phrase
+    ImportFromMnemonic {
+        /// BIP39 mnemonic phrase to import identity from
+        phrase: String,
+        /// Use custom path for data storage instead of platform-specific default
+        #[clap(long, short, value_hint = ValueHint::FilePath)]
+        custom_path: Option<PathBuf>,
+    },
 }
 
 // TODO: Separate commands for erasing the plot and wiping everything
@@ -37,25 +45,25 @@ enum Command {
     /// Erase existing plot (doesn't touch identity)
     ErasePlot {
         /// Use custom path for data storage instead of platform-specific default
-        #[clap(long, value_hint = ValueHint::FilePath)]
+        #[clap(long, short, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
     },
     /// Wipes plot and identity
     Wipe {
         /// Use custom path for data storage instead of platform-specific default
-        #[clap(long, value_hint = ValueHint::FilePath)]
+        #[clap(long, short, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
     },
     /// Start a farmer using previously created plot
     Farm {
         /// Custom path for data storage instead of platform-specific default
-        #[clap(long, value_hint = ValueHint::FilePath)]
+        #[clap(long, short, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
         /// WebSocket RPC URL of the Subspace node to connect to
-        #[clap(long, value_hint = ValueHint::Url, default_value = "ws://127.0.0.1:9944")]
+        #[clap(long, short, value_hint = ValueHint::Url, default_value = "ws://127.0.0.1:9944")]
         node_rpc_url: String,
         /// Host and port where built-in WebSocket RPC server should listen for incoming connections
-        #[clap(long, default_value = "127.0.0.1:9955")]
+        #[clap(long, short, default_value = "127.0.0.1:9955")]
         ws_server_listen_addr: SocketAddr,
     },
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -5,16 +5,37 @@ use anyhow::Result;
 use clap::{Parser, ValueHint};
 use env_logger::Env;
 use log::info;
-use std::fs;
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 // TODO: Separate commands for erasing the plot and wiping everything
 #[derive(Debug, Parser)]
 #[clap(about, version)]
 enum Command {
-    /// Erase existing plot (including identity)
+    /// Identity management
+    Identity {
+        /// Print SS58 address [default if no other option is specified]
+        #[clap(long, short)]
+        address: bool,
+        /// Print public key (hex)
+        #[clap(long, short)]
+        public_key: bool,
+        /// Print mnemonic (NOTE: never share this with anyone!)
+        #[clap(long, short)]
+        mnemonic: bool,
+        // TODO
+        /// Use custom path for data storage instead of platform-specific default
+        #[clap(long, short, value_hint = ValueHint::FilePath)]
+        custom_path: Option<PathBuf>,
+    },
+    /// Erase existing plot (doesn't touch identity)
     ErasePlot {
+        /// Use custom path for data storage instead of platform-specific default
+        #[clap(long, value_hint = ValueHint::FilePath)]
+        custom_path: Option<PathBuf>,
+    },
+    /// Wipes plot and identity
+    Wipe {
         /// Use custom path for data storage instead of platform-specific default
         #[clap(long, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
@@ -33,34 +54,28 @@ enum Command {
     },
 }
 
-/// Helper function for ignoring the error that given file/directory does not exist.
-fn try_remove<P: AsRef<Path>>(
-    path: P,
-    remove: impl FnOnce(P) -> std::io::Result<()>,
-) -> Result<()> {
-    if path.as_ref().exists() {
-        remove(path)?;
-    }
-    Ok(())
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init_from_env(Env::new().default_filter_or("info"));
     let command: Command = Command::parse();
     match command {
+        Command::Identity {
+            address,
+            public_key,
+            mnemonic,
+            custom_path,
+        } => {
+            let path = utils::get_path(custom_path);
+            commands::identity(&path, address, public_key, mnemonic)?;
+        }
         Command::ErasePlot { custom_path } => {
             let path = utils::get_path(custom_path);
-            info!("Erasing the plot");
-            try_remove(path.join("plot.bin"), fs::remove_file)?;
-            info!("Erasing plot metadata");
-            try_remove(path.join("plot-metadata"), fs::remove_dir_all)?;
-            info!("Erasing plot commitments");
-            try_remove(path.join("commitments"), fs::remove_dir_all)?;
-            info!("Erasing object mappings");
-            try_remove(path.join("object-mappings"), fs::remove_dir_all)?;
-            info!("Erasing identity");
-            try_remove(path.join("identity.bin"), fs::remove_file)?;
+            commands::erase_plot(&path)?;
+            info!("Done");
+        }
+        Command::Wipe { custom_path } => {
+            let path = utils::get_path(custom_path);
+            commands::wipe(&path)?;
             info!("Done");
         }
         Command::Farm {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -8,12 +8,10 @@ use log::info;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-// TODO: Separate commands for erasing the plot and wiping everything
 #[derive(Debug, Parser)]
-#[clap(about, version)]
-enum Command {
-    /// Identity management
-    Identity {
+enum IdentityCommand {
+    /// View identity information
+    View {
         /// Print SS58 address [default if no other option is specified]
         #[clap(long, short)]
         address: bool,
@@ -23,11 +21,19 @@ enum Command {
         /// Print mnemonic (NOTE: never share this with anyone!)
         #[clap(long, short)]
         mnemonic: bool,
-        // TODO
         /// Use custom path for data storage instead of platform-specific default
         #[clap(long, short, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
     },
+}
+
+// TODO: Separate commands for erasing the plot and wiping everything
+#[derive(Debug, Parser)]
+#[clap(about, version)]
+enum Command {
+    /// Identity management
+    #[clap(subcommand)]
+    Identity(IdentityCommand),
     /// Erase existing plot (doesn't touch identity)
     ErasePlot {
         /// Use custom path for data storage instead of platform-specific default
@@ -59,14 +65,8 @@ async fn main() -> Result<()> {
     env_logger::init_from_env(Env::new().default_filter_or("info"));
     let command: Command = Command::parse();
     match command {
-        Command::Identity {
-            address,
-            public_key,
-            mnemonic,
-            custom_path,
-        } => {
-            let path = utils::get_path(custom_path);
-            commands::identity(&path, address, public_key, mnemonic)?;
+        Command::Identity(identity_command) => {
+            commands::identity(identity_command)?;
         }
         Command::ErasePlot { custom_path } => {
             let path = utils::get_path(custom_path);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -35,7 +35,6 @@ enum IdentityCommand {
     },
 }
 
-// TODO: Separate commands for erasing the plot and wiping everything
 #[derive(Debug, Parser)]
 #[clap(about, version)]
 enum Command {

--- a/crates/subspace-farmer/src/identity.rs
+++ b/crates/subspace-farmer/src/identity.rs
@@ -1,79 +1,99 @@
 use anyhow::Error;
 use bip39::{Language, Mnemonic, MnemonicType};
 use log::debug;
+use parity_scale_codec::{Decode, Encode};
 use schnorrkel::{context::SigningContext, Keypair, PublicKey, SecretKey, Signature};
 use sp_core::sr25519::Pair;
 use std::fs;
 use std::path::Path;
 use subspace_solving::SOLUTION_SIGNING_CONTEXT;
+use zeroize::{Zeroize, Zeroizing};
 
 // Signing context hardcoded in Substrate implementation and used for signing blocks.
 const SUBSTRATE_SIGNING_CONTEXT: &[u8] = b"substrate";
 
-// TODO: Use `zeroize::Zeroizing`
+#[derive(Debug, Encode, Decode)]
+struct IdentityFileContents {
+    entropy: Vec<u8>,
+}
+
 /// `Identity` struct is an abstraction of public & secret key related operations.
 ///
 /// It is basically a wrapper of the keypair (which holds public & secret keys)
 /// and a context that will be used for signing.
 #[derive(Clone)]
 pub struct Identity {
-    keypair: Keypair,
-    entropy: Vec<u8>,
+    keypair: Zeroizing<Keypair>,
+    entropy: Zeroizing<Vec<u8>>,
     farmer_solution_ctx: SigningContext,
     substrate_ctx: SigningContext,
 }
 
 impl Identity {
     /// Opens the existing identity, or creates a new one.
-    pub fn open_or_create<B: AsRef<Path>>(base_directory: B) -> Result<Identity, Error> {
-        let identity_file = base_directory.as_ref().join("identity.bin");
-        let entropy = if identity_file.exists() {
-            debug!("Opening existing keypair");
-            fs::read(identity_file)?
+    pub fn open_or_create<B: AsRef<Path>>(base_directory: B) -> Result<Self, Error> {
+        if let Some(identity) = Self::open(base_directory.as_ref())? {
+            Ok(identity)
         } else {
-            debug!("Generating new keypair");
-            let entropy = Mnemonic::new(MnemonicType::Words24, Language::English)
-                .entropy()
-                .to_vec();
-            fs::write(identity_file, &entropy)?;
-            entropy
-        };
-        let (pair, _seed) = Pair::from_entropy(&entropy, None);
+            Self::create(base_directory)
+        }
+    }
 
-        Ok(Identity {
-            keypair: pair.into(),
-            entropy,
+    /// Opens the existing identity, returns `Ok(None)` if it doesn't exist.
+    pub fn open<B: AsRef<Path>>(base_directory: B) -> Result<Option<Self>, Error> {
+        let identity_file = base_directory.as_ref().join("identity.bin");
+        if identity_file.exists() {
+            debug!("Opening existing keypair");
+            let bytes = Zeroizing::new(fs::read(identity_file)?);
+            let IdentityFileContents { entropy } =
+                IdentityFileContents::decode(&mut bytes.as_ref())?;
+
+            let (pair, mut seed) = Pair::from_entropy(&entropy, None);
+            seed.zeroize();
+
+            Ok(Some(Self {
+                keypair: Zeroizing::new(pair.into()),
+                entropy: Zeroizing::new(entropy),
+                farmer_solution_ctx: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
+                substrate_ctx: schnorrkel::context::signing_context(SUBSTRATE_SIGNING_CONTEXT),
+            }))
+        } else {
+            debug!("Existing keypair not found");
+            Ok(None)
+        }
+    }
+
+    /// Creates new identity identity, returns `Ok(None)` if it already exists.
+    pub fn create<B: AsRef<Path>>(base_directory: B) -> Result<Self, Error> {
+        let identity_file = base_directory.as_ref().join("identity.bin");
+        debug!("Generating new keypair");
+        let entropy = Mnemonic::new(MnemonicType::Words24, Language::English)
+            .entropy()
+            .to_vec();
+
+        let identity_file_contents = IdentityFileContents { entropy };
+        fs::write(identity_file, identity_file_contents.encode())?;
+
+        let IdentityFileContents { entropy } = identity_file_contents;
+        let (pair, mut seed) = Pair::from_entropy(&entropy, None);
+        seed.zeroize();
+
+        Ok(Self {
+            keypair: Zeroizing::new(pair.into()),
+            entropy: Zeroizing::new(entropy),
             farmer_solution_ctx: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
             substrate_ctx: schnorrkel::context::signing_context(SUBSTRATE_SIGNING_CONTEXT),
         })
     }
 
-    /// Opens the existing identity, returns `Ok(None)` if it doesn't exist.
-    pub fn open<B: AsRef<Path>>(base_directory: B) -> Result<Option<Identity>, Error> {
-        let identity_file = base_directory.as_ref().join("identity.bin");
-        if identity_file.exists() {
-            let entropy = fs::read(identity_file)?;
-            let (pair, _seed) = Pair::from_entropy(&entropy, None);
-
-            Ok(Some(Identity {
-                keypair: pair.into(),
-                entropy,
-                farmer_solution_ctx: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
-                substrate_ctx: schnorrkel::context::signing_context(SUBSTRATE_SIGNING_CONTEXT),
-            }))
-        } else {
-            Ok(None)
-        }
-    }
-
     /// Returns the public key of the identity.
-    pub fn public_key(&self) -> PublicKey {
-        self.keypair.public
+    pub fn public_key(&self) -> &PublicKey {
+        &self.keypair.public
     }
 
     /// Returns the secret key of the identity.
-    pub fn secret_key(&self) -> SecretKey {
-        self.keypair.secret.clone()
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.keypair.secret
     }
 
     /// Returns entropy used to generate keypair.

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -47,7 +47,7 @@ async fn plotting_happy_path() {
     let identity =
         Identity::open_or_create(&base_directory).expect("Could not open/create identity!");
 
-    let subspace_codec = SubspaceCodec::new(&identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key());
 
     let encoded_block0 = EncodedBlockWithObjectMapping {
         block: vec![0u8; SEGMENT_SIZE / 2],
@@ -155,7 +155,7 @@ async fn plotting_continue() {
     let identity =
         Identity::open_or_create(&base_directory).expect("Could not open/create identity!");
 
-    let subspace_codec = SubspaceCodec::new(&identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key());
 
     let encoded_block0 = EncodedBlockWithObjectMapping {
         block: vec![0u8; SEGMENT_SIZE / 2],


### PR DESCRIPTION
This changes in backwards-incompatible `identity.bin` file and introduces CLI commands for following features:
* Viewing identity
  * Address (SS58)
  * Public key (hex)
  * Mnemonic phrase
* Importing identity from mnemonic phrase

No password support yet for mnemonic phrase.