### PR TITLE
Reset secondary runtime version

### DIFF
--- a/crates/subspace-consensus-runtime/src/lib.rs
+++ b/crates/subspace-consensus-runtime/src/lib.rs
@@ -71,12 +71,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 1,
-    // The version of the runtime specification. A full node will not attempt to use its native
-    //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
-    //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
-    //   the compatible custom types.
-    spec_version: 100,
+    spec_version: 1,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/cumulus/parachain-template/runtime/src/lib.rs
+++ b/cumulus/parachain-template/runtime/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("subspace"),
 	impl_name: create_runtime_str!("subspace"),
 	authoring_version: 1,
-	spec_version: 100,
+	spec_version: 1,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/cumulus/parachain-template/runtime/src/lib.rs
+++ b/cumulus/parachain-template/runtime/src/lib.rs
@@ -133,11 +133,11 @@ impl_opaque_keys! {
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("subspace-executor"),
-	impl_name: create_runtime_str!("subspace-executor"),
+	spec_name: create_runtime_str!("subspace"),
+	impl_name: create_runtime_str!("subspace"),
 	authoring_version: 1,
-	spec_version: 1,
-	impl_version: 0,
+	spec_version: 100,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,


### PR DESCRIPTION
Fixes a regression from https://github.com/subspace/subspace/pull/295. We might want to strip the secondary runtime to be as light as possible but should be enough for now.

```
2022-03-27 21:12:09.282 DEBUG tokio-runtime-worker sync: Propagating transactions
2022-03-27 21:12:10.003  WARN tokio-runtime-worker slots: Unable to author block in slot 1648386730,. `can_author_with` returned: `spec_name` does not match `subspace` vs `subspace-executor` Probably a node update is required!
2022-03-27 21:12:11.004  WARN tokio-runtime-worker slots: Unable to author block in slot 1648386731,. `can_author_with` returned: `spec_name` does not match `subspace` vs `subspace-executor` Probably a node update is required!
2022-03-27 21:12:11.388  INFO tokio-runtime-worker substrate: zzz Idle (0 peers), best: #0 (0x494b…f908), finalized #0 (0x494b…f908), arrow_down 0 arrow_up 0
```