### PR TITLE
Remove unnecessarily used nightly feature that became feature-gated (again?)

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -344,10 +344,7 @@ impl NodeRunner {
                         match self.swarm.behaviour_mut().gossipsub.subscribe(&topic) {
                             Ok(true) => {
                                 if result_sender.send(Ok(created_subscription)).is_ok() {
-                                    entry.insert_entry(IntMap::from_iter([(
-                                        subscription_id,
-                                        sender,
-                                    )]));
+                                    entry.insert(IntMap::from_iter([(subscription_id, sender)]));
                                 }
                             }
                             Ok(false) => {


### PR DESCRIPTION
There was no need to use, but it and it wasn't feature-gated and now it is, so let's switch to another method since we don't care about return value anyway.

For reference: https://github.com/rust-lang/rust/issues/65225