### PR TITLE
byte support for loading chain-spec

### DIFF
--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -46,3 +46,4 @@ runtime-benchmarks = [
 	"subspace-runtime/runtime-benchmarks",
 ]
 json-chain-spec = ["subspace-service/json-chain-spec"]
+byte-chain-spec = []

--- a/crates/subspace-node/src/command.rs
+++ b/crates/subspace-node/src/command.rs
@@ -92,6 +92,7 @@ impl SubstrateCli for Cli {
         2021
     }
 
+    #[cfg(not(feature = "byte-chain-spec"))]
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
             "testnet" => Box::new(chain_spec::subspace_testnet_config()?),
@@ -99,6 +100,18 @@ impl SubstrateCli for Cli {
             "" | "local" => Box::new(chain_spec::subspace_local_testnet_config()?),
             path => Box::new(chain_spec::SubspaceChainSpec::from_json_file(
                 std::path::PathBuf::from(path),
+            )?),
+        })
+    }
+
+    #[cfg(feature = "byte-chain-spec")]
+    fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
+        Ok(match id {
+            "testnet" => Box::new(chain_spec::subspace_testnet_config()?),
+            "dev" => Box::new(chain_spec::subspace_development_config()?),
+            "" | "local" => Box::new(chain_spec::subspace_local_testnet_config()?),
+            file => Box::new(chain_spec::SubspaceChainSpec::from_json_bytes(
+                &include_bytes!(file)[..],
             )?),
         })
     }


### PR DESCRIPTION
Let me first explain the reason for this PR:

In the **Desktop App**, we are currently loading the `chain-spec` from a path as a file. And if we build an executable, the `chain-spec` json file should be located in the same folder as an executable. So, basically, the executable looks for an external `chain-spec` file. 
This is not good, since the users will have to download a `chain-spec` file and put it in the respective folder.

We have to somehow embed the contents of the `chain-spec` file into the executable itself. After some research, I found out that Substrate supports loading the `chain-spec` content as bytes. Namely: `from_json_bytes()`.

But in order to access that, we have to utilize `load_spec()` method implementation (AFAIK). 
To override `load_spec()` method for `subspace::cli`, I had to reimplement (or redundant copy-paste) most of the things from **subspace/node** into the **Desktop App**, which is I believe not a good way to solve this problem. So I reverted those changes before committing any of them.

However, a very small change to NODE implementation would fix the main problem (loading the `chain-spec` file as bytes instead of a file, so that the content of the `chain-spec` file could be embeded into the executable itself).

This PR adds the functionality of loading the `chain-spec` file as bytes to the node, so that external crates can utilize it.


P.S.
if you have a better suggestion, I'm all ears. This solution was the easiest and the most convenient one that I could find.