### PR TITLE
Set the default ss58 version on node start up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7999,6 +7999,7 @@ dependencies = [
  "sp-timestamp",
  "structopt",
  "subspace-runtime",
+ "subspace-runtime-primitives",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -60,6 +60,7 @@ sp-runtime = { version = "4.0.0", git = "https://github.com/paritytech/substrate
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 structopt = "0.3.22"
 subspace-runtime = { version = "0.1.0", features = ["do-not-enforce-cost-of-storage"], path = "../subspace-runtime" }
+subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 thiserror = "1.0"

--- a/crates/subspace-node/src/command.rs
+++ b/crates/subspace-node/src/command.rs
@@ -18,6 +18,7 @@ use crate::cli::{Cli, Subcommand};
 use crate::{chain_spec, service};
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
+use sp_core::crypto::Ss58AddressFormatRegistry;
 use subspace_runtime::Block;
 
 /// Subspace node error.
@@ -87,6 +88,13 @@ impl SubstrateCli for Cli {
     }
 }
 
+// TODO: set the default ss58 version properly once we have multiple networks at the same time.
+fn set_default_ss58_version() {
+    let ss58_version = Ss58AddressFormatRegistry::SubspaceTestnetAccount.into();
+
+    sp_core::crypto::set_default_ss58_version(ss58_version);
+}
+
 /// Parse and run command line arguments
 pub fn run() -> std::result::Result<(), Error> {
     let cli = Cli::from_args();
@@ -99,6 +107,7 @@ pub fn run() -> std::result::Result<(), Error> {
         }
         Some(Subcommand::CheckBlock(cmd)) => {
             let runner = cli.create_runner(cmd)?;
+            set_default_ss58_version();
             runner.async_run(|config| {
                 let PartialComponents {
                     client,
@@ -111,6 +120,7 @@ pub fn run() -> std::result::Result<(), Error> {
         }
         Some(Subcommand::ExportBlocks(cmd)) => {
             let runner = cli.create_runner(cmd)?;
+            set_default_ss58_version();
             runner.async_run(|config| {
                 let PartialComponents {
                     client,
@@ -122,6 +132,7 @@ pub fn run() -> std::result::Result<(), Error> {
         }
         Some(Subcommand::ExportState(cmd)) => {
             let runner = cli.create_runner(cmd)?;
+            set_default_ss58_version();
             runner.async_run(|config| {
                 let PartialComponents {
                     client,
@@ -133,6 +144,7 @@ pub fn run() -> std::result::Result<(), Error> {
         }
         Some(Subcommand::ImportBlocks(cmd)) => {
             let runner = cli.create_runner(cmd)?;
+            set_default_ss58_version();
             runner.async_run(|config| {
                 let PartialComponents {
                     client,
@@ -149,6 +161,7 @@ pub fn run() -> std::result::Result<(), Error> {
         }
         Some(Subcommand::Revert(cmd)) => {
             let runner = cli.create_runner(cmd)?;
+            set_default_ss58_version();
             runner.async_run(|config| {
                 let PartialComponents {
                     client,
@@ -162,7 +175,7 @@ pub fn run() -> std::result::Result<(), Error> {
         Some(Subcommand::Benchmark(cmd)) => {
             if cfg!(feature = "runtime-benchmarks") {
                 let runner = cli.create_runner(cmd)?;
-
+                set_default_ss58_version();
                 runner.sync_run(|config| cmd.run::<Block, service::ExecutorDispatch>(config))?;
             } else {
                 return Err(Error::Other(
@@ -174,6 +187,7 @@ pub fn run() -> std::result::Result<(), Error> {
         }
         None => {
             let runner = cli.create_runner(&cli.run.base)?;
+            set_default_ss58_version();
             runner.run_node_until_exit(|config| async move {
                 service::new_full(config)
                     .await

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -23,6 +23,11 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::MultiSignature;
 use subspace_core_primitives::{PIECE_SIZE, SHA256_HASH_SIZE};
 
+/// SS58 prefix for Subspace mainnet.
+pub const MAINNET_SS58_PREFIX: u16 = 6094;
+/// SS58 prefix for Subspace testnet.
+pub const TESTNET_SS58_PREFIX: u16 = 2254;
+
 // TODO: Proper value here
 pub const CONFIRMATION_DEPTH_K: u32 = 100;
 /// 128 data records and 128 parity records (as a result of erasure coding) together form a perfect
@@ -148,4 +153,22 @@ pub mod opaque {
 
     /// Opaque block identifier type.
     pub type BlockId = generic::BlockId<Block>;
+}
+
+/// Identifies which network the SS58 address prefix targets.
+pub trait IdentifyNetwork {
+    /// Returns true if the address prefix is for Subspace mainnet.
+    fn is_mainnet(self) -> bool;
+    /// Returns true if the address prefix is for Subspace testnet.
+    fn is_testnet(self) -> bool;
+}
+
+impl IdentifyNetwork for u16 {
+    fn is_mainnet(self) -> bool {
+        self == MAINNET_SS58_PREFIX
+    }
+
+    fn is_testnet(self) -> bool {
+        self == TESTNET_SS58_PREFIX
+    }
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -60,8 +60,8 @@ use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping};
 use subspace_core_primitives::{RootBlock, Sha256Hash, PIECE_SIZE};
 pub use subspace_runtime_primitives::{
     opaque, AccountId, Balance, BlockNumber, Hash, Index, Moment, Signature, CONFIRMATION_DEPTH_K,
-    MIN_REPLICATION_FACTOR, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
-    STORAGE_FEES_ESCROW_BLOCK_REWARD, STORAGE_FEES_ESCROW_BLOCK_TAX,
+    MAINNET_SS58_PREFIX, MIN_REPLICATION_FACTOR, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
+    STORAGE_FEES_ESCROW_BLOCK_REWARD, STORAGE_FEES_ESCROW_BLOCK_TAX, TESTNET_SS58_PREFIX,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -170,7 +170,7 @@ parameter_types! {
     pub SubspaceBlockLength: BlockLength = BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO);
 }
 
-pub type SS58Prefix = ConstU16<2254>;
+pub type SS58Prefix = ConstU16<TESTNET_SS58_PREFIX>;
 
 // Configure FRAME pallets to include in runtime.
 


### PR DESCRIPTION
The default ss58 version only impacts the address form when you
convert an AccountId to an Address, e.g., if you have an RPC whose
return value contains a field with type `AccountId`, this field can
be ss58 encoded using an unexpected address format if the global default
version(`SubstrateAccount` by default) is not set properly.

This basically won't lead to an error anywhere, just the output address from the node can be wrong.