### PR TITLE
Make the executor literally follow each primary block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8694,6 +8694,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
+ "subspace-core-primitives",
  "subspace-fraud-proof",
  "subspace-runtime-primitives",
  "substrate-frame-rpc-system",

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -566,6 +566,13 @@ impl<Block: BlockT> SubspaceLink<Block> {
         self.archived_segment_notification_stream.clone()
     }
 
+    /// Get stream with notifications about each imported block.
+    pub fn imported_block_notification_stream(
+        &self,
+    ) -> SubspaceNotificationStream<(NumberFor<Block>, mpsc::Sender<RootBlock>)> {
+        self.imported_block_notification_stream.clone()
+    }
+
     /// Get blocks that are expected to be included at specified block number.
     pub fn root_blocks_for_block(&self, block_number: NumberFor<Block>) -> Vec<RootBlock> {
         self.root_blocks

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -51,6 +51,7 @@ sp-runtime = { version = "6.0.0", git = "https://github.com/paritytech/substrate
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 sp-trie = { version = "6.0.0", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }

--- a/cumulus/parachain-template/node/src/service.rs
+++ b/cumulus/parachain-template/node/src/service.rs
@@ -225,6 +225,7 @@ where
 		&primary_chain_full_node.task_manager,
 		primary_chain_full_node.select_chain.clone(),
 		primary_chain_full_node.new_slot_notification_stream.clone(),
+		primary_chain_full_node.imported_block_notification_stream.clone(),
 	)
 	.await
 	.map_err(|error| sc_service::Error::Other(format!("Failed to create overseer: {}", error)))?;

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -198,6 +198,7 @@ where
 		&primary_chain_full_node.task_manager,
 		primary_chain_full_node.select_chain.clone(),
 		primary_chain_full_node.new_slot_notification_stream.clone(),
+		primary_chain_full_node.imported_block_notification_stream.clone(),
 	)
 	.await
 	.map_err(|error| sc_service::Error::Other(format!("Failed to create overseer: {}", error)))?;

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -353,6 +353,8 @@ where
 						);
 					}
 				},
+				// TODO: we still need the context of block, e.g., executor gossips no message
+				// to the primary node during the major sync.
 				Event::BlockImported(block) => {
 					if !config_initialized {
 						if self.config.is_some() {


### PR DESCRIPTION
This PR aims to solve two problems:

1. The primary blocks imported during the initial sync are not notified to the executor, causing these blocks simply ignored by the executor. Switching to the imported block stream from sc-consensus-subspace solves it.
2.  There is always a gap between the secondary chain height and primary chain height, which is caused by the Overseer config initialization delay.

Please refer to the commit message for more explanation.