### PR TITLE
Increase block request timeout

### DIFF
--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 use tokio::sync::oneshot::Receiver;
 use tokio::{sync::oneshot, task::JoinHandle};
 
-const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Error)]
 pub enum PlottingError {


### PR DESCRIPTION
A few users on slower machines complained about farmer exiting due to this error. Having much larger timeout shouldn't hurt and we never really expect to hit it unless know bug with Substrate's RPC.