### PR TITLE
Implement the creation of FraudProof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ version = "0.1.0"
 dependencies = [
  "cirrus-block-builder",
  "cirrus-client-executor-gossip",
+ "cirrus-fraud-proof",
  "cirrus-node-primitives",
  "cirrus-primitives",
  "cirrus-test-service",
@@ -924,6 +925,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
+ "sp-trie",
  "subspace-service",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cirrus-fraud-proof"
+version = "0.1.0"
+dependencies = [
+ "hash-db",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+]
+
+[[package]]
 name = "cirrus-node-primitives"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
  "futures 0.3.21",
  "futures-timer",
  "merkletree",
+ "pallet-balances",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "polkadot-node-subsystem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "cumulus/client/consensus/common",
     "cumulus/client/consensus/relay-chain",
     "cumulus/client/executor-gossip",
+    "cumulus/client/fraud-proof",
     "cumulus/pallets/executive",
     "cumulus/parachain-template/node",
     "cumulus/parachain-template/runtime",

--- a/cumulus/client/block-builder/src/lib.rs
+++ b/cumulus/client/block-builder/src/lib.rs
@@ -283,6 +283,14 @@ where
 		))))
 	}
 
+	/// Returns the state before finalizing the block.
+	pub fn prepare_storage_changes_before_finalize_block(
+		&self,
+	) -> Result<sp_api::StorageChanges<backend::StateBackendFor<B, Block>, Block>, Error> {
+		self.execute_extrinsics()?;
+		self.collect_storage_changes()
+	}
+
 	/// Consume the builder to build a valid `Block` containing all pushed extrinsics.
 	///
 	/// Returns the build `Block`, the changes to the storage and an optional `StorageProof`

--- a/cumulus/client/block-builder/src/lib.rs
+++ b/cumulus/client/block-builder/src/lib.rs
@@ -194,6 +194,22 @@ where
 		})
 	}
 
+	/// Create a new instance of builder with given extrinsics.
+	pub fn with_extrinsics(
+		api: &'a A,
+		parent_hash: Block::Hash,
+		parent_number: NumberFor<Block>,
+		record_proof: RecordProof,
+		inherent_digests: Digest,
+		backend: &'a B,
+		extrinsics: Vec<Block::Extrinsic>,
+	) -> Result<Self, Error> {
+		let mut block_builder =
+			Self::new(api, parent_hash, parent_number, record_proof, inherent_digests, backend)?;
+		block_builder.extrinsics = extrinsics;
+		Ok(block_builder)
+	}
+
 	/// Sets the extrinsics.
 	pub fn set_extrinsics(&mut self, extrinsics: Vec<Block::Extrinsic>) {
 		self.extrinsics = extrinsics;
@@ -231,6 +247,40 @@ where
 		self.api
 			.into_storage_changes(&state, parent_hash)
 			.map_err(sp_blockchain::Error::StorageChanges)
+	}
+
+	/// Returns the state before executing the extrinsic at given extrinsic index.
+	pub fn prepare_storage_changes_before(
+		&self,
+		extrinsic_index: usize,
+	) -> Result<sp_api::StorageChanges<backend::StateBackendFor<B, Block>, Block>, Error> {
+		for (index, xt) in self.extrinsics.iter().enumerate() {
+			if index == extrinsic_index {
+				return Ok(self.collect_storage_changes()?)
+			}
+
+			// TODO: rethink what to do if an error occurs when executing the transaction.
+			self.api.execute_in_transaction(|api| {
+				let res = api.apply_extrinsic_with_context(
+					&self.block_id,
+					ExecutionContext::BlockConstruction,
+					xt.clone(),
+				);
+				match res {
+					Ok(Ok(_)) => TransactionOutcome::Commit(Ok(())),
+					Ok(Err(tx_validity)) => TransactionOutcome::Rollback(Err(
+						ApplyExtrinsicFailed::Validity(tx_validity).into(),
+					)),
+					Err(e) => TransactionOutcome::Rollback(Err(Error::from(e))),
+				}
+			})?;
+		}
+
+		Err(Error::Execution(Box::new(format!(
+			"Invalid extrinsic index, got: {}, max: {}",
+			extrinsic_index,
+			self.extrinsics.len()
+		))))
 	}
 
 	/// Consume the builder to build a valid `Block` containing all pushed extrinsics.

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -42,6 +42,7 @@ polkadot-node-subsystem = { path = "../../../polkadot/node/subsystem" }
 cirrus-block-builder = { path = "../block-builder" }
 cirrus-client-executor-gossip = { path = "../executor-gossip" }
 cirrus-node-primitives = { path = "../../../crates/cirrus-node-primitives" }
+cirrus-fraud-proof = { path = "../fraud-proof" }
 cirrus-primitives = { path = "../../primitives" }
 sp-executor = { path = "../../../crates/sp-executor" }
 subspace-core-primitives = { path = "../../../crates/subspace-core-primitives" }

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -60,6 +60,7 @@ version = "0.10.0"
 
 [dev-dependencies]
 cirrus-test-service = { path = "../../test/service" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sc-cli = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 substrate-test-runtime = { path = "../../../substrate/substrate-test-runtime" }

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -1,9 +1,13 @@
+use cirrus_block_builder::{BlockBuilder, RecordProof};
+use cirrus_primitives::{Hash, SecondaryApi};
 use cirrus_test_service::{
 	run_primary_chain_validator_node,
 	Keyring::{Alice, Charlie, Dave},
 };
+use codec::{Decode, Encode};
 use sc_client_api::HeaderBackend;
-use sp_runtime::generic::BlockId;
+use sp_api::ProvideRuntimeApi;
+use sp_runtime::{generic::BlockId, traits::Header as HeaderT};
 
 #[substrate_test_utils::test]
 async fn test_executor_full_node_catching_up() {
@@ -40,4 +44,146 @@ async fn test_executor_full_node_catching_up() {
 		charlie_block_hash, dave_block_hash,
 		"Executor authority node and full node must have the same state"
 	);
+}
+
+#[substrate_test_utils::test]
+async fn execution_proof_creation_and_verification_should_work() {
+	let mut builder = sc_cli::LoggerBuilder::new("");
+	builder.with_colors(false);
+	let _ = builder.init();
+
+	let tokio_handle = tokio::runtime::Handle::current();
+
+	// start alice
+	let alice = run_primary_chain_validator_node(tokio_handle.clone(), Alice, vec![], true);
+
+	// run cirrus charlie (a secondary chain authority node)
+	let charlie = cirrus_test_service::TestNodeBuilder::new(tokio_handle.clone(), Charlie)
+		.connect_to_relay_chain_node(&alice)
+		.build()
+		.await;
+
+	// run cirrus dave (a secondary chain full node)
+	let dave = cirrus_test_service::TestNodeBuilder::new(tokio_handle, Dave)
+		.connect_to_parachain_node(&charlie)
+		.connect_to_relay_chain_node(&alice)
+		.build()
+		.await;
+
+	// dave is able to sync blocks.
+	futures::future::join(charlie.wait_for_blocks(3), dave.wait_for_blocks(3)).await;
+
+	let transfer_to_charlie = cirrus_test_service::construct_extrinsic(
+		&charlie.client,
+		pallet_balances::Call::transfer {
+			dest: cirrus_test_service::runtime::Address::Id(Charlie.public().into()),
+			value: 8,
+		},
+		Alice.into(),
+		false,
+		0,
+	);
+	let transfer_to_dave = cirrus_test_service::construct_extrinsic(
+		&charlie.client,
+		pallet_balances::Call::transfer {
+			dest: cirrus_test_service::runtime::Address::Id(Dave.public().into()),
+			value: 8,
+		},
+		Alice.into(),
+		false,
+		1,
+	);
+	let transfer_to_charlie_again = cirrus_test_service::construct_extrinsic(
+		&charlie.client,
+		pallet_balances::Call::transfer {
+			dest: cirrus_test_service::runtime::Address::Id(Charlie.public().into()),
+			value: 88,
+		},
+		Alice.into(),
+		false,
+		2,
+	);
+
+	let test_txs = vec![
+		transfer_to_charlie.clone(),
+		transfer_to_dave.clone(),
+		transfer_to_charlie_again.clone(),
+	];
+
+	for tx in test_txs.iter() {
+		charlie.send_extrinsic(tx.clone()).await.expect("Failed to send extrinsic");
+	}
+
+	// Wait until the test txs are included in the next block.
+	charlie.wait_for_blocks(1).await;
+
+	let best_hash = charlie.client.info().best_hash;
+	let header = charlie.client.header(&BlockId::Hash(best_hash)).unwrap().unwrap();
+	let parent_header =
+		charlie.client.header(&BlockId::Hash(*header.parent_hash())).unwrap().unwrap();
+
+	let create_block_builder = || {
+		BlockBuilder::with_extrinsics(
+			&*charlie.client,
+			parent_header.hash(),
+			*parent_header.number(),
+			RecordProof::No,
+			Default::default(),
+			&*charlie.backend,
+			test_txs.clone().into_iter().map(Into::into).collect(),
+		)
+		.unwrap()
+	};
+
+	let intermediate_roots = charlie
+		.client
+		.runtime_api()
+		.intermediate_roots(&BlockId::Hash(best_hash))
+		.expect("Get intermediate roots");
+	println!(
+		"intermediate_roots: {:?}",
+		intermediate_roots.clone().into_iter().map(Hash::from).collect::<Vec<_>>()
+	);
+
+	// Test extrinsic execution.
+	for (target_extrinsic_index, xt) in test_txs.clone().into_iter().enumerate() {
+		let storage_changes = create_block_builder()
+			.prepare_storage_changes_before(target_extrinsic_index)
+			.unwrap_or_else(|_| {
+				panic!("Get StorageChanges before extrinsic #{}", target_extrinsic_index)
+			});
+
+		let delta = storage_changes.transaction;
+		let post_delta_root = storage_changes.transaction_storage_root;
+
+		let storage_proof = cirrus_fraud_proof::prove_execution(
+			&charlie.backend,
+			&*charlie.code_executor,
+			charlie.task_manager.spawn_handle(),
+			&BlockId::Hash(parent_header.hash()),
+			"BlockBuilder_apply_extrinsic",
+			&xt.encode(),
+			Some((delta, post_delta_root)),
+		)
+		.expect("Create extrinsic execution proof");
+
+		let target_trace_root: Hash = intermediate_roots[target_extrinsic_index].into();
+		assert_eq!(target_trace_root, post_delta_root);
+
+		let execution_result = cirrus_fraud_proof::check_execution_proof(
+			&charlie.backend,
+			&*charlie.code_executor,
+			charlie.task_manager.spawn_handle(),
+			&BlockId::Hash(parent_header.hash()),
+			"SecondaryApi_apply_extrinsic_with_post_state_root",
+			&xt.encode(),
+			post_delta_root,
+			storage_proof,
+		)
+		.expect("Check extrinsic execution proof");
+
+		let res = Vec::<u8>::decode(&mut execution_result.as_slice()).unwrap();
+		let post_execution_root = Hash::decode(&mut res.as_slice()).unwrap();
+		assert_eq!(post_execution_root, intermediate_roots[target_extrinsic_index + 1].into());
+	}
 }

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -6,7 +6,7 @@ use cirrus_test_service::{
 	Keyring::{Alice, Charlie, Dave},
 };
 use codec::{Decode, Encode};
-use sc_client_api::HeaderBackend;
+use sc_client_api::{HeaderBackend, StorageProof};
 use sp_api::ProvideRuntimeApi;
 use sp_runtime::{
 	generic::BlockId,
@@ -265,4 +265,124 @@ async fn execution_proof_creation_and_verification_should_work() {
 	let new_header = Header::decode(&mut execution_result.as_slice()).unwrap();
 	let post_execution_root = *new_header.state_root();
 	assert_eq!(post_execution_root, *header.state_root());
+}
+
+#[substrate_test_utils::test]
+async fn invalid_execution_proof_should_not_work() {
+	let mut builder = sc_cli::LoggerBuilder::new("");
+	builder.with_colors(false);
+	let _ = builder.init();
+
+	let tokio_handle = tokio::runtime::Handle::current();
+
+	// start alice
+	let alice = run_primary_chain_validator_node(tokio_handle.clone(), Alice, vec![], true);
+
+	// run cirrus charlie (a secondary chain authority node)
+	let charlie = cirrus_test_service::TestNodeBuilder::new(tokio_handle.clone(), Charlie)
+		.connect_to_relay_chain_node(&alice)
+		.build()
+		.await;
+
+	// run cirrus dave (a secondary chain full node)
+	let dave = cirrus_test_service::TestNodeBuilder::new(tokio_handle, Dave)
+		.connect_to_parachain_node(&charlie)
+		.connect_to_relay_chain_node(&alice)
+		.build()
+		.await;
+
+	// dave is able to sync blocks.
+	futures::future::join(charlie.wait_for_blocks(3), dave.wait_for_blocks(3)).await;
+
+	let transfer_to_charlie = cirrus_test_service::construct_extrinsic(
+		&charlie.client,
+		pallet_balances::Call::transfer {
+			dest: cirrus_test_service::runtime::Address::Id(Charlie.public().into()),
+			value: 8,
+		},
+		Alice.into(),
+		false,
+		0,
+	);
+
+	let transfer_to_charlie_again = cirrus_test_service::construct_extrinsic(
+		&charlie.client,
+		pallet_balances::Call::transfer {
+			dest: cirrus_test_service::runtime::Address::Id(Charlie.public().into()),
+			value: 8,
+		},
+		Alice.into(),
+		false,
+		1,
+	);
+
+	let test_txs = vec![transfer_to_charlie.clone(), transfer_to_charlie_again.clone()];
+
+	for tx in test_txs.iter() {
+		charlie.send_extrinsic(tx.clone()).await.expect("Failed to send extrinsic");
+	}
+
+	// Wait until the test txs are included in the next block.
+	charlie.wait_for_blocks(1).await;
+
+	let best_hash = charlie.client.info().best_hash;
+	let header = charlie.client.header(&BlockId::Hash(best_hash)).unwrap().unwrap();
+	let parent_header =
+		charlie.client.header(&BlockId::Hash(*header.parent_hash())).unwrap().unwrap();
+
+	let create_block_builder = || {
+		BlockBuilder::with_extrinsics(
+			&*charlie.client,
+			parent_header.hash(),
+			*parent_header.number(),
+			RecordProof::No,
+			Default::default(),
+			&*charlie.backend,
+			test_txs.clone().into_iter().map(Into::into).collect(),
+		)
+		.unwrap()
+	};
+
+	let create_extrinsic_proof = |extrinsic_index: usize| {
+		let storage_changes = create_block_builder()
+			.prepare_storage_changes_before(extrinsic_index)
+			.unwrap_or_else(|_| panic!("Get StorageChanges before extrinsic #{}", extrinsic_index));
+
+		let delta = storage_changes.transaction;
+		let post_delta_root = storage_changes.transaction_storage_root;
+
+		let proof = cirrus_fraud_proof::prove_execution(
+			&charlie.backend,
+			&*charlie.code_executor,
+			charlie.task_manager.spawn_handle(),
+			&BlockId::Hash(parent_header.hash()),
+			"BlockBuilder_apply_extrinsic",
+			&test_txs[extrinsic_index].encode(),
+			Some((delta.clone(), post_delta_root.clone())),
+		)
+		.expect("Create extrinsic execution proof");
+
+		(proof, delta, post_delta_root)
+	};
+
+	let (proof0, _delta0, post_delta_root0) = create_extrinsic_proof(0);
+	let (proof1, _delta1, post_delta_root1) = create_extrinsic_proof(1);
+
+	let check_proof = |post_delta_root: Hash, proof: StorageProof| {
+		cirrus_fraud_proof::check_execution_proof(
+			&charlie.backend,
+			&*charlie.code_executor,
+			charlie.task_manager.spawn_handle(),
+			&BlockId::Hash(parent_header.hash()),
+			"SecondaryApi_apply_extrinsic_with_post_state_root",
+			&transfer_to_charlie_again.encode(),
+			post_delta_root,
+			proof,
+		)
+	};
+
+	assert!(check_proof(post_delta_root1, proof0.clone()).is_err());
+	assert!(check_proof(post_delta_root0, proof1.clone()).is_err());
+	assert!(check_proof(post_delta_root0, proof0).is_ok());
+	assert!(check_proof(post_delta_root1, proof1).is_ok());
 }

--- a/cumulus/client/cirrus-service/Cargo.toml
+++ b/cumulus/client/cirrus-service/Cargo.toml
@@ -25,6 +25,7 @@ sp-consensus = { git = "https://github.com/paritytech/substrate", rev = "c364008
 sp-core = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-trie = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 
 # Other deps
 codec = { package = "parity-scale-codec", version = "3.1.2" }

--- a/cumulus/client/cirrus-service/src/lib.rs
+++ b/cumulus/client/cirrus-service/src/lib.rs
@@ -120,6 +120,9 @@ where
 	>,
 	Spawner: SpawnNamed + Clone + Send + Sync + 'static,
 	Backend: BackendT<Block> + 'static,
+	<<Backend as sc_client_api::Backend<Block>>::State as sc_client_api::backend::StateBackend<
+		sp_api::HashFor<Block>,
+	>>::Transaction: sp_trie::HashDBT<sp_api::HashFor<Block>, sp_trie::DBValue>,
 	IQ: ImportQueue<Block> + 'static,
 	TP: TransactionPool<Block = Block> + 'static,
 	CIDP: CreateInherentDataProviders<Block, cirrus_primitives::Hash> + 'static,

--- a/cumulus/client/fraud-proof/Cargo.toml
+++ b/cumulus/client/fraud-proof/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cirrus-fraud-proof"
+version = "0.1.0"
+authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
+edition = "2021"
+license = "GPL-3.0-or-later"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace/"
+description = "Subspace fraud proof utilities"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive"] }
+hash-db = "0.15.2"
+sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-api = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-core = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-trie = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }

--- a/cumulus/client/fraud-proof/src/lib.rs
+++ b/cumulus/client/fraud-proof/src/lib.rs
@@ -1,0 +1,170 @@
+//! Subspace fraud proof
+//!
+//! This crates provides the feature of generating and verifying the execution proof used in
+//! the Subspace fraud proof mechanism. The execution is more fine-grained than the entire
+//! block execution, block execution hooks (`initialize_block` and `finalize_block`) and any
+//! specific extrinsic execution are supported.
+
+#![warn(missing_docs)]
+
+use codec::Codec;
+use hash_db::{HashDB, Hasher, Prefix};
+use sc_client_api::backend;
+use sp_api::{StateBackend, StorageProof};
+use sp_core::{
+	traits::{CodeExecutor, SpawnNamed},
+	H256,
+};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{BlakeTwo256, Block as BlockT, HashFor},
+};
+use sp_state_machine::{TrieBackend, TrieBackendStorage};
+use sp_trie::DBValue;
+use std::sync::Arc;
+
+/// Returns a storage proof which can be used to reconstruct a partial state trie to re-run
+/// the execution by someone who does not own the whole state.
+// TODO: too many arguments, but no need to refactor it right now as the API of execution proof
+// on the primary node might have some other considerations, e.g., RuntimeCode will be fetched
+// another way.
+#[allow(clippy::too_many_arguments)]
+pub fn prove_execution<
+	Block: BlockT,
+	B: backend::Backend<Block>,
+	Exec: CodeExecutor + 'static,
+	Spawn: SpawnNamed + Send + 'static,
+	DB: HashDB<HashFor<Block>, DBValue>,
+>(
+	backend: &Arc<B>,
+	executor: &Exec,
+	spawn_handle: Spawn,
+	at: &BlockId<Block>,
+	method: &str,
+	call_data: &[u8],
+	delta_changes: Option<(DB, Block::Hash)>,
+) -> sp_blockchain::Result<StorageProof> {
+	let state = backend.state_at(*at)?;
+
+	let trie_backend = state.as_trie_backend().ok_or_else(|| {
+		Box::new(sp_state_machine::ExecutionError::UnableToGenerateProof)
+			as Box<dyn sp_state_machine::Error>
+	})?;
+
+	let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(trie_backend);
+	let runtime_code =
+		state_runtime_code.runtime_code().map_err(sp_blockchain::Error::RuntimeCode)?;
+
+	if let Some((delta, post_delta_root)) = delta_changes {
+		let delta_backend = create_delta_backend(trie_backend, delta, post_delta_root);
+		sp_state_machine::prove_execution_on_trie_backend(
+			&delta_backend,
+			&mut Default::default(),
+			executor,
+			spawn_handle,
+			method,
+			call_data,
+			&runtime_code,
+		)
+		.map(|(_ret, proof)| proof)
+		.map_err(Into::into)
+	} else {
+		sp_state_machine::prove_execution_on_trie_backend(
+			trie_backend,
+			&mut Default::default(),
+			executor,
+			spawn_handle,
+			method,
+			call_data,
+			&runtime_code,
+		)
+		.map(|(_ret, proof)| proof)
+		.map_err(Into::into)
+	}
+}
+
+/// Runs the execution using the partial state constructed from the given storage proof and
+/// returns the execution result.
+///
+/// The execution result contains the information of state root after applying the execution
+/// so that it can be used to compare with the one specified in the fraud proof.
+// TODO: too many arguments.
+#[allow(clippy::too_many_arguments)]
+pub fn check_execution_proof<
+	Block: BlockT,
+	B: backend::Backend<Block>,
+	Exec: CodeExecutor + 'static,
+	Spawn: SpawnNamed + Send + 'static,
+>(
+	backend: &Arc<B>,
+	executor: &Exec,
+	spawn_handle: Spawn,
+	at: &BlockId<Block>,
+	method: &str,
+	call_data: &[u8],
+	pre_execution_root: H256,
+	proof: StorageProof,
+) -> sp_blockchain::Result<Vec<u8>> {
+	let state = backend.state_at(*at)?;
+
+	let trie_backend = state.as_trie_backend().ok_or_else(|| {
+		Box::new(sp_state_machine::ExecutionError::UnableToGenerateProof)
+			as Box<dyn sp_state_machine::Error>
+	})?;
+
+	let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(trie_backend);
+	let runtime_code =
+		state_runtime_code.runtime_code().map_err(sp_blockchain::Error::RuntimeCode)?;
+
+	sp_state_machine::execution_proof_check::<BlakeTwo256, _, _>(
+		pre_execution_root,
+		proof,
+		&mut Default::default(),
+		executor,
+		spawn_handle,
+		method,
+		call_data,
+		&runtime_code,
+	)
+	.map_err(Into::into)
+}
+
+/// Create a new trie backend with memory DB delta changes.
+///
+/// This can be used to verify any extrinsic-specific execution on the combined state of `backend`
+/// and `delta`.
+fn create_delta_backend<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher, DB: HashDB<H, DBValue>>(
+	backend: &'a TrieBackend<S, H>,
+	delta: DB,
+	post_delta_root: H::Out,
+) -> TrieBackend<DeltaBackend<'a, S, H, DB>, H>
+where
+	H::Out: Codec,
+{
+	let essence = backend.essence();
+	let delta_backend = DeltaBackend {
+		backend: essence.backend_storage(),
+		delta,
+		_phantom: std::marker::PhantomData::<H>,
+	};
+	TrieBackend::new(delta_backend, post_delta_root)
+}
+
+struct DeltaBackend<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher, DB: HashDB<H, DBValue>> {
+	backend: &'a S,
+	delta: DB,
+	_phantom: std::marker::PhantomData<H>,
+}
+
+impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher, DB: HashDB<H, DBValue>>
+	TrieBackendStorage<H> for DeltaBackend<'a, S, H, DB>
+{
+	type Overlay = S::Overlay;
+
+	fn get(&self, key: &H::Out, prefix: Prefix) -> Result<Option<DBValue>, String> {
+		match HashDB::get(&self.delta, key, prefix) {
+			Some(v) => Ok(Some(v)),
+			None => Ok(self.backend.get(key, prefix)?),
+		}
+	}
+}

--- a/cumulus/pallets/executive/src/lib.rs
+++ b/cumulus/pallets/executive/src/lib.rs
@@ -315,12 +315,6 @@ impl<
 			AllPalletsWithSystem,
 			COnRuntimeUpgrade,
 		>::finalize_block()
-		// NOTE: Somehow the executor will run into an error `state already discarded for ...`
-		// if we note the storage root after the origin `finalize_block`(This error might relate to
-		// the `execute_block`, but not for sure). Since we calculate the final state root anyway,
-		// this step can just be skipped.
-		//
-		// Pallet::<ExecutiveConfig>::push_root(Self::storage_root());
 	}
 
 	// TODO: https://github.com/paritytech/substrate/issues/10711

--- a/cumulus/parachain-template/runtime/src/lib.rs
+++ b/cumulus/parachain-template/runtime/src/lib.rs
@@ -433,6 +433,11 @@ impl_runtime_apis! {
 			ExecutivePallet::intermediate_roots()
 		}
 
+		fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+			Executive::initialize_block(header);
+			Executive::storage_root()
+		}
+
 		fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
 			let _ = Executive::apply_extrinsic(extrinsic);
 			Executive::storage_root()

--- a/cumulus/primitives/src/lib.rs
+++ b/cumulus/primitives/src/lib.rs
@@ -80,6 +80,9 @@ sp_api::decl_runtime_apis! {
 		/// Returns the intermediate storage roots in an encoded form.
 		fn intermediate_roots() -> Vec<[u8; 32]>;
 
+		/// Returns the storage root after initializing the block.
+		fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8>;
+
 		/// Returns the storage root after applying the extrinsic.
 		fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8>;
 	}

--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -434,6 +434,11 @@ impl_runtime_apis! {
 			ExecutivePallet::intermediate_roots()
 		}
 
+		fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+			Executive::initialize_block(header);
+			Executive::storage_root()
+		}
+
 		fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
 			let _ = Executive::apply_extrinsic(extrinsic);
 			Executive::storage_root()

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -555,7 +555,7 @@ impl TestNode {
 		self.client.wait_for_blocks(count)
 	}
 
-	/// Construct and sned an extrinsic to this node.
+	/// Construct and send an extrinsic to this node.
 	pub async fn construct_and_send_extrinsic(
 		&self,
 		function: impl Into<runtime::Call>,


### PR DESCRIPTION
This PR implements the feature of creating a fraud proof by an executor node when an invalid state transition is detected in the received receipt, there are still a few TODOs though. The generated proofs are verified on the secondary node for now, aside from the TODOs, especially [this one](https://github.com/subspace/subspace/blob/9485bf440e/cumulus/pallets/executive/src/lib.rs#L359), the next step will be implementing the proof verification on the primary node. Make sense to review per commit, have a look at the history of https://github.com/paritytech/substrate/pull/10922 if you'd like to know some background and lessons learned behind this PR.
