### PR TITLE
Add custom block rewards address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8633,6 +8633,7 @@ dependencies = [
  "serde",
  "serde_arrays",
  "sha2 0.10.1",
+ "sp-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8633,7 +8633,6 @@ dependencies = [
  "serde",
  "serde_arrays",
  "sha2 0.10.1",
- "sp-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,6 +5048,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]
@@ -5092,6 +5093,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "subspace-core-primitives",
+ "subspace-runtime-primitives",
  "subspace-solving",
 ]
 
@@ -5135,6 +5137,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]

--- a/crates/pallet-rewards/Cargo.toml
+++ b/crates/pallet-rewards/Cargo.toml
@@ -22,6 +22,7 @@ codec = { package = "parity-scale-codec", version = "2.3.0", default-features = 
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -21,9 +21,10 @@
 
 mod default_weights;
 
-use frame_support::traits::{Currency, FindAuthor, Get};
+use frame_support::traits::{Currency, Get};
 use frame_support::weights::Weight;
 pub use pallet::*;
+use subspace_runtime_primitives::FindBlockRewardsAddress;
 
 pub trait WeightInfo {
     fn on_initialize() -> Weight;
@@ -33,8 +34,9 @@ pub trait WeightInfo {
 mod pallet {
     use super::WeightInfo;
     use frame_support::pallet_prelude::*;
-    use frame_support::traits::{Currency, FindAuthor};
+    use frame_support::traits::Currency;
     use frame_system::pallet_prelude::*;
+    use subspace_runtime_primitives::FindBlockRewardsAddress;
 
     type BalanceOf<T> =
         <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -50,7 +52,7 @@ mod pallet {
         #[pallet::constant]
         type BlockReward: Get<BalanceOf<Self>>;
 
-        type FindAuthor: FindAuthor<Self::AccountId>;
+        type FindBlockRewardsAddress: FindBlockRewardsAddress<Self::AccountId>;
 
         type WeightInfo: WeightInfo;
     }
@@ -82,7 +84,7 @@ mod pallet {
 
 impl<T: Config> Pallet<T> {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindAuthor::find_author(
+        let block_author = T::FindBlockRewardsAddress::find_block_rewards_address(
             frame_system::Pallet::<T>::digest()
                 .logs
                 .iter()

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -24,7 +24,7 @@ mod default_weights;
 use frame_support::traits::{Currency, Get};
 use frame_support::weights::Weight;
 pub use pallet::*;
-use subspace_runtime_primitives::FindBlockRewardsAddress;
+use subspace_runtime_primitives::FindBlockRewardAddress;
 
 pub trait WeightInfo {
     fn on_initialize() -> Weight;
@@ -36,7 +36,7 @@ mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_support::traits::Currency;
     use frame_system::pallet_prelude::*;
-    use subspace_runtime_primitives::FindBlockRewardsAddress;
+    use subspace_runtime_primitives::FindBlockRewardAddress;
 
     type BalanceOf<T> =
         <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -52,7 +52,7 @@ mod pallet {
         #[pallet::constant]
         type BlockReward: Get<BalanceOf<Self>>;
 
-        type FindBlockRewardsAddress: FindBlockRewardsAddress<Self::AccountId>;
+        type FindBlockRewardAddress: FindBlockRewardAddress<Self::AccountId>;
 
         type WeightInfo: WeightInfo;
     }
@@ -84,7 +84,7 @@ mod pallet {
 
 impl<T: Config> Pallet<T> {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindBlockRewardsAddress::find_block_reward_address(
+        let block_author = T::FindBlockRewardAddress::find_block_reward_address(
             frame_system::Pallet::<T>::digest()
                 .logs
                 .iter()

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -84,7 +84,7 @@ mod pallet {
 
 impl<T: Config> Pallet<T> {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindBlockRewardsAddress::find_block_rewards_address(
+        let block_author = T::FindBlockRewardsAddress::find_block_reward_address(
             frame_system::Pallet::<T>::digest()
                 .logs
                 .iter()

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -26,6 +26,7 @@ sp-io = { version = "5.0.0", default-features = false, git = "https://github.com
 sp-runtime = { version = "5.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
+subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -848,7 +848,7 @@ impl<T: Config> frame_support::traits::FindAuthor<T::AccountId> for Pallet<T> {
 }
 
 impl<T: Config> subspace_runtime_primitives::FindBlockRewardsAddress<T::AccountId> for Pallet<T> {
-    fn find_block_rewards_address<'a, I>(digests: I) -> Option<T::AccountId>
+    fn find_block_reward_address<'a, I>(digests: I) -> Option<T::AccountId>
     where
         I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
     {

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -843,6 +843,18 @@ impl<T: Config> frame_support::traits::FindAuthor<T::AccountId> for Pallet<T> {
         digests
             .into_iter()
             .find_map(|(id, data)| DigestItemRef::PreRuntime(&id, data).as_subspace_pre_digest())
+            .map(|pre_digest| pre_digest.solution.public_key)
+    }
+}
+
+impl<T: Config> subspace_runtime_primitives::FindBlockRewardsAddress<T::AccountId> for Pallet<T> {
+    fn find_block_rewards_address<'a, I>(digests: I) -> Option<T::AccountId>
+    where
+        I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+    {
+        digests
+            .into_iter()
+            .find_map(|(id, data)| DigestItemRef::PreRuntime(&id, data).as_subspace_pre_digest())
             .map(|pre_digest| pre_digest.solution.reward_address)
     }
 }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -847,7 +847,7 @@ impl<T: Config> frame_support::traits::FindAuthor<T::AccountId> for Pallet<T> {
     }
 }
 
-impl<T: Config> subspace_runtime_primitives::FindBlockRewardsAddress<T::AccountId> for Pallet<T> {
+impl<T: Config> subspace_runtime_primitives::FindBlockRewardAddress<T::AccountId> for Pallet<T> {
     fn find_block_reward_address<'a, I>(digests: I) -> Option<T::AccountId>
     where
         I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -843,7 +843,7 @@ impl<T: Config> frame_support::traits::FindAuthor<T::AccountId> for Pallet<T> {
         digests
             .into_iter()
             .find_map(|(id, data)| DigestItemRef::PreRuntime(&id, data).as_subspace_pre_digest())
-            .map(|pre_digest| pre_digest.solution.public_key)
+            .map(|pre_digest| pre_digest.solution.reward_address)
     }
 }
 

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -194,6 +194,7 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
         slot.into(),
         Solution {
             public_key: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
+            reward_address: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             piece_index: 0,
             encoding,
             signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),
@@ -250,6 +251,7 @@ pub fn generate_equivocation_proof(
             slot,
             Solution {
                 public_key: public_key.clone(),
+                reward_address: public_key.clone(),
                 piece_index,
                 encoding,
                 signature: signature.into(),

--- a/crates/pallet-transaction-fees/Cargo.toml
+++ b/crates/pallet-transaction-fees/Cargo.toml
@@ -22,6 +22,7 @@ codec = { package = "parity-scale-codec", version = "2.3.0", default-features = 
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::traits::{Currency, Get};
 use frame_support::weights::Weight;
 pub use pallet::*;
 use scale_info::TypeInfo;
-use subspace_runtime_primitives::FindBlockRewardsAddress;
+use subspace_runtime_primitives::FindBlockRewardAddress;
 
 type BalanceOf<T> =
     <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -50,7 +50,7 @@ mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_support::traits::Currency;
     use frame_system::pallet_prelude::*;
-    use subspace_runtime_primitives::FindBlockRewardsAddress;
+    use subspace_runtime_primitives::FindBlockRewardAddress;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -87,7 +87,7 @@ mod pallet {
 
         type Currency: Currency<Self::AccountId>;
 
-        type FindBlockRewardsAddress: FindBlockRewardsAddress<Self::AccountId>;
+        type FindBlockRewardAddress: FindBlockRewardAddress<Self::AccountId>;
 
         type WeightInfo: WeightInfo;
     }
@@ -174,7 +174,7 @@ where
     BalanceOf<T>: From<u64>,
 {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindBlockRewardsAddress::find_block_reward_address(
+        let block_author = T::FindBlockRewardAddress::find_block_reward_address(
             frame_system::Pallet::<T>::digest()
                 .logs
                 .iter()

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -23,10 +23,11 @@ mod default_weights;
 
 use codec::{Codec, Decode, Encode};
 use frame_support::sp_runtime::traits::Zero;
-use frame_support::traits::{Currency, FindAuthor, Get};
+use frame_support::traits::{Currency, Get};
 use frame_support::weights::Weight;
 pub use pallet::*;
 use scale_info::TypeInfo;
+use subspace_runtime_primitives::FindBlockRewardsAddress;
 
 type BalanceOf<T> =
     <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -47,8 +48,9 @@ struct CollectedFees<Balance: Codec> {
 mod pallet {
     use super::{BalanceOf, CollectedFees, WeightInfo};
     use frame_support::pallet_prelude::*;
-    use frame_support::traits::{Currency, FindAuthor};
+    use frame_support::traits::Currency;
     use frame_system::pallet_prelude::*;
+    use subspace_runtime_primitives::FindBlockRewardsAddress;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -85,7 +87,7 @@ mod pallet {
 
         type Currency: Currency<Self::AccountId>;
 
-        type FindAuthor: FindAuthor<Self::AccountId>;
+        type FindBlockRewardsAddress: FindBlockRewardsAddress<Self::AccountId>;
 
         type WeightInfo: WeightInfo;
     }
@@ -172,7 +174,7 @@ where
     BalanceOf<T>: From<u64>,
 {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindAuthor::find_author(
+        let block_author = T::FindBlockRewardsAddress::find_block_rewards_address(
             frame_system::Pallet::<T>::digest()
                 .logs
                 .iter()

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -174,7 +174,7 @@ where
     BalanceOf<T>: From<u64>,
 {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindBlockRewardsAddress::find_block_rewards_address(
+        let block_author = T::FindBlockRewardsAddress::find_block_reward_address(
             frame_system::Pallet::<T>::digest()
                 .logs
                 .iter()

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -341,7 +341,7 @@ where
                                 let public_key =
                                     match FarmerPublicKey::from_slice(&solution.public_key) {
                                         Ok(public_key) => public_key,
-                                        Err(_) => {
+                                        Err(()) => {
                                             warn!(
                                                 "Failed to convert public key: {:?}",
                                                 solution.public_key
@@ -352,7 +352,7 @@ where
                                 let reward_address =
                                     match FarmerPublicKey::from_slice(&solution.reward_address) {
                                         Ok(public_key) => public_key,
-                                        Err(_) => {
+                                        Err(()) => {
                                             warn!(
                                                 "Failed to convert reward address: {:?}",
                                                 solution.reward_address,

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -349,8 +349,21 @@ where
                                             return;
                                         }
                                     };
+                                let reward_address =
+                                    match FarmerPublicKey::from_slice(&solution.reward_address) {
+                                        Ok(public_key) => public_key,
+                                        Err(_) => {
+                                            warn!(
+                                                "Failed to convert reward address: {:?}",
+                                                solution.reward_address,
+                                            );
+                                            return;
+                                        }
+                                    };
+
                                 let solution = Solution {
                                     public_key,
+                                    reward_address,
                                     piece_index: solution.piece_index,
                                     encoding: solution.encoding,
                                     signature: solution.signature,

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -560,6 +560,9 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
                     let _ = solution_sender
                         .send(Solution {
                             public_key: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
+                            reward_address: FarmerPublicKey::unchecked_from(
+                                keypair.public.to_bytes(),
+                            ),
                             piece_index,
                             encoding,
                             signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),
@@ -666,6 +669,7 @@ pub fn dummy_claim_slot(slot: Slot) -> Option<(PreDigest<FarmerPublicKey>, Farme
         PreDigest {
             solution: Solution {
                 public_key: FarmerPublicKey::unchecked_from([0u8; 32]),
+                reward_address: FarmerPublicKey::unchecked_from([0u8; 32]),
                 piece_index: 0,
                 encoding: Piece::default(),
                 signature: Signature::default(),
@@ -725,6 +729,7 @@ fn propose_and_import_block<Transaction: Send + 'static>(
                     slot,
                     solution: Solution {
                         public_key: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
+                        reward_address: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                         piece_index: 0,
                         encoding,
                         signature: signature.into(),

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,6 +17,7 @@ parity-scale-codec = { version = "2.3.0", default-features = false, features = [
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1", optional = true }
+sp-core = { version = "5.0.0", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,7 +17,6 @@ parity-scale-codec = { version = "2.3.0", default-features = false, features = [
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1", optional = true }
-sp-core = { version = "5.0.0", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -77,22 +77,6 @@ const PUBLIC_KEY_LENGTH: usize = 32;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct PublicKey([u8; PUBLIC_KEY_LENGTH]);
 
-// TODO: add std::error::Error implementation
-/// Unexpected length for public key
-#[derive(Debug, Clone, Copy)]
-pub struct UnexpectedLengthError;
-
-impl PublicKey {
-    /// Converts slice to public key
-    pub fn from_slice(bytes: &[u8]) -> Result<Self, UnexpectedLengthError> {
-        bytes
-            .to_vec()
-            .try_into()
-            .map(From::<[u8; PUBLIC_KEY_LENGTH]>::from)
-            .map_err(|_| UnexpectedLengthError)
-    }
-}
-
 impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
     fn from(bytes: [u8; PUBLIC_KEY_LENGTH]) -> Self {
         Self(bytes)

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -28,7 +28,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::convert::AsRef;
 use core::ops::{Deref, DerefMut};
-use core::str::FromStr;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
@@ -91,13 +90,6 @@ impl PublicKey {
             .try_into()
             .map(From::<[u8; PUBLIC_KEY_LENGTH]>::from)
             .map_err(|_| UnexpectedLengthError)
-    }
-}
-
-impl FromStr for PublicKey {
-    type Err = sp_core::crypto::PublicError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        sp_core::sr25519::Public::from_str(s).map(|key| Self(key.0))
     }
 }
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -63,7 +63,12 @@ pub(crate) async fn farm(
     let identity = Identity::open_or_create(&base_directory)?;
 
     let reward_address = reward_address.unwrap_or_else(|| {
-        PublicKey::from_slice(identity.public_key().as_ref())
+        identity
+            .public_key()
+            .as_ref()
+            .to_vec()
+            .try_into()
+            .map(From::<[u8; 32]>::from)
             .expect("Length of public key is always correct")
     });
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use subspace_core_primitives::PublicKey;
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{
     Commitments, Farming, Identity, ObjectMappings, Plot, Plotting, RpcClient, WsRpc,
@@ -23,6 +24,7 @@ pub(crate) async fn farm(
     listen_on: Vec<Multiaddr>,
     node_rpc_url: &str,
     ws_server_listen_addr: SocketAddr,
+    reward_address: Option<PublicKey>,
 ) -> Result<(), anyhow::Error> {
     // TODO: This doesn't account for the fact that node can
     // have a completely different history to what farmer expects
@@ -59,6 +61,11 @@ pub(crate) async fn farm(
         .map_err(|error| anyhow::Error::msg(error.to_string()))?;
 
     let identity = Identity::open_or_create(&base_directory)?;
+
+    let reward_address = reward_address.unwrap_or_else(|| {
+        PublicKey::from_slice(identity.public_key().as_ref())
+            .expect("Length of public key is always correct")
+    });
 
     let subspace_codec = SubspaceCodec::new(identity.public_key());
 
@@ -120,8 +127,13 @@ pub(crate) async fn farm(
     });
 
     // start the farming task
-    let farming_instance =
-        Farming::start(plot.clone(), commitments.clone(), client.clone(), identity);
+    let farming_instance = Farming::start(
+        plot.clone(),
+        commitments.clone(),
+        client.clone(),
+        identity,
+        reward_address,
+    );
 
     // start the background plotting
     let plotting_instance = Plotting::start(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -8,7 +8,6 @@ use log::info;
 use sp_core::crypto::PublicError;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::str::FromStr;
 use subspace_core_primitives::PublicKey;
 use subspace_networking::libp2p::Multiaddr;
 
@@ -82,7 +81,8 @@ enum Command {
 }
 
 fn parse_reward_address(s: &str) -> Result<PublicKey, PublicError> {
-    sp_core::sr25519::Public::from_str(s).map(|key| PublicKey::from(key.0))
+    s.parse::<sp_core::sr25519::Public>()
+        .map(|key| PublicKey::from(key.0))
 }
 
 #[tokio::main]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -5,8 +5,11 @@ use anyhow::Result;
 use clap::{Parser, ValueHint};
 use env_logger::Env;
 use log::info;
+use sp_core::crypto::PublicError;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::str::FromStr;
+use subspace_core_primitives::PublicKey;
 use subspace_networking::libp2p::Multiaddr;
 
 #[derive(Debug, Parser)]
@@ -73,9 +76,13 @@ enum Command {
         #[clap(long, short, default_value = "127.0.0.1:9955")]
         ws_server_listen_addr: SocketAddr,
         /// Address for farming rewards
-        #[clap(long)]
-        reward_address: Option<subspace_core_primitives::PublicKey>,
+        #[clap(long, parse(try_from_str = parse_reward_address))]
+        reward_address: Option<PublicKey>,
     },
+}
+
+fn parse_reward_address(s: &str) -> Result<PublicKey, PublicError> {
+    sp_core::sr25519::Public::from_str(s).map(|key| PublicKey::from(key.0))
 }
 
 #[tokio::main]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -72,13 +72,16 @@ enum Command {
         /// Host and port where built-in WebSocket RPC server should listen for incoming connections
         #[clap(long, short, default_value = "127.0.0.1:9955")]
         ws_server_listen_addr: SocketAddr,
+        /// Address for farming rewards
+        #[clap(long)]
+        reward_address: Option<subspace_core_primitives::PublicKey>,
     },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init_from_env(Env::new().default_filter_or("info"));
-    let command: Command = Command::parse();
+    let command = Command::parse();
     match command {
         Command::Identity(identity_command) => {
             commands::identity(identity_command)?;
@@ -99,6 +102,7 @@ async fn main() -> Result<()> {
             listen_on,
             node_rpc_url,
             ws_server_listen_addr,
+            reward_address,
         } => {
             let path = utils::get_path(custom_path);
             commands::farm(
@@ -107,6 +111,7 @@ async fn main() -> Result<()> {
                 listen_on,
                 &node_rpc_url,
                 ws_server_listen_addr,
+                reward_address,
             )
             .await?;
         }

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -6,7 +6,7 @@ use crate::plot::Plot;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Salt, Tag, TAG_SIZE};
+use subspace_core_primitives::{FlatPieces, PublicKey, Salt, Tag, TAG_SIZE};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
@@ -42,6 +42,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
         commitments.clone(),
         client.clone(),
         identity.clone(),
+        PublicKey::from_slice(identity.public_key().as_ref()).unwrap(),
     );
 
     let mut counter = 0;

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -6,7 +6,7 @@ use crate::plot::Plot;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, PublicKey, Salt, Tag, TAG_SIZE};
+use subspace_core_primitives::{FlatPieces, Salt, Tag, TAG_SIZE};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
@@ -36,13 +36,21 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
 
     let client = MockRpc::new();
 
+    let reward_address = identity
+        .public_key()
+        .as_ref()
+        .to_vec()
+        .try_into()
+        .map(From::<[u8; 32]>::from)
+        .unwrap();
+
     // start the farming task
     let farming_instance = Farming::start(
         plot.clone(),
         commitments.clone(),
         client.clone(),
         identity.clone(),
-        PublicKey::from_slice(identity.public_key().as_ref()).unwrap(),
+        reward_address,
     );
 
     let mut counter = 0;

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -151,7 +151,7 @@ pub mod opaque {
 /// A trait for finding the address for a block rewards based on the `PreRuntime` digests contained within it.
 pub trait FindBlockRewardsAddress<Address> {
     /// Find the address for a block rewards based on the pre-runtime digests.
-    fn find_block_rewards_address<'a, I>(digests: I) -> Option<Address>
+    fn find_block_reward_address<'a, I>(digests: I) -> Option<Address>
     where
         I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>;
 }

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -147,3 +147,11 @@ pub mod opaque {
     /// Opaque block identifier type.
     pub type BlockId = generic::BlockId<Block>;
 }
+
+/// A trait for finding the address for a block rewards based on the `PreRuntime` digests contained within it.
+pub trait FindBlockRewardsAddress<Address> {
+    /// Find the address for a block rewards based on the pre-runtime digests.
+    fn find_block_rewards_address<'a, I>(digests: I) -> Option<Address>
+    where
+        I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>;
+}

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -149,7 +149,7 @@ pub mod opaque {
 }
 
 /// A trait for finding the address for a block rewards based on the `PreRuntime` digests contained within it.
-pub trait FindBlockRewardsAddress<Address> {
+pub trait FindBlockRewardAddress<Address> {
     /// Find the address for a block rewards based on the pre-runtime digests.
     fn find_block_reward_address<'a, I>(digests: I) -> Option<Address>
     where

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -148,7 +148,7 @@ pub mod opaque {
     pub type BlockId = generic::BlockId<Block>;
 }
 
-/// A trait for finding the address for a block rewards based on the `PreRuntime` digests contained within it.
+/// A trait for finding the address for a block reward based on the `PreRuntime` digests contained within it.
 pub trait FindBlockRewardAddress<Address> {
     /// Find the address for a block rewards based on the pre-runtime digests.
     fn find_block_reward_address<'a, I>(digests: I) -> Option<Address>

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -318,7 +318,7 @@ impl pallet_transaction_fees::Config for Runtime {
     type TotalSpacePledged = TotalSpacePledged;
     type BlockchainHistorySize = BlockchainHistorySize;
     type Currency = Balances;
-    type FindBlockRewardsAddress = Subspace;
+    type FindBlockRewardAddress = Subspace;
     type WeightInfo = ();
 }
 
@@ -468,7 +468,7 @@ impl pallet_rewards::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type BlockReward = BlockReward;
-    type FindBlockRewardsAddress = Subspace;
+    type FindBlockRewardAddress = Subspace;
     type WeightInfo = ();
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -318,7 +318,7 @@ impl pallet_transaction_fees::Config for Runtime {
     type TotalSpacePledged = TotalSpacePledged;
     type BlockchainHistorySize = BlockchainHistorySize;
     type Currency = Balances;
-    type FindAuthor = Subspace;
+    type FindBlockRewardsAddress = Subspace;
     type WeightInfo = ();
 }
 
@@ -468,7 +468,7 @@ impl pallet_rewards::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type BlockReward = BlockReward;
-    type FindAuthor = Subspace;
+    type FindBlockRewardsAddress = Subspace;
     type WeightInfo = ();
 }
 

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -146,6 +146,7 @@ async fn start_farming<Client>(
             let _ = solution_sender
                 .send(Solution {
                     public_key: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
+                    reward_address: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     piece_index,
                     encoding,
                     signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -315,7 +315,7 @@ impl pallet_transaction_fees::Config for Runtime {
     type TotalSpacePledged = TotalSpacePledged;
     type BlockchainHistorySize = BlockchainHistorySize;
     type Currency = Balances;
-    type FindBlockRewardsAddress = Subspace;
+    type FindBlockRewardAddress = Subspace;
     type WeightInfo = ();
 }
 
@@ -465,7 +465,7 @@ impl pallet_rewards::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type BlockReward = BlockReward;
-    type FindBlockRewardsAddress = Subspace;
+    type FindBlockRewardAddress = Subspace;
     type WeightInfo = ();
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -315,7 +315,7 @@ impl pallet_transaction_fees::Config for Runtime {
     type TotalSpacePledged = TotalSpacePledged;
     type BlockchainHistorySize = BlockchainHistorySize;
     type Currency = Balances;
-    type FindAuthor = Subspace;
+    type FindBlockRewardsAddress = Subspace;
     type WeightInfo = ();
 }
 
@@ -465,7 +465,7 @@ impl pallet_rewards::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type BlockReward = BlockReward;
-    type FindAuthor = Subspace;
+    type FindBlockRewardsAddress = Subspace;
     type WeightInfo = ();
 }
 


### PR DESCRIPTION
This PR decouples farmer identity and block reward address by adding an argument to the CLI and to a farmer solution structure.