### PR TITLE
Just peek into root blocks to not avoid order of elements in LRU cache, tiny simplification

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -75,7 +75,7 @@ where
 pub fn start_subspace_archiver<Block: BlockT, Client>(
     subspace_link: &SubspaceLink<Block>,
     client: Arc<Client>,
-    spawner: &impl sp_core::traits::SpawnNamed,
+    spawner: &impl sp_core::traits::SpawnEssentialNamed,
 ) where
     Client: ProvideRuntimeApi<Block>
         + BlockBackend<Block>
@@ -222,7 +222,7 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
         }
     }
 
-    spawner.spawn_blocking(
+    spawner.spawn_essential_blocking(
         "subspace-archiver",
         None,
         Box::pin({

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -1177,16 +1177,12 @@ where
         }
 
         let import_result = self.inner.import_block(block, new_cache).await?;
-        let (root_block_sender, mut root_block_receiver) = mpsc::channel(0);
+        let (root_block_sender, root_block_receiver) = mpsc::channel(0);
 
         self.imported_block_notification_sender
             .notify(move || (block_number, root_block_sender));
 
-        let mut root_blocks = Vec::new();
-
-        while let Some(root_block) = root_block_receiver.next().await {
-            root_blocks.push(root_block);
-        }
+        let root_blocks = root_block_receiver.collect().await;
 
         self.root_blocks
             .lock()

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -485,7 +485,11 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 
         let task_manager = TaskManager::new(tokio_runtime.handle().clone(), None).unwrap();
 
-        super::start_subspace_archiver(&data.link, client.clone(), &task_manager.spawn_handle());
+        super::start_subspace_archiver(
+            &data.link,
+            client.clone(),
+            &task_manager.spawn_essential_handle(),
+        );
 
         let (archived_pieces_sender, archived_pieces_receiver) = oneshot::channel();
 
@@ -838,7 +842,7 @@ fn verify_slots_are_strictly_increasing() {
 //     let tokio_runtime = sc_cli::build_runtime().unwrap();
 //     let task_manager = TaskManager::new(tokio_runtime.handle().clone(), None).unwrap();
 //
-//     super::start_subspace_archiver(&data.link, client.clone(), &task_manager.spawn_handle());
+//     super::start_subspace_archiver(&data.link, client.clone(), &task_manager.spawn_essential_handle());
 //
 //     let mut archived_segment_notification_stream =
 //         data.link.archived_segment_notification_stream.subscribe();

--- a/crates/subspace-node/src/service.rs
+++ b/crates/subspace-node/src/service.rs
@@ -167,7 +167,7 @@ pub fn new_partial(
     sc_consensus_subspace::start_subspace_archiver(
         &subspace_link,
         client.clone(),
-        &task_manager.spawn_handle(),
+        &task_manager.spawn_essential_handle(),
     );
 
     let slot_duration = subspace_link.config().slot_duration();


### PR DESCRIPTION
One plausible explanation for https://github.com/subspace/subspace/issues/255 I have is that archiving task has crashed. No idea how that could have happened and I don't think we'll be able to recover logs at this point, but crashing the whole app if that ever happens is a good idea since without archiving neither block production not import will work as expected.

This would explain why some nodes think root blocks should be present and some think the opposite. This would also explain why restart helps with recovering from this issue.

First commit is something I noticed along the way, but it should have any impact on the issue.