### PR TITLE
Updated Farming commands to reflect current snapshot

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -3,13 +3,11 @@ name: Rust
 on:
   push:
     paths-ignore:
-      - '*.md'
-      - '**/*.md'
+      - '**.md'
       - '.github/CODEOWNERS'
   pull_request:
     paths-ignore:
-      - '*.md'
-      - '**/*.md'
+      - '**.md'
       - '.github/CODEOWNERS'
 
 env:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -4,10 +4,12 @@ on:
   push:
     paths-ignore:
       - '*.md'
+      - '**/*.md'
       - '.github/CODEOWNERS'
   pull_request:
     paths-ignore:
       - '*.md'
+      - '**/*.md'
       - '.github/CODEOWNERS'
 
 env:

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -31,7 +31,7 @@ You can find these executables in the [Releases](https://github.com/subspace/sub
 
 ```
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-./subspace-node-x86_64-*-snapshot `
+.\subspace-node-x86_64-windows-2019-snapshot-2022-jan-05.exe `
 --chain testnet `
 --wasm-execution compiled `
 --execution wasm `
@@ -68,7 +68,7 @@ You can find these executables in the [Releases](https://github.com/subspace/sub
 6. After running this command, Windows may ask you for permissions related to firewall, select `allow` in this case.
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
-./subspace-farmer-x86_64-*-snapshot farm
+.\subspace-farmer-x86_64-windows-2019-snapshot-2022-jan-05.exe farm
 ```
 
 </details>
@@ -90,7 +90,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 
 ```
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-./subspace-node-x86_64-*-snapshot \
+./subspace-node-x86_64-ubuntu-20.04-snapshot-2022-jan-05.04-SNAPSHOT-2022-JAN-05 \
   --chain testnet \
   --wasm-execution compiled \
   --execution wasm \
@@ -126,7 +126,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
-./subspace-farmer-x86_64-*-snapshot farm
+./subspace-farmer-x86_64-ubuntu-20.04-snapshot-2022-jan-05.04-SNAPSHOT-2022-JAN-05 farm
 ```
 7. It may prompt again in here. Refer to the note on step 4.
 </p>
@@ -149,7 +149,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 
 ```
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-./subspace-node-x86_64-*-snapshot \
+./subspace-node-x86_64-macos-11-snapshot-2022-jan-05 \
   --chain testnet \
   --wasm-execution compiled \
   --execution wasm \
@@ -185,7 +185,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
-./subspace-farmer-x86_64-*-snapshot farm
+./subspace-farmer-x86_64-macos-11-snapshot-2022-jan-05 farm
 ```
 7. It may prompt again in here. Refer to the note on step 4.
 </p>

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -30,8 +30,9 @@ You can find these executables in the [Releases](https://github.com/subspace/sub
 4. We will then start the node using the following command
 
 ```
+# Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases.
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-.\subspace-node-x86_64-windows-2019-snapshot-2022-jan-05.exe `
+.\NODE_FILE_NAME.exe `
 --chain testnet `
 --wasm-execution compiled `
 --execution wasm `
@@ -68,7 +69,7 @@ You can find these executables in the [Releases](https://github.com/subspace/sub
 6. After running this command, Windows may ask you for permissions related to firewall, select `allow` in this case.
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
-.\subspace-farmer-x86_64-windows-2019-snapshot-2022-jan-05.exe farm
+.\FARMER_FILE_NAME.exe farm
 ```
 
 </details>
@@ -89,8 +90,9 @@ To allow execution, go to `System Preferences -> Security & Privacy -> General`,
 After this, simply repeat the step you prompted for (step 4 or 6). This time, click the `Open` button when prompted.
 
 ```
+# Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases.
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-./subspace-node-x86_64-ubuntu-20.04-snapshot-2022-jan-05.04-SNAPSHOT-2022-JAN-05 \
+./NODE_FILE_NAME.NODE_FILE_EXTENSION \
   --chain testnet \
   --wasm-execution compiled \
   --execution wasm \
@@ -126,7 +128,8 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
-./subspace-farmer-x86_64-ubuntu-20.04-snapshot-2022-jan-05.04-SNAPSHOT-2022-JAN-05 farm
+# Replace `FARMER_FILE_NAME` with the name of the node file you downloaded from releases.
+./FARMER_FILE_NAME.FARMER_FILE_EXTENSION farm
 ```
 7. It may prompt again in here. Refer to the note on step 4.
 </p>
@@ -148,8 +151,9 @@ To allow execution, go to `System Preferences -> Security & Privacy -> General`,
 After this, simply repeat the step you prompted for (step 4 or 6). This time, click the `Open` button when prompted.
 
 ```
+# Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases.
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-./subspace-node-x86_64-macos-11-snapshot-2022-jan-05 \
+./NODE_FILE_NAME \
   --chain testnet \
   --wasm-execution compiled \
   --execution wasm \
@@ -185,7 +189,8 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
-./subspace-farmer-x86_64-macos-11-snapshot-2022-jan-05 farm
+# Replace `FARMERS_FILE_NAME` with the name of the node file you downloaded from releases.
+./FARMER_FILE_NAME farm
 ```
 7. It may prompt again in here. Refer to the note on step 4.
 </p>

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -92,7 +92,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 # Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases.
 # Replace `INSERT_YOUR_ID` with a nickname you choose
-./NODE_FILE_NAME.NODE_FILE_EXTENSION \
+./NODE_FILE_NAME \
   --chain testnet \
   --wasm-execution compiled \
   --execution wasm \
@@ -129,7 +129,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```
 # Replace `FARMER_FILE_NAME` with the name of the node file you downloaded from releases.
-./FARMER_FILE_NAME.FARMER_FILE_EXTENSION farm
+./FARMER_FILE_NAME farm
 ```
 7. It may prompt again in here. Refer to the note on step 4.
 </p>


### PR DESCRIPTION
Very simple fix, just added actual release name to command, was causing major confusion. We should be able to update this automatically with a github action down the line. 