### PR TITLE
Solution range adjustment behind a fuse

### DIFF
--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -37,7 +37,6 @@ subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 
 [features]
 default = ["std"]
-no-early-solution-range-updates = []
 std = [
 	"codec/std",
 	"frame-support/std",
@@ -52,5 +51,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"subspace-core-primitives/std",
+	"subspace-runtime-primitives/std"
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -295,7 +295,7 @@ mod pallet {
         InitialSolutionRanges<T>,
     >;
 
-    /// Storage to check if the solution range is adjusted for next era
+    /// Storage to check if the solution range is to be adjusted for next era
     #[pallet::storage]
     pub type ShouldAdjustSolutionRange<T: Config> =
         StorageValue<_, bool, ValueQuery, T::ShouldAdjustSolutionRange>;
@@ -367,7 +367,7 @@ mod pallet {
         }
 
         /// Enables solution range adjustment after every era.
-        /// Note: No effect on the solution range adjustment for this era and and next era.
+        /// Note: No effect on the solution range for the current era
         #[pallet::weight(T::DbWeight::get().writes(1))]
         pub fn enable_solution_range_adjustment(origin: OriginFor<T>) -> DispatchResult {
             ensure_root(origin)?;
@@ -508,7 +508,7 @@ impl<T: Config> Pallet<T> {
 
         SolutionRanges::<T>::mutate(|solution_ranges| {
             solution_ranges.next.replace(
-                // Check if the solution range should be adjusted.
+                // Check if the solution range should be adjusted for next era.
                 if ShouldAdjustSolutionRange::<T>::get() {
                     // If Era start slot is not found it means we have just finished the first era
                     let era_start_slot =

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -218,7 +218,6 @@ mod pallet {
         #[pallet::constant]
         type RecordedHistorySegmentSize: Get<u32>;
 
-        #[pallet::constant]
         type ShouldAdjustSolutionRange: Get<bool>;
 
         /// Subspace requires periodic global randomness update.

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -142,6 +142,7 @@ parameter_types! {
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
     pub const MaxPlotSize: u64 = 10 * 2u64.pow(18);
+    pub const ShouldAdjustSolutionRange: bool = false;
 }
 
 impl Config for Test {
@@ -164,6 +165,7 @@ impl Config for Test {
     type HandleEquivocation = EquivocationHandler<OffencesSubspace, ReportLongevity>;
 
     type WeightInfo = ();
+    type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
 }
 
 pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -30,7 +30,7 @@ pallet-grandpa-finality-verifier = { version = "1.0.0", default-features = false
 pallet-object-store = { version = "0.1.0", default-features = false, path = "../pallet-object-store" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../pallet-offences-subspace" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../pallet-rewards" }
-pallet-subspace = { version = "0.1.0", default-features = false, features = ["no-early-solution-range-updates"], path = "../pallet-subspace" }
+pallet-subspace = { version = "0.1.0", default-features = false, path = "../pallet-subspace" }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 pallet-transaction-fees = { version = "0.1.0", default-features = false, path = "../pallet-transaction-fees" }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -255,6 +255,9 @@ impl frame_system::Config for Runtime {
 parameter_types! {
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
+    // Disable solution range adjustment at the start of chain.
+    // Root origin must enable later
+    pub const ShouldAdjustSolutionRange: bool = false;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -270,6 +273,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
+    type ShouldAdjustSolutionRange = ();
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
     type EonChangeTrigger = pallet_subspace::NormalEonChange;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -273,7 +273,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
-    type ShouldAdjustSolutionRange = ();
+    type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
     type EonChangeTrigger = pallet_subspace::NormalEonChange;

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -651,6 +651,7 @@ impl pallet_babe::Config for Runtime {
 parameter_types! {
     pub const SlotProbability: (u64, u64) = (3, 10);
     pub const ExpectedBlockTime: u64 = 10_000;
+    pub const ShouldAdjustSolutionRange: bool = false;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -666,6 +667,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<3840>;
     type MaxPlotSize = ConstU64<{ 10 * 1024 * 1024 * 1024 / PIECE_SIZE as u64 }>;
     type RecordedHistorySegmentSize = ConstU32<{ 3840 * 256 / 2 }>;
+    type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
     type EonChangeTrigger = pallet_subspace::NormalEonChange;

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -30,7 +30,7 @@ pallet-grandpa-finality-verifier = { version = "1.0.0", default-features = false
 pallet-object-store = { version = "0.1.0", default-features = false, path = "../../crates/pallet-object-store" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../../crates/pallet-offences-subspace" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../../crates/pallet-rewards" }
-pallet-subspace = { version = "0.1.0", default-features = false, features = ["no-early-solution-range-updates"], path = "../../crates/pallet-subspace" }
+pallet-subspace = { version = "0.1.0", default-features = false, path = "../../crates/pallet-subspace" }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 pallet-transaction-fees = { version = "0.1.0", default-features = false, path = "../../crates/pallet-transaction-fees" }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -230,6 +230,7 @@ impl frame_system::Config for Runtime {
 parameter_types! {
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
+    pub const ShouldAdjustSolutionRange: bool = false;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -245,6 +246,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
+    type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
     type EonChangeTrigger = pallet_subspace::NormalEonChange;


### PR DESCRIPTION
This PR add following changes
- Remove enabling solution range adjustment after a magic number
- Wrap solution range adjustment logic under a fuse that can only be enabled by root origin 