### PR TITLE
Upgrade secondary runtime on primary runtime upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "sp-inherents",
  "sp-keyring",
  "sp-runtime",
+ "sp-state-machine",
  "sp-trie",
  "subspace-core-primitives",
  "subspace-fraud-proof",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ name = "cirrus-test-service"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cirrus-client-executor",
  "cirrus-client-service",
  "cirrus-node-primitives",
  "cirrus-test-runtime",
@@ -1040,6 +1041,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
+ "sp-inherents",
  "sp-keyring",
  "sp-runtime",
  "sp-timestamp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,6 +5723,7 @@ dependencies = [
  "sp-core",
  "sp-executor",
  "sp-maybe-compressed-blob",
+ "sp-runtime",
  "subspace-runtime-primitives",
  "thiserror",
  "tracing",

--- a/crates/cirrus-node-primitives/src/lib.rs
+++ b/crates/cirrus-node-primitives/src/lib.rs
@@ -25,7 +25,7 @@ use sp_consensus_slots::Slot;
 use sp_core::bytes;
 use sp_executor::{OpaqueBundle, OpaqueExecutionReceipt};
 use sp_runtime::traits::Hash as HashT;
-use std::pin::Pin;
+use std::{borrow::Cow, pin::Pin};
 use subspace_core_primitives::{Randomness, Tag};
 use subspace_runtime_primitives::{BlockNumber, Hash};
 
@@ -126,6 +126,7 @@ pub type ProcessorFn = Box<
             Hash,
             Vec<OpaqueBundle>,
             Randomness,
+            Option<Cow<'static, [u8]>>,
         ) -> Pin<Box<dyn Future<Output = Option<ProcessorResult>> + Send>>
         + Send
         + Sync,

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -61,7 +61,6 @@ where
         execution_phase: &ExecutionPhase,
         delta_changes: Option<(DB, Block::Hash)>,
     ) -> sp_blockchain::Result<StorageProof> {
-        // TODO: fetch the runtime code from the primary chain instead of the local state.
         let state = self.backend.state_at(at)?;
 
         let trie_backend = state.as_trie_backend().ok_or_else(|| {
@@ -116,7 +115,6 @@ where
         pre_execution_root: H256,
         proof: StorageProof,
     ) -> sp_blockchain::Result<Vec<u8>> {
-        // TODO: fetch the runtime code from the primary chain instead of the local state.
         let state = self.backend.state_at(at)?;
 
         let trie_backend = state.as_trie_backend().ok_or_else(|| {

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -63,6 +63,7 @@ cirrus-test-service = { path = "../../test/service" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sc-cli = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 substrate-test-runtime = { path = "../../../substrate/substrate-test-runtime" }
 substrate-test-runtime-client = { path = "../../../substrate/substrate-test-runtime-client" }
 substrate-test-utils = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -399,7 +399,8 @@ where
 		self.produce_bundle_impl(primary_hash, slot_info).await
 	}
 
-	async fn process_bundles(
+	/// Processes the bundles extracted from the primary block.
+	pub async fn process_bundles(
 		self,
 		primary_hash: PHash,
 		bundles: Vec<OpaqueBundle>,

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -60,7 +60,7 @@ use subspace_core_primitives::Randomness;
 use subspace_runtime_primitives::Hash as PHash;
 
 use futures::FutureExt;
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 use tracing::Instrument;
 
 /// The logging target.
@@ -404,8 +404,12 @@ where
 		primary_hash: PHash,
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
+		maybe_new_runtime: Option<Cow<'static, [u8]>>,
 	) -> Option<ProcessorResult> {
-		match self.process_bundles_impl(primary_hash, bundles, shuffling_seed).await {
+		match self
+			.process_bundles_impl(primary_hash, bundles, shuffling_seed, maybe_new_runtime)
+			.await
+		{
 			Ok(res) => res,
 			Err(err) => {
 				tracing::error!(
@@ -782,10 +786,10 @@ where
 		processor: {
 			let executor = executor.clone();
 
-			Box::new(move |primary_hash, bundles, shuffling_seed| {
+			Box::new(move |primary_hash, bundles, shuffling_seed, maybe_new_runtime| {
 				let executor = executor.clone();
 				executor
-					.process_bundles(primary_hash, bundles, shuffling_seed)
+					.process_bundles(primary_hash, bundles, shuffling_seed, maybe_new_runtime)
 					.instrument(span.clone())
 					.boxed()
 			})

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -12,6 +12,7 @@ use sp_runtime::{
 	traits::{Block as BlockT, Header as HeaderT},
 };
 use std::{
+	borrow::Cow,
 	collections::{BTreeMap, VecDeque},
 	fmt::Debug,
 };
@@ -98,6 +99,7 @@ where
 		primary_hash: PHash,
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
+		maybe_new_runtime: Option<Cow<'static, [u8]>>,
 	) -> Result<Option<ProcessorResult>, sp_blockchain::Error> {
 		let parent_hash = self.client.info().best_hash;
 		let parent_number = self.client.info().best_number;
@@ -114,6 +116,10 @@ where
 		let inherent_data = self.inherent_data(parent_hash, primary_hash).await?;
 
 		let mut final_extrinsics = block_builder.create_inherents(inherent_data)?;
+
+		if let Some(_new_runtime) = maybe_new_runtime {
+			// TODO craft a SetCode extrinsic to mimic the regular runtime upgrade.
+		}
 
 		let extrinsics = self.bundles_to_extrinsics(parent_hash, bundles, shuffling_seed)?;
 		final_extrinsics.extend(extrinsics);

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -117,8 +117,14 @@ where
 
 		let mut final_extrinsics = block_builder.create_inherents(inherent_data)?;
 
-		if let Some(_new_runtime) = maybe_new_runtime {
-			// TODO craft a SetCode extrinsic to mimic the regular runtime upgrade.
+		if let Some(new_runtime) = maybe_new_runtime {
+			let encoded_set_code = self
+				.client
+				.runtime_api()
+				.construct_set_code_extrinsic(&BlockId::Hash(parent_hash), new_runtime.to_vec())?;
+			let set_code_extrinsic =
+				Block::Extrinsic::decode(&mut encoded_set_code.as_slice()).unwrap();
+			final_extrinsics.push(set_code_extrinsic);
 		}
 
 		let extrinsics = self.bundles_to_extrinsics(parent_hash, bundles, shuffling_seed)?;

--- a/cumulus/client/cirrus-service/src/lib.rs
+++ b/cumulus/client/cirrus-service/src/lib.rs
@@ -93,7 +93,7 @@ pub async fn start_executor<'a, Block, Client, Backend, Spawner, RClient, IQ, TP
 		code_executor,
 		is_authority,
 	}: StartExecutorParams<'a, Block, Client, Spawner, RClient, IQ, TP, Backend, CIDP, E>,
-) -> sc_service::error::Result<()>
+) -> sc_service::error::Result<cirrus_client_executor::Executor<Block, Client, TP, Backend, CIDP, E>>
 where
 	Block: BlockT,
 	Client: Finalizer<Block, Backend>
@@ -166,7 +166,7 @@ where
 	let executor_gossip = cirrus_client_executor_gossip::start_gossip_worker(
 		cirrus_client_executor_gossip::ExecutorGossipParams {
 			network,
-			executor,
+			executor: executor.clone(),
 			bundle_receiver,
 			execution_receipt_receiver,
 		},
@@ -177,7 +177,7 @@ where
 
 	task_manager.add_child(primary_chain_full_node.task_manager);
 
-	Ok(())
+	Ok(executor)
 }
 
 /// Parameters given to [`start_full_node`].

--- a/cumulus/parachain-template/node/src/chain_spec.rs
+++ b/cumulus/parachain-template/node/src/chain_spec.rs
@@ -137,6 +137,7 @@ fn testnet_genesis(endowed_accounts: Vec<AccountId>) -> parachain_template_runti
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
 		},
+		transaction_payment: Default::default(),
 		balances: parachain_template_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
 		},

--- a/cumulus/parachain-template/runtime/src/impl.rs
+++ b/cumulus/parachain-template/runtime/src/impl.rs
@@ -312,12 +312,12 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		// System support stuff.
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>} = 0,
-		ExecutivePallet: cirrus_pallet_executive::{Pallet, Storage} = 1,
+		System: frame_system = 0,
+		ExecutivePallet: cirrus_pallet_executive = 1,
 
 		// Monetary stuff.
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 10,
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage} = 11,
+		Balances: pallet_balances = 10,
+		TransactionPayment: pallet_transaction_payment = 11,
 	}
 );
 

--- a/cumulus/parachain-template/runtime/src/impl.rs
+++ b/cumulus/parachain-template/runtime/src/impl.rs
@@ -300,7 +300,10 @@ impl pallet_transaction_payment::Config for Runtime {
 	type OperationalFeeMultiplier = OperationalFeeMultiplier;
 }
 
-impl cirrus_pallet_executive::Config for Runtime {}
+impl cirrus_pallet_executive::Config for Runtime {
+	type Event = Event;
+	type Call = Call;
+}
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 //
@@ -433,6 +436,17 @@ impl_runtime_apis! {
 		fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
 			let _ = Executive::apply_extrinsic(extrinsic);
 			Executive::storage_root()
+		}
+
+		fn construct_set_code_extrinsic(code: Vec<u8>) -> Vec<u8> {
+			use codec::Encode;
+			let set_code_call = frame_system::Call::set_code { code };
+			UncheckedExtrinsic::new_unsigned(
+				cirrus_pallet_executive::Call::sudo_unchecked_weight_unsigned {
+					call: Box::new(set_code_call.into()),
+					weight: 0
+				}.into()
+			).encode()
 		}
 	}
 

--- a/cumulus/primitives/src/lib.rs
+++ b/cumulus/primitives/src/lib.rs
@@ -85,5 +85,8 @@ sp_api::decl_runtime_apis! {
 
 		/// Returns the storage root after applying the extrinsic.
 		fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8>;
+
+		/// Returns an encoded extrinsic aiming to upgrade the runtime using given code.
+		fn construct_set_code_extrinsic(code: Vec<u8>) -> Vec<u8>;
 	}
 }

--- a/cumulus/test/runtime/src/impl.rs
+++ b/cumulus/test/runtime/src/impl.rs
@@ -313,12 +313,12 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		// System support stuff.
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>} = 0,
-		ExecutivePallet: cirrus_pallet_executive::{Pallet, Storage} = 1,
+		System: frame_system,
+		ExecutivePallet: cirrus_pallet_executive,
 
 		// Monetary stuff.
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 10,
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage} = 11,
+		Balances: pallet_balances,
+		TransactionPayment: pallet_transaction_payment,
 	}
 );
 

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -33,6 +33,7 @@ sp-arithmetic = { git = "https://github.com/paritytech/substrate", rev = "c36400
 sp-blockchain = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-core = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-timestamp = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-trie = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
@@ -41,6 +42,7 @@ substrate-test-client = { git = "https://github.com/paritytech/substrate", rev =
 # RPC related dependencies
 jsonrpc-core = "18.0.0"
 
+cirrus-client-executor = { path = "../../client/cirrus-executor" }
 cirrus-client-service = { path = "../../client/cirrus-service" }
 cirrus-node-primitives = { path = "../../../crates/cirrus-node-primitives" }
 cirrus-test-runtime = { path = "../runtime" }

--- a/cumulus/test/service/src/chain_spec.rs
+++ b/cumulus/test/service/src/chain_spec.rs
@@ -72,6 +72,7 @@ fn testnet_genesis(
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
 		},
+		transaction_payment: Default::default(),
 		balances: cirrus_test_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
 		},

--- a/polkadot/node/collation-generation/Cargo.toml
+++ b/polkadot/node/collation-generation/Cargo.toml
@@ -11,6 +11,7 @@ polkadot-node-subsystem = { path = "../subsystem" }
 polkadot-node-subsystem-util = { path = "../subsystem-util" }
 sp-core = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-maybe-compressed-blob  = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 thiserror = "1.0.30"
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["bit-vec", "derive"] }
 

--- a/polkadot/node/core/runtime-api/src/cache.rs
+++ b/polkadot/node/core/runtime-api/src/cache.rs
@@ -61,4 +61,5 @@ pub(crate) enum RequestResult {
 	SubmitInvalidTransactionProof(Hash),
 	ExtractBundles(Hash),
 	ExtrinsicsShufflingSeed(Hash),
+	ExecutionWasmBundle(Hash),
 }

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -117,6 +117,7 @@ where
 			SubmitInvalidTransactionProof(..) => {},
 			ExtractBundles(..) => {},
 			ExtrinsicsShufflingSeed(..) => {},
+			ExecutionWasmBundle(..) => {},
 		}
 	}
 
@@ -155,6 +156,7 @@ where
 			Request::SubmitInvalidTransactionProof(..) => None,
 			Request::ExtractBundles(..) => None,
 			Request::ExtrinsicsShufflingSeed(..) => None,
+			Request::ExecutionWasmBundle(..) => None,
 		}
 	}
 
@@ -329,6 +331,17 @@ where
 			let _ = sender.send(res.clone());
 
 			res.ok().map(|_res| RequestResult::ExtrinsicsShufflingSeed(relay_parent));
+		},
+		Request::ExecutionWasmBundle(sender) => {
+			let api = client.runtime_api();
+			let res = api
+				.execution_wasm_bundle(&BlockId::Hash(relay_parent))
+				.map_err(|e| RuntimeApiError::from(e.to_string()));
+			metrics.on_request(res.is_ok());
+
+			let _ = sender.send(res.clone());
+
+			res.ok().map(|_res| RequestResult::ExecutionWasmBundle(relay_parent));
 		},
 	}
 

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -22,6 +22,8 @@
 //!
 //! Subsystems' APIs are defined separately from their implementation, leading to easier mocking.
 
+use std::borrow::Cow;
+
 use futures::channel::oneshot;
 
 pub use sc_network::IfDisconnected;
@@ -122,6 +124,8 @@ pub enum RuntimeApiRequest {
 	ExtractBundles(Vec<OpaqueExtrinsic>, RuntimeApiSender<Vec<OpaqueBundle>>),
 	/// Get the randomness seed for extrinsics shuffling.
 	ExtrinsicsShufflingSeed(BlockHeader, RuntimeApiSender<Randomness>),
+	/// Get the execution runtime blob.
+	ExecutionWasmBundle(RuntimeApiSender<Cow<'static, [u8]>>),
 }
 
 /// A message to the Runtime API subsystem.

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -54,6 +54,7 @@ use sp_core::traits::SpawnNamed;
 use sp_executor::OpaqueBundle;
 use sp_runtime::OpaqueExtrinsic;
 use std::{
+	borrow::Cow,
 	collections::{hash_map::Entry, HashMap},
 	convert::TryFrom,
 	fmt,
@@ -186,6 +187,7 @@ macro_rules! specialize_requests {
 specialize_requests! {
 	fn request_extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle>; ExtractBundles;
 	fn request_extrinsics_shuffling_seed(header: Header) -> Randomness; ExtrinsicsShufflingSeed;
+	fn request_execution_wasm_bundle() -> Cow<'static, [u8]>; ExecutionWasmBundle;
 }
 
 struct AbortOnDrop(future::AbortHandle);


### PR DESCRIPTION
This PR aims to upgrade the secondary runtime once the primary runtime has been upgraded. On each primary block, we detect whether the primary runtime was upgraded by checking the log `DigestItem::RuntimeEnvironmentUpdated` in the block header. If yes, we retrieve the latest secondary runtime blob and use it to create a SetCode extrinsic on the executor side, mimicking the regular runtime upgrade via the Sudo interface. Should be reviewed commit by commit.

This PR does not take care of the secondary runtime initialization, which will be done after a major refactoring of merging the executor binary into the subspace-node binary.