### PR TITLE
Correct target directory for wasm builds

### DIFF
--- a/crates/subspace-runtime/build.rs
+++ b/crates/subspace-runtime/build.rs
@@ -18,13 +18,21 @@ use std::env;
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("Set by cargo; qed");
+    let relative_target_dir = env!("CARGO_MANIFEST_DIR").to_owned() + "/../../target";
+    let target_dir = option_env!("CARGO_TARGET_DIR")
+        .or(option_env!("WASM_TARGET_DIRECTORY"))
+        .unwrap_or(&relative_target_dir);
+
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
-        &(cargo_manifest_dir + "/../../target"),
+        target_dir,
         "parachain-template-runtime",
         "EXECUTION_WASM_BUNDLE",
         "execution_wasm_bundle.rs",
     );
+
+    if env::var("WASM_TARGET_DIRECTORY").is_err() {
+        env::set_var("WASM_TARGET_DIRECTORY", target_dir);
+    }
 
     WasmBuilder::new()
         .with_current_project()

--- a/test/subspace-test-runtime/build.rs
+++ b/test/subspace-test-runtime/build.rs
@@ -18,13 +18,21 @@ use std::env;
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("Set by cargo; qed");
+    let relative_target_dir = env!("CARGO_MANIFEST_DIR").to_owned() + "/../../target";
+    let target_dir = option_env!("CARGO_TARGET_DIR")
+        .or(option_env!("WASM_TARGET_DIRECTORY"))
+        .unwrap_or(&relative_target_dir);
+
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
-        &(cargo_manifest_dir + "/../../target"),
+        target_dir,
         "cirrus-test-runtime",
         "EXECUTION_WASM_BUNDLE",
         "execution_wasm_bundle.rs",
     );
+
+    if env::var("WASM_TARGET_DIRECTORY").is_err() {
+        env::set_var("WASM_TARGET_DIRECTORY", target_dir);
+    }
 
     WasmBuilder::new()
         .with_current_project()


### PR DESCRIPTION
Fixes #309

There are 3 cases which can encounter during building runtime (in `build.rs`):
- when `CARGO_TARGET_DIR` is unset -- we do the same logic here
- when `CARGO_TARGET_DIR` is set and we are building crate for host target (not for wasm) -- we use `CARGO_TARGET_DIR` for target directory and set `WASM_TARGET_DIRECTORY` in order to pass it to wasm build.
- when `CARGO_TARGET_DIR` is unset and we are building crate for wasm target -- we use `WASM_TARGET_DIR`
