### PR TITLE
Fetch the execution runtime code properly and test the fraud proof verification on parimay node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9035,6 +9035,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-cli",
  "sc-client-api",
+ "sc-executor",
  "sc-network",
  "sc-service",
  "sc-tracing",

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -197,10 +197,6 @@ impl ExecutionPhase {
 /// Error type of fraud proof verification on primary node.
 #[derive(RuntimeDebug)]
 pub enum VerificationError {
-    /// Runtime code backend unavailable.
-    RuntimeCodeBackend,
-    /// Runtime code can not be fetched from the backend.
-    RuntimeCode(&'static str),
     /// Failed to pass the execution proof check.
     BadProof(sp_std::boxed::Box<dyn sp_state_machine::Error>),
     /// The `post_state_root` calculated by farmer does not match the one declared in [`FraudProof`].
@@ -312,6 +308,7 @@ sp_api::decl_runtime_apis! {
     }
 }
 
+// TODO: remove once the fraud proof verification is moved into the client.
 pub mod fraud_proof_ext {
     use sp_externalities::ExternalitiesExt;
     use sp_runtime_interface::runtime_interface;

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -61,7 +61,7 @@ where
         execution_phase: &ExecutionPhase,
         delta_changes: Option<(DB, Block::Hash)>,
     ) -> sp_blockchain::Result<StorageProof> {
-        // TODO: fetch the runtime code properly.
+        // TODO: fetch the runtime code from the primary chain instead of the local state.
         let state = self.backend.state_at(at)?;
 
         let trie_backend = state.as_trie_backend().ok_or_else(|| {
@@ -74,6 +74,8 @@ where
             .runtime_code()
             .map_err(sp_blockchain::Error::RuntimeCode)?;
 
+        // TODO: avoid using the String API specified by `proving_method()`
+        // https://github.com/paritytech/substrate/discussions/11095
         if let Some((delta, post_delta_root)) = delta_changes {
             let delta_backend = create_delta_backend(trie_backend, delta, post_delta_root);
             sp_state_machine::prove_execution_on_trie_backend(
@@ -114,7 +116,7 @@ where
         pre_execution_root: H256,
         proof: StorageProof,
     ) -> sp_blockchain::Result<Vec<u8>> {
-        // TODO: fetch the runtime code properly.
+        // TODO: fetch the runtime code from the primary chain instead of the local state.
         let state = self.backend.state_at(at)?;
 
         let trie_backend = state.as_trie_backend().ok_or_else(|| {

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -229,7 +229,8 @@ where
         }
     }
 
-    fn verify(&self, proof: &FraudProof) -> Result<(), VerificationError> {
+    /// Verifies the fraud proof.
+    pub fn verify(&self, proof: &FraudProof) -> Result<(), VerificationError> {
         let FraudProof {
             parent_hash,
             pre_state_root,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -181,7 +181,10 @@ where
             executor.clone(),
         )?;
 
+    let client = Arc::new(client);
+
     let proof_verifier = subspace_fraud_proof::ProofVerifier::new(
+        client.clone(),
         backend.clone(),
         executor,
         task_manager.spawn_handle(),
@@ -189,8 +192,6 @@ where
     client
         .execution_extensions()
         .set_extensions_factory(Box::new(proof_verifier));
-
-    let client = Arc::new(client);
 
     let telemetry = telemetry.map(|(worker, telemetry)| {
         task_manager

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -341,8 +341,6 @@ where
 
 		let delta = storage_changes.transaction;
 		let post_delta_root = storage_changes.transaction_storage_root;
-		// TODO: way to call some runtime api against any specific state instead of having
-		// to work with String API directly.
 		let execution_proof = prover.prove_execution(
 			BlockId::Hash(parent_header.hash()),
 			&execution_phase,
@@ -614,8 +612,6 @@ where
 				let execution_phase =
 					ExecutionPhase::InitializeBlock { call_data: new_header.encode() };
 
-				// TODO: way to call some runtime api against any specific state instead of having
-				// to work with String API directly.
 				let proof = prover.prove_execution::<TransactionFor<Backend, Block>>(
 					BlockId::Hash(parent_header.hash()),
 					&execution_phase,
@@ -650,8 +646,6 @@ where
 				let delta = storage_changes.transaction;
 				let post_delta_root = storage_changes.transaction_storage_root;
 
-				// TODO: way to call some runtime api against any specific state instead of having
-				// to work with String API directly.
 				let proof = prover.prove_execution(
 					BlockId::Hash(parent_header.hash()),
 					&execution_phase,

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -314,6 +314,7 @@ where
 		extrinsic_index: usize,
 		parent_header: &Block::Header,
 		current_hash: Block::Hash,
+		prover: &subspace_fraud_proof::ExecutionProver<Block, Backend, E>,
 	) -> Result<(StorageProof, ExecutionPhase), GossipMessageError> {
 		let extrinsics = self.block_body(current_hash)?;
 
@@ -342,11 +343,8 @@ where
 		let post_delta_root = storage_changes.transaction_storage_root;
 		// TODO: way to call some runtime api against any specific state instead of having
 		// to work with String API directly.
-		let execution_proof = subspace_fraud_proof::prove_execution(
-			&self.backend,
-			&*self.code_executor,
-			self.spawner.clone() as Box<dyn SpawnNamed>,
-			&BlockId::Hash(parent_header.hash()),
+		let execution_proof = prover.prove_execution(
+			BlockId::Hash(parent_header.hash()),
 			&execution_phase,
 			Some((delta, post_delta_root)),
 		)?;
@@ -594,6 +592,12 @@ where
 					.map_err(|_| Self::Error::InvalidStateRootType)
 			};
 
+			let prover = subspace_fraud_proof::ExecutionProver::new(
+				self.backend.clone(),
+				self.code_executor.clone(),
+				self.spawner.clone() as Box<dyn SpawnNamed>,
+			);
+
 			// TODO: abstract the execution proof impl to be reusable in the test.
 			let fraud_proof = if local_trace_idx == 0 {
 				// `initialize_block` execution proof.
@@ -612,17 +616,8 @@ where
 
 				// TODO: way to call some runtime api against any specific state instead of having
 				// to work with String API directly.
-				let proof = subspace_fraud_proof::prove_execution::<
-					_,
-					_,
-					_,
-					_,
-					TransactionFor<Backend, Block>,
-				>(
-					&self.backend,
-					&*self.code_executor,
-					self.spawner.clone() as Box<dyn SpawnNamed>,
-					&BlockId::Hash(parent_header.hash()),
+				let proof = prover.prove_execution::<TransactionFor<Backend, Block>>(
+					BlockId::Hash(parent_header.hash()),
 					&execution_phase,
 					None,
 				)?;
@@ -657,11 +652,8 @@ where
 
 				// TODO: way to call some runtime api against any specific state instead of having
 				// to work with String API directly.
-				let proof = subspace_fraud_proof::prove_execution(
-					&self.backend,
-					&*self.code_executor,
-					self.spawner.clone() as Box<dyn SpawnNamed>,
-					&BlockId::Hash(parent_header.hash()),
+				let proof = prover.prove_execution(
+					BlockId::Hash(parent_header.hash()),
 					&execution_phase,
 					Some((delta, post_delta_root)),
 				)?;
@@ -682,6 +674,7 @@ where
 					local_trace_idx - 1,
 					&parent_header,
 					execution_receipt.secondary_hash,
+					&prover,
 				)?;
 
 				// TODO: proof should be a CompactProof.

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -183,7 +183,7 @@ async fn execution_proof_creation_and_verification_should_work() {
 		)
 		.expect("Create `initialize_block` proof");
 
-	// Test `initialize_block` verification on executor.
+	// Test `initialize_block` verification.
 	let execution_result = prover
 		.check_execution_proof(
 			BlockId::Hash(parent_header.hash()),
@@ -196,7 +196,6 @@ async fn execution_proof_creation_and_verification_should_work() {
 		execution_phase.decode_execution_result::<Header>(execution_result).unwrap();
 	assert_eq!(post_execution_root, intermediate_roots[0].into());
 
-	// Test `initialize_block` verification on farmer.
 	let proof_verifier = subspace_fraud_proof::ProofVerifier::new(
 		alice.client.clone(),
 		alice.backend.clone(),
@@ -240,7 +239,7 @@ async fn execution_proof_creation_and_verification_should_work() {
 		let target_trace_root: Hash = intermediate_roots[target_extrinsic_index].into();
 		assert_eq!(target_trace_root, post_delta_root);
 
-		// Test `apply_extrinsic` verification on executor.
+		// Test `apply_extrinsic` verification.
 		let execution_result = prover
 			.check_execution_proof(
 				BlockId::Hash(parent_header.hash()),
@@ -253,7 +252,6 @@ async fn execution_proof_creation_and_verification_should_work() {
 			execution_phase.decode_execution_result::<Header>(execution_result).unwrap();
 		assert_eq!(post_execution_root, intermediate_roots[target_extrinsic_index + 1].into());
 
-		// Test `apply_extrinsic` verification on farmer.
 		let fraud_proof = FraudProof {
 			parent_hash: parent_hash_alice,
 			pre_state_root: intermediate_roots[target_extrinsic_index].into(),
@@ -284,7 +282,7 @@ async fn execution_proof_creation_and_verification_should_work() {
 		)
 		.expect("Create `finalize_block` proof");
 
-	// Test `finalize_block` verification on executor.
+	// Test `finalize_block` verification.
 	let execution_result = prover
 		.check_execution_proof(
 			BlockId::Hash(parent_header.hash()),
@@ -297,7 +295,6 @@ async fn execution_proof_creation_and_verification_should_work() {
 		execution_phase.decode_execution_result::<Header>(execution_result).unwrap();
 	assert_eq!(post_execution_root, *header.state_root());
 
-	// Test `finalize_block` verification on farmer.
 	let fraud_proof = FraudProof {
 		parent_hash: parent_hash_alice,
 		pre_state_root: intermediate_roots.last().unwrap().into(),

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -57,6 +57,9 @@ impl sc_executor::NativeExecutionDispatch for TestExecutorDispatch {
 /// The client type being used by the test service.
 pub type Client = FullClient<subspace_test_runtime::RuntimeApi, TestExecutorDispatch>;
 
+/// The backend type being used by the test service.
+pub type Backend = sc_service::TFullBackend<Block>;
+
 /// Run a farmer.
 pub fn start_farmer(new_full: &NewFull<Arc<Client>>) {
     let client = new_full.client.clone();

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -22,6 +22,7 @@ pallet-balances = { git = "https://github.com/paritytech/substrate", rev = "c364
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 polkadot-overseer = { path = "../../polkadot/node/overseer" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sc-executor = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sc-network = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sc-service = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998", features = ["wasmtime"] }
 sc-tracing = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }


### PR DESCRIPTION
Basically a follow-up of #301. One change worth noticing in this PR is the execution runtime code is now properly fetched from the primary runtime using the runtime API. And then the test for `ProofVerifier` is added to test the fraud proof verification on the primary node. There is also a refactoring about the execution proof creation and verification on the executor side. Should be straightforward to review commit by commit.