### PR TITLE
Last pieces of initial version of decoupled execution skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
+ "sp-consensus-slots",
  "sp-core",
  "sp-executor",
  "sp-keyring",
@@ -7545,11 +7546,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
+ "sp-consensus-slots",
  "sp-core",
  "sp-runtime",
  "sp-std",
  "sp-trie",
  "subspace-core-primitives",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]

--- a/crates/sp-executor/Cargo.toml
+++ b/crates/sp-executor/Cargo.toml
@@ -15,11 +15,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { version = "2.3.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sp-core = { version = "4.1.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sp-runtime = { version = "4.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sp-trie = { version = "4.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
+subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [features]
 default = ["std"]
@@ -27,9 +29,11 @@ std = [
 	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-api/std",
+	"sp-consensus-slots/std",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-trie/std",
 	"subspace-core-primitives/std",
+	"subspace-runtime-primitives/std",
 ]

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -131,9 +131,9 @@ pub struct FraudProof {
     pub proof: StorageProof,
 }
 
-/// Represents an equivocation proof. An equivocation happens when a validator
-/// produces more than one block on the same slot. The proof of equivocation
-/// are the given distinct headers that were signed by the validator and which
+/// Represents a bundle equivocation proof. An equivocation happens when an executor
+/// produces more than one bundle on the same slot. The proof of equivocation
+/// are the given distinct bundle headers that were signed by the validator and which
 /// include the slot number.
 #[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
 pub struct BundleEquivocationProof {
@@ -170,6 +170,10 @@ impl BundleEquivocationProof {
     }
 }
 
+/// Represents an invalid transaction proof.
+#[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
+pub struct InvalidTransactionProof;
+
 sp_api::decl_runtime_apis! {
     /// API necessary for executor pallet.
     pub trait ExecutorApi {
@@ -193,6 +197,11 @@ sp_api::decl_runtime_apis! {
         /// Submits the bundle equivocation proof via an unsigned extrinsic.
         fn submit_bundle_equivocation_proof_unsigned(
             bundle_equivocation_proof: BundleEquivocationProof,
+        ) -> Option<()>;
+
+        /// Submits the invalid transaction proof via an unsigned extrinsic.
+        fn submit_invalid_transaction_proof_unsigned(
+            invalid_transaction_proof: InvalidTransactionProof,
         ) -> Option<()>;
 
         /// Extract the bundles from extrinsics in a block.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -910,6 +910,12 @@ impl_runtime_apis! {
             Executor::submit_fraud_proof_unsigned(fraud_proof).ok()
         }
 
+        fn submit_bundle_equivocation_proof_unsigned(
+            bundle_equivocation_proof: sp_executor::BundleEquivocationProof,
+        ) -> Option<()> {
+            Executor::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof).ok()
+        }
+
         fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle> {
             extract_bundles(extrinsics)
         }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -916,6 +916,12 @@ impl_runtime_apis! {
             Executor::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof).ok()
         }
 
+        fn submit_invalid_transaction_proof_unsigned(
+            invalid_transaction_proof: sp_executor::InvalidTransactionProof,
+        ) -> Option<()> {
+            Executor::submit_invalid_transaction_proof_unsigned(invalid_transaction_proof).ok()
+        }
+
         fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle> {
             extract_bundles(extrinsics)
         }

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 # Substrate dependencies
 sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
+sp-consensus-slots = { git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sc-utils = { git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "5bd5b842d4ea520d281b1398e1f54907c9862fcd" }

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use cirrus_node_primitives::{
 	CollationGenerationConfig, ExecutorSlotInfo, PersistedValidationData,
 };
-use sp_executor::FraudProof;
+use sp_executor::{BundleEquivocationProof, FraudProof};
 use subspace_runtime_primitives::Hash;
 
 mod error;
@@ -141,21 +141,37 @@ impl CollationGenerationSubsystem {
 				false
 			},
 			Ok(FromOverseer::Signal(OverseerSignal::Conclude)) => true,
-			Ok(FromOverseer::Communication {
-				msg: CollationGenerationMessage::Initialize(config),
-			}) => {
-				if self.config.is_some() {
-					tracing::error!(target: LOG_TARGET, "double initialization");
-				} else {
-					self.config = Some(Arc::new(config));
-				}
-				false
-			},
-			Ok(FromOverseer::Communication {
-				msg: CollationGenerationMessage::FraudProof(fraud_proof),
-			}) => {
-				if let Err(err) = submit_fraud_proof(fraud_proof, ctx, sender).await {
-					tracing::warn!(target: LOG_TARGET, ?err, "failed to submit fraud proof");
+			Ok(FromOverseer::Communication { msg }) => {
+				match msg {
+					CollationGenerationMessage::Initialize(config) =>
+						if self.config.is_some() {
+							tracing::error!(target: LOG_TARGET, "double initialization");
+						} else {
+							self.config = Some(Arc::new(config));
+						},
+					CollationGenerationMessage::FraudProof(fraud_proof) => {
+						if let Err(err) = submit_fraud_proof(fraud_proof, ctx, sender).await {
+							tracing::warn!(
+								target: LOG_TARGET,
+								?err,
+								"failed to submit fraud proof"
+							);
+						}
+					},
+					CollationGenerationMessage::BundleEquivocationProof(
+						bundle_equivocation_proof,
+					) => {
+						if let Err(err) =
+							submit_bundle_equivocation_proof(bundle_equivocation_proof, ctx, sender)
+								.await
+						{
+							tracing::warn!(
+								target: LOG_TARGET,
+								?err,
+								"failed to submit bundle equivocation proof"
+							);
+						}
+					},
 				}
 				false
 			},
@@ -455,6 +471,41 @@ async fn submit_fraud_proof<Context: SubsystemContext>(
 				tracing::debug!(
 					target: LOG_TARGET,
 					"Sent RuntimeApiRequest::SubmitFraudProof successfully",
+				);
+			}
+		}),
+	)?;
+
+	Ok(())
+}
+
+async fn submit_bundle_equivocation_proof<Context: SubsystemContext>(
+	bundle_equivocation_proof: BundleEquivocationProof,
+	ctx: &mut Context,
+	sender: &mpsc::Sender<AllMessages>,
+) -> SubsystemResult<()> {
+	let best_hash = request_best_primary_hash(ctx).await?;
+
+	let mut task_sender = sender.clone();
+	ctx.spawn(
+		"collation generation bundle equivocation proof builder",
+		Box::pin(async move {
+			if let Err(err) = task_sender
+				.send(AllMessages::RuntimeApi(RuntimeApiMessage::Request(
+					best_hash,
+					RuntimeApiRequest::SubmitBundleEquivocationProof(bundle_equivocation_proof),
+				)))
+				.await
+			{
+				tracing::warn!(
+					target: LOG_TARGET,
+					err = ?err,
+					"Failed to send RuntimeApiRequest::SubmitBundleEquivocationProof",
+				);
+			} else {
+				tracing::debug!(
+					target: LOG_TARGET,
+					"Sent RuntimeApiRequest::SubmitBundleEquivocationProof successfully",
 				);
 			}
 		}),

--- a/polkadot/node/core/runtime-api/src/cache.rs
+++ b/polkadot/node/core/runtime-api/src/cache.rs
@@ -59,6 +59,7 @@ pub(crate) enum RequestResult {
 	SubmitTransactionBundle(Hash, Hash),
 	SubmitFraudProof(Hash),
 	SubmitBundleEquivocationProof(Hash),
+	SubmitInvalidTransactionProof(Hash),
 	ExtractBundles(Hash),
 	ExtrinsicsShufflingSeed(Hash),
 	PendingHead(Hash, Option<Hash>),

--- a/polkadot/node/core/runtime-api/src/cache.rs
+++ b/polkadot/node/core/runtime-api/src/cache.rs
@@ -58,6 +58,7 @@ pub(crate) enum RequestResult {
 	SubmitExecutionReceipt(Hash),
 	SubmitTransactionBundle(Hash, Hash),
 	SubmitFraudProof(Hash),
+	SubmitBundleEquivocationProof(Hash),
 	ExtractBundles(Hash),
 	ExtrinsicsShufflingSeed(Hash),
 	PendingHead(Hash, Option<Hash>),

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -115,6 +115,7 @@ where
 			SubmitTransactionBundle(..) => {},
 			SubmitFraudProof(..) => {},
 			SubmitBundleEquivocationProof(..) => {},
+			SubmitInvalidTransactionProof(..) => {},
 			ExtractBundles(..) => {},
 			ExtrinsicsShufflingSeed(..) => {},
 			PendingHead(..) => {},
@@ -154,6 +155,7 @@ where
 			Request::SubmitTransactionBundle(..) => None,
 			Request::SubmitFraudProof(..) => None,
 			Request::SubmitBundleEquivocationProof(..) => None,
+			Request::SubmitInvalidTransactionProof(..) => None,
 			Request::ExtractBundles(..) => None,
 			Request::ExtrinsicsShufflingSeed(..) => None,
 			Request::PendingHead(..) => None,
@@ -312,6 +314,17 @@ where
 				.map_err(|e| RuntimeApiError::from(format!("{:?}", e)));
 			metrics.on_request(res.is_ok());
 			res.ok().map(|_res| RequestResult::SubmitBundleEquivocationProof(relay_parent));
+		},
+		Request::SubmitInvalidTransactionProof(invalid_transaction_proof) => {
+			let api = client.runtime_api();
+			let res = api
+				.submit_invalid_transaction_proof_unsigned(
+					&BlockId::Hash(relay_parent),
+					invalid_transaction_proof,
+				)
+				.map_err(|e| RuntimeApiError::from(format!("{:?}", e)));
+			metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::SubmitInvalidTransactionProof(relay_parent));
 		},
 		Request::ExtractBundles(extrinsics, sender) => {
 			let api = client.runtime_api();

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -114,6 +114,7 @@ where
 			SubmitExecutionReceipt(..) => {},
 			SubmitTransactionBundle(..) => {},
 			SubmitFraudProof(..) => {},
+			SubmitBundleEquivocationProof(..) => {},
 			ExtractBundles(..) => {},
 			ExtrinsicsShufflingSeed(..) => {},
 			PendingHead(..) => {},
@@ -152,6 +153,7 @@ where
 			Request::SubmitExecutionReceipt(..) => None,
 			Request::SubmitTransactionBundle(..) => None,
 			Request::SubmitFraudProof(..) => None,
+			Request::SubmitBundleEquivocationProof(..) => None,
 			Request::ExtractBundles(..) => None,
 			Request::ExtrinsicsShufflingSeed(..) => None,
 			Request::PendingHead(..) => None,
@@ -299,6 +301,17 @@ where
 				.map_err(|e| RuntimeApiError::from(format!("{:?}", e)));
 			metrics.on_request(res.is_ok());
 			res.ok().map(|_res| RequestResult::SubmitFraudProof(relay_parent));
+		},
+		Request::SubmitBundleEquivocationProof(bundle_equivocation_proof) => {
+			let api = client.runtime_api();
+			let res = api
+				.submit_bundle_equivocation_proof_unsigned(
+					&BlockId::Hash(relay_parent),
+					bundle_equivocation_proof,
+				)
+				.map_err(|e| RuntimeApiError::from(format!("{:?}", e)));
+			metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::SubmitBundleEquivocationProof(relay_parent));
 		},
 		Request::ExtractBundles(extrinsics, sender) => {
 			let api = client.runtime_api();

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -27,7 +27,7 @@ use futures::channel::oneshot;
 pub use sc_network::IfDisconnected;
 
 use cirrus_node_primitives::{BlockWeight, CollationGenerationConfig};
-use sp_executor::{FraudProof, OpaqueBundle, OpaqueExecutionReceipt};
+use sp_executor::{BundleEquivocationProof, FraudProof, OpaqueBundle, OpaqueExecutionReceipt};
 use sp_runtime::OpaqueExtrinsic;
 use subspace_core_primitives::Randomness;
 use subspace_runtime_primitives::{opaque::Header as BlockHeader, BlockNumber, Hash};
@@ -114,6 +114,8 @@ pub enum RuntimeApiRequest {
 	SubmitTransactionBundle(OpaqueBundle),
 	/// Submit the fraud proof to primary chain.
 	SubmitFraudProof(FraudProof),
+	/// Submit the bundle equivocation proof to primary chain.
+	SubmitBundleEquivocationProof(BundleEquivocationProof),
 	/// Extract the bundles from the extrinsics of a block.
 	ExtractBundles(Vec<OpaqueExtrinsic>, RuntimeApiSender<Vec<OpaqueBundle>>),
 	/// Get the randomness seed for extrinsics shuffling.
@@ -145,6 +147,8 @@ pub enum CollationGenerationMessage {
 	Initialize(CollationGenerationConfig),
 	/// Fraud proof needs to be submitted to primary chain.
 	FraudProof(FraudProof),
+	/// Bundle equivocation proof needs to be submitted to primary chain.
+	BundleEquivocationProof(BundleEquivocationProof),
 }
 
 impl CollationGenerationMessage {

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -27,7 +27,7 @@ use futures::channel::oneshot;
 pub use sc_network::IfDisconnected;
 
 use cirrus_node_primitives::{BlockWeight, CollationGenerationConfig};
-use sp_executor::{BundleEquivocationProof, FraudProof, OpaqueBundle, OpaqueExecutionReceipt};
+use sp_executor::{BundleEquivocationProof, FraudProof, OpaqueBundle, OpaqueExecutionReceipt, InvalidTransactionProof};
 use sp_runtime::OpaqueExtrinsic;
 use subspace_core_primitives::Randomness;
 use subspace_runtime_primitives::{opaque::Header as BlockHeader, BlockNumber, Hash};
@@ -116,6 +116,8 @@ pub enum RuntimeApiRequest {
 	SubmitFraudProof(FraudProof),
 	/// Submit the bundle equivocation proof to primary chain.
 	SubmitBundleEquivocationProof(BundleEquivocationProof),
+	/// Submit the invalid transaction proof to primary chain.
+	SubmitInvalidTransactionProof(InvalidTransactionProof),
 	/// Extract the bundles from the extrinsics of a block.
 	ExtractBundles(Vec<OpaqueExtrinsic>, RuntimeApiSender<Vec<OpaqueBundle>>),
 	/// Get the randomness seed for extrinsics shuffling.
@@ -149,6 +151,8 @@ pub enum CollationGenerationMessage {
 	FraudProof(FraudProof),
 	/// Bundle equivocation proof needs to be submitted to primary chain.
 	BundleEquivocationProof(BundleEquivocationProof),
+	/// Invalid transaction proof needs to be submitted to primary chain.
+	InvalidTransactionProof(InvalidTransactionProof),
 }
 
 impl CollationGenerationMessage {


### PR DESCRIPTION
This PR adds the last pieces of decoupled execution skeleton, taking care of the bundle equivocation and invalid transaction. Tested locally, the unsigned extrinsics should be able to be sent if needed.