### PR TITLE
Single archiving optimization take 2

### DIFF
--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,7 +1,6 @@
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::rpc::RpcClient;
-use crate::PlottingError;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use log::{debug, error, info, warn};
@@ -12,299 +11,357 @@ use subspace_archiving::archiver::{ArchivedSegment, Archiver};
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
 use subspace_core_primitives::{FlatPieces, Sha256Hash};
 use subspace_rpc_primitives::{EncodedBlockWithObjectMapping, FarmerMetadata};
-use tokio::sync::oneshot::Receiver;
+use thiserror::Error;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 
 const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
-pub(crate) struct PiecesToPlot {
-    /// Offset of the index of the first piece in `pieces`
-    pub(crate) piece_index_offset: u64,
-    pub(crate) pieces: FlatPieces,
+#[derive(Debug, Error)]
+pub enum ArchivingError {
+    #[error("Plot is empty on restart, can't continue")]
+    ContinueError,
+    #[error("Failed to get block {0} from the chain, probably need to erase existing plot")]
+    GetBlockError(u32),
+    #[error("jsonrpsee error: {0}")]
+    RpcError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Last block retrieval from plot, rocksdb error: {0}")]
+    LastBlock(rocksdb::Error),
+    #[error("Error joining task: {0}")]
+    JoinTask(tokio::task::JoinError),
+    #[error("Archiver instantiation error: {0}")]
+    Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
 }
 
-// TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
-//  don't want eventually
-/// Maintains plot in up to date state plotting new pieces as they are produced on the network.
-pub(crate) async fn background_archiving<T: RpcClient + Clone + Send + 'static>(
-    pieces_to_plot_sender: std::sync::mpsc::SyncSender<PiecesToPlot>,
-    plot: Plot,
-    metadata: FarmerMetadata,
-    object_mappings: ObjectMappings,
-    client: T,
-    best_block_number_check_interval: Duration,
-    mut stop_receiver: Receiver<()>,
-) -> Result<(), PlottingError> {
-    let weak_plot = plot.downgrade();
-    let FarmerMetadata {
-        confirmation_depth_k,
-        record_size,
-        recorded_history_segment_size,
-        ..
-    } = metadata;
+/// Collection of pieces that potentially need to be plotted
+pub struct PiecesToPlot {
+    /// Offset of the index of the first piece in `pieces`
+    pub piece_index_offset: u64,
+    /// Pieces themselves
+    pub pieces: FlatPieces,
+}
 
-    // TODO: This assumes fixed size segments, which might not be the case
-    let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
+pub struct Archiving {
+    stop_sender: Option<oneshot::Sender<()>>,
+    archiving_handle: Option<JoinHandle<()>>,
+}
 
-    let maybe_last_root_block = tokio::task::spawn_blocking({
-        let plot = plot.clone();
+impl Archiving {
+    // TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
+    //  don't want eventually
+    /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
+    pub async fn start<Client, OPTP>(
+        plot: Plot,
+        farmer_metadata: FarmerMetadata,
+        object_mappings: ObjectMappings,
+        client: Client,
+        best_block_number_check_interval: Duration,
+        mut on_pieces_to_plot: OPTP,
+    ) -> Result<Archiving, ArchivingError>
+    where
+        Client: RpcClient + Clone + Send + Sync + 'static,
+        OPTP: FnMut(PiecesToPlot) -> bool + Send + 'static,
+    {
+        // Oneshot channels, that will be used for interrupt/stop the process
+        let (stop_sender, mut stop_receiver) = oneshot::channel();
 
-        move || plot.get_last_root_block().map_err(PlottingError::LastBlock)
-    })
-    .await
-    .unwrap()?;
+        let weak_plot = plot.downgrade();
+        let FarmerMetadata {
+            confirmation_depth_k,
+            record_size,
+            recorded_history_segment_size,
+            ..
+        } = farmer_metadata;
 
-    let mut archiver = if let Some(last_root_block) = maybe_last_root_block {
-        // Continuing from existing initial state
-        if plot.is_empty() {
-            return Err(PlottingError::ContinueError);
-        }
+        // TODO: This assumes fixed size segments, which might not be the case
+        let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
 
-        let last_archived_block_number = last_root_block.last_archived_block().number;
-        info!("Last archived block {}", last_archived_block_number);
+        let maybe_last_root_block = tokio::task::spawn_blocking({
+            let plot = plot.clone();
 
-        let maybe_last_archived_block = client
-            .block_by_number(last_archived_block_number)
-            .await
-            .map_err(PlottingError::RpcError)?;
-
-        match maybe_last_archived_block {
-            Some(EncodedBlockWithObjectMapping {
-                block,
-                object_mapping,
-            }) => Archiver::with_initial_state(
-                record_size as usize,
-                recorded_history_segment_size as usize,
-                last_root_block,
-                &block,
-                object_mapping,
-            )
-            .map_err(PlottingError::Archiver)?,
-            None => {
-                return Err(PlottingError::GetBlockError(last_archived_block_number));
+            move || {
+                plot.get_last_root_block()
+                    .map_err(ArchivingError::LastBlock)
             }
-        }
-    } else {
-        // Starting from genesis
-        if !plot.is_empty() {
-            // Restart before first block was archived, erase the plot
-            // TODO: Erase plot
-        }
+        })
+        .await
+        .unwrap()?;
 
-        Archiver::new(record_size as usize, recorded_history_segment_size as usize)
-            .map_err(PlottingError::Archiver)?
-    };
+        let mut archiver = if let Some(last_root_block) = maybe_last_root_block {
+            // Continuing from existing initial state
+            if plot.is_empty() {
+                return Err(ArchivingError::ContinueError);
+            }
 
-    drop(plot);
+            let last_archived_block_number = last_root_block.last_archived_block().number;
+            info!("Last archived block {}", last_archived_block_number);
 
-    let (new_block_to_archive_sender, new_block_to_archive_receiver) =
-        std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
+            let maybe_last_archived_block = client
+                .block_by_number(last_archived_block_number)
+                .await
+                .map_err(ArchivingError::RpcError)?;
 
-    // Process blocks since last fully archived block (or genesis) up to the current head minus K
-    let mut blocks_to_archive_from = archiver
-        .last_archived_block_number()
-        .map(|n| n + 1)
-        .unwrap_or_default();
-
-    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
-    tokio::task::spawn_blocking({
-        let client = client.clone();
-        let weak_plot = weak_plot.clone();
-
-        #[allow(clippy::mut_range_bound)]
-        move || {
-            let runtime_handle = tokio::runtime::Handle::current();
-            info!("Plotting new blocks in the background");
-
-            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
-                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
-                if blocks_to_archive_to >= blocks_to_archive_from {
-                    debug!(
-                        "Archiving blocks {}..={}",
-                        blocks_to_archive_from, blocks_to_archive_to,
-                    );
+            match maybe_last_archived_block {
+                Some(EncodedBlockWithObjectMapping {
+                    block,
+                    object_mapping,
+                }) => Archiver::with_initial_state(
+                    record_size as usize,
+                    recorded_history_segment_size as usize,
+                    last_root_block,
+                    &block,
+                    object_mapping,
+                )
+                .map_err(ArchivingError::Archiver)?,
+                None => {
+                    return Err(ArchivingError::GetBlockError(last_archived_block_number));
                 }
+            }
+        } else {
+            // Starting from genesis
+            if !plot.is_empty() {
+                // Restart before first block was archived, erase the plot
+                // TODO: Erase plot
+            }
 
-                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
-                    let EncodedBlockWithObjectMapping {
-                        block,
-                        object_mapping,
-                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
-                        Ok(Some(block)) => block,
-                        Ok(None) => {
-                            error!(
-                                "Failed to get block #{} from RPC: Block not found",
-                                block_to_archive,
-                            );
+            Archiver::new(record_size as usize, recorded_history_segment_size as usize)
+                .map_err(ArchivingError::Archiver)?
+        };
 
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                        Err(error) => {
-                            error!(
-                                "Failed to get block #{} from RPC: {}",
-                                block_to_archive, error,
-                            );
+        drop(plot);
 
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                    };
+        let (new_block_to_archive_sender, new_block_to_archive_receiver) =
+            std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
 
-                    let mut last_root_block = None;
-                    for archived_segment in archiver.add_block(block, object_mapping) {
-                        let ArchivedSegment {
-                            root_block,
-                            pieces,
-                            object_mapping,
-                        } = archived_segment;
-                        let piece_index_offset = merkle_num_leaves * root_block.segment_index();
+        // Process blocks since last fully archived block (or genesis) up to the current head minus K
+        let mut blocks_to_archive_from = archiver
+            .last_archived_block_number()
+            .map(|n| n + 1)
+            .unwrap_or_default();
 
-                        let pieces_to_plot = PiecesToPlot {
-                            piece_index_offset,
-                            pieces,
-                        };
-                        if let Err(_error) = pieces_to_plot_sender.send(pieces_to_plot) {
-                            // No receivers, exiting
-                            break 'outer;
-                        }
+        // Erasure coding in archiver and piece encoding are CPU-intensive operations.
+        tokio::task::spawn_blocking({
+            let client = client.clone();
+            let weak_plot = weak_plot.clone();
 
-                        let object_mapping =
-                            create_global_object_mapping(piece_index_offset, object_mapping);
+            #[allow(clippy::mut_range_bound)]
+            move || {
+                let runtime_handle = tokio::runtime::Handle::current();
+                info!("Plotting new blocks in the background");
 
-                        if let Err(error) = object_mappings.store(&object_mapping) {
-                            error!("Failed to store object mappings for pieces: {}", error);
-                        }
-                        let segment_index = root_block.segment_index();
-                        last_root_block.replace(root_block);
-
-                        info!(
-                            "Archived segment {} at block {}",
-                            segment_index, block_to_archive
+                'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
+                    let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
+                    if blocks_to_archive_to >= blocks_to_archive_from {
+                        debug!(
+                            "Archiving blocks {}..={}",
+                            blocks_to_archive_from, blocks_to_archive_to,
                         );
                     }
 
-                    if let Some(last_root_block) = last_root_block {
-                        if let Some(plot) = weak_plot.upgrade() {
-                            if let Err(error) = plot.set_last_root_block(&last_root_block) {
-                                error!("Failed to store last root block: {}", error);
+                    for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
+                        let EncodedBlockWithObjectMapping {
+                            block,
+                            object_mapping,
+                        } = match runtime_handle.block_on(client.block_by_number(block_to_archive))
+                        {
+                            Ok(Some(block)) => block,
+                            Ok(None) => {
+                                error!(
+                                    "Failed to get block #{} from RPC: Block not found",
+                                    block_to_archive,
+                                );
+
+                                blocks_to_archive_from = block_to_archive;
+                                continue 'outer;
+                            }
+                            Err(error) => {
+                                error!(
+                                    "Failed to get block #{} from RPC: {}",
+                                    block_to_archive, error,
+                                );
+
+                                blocks_to_archive_from = block_to_archive;
+                                continue 'outer;
+                            }
+                        };
+
+                        let mut last_root_block = None;
+                        for archived_segment in archiver.add_block(block, object_mapping) {
+                            let ArchivedSegment {
+                                root_block,
+                                pieces,
+                                object_mapping,
+                            } = archived_segment;
+                            let piece_index_offset = merkle_num_leaves * root_block.segment_index();
+
+                            let pieces_to_plot = PiecesToPlot {
+                                piece_index_offset,
+                                pieces,
+                            };
+                            if !on_pieces_to_plot(pieces_to_plot) {
+                                // No need to continue
+                                break 'outer;
+                            }
+
+                            let object_mapping =
+                                create_global_object_mapping(piece_index_offset, object_mapping);
+
+                            if let Err(error) = object_mappings.store(&object_mapping) {
+                                error!("Failed to store object mappings for pieces: {}", error);
+                            }
+                            let segment_index = root_block.segment_index();
+                            last_root_block.replace(root_block);
+
+                            info!(
+                                "Archived segment {} at block {}",
+                                segment_index, block_to_archive
+                            );
+                        }
+
+                        if let Some(last_root_block) = last_root_block {
+                            if let Some(plot) = weak_plot.upgrade() {
+                                if let Err(error) = plot.set_last_root_block(&last_root_block) {
+                                    error!("Failed to store last root block: {}", error);
+                                }
+                            }
+                        }
+                    }
+
+                    blocks_to_archive_from = blocks_to_archive_to + 1;
+                }
+            }
+        });
+
+        info!("Subscribing to new heads");
+        let mut new_head = client
+            .subscribe_new_head()
+            .await
+            .map_err(ArchivingError::RpcError)?;
+
+        let block_to_archive = Arc::new(AtomicU32::default());
+
+        if maybe_last_root_block.is_none() {
+            // If not continuation, archive genesis block
+            new_block_to_archive_sender
+                .send(Arc::clone(&block_to_archive))
+                .expect("Failed to send genesis block archiving message");
+        }
+
+        let (mut best_block_number_sender, mut best_block_number_receiver) = mpsc::channel(1);
+
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(best_block_number_check_interval).await;
+
+                // In case connection dies, we need to disconnect from the node
+                let best_block_number_result =
+                    tokio::time::timeout(BEST_BLOCK_REQUEST_TIMEOUT, client.best_block_number())
+                        .await;
+
+                let is_error = !matches!(best_block_number_result, Ok(Ok(_)));
+                // Result doesn't matter here
+                let _ = best_block_number_sender
+                    .send(best_block_number_result)
+                    .await;
+
+                if is_error {
+                    break;
+                }
+            }
+        });
+
+        let mut last_best_block_number_error = false;
+
+        let archiving_handle = tokio::spawn(async move {
+            // Listen for new blocks produced on the network
+            loop {
+                tokio::select! {
+                    _ = &mut stop_receiver => {
+                        info!("Plotting stopped!");
+                        break;
+                    }
+                    result = new_head.recv() => {
+                        match result {
+                            Some(head) => {
+                                let block_number = u32::from_str_radix(&head.number[2..], 16).unwrap();
+                                debug!("Last block number: {:#?}", block_number);
+
+                                if let Some(block_number) = block_number.checked_sub(confirmation_depth_k) {
+                                    // We send block that should be archived over channel that doesn't have
+                                    // a buffer, atomic integer is used to make sure archiving process
+                                    // always read up to date value
+                                    block_to_archive.store(block_number, Ordering::Relaxed);
+                                    let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
+                                }
+                            },
+                            None => {
+                                debug!("Subscription has forcefully closed from node side!");
+                                break;
+                            }
+                        }
+                    }
+                    maybe_result = best_block_number_receiver.next() => {
+                        match maybe_result {
+                            Some(Ok(Ok(best_block_number))) => {
+                                debug!("Best block number: {:#?}", best_block_number);
+                                last_best_block_number_error = false;
+
+                                if let Some(block_number) = best_block_number.checked_sub(confirmation_depth_k) {
+                                    // We send block that should be archived over channel that doesn't have
+                                    // a buffer, atomic integer is used to make sure archiving process
+                                    // always read up to date value
+                                    block_to_archive.fetch_max(block_number, Ordering::Relaxed);
+                                    let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
+                                }
+                            }
+                            Some(Ok(Err(error))) => {
+                                if last_best_block_number_error {
+                                    error!("Request to get new best block failed second time: {error}");
+                                    break;
+                                } else {
+                                    warn!("Request to get new best block failed: {error}");
+                                    last_best_block_number_error = true;
+                                }
+                            }
+                            Some(Err(_error)) => {
+                                if last_best_block_number_error {
+                                    error!("Request to get new best block timed out second time");
+                                    break;
+                                } else {
+                                    warn!("Request to get new best block timed out");
+                                    last_best_block_number_error = true;
+                                }
+                            }
+                            None => {
+                                debug!("Best block number channel closed!");
+                                break;
                             }
                         }
                     }
                 }
-
-                blocks_to_archive_from = blocks_to_archive_to + 1;
             }
-        }
-    });
+        });
 
-    info!("Subscribing to new heads");
-    let mut new_head = client
-        .subscribe_new_head()
-        .await
-        .map_err(PlottingError::RpcError)?;
-
-    let block_to_archive = Arc::new(AtomicU32::default());
-
-    if maybe_last_root_block.is_none() {
-        // If not continuation, archive genesis block
-        new_block_to_archive_sender
-            .send(Arc::clone(&block_to_archive))
-            .expect("Failed to send genesis block archiving message");
+        Ok(Self {
+            stop_sender: Some(stop_sender),
+            archiving_handle: Some(archiving_handle),
+        })
     }
 
-    let (mut best_block_number_sender, mut best_block_number_receiver) = mpsc::channel(1);
-
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(best_block_number_check_interval).await;
-
-            // In case connection dies, we need to disconnect from the node
-            let best_block_number_result =
-                tokio::time::timeout(BEST_BLOCK_REQUEST_TIMEOUT, client.best_block_number()).await;
-
-            let is_error = !matches!(best_block_number_result, Ok(Ok(_)));
-            // Result doesn't matter here
-            let _ = best_block_number_sender
-                .send(best_block_number_result)
-                .await;
-
-            if is_error {
-                break;
-            }
-        }
-    });
-
-    let mut last_best_block_number_error = false;
-
-    // Listen for new blocks produced on the network
-    loop {
-        tokio::select! {
-            _ = &mut stop_receiver => {
-                info!("Plotting stopped!");
-                break;
-            }
-            result = new_head.recv() => {
-                match result {
-                    Some(head) => {
-                        let block_number = u32::from_str_radix(&head.number[2..], 16).unwrap();
-                        debug!("Last block number: {:#?}", block_number);
-
-                        if let Some(block_number) = block_number.checked_sub(confirmation_depth_k) {
-                            // We send block that should be archived over channel that doesn't have
-                            // a buffer, atomic integer is used to make sure archiving process
-                            // always read up to date value
-                            block_to_archive.store(block_number, Ordering::Relaxed);
-                            let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
-                        }
-                    },
-                    None => {
-                        debug!("Subscription has forcefully closed from node side!");
-                        break;
-                    }
-                }
-            }
-            maybe_result = best_block_number_receiver.next() => {
-                match maybe_result {
-                    Some(Ok(Ok(best_block_number))) => {
-                        debug!("Best block number: {:#?}", best_block_number);
-                        last_best_block_number_error = false;
-
-                        if let Some(block_number) = best_block_number.checked_sub(confirmation_depth_k) {
-                            // We send block that should be archived over channel that doesn't have
-                            // a buffer, atomic integer is used to make sure archiving process
-                            // always read up to date value
-                            block_to_archive.fetch_max(block_number, Ordering::Relaxed);
-                            let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
-                        }
-                    }
-                    Some(Ok(Err(error))) => {
-                        if last_best_block_number_error {
-                            error!("Request to get new best block failed second time: {error}");
-                            break;
-                        } else {
-                            warn!("Request to get new best block failed: {error}");
-                            last_best_block_number_error = true;
-                        }
-                    }
-                    Some(Err(_error)) => {
-                        if last_best_block_number_error {
-                            error!("Request to get new best block timed out second time");
-                            break;
-                        } else {
-                            warn!("Request to get new best block timed out");
-                            last_best_block_number_error = true;
-                        }
-                    }
-                    None => {
-                        debug!("Best block number channel closed!");
-                        break;
-                    }
-                }
-            }
-        }
+    /// Waits for the background archiving to finish
+    pub async fn wait(mut self) -> Result<(), ArchivingError> {
+        self.archiving_handle
+            .take()
+            .unwrap()
+            .await
+            .map_err(ArchivingError::JoinTask)
     }
+}
 
-    Ok(())
+impl Drop for Archiving {
+    fn drop(&mut self) {
+        let _ = self.stop_sender.take().unwrap().send(());
+    }
 }
 
 fn create_global_object_mapping(

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -34,6 +34,7 @@ pub enum ArchivingError {
 }
 
 /// Collection of pieces that potentially need to be plotted
+#[derive(Debug, Clone)]
 pub struct PiecesToPlot {
     /// Offset of the index of the first piece in `pieces`
     pub piece_index_offset: u64,

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,0 +1,330 @@
+use crate::object_mappings::ObjectMappings;
+use crate::plot::Plot;
+use crate::rpc::RpcClient;
+use crate::PlottingError;
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+use log::{debug, error, info, warn};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use subspace_archiving::archiver::{ArchivedSegment, Archiver};
+use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
+use subspace_core_primitives::{FlatPieces, Sha256Hash};
+use subspace_rpc_primitives::{EncodedBlockWithObjectMapping, FarmerMetadata};
+use tokio::sync::oneshot::Receiver;
+
+const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub(crate) struct PiecesToPlot {
+    /// Offset of the index of the first piece in `pieces`
+    pub(crate) piece_index_offset: u64,
+    pub(crate) pieces: FlatPieces,
+}
+
+// TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
+//  don't want eventually
+/// Maintains plot in up to date state plotting new pieces as they are produced on the network.
+pub(crate) async fn background_archiving<T: RpcClient + Clone + Send + 'static>(
+    pieces_to_plot_sender: std::sync::mpsc::SyncSender<PiecesToPlot>,
+    plot: Plot,
+    metadata: FarmerMetadata,
+    object_mappings: ObjectMappings,
+    client: T,
+    best_block_number_check_interval: Duration,
+    mut stop_receiver: Receiver<()>,
+) -> Result<(), PlottingError> {
+    let weak_plot = plot.downgrade();
+    let FarmerMetadata {
+        confirmation_depth_k,
+        record_size,
+        recorded_history_segment_size,
+        ..
+    } = metadata;
+
+    // TODO: This assumes fixed size segments, which might not be the case
+    let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
+
+    let maybe_last_root_block = tokio::task::spawn_blocking({
+        let plot = plot.clone();
+
+        move || plot.get_last_root_block().map_err(PlottingError::LastBlock)
+    })
+    .await
+    .unwrap()?;
+
+    let mut archiver = if let Some(last_root_block) = maybe_last_root_block {
+        // Continuing from existing initial state
+        if plot.is_empty() {
+            return Err(PlottingError::ContinueError);
+        }
+
+        let last_archived_block_number = last_root_block.last_archived_block().number;
+        info!("Last archived block {}", last_archived_block_number);
+
+        let maybe_last_archived_block = client
+            .block_by_number(last_archived_block_number)
+            .await
+            .map_err(PlottingError::RpcError)?;
+
+        match maybe_last_archived_block {
+            Some(EncodedBlockWithObjectMapping {
+                block,
+                object_mapping,
+            }) => Archiver::with_initial_state(
+                record_size as usize,
+                recorded_history_segment_size as usize,
+                last_root_block,
+                &block,
+                object_mapping,
+            )
+            .map_err(PlottingError::Archiver)?,
+            None => {
+                return Err(PlottingError::GetBlockError(last_archived_block_number));
+            }
+        }
+    } else {
+        // Starting from genesis
+        if !plot.is_empty() {
+            // Restart before first block was archived, erase the plot
+            // TODO: Erase plot
+        }
+
+        Archiver::new(record_size as usize, recorded_history_segment_size as usize)
+            .map_err(PlottingError::Archiver)?
+    };
+
+    drop(plot);
+
+    let (new_block_to_archive_sender, new_block_to_archive_receiver) =
+        std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
+
+    // Process blocks since last fully archived block (or genesis) up to the current head minus K
+    let mut blocks_to_archive_from = archiver
+        .last_archived_block_number()
+        .map(|n| n + 1)
+        .unwrap_or_default();
+
+    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
+    tokio::task::spawn_blocking({
+        let client = client.clone();
+        let weak_plot = weak_plot.clone();
+
+        #[allow(clippy::mut_range_bound)]
+        move || {
+            let runtime_handle = tokio::runtime::Handle::current();
+            info!("Plotting new blocks in the background");
+
+            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
+                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
+                if blocks_to_archive_to >= blocks_to_archive_from {
+                    debug!(
+                        "Archiving blocks {}..={}",
+                        blocks_to_archive_from, blocks_to_archive_to,
+                    );
+                }
+
+                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
+                    let EncodedBlockWithObjectMapping {
+                        block,
+                        object_mapping,
+                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
+                        Ok(Some(block)) => block,
+                        Ok(None) => {
+                            error!(
+                                "Failed to get block #{} from RPC: Block not found",
+                                block_to_archive,
+                            );
+
+                            blocks_to_archive_from = block_to_archive;
+                            continue 'outer;
+                        }
+                        Err(error) => {
+                            error!(
+                                "Failed to get block #{} from RPC: {}",
+                                block_to_archive, error,
+                            );
+
+                            blocks_to_archive_from = block_to_archive;
+                            continue 'outer;
+                        }
+                    };
+
+                    let mut last_root_block = None;
+                    for archived_segment in archiver.add_block(block, object_mapping) {
+                        let ArchivedSegment {
+                            root_block,
+                            pieces,
+                            object_mapping,
+                        } = archived_segment;
+                        let piece_index_offset = merkle_num_leaves * root_block.segment_index();
+
+                        let pieces_to_plot = PiecesToPlot {
+                            piece_index_offset,
+                            pieces,
+                        };
+                        if let Err(_error) = pieces_to_plot_sender.send(pieces_to_plot) {
+                            // No receivers, exiting
+                            break 'outer;
+                        }
+
+                        let object_mapping =
+                            create_global_object_mapping(piece_index_offset, object_mapping);
+
+                        if let Err(error) = object_mappings.store(&object_mapping) {
+                            error!("Failed to store object mappings for pieces: {}", error);
+                        }
+                        let segment_index = root_block.segment_index();
+                        last_root_block.replace(root_block);
+
+                        info!(
+                            "Archived segment {} at block {}",
+                            segment_index, block_to_archive
+                        );
+                    }
+
+                    if let Some(last_root_block) = last_root_block {
+                        if let Some(plot) = weak_plot.upgrade() {
+                            if let Err(error) = plot.set_last_root_block(&last_root_block) {
+                                error!("Failed to store last root block: {}", error);
+                            }
+                        }
+                    }
+                }
+
+                blocks_to_archive_from = blocks_to_archive_to + 1;
+            }
+        }
+    });
+
+    info!("Subscribing to new heads");
+    let mut new_head = client
+        .subscribe_new_head()
+        .await
+        .map_err(PlottingError::RpcError)?;
+
+    let block_to_archive = Arc::new(AtomicU32::default());
+
+    if maybe_last_root_block.is_none() {
+        // If not continuation, archive genesis block
+        new_block_to_archive_sender
+            .send(Arc::clone(&block_to_archive))
+            .expect("Failed to send genesis block archiving message");
+    }
+
+    let (mut best_block_number_sender, mut best_block_number_receiver) = mpsc::channel(1);
+
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(best_block_number_check_interval).await;
+
+            // In case connection dies, we need to disconnect from the node
+            let best_block_number_result =
+                tokio::time::timeout(BEST_BLOCK_REQUEST_TIMEOUT, client.best_block_number()).await;
+
+            let is_error = !matches!(best_block_number_result, Ok(Ok(_)));
+            // Result doesn't matter here
+            let _ = best_block_number_sender
+                .send(best_block_number_result)
+                .await;
+
+            if is_error {
+                break;
+            }
+        }
+    });
+
+    let mut last_best_block_number_error = false;
+
+    // Listen for new blocks produced on the network
+    loop {
+        tokio::select! {
+            _ = &mut stop_receiver => {
+                info!("Plotting stopped!");
+                break;
+            }
+            result = new_head.recv() => {
+                match result {
+                    Some(head) => {
+                        let block_number = u32::from_str_radix(&head.number[2..], 16).unwrap();
+                        debug!("Last block number: {:#?}", block_number);
+
+                        if let Some(block_number) = block_number.checked_sub(confirmation_depth_k) {
+                            // We send block that should be archived over channel that doesn't have
+                            // a buffer, atomic integer is used to make sure archiving process
+                            // always read up to date value
+                            block_to_archive.store(block_number, Ordering::Relaxed);
+                            let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
+                        }
+                    },
+                    None => {
+                        debug!("Subscription has forcefully closed from node side!");
+                        break;
+                    }
+                }
+            }
+            maybe_result = best_block_number_receiver.next() => {
+                match maybe_result {
+                    Some(Ok(Ok(best_block_number))) => {
+                        debug!("Best block number: {:#?}", best_block_number);
+                        last_best_block_number_error = false;
+
+                        if let Some(block_number) = best_block_number.checked_sub(confirmation_depth_k) {
+                            // We send block that should be archived over channel that doesn't have
+                            // a buffer, atomic integer is used to make sure archiving process
+                            // always read up to date value
+                            block_to_archive.fetch_max(block_number, Ordering::Relaxed);
+                            let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
+                        }
+                    }
+                    Some(Ok(Err(error))) => {
+                        if last_best_block_number_error {
+                            error!("Request to get new best block failed second time: {error}");
+                            break;
+                        } else {
+                            warn!("Request to get new best block failed: {error}");
+                            last_best_block_number_error = true;
+                        }
+                    }
+                    Some(Err(_error)) => {
+                        if last_best_block_number_error {
+                            error!("Request to get new best block timed out second time");
+                            break;
+                        } else {
+                            warn!("Request to get new best block timed out");
+                            last_best_block_number_error = true;
+                        }
+                    }
+                    None => {
+                        debug!("Best block number channel closed!");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn create_global_object_mapping(
+    piece_index_offset: u64,
+    object_mapping: Vec<PieceObjectMapping>,
+) -> Vec<(Sha256Hash, GlobalObject)> {
+    object_mapping
+        .iter()
+        .enumerate()
+        .flat_map(move |(position, object_mapping)| {
+            object_mapping.objects.iter().map(move |piece_object| {
+                let PieceObject::V0 { hash, offset } = piece_object;
+                (
+                    *hash,
+                    GlobalObject::V0 {
+                        piece_index: piece_index_offset + position as u64,
+                        offset: *offset,
+                    },
+                )
+            })
+        })
+        .collect()
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -8,7 +8,10 @@ use std::path::Path;
 use std::{fs, io};
 
 pub(crate) fn erase(path: impl AsRef<Path>) -> io::Result<()> {
+    // TODO: Remove this line in one of future releases
     subspace_farmer::Plot::erase(path.as_ref())?;
+
+    let _ = std::fs::remove_dir_all(path.as_ref().join("object-mappings"));
     (0..)
         .map(|i| path.as_ref().join(format!("plot{i}")))
         .take_while(|path| path.is_dir())

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -31,12 +31,13 @@ pub(crate) mod rpc;
 pub(crate) mod ws_rpc;
 pub mod ws_rpc_server;
 
+pub use archiving::{Archiving, ArchivingError, PiecesToPlot};
 pub use commitments::{CommitmentError, Commitments};
 pub use farming::{Farming, FarmingError};
 pub use identity::Identity;
 pub use jsonrpsee;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
 pub use plot::{retrieve_piece_from_plots, Plot, PlotError};
-pub use plotting::{FarmerData, Plotting, PlottingError};
+pub use plotting::plot_pieces;
 pub use rpc::RpcClient;
 pub use ws_rpc::WsRpc;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -17,9 +17,12 @@
 
 #![feature(try_blocks, hash_drain_filter, int_log, io_error_other)]
 
+pub(crate) mod archiving;
 pub(crate) mod commitments;
 pub(crate) mod farming;
 pub(crate) mod identity;
+#[cfg(test)]
+mod mock_rpc;
 pub mod multi_farming;
 pub(crate) mod object_mappings;
 pub(crate) mod plot;
@@ -27,9 +30,6 @@ pub(crate) mod plotting;
 pub(crate) mod rpc;
 pub(crate) mod ws_rpc;
 pub mod ws_rpc_server;
-
-#[cfg(test)]
-mod mock_rpc;
 
 pub use commitments::{CommitmentError, Commitments};
 pub use farming::{Farming, FarmingError};

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -4,15 +4,16 @@ use crate::{
 use anyhow::anyhow;
 use futures::stream::{FuturesUnordered, StreamExt};
 use log::info;
+use rayon::prelude::*;
 use std::{path::Path, sync::Arc, time::Duration};
 use subspace_core_primitives::PublicKey;
 use subspace_solving::SubspaceCodec;
 
-/// Abstraction around having multiple plots, farmings and archivings
+/// Abstraction around having multiple plots, farmings and archiving
 pub struct MultiFarming {
     pub plots: Arc<Vec<Plot>>,
     farmings: Vec<Farming>,
-    archivings: Vec<Archiving>,
+    archiving: Archiving,
 }
 
 impl MultiFarming {
@@ -26,56 +27,90 @@ impl MultiFarming {
         best_block_number_check_interval: Duration,
     ) -> anyhow::Result<Self> {
         let mut plots = Vec::with_capacity(plot_sizes.len());
+        let mut subspace_codecs = Vec::with_capacity(plot_sizes.len());
+        let mut commitments = Vec::with_capacity(plot_sizes.len());
         let mut farmings = Vec::with_capacity(plot_sizes.len());
-        let mut archivings = Vec::with_capacity(plot_sizes.len());
 
         for (plot_index, max_plot_pieces) in plot_sizes.into_iter().enumerate() {
             let base_directory = base_directory.as_ref().join(format!("plot{plot_index}"));
             std::fs::create_dir_all(&base_directory)?;
-            let (plot, archiving, farming) = farm_single_plot(
+            let (plot, subspace_codec, plot_commitments, farming) = farm_single_plot(
                 base_directory,
                 reward_address,
                 client.clone(),
-                object_mappings.clone(),
                 max_plot_pieces,
-                best_block_number_check_interval,
             )
             .await?;
             plots.push(plot);
+            subspace_codecs.push(subspace_codec);
+            commitments.push(plot_commitments);
             farmings.push(farming);
-            archivings.push(archiving);
         }
+
+        let farmer_metadata = client
+            .farmer_metadata()
+            .await
+            .map_err(|error| anyhow!(error))?;
+
+        // Start archiving task
+        let archiving = Archiving::start(
+            plots
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow!("Must have at least one plot"))?,
+            farmer_metadata,
+            object_mappings,
+            client.clone(),
+            best_block_number_check_interval,
+            {
+                let mut on_pieces_to_plots = plots
+                    .iter()
+                    .zip(subspace_codecs)
+                    .zip(&commitments)
+                    .map(|((plot, subspace_codec), commitments)| {
+                        plotting::plot_pieces(subspace_codec, plot, commitments.clone())
+                    })
+                    .collect::<Vec<_>>();
+
+                move |pieces_to_plot| {
+                    on_pieces_to_plots
+                        .par_iter_mut()
+                        .map(|on_pieces_to_plot| {
+                            // TODO: It might be desirable to not clone it and instead pick just
+                            //  unnecessary pieces and copy pieces once since different plots will
+                            //  care about different pieces
+                            on_pieces_to_plot(pieces_to_plot.clone())
+                        })
+                        .reduce(|| true, |result, should_continue| result && should_continue)
+                }
+            },
+        )
+        .await?;
 
         Ok(Self {
             plots: Arc::new(plots),
             farmings,
-            archivings,
+            archiving,
         })
     }
 
     /// Waits for farming and plotting completion (or errors)
     pub async fn wait(self) -> anyhow::Result<()> {
-        let mut farming_plotting = self
+        let mut farming = self
             .farmings
             .into_iter()
-            .zip(self.archivings)
-            .into_iter()
-            .map(|(farming, plotting)| async move {
-                tokio::select! {
-                    res = plotting.wait() => if let Err(error) = res {
-                        return Err(anyhow!(error))
-                    },
-                    res = farming.wait() => if let Err(error) = res {
-                        return Err(anyhow!(error))
-                    },
-                }
-                Ok(())
-            })
+            .map(|farming| farming.wait())
             .collect::<FuturesUnordered<_>>();
 
-        if let Some(res) = farming_plotting.next().await {
-            res?;
+        tokio::select! {
+            res = farming.select_next_some() => {
+                res?;
+            },
+            res = self.archiving.wait() => {
+                res?;
+            },
         }
+
         Ok(())
     }
 }
@@ -85,10 +120,8 @@ pub(crate) async fn farm_single_plot(
     base_directory: impl AsRef<Path>,
     reward_address: PublicKey,
     client: WsRpc,
-    object_mappings: ObjectMappings,
     max_plot_pieces: u64,
-    best_block_number_check_interval: Duration,
-) -> anyhow::Result<(Plot, Archiving, Farming)> {
+) -> anyhow::Result<(Plot, SubspaceCodec, Commitments, Farming)> {
     let identity = Identity::open_or_create(&base_directory)?;
     let public_key = identity.public_key().to_bytes().into();
 
@@ -122,21 +155,5 @@ pub(crate) async fn farm_single_plot(
         reward_address,
     );
 
-    let farmer_metadata = client
-        .farmer_metadata()
-        .await
-        .map_err(|error| anyhow!(error))?;
-
-    // Start archiving task
-    let archiving_instance = Archiving::start(
-        plot.clone(),
-        farmer_metadata,
-        object_mappings,
-        client.clone(),
-        best_block_number_check_interval,
-        plotting::plot_pieces(subspace_codec, &plot, commitments),
-    )
-    .await?;
-
-    Ok((plot, archiving_instance, farming_instance))
+    Ok((plot, subspace_codec, commitments, farming_instance))
 }

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -178,11 +178,11 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
             // TODO: Erase plot
         }
 
-        drop(farmer_data.plot);
-
         Archiver::new(record_size as usize, recorded_history_segment_size as usize)
             .map_err(PlottingError::Archiver)?
     };
+
+    drop(farmer_data.plot);
 
     let (new_block_to_archive_sender, new_block_to_archive_receiver) =
         std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -276,8 +276,6 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
                                         );
                                     }
 
-                                    // TODO: This will not create commitments properly if pieces are
-                                    //  evicted during plotting
                                     if let Err(error) =
                                         farmer_data.commitments.create_for_pieces(|| {
                                             write_result.to_recommitment_iterator()

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -1,152 +1,44 @@
 #[cfg(test)]
 mod tests;
 
-use crate::archiving::PiecesToPlot;
 use crate::commitments::Commitments;
-use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
-use crate::rpc::RpcClient;
+use crate::PiecesToPlot;
 use log::error;
 use std::sync::Arc;
-use std::time::Duration;
 use subspace_core_primitives::{FlatPieces, PieceIndex};
-use subspace_rpc_primitives::FarmerMetadata;
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
-use thiserror::Error;
-use tokio::{sync::oneshot, task::JoinHandle};
 
-#[derive(Debug, Error)]
-pub enum PlottingError {
-    #[error("Plot is empty on restart, can't continue")]
-    ContinueError,
-    #[error("Failed to get block {0} from the chain, probably need to erase existing plot")]
-    GetBlockError(u32),
-    #[error("jsonrpsee error: {0}")]
-    RpcError(Box<dyn std::error::Error + Send + Sync>),
-    #[error("Last block retrieval from plot, rocksdb error: {0}")]
-    LastBlock(rocksdb::Error),
-    #[error("Error joining task: {0}")]
-    JoinTask(tokio::task::JoinError),
-    #[error("Archiver instantiation error: {0}")]
-    Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
-}
-
-/// `Plotting` struct is the abstraction of the plotting process
-///
-/// Plotting Instance that stores a channel to stop/pause the background farming task
-/// and a handle to make it possible to wait on this background task
-pub struct Plotting {
-    stop_sender: Option<oneshot::Sender<()>>,
-    archiving_handle: Option<JoinHandle<Result<(), PlottingError>>>,
-    plotting_handle: Option<JoinHandle<()>>,
-}
-
-pub struct FarmerData {
-    plot: Plot,
+/// Generates a function that will plot pieces.
+pub fn plot_pieces(
+    mut subspace_codec: SubspaceCodec,
+    plot: &Plot,
     commitments: Commitments,
-    object_mappings: ObjectMappings,
-    metadata: FarmerMetadata,
-}
+) -> impl FnMut(PiecesToPlot) -> bool + Send + 'static {
+    let weak_plot = plot.downgrade();
 
-impl FarmerData {
-    pub fn new(
-        plot: Plot,
-        commitments: Commitments,
-        object_mappings: ObjectMappings,
-        metadata: FarmerMetadata,
-    ) -> Self {
-        Self {
-            plot,
-            commitments,
-            object_mappings,
-            metadata,
-        }
-    }
-}
-
-/// Assumes `plot`, `commitment`, `object_mappings`, `client` and `identity` are already initialized
-impl Plotting {
-    /// Returns an instance of plotting, and also starts a concurrent background plotting task
-    pub fn start<T: RpcClient + Clone + Send + Sync + 'static>(
-        farmer_data: FarmerData,
-        client: T,
-        mut subspace_codec: SubspaceCodec,
-        best_block_number_check_interval: Duration,
-    ) -> Self {
-        // Oneshot channels, that will be used for interrupt/stop the process
-        let (stop_sender, stop_receiver) = oneshot::channel();
-
-        let FarmerData {
-            plot,
-            commitments,
-            object_mappings,
-            metadata,
-        } = farmer_data;
-        let weak_plot = plot.downgrade();
-
-        let (pieces_to_plot_sender, pieces_to_plot_receiver) =
-            std::sync::mpsc::sync_channel::<PiecesToPlot>(0);
-
-        // Get a handle for the background task, so that we can wait on it later if we want to
-        let archiving_handle = tokio::spawn(crate::archiving::background_archiving(
-            pieces_to_plot_sender,
-            plot,
-            metadata,
-            object_mappings,
-            client,
-            best_block_number_check_interval,
-            stop_receiver,
-        ));
-
-        // Get a handle for the background task, so that we can wait on it later if we want to
-        let plotting_handle = tokio::task::spawn_blocking(move || {
-            // TODO: Batch encoding with more than 1 archived segment worth of data
-            while let Ok(pieces_to_plot) = pieces_to_plot_receiver.recv() {
-                if let Some(plot) = weak_plot.upgrade() {
-                    if let Err(error) = plot_pieces(
-                        &mut subspace_codec,
-                        &plot,
-                        &commitments,
-                        pieces_to_plot.piece_index_offset,
-                        pieces_to_plot.pieces,
-                    ) {
-                        error!("Failed to encode a piece: error: {}", error);
-                        break;
-                    }
-                }
+    move |pieces_to_plot| {
+        if let Some(plot) = weak_plot.upgrade() {
+            if let Err(error) = plot_pieces_internal(
+                &mut subspace_codec,
+                &plot,
+                &commitments,
+                pieces_to_plot.piece_index_offset,
+                pieces_to_plot.pieces,
+            ) {
+                error!("Failed to encode a piece: error: {}", error);
+                return false;
             }
-        });
-
-        Plotting {
-            stop_sender: Some(stop_sender),
-            archiving_handle: Some(archiving_handle),
-            plotting_handle: Some(plotting_handle),
+        } else {
+            return false;
         }
-    }
 
-    /// Waits for the background plotting to finish
-    pub async fn wait(mut self) -> Result<(), PlottingError> {
-        self.archiving_handle
-            .take()
-            .unwrap()
-            .await
-            .map_err(PlottingError::JoinTask)??;
-        self.plotting_handle
-            .take()
-            .unwrap()
-            .await
-            .map_err(PlottingError::JoinTask)
-    }
-}
-
-impl Drop for Plotting {
-    fn drop(&mut self) {
-        let _ = self.stop_sender.take().unwrap().send(());
+        true
     }
 }
 
 /// Plot a set of pieces into a particular plot and commitment database.
-fn plot_pieces(
+fn plot_pieces_internal(
     subspace_codec: &mut SubspaceCodec,
     plot: &Plot,
     commitments: &Commitments,

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -247,9 +247,6 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
                         } = archived_segment;
                         let piece_index_offset = merkle_num_leaves * root_block.segment_index();
 
-                        let object_mapping =
-                            create_global_object_mapping(piece_index_offset, object_mapping);
-
                         // TODO: Batch encoding with more than 1 archived segment worth of data
                         if let Some(plot) = weak_plot.upgrade() {
                             let plot_pieces_result = plot_pieces(
@@ -262,6 +259,10 @@ async fn background_plotting<T: RpcClient + Clone + Send + 'static>(
                             if plot_pieces_result.is_err() {
                                 continue;
                             }
+
+                            let object_mapping =
+                                create_global_object_mapping(piece_index_offset, object_mapping);
+
                             if let Err(error) = farmer_data.object_mappings.store(&object_mapping) {
                                 error!("Failed to store object mappings for pieces: {}", error);
                             }

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -1,26 +1,19 @@
 #[cfg(test)]
 mod tests;
 
+use crate::archiving::PiecesToPlot;
 use crate::commitments::Commitments;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::rpc::RpcClient;
-use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
-use log::{debug, error, info, warn};
-use std::sync::atomic::{AtomicU32, Ordering};
+use log::error;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_archiving::archiver::{ArchivedSegment, Archiver};
-use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
-use subspace_core_primitives::{FlatPieces, PieceIndex, Sha256Hash};
-use subspace_rpc_primitives::{EncodedBlockWithObjectMapping, FarmerMetadata};
+use subspace_core_primitives::{FlatPieces, PieceIndex};
+use subspace_rpc_primitives::FarmerMetadata;
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
 use thiserror::Error;
-use tokio::sync::oneshot::Receiver;
 use tokio::{sync::oneshot, task::JoinHandle};
-
-const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Error)]
 pub enum PlottingError {
@@ -36,12 +29,6 @@ pub enum PlottingError {
     JoinTask(tokio::task::JoinError),
     #[error("Archiver instantiation error: {0}")]
     Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
-}
-
-struct PiecesToPlot {
-    /// Offset of the index of the first piece in `pieces`
-    piece_index_offset: u64,
-    pieces: FlatPieces,
 }
 
 /// `Plotting` struct is the abstraction of the plotting process
@@ -101,7 +88,7 @@ impl Plotting {
             std::sync::mpsc::sync_channel::<PiecesToPlot>(0);
 
         // Get a handle for the background task, so that we can wait on it later if we want to
-        let archiving_handle = tokio::spawn(background_archiving(
+        let archiving_handle = tokio::spawn(crate::archiving::background_archiving(
             pieces_to_plot_sender,
             plot,
             metadata,
@@ -158,291 +145,6 @@ impl Drop for Plotting {
     }
 }
 
-// TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
-//  don't want eventually
-/// Maintains plot in up to date state plotting new pieces as they are produced on the network.
-async fn background_archiving<T: RpcClient + Clone + Send + 'static>(
-    pieces_to_plot_sender: std::sync::mpsc::SyncSender<PiecesToPlot>,
-    plot: Plot,
-    metadata: FarmerMetadata,
-    object_mappings: ObjectMappings,
-    client: T,
-    best_block_number_check_interval: Duration,
-    mut stop_receiver: Receiver<()>,
-) -> Result<(), PlottingError> {
-    let weak_plot = plot.downgrade();
-    let FarmerMetadata {
-        confirmation_depth_k,
-        record_size,
-        recorded_history_segment_size,
-        ..
-    } = metadata;
-
-    // TODO: This assumes fixed size segments, which might not be the case
-    let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
-
-    let maybe_last_root_block = tokio::task::spawn_blocking({
-        let plot = plot.clone();
-
-        move || plot.get_last_root_block().map_err(PlottingError::LastBlock)
-    })
-    .await
-    .unwrap()?;
-
-    let mut archiver = if let Some(last_root_block) = maybe_last_root_block {
-        // Continuing from existing initial state
-        if plot.is_empty() {
-            return Err(PlottingError::ContinueError);
-        }
-
-        let last_archived_block_number = last_root_block.last_archived_block().number;
-        info!("Last archived block {}", last_archived_block_number);
-
-        let maybe_last_archived_block = client
-            .block_by_number(last_archived_block_number)
-            .await
-            .map_err(PlottingError::RpcError)?;
-
-        match maybe_last_archived_block {
-            Some(EncodedBlockWithObjectMapping {
-                block,
-                object_mapping,
-            }) => Archiver::with_initial_state(
-                record_size as usize,
-                recorded_history_segment_size as usize,
-                last_root_block,
-                &block,
-                object_mapping,
-            )
-            .map_err(PlottingError::Archiver)?,
-            None => {
-                return Err(PlottingError::GetBlockError(last_archived_block_number));
-            }
-        }
-    } else {
-        // Starting from genesis
-        if !plot.is_empty() {
-            // Restart before first block was archived, erase the plot
-            // TODO: Erase plot
-        }
-
-        Archiver::new(record_size as usize, recorded_history_segment_size as usize)
-            .map_err(PlottingError::Archiver)?
-    };
-
-    drop(plot);
-
-    let (new_block_to_archive_sender, new_block_to_archive_receiver) =
-        std::sync::mpsc::sync_channel::<Arc<AtomicU32>>(0);
-
-    // Process blocks since last fully archived block (or genesis) up to the current head minus K
-    let mut blocks_to_archive_from = archiver
-        .last_archived_block_number()
-        .map(|n| n + 1)
-        .unwrap_or_default();
-
-    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
-    tokio::task::spawn_blocking({
-        let client = client.clone();
-        let weak_plot = weak_plot.clone();
-
-        #[allow(clippy::mut_range_bound)]
-        move || {
-            let runtime_handle = tokio::runtime::Handle::current();
-            info!("Plotting new blocks in the background");
-
-            'outer: for blocks_to_archive_to in new_block_to_archive_receiver.into_iter() {
-                let blocks_to_archive_to = blocks_to_archive_to.load(Ordering::Relaxed);
-                if blocks_to_archive_to >= blocks_to_archive_from {
-                    debug!(
-                        "Archiving blocks {}..={}",
-                        blocks_to_archive_from, blocks_to_archive_to,
-                    );
-                }
-
-                for block_to_archive in blocks_to_archive_from..=blocks_to_archive_to {
-                    let EncodedBlockWithObjectMapping {
-                        block,
-                        object_mapping,
-                    } = match runtime_handle.block_on(client.block_by_number(block_to_archive)) {
-                        Ok(Some(block)) => block,
-                        Ok(None) => {
-                            error!(
-                                "Failed to get block #{} from RPC: Block not found",
-                                block_to_archive,
-                            );
-
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                        Err(error) => {
-                            error!(
-                                "Failed to get block #{} from RPC: {}",
-                                block_to_archive, error,
-                            );
-
-                            blocks_to_archive_from = block_to_archive;
-                            continue 'outer;
-                        }
-                    };
-
-                    let mut last_root_block = None;
-                    for archived_segment in archiver.add_block(block, object_mapping) {
-                        let ArchivedSegment {
-                            root_block,
-                            pieces,
-                            object_mapping,
-                        } = archived_segment;
-                        let piece_index_offset = merkle_num_leaves * root_block.segment_index();
-
-                        let pieces_to_plot = PiecesToPlot {
-                            piece_index_offset,
-                            pieces,
-                        };
-                        if let Err(_error) = pieces_to_plot_sender.send(pieces_to_plot) {
-                            // No receivers, exiting
-                            break 'outer;
-                        }
-
-                        let object_mapping =
-                            create_global_object_mapping(piece_index_offset, object_mapping);
-
-                        if let Err(error) = object_mappings.store(&object_mapping) {
-                            error!("Failed to store object mappings for pieces: {}", error);
-                        }
-                        let segment_index = root_block.segment_index();
-                        last_root_block.replace(root_block);
-
-                        info!(
-                            "Archived segment {} at block {}",
-                            segment_index, block_to_archive
-                        );
-                    }
-
-                    if let Some(last_root_block) = last_root_block {
-                        if let Some(plot) = weak_plot.upgrade() {
-                            if let Err(error) = plot.set_last_root_block(&last_root_block) {
-                                error!("Failed to store last root block: {}", error);
-                            }
-                        }
-                    }
-                }
-
-                blocks_to_archive_from = blocks_to_archive_to + 1;
-            }
-        }
-    });
-
-    info!("Subscribing to new heads");
-    let mut new_head = client
-        .subscribe_new_head()
-        .await
-        .map_err(PlottingError::RpcError)?;
-
-    let block_to_archive = Arc::new(AtomicU32::default());
-
-    if maybe_last_root_block.is_none() {
-        // If not continuation, archive genesis block
-        new_block_to_archive_sender
-            .send(Arc::clone(&block_to_archive))
-            .expect("Failed to send genesis block archiving message");
-    }
-
-    let (mut best_block_number_sender, mut best_block_number_receiver) = mpsc::channel(1);
-
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(best_block_number_check_interval).await;
-
-            // In case connection dies, we need to disconnect from the node
-            let best_block_number_result =
-                tokio::time::timeout(BEST_BLOCK_REQUEST_TIMEOUT, client.best_block_number()).await;
-
-            let is_error = !matches!(best_block_number_result, Ok(Ok(_)));
-            // Result doesn't matter here
-            let _ = best_block_number_sender
-                .send(best_block_number_result)
-                .await;
-
-            if is_error {
-                break;
-            }
-        }
-    });
-
-    let mut last_best_block_number_error = false;
-
-    // Listen for new blocks produced on the network
-    loop {
-        tokio::select! {
-            _ = &mut stop_receiver => {
-                info!("Plotting stopped!");
-                break;
-            }
-            result = new_head.recv() => {
-                match result {
-                    Some(head) => {
-                        let block_number = u32::from_str_radix(&head.number[2..], 16).unwrap();
-                        debug!("Last block number: {:#?}", block_number);
-
-                        if let Some(block_number) = block_number.checked_sub(confirmation_depth_k) {
-                            // We send block that should be archived over channel that doesn't have
-                            // a buffer, atomic integer is used to make sure archiving process
-                            // always read up to date value
-                            block_to_archive.store(block_number, Ordering::Relaxed);
-                            let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
-                        }
-                    },
-                    None => {
-                        debug!("Subscription has forcefully closed from node side!");
-                        break;
-                    }
-                }
-            }
-            maybe_result = best_block_number_receiver.next() => {
-                match maybe_result {
-                    Some(Ok(Ok(best_block_number))) => {
-                        debug!("Best block number: {:#?}", best_block_number);
-                        last_best_block_number_error = false;
-
-                        if let Some(block_number) = best_block_number.checked_sub(confirmation_depth_k) {
-                            // We send block that should be archived over channel that doesn't have
-                            // a buffer, atomic integer is used to make sure archiving process
-                            // always read up to date value
-                            block_to_archive.fetch_max(block_number, Ordering::Relaxed);
-                            let _ = new_block_to_archive_sender.try_send(Arc::clone(&block_to_archive));
-                        }
-                    }
-                    Some(Ok(Err(error))) => {
-                        if last_best_block_number_error {
-                            error!("Request to get new best block failed second time: {error}");
-                            break;
-                        } else {
-                            warn!("Request to get new best block failed: {error}");
-                            last_best_block_number_error = true;
-                        }
-                    }
-                    Some(Err(_error)) => {
-                        if last_best_block_number_error {
-                            error!("Request to get new best block timed out second time");
-                            break;
-                        } else {
-                            warn!("Request to get new best block timed out");
-                            last_best_block_number_error = true;
-                        }
-                    }
-                    None => {
-                        debug!("Best block number channel closed!");
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
 /// Plot a set of pieces into a particular plot and commitment database.
 fn plot_pieces(
     subspace_codec: &mut SubspaceCodec,
@@ -475,26 +177,4 @@ fn plot_pieces(
     }
 
     Ok(())
-}
-
-fn create_global_object_mapping(
-    piece_index_offset: u64,
-    object_mapping: Vec<PieceObjectMapping>,
-) -> Vec<(Sha256Hash, GlobalObject)> {
-    object_mapping
-        .iter()
-        .enumerate()
-        .flat_map(move |(position, object_mapping)| {
-            object_mapping.objects.iter().map(move |piece_object| {
-                let PieceObject::V0 { hash, offset } = piece_object;
-                (
-                    *hash,
-                    GlobalObject::V0 {
-                        piece_index: piece_index_offset + position as u64,
-                        offset: *offset,
-                    },
-                )
-            })
-        })
-        .collect()
 }

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -21,7 +21,7 @@
 
 mod codec;
 
-pub use codec::SubspaceCodec;
+pub use codec::{BatchEncodeError, SubspaceCodec};
 pub use construct_uint::PieceDistance;
 use schnorrkel::SignatureResult;
 use sha2::{Digest, Sha256};


### PR DESCRIPTION
I thought some more on https://github.com/subspace/subspace/pull/348 and created this as the result as I don't think I can articulate it with words clearly enough.

If you go commit by commit (while ignoring whitespace changes) it should make some sense. It is just a bit bigger than current `main` and supports both single archiving and single object mapping instance in multi-farming context.

I haven't slept for 21 hours now, but the next step would be to create an abstraction for plot, identity, codec and commitments (not sure how to name that) such that instead of 3 vectors of singular things we have one vector of the combined data structure. Then We can replace `farm_single_plot` with its constructor and then:
* map to a vector of farming instances
* map to a single global archiving instance that will plot all the stuff necessary

Also there is one ugly thing that is `*_last_root_block` and `public_key` methods on the `Plot` instance. Both need to be removed and `*_last_root_block` should be replaced with a global configuration (that will also remember some info about the chain used to create the plot on restart and potentially more things). Implementation in this PR just uses `*_last_root_block` of the first plot for all plots, but that needs to go