### PR TITLE
Make `ConsensusLog` and `SUBSPACE_ENGINE_ID` private, add cleaner APIs instead and use them everywhere

### DIFF
--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -32,10 +32,10 @@ use frame_support::{assert_err, assert_noop, assert_ok};
 use frame_system::{EventRecord, Phase};
 use schnorrkel::Keypair;
 use sp_consensus_slots::Slot;
-use sp_consensus_subspace::digests::NextConfigDescriptor;
-use sp_consensus_subspace::{
-    digests::Solution, FarmerPublicKey, SubspaceEpochConfiguration, SUBSPACE_ENGINE_ID,
+use sp_consensus_subspace::digests::{
+    CompatibleDigestItem, NextConfigDescriptor, NextEpochDescriptor,
 };
+use sp_consensus_subspace::{digests::Solution, FarmerPublicKey, SubspaceEpochConfiguration};
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Header;
 use sp_runtime::transaction_validity::{
@@ -87,12 +87,9 @@ fn first_block_epoch_zero_start() {
         assert_eq!(pre_digest.logs.len(), 1);
         assert_eq!(header.digest.logs[0], pre_digest.logs[0]);
 
-        let consensus_log = sp_consensus_subspace::ConsensusLog::NextEpochData(
-            sp_consensus_subspace::digests::NextEpochDescriptor {
-                randomness: Subspace::randomness(),
-            },
-        );
-        let consensus_digest = DigestItem::Consensus(SUBSPACE_ENGINE_ID, consensus_log.encode());
+        let consensus_digest = DigestItem::next_epoch_descriptor(NextEpochDescriptor {
+            randomness: Subspace::randomness(),
+        });
 
         // first epoch descriptor has same info as last.
         assert_eq!(header.digest.logs[1], consensus_digest.clone())
@@ -280,11 +277,9 @@ fn can_enact_next_config() {
             Some(next_next_config.clone())
         );
 
-        let consensus_log =
-            sp_consensus_subspace::ConsensusLog::NextConfigData(NextConfigDescriptor::V1 {
-                c: next_next_config.c,
-            });
-        let consensus_digest = DigestItem::Consensus(SUBSPACE_ENGINE_ID, consensus_log.encode());
+        let consensus_digest = DigestItem::next_config_descriptor(NextConfigDescriptor::V1 {
+            c: next_next_config.c,
+        });
 
         assert_eq!(header.digest.logs[4], consensus_digest.clone())
     });

--- a/crates/sc-consensus-subspace/src/verification.rs
+++ b/crates/sc-consensus-subspace/src/verification.rs
@@ -90,7 +90,8 @@ pub(super) fn check_header<B: BlockT + Sized>(
         .pop()
         .ok_or_else(|| subspace_err(Error::HeaderUnsealed(header.hash())))?;
 
-    let sig = CompatibleDigestItem::<FarmerPublicKey>::as_subspace_seal(&seal)
+    let sig = seal
+        .as_subspace_seal()
         .ok_or_else(|| subspace_err(Error::HeaderBadSeal(header.hash())))?;
 
     // the pre-hash of the header doesn't include the seal

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -56,12 +56,7 @@ pub type FarmerSignature = app::Signature;
 pub type FarmerPublicKey = app::Public;
 
 /// The `ConsensusEngineId` of Subspace.
-pub const SUBSPACE_ENGINE_ID: ConsensusEngineId = *b"SUB_";
-
-/// How many blocks to wait before running the median algorithm for relative time
-/// This will not vary from chain to chain as it is not dependent on slot duration
-/// or epoch length.
-pub const MEDIAN_ALGORITHM_CARDINALITY: usize = 1200; // arbitrary suggestion by w3f-research.
+const SUBSPACE_ENGINE_ID: ConsensusEngineId = *b"SUB_";
 
 /// An equivocation proof for multiple block authorships on the same slot (i.e. double vote).
 pub type EquivocationProof<H> = sp_consensus_slots::EquivocationProof<H, FarmerPublicKey>;
@@ -74,28 +69,28 @@ pub type SubspaceBlockWeight = u128;
 
 /// An consensus log item for Subspace.
 #[derive(Decode, Encode, Clone, PartialEq, Eq, RuntimeDebug)]
-pub enum ConsensusLog {
+enum ConsensusLog {
     /// The epoch has changed. This provides information about the _next_
     /// epoch - information about the _current_ epoch (i.e. the one we've just
     /// entered) should already be available earlier in the chain.
     #[codec(index = 1)]
-    NextEpochData(NextEpochDescriptor),
+    NextEpoch(NextEpochDescriptor),
     /// The epoch has changed, and the epoch after the current one will
     /// enact different epoch configurations.
     #[codec(index = 2)]
-    NextConfigData(NextConfigDescriptor),
+    NextConfig(NextConfigDescriptor),
     /// Solution range for this block.
     #[codec(index = 3)]
-    SolutionRangeData(SolutionRangeDescriptor),
+    SolutionRange(SolutionRangeDescriptor),
     /// Salt for this block.
     #[codec(index = 4)]
-    SaltData(SaltDescriptor),
+    Salt(SaltDescriptor),
     /// The era has changed and the solution range has changed because of that.
     #[codec(index = 5)]
-    NextSolutionRangeData(UpdatedSolutionRangeDescriptor),
+    UpdatedSolutionRange(UpdatedSolutionRangeDescriptor),
     /// The eon has changed and the salt has changed because of that.
     #[codec(index = 6)]
-    UpdatedSaltData(UpdatedSaltDescriptor),
+    UpdatedSalt(UpdatedSaltDescriptor),
 }
 
 /// Configuration data used by the Subspace consensus engine.
@@ -160,8 +155,7 @@ where
     };
 
     let verify_seal_signature = |mut header: H, offender: &FarmerPublicKey| {
-        let seal =
-            CompatibleDigestItem::<FarmerPublicKey>::as_subspace_seal(&header.digest_mut().pop()?)?;
+        let seal = CompatibleDigestItem::as_subspace_seal(&header.digest_mut().pop()?)?;
         let pre_hash = header.hash();
 
         if !offender.verify(&pre_hash.as_ref(), &seal) {


### PR DESCRIPTION
This unifies codebase, hides implementation details behind clean API in a consistent way (similar refactoring would be useful for BABE where this code originated for the most part).