### PR TITLE
Feed ownership

### DIFF
--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -85,22 +85,27 @@ mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn metadata)]
     pub(super) type Metadata<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::FeedId, FeedMetadata, OptionQuery>;
+        StorageMap<_, Identity, T::FeedId, FeedMetadata, OptionQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn feed_configs)]
     pub(super) type FeedConfigs<T: Config> = StorageMap<
         _,
-        Blake2_128Concat,
+        Identity,
         T::FeedId,
         FeedConfig<T::FeedProcessorKind, T::AccountId>,
         OptionQuery,
     >;
 
     #[pallet::storage]
+    #[pallet::getter(fn feeds)]
+    pub(super) type Feeds<T: Config> =
+        StorageDoubleMap<_, Identity, T::AccountId, Identity, T::FeedId, (), OptionQuery>;
+
+    #[pallet::storage]
     #[pallet::getter(fn totals)]
     pub(super) type Totals<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::FeedId, TotalObjectsAndSize, ValueQuery>;
+        StorageMap<_, Identity, T::FeedId, TotalObjectsAndSize, ValueQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn next_feed_id)]
@@ -183,6 +188,7 @@ mod pallet {
                     owner: who.clone(),
                 },
             );
+            Feeds::<T>::insert(who.clone(), feed_id, ());
             Totals::<T>::insert(feed_id, TotalObjectsAndSize::default());
 
             Self::deposit_event(Event::FeedCreated { feed_id, who });
@@ -273,6 +279,7 @@ mod pallet {
             FeedConfigs::<T>::remove(feed_id);
             Metadata::<T>::remove(feed_id);
             Totals::<T>::remove(feed_id);
+            Feeds::<T>::remove(owner.clone(), feed_id);
             Self::deposit_event(Event::FeedDeleted {
                 feed_id,
                 who: owner,

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -286,21 +286,6 @@ mod pallet {
             Ok(())
         }
 
-        /// Deletes the complete state of the Feed.
-        #[pallet::weight((T::DbWeight::get().reads_writes(1, 3), Pays::No))]
-        pub fn delete(origin: OriginFor<T>, feed_id: T::FeedId) -> DispatchResult {
-            let (owner, _feed_config) = ensure_owner!(origin, feed_id);
-            FeedConfigs::<T>::remove(feed_id);
-            Metadata::<T>::remove(feed_id);
-            Totals::<T>::remove(feed_id);
-            Feeds::<T>::remove(owner.clone(), feed_id);
-            Self::deposit_event(Event::FeedDeleted {
-                feed_id,
-                who: owner,
-            });
-            Ok(())
-        }
-
         /// Transfers feed from current owner to new owner
         #[pallet::weight((T::DbWeight::get().reads_writes(1, 3), Pays::No))]
         pub fn transfer(

--- a/crates/pallet-feeds/src/mock.rs
+++ b/crates/pallet-feeds/src/mock.rs
@@ -53,12 +53,14 @@ impl frame_system::Config for Test {
 
 parameter_types! {
     pub const ExistentialDeposit: u64 = 1;
+    pub const MaxFeeds: u32 = 1;
 }
 
 impl pallet_feeds::Config for Test {
     type Event = Event;
     type FeedId = FeedId;
     type FeedProcessorKind = ();
+    type MaxFeeds = MaxFeeds;
 
     fn feed_processor(
         _feed_processor_kind: Self::FeedProcessorKind,

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     mock::{new_test_ext, Event, Feeds, Origin, System, Test},
-    Error, FeedConfigs, Feeds as FeedsStorage, Metadata, Object, TotalObjectsAndSize, Totals,
+    Error, Feeds as FeedsStorage, Object, TotalObjectsAndSize,
 };
 use frame_support::{assert_noop, assert_ok};
 
@@ -116,27 +116,6 @@ fn cannot_close_invalid_feed() {
             Feeds::close(Origin::signed(OWNER), feed_id),
             Error::<Test>::UnknownFeedId
         );
-    });
-}
-
-#[test]
-fn delete_feed() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(Feeds::create(Origin::signed(OWNER), (), None));
-
-        assert!(FeedConfigs::<Test>::contains_key(FEED_ID));
-        assert!(Totals::<Test>::contains_key(FEED_ID));
-
-        // only owner can delete
-        assert_noop!(
-            Feeds::delete(Origin::signed(NOT_OWNER), FEED_ID),
-            Error::<Test>::NotFeedOwner
-        );
-        assert_ok!(Feeds::delete(Origin::signed(OWNER), FEED_ID));
-        assert!(!FeedConfigs::<Test>::contains_key(FEED_ID));
-        assert!(!Metadata::<Test>::contains_key(FEED_ID));
-        assert!(!Totals::<Test>::contains_key(FEED_ID));
-        assert!(!FeedsStorage::<Test>::contains_key(OWNER, FEED_ID));
     });
 }
 

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -167,3 +167,21 @@ fn cannot_update_unknown_feed() {
         );
     });
 }
+
+#[test]
+fn transfer_feed_ownership() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Feeds::create(Origin::signed(OWNER), (), None));
+        assert_eq!(Feeds::feeds(OWNER, FEED_ID), Some(()));
+
+        let new_owner = 102u64;
+        // only owner can transfer
+        assert_noop!(
+            Feeds::transfer(Origin::signed(NOT_OWNER), FEED_ID, new_owner),
+            Error::<Test>::NotFeedOwner
+        );
+        assert_ok!(Feeds::transfer(Origin::signed(OWNER), FEED_ID, new_owner));
+        assert_eq!(Feeds::feeds(OWNER, FEED_ID), None);
+        assert_eq!(Feeds::feeds(new_owner, FEED_ID), Some(()));
+    });
+}

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     mock::{new_test_ext, Event, Feeds, Origin, System, Test},
-    Error, FeedConfigs, Metadata, Object, TotalObjectsAndSize, Totals,
+    Error, FeedConfigs, Feeds as FeedsStorage, Metadata, Object, TotalObjectsAndSize, Totals,
 };
 use frame_support::{assert_noop, assert_ok};
 
@@ -19,7 +19,13 @@ fn create_feed() {
             feed_id: FEED_ID,
             who: OWNER,
         }));
-        assert_eq!(Feeds::next_feed_id(), 1)
+        assert_eq!(Feeds::next_feed_id(), 1);
+        assert_eq!(Feeds::feeds(OWNER, FEED_ID), Some(()));
+        assert_eq!(
+            FeedsStorage::<Test>::iter_prefix(OWNER).collect::<Vec<(u64, ())>>(),
+            vec![(FEED_ID, ())]
+        );
+        assert_eq!(Feeds::feeds(NOT_OWNER, FEED_ID), None);
     });
 }
 
@@ -130,6 +136,7 @@ fn delete_feed() {
         assert!(!FeedConfigs::<Test>::contains_key(FEED_ID));
         assert!(!Metadata::<Test>::contains_key(FEED_ID));
         assert!(!Totals::<Test>::contains_key(FEED_ID));
+        assert!(!FeedsStorage::<Test>::contains_key(OWNER, FEED_ID));
     });
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -581,10 +581,16 @@ impl Default for FeedProcessorKind {
     }
 }
 
+parameter_types! {
+    // Limit maximum number of feeds per account
+    pub const MaxFeeds: u32 = 100;
+}
+
 impl pallet_feeds::Config for Runtime {
     type Event = Event;
     type FeedId = FeedId;
     type FeedProcessorKind = FeedProcessorKind;
+    type MaxFeeds = MaxFeeds;
 
     fn feed_processor(
         feed_processor_kind: FeedProcessorKind,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -521,10 +521,15 @@ impl<C: Chain> FeedProcessor<FeedId> for GrandpaValidator<C> {
     }
 }
 
+parameter_types! {
+    pub const MaxFeeds: u32 = 10;
+}
+
 impl pallet_feeds::Config for Runtime {
     type Event = Event;
     type FeedId = FeedId;
     type FeedProcessorKind = ();
+    type MaxFeeds = MaxFeeds;
 
     fn feed_processor(
         _feed_processor_id: Self::FeedProcessorKind,


### PR DESCRIPTION
This PR introduces following changes:
- Feed ownership: whoever creates the feed is taken as the owner of the feed
- All extrinsics except `create` are permissioned and only owner can successfully call them
- Ability to transfer ownership to someone
- View Feeds owned by any account

Closes: #136 

Edit:
Note: Regarding the indexing the feed owner to feed, there are multiple ways to achieve that. I have made the following assumptions to reach to current storage model
- Fetch all the Feeds
- Fetch Specific feed with feed_id
- Fetch feeds owned by given account
With the current model, we track the owners to feeds in a seperate double map and need to be updated on every transfer

There is an another approach. Combining current Feed config under `owner, feed_id` namespace. The only limiting factor is that we cannot iterate all the feed_ids directly
