### PR TITLE
Fix plot::read_write test

### DIFF
--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -15,15 +15,6 @@ fn generate_random_piece() -> Piece {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = r#"
-    TODO: Fix test
-
-    Plot for now has a background worker which has rocksdb in it. We need to synchronize
-    dropping plot and its background worker for the following reason:
-
-    If we open the same plot while background worker of dropped plot is still alive and
-    tries to close everything, we will have a rocksdb error (trying to acquire the taken file lock).
-"#]
 async fn read_write() {
     init();
     let base_directory = TempDir::new().unwrap();


### PR DESCRIPTION
This pr fixes plot test by synchronizing drop of the last plot copy and its plot worker. It needs to be done because otherwise:
- plot data and databases won't be synced after plot drop
- Rockdb lock might be still taken by the plot worker