### PR TITLE
Fix `subspace_wasm_tools` for builds outside of subspace workspace

### DIFF
--- a/crates/subspace-runtime/build.rs
+++ b/crates/subspace-runtime/build.rs
@@ -14,25 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::env;
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-    let relative_target_dir = env!("CARGO_MANIFEST_DIR").to_owned() + "/../../target";
-    let target_dir = option_env!("CARGO_TARGET_DIR")
-        .or(option_env!("WASM_TARGET_DIRECTORY"))
-        .unwrap_or(&relative_target_dir);
-
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
-        target_dir,
         "parachain-template-runtime",
         "EXECUTION_WASM_BUNDLE",
         "execution_wasm_bundle.rs",
     );
-
-    if env::var("WASM_TARGET_DIRECTORY").is_err() {
-        env::set_var("WASM_TARGET_DIRECTORY", target_dir);
-    }
 
     WasmBuilder::new()
         .with_current_project()

--- a/crates/subspace-wasm-tools/src/lib.rs
+++ b/crates/subspace-wasm-tools/src/lib.rs
@@ -1,15 +1,38 @@
-use std::{env, fs};
+use std::{env, fs, path::PathBuf};
+
+fn get_relative_target(dir: PathBuf) -> Option<PathBuf> {
+    if dir.join("Cargo.lock").is_file() && dir.join("target").is_dir() {
+        return Some(dir.join("target"));
+    }
+    dir.parent()
+        .map(ToOwned::to_owned)
+        .and_then(get_relative_target)
+}
 
 /// Creates a `target_file_name` in `OUT_DIR` that will contain constant `bundle_const_name` with
 /// runtime of `runtime_crate_name` stored in it.
 ///
 /// Must be called before Substrate's WASM builder.
 pub fn create_runtime_bundle_inclusion_file(
-    target_dir: &str,
     runtime_crate_name: &str,
     bundle_const_name: &str,
     target_file_name: &str,
 ) {
+    let target_dir = if let Ok(target_dir) =
+        env::var("CARGO_TARGET_DIR").or_else(|_| env::var("WASM_TARGET_DIRECTORY"))
+    {
+        // Propagate target directory to wasm build
+        target_dir.into()
+    } else {
+        let out_dir = env::var("OUT_DIR").expect("Always set by cargo");
+        get_relative_target(out_dir.into())
+            .map(|target_dir| get_relative_target(target_dir.clone()).unwrap_or(target_dir))
+            .expect("Out dir is always inside the target directory")
+    };
+    if env::var("WASM_TARGET_DIRECTORY").is_err() {
+        env::set_var("WASM_TARGET_DIRECTORY", &target_dir);
+    }
+
     // Make correct profile accessible in child processes.
     env::set_var(
         "WBUILD_PROFILE",
@@ -19,10 +42,14 @@ pub fn create_runtime_bundle_inclusion_file(
 
     // Create a file that will include execution runtime into consensus runtime
     let profile = env::var("WBUILD_PROFILE").expect("Set above; qed");
-    let execution_wasm_bundle_path = format!(
-        "{target_dir}/{profile}/wbuild/{runtime_crate_name}/{}.compact.wasm",
-        runtime_crate_name.replace('-', "_")
-    );
+    let execution_wasm_bundle_path = target_dir
+        .join(profile)
+        .join("wbuild")
+        .join(runtime_crate_name)
+        .join(format!(
+            "{}.compact.wasm",
+            runtime_crate_name.replace('-', "_")
+        ));
 
     let execution_wasm_bundle_rs_path =
         env::var("OUT_DIR").expect("Set by cargo; qed") + "/" + target_file_name;
@@ -30,7 +57,9 @@ pub fn create_runtime_bundle_inclusion_file(
         r#"
             pub const {bundle_const_name}: &[u8] = include_bytes!("{}");
         "#,
-        execution_wasm_bundle_path.escape_default()
+        execution_wasm_bundle_path
+            .to_string_lossy()
+            .escape_default()
     );
 
     fs::write(

--- a/test/subspace-test-runtime/build.rs
+++ b/test/subspace-test-runtime/build.rs
@@ -14,25 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::env;
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-    let relative_target_dir = env!("CARGO_MANIFEST_DIR").to_owned() + "/../../target";
-    let target_dir = option_env!("CARGO_TARGET_DIR")
-        .or(option_env!("WASM_TARGET_DIRECTORY"))
-        .unwrap_or(&relative_target_dir);
-
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
-        target_dir,
         "cirrus-test-runtime",
         "EXECUTION_WASM_BUNDLE",
         "execution_wasm_bundle.rs",
     );
-
-    if env::var("WASM_TARGET_DIRECTORY").is_err() {
-        env::set_var("WASM_TARGET_DIRECTORY", target_dir);
-    }
 
     WasmBuilder::new()
         .with_current_project()


### PR DESCRIPTION
Closes #324

Move target finding to `subspace_wasm_tools` so that it would lookup for `target` directory relative to `OUT_DIR` (or use just `CARGO_TARGET_DIR` if it set).