### PR TITLE
Fix Rust nightly version to un-break CI, 

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-02-15
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy
@@ -73,7 +73,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-02-15
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy
@@ -134,7 +134,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-02-15
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2022-02-15
         target: wasm32-unknown-unknown
         profile: minimal
         override: true

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-02-15
           target: wasm32-unknown-unknown
           override: true
 

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly
+ARG RUSTC_VERSION=nightly-2022-02-15
 
 WORKDIR /code
 

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly
+ARG RUSTC_VERSION=nightly-2022-02-15
 
 WORKDIR /code
 

--- a/crates/subspace-farmer/README.md
+++ b/crates/subspace-farmer/README.md
@@ -39,12 +39,7 @@ sudo apt-get install llvm clang
 
 Then install the framer using Cargo:
 ```
-cargo +nightly install subspace-farmer
-```
-
-NOTE: Above command requires nightly compiler for now, make sure to install it if you don't have one yet:
-```
-rustup toolchain install nightly
+cargo install subspace-farmer
 ```
 
 ## Usage

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-02-15"
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
Also minor docs tweaks (no need to install compiler manually, we have toolchain file for that).

I had this in https://github.com/subspace/subspace/pull/291, but I think makes sense to merge already.