### PR TITLE
Fix consensus verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8889,6 +8889,7 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-executor",

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -16,8 +16,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    find_pre_digest, verification, BlockSigningNotification, NewSlotInfo, NewSlotNotification,
-    SubspaceLink,
+    find_pre_digest, subspace_err, verification, BlockSigningNotification, NewSlotInfo,
+    NewSlotNotification, SubspaceLink,
 };
 use futures::StreamExt;
 use futures::TryFutureExt;
@@ -283,7 +283,9 @@ where
 
     fn should_backoff(&self, slot: Slot, chain_head: &B::Header) -> bool {
         if let Some(ref strategy) = self.backoff_authoring_blocks {
-            if let Ok(chain_head_slot) = find_pre_digest::<B>(chain_head).map(|digest| digest.slot)
+            if let Ok(chain_head_slot) = find_pre_digest::<B>(chain_head)
+                .map(|digest| digest.slot)
+                .map_err(subspace_err)
             {
                 return strategy.should_backoff(
                     *chain_head.number(),
@@ -319,6 +321,7 @@ where
 
     fn proposing_remaining_duration(&self, slot_info: &SlotInfo<B>) -> std::time::Duration {
         let parent_slot = find_pre_digest::<B>(&slot_info.chain_head)
+            .map_err(subspace_err)
             .ok()
             .map(|d| d.slot);
 

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::verification::PieceCheckParams;
 use crate::{
     find_pre_digest, subspace_err, verification, BlockSigningNotification, NewSlotInfo,
     NewSlotNotification, SubspaceLink,
@@ -206,9 +207,11 @@ where
                     solution_range,
                     slot,
                     salt,
-                    records_root: &records_root,
-                    position,
-                    record_size,
+                    piece_check_params: Some(PieceCheckParams {
+                        records_root,
+                        position,
+                        record_size,
+                    }),
                     signing_context: &self.signing_context,
                 },
             ) {

--- a/crates/sc-consensus-subspace/src/verification.rs
+++ b/crates/sc-consensus-subspace/src/verification.rs
@@ -96,7 +96,8 @@ pub(super) fn check_header<B: BlockT + Sized>(
         return Ok(CheckedHeader::Deferred(header, pre_digest.slot));
     }
 
-    debug!(target: "subspace",
+    debug!(
+        target: "subspace",
         "Verifying primary block #{} at slot: {}",
         header.number(),
         pre_digest.slot,

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -47,6 +47,7 @@ sp-authorship = { version = "4.0.0-dev", git = "https://github.com/paritytech/su
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-executor = { version = "0.1.0", path = "../sp-executor" }


### PR DESCRIPTION
This moves most of non-stateless (except equivocation) block checks to block import pipeline, otherwise it is not guaranteed that the parent block is already imported and all kinds of weird behaviors can be observed, like https://github.com/subspace/subspace/issues/255 for instance.

Reviewing by commit by commit would make be the easiest approach.