### PR TITLE
Production profile for snapshots/release builds (slower to build and more optimized than just `--release`)

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -123,28 +123,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --bins --features=subspace-node/json-chain-spec,subspace-farmer/cuda
+          args: --profile production --bins --features=subspace-node/json-chain-spec,subspace-farmer/cuda
         if: runner.os == 'Linux' || runner.os == 'Windows'
 
       - name: Build (macOS without CUDA)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --bins --features=subspace-node/json-chain-spec
+          args: --profile production --bins --features=subspace-node/json-chain-spec
         if: runner.os == 'macOS'
 
       - name: Prepare executables for uploading (Linux or macOS)
         run: |
           mkdir executables
-          mv target/release/subspace-node executables/subspace-node-x86_64-${{ matrix.os }}-${{ github.ref_name }}
-          mv target/release/subspace-farmer executables/subspace-farmer-x86_64-${{ matrix.os }}-${{ github.ref_name }}
+          mv target/production/subspace-node executables/subspace-node-x86_64-${{ matrix.os }}-${{ github.ref_name }}
+          mv target/production/subspace-farmer executables/subspace-farmer-x86_64-${{ matrix.os }}-${{ github.ref_name }}
         if: runner.os == 'Linux' || runner.os == 'macOS'
 
       - name: Prepare executables for uploading (Windows)
         run: |
           mkdir executables
-          move target/release/subspace-node.exe executables/subspace-node-x86_64-${{ matrix.os }}-${{ github.ref_name }}.exe
-          move target/release/subspace-farmer.exe executables/subspace-farmer-x86_64-${{ matrix.os }}-${{ github.ref_name }}.exe
+          move target/production/subspace-node.exe executables/subspace-node-x86_64-${{ matrix.os }}-${{ github.ref_name }}.exe
+          move target/production/subspace-farmer.exe executables/subspace-farmer-x86_64-${{ matrix.os }}-${{ github.ref_name }}.exe
         if: runner.os == 'Windows'
 
       - name: Upload node and farmer executables to assets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,8 @@ zeroize = { opt-level = 3 }
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"
+
+[profile.production]
+inherits = "release"
+lto = "fat"
+codegen-units = 1

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -27,8 +27,8 @@ COPY substrate /code/substrate
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 RUN \
-    /root/.cargo/bin/cargo build --release --bin subspace-farmer && \
-    mv target/release/subspace-farmer subspace-farmer && \
+    /root/.cargo/bin/cargo build --profile production --bin subspace-farmer && \
+    mv target/production/subspace-farmer subspace-farmer && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -29,8 +29,8 @@ COPY substrate /code/substrate
 ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
 
 RUN \
-    /root/.cargo/bin/cargo build --release --bin subspace-node && \
-    mv target/release/subspace-node subspace-node && \
+    /root/.cargo/bin/cargo build --profile production --bin subspace-node && \
+    mv target/production/subspace-node subspace-node && \
     rm -rf target
 
 FROM ubuntu:20.04


### PR DESCRIPTION
Cargo supports custom profiles, so why not, right?