### PR TITLE
Secondary chain cleanup part 9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "cirrus-client-executor",
  "cirrus-client-executor-gossip",
  "cirrus-primitives",
+ "futures 0.3.21",
  "parking_lot 0.12.0",
  "sc-client-api",
  "sc-consensus",
@@ -910,6 +911,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-executor",
  "sp-runtime",
  "sp-trie",
  "subspace-service",
@@ -5166,6 +5168,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "futures 0.3.21",
  "hex-literal",
  "jsonrpc-core",
  "log",
@@ -8617,7 +8620,6 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
- "cirrus-client-executor",
  "frame-support",
  "frame-system-rpc-runtime-api",
  "futures 0.3.21",

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,7 +16,6 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-cirrus-client-executor = { path = "../../cumulus/client/cirrus-executor" }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 futures = "0.3.21"
 jsonrpc-core = "18.0.0"

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -628,13 +628,13 @@ where
 		// TODO: validate the Proof-of-Election
 
 		let block_hash = execution_receipt.secondary_hash;
-		let primary_chain_primary_hash =
+		let primary_hash =
 			PBlock::Hash::decode(&mut execution_receipt.primary_hash.encode().as_slice())
 				.expect("Hash type must be correct");
 
 		let block_number = TryInto::<BlockNumber>::try_into(
 			self.primary_chain_client
-				.block_number_from_id(&BlockId::Hash(primary_chain_primary_hash))?
+				.block_number_from_id(&BlockId::Hash(primary_hash))?
 				.ok_or_else(|| {
 					sp_blockchain::Error::Backend(format!(
 						"Primary block number not found for {:?}",

--- a/cumulus/client/cirrus-executor/src/overseer.rs
+++ b/cumulus/client/cirrus-executor/src/overseer.rs
@@ -394,20 +394,20 @@ where
 	events_rx: mpsc::Receiver<Event<PBlock>>,
 }
 
-impl<PBlock, Client> Overseer<PBlock, Client>
+impl<PBlock, PClient> Overseer<PBlock, PClient>
 where
 	PBlock: BlockT,
-	Client: HeaderBackend<PBlock>
+	PClient: HeaderBackend<PBlock>
 		+ BlockBackend<PBlock>
 		+ ProvideRuntimeApi<PBlock>
 		+ Send
 		+ 'static
 		+ Sync,
-	Client::Api: ExecutorApi<PBlock>,
+	PClient::Api: ExecutorApi<PBlock>,
 {
 	/// Create a new overseer.
 	pub fn new(
-		primary_chain_client: Arc<Client>,
+		primary_chain_client: Arc<PClient>,
 		leaves: Vec<(PBlock::Hash, NumberFor<PBlock>)>,
 		active_leaves: HashMap<PBlock::Hash, NumberFor<PBlock>>,
 	) -> (Self, OverseerHandle<PBlock>) {

--- a/cumulus/client/cirrus-service/Cargo.toml
+++ b/cumulus/client/cirrus-service/Cargo.toml
@@ -23,6 +23,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", rev = "c364008a6
 sp-trie = { git = "https://github.com/paritytech/substrate", rev = "c364008a6c7da8456e17967f55edf51e45146998" }
 
 # Other deps
+futures = "0.3.21"
 parking_lot = "0.12.0"
 tracing = "0.1.32"
 
@@ -32,4 +33,5 @@ cirrus-client-executor-gossip = { path = "../executor-gossip" }
 cirrus-primitives = { path = "../../primitives" }
 
 # Subspace
+sp-executor = { path = "../../../crates/sp-executor" }
 subspace-service = { path = "../../../crates/subspace-service" }

--- a/cumulus/client/executor-gossip/src/lib.rs
+++ b/cumulus/client/executor-gossip/src/lib.rs
@@ -107,7 +107,6 @@ where
 pub struct GossipValidator<Block, Executor>
 where
 	Block: BlockT,
-
 	Executor: GossipMessageHandler<Block>,
 {
 	topic: Block::Hash,

--- a/cumulus/client/executor-gossip/src/worker.rs
+++ b/cumulus/client/executor-gossip/src/worker.rs
@@ -23,7 +23,6 @@ where
 impl<Block, Executor> GossipWorker<Block, Executor>
 where
 	Block: BlockT,
-
 	Executor: GossipMessageHandler<Block>,
 {
 	pub(super) fn new(

--- a/cumulus/parachain-template/node/Cargo.toml
+++ b/cumulus/parachain-template/node/Cargo.toml
@@ -26,6 +26,7 @@ runtime-benchmarks = [
 ]
 
 [dependencies]
+futures = "0.3.21"
 hex-literal = "0.3.1"
 log = "0.4.14"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -12,8 +12,9 @@ include = [
 ]
 
 [dependencies]
-rand = "0.8.5"
 async-trait = "0.1.42"
+futures = "0.3.21"
+rand = "0.8.5"
 tokio = { version = "1.17.0", features = ["macros"] }
 tracing = "0.1.32"
 

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -20,8 +20,10 @@
 
 pub mod chain_spec;
 
-use std::{future::Future, sync::Arc};
-
+use cirrus_client_executor::ExecutorSlotInfo;
+use cirrus_client_service::StartExecutorParams;
+use cirrus_test_runtime::{opaque::Block, Hash, RuntimeApi};
+use futures::StreamExt;
 use sc_client_api::execution_extensions::ExecutionStrategies;
 use sc_network::{config::TransportConfig, multiaddr, NetworkService};
 use sc_service::{
@@ -38,13 +40,11 @@ use sp_core::H256;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::{codec::Encode, generic, traits::BlakeTwo256, OpaqueExtrinsic};
 use sp_trie::PrefixedMemoryDB;
+use std::{future::Future, sync::Arc};
 use subspace_runtime_primitives::opaque::Block as PBlock;
 use substrate_test_client::{
 	BlockchainEventsExt, RpcHandlersExt, RpcTransactionError, RpcTransactionOutput,
 };
-
-use cirrus_client_service::{start_executor, StartExecutorParams};
-use cirrus_test_runtime::{opaque::Block, Hash, RuntimeApi};
 
 pub use cirrus_test_runtime as runtime;
 pub use sp_keyring::Sr25519Keyring as Keyring;
@@ -195,16 +195,6 @@ where
 		.map_err(|_| sc_service::Error::Other("Failed to build a full subspace node".into()))?
 	};
 
-	let overseer_handle = subspace_service::create_overseer(
-		primary_chain_full_node.client.clone(),
-		&primary_chain_full_node.task_manager,
-		primary_chain_full_node.select_chain.clone(),
-		primary_chain_full_node.new_slot_notification_stream.clone(),
-		primary_chain_full_node.imported_block_notification_stream.clone(),
-	)
-	.await
-	.map_err(|error| sc_service::Error::Other(format!("Failed to create overseer: {}", error)))?;
-
 	let client = params.client.clone();
 	let backend = params.backend.clone();
 
@@ -240,11 +230,25 @@ where
 
 	let code_executor = Arc::new(params.other);
 	let params = StartExecutorParams {
+		primary_chain_client: primary_chain_full_node.client.clone(),
+		spawn_essential: &task_manager.spawn_essential_handle(),
+		select_chain: &primary_chain_full_node.select_chain,
+		imported_block_notification_stream: primary_chain_full_node
+			.imported_block_notification_stream
+			.subscribe()
+			.then(|(block_number, _)| async move { block_number }),
+		new_slot_notification_stream: primary_chain_full_node
+			.new_slot_notification_stream
+			.subscribe()
+			.then(|slot_notification| async move {
+				let slot_info = slot_notification.new_slot_info;
+				ExecutorSlotInfo {
+					slot: slot_info.slot,
+					global_challenge: slot_info.global_challenge,
+				}
+			}),
 		client: client.clone(),
 		spawner: Box::new(task_manager.spawn_handle()),
-		task_manager: &mut task_manager,
-		primary_chain_full_node,
-		overseer_handle,
 		transaction_pool,
 		network: network.clone(),
 		backend: backend.clone(),
@@ -252,7 +256,9 @@ where
 		is_authority: validator,
 	};
 
-	let executor = start_executor(params).await?;
+	let executor = cirrus_client_service::start_executor(params).await?;
+
+	task_manager.add_child(primary_chain_full_node.task_manager);
 
 	start_network.start_network();
 


### PR DESCRIPTION
This is the last PR in a series.

Executor is the only thing aware of what has left of overseer (still needs more refactoring, as part of executor now, but should be fine otherwise).

@liuchengxu please take it from here and integrate execution into consensus node. The only thing not done here is delaying the start of the networking of the primary node. Subscription refactoring and other things are done either in this PR or in the previous one.

As of this PR primary chain doesn't have any logic that is aware of secondary chain existence, its API is abstracted in a good enough way. What I think needs to be done is to assemble everything with secondary chain in `subspace-node` rather than in `subspace-service`, but `network_starter` needs to be exposed from `subspace-service` so we can control when to call it.