### PR TITLE
Runtime snapshot

### DIFF
--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -1,0 +1,38 @@
+name: Runtime snapshot build
+
+on:
+  push:
+    tags:
+      - 'runtime-snapshot-*'
+
+jobs:
+  runtime:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build runtime
+        id: build
+        uses: docker/build-push-action@v2
+        with:
+          file: Dockerfile-runtime
+          push: false
+
+      - name: Extract runtime
+        run: |
+          SPEC_VERSION=$(sed -nr 's/.*spec_version: ([0-9]+),/\1/p' crates/subspace-runtime/src/lib.rs)
+          docker run --rm -u root ${{ steps.build.outputs.digest }} > subspace_runtime-$SPEC_VERSION.compact.compressed.wasm
+          echo "SPEC_VERSION=$SPEC_VERSION" >> $GITHUB_ENV
+
+      - name: Upload runtime to assets
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["subspace_runtime-${{ env.SPEC_VERSION }}.compact.compressed.wasm"]'
+

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+ARG RUSTC_VERSION=nightly-2022-02-15
+
+WORKDIR /code
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        llvm \
+        clang \
+        make && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
+
+RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+
+COPY Cargo.lock /code/Cargo.lock
+COPY Cargo.toml /code/Cargo.toml
+COPY rust-toolchain.toml /code/rust-toolchain.toml
+
+COPY crates /code/crates
+COPY cumulus /code/cumulus
+COPY substrate /code/substrate
+COPY test /code/test
+
+# Up until this line all Rust images in this repo should be the same to share the same layers
+
+RUN \
+    /root/.cargo/bin/cargo build --profile production --package subspace-runtime && \
+    mv target/production/wbuild/subspace-runtime/subspace_runtime.compact.compressed.wasm subspace_runtime.compact.compressed.wasm && \
+    rm -rf target
+
+ENTRYPOINT ["/usr/bin/cat", "subspace_runtime.compact.compressed.wasm"]

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 100,
+    spec_version: 101,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/crates/subspace-wasm-tools/src/lib.rs
+++ b/crates/subspace-wasm-tools/src/lib.rs
@@ -1,12 +1,11 @@
-use std::{env, fs, path::PathBuf};
+use std::path::{Component, Path, PathBuf};
+use std::{env, fs};
 
-fn get_relative_target(dir: PathBuf) -> Option<PathBuf> {
+fn get_relative_target(dir: &Path) -> Option<PathBuf> {
     if dir.join("Cargo.lock").is_file() && dir.join("target").is_dir() {
         return Some(dir.join("target"));
     }
-    dir.parent()
-        .map(ToOwned::to_owned)
-        .and_then(get_relative_target)
+    dir.parent().and_then(get_relative_target)
 }
 
 /// Creates a `target_file_name` in `OUT_DIR` that will contain constant `bundle_const_name` with
@@ -18,32 +17,52 @@ pub fn create_runtime_bundle_inclusion_file(
     bundle_const_name: &str,
     target_file_name: &str,
 ) {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("Always set by cargo"));
     let target_dir = env::var("CARGO_TARGET_DIR")
-        .or_else(|_| env::var("WASM_TARGET_DIRECTORY"))
+        .or_else(|_| env::var("SUBSPACE_WASM_TARGET_DIRECTORY"))
         .map(Into::into)
         .unwrap_or_else(|_| {
-            let out_dir = env::var("OUT_DIR").expect("Always set by cargo");
             // Call get `get_relative_target` twice if possible, as wasm target directory is
             // contained in host target directory, and we actually need host one.
-            get_relative_target(out_dir.into())
-                .map(|target_dir| get_relative_target(target_dir.clone()).unwrap_or(target_dir))
+            get_relative_target(&out_dir)
+                .map(|target_dir| get_relative_target(&target_dir).unwrap_or(target_dir))
                 .expect("Out dir is always inside the target directory")
         });
 
     // Propagate target directory to wasm build
-    if env::var("WASM_TARGET_DIRECTORY").is_err() {
-        env::set_var("WASM_TARGET_DIRECTORY", &target_dir);
+    if env::var("SUBSPACE_WASM_TARGET_DIRECTORY").is_err() {
+        env::set_var("SUBSPACE_WASM_TARGET_DIRECTORY", &target_dir);
     }
 
     // Make correct profile accessible in child processes.
     env::set_var(
-        "WBUILD_PROFILE",
-        env::var("WBUILD_PROFILE")
-            .unwrap_or_else(|_| env::var("PROFILE").expect("Defined by cargo; qed")),
+        "SUBSPACE_WASM_BUILD_PROFILE",
+        env::var("SUBSPACE_WASM_BUILD_PROFILE").unwrap_or_else(|_| {
+            // The tricky situation, Cargo doesn't put custom profiles like `production` in
+            // `PROFILE` environment variable, so we need to find the actual profile ourselves by
+            // extracting the first component of `OUT_DIR` that comes after `CARGO_TARGET_DIR`.
+            let mut out_components = out_dir.components();
+            let mut target_components = target_dir.components();
+            while target_components.next().is_some() {
+                out_components.next();
+            }
+
+            if let Component::Normal(profile) = out_components
+                .next()
+                .expect("OUT_DIR has CARGO_TARGET_DIR as prefix")
+            {
+                profile
+                    .to_str()
+                    .expect("Profile is always a utf-8 string")
+                    .to_string()
+            } else {
+                unreachable!("OUT_DIR has CARGO_TARGET_DIR as prefix")
+            }
+        }),
     );
 
     // Create a file that will include execution runtime into consensus runtime
-    let profile = env::var("WBUILD_PROFILE").expect("Set above; qed");
+    let profile = env::var("SUBSPACE_WASM_BUILD_PROFILE").expect("Set above; qed");
     let execution_wasm_bundle_path = target_dir
         .join(profile)
         .join("wbuild")


### PR DESCRIPTION
This adds an action capable of building and attaching runtime blob to GitHub releases.

I decided to go with a separate action and tagging system for now because we need to clarify organization around releases and documentation, so clearly separate release for runtime that doesn't have other binaries should help in preventing confusion for users in the meantime.

Here is an example of what it looks like: https://github.com/nazar-pc/subspace/releases/tag/runtime-snapshot-test

I had to fix runtime building for `production` profile, the issue was quite unexpected.