### PR TITLE
Add support for building runtime and executables via manual trigger

### DIFF
--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -1,6 +1,11 @@
+# This action enabling building WASM runtime used for forkless runtime upgrades, can be triggered manually or by
+# release creation.
+#
+# WASM bundles are built both for releases and for manually triggered runs, uploaded to artifacts and assets.
 name: Runtime snapshot build
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'runtime-snapshot-*'
@@ -29,10 +34,19 @@ jobs:
           docker run --rm -u root ${{ steps.build.outputs.digest }} > subspace_runtime-$SPEC_VERSION.compact.compressed.wasm
           echo "SPEC_VERSION=$SPEC_VERSION" >> $GITHUB_ENV
 
+      - name: Upload runtime to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: subspace_runtime
+          path: |
+            subspace_runtime-${{ env.SPEC_VERSION }}.compact.compressed.wasm
+          if-no-files-found: error
+
       - name: Upload runtime to assets
         uses: alexellis/upload-assets@0.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["subspace_runtime-${{ env.SPEC_VERSION }}.compact.compressed.wasm"]'
-
+        # Only run for releases
+        if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -1,12 +1,20 @@
+# This action enables building container images and executables for farmer and node, can be triggered manually or by
+# release creation.
+#
+# Container images are only built for releases, pushed to GitHub Container Registry.
+# Executables are built both for releases and for manually triggered runs, uploaded to artifacts and assets.
 name: Snapshot build
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'snapshot-*'
 
 jobs:
   container-images:
+    # Only run for releases
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -164,9 +172,18 @@ jobs:
           move target/production/subspace-node.exe executables/subspace-node-${{ matrix.build.suffix }}.exe
         if: runner.os == 'Windows'
 
+      - name: Upload node and farmer executables to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: executables-{{ matrix.build.suffix }}
+          path: |
+            executables/*
+          if-no-files-found: error
+
       - name: Upload node and farmer executables to assets
         uses: alexellis/upload-assets@0.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["executables/*"]'
+        if: github.event_name == 'push' && github.ref_type == 'tag'


### PR DESCRIPTION
This allows anyone to trigger build of runtime or executables without creating release. Artifacts will be present on the workflow run page.