### PR TITLE
Fix runtime version mismatch due to global sections in WASM blob

### DIFF
--- a/crates/subspace-consensus-runtime/src/lib.rs
+++ b/crates/subspace-consensus-runtime/src/lib.rs
@@ -66,7 +66,8 @@ sp_runtime::impl_opaque_keys! {
 
 // To learn more about runtime versioning and what each of the following value means:
 //   https://substrate.dev/docs/en/knowledgebase/runtime/upgrades#runtime-versioning
-#[sp_version::runtime_version]
+// TODO: Disable runtime version in WASM sections for now, see https://github.com/paritytech/substrate/issues/7327#issuecomment-1079983110
+// #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),

--- a/cumulus/parachain-template/runtime/src/lib.rs
+++ b/cumulus/parachain-template/runtime/src/lib.rs
@@ -131,7 +131,8 @@ impl_opaque_keys! {
 	pub struct SessionKeys { }
 }
 
-#[sp_version::runtime_version]
+// TODO: Disable runtime version in WASM sections for now, see https://github.com/paritytech/substrate/issues/7327#issuecomment-1079983110
+// #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("subspace-executor"),
 	impl_name: create_runtime_str!("subspace-executor"),


### PR DESCRIPTION
As discovered in #297 we have a problem in combined WASM runtime blob, but the root cause is more complex, see https://github.com/paritytech/substrate/issues/7327#ref-pullrequest-1182530459

This works around the problem by not including runtime version in section of WASM blob, so Substrate internals have to rely on legacy way of extracting this information by actually instantiating runtime (which has distinct info for both included runtimes): https://github.com/paritytech/substrate/blob/36b8970ef68b2f8d031f0aeadbe47d06a2679332/client/executor/src/wasm_runtime.rs#L392-L448

Implementation details of Substrate allow us to do this with a small hack because if runtime version is not found, runtime APIs (another global section) is not read either: https://github.com/paritytech/substrate/blob/36b8970ef68b2f8d031f0aeadbe47d06a2679332/client/executor/src/wasm_runtime.rs#L358-L390

Closes #297