### PR TITLE
Fix the incorrect SubspaceApi version

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -294,7 +294,7 @@ impl Config {
 
         let version = runtime_api.api_version::<dyn SubspaceApi<B>>(&best_block_id)?;
 
-        let slot_duration = if version == Some(2) {
+        let slot_duration = if version == Some(1) {
             runtime_api.configuration(&best_block_id)?
         } else {
             return Err(sp_blockchain::Error::VersionInvalid(


### PR DESCRIPTION
After #227, you'll run into `Error: SubspaceService(Sub(Client(VersionInvalid("Unsupported or invalid SubspaceApi version"))))` due to the incorrect SubspaceApi version check. Since we don't bump the version, it should just `Some(1)`, not `Some(2)`. Furthermore, I skipped this version checking given that we doesn't have the versioned api right now. I can change it to just `Some(1)` if you prefer.