### PR TITLE
Fix bug with erasing plot

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -6,36 +6,16 @@ pub(crate) use identity::identity;
 use log::info;
 use std::path::Path;
 use std::{fs, io};
-
-/// Helper function for ignoring the error that given file/directory does not exist.
-fn try_remove<P: AsRef<Path>>(
-    path: P,
-    remove: impl FnOnce(P) -> std::io::Result<()>,
-) -> io::Result<()> {
-    if path.as_ref().exists() {
-        remove(path)?;
-    }
-    Ok(())
-}
-
-pub(crate) fn erase_plot<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    info!("Erasing the plot");
-    try_remove(path.as_ref().join("plot.bin"), fs::remove_file)?;
-    info!("Erasing plot metadata");
-    try_remove(path.as_ref().join("plot-metadata"), fs::remove_dir_all)?;
-    info!("Erasing plot commitments");
-    try_remove(path.as_ref().join("commitments"), fs::remove_dir_all)?;
-    info!("Erasing object mappings");
-    try_remove(path.as_ref().join("object-mappings"), fs::remove_dir_all)?;
-
-    Ok(())
-}
+use subspace_farmer::Plot;
 
 pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    erase_plot(path.as_ref())?;
+    Plot::erase(path.as_ref())?;
 
     info!("Erasing identity");
-    try_remove(path.as_ref().join("identity.bin"), fs::remove_file)?;
+    let identity = path.as_ref().join("identity.bin");
+    if identity.exists() {
+        fs::remove_file(identity)?;
+    }
 
     Ok(())
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -10,6 +10,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 use subspace_core_primitives::PublicKey;
+use subspace_farmer::Plot;
 use subspace_networking::libp2p::Multiaddr;
 
 const BEST_BLOCK_NUMBER_CHECK_INTERVAL: Duration = Duration::from_secs(5);
@@ -115,8 +116,7 @@ async fn main() -> Result<()> {
             commands::identity(identity_command)?;
         }
         Command::ErasePlot { custom_path } => {
-            let path = utils::get_path(custom_path);
-            commands::erase_plot(&path)?;
+            Plot::erase(utils::get_path(custom_path))?;
             info!("Done");
         }
         Command::Wipe { custom_path } => {

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -2,10 +2,10 @@
 mod tests;
 
 use event_listener_primitives::{Bag, HandlerId};
-use log::error;
+use log::{error, info};
 use rocksdb::DB;
 use std::collections::VecDeque;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
@@ -146,6 +146,41 @@ pub struct Plot {
 }
 
 impl Plot {
+    /// Helper function for ignoring the error that given file/directory does not exist.
+    fn try_remove<P: AsRef<Path>>(
+        path: P,
+        remove: impl FnOnce(P) -> io::Result<()>,
+    ) -> io::Result<()> {
+        if path.as_ref().exists() {
+            remove(path)?;
+        }
+        Ok(())
+    }
+
+    /// Erases plot in specific directory
+    pub fn erase(path: impl AsRef<Path>) -> io::Result<()> {
+        info!("Erasing the plot");
+        Self::try_remove(path.as_ref().join("plot.bin"), fs::remove_file)?;
+        info!("Erasing the plot offset to index db");
+        Self::try_remove(
+            path.as_ref().join("plot-offset-to-index.bin"),
+            fs::remove_file,
+        )?;
+        info!("Erasing the plot index to offset db");
+        Self::try_remove(
+            path.as_ref().join("plot-index-to-offset"),
+            fs::remove_dir_all,
+        )?;
+        info!("Erasing plot metadata");
+        Self::try_remove(path.as_ref().join("plot-metadata"), fs::remove_dir_all)?;
+        info!("Erasing plot commitments");
+        Self::try_remove(path.as_ref().join("commitments"), fs::remove_dir_all)?;
+        info!("Erasing object mappings");
+        Self::try_remove(path.as_ref().join("object-mappings"), fs::remove_dir_all)?;
+
+        Ok(())
+    }
+
     /// Creates a new plot for persisting encoded pieces to disk
     pub fn open_or_create<B: AsRef<Path>>(
         base_directory: B,

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -135,3 +135,29 @@ async fn partial_plot() {
         assert!(plot.read(i).is_err());
     }
 }
+
+#[tokio::test()]
+async fn wipe_cleans_everything() {
+    init();
+    let base_directory = TempDir::new().unwrap();
+
+    let plot =
+        Plot::open_or_create(&base_directory, rand::random::<[u8; 32]>().into(), u64::MAX).unwrap();
+
+    let pieces = Arc::new(generate_random_pieces(20));
+    plot.write_many(Arc::clone(&pieces), (0..).take(pieces.count()).collect())
+        .unwrap();
+    assert!(!plot.is_empty());
+    drop(plot);
+
+    std::fs::read_dir(&base_directory)
+        .unwrap()
+        .next()
+        .expect("Plot at least has 1 dir entry")
+        .unwrap();
+    Plot::erase(&base_directory).unwrap();
+    assert!(
+        std::fs::read_dir(&base_directory).unwrap().next().is_none(),
+        "Plot directory is clean"
+    );
+}


### PR DESCRIPTION
This pr moves `erase` function to plot itself in order to make plot layout logic self contained and for it to be synced in future. Also it adds test for adding new files to a plot.