### PR TITLE
revert to CPU encoding if CUDA fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8231,6 +8231,7 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
+ "log",
  "num_cpus",
  "rand 0.8.4",
  "rayon",

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -100,7 +100,7 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
     commitments: Commitments,
     object_mappings: ObjectMappings,
     farmer_metadata: FarmerMetadata,
-    subspace_codec: SubspaceCodec,
+    mut subspace_codec: SubspaceCodec,
     mut stop_receiver: Receiver<()>,
 ) -> Result<(), PlottingError> {
     let weak_plot = plot.downgrade();

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+log = "0.4.14"
 num_cpus = "1.13.0"
 rayon = "1.5.1"
 schnorrkel = "0.9.1"

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -140,8 +140,12 @@ impl SubspaceCodec {
                 &piece_indexes[..pieces_to_process],
             );
 
-            // Leave the rest for CPU (update the remaining pieces if CUDA was successful)
-            if cuda_result.is_ok() {
+            // check if CUDA operation was successful
+            if let Err(e) = cuda_result {
+                println!("Error happened on the GPU: '{}'.", e);
+                self.cuda_available = false;
+            } else {
+                // Leave the remainder pieces for CPU (update the remaining pieces if CUDA was successful)
                 pieces = &mut pieces[pieces_to_process * PIECE_SIZE..];
                 piece_indexes = &piece_indexes[pieces_to_process..];
             }

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -24,7 +24,6 @@ use sloth256_189::cuda;
 use subspace_core_primitives::{crypto, Sha256Hash, PIECE_SIZE};
 use thiserror::Error;
 
-
 /// Number of pieces for GPU should be multiples of 1024
 #[cfg(feature = "cuda")]
 const GPU_PIECE_BLOCK: usize = 1024;

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -16,12 +16,14 @@
 //! Codec for the [Subspace Network Blockchain](https://subspace.network) based on the
 //! [SLOTH permutation](https://eprint.iacr.org/2015/366).
 
+use log::error;
 use rayon::prelude::*;
 use sloth256_189::cpu;
 #[cfg(feature = "cuda")]
 use sloth256_189::cuda;
 use subspace_core_primitives::{crypto, Sha256Hash, PIECE_SIZE};
 use thiserror::Error;
+
 
 /// Number of pieces for GPU should be multiples of 1024
 #[cfg(feature = "cuda")]
@@ -123,7 +125,7 @@ impl SubspaceCodec {
     /// in inconsistent state!
     #[allow(unused_mut)]
     pub fn batch_encode(
-        &self,
+        &mut self,
         mut pieces: &mut [u8],
         mut piece_indexes: &[u64],
     ) -> Result<(), BatchEncodeError> {
@@ -142,7 +144,7 @@ impl SubspaceCodec {
 
             // check if CUDA operation was successful
             if let Err(e) = cuda_result {
-                println!("Error happened on the GPU: '{}'.", e);
+                error!("Error happened on the GPU: '{}'.", e);
                 self.cuda_available = false;
             } else {
                 // Leave the remainder pieces for CPU (update the remaining pieces if CUDA was successful)


### PR DESCRIPTION
This fixes #239 

I still haven't discovered why CUDA GPU is not working. Switched back to a very old revision (spartan times), and tried to plot with GPU. It worked. And that old revision is using the latest version of `sloth256-189`. So, I don't think there is something wrong with `sloth256-189`, but how we integrate it to the monorepo. Will inspect further.

Nevertheless, problems may always arise and this is a good fix as suggested in #239. 

Now, it always reverts back to CPU encoding, if CUDA encoding fails.