### PR TITLE
commitment database structure changed and RwLock introduced

### DIFF
--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -24,7 +24,7 @@ async fn create() {
     let plot = Plot::open_or_create(&base_directory).unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
     plot.write_many(Arc::new(pieces), index).unwrap();
-    commitments.create(salt, plot).unwrap();
+    commitments.create(salt, plot, salt).unwrap();
 
     let (tag, _) = commitments
         .find_by_range(correct_tag, solution_range, salt)
@@ -49,7 +49,7 @@ async fn find_by_tag() {
     rng.fill(pieces.as_mut());
     plot.write_many(Arc::new(pieces), 0).unwrap();
 
-    commitments.create(salt, plot).unwrap();
+    commitments.create(salt, plot, salt).unwrap();
 
     {
         let target = [0u8, 0, 0, 0, 0, 0, 0, 1];

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -243,7 +243,7 @@ fn update_commitments(
                         hex::encode(salt)
                     );
 
-                    if let Err(error) = commitments.create(salt, plot) {
+                    if let Err(error) = commitments.create(salt, plot, salt) {
                         error!(
                             "Failed to create commitment for {}: {}",
                             hex::encode(salt),
@@ -267,6 +267,7 @@ fn update_commitments(
     if let Some(new_next_salt) = slot_info.next_salt {
         if salts.next != Some(new_next_salt) {
             salts.next.replace(new_next_salt);
+            let current_salt = slot_info.salt;
 
             tokio::task::spawn_blocking({
                 let plot = plot.clone();
@@ -284,7 +285,7 @@ fn update_commitments(
                         "Salt will update to {} soon, recommitting in background",
                         hex::encode(new_next_salt)
                     );
-                    if let Err(error) = commitments.create(new_next_salt, plot) {
+                    if let Err(error) = commitments.create(new_next_salt, plot, current_salt) {
                         error!(
                             "Recommitting salt in background failed for {}: {}",
                             hex::encode(new_next_salt),

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -29,7 +29,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
 
     plot.write_many(Arc::new(pieces), index).unwrap();
-    commitments.create(salt, plot.clone()).unwrap();
+    commitments.create(salt, plot.clone(), salt).unwrap();
 
     let identity =
         Identity::open_or_create(&base_directory).expect("Could not open/create identity!");


### PR DESCRIPTION
This PR restructures the `commitments.rs` and `commitment_databases.rs`. It basically enables the first and the second database to work independently from each other by separating these data structures.

Please see the self-comments down below to address the places that I think can be improved. 

Note: I have tested the failing farming tests, and created 1000 run versions of them temporarily, they are passing :)