### PR TITLE
encode the entrinsics again to get the correct root

### DIFF
--- a/crates/pallet-grandpa-finality-verifier/src/lib.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/lib.rs
@@ -165,8 +165,10 @@ pub mod pallet {
             (*block.block.header.parent_hash()).into() == parent_hash,
             Error::<T>::InvalidBlock
         );
-        let extrinsics_root =
-            C::Hasher::ordered_trie_root(block.block.extrinsics, sp_runtime::StateVersion::V0);
+        let extrinsics_root = C::Hasher::ordered_trie_root(
+            block.block.extrinsics.iter().map(Encode::encode).collect(),
+            sp_runtime::StateVersion::V0,
+        );
         ensure!(
             extrinsics_root == *block.block.header.extrinsics_root(),
             Error::<T>::InvalidBlock

--- a/crates/pallet-grandpa-finality-verifier/src/tests/mod.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/tests/mod.rs
@@ -243,7 +243,10 @@ fn invalid_extrinsics() -> Vec<OpaqueExtrinsic> {
 }
 
 fn valid_extrinsics_root<H: Header>() -> H::Hash {
-    H::Hashing::ordered_trie_root(valid_extrinsics(), sp_runtime::StateVersion::V0)
+    H::Hashing::ordered_trie_root(
+        valid_extrinsics().iter().map(Encode::encode).collect(),
+        sp_runtime::StateVersion::V0,
+    )
 }
 
 fn submit_valid_finality_proof(chain_id: ChainId, header: u8) -> Result<TestHeader, DispatchError> {


### PR DESCRIPTION
From here - https://substrate.stackexchange.com/questions/2153/calculate-extrinsincs-root/2172#2172

OpaqueExtrinsics need to be encoded to actually get the correct extrinsic root