### PR TITLE
Retire `OpaqueExecutionReceipt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8523,7 +8523,6 @@ dependencies = [
 name = "subspace-fraud-proof"
 version = "0.1.0"
 dependencies = [
- "cirrus-primitives",
  "hash-db",
  "parity-scale-codec",
  "sc-client-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8523,6 +8523,7 @@ dependencies = [
 name = "subspace-fraud-proof"
 version = "0.1.0"
 dependencies = [
+ "cirrus-primitives",
  "hash-db",
  "parity-scale-codec",
  "sc-client-api",
@@ -8667,6 +8668,7 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
+ "cirrus-primitives",
  "derive_more",
  "frame-support",
  "frame-system-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,6 +5021,8 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-executor",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8603,6 +8605,7 @@ dependencies = [
 name = "subspace-runtime"
 version = "0.1.0"
 dependencies = [
+ "cirrus-primitives",
  "cirrus-runtime",
  "frame-benchmarking",
  "frame-executive",
@@ -8756,6 +8759,7 @@ dependencies = [
 name = "subspace-test-runtime"
 version = "0.1.0"
 dependencies = [
+ "cirrus-primitives",
  "cirrus-test-runtime",
  "frame-executive",
  "frame-support",

--- a/crates/pallet-executor/Cargo.toml
+++ b/crates/pallet-executor/Cargo.toml
@@ -19,6 +19,8 @@ log = { version = "0.4.16", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sp-executor = { version = "0.1.0", default-features = false, path = "../sp-executor" }
+sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
+sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 
 [features]
 default = ["std"]
@@ -30,5 +32,7 @@ std = [
   "scale-info/std",
   "sp-core/std",
   "sp-executor/std",
+  "sp-runtime/std",
+  "sp-std/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -36,10 +36,29 @@ mod pallet {
         BundleEquivocationProof, ExecutionReceipt, ExecutorId, FraudProof, InvalidTransactionProof,
         OpaqueBundle,
     };
+    use sp_runtime::traits::{CheckEqual, MaybeDisplay, MaybeMallocSizeOf, SimpleBitOps};
+    use sp_std::fmt::Debug;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        /// Secondary chain block hash type.
+        type SecondaryHash: Parameter
+            + Member
+            + MaybeSerializeDeserialize
+            + Debug
+            + MaybeDisplay
+            + SimpleBitOps
+            + Ord
+            + Default
+            + Copy
+            + CheckEqual
+            + sp_std::hash::Hash
+            + AsRef<[u8]>
+            + AsMut<[u8]>
+            + MaybeMallocSizeOf
+            + MaxEncodedLen;
     }
 
     #[pallet::pallet]
@@ -72,7 +91,7 @@ mod pallet {
         #[pallet::weight((10_000, Pays::No))]
         pub fn submit_execution_receipt(
             origin: OriginFor<T>,
-            execution_receipt: ExecutionReceipt<T::Hash>,
+            execution_receipt: ExecutionReceipt<T::SecondaryHash>,
         ) -> DispatchResult {
             ensure_none(origin)?;
 
@@ -310,7 +329,7 @@ where
 {
     /// Submits an unsigned extrinsic [`Call::submit_execution_receipt`].
     pub fn submit_execution_receipt_unsigned(
-        execution_receipt: ExecutionReceipt<T::Hash>,
+        execution_receipt: ExecutionReceipt<T::SecondaryHash>,
     ) -> frame_support::pallet_prelude::DispatchResult {
         let call = Call::submit_execution_receipt { execution_receipt };
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -150,17 +150,6 @@ pub struct SignedExecutionReceipt<Hash> {
     pub signer: ExecutorId,
 }
 
-// TODO: this might be unneccessary, ideally we could interact with the runtime using `ExecutionReceipt` directly.
-// Refer to the comment https://github.com/subspace/subspace/pull/219#discussion_r776749767
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
-pub struct OpaqueExecutionReceipt(Vec<u8>);
-
-impl<Hash: Encode> From<ExecutionReceipt<Hash>> for OpaqueExecutionReceipt {
-    fn from(inner: ExecutionReceipt<Hash>) -> Self {
-        Self(inner.encode())
-    }
-}
-
 /// Execution phase along with an optional encoded call data.
 ///
 /// Each execution phase has a different method for the runtime call.
@@ -310,10 +299,10 @@ pub struct InvalidTransactionProof;
 
 sp_api::decl_runtime_apis! {
     /// API necessary for executor pallet.
-    pub trait ExecutorApi {
+    pub trait ExecutorApi<SecondaryHash: Encode + Decode> {
         /// Submits the execution receipt via an unsigned extrinsic.
         fn submit_execution_receipt_unsigned(
-            opaque_execution_receipt: OpaqueExecutionReceipt,
+            execution_receipt: ExecutionReceipt<SecondaryHash>,
         ) -> Option<()>;
 
         /// Submits the transaction bundle via an unsigned extrinsic.

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -12,6 +12,7 @@ description = "Subspace fraud proof utilities"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+cirrus-primitives = { version = "0.1.0", path = "../../cumulus/primitives" }
 codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive"] }
 hash-db = "0.15.2"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -12,7 +12,6 @@ description = "Subspace fraud proof utilities"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-cirrus-primitives = { version = "0.1.0", path = "../../cumulus/primitives" }
 codec = { package = "parity-scale-codec", version = "3.1.2", features = ["derive"] }
 hash-db = "0.15.2"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![warn(missing_docs)]
 
+use cirrus_primitives::Hash as SecondaryHash;
 use codec::{Codec, Decode, Encode};
 use hash_db::{HashDB, Hasher, Prefix};
 use sc_client_api::backend;
@@ -190,7 +191,7 @@ impl<Block, C> FetchRuntimeCode for RuntimCodeFetcher<Block, C>
 where
     Block: BlockT,
     C: ProvideRuntimeApi<Block> + Send + Sync,
-    C::Api: ExecutorApi<Block>,
+    C::Api: ExecutorApi<Block, SecondaryHash>,
 {
     fn fetch_runtime_code(&self) -> Option<std::borrow::Cow<[u8]>> {
         self.client
@@ -225,7 +226,7 @@ impl<Block, C, B, Exec, Spawn> ProofVerifier<Block, C, B, Exec, Spawn>
 where
     Block: BlockT,
     C: ProvideRuntimeApi<Block> + Send + Sync,
-    C::Api: ExecutorApi<Block>,
+    C::Api: ExecutorApi<Block, SecondaryHash>,
     B: backend::Backend<Block>,
     Exec: CodeExecutor + Clone + 'static,
     Spawn: SpawnNamed + Clone + Send + 'static,
@@ -297,7 +298,7 @@ impl<Block, C, B, Exec, Spawn> sp_executor::fraud_proof_ext::Externalities
 where
     Block: BlockT,
     C: ProvideRuntimeApi<Block> + Send + Sync,
-    C::Api: ExecutorApi<Block>,
+    C::Api: ExecutorApi<Block, SecondaryHash>,
     B: backend::Backend<Block>,
     Exec: CodeExecutor + Clone + 'static,
     Spawn: SpawnNamed + Clone + Send + 'static,
@@ -317,7 +318,7 @@ impl<Block, C, B, Exec, Spawn> ExtensionsFactory for ProofVerifier<Block, C, B, 
 where
     Block: BlockT,
     C: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-    C::Api: ExecutorApi<Block>,
+    C::Api: ExecutorApi<Block, SecondaryHash>,
     B: backend::Backend<Block> + 'static,
     Exec: CodeExecutor + Clone + Send + Sync,
     Spawn: SpawnNamed + Clone + Send + Sync + 'static,

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -7,7 +7,6 @@
 
 #![warn(missing_docs)]
 
-use cirrus_primitives::Hash as SecondaryHash;
 use codec::{Codec, Decode, Encode};
 use hash_db::{HashDB, Hasher, Prefix};
 use sc_client_api::backend;
@@ -158,7 +157,7 @@ where
     let delta_backend = DeltaBackend {
         backend: essence.backend_storage(),
         delta,
-        _phantom: std::marker::PhantomData::<H>,
+        _phantom: PhantomData::<H>,
     };
     TrieBackend::new(delta_backend, post_delta_root)
 }
@@ -166,7 +165,7 @@ where
 struct DeltaBackend<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher, DB: HashDB<H, DBValue>> {
     backend: &'a S,
     delta: DB,
-    _phantom: std::marker::PhantomData<H>,
+    _phantom: PhantomData<H>,
 }
 
 impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher, DB: HashDB<H, DBValue>>
@@ -182,16 +181,18 @@ impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher, DB: HashDB<H, DBValue>>
     }
 }
 
-struct RuntimCodeFetcher<Block: BlockT, C> {
+struct RuntimCodeFetcher<PBlock: BlockT, C, Hash: Encode + Decode> {
     client: Arc<C>,
-    at: Block::Hash,
+    at: PBlock::Hash,
+    _phantom: PhantomData<Hash>,
 }
 
-impl<Block, C> FetchRuntimeCode for RuntimCodeFetcher<Block, C>
+impl<PBlock, C, Hash> FetchRuntimeCode for RuntimCodeFetcher<PBlock, C, Hash>
 where
-    Block: BlockT,
-    C: ProvideRuntimeApi<Block> + Send + Sync,
-    C::Api: ExecutorApi<Block, SecondaryHash>,
+    PBlock: BlockT,
+    C: ProvideRuntimeApi<PBlock> + Send + Sync,
+    C::Api: ExecutorApi<PBlock, Hash>,
+    Hash: Encode + Decode,
 {
     fn fetch_runtime_code(&self) -> Option<std::borrow::Cow<[u8]>> {
         self.client
@@ -202,15 +203,17 @@ where
 }
 
 /// Fraud proof verifier.
-pub struct ProofVerifier<Block, C, B, Exec, Spawn> {
+pub struct ProofVerifier<PBlock, C, B, Exec, Spawn, Hash> {
     client: Arc<C>,
     backend: Arc<B>,
     executor: Exec,
     spawn_handle: Spawn,
-    _phantom: PhantomData<Block>,
+    _phantom: PhantomData<(PBlock, Hash)>,
 }
 
-impl<Block, C, B, Exec: Clone, Spawn: Clone> Clone for ProofVerifier<Block, C, B, Exec, Spawn> {
+impl<PBlock, C, B, Exec: Clone, Spawn: Clone, Hash> Clone
+    for ProofVerifier<PBlock, C, B, Exec, Spawn, Hash>
+{
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
@@ -222,14 +225,15 @@ impl<Block, C, B, Exec: Clone, Spawn: Clone> Clone for ProofVerifier<Block, C, B
     }
 }
 
-impl<Block, C, B, Exec, Spawn> ProofVerifier<Block, C, B, Exec, Spawn>
+impl<PBlock, C, B, Exec, Spawn, Hash> ProofVerifier<PBlock, C, B, Exec, Spawn, Hash>
 where
-    Block: BlockT,
-    C: ProvideRuntimeApi<Block> + Send + Sync,
-    C::Api: ExecutorApi<Block, SecondaryHash>,
-    B: backend::Backend<Block>,
+    PBlock: BlockT,
+    C: ProvideRuntimeApi<PBlock> + Send + Sync,
+    C::Api: ExecutorApi<PBlock, Hash>,
+    B: backend::Backend<PBlock>,
     Exec: CodeExecutor + Clone + 'static,
     Spawn: SpawnNamed + Clone + Send + 'static,
+    Hash: Encode + Decode,
 {
     /// Constructs a new instance of [`ProofVerifier`].
     pub fn new(client: Arc<C>, backend: Arc<B>, executor: Exec, spawn_handle: Spawn) -> Self {
@@ -238,7 +242,7 @@ where
             backend,
             executor,
             spawn_handle,
-            _phantom: PhantomData::<Block>,
+            _phantom: PhantomData::<(PBlock, Hash)>,
         }
     }
 
@@ -254,8 +258,9 @@ where
 
         let code_fetcher = RuntimCodeFetcher {
             client: self.client.clone(),
-            at: Block::Hash::decode(&mut parent_hash.encode().as_slice())
+            at: PBlock::Hash::decode(&mut parent_hash.encode().as_slice())
                 .expect("Block Hash must be H256; qed"),
+            _phantom: PhantomData::<Hash>,
         };
 
         let runtime_code = RuntimeCode {
@@ -278,7 +283,7 @@ where
         .map_err(VerificationError::BadProof)?;
 
         let new_post_state_root =
-            execution_phase.decode_execution_result::<Block::Header>(execution_result)?;
+            execution_phase.decode_execution_result::<PBlock::Header>(execution_result)?;
         let new_post_state_root = H256::decode(&mut new_post_state_root.encode().as_slice())
             .expect("Block Hash must be H256; qed");
 
@@ -293,15 +298,16 @@ where
     }
 }
 
-impl<Block, C, B, Exec, Spawn> sp_executor::fraud_proof_ext::Externalities
-    for ProofVerifier<Block, C, B, Exec, Spawn>
+impl<PBlock, C, B, Exec, Spawn, Hash> sp_executor::fraud_proof_ext::Externalities
+    for ProofVerifier<PBlock, C, B, Exec, Spawn, Hash>
 where
-    Block: BlockT,
-    C: ProvideRuntimeApi<Block> + Send + Sync,
-    C::Api: ExecutorApi<Block, SecondaryHash>,
-    B: backend::Backend<Block>,
+    PBlock: BlockT,
+    C: ProvideRuntimeApi<PBlock> + Send + Sync,
+    C::Api: ExecutorApi<PBlock, Hash>,
+    B: backend::Backend<PBlock>,
     Exec: CodeExecutor + Clone + 'static,
     Spawn: SpawnNamed + Clone + Send + 'static,
+    Hash: Encode + Decode + Send + Sync,
 {
     fn verify_fraud_proof(&self, proof: &sp_executor::FraudProof) -> bool {
         match self.verify(proof) {
@@ -314,14 +320,16 @@ where
     }
 }
 
-impl<Block, C, B, Exec, Spawn> ExtensionsFactory for ProofVerifier<Block, C, B, Exec, Spawn>
+impl<PBlock, C, B, Exec, Spawn, Hash> ExtensionsFactory
+    for ProofVerifier<PBlock, C, B, Exec, Spawn, Hash>
 where
-    Block: BlockT,
-    C: ProvideRuntimeApi<Block> + Send + Sync + 'static,
-    C::Api: ExecutorApi<Block, SecondaryHash>,
-    B: backend::Backend<Block> + 'static,
+    PBlock: BlockT,
+    C: ProvideRuntimeApi<PBlock> + Send + Sync + 'static,
+    C::Api: ExecutorApi<PBlock, Hash>,
+    B: backend::Backend<PBlock> + 'static,
     Exec: CodeExecutor + Clone + Send + Sync,
     Spawn: SpawnNamed + Clone + Send + Sync + 'static,
+    Hash: Encode + Decode + Send + Sync + 'static,
 {
     fn extensions_for(&self, _: sp_core::offchain::Capabilities) -> Extensions {
         let mut exts = Extensions::new();

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+cirrus-primitives = { version = "0.1.0", default-features = false, path = "../../cumulus/primitives" }
 cirrus-runtime = { version = "0.1.0", default-features = false, path = "../../cumulus/runtime" }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
@@ -72,6 +73,7 @@ hex-literal = { version = "0.3.3" }
 [features]
 default = ["std"]
 std = [
+	"cirrus-primitives/std",
 	"cirrus-runtime/std",
 	"codec/std",
 	"frame-executive/std",

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -492,6 +492,7 @@ impl pallet_offences_subspace::Config for Runtime {
 
 impl pallet_executor::Config for Runtime {
     type Event = Event;
+    type SecondaryHash = cirrus_primitives::Hash;
 }
 
 parameter_types! {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1006,17 +1006,11 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_executor::ExecutorApi<Block> for Runtime {
+    impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {
         fn submit_execution_receipt_unsigned(
-            opaque_execution_receipt: sp_executor::OpaqueExecutionReceipt,
+            execution_receipt: sp_executor::ExecutionReceipt<cirrus_primitives::Hash>,
         ) -> Option<()> {
-            <sp_executor::ExecutionReceipt<<Block as BlockT>::Hash>>::decode(
-                &mut opaque_execution_receipt.encode().as_slice(),
-            )
-            .ok()
-            .and_then(|execution_receipt| {
-                Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
-            })
+            Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
         }
 
         fn submit_transaction_bundle_unsigned(opaque_bundle: OpaqueBundle) -> Option<()> {

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+cirrus-primitives = { version = "0.1.0", path = "../../cumulus/primitives" }
 derive_more = "0.99.17"
 frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 futures = "0.3.21"

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod rpc;
 
+use cirrus_primitives::Hash as SecondaryHash;
 use derive_more::{Deref, DerefMut, Into};
 use futures::channel::mpsc;
 use sc_basic_authorship::ProposerFactory;
@@ -47,7 +48,7 @@ pub trait RuntimeApiCollection:
     sp_api::ApiExt<Block>
     + sp_api::Metadata<Block>
     + sp_block_builder::BlockBuilder<Block>
-    + sp_executor::ExecutorApi<Block>
+    + sp_executor::ExecutorApi<Block, SecondaryHash>
     + sp_offchain::OffchainWorkerApi<Block>
     + sp_session::SessionKeys<Block>
     + sp_consensus_subspace::SubspaceApi<Block>
@@ -64,7 +65,7 @@ where
     Api: sp_api::ApiExt<Block>
         + sp_api::Metadata<Block>
         + sp_block_builder::BlockBuilder<Block>
-        + sp_executor::ExecutorApi<Block>
+        + sp_executor::ExecutorApi<Block, SecondaryHash>
         + sp_offchain::OffchainWorkerApi<Block>
         + sp_session::SessionKeys<Block>
         + sp_consensus_subspace::SubspaceApi<Block>

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -82,8 +82,7 @@ use sp_core::{
 };
 use sp_executor::{
 	Bundle, BundleEquivocationProof, ExecutionPhase, ExecutionReceipt, ExecutorApi, ExecutorId,
-	FraudProof, InvalidTransactionProof, OpaqueBundle, OpaqueExecutionReceipt,
-	SignedExecutionReceipt,
+	FraudProof, InvalidTransactionProof, OpaqueBundle, SignedExecutionReceipt,
 };
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::{
@@ -110,7 +109,7 @@ where
 	primary_chain_client: Arc<PClient>,
 	client: Arc<Client>,
 	spawner: Box<dyn SpawnNamed + Send + Sync>,
-	overseer_handle: OverseerHandle<PBlock>,
+	overseer_handle: OverseerHandle<PBlock, Block::Hash>,
 	transaction_pool: Arc<TransactionPool>,
 	bundle_sender: Arc<TracingUnboundedSender<Bundle<Block::Extrinsic>>>,
 	execution_receipt_sender: Arc<TracingUnboundedSender<SignedExecutionReceipt<Block::Hash>>>,
@@ -172,7 +171,7 @@ where
 		+ Send
 		+ Sync
 		+ 'static,
-	PClient::Api: ExecutorApi<PBlock>,
+	PClient::Api: ExecutorApi<PBlock, Block::Hash>,
 	Backend: sc_client_api::Backend<Block> + Send + Sync + 'static,
 	TransactionFor<Backend, Block>: sp_trie::HashDBT<HashFor<Block>, sp_trie::DBValue>,
 	TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block> + 'static,
@@ -535,7 +534,7 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Option<OpaqueExecutionReceipt> {
+	) -> Option<ExecutionReceipt<Block::Hash>> {
 		match self
 			.process_bundles_impl(primary_hash, bundles, shuffling_seed, maybe_new_runtime)
 			.await
@@ -612,7 +611,7 @@ where
 		+ Send
 		+ Sync
 		+ 'static,
-	PClient::Api: ExecutorApi<PBlock>,
+	PClient::Api: ExecutorApi<PBlock, Block::Hash>,
 	Backend: sc_client_api::Backend<Block> + Send + Sync + 'static,
 	TransactionFor<Backend, Block>: sp_trie::HashDBT<HashFor<Block>, sp_trie::DBValue>,
 	TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block> + 'static,

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -23,7 +23,7 @@ use cirrus_block_builder::{BlockBuilder, BuiltBlock, RecordProof};
 use cirrus_primitives::{AccountId, SecondaryApi};
 use sp_executor::{
 	ExecutionReceipt, ExecutorApi, ExecutorId, ExecutorSignature, OpaqueBundle,
-	OpaqueExecutionReceipt, SignedExecutionReceipt,
+	SignedExecutionReceipt,
 };
 use subspace_core_primitives::Randomness;
 use subspace_runtime_primitives::Hash as PHash;
@@ -95,7 +95,7 @@ where
 		Error = sp_consensus::Error,
 	>,
 	PClient: ProvideRuntimeApi<PBlock>,
-	PClient::Api: ExecutorApi<PBlock>,
+	PClient::Api: ExecutorApi<PBlock, Block::Hash>,
 	Backend: sc_client_api::Backend<Block>,
 	TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block>,
 {
@@ -106,7 +106,7 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Result<Option<OpaqueExecutionReceipt>, sp_blockchain::Error> {
+	) -> Result<Option<ExecutionReceipt<Block::Hash>>, sp_blockchain::Error> {
 		let parent_hash = self.client.info().best_hash;
 		let parent_number = self.client.info().best_number;
 
@@ -257,7 +257,7 @@ where
 					}
 
 					// Return `Some(_)` to broadcast ER to all farmers via unsigned extrinsic.
-					Ok(Some(execution_receipt.into()))
+					Ok(Some(execution_receipt))
 				},
 				Ok(None) => Err(sp_blockchain::Error::Application(Box::from(
 					"This should not happen as the existence of key was just checked",

--- a/cumulus/node/src/service.rs
+++ b/cumulus/node/src/service.rs
@@ -2,7 +2,7 @@
 
 use cirrus_client_executor::{Executor, ExecutorSlotInfo};
 use cirrus_client_executor_gossip::ExecutorGossipParams;
-use cirrus_runtime::{opaque::Block, RuntimeApi};
+use cirrus_runtime::{opaque::Block, Hash, RuntimeApi};
 use futures::{Stream, StreamExt};
 use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
@@ -154,7 +154,7 @@ where
 		+ Send
 		+ 'static
 		+ Sync,
-	PClient::Api: ExecutorApi<PBlock>,
+	PClient::Api: ExecutorApi<PBlock, Hash>,
 	SC: SelectChain<PBlock>,
 	IBNS: Stream<Item = NumberFor<PBlock>> + Send + 'static,
 	NSNS: Stream<Item = (Slot, Tag)> + Send + 'static,

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+cirrus-primitives = { version = "0.1.0", default-features = false, path = "../../cumulus/primitives" }
 cirrus-test-runtime = { version = "0.1.0", default-features = false, path = "../../cumulus/test/runtime" }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -465,6 +465,7 @@ impl pallet_offences_subspace::Config for Runtime {
 
 impl pallet_executor::Config for Runtime {
     type Event = Event;
+    type SecondaryHash = cirrus_primitives::Hash;
 }
 
 parameter_types! {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -929,17 +929,11 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_executor::ExecutorApi<Block> for Runtime {
+    impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {
         fn submit_execution_receipt_unsigned(
-            opaque_execution_receipt: sp_executor::OpaqueExecutionReceipt,
+            execution_receipt: sp_executor::ExecutionReceipt<cirrus_primitives::Hash>,
         ) -> Option<()> {
-            <sp_executor::ExecutionReceipt<<Block as BlockT>::Hash>>::decode(
-                &mut opaque_execution_receipt.encode().as_slice(),
-            )
-            .ok()
-            .and_then(|execution_receipt| {
-                Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
-            })
+            Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
         }
 
         fn submit_transaction_bundle_unsigned(opaque_bundle: OpaqueBundle) -> Option<()> {


### PR DESCRIPTION
This PR was intended for fixing the regression of codec incompatibility between `ExecutionReceipt` and `OpaqueExecutionReceipt` in the latest commit. Since the executor code has been significantly simplified, we can just remove `OpaqueExecutionReceipt` directly which solves the regression naturally.