### PR TITLE
Moving global object mapping update to multifarming

### DIFF
--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,0 +1,314 @@
+use crate::rpc::{self, RpcClient};
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+use log::{debug, error, info, warn};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use subspace_archiving::archiver::{ArchivedSegment, Archiver};
+use subspace_core_primitives::{BlockNumber, RootBlock};
+use subspace_rpc_primitives::{EncodedBlockWithObjectMapping, FarmerMetadata};
+use tokio::task::JoinError;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+// Abstraction around background block querying and archiving
+pub struct Archiving {
+    stop_sender: Option<oneshot::Sender<()>>,
+    new_blocks_handle: Option<JoinHandle<()>>,
+    archiving_handle: Option<JoinHandle<()>>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Plot is empty on restart, can't continue")]
+    ContinueError,
+    #[error("Failed to get block {0} from the chain, probably need to erase existing plot")]
+    GetBlockError(u32),
+    #[error("jsonrpsee error: {0}")]
+    RpcError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Archiver instantiation error: {0}")]
+    Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
+}
+
+impl Archiving {
+    // Start block archiving in the background
+    pub async fn start(
+        client: impl RpcClient + Clone + Send + Sync + 'static,
+        maybe_last_root_block: Option<RootBlock>,
+        best_block_number_check_interval: Duration,
+        plot_is_empty: bool,
+        archived_blocks_sender: std::sync::mpsc::SyncSender<(BlockNumber, Vec<ArchivedSegment>)>,
+    ) -> Result<Self, Error> {
+        let FarmerMetadata {
+            record_size,
+            recorded_history_segment_size,
+            ..
+        } = client.farmer_metadata().await.map_err(Error::RpcError)?;
+
+        let archiver = if let Some(last_root_block) = maybe_last_root_block {
+            // Continuing from existing initial state
+            if plot_is_empty {
+                return Err(Error::ContinueError);
+            }
+
+            let last_archived_block_number = last_root_block.last_archived_block().number;
+            info!("Last archived block {}", last_archived_block_number);
+
+            let maybe_last_archived_block = client
+                .block_by_number(last_archived_block_number)
+                .await
+                .map_err(Error::RpcError)?;
+
+            match maybe_last_archived_block {
+                Some(EncodedBlockWithObjectMapping {
+                    block,
+                    object_mapping,
+                }) => Archiver::with_initial_state(
+                    record_size as usize,
+                    recorded_history_segment_size as usize,
+                    last_root_block,
+                    &block,
+                    object_mapping,
+                )
+                .map_err(Error::Archiver)?,
+                None => {
+                    return Err(Error::GetBlockError(last_archived_block_number));
+                }
+            }
+        } else {
+            // Starting from genesis
+            if !plot_is_empty {
+                // Restart before first block was archived, erase the plot
+                // TODO: Erase plot
+            }
+
+            Archiver::new(record_size as usize, recorded_history_segment_size as usize)
+                .map_err(Error::Archiver)?
+        };
+
+        let (new_block_to_archive_sender, new_block_to_archive_receiver) =
+            std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
+        let (stop_sender, stop_receiver) = oneshot::channel::<()>();
+
+        let new_blocks_handle = spawn_listening_to_blocks(
+            client.clone(),
+            maybe_last_root_block,
+            new_block_to_archive_sender,
+            stop_receiver,
+            best_block_number_check_interval,
+        )
+        .await
+        .map_err(Error::RpcError)?;
+
+        let archiving_handle = spawn_archiving(
+            client,
+            archiver,
+            new_block_to_archive_receiver,
+            archived_blocks_sender,
+        );
+        Ok(Self {
+            stop_sender: Some(stop_sender),
+            new_blocks_handle: Some(new_blocks_handle),
+            archiving_handle: Some(archiving_handle),
+        })
+    }
+
+    /// Waits for the background block archiving to finish
+    pub async fn wait(mut self) -> Result<(), JoinError> {
+        self.new_blocks_handle.take().unwrap().await?;
+        self.archiving_handle.take().unwrap().await
+    }
+}
+
+impl Drop for Archiving {
+    fn drop(&mut self) {
+        let _ = self.stop_sender.take().unwrap().send(());
+    }
+}
+
+async fn spawn_listening_to_blocks(
+    client: impl RpcClient + Clone + Send + Sync + 'static,
+    maybe_last_root_block: Option<RootBlock>,
+    new_block_to_archive_sender: std::sync::mpsc::SyncSender<Arc<AtomicU32>>,
+    mut stop_receiver: oneshot::Receiver<()>,
+    best_block_number_check_interval: Duration,
+) -> Result<JoinHandle<()>, rpc::Error> {
+    let confirmation_depth_k = client.farmer_metadata().await?.confirmation_depth_k;
+
+    info!("Subscribing to new heads");
+    let mut new_head = client.subscribe_new_head().await?;
+
+    let block_to_archive = Arc::new(AtomicU32::default());
+
+    if maybe_last_root_block.is_none() {
+        // If not continuation, archive genesis block
+        new_block_to_archive_sender
+            .send(Arc::clone(&block_to_archive))
+            .expect("Failed to send genesis block archiving message");
+    }
+
+    let (mut best_block_number_sender, mut best_block_number_receiver) = mpsc::channel(1);
+
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(best_block_number_check_interval).await;
+
+            // In case connection dies, we need to disconnect from the node
+            let best_block_number_result =
+                tokio::time::timeout(BEST_BLOCK_REQUEST_TIMEOUT, client.best_block_number()).await;
+
+            let is_error = !matches!(best_block_number_result, Ok(Ok(_)));
+            // Result doesn't matter here
+            let _ = best_block_number_sender
+                .send(best_block_number_result)
+                .await;
+
+            if is_error {
+                break;
+            }
+        }
+    });
+
+    let mut last_best_block_number_error = false;
+
+    // Listen for new blocks produced on the network
+    let handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut stop_receiver => {
+                    info!("Plotting stopped!");
+                    break;
+                }
+                result = new_head.recv() => {
+                    match result {
+                        Some(head) => {
+                            let block_number = u32::from_str_radix(&head.number[2..], 16).unwrap();
+                            debug!("Last block number: {:#?}", block_number);
+
+                            if let Some(block_number) = block_number.checked_sub(confirmation_depth_k) {
+                                // We send block that should be archived over channel that doesn't have
+                                // a buffer, atomic integer is used to make sure archiving process
+                                // always read up to date value
+                                block_to_archive.store(block_number, Ordering::Relaxed);
+                                let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
+                            }
+                        },
+                        None => {
+                            debug!("Subscription has forcefully closed from node side!");
+                            break;
+                        }
+                    }
+                }
+                maybe_result = best_block_number_receiver.next() => {
+                    match maybe_result {
+                        Some(Ok(Ok(best_block_number))) => {
+                            debug!("Best block number: {:#?}", best_block_number);
+                            last_best_block_number_error = false;
+
+                            if let Some(block_number) = best_block_number.checked_sub(confirmation_depth_k) {
+                                // We send block that should be archived over channel that doesn't have
+                                // a buffer, atomic integer is used to make sure archiving process
+                                // always read up to date value
+                                block_to_archive.fetch_max(block_number, Ordering::Relaxed);
+                                let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
+                            }
+                        }
+                        Some(Ok(Err(error))) => {
+                            if last_best_block_number_error {
+                                error!("Request to get new best block failed second time: {error}");
+                                break;
+                            } else {
+                                warn!("Request to get new best block failed: {error}");
+                                last_best_block_number_error = true;
+                            }
+                        }
+                        Some(Err(_error)) => {
+                            if last_best_block_number_error {
+                                error!("Request to get new best block timed out second time");
+                                break;
+                            } else {
+                                warn!("Request to get new best block timed out");
+                                last_best_block_number_error = true;
+                            }
+                        }
+                        None => {
+                            debug!("Best block number channel closed!");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(handle)
+}
+
+fn spawn_archiving(
+    client: impl RpcClient + Clone + Send + Sync + 'static,
+    mut archiver: Archiver,
+    new_block_to_archive_receiver: std::sync::mpsc::Receiver<Arc<AtomicU32>>,
+    archived_blocks_sender: std::sync::mpsc::SyncSender<(BlockNumber, Vec<ArchivedSegment>)>,
+) -> JoinHandle<()> {
+    // Process blocks since last fully archived block (or genesis) up to the current head minus K
+    let mut blocks_to_archive_from = archiver
+        .last_archived_block_number()
+        .map(|n| n + 1)
+        .unwrap_or_default();
+
+    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
+    tokio::task::spawn_blocking({
+        #[allow(clippy::mut_range_bound)]
+        move || {
+            let runtime_handle = tokio::runtime::Handle::current();
+
+            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
+                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
+                if blocks_to_archive_to >= blocks_to_archive_from {
+                    debug!(
+                        "Archiving blocks {}..={}",
+                        blocks_to_archive_from, blocks_to_archive_to,
+                    );
+                }
+
+                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
+                    let EncodedBlockWithObjectMapping {
+                        block,
+                        object_mapping,
+                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
+                        Ok(Some(block)) => block,
+                        Ok(None) => {
+                            error!(
+                                "Failed to get block #{} from RPC: Block not found",
+                                block_to_archive,
+                            );
+
+                            blocks_to_archive_from = block_to_archive;
+                            continue 'outer;
+                        }
+                        Err(error) => {
+                            error!(
+                                "Failed to get block #{} from RPC: {}",
+                                block_to_archive, error,
+                            );
+
+                            blocks_to_archive_from = block_to_archive;
+                            continue 'outer;
+                        }
+                    };
+
+                    if archived_blocks_sender
+                        .send((block_to_archive, archiver.add_block(block, object_mapping)))
+                        .is_err()
+                    {
+                        break 'outer;
+                    }
+                }
+
+                blocks_to_archive_from = blocks_to_archive_to + 1;
+            }
+        }
+    })
+}

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -17,6 +17,7 @@
 
 #![feature(try_blocks, hash_drain_filter, int_log, io_error_other)]
 
+pub(crate) mod archiving;
 pub(crate) mod commitments;
 pub(crate) mod farming;
 pub(crate) mod identity;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -32,6 +32,7 @@ pub mod ws_rpc_server;
 #[cfg(test)]
 mod mock_rpc;
 
+pub use archiving::{Archiving, Error as ArchivingError};
 pub use commitments::{CommitmentError, Commitments};
 pub use farming::{Farming, FarmingError};
 pub use identity::Identity;

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -140,7 +140,8 @@ pub(crate) async fn farm_single_plot(
         client,
         subspace_codec,
         best_block_number_check_interval,
-    );
+    )
+    .await?;
 
     Ok((plot, plotting_instance, farming_instance))
 }

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -1,48 +1,41 @@
 #[cfg(test)]
 mod tests;
 
+use crate::archiving::{self, Archiving};
 use crate::commitments::Commitments;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::rpc::RpcClient;
-use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
-use log::{debug, error, info, warn};
-use std::sync::atomic::{AtomicU32, Ordering};
+use log::{error, info};
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_archiving::archiver::{ArchivedSegment, Archiver};
+use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
-use subspace_core_primitives::{BlockNumber, PieceIndex, RootBlock, Sha256Hash};
-use subspace_rpc_primitives::{EncodedBlockWithObjectMapping, FarmerMetadata};
+use subspace_core_primitives::{BlockNumber, PieceIndex, Sha256Hash};
+use subspace_rpc_primitives::FarmerMetadata;
 use subspace_solving::SubspaceCodec;
 use thiserror::Error;
-use tokio::sync::oneshot::Receiver;
-use tokio::{sync::oneshot, task::JoinHandle};
-
-const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+use tokio::task::JoinHandle;
 
 #[derive(Debug, Error)]
 pub enum PlottingError {
-    #[error("Plot is empty on restart, can't continue")]
-    ContinueError,
-    #[error("Failed to get block {0} from the chain, probably need to erase existing plot")]
-    GetBlockError(u32),
-    #[error("jsonrpsee error: {0}")]
-    RpcError(Box<dyn std::error::Error + Send + Sync>),
     #[error("Last block retrieval from plot, rocksdb error: {0}")]
     LastBlock(rocksdb::Error),
     #[error("Error joining task: {0}")]
     JoinTask(tokio::task::JoinError),
-    #[error("Archiver instantiation error: {0}")]
-    Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
+    #[error("Error during archiving start")]
+    ArchivingStart(
+        #[from]
+        #[source]
+        archiving::Error,
+    ),
 }
 /// `Plotting` struct is the abstraction of the plotting process
 ///
 /// Plotting Instance that stores a channel to stop/pause the background farming task
 /// and a handle to make it possible to wait on this background task
 pub struct Plotting {
-    stop_sender: Option<oneshot::Sender<()>>,
+    archiving: Archiving,
     handle: Option<JoinHandle<Result<(), PlottingError>>>,
 }
 
@@ -72,32 +65,50 @@ impl FarmerData {
 /// Assumes `plot`, `commitment`, `object_mappings`, `client` and `identity` are already initialized
 impl Plotting {
     /// Returns an instance of plotting, and also starts a concurrent background plotting task
-    pub fn start<T: RpcClient + Clone + Send + Sync + 'static>(
+    pub async fn start<T: RpcClient + Clone + Send + Sync + 'static>(
         farmer_data: FarmerData,
         client: T,
         subspace_codec: SubspaceCodec,
         best_block_number_check_interval: Duration,
-    ) -> Self {
-        // Oneshot channels, that will be used for interrupt/stop the process
-        let (stop_sender, stop_receiver) = oneshot::channel();
+    ) -> Result<Self, PlottingError> {
+        let (archived_blocks_sender, archived_blocks_receiver) =
+            std::sync::mpsc::sync_channel::<(BlockNumber, Vec<ArchivedSegment>)>(0);
+        let maybe_last_root_block = tokio::task::spawn_blocking({
+            let plot = farmer_data.plot.clone();
+
+            move || plot.get_last_root_block().map_err(PlottingError::LastBlock)
+        })
+        .await
+        .unwrap()?;
+
+        let archiving = Archiving::start(
+            client.clone(),
+            maybe_last_root_block,
+            best_block_number_check_interval,
+            farmer_data.plot.is_empty(),
+            archived_blocks_sender,
+        )
+        .await?;
 
         // Get a handle for the background task, so that we can wait on it later if we want to
         let plotting_handle = tokio::spawn(background_plotting(
             farmer_data,
-            client,
             subspace_codec,
-            best_block_number_check_interval,
-            stop_receiver,
+            archived_blocks_receiver,
         ));
 
-        Plotting {
-            stop_sender: Some(stop_sender),
+        Ok(Plotting {
+            archiving,
             handle: Some(plotting_handle),
-        }
+        })
     }
 
     /// Waits for the background plotting to finish
     pub async fn wait(mut self) -> Result<(), PlottingError> {
+        self.archiving
+            .wait()
+            .await
+            .map_err(PlottingError::JoinTask)?;
         self.handle
             .take()
             .unwrap()
@@ -106,25 +117,16 @@ impl Plotting {
     }
 }
 
-impl Drop for Plotting {
-    fn drop(&mut self) {
-        let _ = self.stop_sender.take().unwrap().send(());
-    }
-}
-
 // TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
 //  don't want eventually
 /// Maintains plot in up to date state plotting new pieces as they are produced on the network.
-async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
+async fn background_plotting(
     farmer_data: FarmerData,
-    client: T,
     mut subspace_codec: SubspaceCodec,
-    best_block_number_check_interval: Duration,
-    stop_receiver: Receiver<()>,
+    archived_blocks_receiver: std::sync::mpsc::Receiver<(BlockNumber, Vec<ArchivedSegment>)>,
 ) -> Result<(), PlottingError> {
     let weak_plot = farmer_data.plot.downgrade();
     let FarmerMetadata {
-        confirmation_depth_k,
         record_size,
         recorded_history_segment_size,
         ..
@@ -132,69 +134,6 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
 
     // TODO: This assumes fixed size segments, which might not be the case
     let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
-
-    let maybe_last_root_block = tokio::task::spawn_blocking({
-        let plot = farmer_data.plot.clone();
-
-        move || plot.get_last_root_block().map_err(PlottingError::LastBlock)
-    })
-    .await
-    .unwrap()?;
-
-    let archiver = if let Some(last_root_block) = maybe_last_root_block {
-        // Continuing from existing initial state
-        if farmer_data.plot.is_empty() {
-            return Err(PlottingError::ContinueError);
-        }
-
-        let last_archived_block_number = last_root_block.last_archived_block().number;
-        info!("Last archived block {}", last_archived_block_number);
-
-        let maybe_last_archived_block = client
-            .block_by_number(last_archived_block_number)
-            .await
-            .map_err(PlottingError::RpcError)?;
-
-        match maybe_last_archived_block {
-            Some(EncodedBlockWithObjectMapping {
-                block,
-                object_mapping,
-            }) => Archiver::with_initial_state(
-                record_size as usize,
-                recorded_history_segment_size as usize,
-                last_root_block,
-                &block,
-                object_mapping,
-            )
-            .map_err(PlottingError::Archiver)?,
-            None => {
-                return Err(PlottingError::GetBlockError(last_archived_block_number));
-            }
-        }
-    } else {
-        // Starting from genesis
-        if !farmer_data.plot.is_empty() {
-            // Restart before first block was archived, erase the plot
-            // TODO: Erase plot
-        }
-
-        drop(farmer_data.plot);
-
-        Archiver::new(record_size as usize, recorded_history_segment_size as usize)
-            .map_err(PlottingError::Archiver)?
-    };
-
-    let (new_block_to_archive_sender, new_block_to_archive_receiver) =
-        std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
-    let (archived_blocks_sender, archived_blocks_receiver) =
-        std::sync::mpsc::sync_channel::<(BlockNumber, Vec<ArchivedSegment>)>(0);
-
-    spawn_archiving(
-        client.clone(),
-        archiver,
-        new_block_to_archive_receiver,
-        archived_blocks_sender,
-    );
 
     // Erasure coding in archiver and piece encoding are CPU-intensive operations.
     tokio::task::spawn_blocking({
@@ -276,204 +215,7 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
         }
     });
 
-    spawn_listening_to_blocks(
-        client,
-        maybe_last_root_block,
-        new_block_to_archive_sender,
-        stop_receiver,
-        best_block_number_check_interval,
-        confirmation_depth_k,
-    )
-    .await?;
-
     Ok(())
-}
-
-async fn spawn_listening_to_blocks(
-    client: impl RpcClient + Clone + Send + Sync + 'static,
-    maybe_last_root_block: Option<RootBlock>,
-    new_block_to_archive_sender: std::sync::mpsc::SyncSender<Arc<AtomicU32>>,
-    mut stop_receiver: oneshot::Receiver<()>,
-    best_block_number_check_interval: Duration,
-    confirmation_depth_k: BlockNumber,
-) -> Result<JoinHandle<()>, PlottingError> {
-    info!("Subscribing to new heads");
-    let mut new_head = client
-        .subscribe_new_head()
-        .await
-        .map_err(PlottingError::RpcError)?;
-
-    let block_to_archive = Arc::new(AtomicU32::default());
-
-    if maybe_last_root_block.is_none() {
-        // If not continuation, archive genesis block
-        new_block_to_archive_sender
-            .send(Arc::clone(&block_to_archive))
-            .expect("Failed to send genesis block archiving message");
-    }
-
-    let (mut best_block_number_sender, mut best_block_number_receiver) = mpsc::channel(1);
-
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(best_block_number_check_interval).await;
-
-            // In case connection dies, we need to disconnect from the node
-            let best_block_number_result =
-                tokio::time::timeout(BEST_BLOCK_REQUEST_TIMEOUT, client.best_block_number()).await;
-
-            let is_error = !matches!(best_block_number_result, Ok(Ok(_)));
-            // Result doesn't matter here
-            let _ = best_block_number_sender
-                .send(best_block_number_result)
-                .await;
-
-            if is_error {
-                break;
-            }
-        }
-    });
-
-    let mut last_best_block_number_error = false;
-
-    // Listen for new blocks produced on the network
-    let handle = tokio::spawn(async move {
-        loop {
-            tokio::select! {
-                _ = &mut stop_receiver => {
-                    info!("Plotting stopped!");
-                    break;
-                }
-                result = new_head.recv() => {
-                    match result {
-                        Some(head) => {
-                            let block_number = u32::from_str_radix(&head.number[2..], 16).unwrap();
-                            debug!("Last block number: {:#?}", block_number);
-
-                            if let Some(block_number) = block_number.checked_sub(confirmation_depth_k) {
-                                // We send block that should be archived over channel that doesn't have
-                                // a buffer, atomic integer is used to make sure archiving process
-                                // always read up to date value
-                                block_to_archive.store(block_number, Ordering::Relaxed);
-                                let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
-                            }
-                        },
-                        None => {
-                            debug!("Subscription has forcefully closed from node side!");
-                            break;
-                        }
-                    }
-                }
-                maybe_result = best_block_number_receiver.next() => {
-                    match maybe_result {
-                        Some(Ok(Ok(best_block_number))) => {
-                            debug!("Best block number: {:#?}", best_block_number);
-                            last_best_block_number_error = false;
-
-                            if let Some(block_number) = best_block_number.checked_sub(confirmation_depth_k) {
-                                // We send block that should be archived over channel that doesn't have
-                                // a buffer, atomic integer is used to make sure archiving process
-                                // always read up to date value
-                                block_to_archive.fetch_max(block_number, Ordering::Relaxed);
-                                let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
-                            }
-                        }
-                        Some(Ok(Err(error))) => {
-                            if last_best_block_number_error {
-                                error!("Request to get new best block failed second time: {error}");
-                                break;
-                            } else {
-                                warn!("Request to get new best block failed: {error}");
-                                last_best_block_number_error = true;
-                            }
-                        }
-                        Some(Err(_error)) => {
-                            if last_best_block_number_error {
-                                error!("Request to get new best block timed out second time");
-                                break;
-                            } else {
-                                warn!("Request to get new best block timed out");
-                                last_best_block_number_error = true;
-                            }
-                        }
-                        None => {
-                            debug!("Best block number channel closed!");
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    });
-
-    Ok(handle)
-}
-
-fn spawn_archiving(
-    client: impl RpcClient + Clone + Send + Sync + 'static,
-    mut archiver: Archiver,
-    new_block_to_archive_receiver: std::sync::mpsc::Receiver<Arc<AtomicU32>>,
-    archived_blocks_sender: std::sync::mpsc::SyncSender<(BlockNumber, Vec<ArchivedSegment>)>,
-) -> JoinHandle<()> {
-    // Process blocks since last fully archived block (or genesis) up to the current head minus K
-    let mut blocks_to_archive_from = archiver
-        .last_archived_block_number()
-        .map(|n| n + 1)
-        .unwrap_or_default();
-
-    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
-    tokio::task::spawn_blocking({
-        #[allow(clippy::mut_range_bound)]
-        move || {
-            let runtime_handle = tokio::runtime::Handle::current();
-
-            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
-                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
-                if blocks_to_archive_to >= blocks_to_archive_from {
-                    debug!(
-                        "Archiving blocks {}..={}",
-                        blocks_to_archive_from, blocks_to_archive_to,
-                    );
-                }
-
-                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
-                    let EncodedBlockWithObjectMapping {
-                        block,
-                        object_mapping,
-                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
-                        Ok(Some(block)) => block,
-                        Ok(None) => {
-                            error!(
-                                "Failed to get block #{} from RPC: Block not found",
-                                block_to_archive,
-                            );
-
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                        Err(error) => {
-                            error!(
-                                "Failed to get block #{} from RPC: {}",
-                                block_to_archive, error,
-                            );
-
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                    };
-
-                    if archived_blocks_sender
-                        .send((block_to_archive, archiver.add_block(block, object_mapping)))
-                        .is_err()
-                    {
-                        break 'outer;
-                    }
-                }
-
-                blocks_to_archive_from = blocks_to_archive_to + 1;
-            }
-        }
-    })
 }
 
 fn create_global_object_mapping(

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -141,7 +141,7 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
     .await
     .unwrap()?;
 
-    let mut archiver = if let Some(last_root_block) = maybe_last_root_block {
+    let archiver = if let Some(last_root_block) = maybe_last_root_block {
         // Continuing from existing initial state
         if farmer_data.plot.is_empty() {
             return Err(PlottingError::ContinueError);
@@ -186,134 +186,92 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
 
     let (new_block_to_archive_sender, new_block_to_archive_receiver) =
         std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
+    let (archived_blocks_sender, archived_blocks_receiver) =
+        std::sync::mpsc::sync_channel::<(BlockNumber, Vec<ArchivedSegment>)>(0);
 
-    // Process blocks since last fully archived block (or genesis) up to the current head minus K
-    let mut blocks_to_archive_from = archiver
-        .last_archived_block_number()
-        .map(|n| n + 1)
-        .unwrap_or_default();
+    spawn_archiving(
+        client.clone(),
+        archiver,
+        new_block_to_archive_receiver,
+        archived_blocks_sender,
+    );
 
     // Erasure coding in archiver and piece encoding are CPU-intensive operations.
     tokio::task::spawn_blocking({
-        let client = client.clone();
         let weak_plot = weak_plot.clone();
 
-        #[allow(clippy::mut_range_bound)]
         move || {
-            let runtime_handle = tokio::runtime::Handle::current();
             info!("Plotting new blocks in the background");
 
-            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
-                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
-                if blocks_to_archive_to >= blocks_to_archive_from {
-                    debug!(
-                        "Archiving blocks {}..={}",
-                        blocks_to_archive_from, blocks_to_archive_to,
-                    );
-                }
-
-                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
-                    let EncodedBlockWithObjectMapping {
-                        block,
+            for (block_number, archived_block) in archived_blocks_receiver {
+                let mut last_root_block = None;
+                for archived_segment in archived_block {
+                    let ArchivedSegment {
+                        root_block,
+                        mut pieces,
                         object_mapping,
-                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
-                        Ok(Some(block)) => block,
-                        Ok(None) => {
-                            error!(
-                                "Failed to get block #{} from RPC: Block not found",
-                                block_to_archive,
-                            );
+                    } = archived_segment;
+                    let piece_index_offset = merkle_num_leaves * root_block.segment_index();
 
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
+                    let object_mapping =
+                        create_global_object_mapping(piece_index_offset, object_mapping);
+
+                    // TODO: Batch encoding with more than 1 archived segment worth of data
+                    if let Some(plot) = weak_plot.upgrade() {
+                        let piece_indexes = (piece_index_offset..)
+                            .take(pieces.count())
+                            .collect::<Vec<PieceIndex>>();
+
+                        if let Err(error) = subspace_codec.batch_encode(&mut pieces, &piece_indexes)
+                        {
+                            error!("Failed to encode a piece: error: {}", error);
+                            continue;
                         }
-                        Err(error) => {
-                            error!(
-                                "Failed to get block #{} from RPC: {}",
-                                block_to_archive, error,
-                            );
+                        let pieces = Arc::new(pieces);
 
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                    };
-
-                    let mut last_root_block = None;
-                    for archived_segment in archiver.add_block(block, object_mapping) {
-                        let ArchivedSegment {
-                            root_block,
-                            mut pieces,
-                            object_mapping,
-                        } = archived_segment;
-                        let piece_index_offset = merkle_num_leaves * root_block.segment_index();
-
-                        let object_mapping =
-                            create_global_object_mapping(piece_index_offset, object_mapping);
-
-                        // TODO: Batch encoding with more than 1 archived segment worth of data
-                        if let Some(plot) = weak_plot.upgrade() {
-                            let piece_indexes = (piece_index_offset..)
-                                .take(pieces.count())
-                                .collect::<Vec<PieceIndex>>();
-
-                            if let Err(error) =
-                                subspace_codec.batch_encode(&mut pieces, &piece_indexes)
-                            {
-                                error!("Failed to encode a piece: error: {}", error);
-                                continue;
-                            }
-                            let pieces = Arc::new(pieces);
-
-                            match plot.write_many(Arc::clone(&pieces), piece_indexes) {
-                                Ok(write_result) => {
-                                    if let Err(error) = farmer_data
-                                        .commitments
-                                        .remove_pieces(write_result.evicted_pieces())
-                                    {
-                                        error!(
-                                            "Failed to remove old commitments for pieces: {}",
-                                            error
-                                        );
-                                    }
-
-                                    // TODO: This will not create commitments properly if pieces are
-                                    //  evicted during plotting
-                                    if let Err(error) =
-                                        farmer_data.commitments.create_for_pieces(|| {
-                                            write_result.to_recommitment_iterator()
-                                        })
-                                    {
-                                        error!(
-                                            "Failed to create commitments for pieces: {}",
-                                            error
-                                        );
-                                    }
+                        match plot.write_many(Arc::clone(&pieces), piece_indexes) {
+                            Ok(write_result) => {
+                                if let Err(error) = farmer_data
+                                    .commitments
+                                    .remove_pieces(write_result.evicted_pieces())
+                                {
+                                    error!(
+                                        "Failed to remove old commitments for pieces: {}",
+                                        error
+                                    );
                                 }
-                                Err(error) => error!("Failed to write encoded pieces: {}", error),
-                            }
-                            if let Err(error) = farmer_data.object_mappings.store(&object_mapping) {
-                                error!("Failed to store object mappings for pieces: {}", error);
-                            }
-                            let segment_index = root_block.segment_index();
-                            last_root_block.replace(root_block);
 
-                            info!(
-                                "Archived segment {} at block {}",
-                                segment_index, block_to_archive
-                            );
-                        }
-                    }
-
-                    if let Some(last_root_block) = last_root_block {
-                        if let Some(plot) = weak_plot.upgrade() {
-                            if let Err(error) = plot.set_last_root_block(&last_root_block) {
-                                error!("Failed to store last root block: {}", error);
+                                // TODO: This will not create commitments properly if pieces are
+                                //  evicted during plotting
+                                if let Err(error) = farmer_data
+                                    .commitments
+                                    .create_for_pieces(|| write_result.to_recommitment_iterator())
+                                {
+                                    error!("Failed to create commitments for pieces: {}", error);
+                                }
                             }
+                            Err(error) => error!("Failed to write encoded pieces: {}", error),
                         }
+                        if let Err(error) = farmer_data.object_mappings.store(&object_mapping) {
+                            error!("Failed to store object mappings for pieces: {}", error);
+                        }
+                        let segment_index = root_block.segment_index();
+                        last_root_block.replace(root_block);
+
+                        info!(
+                            "Archived segment {} at block {}",
+                            segment_index, block_number
+                        );
                     }
                 }
 
-                blocks_to_archive_from = blocks_to_archive_to + 1;
+                if let Some(last_root_block) = last_root_block {
+                    if let Some(plot) = weak_plot.upgrade() {
+                        if let Err(error) = plot.set_last_root_block(&last_root_block) {
+                            error!("Failed to store last root block: {}", error);
+                        }
+                    }
+                }
             }
         }
     });
@@ -449,6 +407,73 @@ async fn spawn_listening_to_blocks(
     });
 
     Ok(handle)
+}
+
+fn spawn_archiving(
+    client: impl RpcClient + Clone + Send + Sync + 'static,
+    mut archiver: Archiver,
+    new_block_to_archive_receiver: std::sync::mpsc::Receiver<Arc<AtomicU32>>,
+    archived_blocks_sender: std::sync::mpsc::SyncSender<(BlockNumber, Vec<ArchivedSegment>)>,
+) -> JoinHandle<()> {
+    // Process blocks since last fully archived block (or genesis) up to the current head minus K
+    let mut blocks_to_archive_from = archiver
+        .last_archived_block_number()
+        .map(|n| n + 1)
+        .unwrap_or_default();
+
+    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
+    tokio::task::spawn_blocking({
+        #[allow(clippy::mut_range_bound)]
+        move || {
+            let runtime_handle = tokio::runtime::Handle::current();
+
+            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
+                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
+                if blocks_to_archive_to >= blocks_to_archive_from {
+                    debug!(
+                        "Archiving blocks {}..={}",
+                        blocks_to_archive_from, blocks_to_archive_to,
+                    );
+                }
+
+                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
+                    let EncodedBlockWithObjectMapping {
+                        block,
+                        object_mapping,
+                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
+                        Ok(Some(block)) => block,
+                        Ok(None) => {
+                            error!(
+                                "Failed to get block #{} from RPC: Block not found",
+                                block_to_archive,
+                            );
+
+                            blocks_to_archive_from = block_to_archive;
+                            continue 'outer;
+                        }
+                        Err(error) => {
+                            error!(
+                                "Failed to get block #{} from RPC: {}",
+                                block_to_archive, error,
+                            );
+
+                            blocks_to_archive_from = block_to_archive;
+                            continue 'outer;
+                        }
+                    };
+
+                    if archived_blocks_sender
+                        .send((block_to_archive, archiver.add_block(block, object_mapping)))
+                        .is_err()
+                    {
+                        break 'outer;
+                    }
+                }
+
+                blocks_to_archive_from = blocks_to_archive_to + 1;
+            }
+        }
+    })
 }
 
 fn create_global_object_mapping(

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -1,7 +1,6 @@
 use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::mock_rpc::MockRpc;
-use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::plotting::{FarmerData, Plotting};
 use crate::rpc::NewHead;
@@ -38,7 +37,6 @@ async fn plotting_happy_path() {
     let address = identity.public_key().to_bytes().into();
     let plot = Plot::open_or_create(&base_directory, address, u64::MAX).unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
-    let object_mappings = ObjectMappings::open_or_create(&base_directory).unwrap();
 
     let client = MockRpc::new();
 
@@ -54,7 +52,7 @@ async fn plotting_happy_path() {
 
     let subspace_codec = SubspaceCodec::new(identity.public_key());
 
-    let farmer_data = FarmerData::new(plot.clone(), commitments, object_mappings, farmer_metadata);
+    let farmer_data = FarmerData::new(plot.clone(), commitments, farmer_metadata);
 
     let encoded_block0 = EncodedBlockWithObjectMapping {
         block: vec![0u8; SEGMENT_SIZE / 2],
@@ -147,7 +145,6 @@ async fn plotting_continue() {
 
     let plot = Plot::open_or_create(&base_directory, address, u64::MAX).unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
-    let object_mappings = ObjectMappings::open_or_create(&base_directory).unwrap();
 
     let client = MockRpc::new();
 
@@ -163,12 +160,7 @@ async fn plotting_continue() {
 
     let subspace_codec = SubspaceCodec::new(identity.public_key());
 
-    let farmer_data = FarmerData::new(
-        plot.clone(),
-        commitments.clone(),
-        object_mappings.clone(),
-        farmer_metadata.clone(),
-    );
+    let farmer_data = FarmerData::new(plot.clone(), commitments.clone(), farmer_metadata.clone());
 
     let encoded_block0 = EncodedBlockWithObjectMapping {
         block: vec![0u8; SEGMENT_SIZE / 2],
@@ -230,12 +222,7 @@ async fn plotting_continue() {
     // phase 2 - continue with new blocks after dropping the old plotting
     let client = MockRpc::new();
 
-    let farmer_data = FarmerData::new(
-        plot.clone(),
-        commitments.clone(),
-        object_mappings.clone(),
-        farmer_metadata.clone(),
-    );
+    let farmer_data = FarmerData::new(plot.clone(), commitments.clone(), farmer_metadata.clone());
 
     // plotting will ask for the last encoded block to continue from where it's left off
     let prev_encoded_block = EncodedBlockWithObjectMapping {
@@ -352,7 +339,6 @@ async fn plotting_piece_eviction() {
     let salt = Salt::default();
     let plot = Plot::open_or_create(&base_directory, address, 5).unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
-    let object_mappings = ObjectMappings::open_or_create(&base_directory).unwrap();
 
     // There are no pieces, but we need to create empty commitments database for this salt, such
     //  that plotter will create commitments for plotted pieces
@@ -372,12 +358,7 @@ async fn plotting_piece_eviction() {
 
     let subspace_codec = SubspaceCodec::new(identity.public_key());
 
-    let farmer_data = FarmerData::new(
-        plot.clone(),
-        commitments.clone(),
-        object_mappings,
-        farmer_metadata,
-    );
+    let farmer_data = FarmerData::new(plot.clone(), commitments.clone(), farmer_metadata);
 
     let encoded_block0 = EncodedBlockWithObjectMapping {
         block: {


### PR DESCRIPTION
Global object mapping is also independent from identity of farmer and is shared between all plots, so it can be updated once for all plots.
This pr should be merged after #348. It should be reviewed from commit [`Move global object mapping update to multifarming`](https://github.com/subspace/subspace/commit/9e5e850b9a4d534346b722cbbc2b7688ea00843f)