### PR TITLE
Subspace networking (farmer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8549,6 +8549,7 @@ dependencies = [
  "ss58-registry",
  "subspace-archiving",
  "subspace-core-primitives",
+ "subspace-networking",
  "subspace-rpc-primitives",
  "subspace-solving",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94ba84325db59637ffc528bbe8c7f86c02c57cff5c0e2b9b00f9a851f42f309"
+dependencies = [
+ "digest 0.10.1",
+]
+
+[[package]]
 name = "blake2-rfc"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,13 +755,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures 0.2.1",
+ "zeroize",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.7.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+dependencies = [
+ "aead",
+ "chacha20 0.8.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1028,6 +1062,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpp_demangle"
@@ -1405,6 +1448,19 @@ dependencies = [
  "byteorder 1.4.3",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4033478fbf70d6acf2655ac70da91ee65852d69daf7a67bf7a2f518fb47aafcf"
+dependencies = [
+ "byteorder 1.4.3",
+ "digest 0.9.0",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
@@ -3203,7 +3259,7 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket 0.31.0",
  "libp2p-yamux 0.34.0",
- "multiaddr",
+ "multiaddr 0.13.0",
  "parking_lot 0.11.2",
  "pin-project 1.0.10",
  "smallvec",
@@ -3212,9 +3268,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7b096cb389649749d0f9ddef519436e2daa3a9a8638434d3b1e7170721f45f"
+version = "0.43.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "atomic",
  "bytes 1.1.0",
@@ -3223,20 +3278,20 @@ dependencies = [
  "getrandom 0.2.4",
  "instant",
  "lazy_static",
- "libp2p-core 0.31.0",
- "libp2p-dns 0.31.0",
- "libp2p-gossipsub 0.35.0",
- "libp2p-identify 0.33.0",
- "libp2p-kad 0.34.0",
- "libp2p-metrics 0.3.0",
- "libp2p-noise 0.34.0",
- "libp2p-ping 0.33.0",
- "libp2p-swarm 0.33.0",
+ "libp2p-core 0.32.0",
+ "libp2p-dns 0.32.0",
+ "libp2p-gossipsub 0.36.0",
+ "libp2p-identify 0.34.0",
+ "libp2p-kad 0.35.0",
+ "libp2p-metrics 0.4.0",
+ "libp2p-noise 0.35.0",
+ "libp2p-ping 0.34.0",
+ "libp2p-swarm 0.34.0",
  "libp2p-swarm-derive 0.26.1",
- "libp2p-tcp 0.31.0",
- "libp2p-websocket 0.33.0",
- "libp2p-yamux 0.35.0",
- "multiaddr",
+ "libp2p-tcp 0.32.0",
+ "libp2p-websocket 0.34.0",
+ "libp2p-yamux 0.36.0",
+ "multiaddr 0.14.0",
  "parking_lot 0.11.2",
  "pin-project 1.0.10",
  "rand 0.7.3",
@@ -3259,7 +3314,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multiaddr",
+ "multiaddr 0.13.0",
  "multihash 0.14.0",
  "multistream-select 0.10.4",
  "parking_lot 0.11.2",
@@ -3279,9 +3334,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24250cce58fb6ccb32e26647c1c25b48b6f7bd2d6fb3d6dba72001a6694b385"
+version = "0.32.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3293,8 +3347,8 @@ dependencies = [
  "instant",
  "lazy_static",
  "log",
- "multiaddr",
- "multihash 0.14.0",
+ "multiaddr 0.14.0",
+ "multihash 0.16.1",
  "multistream-select 0.11.0",
  "parking_lot 0.11.2",
  "pin-project 1.0.10",
@@ -3338,12 +3392,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d4a2e7efe62c738833b6be6c0f158cf7ffccba462320f4b3bebe43e1050e7b"
+version = "0.32.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "futures 0.3.19",
- "libp2p-core 0.31.0",
+ "libp2p-core 0.32.0",
  "log",
  "smallvec",
  "trust-dns-resolver",
@@ -3395,9 +3448,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385ae5f44e84f51e17014c9f1d98464121d3b1b182c167a0b4482d6250c61926"
+version = "0.36.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "asynchronous-codec 0.6.0",
  "base64",
@@ -3408,11 +3460,11 @@ dependencies = [
  "futures-timer",
  "hex_fmt",
  "instant",
- "libp2p-core 0.31.0",
- "libp2p-swarm 0.33.0",
+ "libp2p-core 0.32.0",
+ "libp2p-swarm 0.34.0",
  "log",
- "open-metrics-client 0.14.0",
  "pin-project 1.0.10",
+ "prometheus-client",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3441,14 +3493,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5d84b4e57cb66abb9dd28ea36f69620816e004a7479c0ad76f45002820f99b"
+version = "0.34.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "futures 0.3.19",
  "futures-timer",
- "libp2p-core 0.31.0",
- "libp2p-swarm 0.33.0",
+ "libp2p-core 0.32.0",
+ "libp2p-swarm 0.34.0",
  "log",
  "lru 0.7.2",
  "prost",
@@ -3484,9 +3535,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eeaa28a4c7a8c574874e090c2a731ecc7b81595911fee425b552c799a20abbb"
+version = "0.35.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec 0.6.0",
@@ -3496,8 +3546,8 @@ dependencies = [
  "futures 0.3.19",
  "futures-timer",
  "instant",
- "libp2p-core 0.31.0",
- "libp2p-swarm 0.33.0",
+ "libp2p-core 0.32.0",
+ "libp2p-swarm 0.34.0",
  "log",
  "prost",
  "prost-build",
@@ -3542,22 +3592,21 @@ dependencies = [
  "libp2p-kad 0.32.0",
  "libp2p-ping 0.31.0",
  "libp2p-swarm 0.31.0",
- "open-metrics-client 0.12.0",
+ "open-metrics-client",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0791098ddec13b0c2f9ed37a29175f7c712ce8804ebaba7cbd8bddbc83120190"
+version = "0.4.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
- "libp2p-core 0.31.0",
- "libp2p-gossipsub 0.35.0",
- "libp2p-identify 0.33.0",
- "libp2p-kad 0.34.0",
- "libp2p-ping 0.33.0",
- "libp2p-swarm 0.33.0",
- "open-metrics-client 0.14.0",
+ "libp2p-core 0.32.0",
+ "libp2p-gossipsub 0.36.0",
+ "libp2p-identify 0.34.0",
+ "libp2p-kad 0.35.0",
+ "libp2p-ping 0.34.0",
+ "libp2p-swarm 0.34.0",
+ "prometheus-client",
 ]
 
 [[package]]
@@ -3594,7 +3643,7 @@ dependencies = [
  "prost-build",
  "rand 0.8.4",
  "sha2 0.9.9",
- "snow",
+ "snow 0.8.0",
  "static_assertions",
  "x25519-dalek",
  "zeroize",
@@ -3602,21 +3651,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676dc2df10a7f4f6a80fbeaf2ce4168a0ca6567273e3105b21fa4c877be9017"
+version = "0.35.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "bytes 1.1.0",
  "curve25519-dalek 3.2.0",
  "futures 0.3.19",
  "lazy_static",
- "libp2p-core 0.31.0",
+ "libp2p-core 0.32.0",
  "log",
  "prost",
  "prost-build",
  "rand 0.8.4",
  "sha2 0.10.1",
- "snow",
+ "snow 0.9.0",
  "static_assertions",
  "x25519-dalek",
  "zeroize",
@@ -3639,15 +3687,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d384b30135f122a59bf0d186647ad307da0878a9563232cb382d9dbded6a393e"
+version = "0.34.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "futures 0.3.19",
  "futures-timer",
  "instant",
- "libp2p-core 0.31.0",
- "libp2p-swarm 0.33.0",
+ "libp2p-core 0.32.0",
+ "libp2p-swarm 0.34.0",
  "log",
  "rand 0.7.3",
  "void",
@@ -3766,15 +3813,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8ae0811c7a05b6edc6684eb5cc69b055cbb715ad780e6b97872d90308503c1"
+version = "0.34.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "either",
  "futures 0.3.19",
  "futures-timer",
  "instant",
- "libp2p-core 0.31.0",
+ "libp2p-core 0.32.0",
  "log",
  "rand 0.7.3",
  "smallvec",
@@ -3794,8 +3840,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b4d0acd47739fe0b570728d8d11bbb535050d84c0cf05d6477a4891fceae10"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "quote",
  "syn",
@@ -3820,16 +3865,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074c4ff21166a4d69a3e39b483ca3d38f0fc56002ae520f68ee5a76245531741"
+version = "0.32.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "futures 0.3.19",
  "futures-timer",
  "if-addrs 0.7.0",
  "ipnet",
  "libc",
- "libp2p-core 0.31.0",
+ "libp2p-core 0.32.0",
  "log",
  "socket2 0.4.4",
  "tokio",
@@ -3881,14 +3925,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d788da0ab952632d6ead2486baf38a98db92907d4bc5d0f324af0d0fab803d"
+version = "0.34.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "either",
  "futures 0.3.19",
  "futures-rustls 0.22.0",
- "libp2p-core 0.31.0",
+ "libp2p-core 0.32.0",
  "log",
  "quicksink",
  "rw-stream-sink",
@@ -3912,12 +3955,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053d13ce0670d29f9c5a974cf371e6cc4d2d864da1c72bf6870ac5d5e45e2036"
+version = "0.36.0"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "futures 0.3.19",
- "libp2p-core 0.31.0",
+ "libp2p-core 0.32.0",
  "parking_lot 0.11.2",
  "thiserror",
  "yamux 0.10.0",
@@ -4378,6 +4420,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder 1.4.3",
+ "data-encoding",
+ "multihash 0.16.1",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.1",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "multibase"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,7 +4459,7 @@ dependencies = [
  "blake3",
  "digest 0.9.0",
  "generic-array 0.14.5",
- "multihash-derive",
+ "multihash-derive 0.7.2",
  "sha2 0.9.9",
  "sha3",
  "unsigned-varint 0.5.1",
@@ -4413,8 +4473,21 @@ checksum = "752a61cd890ff691b4411423d23816d5866dd5621e4d1c5687a53b94b5a979d8"
 dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.5",
- "multihash-derive",
+ "multihash-derive 0.7.2",
  "sha2 0.9.9",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
+name = "multihash"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7392bffd88bc0c4f8297e36a777ab9f80b7127409c4a1acb8fee99c9f27addcd"
+dependencies = [
+ "core2",
+ "digest 0.10.1",
+ "multihash-derive 0.8.0",
+ "sha2 0.10.1",
  "unsigned-varint 0.7.1",
 ]
 
@@ -4423,6 +4496,20 @@ name = "multihash-derive"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro-error",
@@ -4455,8 +4542,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
+source = "git+https://github.com/libp2p/rust-libp2p#b39770b8e9bfb113235c9ab8f7f2df2392482073"
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.19",
@@ -4663,18 +4749,6 @@ checksum = "7337d80c23c2d8b1349563981bc4fb531220733743ba8115454a67b181173f0d"
 dependencies = [
  "dtoa 0.4.8",
  "itoa 0.4.8",
- "open-metrics-client-derive-text-encode",
- "owning_ref",
-]
-
-[[package]]
-name = "open-metrics-client"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85842b073145726190373213c63f852020fb884c841a3a1f390637267a2fb8c"
-dependencies = [
- "dtoa 1.0.2",
- "itoa 1.0.1",
  "open-metrics-client-derive-text-encode",
  "owning_ref",
 ]
@@ -5776,6 +5850,29 @@ dependencies = [
  "memchr",
  "parking_lot 0.11.2",
  "thiserror",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a896938cc6018c64f279888b8c7559d3725210d5db9a3a1ee6bc7188d51d34"
+dependencies = [
+ "dtoa 1.0.2",
+ "itoa 1.0.1",
+ "owning_ref",
+ "prometheus-client-derive-text-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-text-encode"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7559,8 +7656,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6142f7c25e94f6fd25a32c3348ec230df9109b463f59c8c7acc4bd34936babb7"
 dependencies = [
  "aes-gcm",
- "blake2",
- "chacha20poly1305",
+ "blake2 0.9.2",
+ "chacha20poly1305 0.8.0",
  "rand 0.8.4",
  "rand_core 0.6.3",
  "ring",
@@ -7568,6 +7665,23 @@ dependencies = [
  "sha2 0.9.9",
  "subtle",
  "x25519-dalek",
+]
+
+[[package]]
+name = "snow"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
+dependencies = [
+ "aes-gcm",
+ "blake2 0.10.2",
+ "chacha20poly1305 0.9.0",
+ "curve25519-dalek 4.0.0-pre.1",
+ "rand_core 0.6.3",
+ "ring",
+ "rustc_version 0.4.0",
+ "sha2 0.10.1",
+ "subtle",
 ]
 
 [[package]]
@@ -8452,9 +8566,10 @@ dependencies = [
  "event-listener-primitives",
  "futures 0.3.19",
  "hex",
- "libp2p 0.42.0",
+ "libp2p 0.43.0",
  "log",
  "parking_lot 0.12.0",
+ "subspace-core-primitives",
  "thiserror",
  "tokio",
 ]
@@ -9972,9 +10087,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8563,6 +8563,8 @@ dependencies = [
 name = "subspace-networking"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "clap 3.0.13",
  "env_logger 0.9.0",
  "event-listener-primitives",
  "futures 0.3.19",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -37,11 +37,12 @@ ss58-registry = "1.10.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
+subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
 thiserror = "1.0.30"
 tiny-bip39 = "0.8.2"
 tokio = { version = "1.16.1", features = ["macros", "rt-multi-thread"] }
-zeroize = "1.5.2"
+zeroize = "1.4.3"
 
 [dependencies.rocksdb]
 # This disables compression algorithms that cause issues during linking due to

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -58,7 +58,7 @@ enum Command {
     Farm {
         /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
         #[clap(long)]
-        bootstrap_nodes: Vec<Multiaddr>,
+        bootstrap_node: Vec<Multiaddr>,
         /// Custom path for data storage instead of platform-specific default
         #[clap(long, value_hint = ValueHint::FilePath)]
         custom_path: Option<PathBuf>,
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
             info!("Done");
         }
         Command::Farm {
-            bootstrap_nodes,
+            bootstrap_node,
             custom_path,
             listen_on,
             node_rpc_url,
@@ -103,7 +103,7 @@ async fn main() -> Result<()> {
             let path = utils::get_path(custom_path);
             commands::farm(
                 path,
-                bootstrap_nodes,
+                bootstrap_node,
                 listen_on,
                 &node_rpc_url,
                 ws_server_listen_addr,

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -302,6 +302,10 @@ impl Plot {
         }
     }
 
+    pub fn read_piece(&self, piece_index: u64) -> io::Result<Vec<u8>> {
+        self.read_pieces(piece_index, 1)
+    }
+
     // TODO: Replace index with offset
     /// Returns pieces packed one after another in contiguous `Vec<u8>`
     pub(crate) fn read_pieces(&self, first_index: u64, count: u64) -> io::Result<Vec<u8>> {

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -18,11 +18,13 @@ futures = "0.3.19"
 hex = "0.4.3"
 log = "0.4.14"
 parking_lot = "0.12.0"
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 thiserror = "1.0.30"
 tokio = { version = "1.14.0", features = ["macros", "rt-multi-thread", "time"] }
 
 [dependencies.libp2p]
-version = "0.42.0"
+version = "0.43.0"
+git = "https://github.com/libp2p/rust-libp2p"
 default-features = false
 features = [
     "dns-tokio",

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -39,4 +39,6 @@ features = [
 ]
 
 [dev-dependencies]
+anyhow = "1.0.53"
+clap = { version = "3.0.13", features = ["color", "derive"] }
 env_logger = "0.9.0"

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -1,0 +1,71 @@
+//! Simple bootstrap node implementation
+
+use clap::{AppSettings, Parser};
+use env_logger::Env;
+use libp2p::identity::ed25519::Keypair;
+use libp2p::Multiaddr;
+use log::info;
+use std::sync::Arc;
+use subspace_networking::libp2p::multiaddr::Protocol;
+use subspace_networking::Config;
+
+#[derive(Debug, Parser)]
+#[clap(about, version)]
+#[clap(global_setting(AppSettings::AllArgsOverrideSelf))]
+enum Command {
+    /// Start bootstrap node
+    Start {
+        /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
+        #[clap(long)]
+        bootstrap_node: Vec<Multiaddr>,
+        /// Keypair for node identity, can be obtained with `generate-keypair` command
+        keypair: String,
+        /// Multiaddr to listen on for subspace networking, multiple are supported
+        #[clap(default_value = "/ip4/0.0.0.0/tcp/0")]
+        listen_on: Vec<Multiaddr>,
+    },
+    /// Generate a new keypair
+    GenerateKeypair,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init_from_env(Env::new().default_filter_or("info"));
+
+    let command: Command = Command::parse();
+
+    match command {
+        Command::Start {
+            bootstrap_node,
+            keypair,
+            listen_on,
+        } => {
+            let config = Config {
+                bootstrap_nodes: bootstrap_node,
+                listen_on,
+                allow_non_globals_in_dht: true,
+                ..Config::with_keypair(Keypair::decode(hex::decode(keypair)?.as_mut_slice())?)
+            };
+            let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+
+            node.on_new_listener(Arc::new({
+                let node_id = node.id();
+
+                move |multiaddr| {
+                    info!(
+                        "Listening on {}",
+                        multiaddr.clone().with(Protocol::P2p(node_id.into()))
+                    );
+                }
+            }))
+            .detach();
+
+            node_runner.run().await
+        }
+        Command::GenerateKeypair => {
+            println!("{}", hex::encode(Keypair::generate().encode()))
+        }
+    }
+
+    Ok(())
+}

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -1,6 +1,7 @@
 use env_logger::Env;
 use futures::channel::mpsc;
 use futures::StreamExt;
+use libp2p::multiaddr::Protocol;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_networking::Config;
@@ -36,7 +37,11 @@ async fn main() {
     });
 
     let config_2 = Config {
-        bootstrap_nodes: vec![(node_1.id(), node_1_addresses_receiver.next().await.unwrap())],
+        bootstrap_nodes: vec![node_1_addresses_receiver
+            .next()
+            .await
+            .unwrap()
+            .with(Protocol::P2p(node_1.id().into()))],
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -4,6 +4,7 @@ use futures::StreamExt;
 use libp2p::multiaddr::Protocol;
 use std::sync::Arc;
 use std::time::Duration;
+use subspace_core_primitives::Sha256Hash;
 use subspace_networking::Config;
 
 #[tokio::main]
@@ -13,8 +14,8 @@ async fn main() {
     let config_1 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         value_getter: Arc::new(|key| {
-            // Return the reversed key as a value
-            Some(key.to_vec().into_iter().rev().collect())
+            // Return the reversed digest as a value
+            Some(key.digest().iter().copied().rev().collect())
         }),
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
@@ -57,8 +58,11 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let result = node_2.get_value(vec![1, 2, 3].into()).await;
-    println!("Get value result: {result:?}");
+    let key = subspace_networking::multimess::create_piece_multihash(&Sha256Hash::default(), 1);
+    println!("Get value result for:");
+    println!("Key: {key:?}");
+    let result = node_2.get_value(key).await;
+    println!("Value: {result:?}");
 
     tokio::time::sleep(Duration::from_secs(5)).await;
 }

--- a/crates/subspace-networking/src/behavior/custom_record_store.rs
+++ b/crates/subspace-networking/src/behavior/custom_record_store.rs
@@ -17,7 +17,7 @@ pub(crate) struct CustomRecordStore {
 }
 
 impl CustomRecordStore {
-    pub(crate) fn new(value_getter: ValueGetter) -> Self {
+    pub(super) fn new(value_getter: ValueGetter) -> Self {
         Self { value_getter }
     }
 }

--- a/crates/subspace-networking/src/kad.rs
+++ b/crates/subspace-networking/src/kad.rs
@@ -1,1 +1,1 @@
-pub(crate) mod custom_record_store;
+

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -19,7 +19,6 @@
 
 mod behavior;
 mod create;
-mod kad;
 mod node;
 mod node_runner;
 mod shared;

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod behavior;
 mod create;
+pub mod multimess;
 mod node;
 mod node_runner;
 mod shared;

--- a/crates/subspace-networking/src/multimess.rs
+++ b/crates/subspace-networking/src/multimess.rs
@@ -1,0 +1,19 @@
+// TODO: Find a better place and architecture for this module
+use libp2p::multihash::Multihash;
+use subspace_core_primitives::Sha256Hash;
+
+const SUBSPACE_MULTICODEC_NAMESPACE_START: usize = 0xb39910;
+
+#[repr(usize)]
+pub enum MultihashCode {
+    Piece = SUBSPACE_MULTICODEC_NAMESPACE_START,
+}
+
+pub fn create_piece_multihash(records_root: &Sha256Hash, piece_index: u64) -> Multihash {
+    let piece_index_bytes = piece_index.to_le_bytes();
+    let mut input = Vec::with_capacity(records_root.len() + piece_index_bytes.len());
+    input.extend_from_slice(records_root);
+    input.extend_from_slice(&piece_index_bytes);
+    Multihash::wrap(MultihashCode::Piece as u64, &input)
+        .expect("Input never exceeds allocated size; qed")
+}

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -2,7 +2,7 @@ use crate::shared::{Command, Shared};
 use event_listener_primitives::HandlerId;
 use futures::channel::oneshot;
 use futures::SinkExt;
-use libp2p::kad::record::Key;
+use libp2p::core::multihash::Multihash;
 use libp2p::{Multiaddr, PeerId};
 use std::sync::Arc;
 use thiserror::Error;
@@ -30,7 +30,7 @@ impl Node {
         self.shared.id
     }
 
-    pub async fn get_value(&self, key: Key) -> Result<Option<Vec<u8>>, GetValueError> {
+    pub async fn get_value(&self, key: Multihash) -> Result<Option<Vec<u8>>, GetValueError> {
         let (result_sender, result_receiver) = oneshot::channel();
 
         self.shared

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -86,7 +86,7 @@ impl NodeRunner {
     fn handle_random_query_interval(&mut self) {
         let random_peer_id = PeerId::random();
 
-        debug!("Starting random Kademlia query for {}", random_peer_id);
+        trace!("Starting random Kademlia query for {}", random_peer_id);
 
         self.swarm
             .behaviour_mut()
@@ -144,7 +144,7 @@ impl NodeRunner {
                 }
             }
             SwarmEvent::Behaviour(Event::Kademlia(kademlia_event)) => {
-                debug!("Kademlia event: {:?}", kademlia_event);
+                trace!("Kademlia event: {:?}", kademlia_event);
 
                 match kademlia_event {
                     KademliaEvent::OutboundQueryCompleted {
@@ -237,18 +237,29 @@ impl NodeRunner {
                 self.shared.listeners.lock().push(address.clone());
                 self.shared.handlers.new_listener.call_simple(&address);
             }
-            SwarmEvent::ConnectionEstablished { .. } => {
+            SwarmEvent::ConnectionEstablished {
+                peer_id,
+                num_established,
+                ..
+            } => {
+                debug!("Connection established with peer {peer_id} [{num_established} total]");
                 self.shared
                     .connected_peers_count
                     .fetch_add(1, Ordering::SeqCst);
             }
-            SwarmEvent::ConnectionClosed { .. } => {
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                num_established,
+                ..
+            } => {
+                debug!("Connection closed with peer {peer_id} [{num_established} total]");
+
                 self.shared
                     .connected_peers_count
                     .fetch_sub(1, Ordering::SeqCst);
             }
             other => {
-                debug!("Other swarm event: {:?}", other);
+                trace!("Other swarm event: {:?}", other);
             }
         }
     }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1,4 +1,4 @@
-use crate::behavior::{Behaviour, Event};
+use crate::behavior::{Behavior, Event};
 use crate::shared::{Command, Shared};
 use crate::utils;
 use futures::channel::{mpsc, oneshot};
@@ -32,7 +32,7 @@ pub struct NodeRunner {
     /// Should non-global addresses be added to the DHT?
     allow_non_globals_in_dht: bool,
     command_receiver: mpsc::Receiver<Command>,
-    swarm: Swarm<Behaviour>,
+    swarm: Swarm<Behavior>,
     shared: Arc<Shared>,
     /// How frequently should random queries be done using Kademlia DHT to populate routing table.
     next_random_query_interval: Duration,
@@ -44,7 +44,7 @@ impl NodeRunner {
         permanent_addresses: Vec<(PeerId, Multiaddr)>,
         allow_non_globals_in_dht: bool,
         command_receiver: mpsc::Receiver<Command>,
-        swarm: Swarm<Behaviour>,
+        swarm: Swarm<Behavior>,
         shared: Arc<Shared>,
         initial_random_query_interval: Duration,
     ) -> Self {

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -9,7 +9,7 @@ use libp2p::kad::{
     QueryResult, Quorum,
 };
 use libp2p::swarm::SwarmEvent;
-use libp2p::{futures, Multiaddr, PeerId, Swarm};
+use libp2p::{futures, PeerId, Swarm};
 use log::{debug, trace};
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
@@ -25,10 +25,6 @@ enum QueryResultSender {
 /// Runner for the Node.
 #[must_use = "Node does not function properly unless its runner is driven forward"]
 pub struct NodeRunner {
-    // TODO: This might be useful later
-    /// Bootstrap or reserved nodes.
-    #[allow(dead_code)]
-    permanent_addresses: Vec<(PeerId, Multiaddr)>,
     /// Should non-global addresses be added to the DHT?
     allow_non_globals_in_dht: bool,
     command_receiver: mpsc::Receiver<Command>,
@@ -41,7 +37,6 @@ pub struct NodeRunner {
 
 impl NodeRunner {
     pub(crate) fn new(
-        permanent_addresses: Vec<(PeerId, Multiaddr)>,
         allow_non_globals_in_dht: bool,
         command_receiver: mpsc::Receiver<Command>,
         swarm: Swarm<Behavior>,
@@ -49,7 +44,6 @@ impl NodeRunner {
         initial_random_query_interval: Duration,
     ) -> Self {
         Self {
-            permanent_addresses,
             allow_non_globals_in_dht,
             command_receiver,
             swarm,

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -261,7 +261,7 @@ impl NodeRunner {
                     .behaviour_mut()
                     .kademlia
                     // TODO: Will probably want something different and validate data instead.
-                    .get_record(&key, Quorum::One);
+                    .get_record(key.to_bytes().into(), Quorum::One);
 
                 self.query_id_receivers.insert(
                     query_id,

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -1,6 +1,6 @@
 use event_listener_primitives::Bag;
 use futures::channel::{mpsc, oneshot};
-use libp2p::kad::record::Key;
+use libp2p::core::multihash::Multihash;
 use libp2p::{Multiaddr, PeerId};
 use parking_lot::Mutex;
 use std::sync::atomic::AtomicUsize;
@@ -10,7 +10,7 @@ use std::sync::Arc;
 pub(crate) enum Command {
     // TODO: We might want to have more specific gets eventually
     GetValue {
-        key: Key,
+        key: Multihash,
         result_sender: oneshot::Sender<Option<Vec<u8>>>,
     },
 }


### PR DESCRIPTION
This introduces a bit of refactoring to the networking, initial support for retrieving pieces from farmers over the network (connection to this new networking on farmer side is currently optional) and prototype of the mechanism for managing different kinds of content on the network using multihashes (will write docs about how once I figure out where to put it).

Simple bootstrap node implementation was written as an example for farmers (and soon substrate nodes) to connect to.

The code is a mess, still figuring how to put it all together. The next step is to add gossipsub implementation, but it will be in a separate PR, trying to make incremental progress here.