### PR TITLE
Add healthcheck for docker-compose setup

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -43,6 +43,11 @@ RUN \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+HEALTHCHECK CMD curl \
+                  -H "Content-Type: application/json" \
+                  -d '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }" \
+                  -f "http://localhost:9933"
+
 COPY --from=0 /code/subspace-node /subspace-node
 
 RUN mkdir /var/subspace && chown nobody:nogroup /var/subspace

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -39,7 +39,7 @@ FROM ubuntu:20.04
 
 RUN \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -215,10 +215,16 @@ services:
 # Replace `INSERT_YOUR_ID` with your node ID (will be shown in telemetry)
       "--name", "INSERT_YOUR_ID"
     ]
+    healthcheck:
+      timeout: 5s
+# If node setup takes longer then expected, you want to increase `interval` and `retries` number.
+      interval: 30s
+      retries: 5
 
   farmer:
     depends_on:
-      - node
+      node:
+        condition: service_healthy
 # Replace `snapshot-DATE` with latest release (like `snapshot-2022-mar-09`)
     image: ghcr.io/subspace/farmer:snapshot-DATE
 # Un-comment following 2 lines to unlock farmer's RPC


### PR DESCRIPTION
This pr fixes the issue described here:
https://github.com/subspace/subspace/pull/389#discussion_r857123402

Node startup may take some time, so farmer container will try to connect with busy waiting. Here we utilize docker health check for that. So farmer will start after node will be ready.