### PR TITLE
Skip the signed execution receipt processing while major syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,7 @@ dependencies = [
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
+ "sc-network",
  "sc-transaction-pool-api",
  "sc-utils",
  "sha2 0.10.2",

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -281,6 +281,7 @@ fn main() -> std::result::Result<(), Error> {
                     let secondary_chain_full_node_fut = cirrus_node::service::new_full(
                         secondary_chain_config,
                         primary_chain_full_node.client.clone(),
+                        primary_chain_full_node.network.clone(),
                         &primary_chain_full_node.select_chain,
                         primary_chain_full_node
                             .imported_block_notification_stream

--- a/cumulus/client/cirrus-executor/Cargo.toml
+++ b/cumulus/client/cirrus-executor/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # Substrate dependencies
 sc-client-api = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
+sc-network = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-utils = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sp-api = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -72,6 +72,7 @@ use cirrus_primitives::{AccountId, SecondaryApi};
 use codec::{Decode, Encode};
 use futures::{pin_mut, select, FutureExt, Stream, StreamExt};
 use sc_client_api::{AuxStore, BlockBackend};
+use sc_network::NetworkService;
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -107,6 +108,7 @@ where
 {
 	// TODO: no longer used in executor, revisit this with ParachainBlockImport together.
 	primary_chain_client: Arc<PClient>,
+	primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
 	client: Arc<Client>,
 	spawner: Box<dyn SpawnNamed + Send + Sync>,
 	overseer_handle: OverseerHandle<PBlock, Block::Hash>,
@@ -128,6 +130,7 @@ where
 	fn clone(&self) -> Self {
 		Self {
 			primary_chain_client: self.primary_chain_client.clone(),
+			primary_network: self.primary_network.clone(),
 			client: self.client.clone(),
 			spawner: self.spawner.clone(),
 			overseer_handle: self.overseer_handle.clone(),
@@ -181,6 +184,7 @@ where
 	#[allow(clippy::too_many_arguments)]
 	pub async fn new<SE, SC, IBNS, NSNS>(
 		primary_chain_client: Arc<PClient>,
+		primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
 		spawn_essential: &SE,
 		select_chain: &SC,
 		imported_block_notification_stream: IBNS,
@@ -247,6 +251,7 @@ where
 
 		let mut executor = Self {
 			primary_chain_client,
+			primary_network,
 			client,
 			spawner,
 			overseer_handle,

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -214,6 +214,14 @@ where
 
 		// TODO: The applied txs can be fully removed from the transaction pool
 
+		if self.primary_network.is_major_syncing() {
+			tracing::debug!(
+				target: LOG_TARGET,
+				"Skip generating signed execution receipt as the primary node is still major syncing..."
+			);
+			return Ok(None)
+		}
+
 		let executor_id = self.primary_chain_client.runtime_api().executor_id(&BlockId::Hash(
 			PBlock::Hash::decode(&mut primary_hash.encode().as_slice())
 				.expect("Primary block hash must be the correct type; qed"),

--- a/cumulus/node/src/service.rs
+++ b/cumulus/node/src/service.rs
@@ -6,6 +6,7 @@ use cirrus_runtime::{opaque::Block, Hash, RuntimeApi};
 use futures::{Stream, StreamExt};
 use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
+use sc_network::NetworkService;
 use sc_service::{
 	BuildNetworkParams, Configuration, NetworkStarter, PartialComponents, Role, SpawnTasksParams,
 	TFullBackend, TFullClient, TaskManager,
@@ -142,6 +143,7 @@ pub struct NewFull<C> {
 pub async fn new_full<PBlock, PClient, SC, IBNS, NSNS>(
 	mut parachain_config: Configuration,
 	primary_chain_client: Arc<PClient>,
+	primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
 	select_chain: &SC,
 	imported_block_notification_stream: IBNS,
 	new_slot_notification_stream: NSNS,
@@ -229,6 +231,7 @@ where
 
 		let executor = Executor::new(
 			primary_chain_client,
+			primary_network,
 			&spawn_essential,
 			select_chain,
 			imported_block_notification_stream,

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -232,6 +232,7 @@ async fn start_node_impl(
 
 		let executor = Executor::new(
 			primary_chain_full_node.client.clone(),
+			primary_chain_full_node.network.clone(),
 			&spawn_essential,
 			&primary_chain_full_node.select_chain,
 			primary_chain_full_node


### PR DESCRIPTION
The new slot notification is disabled while the primary chain is major
syncing, which means the bundle production is disabled in the meantime.
Similarly, I think it makes sense to also skip the signed execution
receipt processing while major syncing. Assuming the executor chain
is built by only processing the primary blocks(no syncing from the other executors),
then we can use the network sync state of primary chain as an indicator to skip that.