### PR TITLE
Check the signature and signer of execution receipt on farmer

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -17,7 +17,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::Encode;
 use frame_system::offchain::SubmitTransaction;
 pub use pallet::*;
 use sp_executor::{
@@ -331,7 +330,7 @@ impl<T: Config> Pallet<T> {
             signer,
         }: &SignedExecutionReceipt<T::SecondaryHash>,
     ) -> Result<(), Error<T>> {
-        let msg = execution_receipt.hash().encode();
+        let msg = execution_receipt.hash();
         if !signer.verify(&msg, signature) {
             return Err(Error::<T>::BadExecutionReceiptSignature);
         }

--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -20,7 +20,8 @@
 use frame_system::offchain::SubmitTransaction;
 pub use pallet::*;
 use sp_executor::{
-    BundleEquivocationProof, ExecutionReceipt, FraudProof, InvalidTransactionProof, OpaqueBundle,
+    BundleEquivocationProof, FraudProof, InvalidTransactionProof, OpaqueBundle,
+    SignedExecutionReceipt,
 };
 
 const INVALID_BUNDLE_EQUIVOCATION_PROOF: u8 = 101;
@@ -33,8 +34,8 @@ mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_core::H256;
     use sp_executor::{
-        BundleEquivocationProof, ExecutionReceipt, ExecutorId, FraudProof, InvalidTransactionProof,
-        OpaqueBundle,
+        BundleEquivocationProof, ExecutorId, FraudProof, InvalidTransactionProof, OpaqueBundle,
+        SignedExecutionReceipt,
     };
     use sp_runtime::traits::{CheckEqual, MaybeDisplay, MaybeMallocSizeOf, SimpleBitOps};
     use sp_std::fmt::Debug;
@@ -91,7 +92,7 @@ mod pallet {
         #[pallet::weight((10_000, Pays::No))]
         pub fn submit_execution_receipt(
             origin: OriginFor<T>,
-            execution_receipt: ExecutionReceipt<T::SecondaryHash>,
+            execution_receipt: SignedExecutionReceipt<T::SecondaryHash>,
         ) -> DispatchResult {
             ensure_none(origin)?;
 
@@ -329,7 +330,7 @@ where
 {
     /// Submits an unsigned extrinsic [`Call::submit_execution_receipt`].
     pub fn submit_execution_receipt_unsigned(
-        execution_receipt: ExecutionReceipt<T::SecondaryHash>,
+        execution_receipt: SignedExecutionReceipt<T::SecondaryHash>,
     ) -> frame_support::pallet_prelude::DispatchResult {
         let call = Call::submit_execution_receipt { execution_receipt };
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -150,6 +150,13 @@ pub struct SignedExecutionReceipt<Hash> {
     pub signer: ExecutorId,
 }
 
+impl<Hash: Encode> SignedExecutionReceipt<Hash> {
+    /// Returns the hash of inner execution receipt.
+    pub fn hash(&self) -> H256 {
+        self.execution_receipt.hash()
+    }
+}
+
 /// Execution phase along with an optional encoded call data.
 ///
 /// Each execution phase has a different method for the runtime call.
@@ -302,7 +309,7 @@ sp_api::decl_runtime_apis! {
     pub trait ExecutorApi<SecondaryHash: Encode + Decode> {
         /// Submits the execution receipt via an unsigned extrinsic.
         fn submit_execution_receipt_unsigned(
-            execution_receipt: ExecutionReceipt<SecondaryHash>,
+            execution_receipt: SignedExecutionReceipt<SecondaryHash>,
         ) -> Option<()>;
 
         /// Submits the transaction bundle via an unsigned extrinsic.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1007,7 +1007,7 @@ impl_runtime_apis! {
 
     impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {
         fn submit_execution_receipt_unsigned(
-            execution_receipt: sp_executor::ExecutionReceipt<cirrus_primitives::Hash>,
+            execution_receipt: sp_executor::SignedExecutionReceipt<cirrus_primitives::Hash>,
         ) -> Option<()> {
             Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
         }

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -539,7 +539,7 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Option<ExecutionReceipt<Block::Hash>> {
+	) -> Option<SignedExecutionReceipt<Block::Hash>> {
 		match self
 			.process_bundles_impl(primary_hash, bundles, shuffling_seed, maybe_new_runtime)
 			.await

--- a/cumulus/client/cirrus-executor/src/overseer.rs
+++ b/cumulus/client/cirrus-executor/src/overseer.rs
@@ -24,8 +24,8 @@ use sp_api::{ApiError, BlockT, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus_slots::Slot;
 use sp_executor::{
-	BundleEquivocationProof, ExecutionReceipt, ExecutorApi, FraudProof, InvalidTransactionProof,
-	OpaqueBundle,
+	BundleEquivocationProof, ExecutorApi, FraudProof, InvalidTransactionProof, OpaqueBundle,
+	SignedExecutionReceipt,
 };
 use sp_runtime::{
 	generic::{BlockId, DigestItem},
@@ -74,7 +74,7 @@ pub type ProcessorFn<Hash> = Box<
 			Vec<OpaqueBundle>,
 			Randomness,
 			Option<Cow<'static, [u8]>>,
-		) -> Pin<Box<dyn Future<Output = Option<ExecutionReceipt<Hash>>> + Send>>
+		) -> Pin<Box<dyn Future<Output = Option<SignedExecutionReceipt<Hash>>> + Send>>
 		+ Send
 		+ Sync,
 >;

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -106,7 +106,7 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Result<Option<ExecutionReceipt<Block::Hash>>, sp_blockchain::Error> {
+	) -> Result<Option<SignedExecutionReceipt<Block::Hash>>, sp_blockchain::Error> {
 		let parent_hash = self.client.info().best_hash;
 		let parent_number = self.client.info().best_number;
 
@@ -247,7 +247,7 @@ where
 					);
 
 					let signed_execution_receipt = SignedExecutionReceipt {
-						execution_receipt: execution_receipt.clone(),
+						execution_receipt,
 						signature: ExecutorSignature::decode(&mut signature.as_slice()).map_err(
 							|err| {
 								sp_blockchain::Error::Application(Box::from(format!(
@@ -258,14 +258,15 @@ where
 						signer: executor_id,
 					};
 
-					if let Err(e) =
-						self.execution_receipt_sender.unbounded_send(signed_execution_receipt)
+					if let Err(e) = self
+						.execution_receipt_sender
+						.unbounded_send(signed_execution_receipt.clone())
 					{
 						tracing::error!(target: LOG_TARGET, error = ?e, "Failed to send signed execution receipt");
 					}
 
 					// Return `Some(_)` to broadcast ER to all farmers via unsigned extrinsic.
-					Ok(Some(execution_receipt))
+					Ok(Some(signed_execution_receipt))
 				},
 				Ok(None) => Err(sp_blockchain::Error::Application(Box::from(
 					"This should not happen as the existence of key was just checked",

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -232,12 +232,12 @@ where
 				&*self.keystore,
 				&[(ByteArray::to_raw_vec(&executor_id), ExecutorId::ID)],
 			) {
-			let to_sign = execution_receipt.hash().encode();
+			let to_sign = execution_receipt.hash();
 			match SyncCryptoStore::sign_with(
 				&*self.keystore,
 				ExecutorId::ID,
 				&executor_id.clone().into(),
-				&to_sign,
+				to_sign.as_ref(),
 			) {
 				Ok(Some(signature)) => {
 					tracing::debug!(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -930,7 +930,7 @@ impl_runtime_apis! {
 
     impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {
         fn submit_execution_receipt_unsigned(
-            execution_receipt: sp_executor::ExecutionReceipt<cirrus_primitives::Hash>,
+            execution_receipt: sp_executor::SignedExecutionReceipt<cirrus_primitives::Hash>,
         ) -> Option<()> {
             Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
         }


### PR DESCRIPTION
This PR checks the execution receipt signature validity and is signed by expected author on the farmer side. Now `ExecutionReceipt` is only used locally, `SignedExecutionReceipt` will be gossiped over the executor network and sent to farmers.