### PR TITLE
Cuda codec revamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8231,6 +8231,7 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
+ "log",
  "num_cpus",
  "rand 0.8.4",
  "rayon",

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -100,7 +100,7 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
     commitments: Commitments,
     object_mappings: ObjectMappings,
     farmer_metadata: FarmerMetadata,
-    subspace_codec: SubspaceCodec,
+    mut subspace_codec: SubspaceCodec,
     mut stop_receiver: Receiver<()>,
 ) -> Result<(), PlottingError> {
     let weak_plot = plot.downgrade();

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+log = "0.4.14"
 num_cpus = "1.13.0"
 rayon = "1.5.1"
 schnorrkel = "0.9.1"

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -136,10 +136,9 @@ impl SubspaceCodec {
         if self.cuda_available {
             let mut pieces_to_process = pieces.len() / PIECE_SIZE;
 
-            // GPU will accept multiples of 1024 pieces
-            if pieces_to_process >= 1024 {
+            if pieces_to_process >= GPU_PIECE_BLOCK {
                 pieces_to_process = pieces_to_process / GPU_PIECE_BLOCK * GPU_PIECE_BLOCK;
-                // process the multiples of 1024 pieces in GPU
+
                 let cuda_result = self.batch_encode_cuda(
                     &mut pieces[..pieces_to_process * PIECE_SIZE],
                     &piece_indexes[..pieces_to_process],

--- a/crates/subspace-solving/tests/integration/codec.rs
+++ b/crates/subspace-solving/tests/integration/codec.rs
@@ -21,7 +21,7 @@ fn single_piece() {
 #[test]
 fn batch() {
     let public_key = rand::random::<[u8; 32]>();
-    let subspace_codec = SubspaceCodec::new(&public_key);
+    let mut subspace_codec = SubspaceCodec::new(&public_key);
     // Use 2.5 batches worth of pieces
     let piece_count = subspace_codec.batch_size() * 2 + subspace_codec.batch_size() / 2;
 


### PR DESCRIPTION
Fixes #239 and #244 together.

The encoding error on the GPU side was because of here: https://github.com/subspace/subspace/blob/main/crates/subspace-solving/src/codec.rs#L136
In the link above, `pieces_to_process` may not be greater than 1024, and ultimately becomes 0 because of the equation. 

There was no check on the `sloth256-189` side that prevents receiving a piece, length of 0. 

There will be 1 more update on the `sloth256-189` side, however, irrelevant to the issues mentioned above. So these changes will be a separate PR for the `sloth256-189`
