### PR TITLE
Include inherent extrinsics when collecting transactions in cirrus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cirrus-block-builder"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "substrate-test-runtime-client",
+]
+
+[[package]]
 name = "cirrus-client-executor"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
 name = "cirrus-client-executor"
 version = "0.1.0"
 dependencies = [
+ "cirrus-block-builder",
  "cirrus-client-executor-gossip",
  "cirrus-node-primitives",
  "cirrus-primitives",
@@ -830,11 +831,13 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core",
  "sp-executor",
+ "sp-inherents",
  "sp-keyring",
  "sp-runtime",
  "sp-trie",
@@ -880,9 +883,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-inherents",
  "sp-runtime",
  "subspace-node",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/*",
+    "cumulus/client/block-builder",
     "cumulus/client/cli",
     "cumulus/client/cirrus-service",
     "cumulus/client/cirrus-executor",

--- a/crates/cirrus-node-primitives/src/lib.rs
+++ b/crates/cirrus-node-primitives/src/lib.rs
@@ -154,7 +154,7 @@ pub type CollatorFn = Box<
 ///
 /// Returns an optional [`BundleResult`].
 pub type BundlerFn = Box<
-    dyn Fn(ExecutorSlotInfo) -> Pin<Box<dyn Future<Output = Option<BundleResult>> + Send>>
+    dyn Fn(Hash, ExecutorSlotInfo) -> Pin<Box<dyn Future<Output = Option<BundleResult>> + Send>>
         + Send
         + Sync,
 >;

--- a/cumulus/client/block-builder/Cargo.toml
+++ b/cumulus/client/block-builder/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "cirrus-block-builder"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://substrate.io"
+repository = "https://github.com/paritytech/substrate/"
+description = "Substrate block builder"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.3.0", features = ["derive"] }
+sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+
+[dev-dependencies]
+substrate-test-runtime-client = { path = "../../../substrate/substrate-test-runtime-client" }

--- a/cumulus/client/block-builder/README.md
+++ b/cumulus/client/block-builder/README.md
@@ -1,0 +1,9 @@
+Substrate block builder
+
+This crate provides the [`BlockBuilder`] utility and the corresponding runtime api
+[`BlockBuilder`](https://docs.rs/sc-block-builder/latest/sc_block_builder/struct.BlockBuilder.html).Error
+
+The block builder utility is used in the node as an abstraction over the runtime api to
+initialize a block, to push extrinsics and to finalize a block.
+
+License: GPL-3.0-or-later WITH Classpath-exception-2.0

--- a/cumulus/client/block-builder/src/lib.rs
+++ b/cumulus/client/block-builder/src/lib.rs
@@ -1,0 +1,332 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Substrate block builder
+//!
+//! This crate provides the [`BlockBuilder`] utility and the corresponding runtime api
+//! [`BlockBuilder`](sp_block_builder::BlockBuilder).
+//!
+//! The block builder utility is used in the node as an abstraction over the runtime api to
+//! initialize a block, to push extrinsics and to finalize a block.
+
+#![warn(missing_docs)]
+#![allow(clippy::all)]
+
+use codec::Encode;
+
+use sp_api::{
+	ApiExt, ApiRef, Core, ProvideRuntimeApi, StorageChanges, StorageProof, TransactionOutcome,
+};
+use sp_blockchain::{ApplyExtrinsicFailed, Error};
+use sp_core::ExecutionContext;
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Hash, HashFor, Header as HeaderT, NumberFor, One},
+	Digest,
+};
+
+pub use sp_block_builder::BlockBuilder as BlockBuilderApi;
+
+use sc_client_api::backend;
+
+/// Used as parameter to [`BlockBuilderProvider`] to express if proof recording should be enabled.
+///
+/// When `RecordProof::Yes` is given, all accessed trie nodes should be saved. These recorded
+/// trie nodes can be used by a third party to proof this proposal without having access to the
+/// full storage.
+#[derive(Copy, Clone, PartialEq)]
+pub enum RecordProof {
+	/// `Yes`, record a proof.
+	Yes,
+	/// `No`, don't record any proof.
+	No,
+}
+
+impl RecordProof {
+	/// Returns if `Self` == `Yes`.
+	pub fn yes(&self) -> bool {
+		matches!(self, Self::Yes)
+	}
+}
+
+/// Will return [`RecordProof::No`] as default value.
+impl Default for RecordProof {
+	fn default() -> Self {
+		Self::No
+	}
+}
+
+impl From<bool> for RecordProof {
+	fn from(val: bool) -> Self {
+		if val {
+			Self::Yes
+		} else {
+			Self::No
+		}
+	}
+}
+
+/// A block that was build by [`BlockBuilder`] plus some additional data.
+///
+/// This additional data includes the `storage_changes`, these changes can be applied to the
+/// backend to get the state of the block. Furthermore an optional `proof` is included which
+/// can be used to proof that the build block contains the expected data. The `proof` will
+/// only be set when proof recording was activated.
+pub struct BuiltBlock<Block: BlockT, StateBackend: backend::StateBackend<HashFor<Block>>> {
+	/// The actual block that was build.
+	pub block: Block,
+	/// The changes that need to be applied to the backend to get the state of the build block.
+	pub storage_changes: StorageChanges<StateBackend, Block>,
+	/// An optional proof that was recorded while building the block.
+	pub proof: Option<StorageProof>,
+}
+
+impl<Block: BlockT, StateBackend: backend::StateBackend<HashFor<Block>>>
+	BuiltBlock<Block, StateBackend>
+{
+	/// Convert into the inner values.
+	pub fn into_inner(self) -> (Block, StorageChanges<StateBackend, Block>, Option<StorageProof>) {
+		(self.block, self.storage_changes, self.proof)
+	}
+}
+
+/// Block builder provider
+pub trait BlockBuilderProvider<B, Block, RA>
+where
+	Block: BlockT,
+	B: backend::Backend<Block>,
+	Self: Sized,
+	RA: ProvideRuntimeApi<Block>,
+{
+	/// Create a new block, built on top of `parent`.
+	///
+	/// When proof recording is enabled, all accessed trie nodes are saved.
+	/// These recorded trie nodes can be used by a third party to proof the
+	/// output of this block builder without having access to the full storage.
+	fn new_block_at<R: Into<RecordProof>>(
+		&self,
+		parent: &BlockId<Block>,
+		inherent_digests: Digest,
+		record_proof: R,
+	) -> sp_blockchain::Result<BlockBuilder<Block, RA, B>>;
+
+	/// Create a new block, built on the head of the chain.
+	fn new_block(
+		&self,
+		inherent_digests: Digest,
+	) -> sp_blockchain::Result<BlockBuilder<Block, RA, B>>;
+}
+
+/// Utility for building new (valid) blocks from a stream of extrinsics.
+pub struct BlockBuilder<'a, Block: BlockT, A: ProvideRuntimeApi<Block>, B> {
+	extrinsics: Vec<Block::Extrinsic>,
+	api: ApiRef<'a, A::Api>,
+	block_id: BlockId<Block>,
+	parent_hash: Block::Hash,
+	backend: &'a B,
+	/// The estimated size of the block header.
+	estimated_header_size: usize,
+}
+
+impl<'a, Block, A, B> BlockBuilder<'a, Block, A, B>
+where
+	Block: BlockT,
+	A: ProvideRuntimeApi<Block> + 'a,
+	A::Api:
+		BlockBuilderApi<Block> + ApiExt<Block, StateBackend = backend::StateBackendFor<B, Block>>,
+	B: backend::Backend<Block>,
+{
+	/// Create a new instance of builder based on the given `parent_hash` and `parent_number`.
+	///
+	/// While proof recording is enabled, all accessed trie nodes are saved.
+	/// These recorded trie nodes can be used by a third party to prove the
+	/// output of this block builder without having access to the full storage.
+	pub fn new(
+		api: &'a A,
+		parent_hash: Block::Hash,
+		parent_number: NumberFor<Block>,
+		record_proof: RecordProof,
+		inherent_digests: Digest,
+		backend: &'a B,
+	) -> Result<Self, Error> {
+		let header = <<Block as BlockT>::Header as HeaderT>::new(
+			parent_number + One::one(),
+			Default::default(),
+			Default::default(),
+			parent_hash,
+			inherent_digests,
+		);
+
+		let estimated_header_size = header.encoded_size();
+
+		let mut api = api.runtime_api();
+
+		if record_proof.yes() {
+			api.record_proof();
+		}
+
+		let block_id = BlockId::Hash(parent_hash);
+
+		api.initialize_block_with_context(&block_id, ExecutionContext::BlockConstruction, &header)?;
+
+		Ok(Self {
+			parent_hash,
+			extrinsics: Vec::new(),
+			api,
+			block_id,
+			backend,
+			estimated_header_size,
+		})
+	}
+
+	/// Push onto the block's list of extrinsics.
+	///
+	/// This will ensure the extrinsic can be validly executed (by executing it).
+	pub fn push(&mut self, xt: <Block as BlockT>::Extrinsic) -> Result<(), Error> {
+		let block_id = &self.block_id;
+		let extrinsics = &mut self.extrinsics;
+
+		self.api.execute_in_transaction(|api| {
+			match api.apply_extrinsic_with_context(
+				block_id,
+				ExecutionContext::BlockConstruction,
+				xt.clone(),
+			) {
+				Ok(Ok(_)) => {
+					extrinsics.push(xt);
+					TransactionOutcome::Commit(Ok(()))
+				},
+				Ok(Err(tx_validity)) => TransactionOutcome::Rollback(Err(
+					ApplyExtrinsicFailed::Validity(tx_validity).into(),
+				)),
+				Err(e) => TransactionOutcome::Rollback(Err(Error::from(e))),
+			}
+		})
+	}
+
+	/// Consume the builder to build a valid `Block` containing all pushed extrinsics.
+	///
+	/// Returns the build `Block`, the changes to the storage and an optional `StorageProof`
+	/// supplied by `self.api`, combined as [`BuiltBlock`].
+	/// The storage proof will be `Some(_)` when proof recording was enabled.
+	pub fn build(mut self) -> Result<BuiltBlock<Block, backend::StateBackendFor<B, Block>>, Error> {
+		let header = self
+			.api
+			.finalize_block_with_context(&self.block_id, ExecutionContext::BlockConstruction)?;
+
+		debug_assert_eq!(
+			header.extrinsics_root().clone(),
+			HashFor::<Block>::ordered_trie_root(
+				self.extrinsics.iter().map(Encode::encode).collect(),
+				sp_core::storage::StateVersion::V1
+			),
+		);
+
+		let proof = self.api.extract_proof();
+
+		let state = self.backend.state_at(self.block_id)?;
+		let parent_hash = self.parent_hash;
+
+		let storage_changes = self
+			.api
+			.into_storage_changes(&state, parent_hash)
+			.map_err(|e| sp_blockchain::Error::StorageChanges(e))?;
+
+		Ok(BuiltBlock {
+			block: <Block as BlockT>::new(header, self.extrinsics),
+			storage_changes,
+			proof,
+		})
+	}
+
+	/// Create the inherents for the block.
+	///
+	/// Returns the inherents created by the runtime or an error if something failed.
+	pub fn create_inherents(
+		&mut self,
+		inherent_data: sp_inherents::InherentData,
+	) -> Result<Vec<Block::Extrinsic>, Error> {
+		let block_id = self.block_id;
+		self.api
+			.execute_in_transaction(move |api| {
+				// `create_inherents` should not change any state, to ensure this we always rollback
+				// the transaction.
+				TransactionOutcome::Rollback(api.inherent_extrinsics_with_context(
+					&block_id,
+					ExecutionContext::BlockConstruction,
+					inherent_data,
+				))
+			})
+			.map_err(|e| Error::Application(Box::new(e)))
+	}
+
+	/// Estimate the size of the block in the current state.
+	///
+	/// If `include_proof` is `true`, the estimated size of the storage proof will be added
+	/// to the estimation.
+	pub fn estimate_block_size(&self, include_proof: bool) -> usize {
+		let size = self.estimated_header_size + self.extrinsics.encoded_size();
+
+		if include_proof {
+			size + self.api.proof_recorder().map(|pr| pr.estimate_encoded_size()).unwrap_or(0)
+		} else {
+			size
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_blockchain::HeaderBackend;
+	use sp_core::Blake2Hasher;
+	use sp_state_machine::Backend;
+	use substrate_test_runtime_client::{DefaultTestClientBuilderExt, TestClientBuilderExt};
+
+	#[test]
+	fn block_building_storage_proof_does_not_include_runtime_by_default() {
+		let builder = substrate_test_runtime_client::TestClientBuilder::new();
+		let backend = builder.backend();
+		let client = builder.build();
+
+		let block = BlockBuilder::new(
+			&client,
+			client.info().best_hash,
+			client.info().best_number,
+			RecordProof::Yes,
+			Default::default(),
+			&*backend,
+		)
+		.unwrap()
+		.build()
+		.unwrap();
+
+		let proof = block.proof.expect("Proof is build on request");
+
+		let backend = sp_state_machine::create_proof_check_backend::<Blake2Hasher>(
+			block.storage_changes.transaction_storage_root,
+			proof,
+		)
+		.unwrap();
+
+		assert!(backend
+			.storage(&sp_core::storage::well_known_keys::CODE)
+			.unwrap_err()
+			.contains("Database missing expected key"),);
+	}
+}

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -11,9 +11,11 @@ sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", rev
 sc-utils = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-consensus-slots = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-trie = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 
@@ -32,6 +34,7 @@ tracing = "0.1.25"
 polkadot-overseer = { path = "../../../polkadot/node/overseer" }
 polkadot-node-subsystem = { path = "../../../polkadot/node/subsystem" }
 
+cirrus-block-builder = { path = "../block-builder" }
 cirrus-client-executor-gossip = { path = "../executor-gossip" }
 cirrus-node-primitives = { path = "../../../crates/cirrus-node-primitives" }
 cirrus-primitives = { path = "../../primitives" }

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 [dependencies]
 # Substrate dependencies
 sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-consensus-slots = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-utils = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-consensus-slots = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-trie = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 
 # Cumulus dependencies

--- a/cumulus/client/cirrus-executor/src/bundler.rs
+++ b/cumulus/client/cirrus-executor/src/bundler.rs
@@ -1,0 +1,153 @@
+use codec::Encode;
+use futures::{select, FutureExt};
+use sc_client_api::BlockBackend;
+use sc_transaction_pool_api::InPoolTransaction;
+use sp_api::ProvideRuntimeApi;
+use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT},
+};
+use std::time;
+
+use cirrus_block_builder::{BlockBuilder, RecordProof};
+use cirrus_node_primitives::{BundleResult, ExecutorSlotInfo};
+use cirrus_primitives::{AccountId, SecondaryApi};
+use sp_executor::{Bundle, BundleHeader};
+
+use subspace_runtime_primitives::Hash as PHash;
+
+use super::{Executor, LOG_TARGET};
+
+impl<Block, BS, RA, Client, TransactionPool, Backend, CIDP>
+	Executor<Block, BS, RA, Client, TransactionPool, Backend, CIDP>
+where
+	Block: BlockT,
+	Client: sp_blockchain::HeaderBackend<Block>,
+	BS: BlockBackend<Block>,
+	Backend: sc_client_api::Backend<Block>,
+	RA: ProvideRuntimeApi<Block>,
+	RA::Api: SecondaryApi<Block, AccountId>
+		+ sp_block_builder::BlockBuilder<Block>
+		+ sp_api::ApiExt<
+			Block,
+			StateBackend = sc_client_api::backend::StateBackendFor<Backend, Block>,
+		>,
+	TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block>,
+	CIDP: CreateInherentDataProviders<Block, cirrus_primitives::Hash>,
+{
+	pub(super) async fn produce_bundle_impl(
+		self,
+		primary_hash: PHash,
+		slot_info: ExecutorSlotInfo,
+		include_inherents: bool,
+	) -> Option<BundleResult> {
+		println!("TODO: solve some puzzle based on `slot_info` to be allowed to produce a bundle");
+
+		let parent_hash = self.client.info().best_hash;
+		let parent_number = self.client.info().best_number;
+
+		let mut t1 = self.transaction_pool.ready_at(parent_number).fuse();
+		// TODO: proper timeout
+		let mut t2 = futures_timer::Delay::new(time::Duration::from_micros(100)).fuse();
+
+		let mut pending_iterator = select! {
+			res = t1 => res,
+			_ = t2 => {
+				tracing::warn!(
+					target: LOG_TARGET,
+					"Timeout fired waiting for transaction pool at #{}, proceeding with production.",
+					parent_number,
+				);
+				self.transaction_pool.ready()
+			}
+		};
+
+		// TODO: proper deadline
+		let pushing_duration = time::Duration::from_micros(500);
+
+		let start = time::Instant::now();
+
+		// TODO: Select transactions properly from the transaction pool
+		//
+		// Selection policy:
+		// - minimize the transaction equivocation.
+		// - maximize the executor computation power.
+		let mut extrinsics = if include_inherents {
+			// TODO: is creating inherents fallible?
+			let mut block_builder = BlockBuilder::new(
+				&*self.runtime_api,
+				parent_hash,
+				parent_number,
+				RecordProof::No,
+				Default::default(),
+				&*self.backend,
+			)
+			.ok()?;
+
+			let inherent_data = self.inherent_data(parent_hash, primary_hash).await?;
+
+			block_builder.create_inherents(inherent_data).ok().unwrap_or_default()
+		} else {
+			Vec::new()
+		};
+
+		while let Some(pending_tx) = pending_iterator.next() {
+			if start.elapsed() >= pushing_duration {
+				break
+			}
+			let pending_tx_data = pending_tx.data().clone();
+			extrinsics.push(pending_tx_data);
+		}
+
+		let extrinsics_root = BlakeTwo256::ordered_trie_root(
+			extrinsics.iter().map(|xt| xt.encode()).collect(),
+			sp_core::storage::StateVersion::V1,
+		);
+
+		let _state_root =
+			self.client.expect_header(BlockId::Number(parent_number)).ok()?.state_root();
+
+		let bundle = Bundle {
+			header: BundleHeader { slot_number: slot_info.slot.into(), extrinsics_root },
+			extrinsics,
+		};
+
+		if let Err(e) = self.bundle_sender.unbounded_send(bundle.clone()) {
+			tracing::error!(target: LOG_TARGET, error = ?e, "Failed to send transaction bundle");
+		}
+
+		Some(BundleResult { opaque_bundle: bundle.into() })
+	}
+
+	/// Get the inherent data.
+	async fn inherent_data(
+		&self,
+		parent: Block::Hash,
+		relay_parent: PHash,
+	) -> Option<InherentData> {
+		let inherent_data_providers = self
+			.create_inherent_data_providers
+			.create_inherent_data_providers(parent, relay_parent)
+			.await
+			.map_err(|e| {
+				tracing::error!(
+					target: LOG_TARGET,
+					error = ?e,
+					"Failed to create inherent data providers.",
+				)
+			})
+			.ok()?;
+
+		inherent_data_providers
+			.create_inherent_data()
+			.map_err(|e| {
+				tracing::error!(
+					target: LOG_TARGET,
+					error = ?e,
+					"Failed to create inherent data.",
+				)
+			})
+			.ok()
+	}
+}

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -75,7 +75,7 @@ where
 		primary_hash: PHash,
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
-	) -> Option<ProcessorResult> {
+	) -> Result<Option<ProcessorResult>, sp_blockchain::Error> {
 		let mut extrinsics = bundles
 			.into_iter()
 			.flat_map(|bundle| {
@@ -127,7 +127,7 @@ where
 					error = ?e,
 					"Error at calling runtime api: extract_signer"
 				);
-				return None
+				return Err(e.into())
 			},
 		};
 
@@ -157,9 +157,9 @@ where
 			}
 
 			// Return `Some(_)` to broadcast ER to all farmers via unsigned extrinsic.
-			Some(ProcessorResult { opaque_execution_receipt: execution_receipt.into() })
+			Ok(Some(ProcessorResult { opaque_execution_receipt: execution_receipt.into() }))
 		} else {
-			None
+			Ok(None)
 		}
 	}
 }

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -60,7 +60,8 @@ fn shuffle_extrinsics<Extrinsic: Debug>(
 	shuffled_extrinsics
 }
 
-impl<Block, BS, RA, Client, TransactionPool> Executor<Block, BS, RA, Client, TransactionPool>
+impl<Block, BS, RA, Client, TransactionPool, Backend, CIDP>
+	Executor<Block, BS, RA, Client, TransactionPool, Backend, CIDP>
 where
 	Block: BlockT,
 	Client: sp_blockchain::HeaderBackend<Block>,

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -6,7 +6,6 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::{
 	collections::{BTreeMap, VecDeque},
 	fmt::Debug,
-	sync::atomic::Ordering,
 };
 
 use cirrus_node_primitives::ProcessorResult;
@@ -73,7 +72,7 @@ where
 {
 	/// Actually implements `process_bundles`.
 	pub(super) async fn process_bundles_impl(
-		self,
+		&self,
 		primary_hash: PHash,
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
@@ -135,9 +134,6 @@ where
 
 		let _final_extrinsics =
 			shuffle_extrinsics::<<Block as BlockT>::Extrinsic>(extrinsics, shuffling_seed);
-
-		// Reset the signal to include the inherent extrinsics on next `produce_bundle`.
-		self.to_include_inherents.store(true, Ordering::Relaxed);
 
 		// TODO: now we have the final transaction list:
 		// - apply each tx one by one.

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -6,6 +6,7 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::{
 	collections::{BTreeMap, VecDeque},
 	fmt::Debug,
+	sync::atomic::Ordering,
 };
 
 use cirrus_node_primitives::ProcessorResult;
@@ -134,6 +135,9 @@ where
 
 		let _final_extrinsics =
 			shuffle_extrinsics::<<Block as BlockT>::Extrinsic>(extrinsics, shuffling_seed);
+
+		// Reset the signal to include the inherent extrinsics on next `produce_bundle`.
+		self.to_include_inherents.store(true, Ordering::Relaxed);
 
 		// TODO: now we have the final transaction list:
 		// - apply each tx one by one.

--- a/cumulus/client/cirrus-service/Cargo.toml
+++ b/cumulus/client/cirrus-service/Cargo.toml
@@ -20,8 +20,10 @@ sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", rev
 sc-utils = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 
 # Other deps

--- a/cumulus/client/cirrus-service/Cargo.toml
+++ b/cumulus/client/cirrus-service/Cargo.toml
@@ -18,16 +18,16 @@ sc-telemetry = { git = "https://github.com/paritytech/substrate", rev = "04c7c6a
 sc-tracing = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-utils = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 
 # Other deps
-tracing = "0.1.22"
 codec = { package = "parity-scale-codec", version = "2.3.0" }
 parking_lot = "0.11.2"
+tracing = "0.1.22"
 
 # Cirrus
 cirrus-client-executor = { path = "../cirrus-executor" }

--- a/cumulus/client/consensus/common/Cargo.toml
+++ b/cumulus/client/consensus/common/Cargo.toml
@@ -7,21 +7,21 @@ edition = "2021"
 
 [dependencies]
 # Substrate deps
-sc-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sp-trie = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 
 # Other deps
-futures = { version = "0.3.19", features = ["compat"] }
-codec = { package = "parity-scale-codec", version = "2.3.0", features = [ "derive" ] }
-tracing = "0.1.25"
 async-trait = "0.1.52"
+codec = { package = "parity-scale-codec", version = "2.3.0", features = [ "derive" ] }
 dyn-clone = "1.0.4"
+futures = { version = "0.3.19", features = ["compat"] }
+tracing = "0.1.25"
 
-sp-executor = { path = "../../../../crates/sp-executor" }
 cirrus-node-primitives = { path = "../../../../crates/cirrus-node-primitives" }
+sp-executor = { path = "../../../../crates/sp-executor" }
 subspace-runtime-primitives = { path = "../../../../crates/subspace-runtime-primitives" }

--- a/cumulus/client/consensus/relay-chain/Cargo.toml
+++ b/cumulus/client/consensus/relay-chain/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2021"
 
 [dependencies]
 # Substrate deps
-sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
-sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-api = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-core = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", rev = "04c7c6abef1e0c6b4126427159090a44f3221333" }
 
 # Cumulus dependencies
@@ -23,9 +23,9 @@ cumulus-client-consensus-common = { path = "../common" }
 
 # Other deps
 futures = { version = "0.3.19", features = ["compat"] }
-tracing = "0.1.22"
 async-trait = "0.1.52"
 parking_lot = "0.11.2"
+tracing = "0.1.22"
 
 cirrus-node-primitives = { path = "../../../../crates/cirrus-node-primitives" }
 subspace-node = { path = "../../../../crates/subspace-node" }

--- a/cumulus/parachain-template/node/Cargo.toml
+++ b/cumulus/parachain-template/node/Cargo.toml
@@ -23,12 +23,12 @@ path = "src/main.rs"
 runtime-benchmarks = ["parachain-template-runtime/runtime-benchmarks"]
 
 [dependencies]
-derive_more = "0.99.2"
-log = "0.4.14"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-structopt = "0.3.8"
-serde = { version = "1.0.132", features = ["derive"] }
+derive_more = "0.99.2"
 hex-literal = "0.3.1"
+log = "0.4.14"
+serde = { version = "1.0.132", features = ["derive"] }
+structopt = "0.3.8"
 
 # RPC related Dependencies
 jsonrpc-core = "18.0.0"

--- a/cumulus/parachain-template/node/src/service.rs
+++ b/cumulus/parachain-template/node/src/service.rs
@@ -321,6 +321,11 @@ where
 			import_queue,
 			transaction_pool,
 			network,
+			backend,
+			create_inherent_data_providers: Arc::new(move |_, _relay_parent| async move {
+				let time = sp_timestamp::InherentDataProvider::from_system_time();
+				Ok(time)
+			}),
 		};
 
 		cirrus_client_service::start_executor(params).await?;

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -420,15 +420,15 @@ async fn produce_bundle<Context: SubsystemContext>(
 	ctx: &mut Context,
 	sender: &mpsc::Sender<AllMessages>,
 ) -> SubsystemResult<()> {
-	let opaque_bundle = match (config.bundler)(slot_info).await {
+	let best_hash = request_best_primary_hash(ctx).await?;
+
+	let opaque_bundle = match (config.bundler)(best_hash, slot_info).await {
 		Some(bundle_result) => bundle_result.to_opaque_bundle(),
 		None => {
 			tracing::debug!(target: LOG_TARGET, "executor returned no bundle on bundling",);
 			return Ok(())
 		},
 	};
-
-	let best_hash = request_best_primary_hash(ctx).await?;
 
 	let mut task_sender = sender.clone();
 	ctx.spawn(


### PR DESCRIPTION
This PR is required for the custom `BlockBuilder` work later. The current `cirrus-block-builder` is copied from the upstream `sc-block-builder` without any modifications. Should be reviewed per commit.