### PR TITLE
Format cumulus and polkadot in the original form

### DIFF
--- a/cumulus/client/cli/src/lib.rs
+++ b/cumulus/client/cli/src/lib.rs
@@ -19,6 +19,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::all)]
 
+use clap::Parser;
 use sc_service::{
 	config::{PrometheusConfig, TelemetryEndpoints},
 	BasePath, TransactionPoolOptions,
@@ -28,7 +29,6 @@ use std::{
 	io::{self, Write},
 	net::SocketAddr,
 };
-use clap::Parser;
 
 /// The `purge-chain` command used to remove the whole chain: the parachain and the relaychain.
 #[derive(Debug, Parser)]

--- a/cumulus/client/consensus/relay-chain/src/import_queue.rs
+++ b/cumulus/client/consensus/relay-chain/src/import_queue.rs
@@ -17,8 +17,8 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use sc_consensus::{
-    import_queue::{BasicQueue, Verifier as VerifierT},
-    BlockImport, BlockImportParams,
+	import_queue::{BasicQueue, Verifier as VerifierT},
+	BlockImport, BlockImportParams,
 };
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
@@ -26,115 +26,102 @@ use sp_blockchain::Result as ClientResult;
 use sp_consensus::{error::Error as ConsensusError, CacheKeyId};
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
 use sp_runtime::{
-    generic::BlockId,
-    traits::{Block as BlockT, Header as HeaderT},
+	generic::BlockId,
+	traits::{Block as BlockT, Header as HeaderT},
 };
 
 /// A verifier that just checks the inherents.
 pub struct Verifier<Client, Block, CIDP> {
-    client: Arc<Client>,
-    create_inherent_data_providers: CIDP,
-    _marker: PhantomData<Block>,
+	client: Arc<Client>,
+	create_inherent_data_providers: CIDP,
+	_marker: PhantomData<Block>,
 }
 
 impl<Client, Block, CIDP> Verifier<Client, Block, CIDP> {
-    /// Create a new instance.
-    pub fn new(client: Arc<Client>, create_inherent_data_providers: CIDP) -> Self {
-        Self {
-            client,
-            create_inherent_data_providers,
-            _marker: PhantomData,
-        }
-    }
+	/// Create a new instance.
+	pub fn new(client: Arc<Client>, create_inherent_data_providers: CIDP) -> Self {
+		Self { client, create_inherent_data_providers, _marker: PhantomData }
+	}
 }
 
 #[async_trait::async_trait]
 impl<Client, Block, CIDP> VerifierT<Block> for Verifier<Client, Block, CIDP>
 where
-    Block: BlockT,
-    Client: ProvideRuntimeApi<Block> + Send + Sync,
-    <Client as ProvideRuntimeApi<Block>>::Api: BlockBuilderApi<Block>,
-    CIDP: CreateInherentDataProviders<Block, ()>,
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + Send + Sync,
+	<Client as ProvideRuntimeApi<Block>>::Api: BlockBuilderApi<Block>,
+	CIDP: CreateInherentDataProviders<Block, ()>,
 {
-    async fn verify(
-        &mut self,
-        mut block_params: BlockImportParams<Block, ()>,
-    ) -> Result<
-        (
-            BlockImportParams<Block, ()>,
-            Option<Vec<(CacheKeyId, Vec<u8>)>>,
-        ),
-        String,
-    > {
-        if let Some(inner_body) = block_params.body.take() {
-            let inherent_data_providers = self
-                .create_inherent_data_providers
-                .create_inherent_data_providers(*block_params.header.parent_hash(), ())
-                .await
-                .map_err(|e| e.to_string())?;
+	async fn verify(
+		&mut self,
+		mut block_params: BlockImportParams<Block, ()>,
+	) -> Result<(BlockImportParams<Block, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+		if let Some(inner_body) = block_params.body.take() {
+			let inherent_data_providers = self
+				.create_inherent_data_providers
+				.create_inherent_data_providers(*block_params.header.parent_hash(), ())
+				.await
+				.map_err(|e| e.to_string())?;
 
-            let inherent_data = inherent_data_providers
-                .create_inherent_data()
-                .map_err(|e| e.to_string())?;
+			let inherent_data =
+				inherent_data_providers.create_inherent_data().map_err(|e| e.to_string())?;
 
-            let block = Block::new(block_params.header.clone(), inner_body);
+			let block = Block::new(block_params.header.clone(), inner_body);
 
-            let inherent_res = self
-                .client
-                .runtime_api()
-                .check_inherents(
-                    &BlockId::Hash(*block.header().parent_hash()),
-                    block.clone(),
-                    inherent_data,
-                )
-                .map_err(|e| e.to_string())?;
+			let inherent_res = self
+				.client
+				.runtime_api()
+				.check_inherents(
+					&BlockId::Hash(*block.header().parent_hash()),
+					block.clone(),
+					inherent_data,
+				)
+				.map_err(|e| e.to_string())?;
 
-            if !inherent_res.ok() {
-                for (i, e) in inherent_res.into_errors() {
-                    match inherent_data_providers.try_handle_error(&i, &e).await {
-                        Some(r) => r.map_err(|e| e.to_string())?,
-                        None => Err(format!(
-                            "Unhandled inherent error from `{}`.",
-                            String::from_utf8_lossy(&i)
-                        ))?,
-                    }
-                }
-            }
+			if !inherent_res.ok() {
+				for (i, e) in inherent_res.into_errors() {
+					match inherent_data_providers.try_handle_error(&i, &e).await {
+						Some(r) => r.map_err(|e| e.to_string())?,
+						None => Err(format!(
+							"Unhandled inherent error from `{}`.",
+							String::from_utf8_lossy(&i)
+						))?,
+					}
+				}
+			}
 
-            let (_, inner_body) = block.deconstruct();
-            block_params.body = Some(inner_body);
-        }
+			let (_, inner_body) = block.deconstruct();
+			block_params.body = Some(inner_body);
+		}
 
-        block_params.post_hash = Some(block_params.header.hash());
+		block_params.post_hash = Some(block_params.header.hash());
 
-        Ok((block_params, None))
-    }
+		Ok((block_params, None))
+	}
 }
 
 /// Start an import queue for a Cumulus collator that does not uses any special authoring logic.
 pub fn import_queue<Client, Block: BlockT, I, CIDP>(
-    client: Arc<Client>,
-    block_import: I,
-    create_inherent_data_providers: CIDP,
-    spawner: &impl sp_core::traits::SpawnEssentialNamed,
-    registry: Option<&substrate_prometheus_endpoint::Registry>,
+	client: Arc<Client>,
+	block_import: I,
+	create_inherent_data_providers: CIDP,
+	spawner: &impl sp_core::traits::SpawnEssentialNamed,
+	registry: Option<&substrate_prometheus_endpoint::Registry>,
 ) -> ClientResult<BasicQueue<Block, I::Transaction>>
 where
-    I: BlockImport<Block, Error = ConsensusError> + Send + Sync + 'static,
-    I::Transaction: Send,
-    Client: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-    <Client as ProvideRuntimeApi<Block>>::Api: BlockBuilderApi<Block>,
-    CIDP: CreateInherentDataProviders<Block, ()> + 'static,
+	I: BlockImport<Block, Error = ConsensusError> + Send + Sync + 'static,
+	I::Transaction: Send,
+	Client: ProvideRuntimeApi<Block> + Send + Sync + 'static,
+	<Client as ProvideRuntimeApi<Block>>::Api: BlockBuilderApi<Block>,
+	CIDP: CreateInherentDataProviders<Block, ()> + 'static,
 {
-    let verifier = Verifier::new(client, create_inherent_data_providers);
+	let verifier = Verifier::new(client, create_inherent_data_providers);
 
-    Ok(BasicQueue::new(
-        verifier,
-        Box::new(cumulus_client_consensus_common::ParachainBlockImport::new(
-            block_import,
-        )),
-        None,
-        spawner,
-        registry,
-    ))
+	Ok(BasicQueue::new(
+		verifier,
+		Box::new(cumulus_client_consensus_common::ParachainBlockImport::new(block_import)),
+		None,
+		spawner,
+		registry,
+	))
 }

--- a/cumulus/parachain-template/node/src/cli.rs
+++ b/cumulus/parachain-template/node/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::chain_spec;
-use std::path::PathBuf;
 use clap::{AppSettings, Parser};
+use std::path::PathBuf;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, clap::Subcommand)]

--- a/cumulus/parachain-template/node/src/service.rs
+++ b/cumulus/parachain-template/node/src/service.rs
@@ -1,13 +1,11 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 // std
-use std::sync::Arc;
 use sc_basic_authorship::ProposerFactory;
+use std::sync::Arc;
 
 // Local Runtime Types
-use parachain_template_runtime::{
-	opaque::Block, AccountId, Balance, Index as Nonce, RuntimeApi,
-};
+use parachain_template_runtime::{opaque::Block, AccountId, Balance, Index as Nonce, RuntimeApi};
 
 // Cumulus Imports
 use cirrus_client_service::prepare_node_config;
@@ -230,18 +228,15 @@ where
 	let (mut telemetry, _telemetry_worker_handle) = params.other;
 
 	let primary_chain_full_node = {
-		let span = tracing::info_span!(
-			sc_tracing::logging::PREFIX_LOG_SPAN,
-			name = "Primarychain"
-		);
+		let span = tracing::info_span!(sc_tracing::logging::PREFIX_LOG_SPAN, name = "Primarychain");
 		let _enter = span.enter();
 
 		subspace_service::new_full::<subspace_runtime::RuntimeApi, SubspaceExecutorDispatch>(
 			polkadot_config,
 			false,
 		)
-			.await
-			.map_err(|_| sc_service::Error::Other("Failed to build a full subspace node".into()))?
+		.await
+		.map_err(|_| sc_service::Error::Other("Failed to build a full subspace node".into()))?
 	};
 
 	let client = params.client.clone();

--- a/cumulus/rustfmt.toml
+++ b/cumulus/rustfmt.toml
@@ -1,0 +1,24 @@
+# Basic
+edition = "2021"
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+
+# Consistency
+newline_style = "Unix"
+
+# Misc
+binop_separator = "Back"
+chain_width = 80
+match_arm_blocks = false
+match_arm_leading_pipes = "Preserve"
+match_block_trailing_comma = true
+reorder_impl_items = false
+spaces_around_ranges = false
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -25,14 +25,14 @@
 
 use polkadot_node_subsystem_util::metrics::{self, prometheus};
 use polkadot_subsystem::{
-    errors::RuntimeApiError,
-    messages::{RuntimeApiMessage, RuntimeApiRequest as Request},
-    overseer, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext, SubsystemError,
-    SubsystemResult,
+	errors::RuntimeApiError,
+	messages::{RuntimeApiMessage, RuntimeApiRequest as Request},
+	overseer, FromOverseer, OverseerSignal, SpawnedSubsystem, SubsystemContext, SubsystemError,
+	SubsystemResult,
 };
 use subspace_runtime_primitives::{
-    opaque::{Block, BlockId},
-    Hash,
+	opaque::{Block, BlockId},
+	Hash,
 };
 
 use sp_api::ProvideRuntimeApi;
@@ -55,77 +55,74 @@ const API_REQUEST_TASK_NAME: &str = "polkadot-runtime-api-request";
 
 /// The `RuntimeApiSubsystem`. See module docs for more details.
 pub struct RuntimeApiSubsystem<Client> {
-    client: Arc<Client>,
-    metrics: Metrics,
-    spawn_handle: Box<dyn SpawnNamed>,
-    /// If there are [`MAX_PARALLEL_REQUESTS`] requests being executed, we buffer them in here until they can be executed.
-    #[allow(unused)]
-    waiting_requests: VecDeque<(
-        Pin<Box<dyn Future<Output = ()> + Send>>,
-        oneshot::Receiver<Option<RequestResult>>,
-    )>,
-    /// All the active runtime API requests that are currently being executed.
-    active_requests: FuturesUnordered<oneshot::Receiver<Option<RequestResult>>>,
-    /// Requests results cache
-    #[allow(unused)]
-    requests_cache: RequestResultCache,
+	client: Arc<Client>,
+	metrics: Metrics,
+	spawn_handle: Box<dyn SpawnNamed>,
+	/// If there are [`MAX_PARALLEL_REQUESTS`] requests being executed, we buffer them in here until they can be executed.
+	#[allow(unused)]
+	waiting_requests: VecDeque<(
+		Pin<Box<dyn Future<Output = ()> + Send>>,
+		oneshot::Receiver<Option<RequestResult>>,
+	)>,
+	/// All the active runtime API requests that are currently being executed.
+	active_requests: FuturesUnordered<oneshot::Receiver<Option<RequestResult>>>,
+	/// Requests results cache
+	#[allow(unused)]
+	requests_cache: RequestResultCache,
 }
 
 impl<Client> RuntimeApiSubsystem<Client> {
-    /// Create a new Runtime API subsystem wrapping the given client and metrics.
-    pub fn new(
-        client: Arc<Client>,
-        metrics: Metrics,
-        spawn_handle: impl SpawnNamed + 'static,
-    ) -> Self {
-        RuntimeApiSubsystem {
-            client,
-            metrics,
-            spawn_handle: Box::new(spawn_handle),
-            waiting_requests: Default::default(),
-            active_requests: Default::default(),
-            requests_cache: RequestResultCache::default(),
-        }
-    }
+	/// Create a new Runtime API subsystem wrapping the given client and metrics.
+	pub fn new(
+		client: Arc<Client>,
+		metrics: Metrics,
+		spawn_handle: impl SpawnNamed + 'static,
+	) -> Self {
+		RuntimeApiSubsystem {
+			client,
+			metrics,
+			spawn_handle: Box::new(spawn_handle),
+			waiting_requests: Default::default(),
+			active_requests: Default::default(),
+			requests_cache: RequestResultCache::default(),
+		}
+	}
 }
 
 impl<Client, Context> overseer::Subsystem<Context, SubsystemError> for RuntimeApiSubsystem<Client>
 where
-    Client: ProvideRuntimeApi<Block> + Send + 'static + Sync,
-    Client::Api: ExecutorApi<Block>,
-    Context: SubsystemContext<Message = RuntimeApiMessage>,
-    Context: overseer::SubsystemContext<Message = RuntimeApiMessage>,
+	Client: ProvideRuntimeApi<Block> + Send + 'static + Sync,
+	Client::Api: ExecutorApi<Block>,
+	Context: SubsystemContext<Message = RuntimeApiMessage>,
+	Context: overseer::SubsystemContext<Message = RuntimeApiMessage>,
 {
-    fn start(self, ctx: Context) -> SpawnedSubsystem {
-        SpawnedSubsystem {
-            future: run(ctx, self).boxed(),
-            name: "runtime-api-subsystem",
-        }
-    }
+	fn start(self, ctx: Context) -> SpawnedSubsystem {
+		SpawnedSubsystem { future: run(ctx, self).boxed(), name: "runtime-api-subsystem" }
+	}
 }
 
 impl<Client> RuntimeApiSubsystem<Client>
 where
-    Client: ProvideRuntimeApi<Block> + Send + 'static + Sync,
-    Client::Api: ExecutorApi<Block>,
+	Client: ProvideRuntimeApi<Block> + Send + 'static + Sync,
+	Client::Api: ExecutorApi<Block>,
 {
-    fn store_cache(&mut self, result: RequestResult) {
-        use RequestResult::*;
+	fn store_cache(&mut self, result: RequestResult) {
+		use RequestResult::*;
 
-        match result {
-            SubmitExecutionReceipt(..) => {}
-            SubmitTransactionBundle(..) => {}
-            SubmitFraudProof(..) => {}
-            SubmitBundleEquivocationProof(..) => {}
-            SubmitInvalidTransactionProof(..) => {}
-            ExtractBundles(..) => {}
-            ExtrinsicsShufflingSeed(..) => {}
-        }
-    }
+		match result {
+			SubmitExecutionReceipt(..) => {},
+			SubmitTransactionBundle(..) => {},
+			SubmitFraudProof(..) => {},
+			SubmitBundleEquivocationProof(..) => {},
+			SubmitInvalidTransactionProof(..) => {},
+			ExtractBundles(..) => {},
+			ExtrinsicsShufflingSeed(..) => {},
+		}
+	}
 
-    #[allow(unused)]
-    fn query_cache(&mut self, _relay_parent: Hash, request: Request) -> Option<Request> {
-        macro_rules! query {
+	#[allow(unused)]
+	fn query_cache(&mut self, _relay_parent: Hash, request: Request) -> Option<Request> {
+		macro_rules! query {
 			// Just query by relay parent
 			($cache_api_name:ident (), $sender:expr) => {{
 				let sender = $sender;
@@ -150,204 +147,198 @@ where
 			}}
 		}
 
-        match request {
-            Request::SubmitExecutionReceipt(..) => None,
-            Request::SubmitTransactionBundle(..) => None,
-            Request::SubmitFraudProof(..) => None,
-            Request::SubmitBundleEquivocationProof(..) => None,
-            Request::SubmitInvalidTransactionProof(..) => None,
-            Request::ExtractBundles(..) => None,
-            Request::ExtrinsicsShufflingSeed(..) => None,
-        }
-    }
+		match request {
+			Request::SubmitExecutionReceipt(..) => None,
+			Request::SubmitTransactionBundle(..) => None,
+			Request::SubmitFraudProof(..) => None,
+			Request::SubmitBundleEquivocationProof(..) => None,
+			Request::SubmitInvalidTransactionProof(..) => None,
+			Request::ExtractBundles(..) => None,
+			Request::ExtrinsicsShufflingSeed(..) => None,
+		}
+	}
 
-    /// Spawn a runtime API request.
-    ///
-    /// If there are already [`MAX_PARALLEL_REQUESTS`] requests being executed, the request will be buffered.
-    fn spawn_request(&mut self, relay_parent: Hash, request: Request) {
-        let client = self.client.clone();
-        let metrics = self.metrics.clone();
-        let (sender, receiver) = oneshot::channel();
+	/// Spawn a runtime API request.
+	///
+	/// If there are already [`MAX_PARALLEL_REQUESTS`] requests being executed, the request will be buffered.
+	fn spawn_request(&mut self, relay_parent: Hash, request: Request) {
+		let client = self.client.clone();
+		let metrics = self.metrics.clone();
+		let (sender, receiver) = oneshot::channel();
 
-        // FIXME: Re-enable the cache
-        // let request = match self.query_cache(relay_parent.clone(), request) {
-        // Some(request) => request,
-        // None => return,
-        // };
+		// FIXME: Re-enable the cache
+		// let request = match self.query_cache(relay_parent.clone(), request) {
+		// Some(request) => request,
+		// None => return,
+		// };
 
-        let request = async move {
-            let result = make_runtime_api_request(client, metrics, relay_parent, request);
-            let _ = sender.send(result);
-        }
-        .boxed();
+		let request = async move {
+			let result = make_runtime_api_request(client, metrics, relay_parent, request);
+			let _ = sender.send(result);
+		}
+		.boxed();
 
-        if self.active_requests.len() >= MAX_PARALLEL_REQUESTS {
-            self.waiting_requests.push_back((request, receiver));
+		if self.active_requests.len() >= MAX_PARALLEL_REQUESTS {
+			self.waiting_requests.push_back((request, receiver));
 
-            if self.waiting_requests.len() > MAX_PARALLEL_REQUESTS * 10 {
-                tracing::warn!(
-                    target: LOG_TARGET,
-                    "{} runtime API requests waiting to be executed.",
-                    self.waiting_requests.len(),
-                )
-            }
-        } else {
-            self.spawn_handle
-                .spawn_blocking(API_REQUEST_TASK_NAME, Some("runtime-api"), request);
-            self.active_requests.push(receiver);
-        }
-    }
+			if self.waiting_requests.len() > MAX_PARALLEL_REQUESTS * 10 {
+				tracing::warn!(
+					target: LOG_TARGET,
+					"{} runtime API requests waiting to be executed.",
+					self.waiting_requests.len(),
+				)
+			}
+		} else {
+			self.spawn_handle
+				.spawn_blocking(API_REQUEST_TASK_NAME, Some("runtime-api"), request);
+			self.active_requests.push(receiver);
+		}
+	}
 
-    /// Poll the active runtime API requests.
-    async fn poll_requests(&mut self) {
-        // If there are no active requests, this future should be pending forever.
-        if self.active_requests.len() == 0 {
-            return futures::pending!();
-        }
+	/// Poll the active runtime API requests.
+	async fn poll_requests(&mut self) {
+		// If there are no active requests, this future should be pending forever.
+		if self.active_requests.len() == 0 {
+			return futures::pending!()
+		}
 
-        // If there are active requests, this will always resolve to `Some(_)` when a request is finished.
-        if let Some(Ok(Some(result))) = self.active_requests.next().await {
-            self.store_cache(result);
-        }
+		// If there are active requests, this will always resolve to `Some(_)` when a request is finished.
+		if let Some(Ok(Some(result))) = self.active_requests.next().await {
+			self.store_cache(result);
+		}
 
-        if let Some((req, recv)) = self.waiting_requests.pop_front() {
-            self.spawn_handle
-                .spawn_blocking(API_REQUEST_TASK_NAME, Some("runtime-api"), req);
-            self.active_requests.push(recv);
-        }
-    }
+		if let Some((req, recv)) = self.waiting_requests.pop_front() {
+			self.spawn_handle
+				.spawn_blocking(API_REQUEST_TASK_NAME, Some("runtime-api"), req);
+			self.active_requests.push(recv);
+		}
+	}
 }
 
 async fn run<Client, Context>(
-    mut ctx: Context,
-    mut subsystem: RuntimeApiSubsystem<Client>,
+	mut ctx: Context,
+	mut subsystem: RuntimeApiSubsystem<Client>,
 ) -> SubsystemResult<()>
 where
-    Client: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-    Client::Api: ExecutorApi<Block>,
-    Context: SubsystemContext<Message = RuntimeApiMessage>,
-    Context: overseer::SubsystemContext<Message = RuntimeApiMessage>,
+	Client: ProvideRuntimeApi<Block> + Send + Sync + 'static,
+	Client::Api: ExecutorApi<Block>,
+	Context: SubsystemContext<Message = RuntimeApiMessage>,
+	Context: overseer::SubsystemContext<Message = RuntimeApiMessage>,
 {
-    loop {
-        select! {
-            req = ctx.recv().fuse() => match req? {
-                FromOverseer::Signal(OverseerSignal::Conclude) => return Ok(()),
-                FromOverseer::Signal(OverseerSignal::ActiveLeaves(_)) => {},
-                FromOverseer::Signal(OverseerSignal::BlockFinalized(..)) => {},
-                FromOverseer::Signal(OverseerSignal::NewSlot(..)) => {},
-                FromOverseer::Communication { msg } => match msg {
-                    RuntimeApiMessage::Request(relay_parent, request) => {
-                        subsystem.spawn_request(relay_parent, request);
-                    },
-                }
-            },
-            _ = subsystem.poll_requests().fuse() => {},
-        }
-    }
+	loop {
+		select! {
+			req = ctx.recv().fuse() => match req? {
+				FromOverseer::Signal(OverseerSignal::Conclude) => return Ok(()),
+				FromOverseer::Signal(OverseerSignal::ActiveLeaves(_)) => {},
+				FromOverseer::Signal(OverseerSignal::BlockFinalized(..)) => {},
+				FromOverseer::Signal(OverseerSignal::NewSlot(..)) => {},
+				FromOverseer::Communication { msg } => match msg {
+					RuntimeApiMessage::Request(relay_parent, request) => {
+						subsystem.spawn_request(relay_parent, request);
+					},
+				}
+			},
+			_ = subsystem.poll_requests().fuse() => {},
+		}
+	}
 }
 
 fn make_runtime_api_request<Client>(
-    client: Arc<Client>,
-    metrics: Metrics,
-    relay_parent: Hash,
-    request: Request,
+	client: Arc<Client>,
+	metrics: Metrics,
+	relay_parent: Hash,
+	request: Request,
 ) -> Option<RequestResult>
 where
-    Client: ProvideRuntimeApi<Block>,
-    Client::Api: ExecutorApi<Block>,
+	Client: ProvideRuntimeApi<Block>,
+	Client::Api: ExecutorApi<Block>,
 {
-    let _timer = metrics.time_make_runtime_api_request();
+	let _timer = metrics.time_make_runtime_api_request();
 
-    // TODO: re-enable the marco to reduce the pattern duplication.
-    match request {
-        Request::SubmitExecutionReceipt(opaque_execution_receipt) => {
-            let api = client.runtime_api();
-            let res = api
-                .submit_execution_receipt_unsigned(
-                    &BlockId::Hash(relay_parent),
-                    opaque_execution_receipt,
-                )
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
-            res.ok()
-                .map(|_res| RequestResult::SubmitExecutionReceipt(relay_parent));
-        }
-        Request::SubmitTransactionBundle(opaque_bundle) => {
-            let api = client.runtime_api();
-            let bundle_hash = opaque_bundle.hash();
-            let res = api
-                .submit_transaction_bundle_unsigned(&BlockId::Hash(relay_parent), opaque_bundle)
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
-            res.ok()
-                .map(|_res| RequestResult::SubmitTransactionBundle(relay_parent, bundle_hash));
-        }
-        Request::SubmitFraudProof(fraud_proof) => {
-            let api = client.runtime_api();
-            let res = api
-                .submit_fraud_proof_unsigned(&BlockId::Hash(relay_parent), fraud_proof)
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
-            res.ok()
-                .map(|_res| RequestResult::SubmitFraudProof(relay_parent));
-        }
-        Request::SubmitBundleEquivocationProof(bundle_equivocation_proof) => {
-            let api = client.runtime_api();
-            let res = api
-                .submit_bundle_equivocation_proof_unsigned(
-                    &BlockId::Hash(relay_parent),
-                    bundle_equivocation_proof,
-                )
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
-            res.ok()
-                .map(|_res| RequestResult::SubmitBundleEquivocationProof(relay_parent));
-        }
-        Request::SubmitInvalidTransactionProof(invalid_transaction_proof) => {
-            let api = client.runtime_api();
-            let res = api
-                .submit_invalid_transaction_proof_unsigned(
-                    &BlockId::Hash(relay_parent),
-                    invalid_transaction_proof,
-                )
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
-            res.ok()
-                .map(|_res| RequestResult::SubmitInvalidTransactionProof(relay_parent));
-        }
-        Request::ExtractBundles(extrinsics, sender) => {
-            let api = client.runtime_api();
-            let res = api
-                .extract_bundles(&BlockId::Hash(relay_parent), extrinsics)
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
+	// TODO: re-enable the marco to reduce the pattern duplication.
+	match request {
+		Request::SubmitExecutionReceipt(opaque_execution_receipt) => {
+			let api = client.runtime_api();
+			let res = api
+				.submit_execution_receipt_unsigned(
+					&BlockId::Hash(relay_parent),
+					opaque_execution_receipt,
+				)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::SubmitExecutionReceipt(relay_parent));
+		},
+		Request::SubmitTransactionBundle(opaque_bundle) => {
+			let api = client.runtime_api();
+			let bundle_hash = opaque_bundle.hash();
+			let res = api
+				.submit_transaction_bundle_unsigned(&BlockId::Hash(relay_parent), opaque_bundle)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
+			res.ok()
+				.map(|_res| RequestResult::SubmitTransactionBundle(relay_parent, bundle_hash));
+		},
+		Request::SubmitFraudProof(fraud_proof) => {
+			let api = client.runtime_api();
+			let res = api
+				.submit_fraud_proof_unsigned(&BlockId::Hash(relay_parent), fraud_proof)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::SubmitFraudProof(relay_parent));
+		},
+		Request::SubmitBundleEquivocationProof(bundle_equivocation_proof) => {
+			let api = client.runtime_api();
+			let res = api
+				.submit_bundle_equivocation_proof_unsigned(
+					&BlockId::Hash(relay_parent),
+					bundle_equivocation_proof,
+				)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::SubmitBundleEquivocationProof(relay_parent));
+		},
+		Request::SubmitInvalidTransactionProof(invalid_transaction_proof) => {
+			let api = client.runtime_api();
+			let res = api
+				.submit_invalid_transaction_proof_unsigned(
+					&BlockId::Hash(relay_parent),
+					invalid_transaction_proof,
+				)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::SubmitInvalidTransactionProof(relay_parent));
+		},
+		Request::ExtractBundles(extrinsics, sender) => {
+			let api = client.runtime_api();
+			let res = api
+				.extract_bundles(&BlockId::Hash(relay_parent), extrinsics)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
 
-            let _ = sender.send(res.clone());
+			let _ = sender.send(res.clone());
 
-            res.ok()
-                .map(|_res| RequestResult::ExtractBundles(relay_parent));
-        }
-        Request::ExtrinsicsShufflingSeed(header, sender) => {
-            let api = client.runtime_api();
-            let res = api
-                .extrinsics_shuffling_seed(&BlockId::Hash(relay_parent), header)
-                .map_err(|e| RuntimeApiError::from(e.to_string()));
-            metrics.on_request(res.is_ok());
+			res.ok().map(|_res| RequestResult::ExtractBundles(relay_parent));
+		},
+		Request::ExtrinsicsShufflingSeed(header, sender) => {
+			let api = client.runtime_api();
+			let res = api
+				.extrinsics_shuffling_seed(&BlockId::Hash(relay_parent), header)
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
 
-            let _ = sender.send(res.clone());
+			let _ = sender.send(res.clone());
 
-            res.ok()
-                .map(|_res| RequestResult::ExtrinsicsShufflingSeed(relay_parent));
-        }
-    }
+			res.ok().map(|_res| RequestResult::ExtrinsicsShufflingSeed(relay_parent));
+		},
+	}
 
-    None
+	None
 }
 
 #[derive(Clone)]
 struct MetricsInner {
-    chain_api_requests: prometheus::CounterVec<prometheus::U64>,
-    make_runtime_api_request: prometheus::Histogram,
+	chain_api_requests: prometheus::CounterVec<prometheus::U64>,
+	make_runtime_api_request: prometheus::Histogram,
 }
 
 /// Runtime API metrics.
@@ -355,63 +346,52 @@ struct MetricsInner {
 pub struct Metrics(Option<MetricsInner>);
 
 impl Metrics {
-    fn on_request(&self, succeeded: bool) {
-        if let Some(metrics) = &self.0 {
-            if succeeded {
-                metrics
-                    .chain_api_requests
-                    .with_label_values(&["succeeded"])
-                    .inc();
-            } else {
-                metrics
-                    .chain_api_requests
-                    .with_label_values(&["failed"])
-                    .inc();
-            }
-        }
-    }
+	fn on_request(&self, succeeded: bool) {
+		if let Some(metrics) = &self.0 {
+			if succeeded {
+				metrics.chain_api_requests.with_label_values(&["succeeded"]).inc();
+			} else {
+				metrics.chain_api_requests.with_label_values(&["failed"]).inc();
+			}
+		}
+	}
 
-    #[allow(unused)]
-    fn on_cached_request(&self) {
-        self.0.as_ref().map(|metrics| {
-            metrics
-                .chain_api_requests
-                .with_label_values(&["cached"])
-                .inc()
-        });
-    }
+	#[allow(unused)]
+	fn on_cached_request(&self) {
+		self.0
+			.as_ref()
+			.map(|metrics| metrics.chain_api_requests.with_label_values(&["cached"]).inc());
+	}
 
-    /// Provide a timer for `make_runtime_api_request` which observes on drop.
-    fn time_make_runtime_api_request(
-        &self,
-    ) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
-        self.0
-            .as_ref()
-            .map(|metrics| metrics.make_runtime_api_request.start_timer())
-    }
+	/// Provide a timer for `make_runtime_api_request` which observes on drop.
+	fn time_make_runtime_api_request(
+		&self,
+	) -> Option<metrics::prometheus::prometheus::HistogramTimer> {
+		self.0.as_ref().map(|metrics| metrics.make_runtime_api_request.start_timer())
+	}
 }
 
 impl metrics::Metrics for Metrics {
-    fn try_register(registry: &prometheus::Registry) -> Result<Self, prometheus::PrometheusError> {
-        let metrics = MetricsInner {
-            chain_api_requests: prometheus::register(
-                prometheus::CounterVec::new(
-                    prometheus::Opts::new(
-                        "parachain_runtime_api_requests_total",
-                        "Number of Runtime API requests served.",
-                    ),
-                    &["success"],
-                )?,
-                registry,
-            )?,
-            make_runtime_api_request: prometheus::register(
-                prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
-                    "parachain_runtime_api_make_runtime_api_request",
-                    "Time spent within `runtime_api::make_runtime_api_request`",
-                ))?,
-                registry,
-            )?,
-        };
-        Ok(Metrics(Some(metrics)))
-    }
+	fn try_register(registry: &prometheus::Registry) -> Result<Self, prometheus::PrometheusError> {
+		let metrics = MetricsInner {
+			chain_api_requests: prometheus::register(
+				prometheus::CounterVec::new(
+					prometheus::Opts::new(
+						"parachain_runtime_api_requests_total",
+						"Number of Runtime API requests served.",
+					),
+					&["success"],
+				)?,
+				registry,
+			)?,
+			make_runtime_api_request: prometheus::register(
+				prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(
+					"parachain_runtime_api_make_runtime_api_request",
+					"Time spent within `runtime_api::make_runtime_api_request`",
+				))?,
+				registry,
+			)?,
+		};
+		Ok(Metrics(Some(metrics)))
+	}
 }

--- a/polkadot/rustfmt.toml
+++ b/polkadot/rustfmt.toml
@@ -1,0 +1,24 @@
+# Basic
+edition = "2021"
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+
+# Consistency
+newline_style = "Unix"
+
+# Misc
+binop_separator = "Back"
+chain_width = 80
+match_arm_blocks = false
+match_arm_leading_pipes = "Preserve"
+match_block_trailing_comma = true
+reorder_impl_items = false
+spaces_around_ranges = false
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true


### PR DESCRIPTION
Add the rustfmt.yml accordingly to avoid the accidental
formatting again since it makes more sense to keep the
original format under cumulus and polkadot folder IMO.

No code changes, just rerun the format command for the project.