### PR TITLE
Allow only the trusted executor to produce bundle

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -347,8 +347,7 @@ impl<T: Config> Pallet<T> {
             signer,
         }: &SignedExecutionReceipt<T::SecondaryHash>,
     ) -> Result<(), Error<T>> {
-        let msg = execution_receipt.hash();
-        if !signer.verify(&msg, signature) {
+        if !signer.verify(&execution_receipt.hash(), signature) {
             return Err(Error::<T>::BadExecutionReceiptSignature);
         }
 
@@ -370,8 +369,7 @@ impl<T: Config> Pallet<T> {
             signer,
         }: &SignedOpaqueBundle,
     ) -> Result<(), Error<T>> {
-        let msg = opaque_bundle.hash();
-        if !signer.verify(&msg, signature) {
+        if !signer.verify(&opaque_bundle.hash(), signature) {
             return Err(Error::<T>::BadBundleSignature);
         }
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -115,7 +115,7 @@ impl OpaqueBundle {
     }
 }
 
-impl<Extrinsic: sp_runtime::traits::Extrinsic + Encode> From<Bundle<Extrinsic>> for OpaqueBundle {
+impl<Extrinsic: Encode> From<Bundle<Extrinsic>> for OpaqueBundle {
     fn from(bundle: Bundle<Extrinsic>) -> Self {
         let Bundle { header, extrinsics } = bundle;
         let opaque_extrinsics = extrinsics
@@ -150,9 +150,7 @@ impl SignedOpaqueBundle {
     }
 }
 
-impl<Extrinsic: sp_runtime::traits::Extrinsic + Encode> From<SignedBundle<Extrinsic>>
-    for SignedOpaqueBundle
-{
+impl<Extrinsic: Encode> From<SignedBundle<Extrinsic>> for SignedOpaqueBundle {
     fn from(
         SignedBundle {
             bundle,

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -57,6 +57,8 @@ impl sp_runtime::BoundToRuntimeAppPublic for ExecutorKey {
 /// Header of transaction bundle.
 #[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
 pub struct BundleHeader {
+    /// The hash of primary block at which the bundle was created.
+    pub primary_hash: PHash,
     /// The slot number.
     pub slot_number: u64,
     /// The merkle root of the extrinsics.
@@ -298,6 +300,7 @@ impl BundleEquivocationProof {
     /// Constructs a dummy bundle equivocation proof.
     pub fn dummy_at(slot_number: u64) -> Self {
         let dummy_header = BundleHeader {
+            primary_hash: PHash::default(),
             slot_number,
             extrinsics_root: H256::default(),
         };

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -132,6 +132,42 @@ impl<Extrinsic: sp_runtime::traits::Extrinsic + Encode> From<Bundle<Extrinsic>> 
     }
 }
 
+/// Signed version of [`OpaqueBundle`].
+#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+pub struct SignedOpaqueBundle {
+    /// The bundle header.
+    pub opaque_bundle: OpaqueBundle,
+    /// Signature of the opaque bundle.
+    pub signature: ExecutorSignature,
+    /// Signer of the signature.
+    pub signer: ExecutorId,
+}
+
+impl SignedOpaqueBundle {
+    /// Returns the hash of inner opaque bundle.
+    pub fn hash(&self) -> H256 {
+        self.opaque_bundle.hash()
+    }
+}
+
+impl<Extrinsic: sp_runtime::traits::Extrinsic + Encode> From<SignedBundle<Extrinsic>>
+    for SignedOpaqueBundle
+{
+    fn from(
+        SignedBundle {
+            bundle,
+            signature,
+            signer,
+        }: SignedBundle<Extrinsic>,
+    ) -> Self {
+        Self {
+            opaque_bundle: bundle.into(),
+            signature,
+            signer,
+        }
+    }
+}
+
 /// Receipt of state execution.
 #[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
 pub struct ExecutionReceipt<Hash> {
@@ -327,7 +363,7 @@ sp_api::decl_runtime_apis! {
         ) -> Option<()>;
 
         /// Submits the transaction bundle via an unsigned extrinsic.
-        fn submit_transaction_bundle_unsigned(opaque_bundle: OpaqueBundle) -> Option<()>;
+        fn submit_transaction_bundle_unsigned(opaque_bundle: SignedOpaqueBundle) -> Option<()>;
 
         /// Submits the fraud proof via an unsigned extrinsic.
         fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) -> Option<()>;

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -86,6 +86,17 @@ impl<Extrinsic> Bundle<Extrinsic> {
     }
 }
 
+/// Signed version of [`Bundle`].
+#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+pub struct SignedBundle<Extrinsic> {
+    /// The bundle header.
+    pub bundle: Bundle<Extrinsic>,
+    /// Signature of the bundle.
+    pub signature: ExecutorSignature,
+    /// Signer of the signature.
+    pub signer: ExecutorId,
+}
+
 /// Bundle with opaque extrinsics.
 #[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
 pub struct OpaqueBundle {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -849,10 +849,10 @@ fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle> {
             match <UncheckedExtrinsic>::decode(&mut opaque_extrinsic.encode().as_slice()) {
                 Ok(uxt) => {
                     if let Call::Executor(pallet_executor::Call::submit_transaction_bundle {
-                        opaque_bundle,
+                        signed_opaque_bundle,
                     }) = uxt.function
                     {
-                        Some(opaque_bundle)
+                        Some(signed_opaque_bundle.opaque_bundle)
                     } else {
                         None
                     }
@@ -1012,7 +1012,7 @@ impl_runtime_apis! {
             Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
         }
 
-        fn submit_transaction_bundle_unsigned(opaque_bundle: OpaqueBundle) -> Option<()> {
+        fn submit_transaction_bundle_unsigned(opaque_bundle: sp_executor::SignedOpaqueBundle) -> Option<()> {
             Executor::submit_transaction_bundle_unsigned(opaque_bundle).ok()
         }
 

--- a/cumulus/client/cirrus-executor/src/bundler.rs
+++ b/cumulus/client/cirrus-executor/src/bundler.rs
@@ -1,17 +1,20 @@
-use codec::Encode;
+use codec::{Decode, Encode};
 use futures::{select, FutureExt};
 use sc_client_api::BlockBackend;
 use sc_transaction_pool_api::InPoolTransaction;
 use sp_api::ProvideRuntimeApi;
+use sp_core::ByteArray;
+use sp_keystore::SyncCryptoStore;
 use sp_runtime::{
 	generic::BlockId,
 	traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT},
+	RuntimeAppPublic,
 };
 use std::time;
 
 use crate::overseer::ExecutorSlotInfo;
 use cirrus_primitives::{AccountId, SecondaryApi};
-use sp_executor::{Bundle, BundleHeader, OpaqueBundle};
+use sp_executor::{Bundle, BundleHeader, ExecutorApi, ExecutorId, OpaqueBundle};
 
 use subspace_runtime_primitives::Hash as PHash;
 
@@ -29,16 +32,16 @@ where
 			Block,
 			StateBackend = sc_client_api::backend::StateBackendFor<Backend, Block>,
 		>,
+	PClient: ProvideRuntimeApi<PBlock>,
+	PClient::Api: ExecutorApi<PBlock, Block::Hash>,
 	Backend: sc_client_api::Backend<Block>,
 	TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block>,
 {
 	pub(super) async fn produce_bundle_impl(
 		self,
-		_primary_hash: PHash,
+		primary_hash: PHash,
 		slot_info: ExecutorSlotInfo,
 	) -> Result<Option<OpaqueBundle>, sp_blockchain::Error> {
-		println!("TODO: solve some puzzle based on `slot_info` to be allowed to produce a bundle");
-
 		let parent_number = self.client.info().best_number;
 
 		let mut t1 = self.transaction_pool.ready_at(parent_number).fuse();
@@ -89,10 +92,40 @@ where
 			extrinsics,
 		};
 
-		if let Err(e) = self.bundle_sender.unbounded_send(bundle.clone()) {
-			tracing::error!(target: LOG_TARGET, error = ?e, "Failed to send transaction bundle");
-		}
+		let executor_id = self.primary_chain_client.runtime_api().executor_id(&BlockId::Hash(
+			PBlock::Hash::decode(&mut primary_hash.encode().as_slice())
+				.expect("Primary block hash must be the correct type; qed"),
+		))?;
 
-		Ok(Some(bundle.into()))
+		if self.is_authority &&
+			SyncCryptoStore::has_keys(
+				&*self.keystore,
+				&[(ByteArray::to_raw_vec(&executor_id), ExecutorId::ID)],
+			) {
+			let to_sign = bundle.hash();
+			match SyncCryptoStore::sign_with(
+				&*self.keystore,
+				ExecutorId::ID,
+				&executor_id.into(),
+				to_sign.as_ref(),
+			) {
+				Ok(Some(_signature)) => {
+					// TODO: SignedBundle
+					if let Err(e) = self.bundle_sender.unbounded_send(bundle.clone()) {
+						tracing::error!(target: LOG_TARGET, error = ?e, "Failed to send transaction bundle");
+					}
+
+					Ok(Some(bundle.into()))
+				},
+				Ok(None) => Err(sp_blockchain::Error::Application(Box::from(
+					"This should not happen as the existence of key was just checked",
+				))),
+				Err(error) => Err(sp_blockchain::Error::Application(Box::from(format!(
+					"Error occurred when signing the bundle: {error}"
+				)))),
+			}
+		} else {
+			Ok(None)
+		}
 	}
 }

--- a/cumulus/client/cirrus-executor/src/bundler.rs
+++ b/cumulus/client/cirrus-executor/src/bundler.rs
@@ -90,7 +90,11 @@ where
 		let _state_root = self.client.expect_header(BlockId::Number(parent_number))?.state_root();
 
 		let bundle = Bundle {
-			header: BundleHeader { slot_number: slot_info.slot.into(), extrinsics_root },
+			header: BundleHeader {
+				primary_hash,
+				slot_number: slot_info.slot.into(),
+				extrinsics_root,
+			},
 			extrinsics,
 		};
 

--- a/cumulus/client/cirrus-executor/src/bundler.rs
+++ b/cumulus/client/cirrus-executor/src/bundler.rs
@@ -36,7 +36,7 @@ where
 		self,
 		_primary_hash: PHash,
 		slot_info: ExecutorSlotInfo,
-	) -> Option<OpaqueBundle> {
+	) -> Result<Option<OpaqueBundle>, sp_blockchain::Error> {
 		println!("TODO: solve some puzzle based on `slot_info` to be allowed to produce a bundle");
 
 		let parent_number = self.client.info().best_number;
@@ -82,8 +82,7 @@ where
 			sp_core::storage::StateVersion::V1,
 		);
 
-		let _state_root =
-			self.client.expect_header(BlockId::Number(parent_number)).ok()?.state_root();
+		let _state_root = self.client.expect_header(BlockId::Number(parent_number))?.state_root();
 
 		let bundle = Bundle {
 			header: BundleHeader { slot_number: slot_info.slot.into(), extrinsics_root },
@@ -94,6 +93,6 @@ where
 			tracing::error!(target: LOG_TARGET, error = ?e, "Failed to send transaction bundle");
 		}
 
-		Some(bundle.into())
+		Ok(Some(bundle.into()))
 	}
 }

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -84,6 +84,7 @@ use sp_core::{
 use sp_executor::{
 	Bundle, BundleEquivocationProof, ExecutionPhase, ExecutionReceipt, ExecutorApi, ExecutorId,
 	FraudProof, InvalidTransactionProof, OpaqueBundle, SignedBundle, SignedExecutionReceipt,
+	SignedOpaqueBundle,
 };
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::{
@@ -528,7 +529,7 @@ where
 		self,
 		primary_hash: PHash,
 		slot_info: ExecutorSlotInfo,
-	) -> Option<OpaqueBundle> {
+	) -> Option<SignedOpaqueBundle> {
 		match self.produce_bundle_impl(primary_hash, slot_info).await {
 			Ok(res) => res,
 			Err(err) => {

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -529,7 +529,18 @@ where
 		primary_hash: PHash,
 		slot_info: ExecutorSlotInfo,
 	) -> Option<OpaqueBundle> {
-		self.produce_bundle_impl(primary_hash, slot_info).await
+		match self.produce_bundle_impl(primary_hash, slot_info).await {
+			Ok(res) => res,
+			Err(err) => {
+				tracing::error!(
+					target: LOG_TARGET,
+					relay_parent = ?primary_hash,
+					error = ?err,
+					"Error at producing bundle.",
+				);
+				None
+			},
+		}
 	}
 
 	/// Processes the bundles extracted from the primary block.

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -669,8 +669,7 @@ where
 				PBlock::Hash::decode(&mut bundle.header.primary_hash.encode().as_slice())
 					.expect("Hash type must be correct");
 
-			let msg = bundle.hash();
-			if !signer.verify(&msg, signature) {
+			if !signer.verify(&bundle.hash(), signature) {
 				return Err(Self::Error::BadBundleSignature)
 			}
 
@@ -721,8 +720,7 @@ where
 			PBlock::Hash::decode(&mut execution_receipt.primary_hash.encode().as_slice())
 				.expect("Hash type must be correct");
 
-		let msg = execution_receipt.hash().encode();
-		if !signer.verify(&msg, signature) {
+		if !signer.verify(&execution_receipt.hash(), signature) {
 			return Err(Self::Error::BadExecutionReceiptSignature)
 		}
 

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -83,7 +83,7 @@ use sp_core::{
 };
 use sp_executor::{
 	Bundle, BundleEquivocationProof, ExecutionPhase, ExecutionReceipt, ExecutorApi, ExecutorId,
-	FraudProof, InvalidTransactionProof, OpaqueBundle, SignedExecutionReceipt,
+	FraudProof, InvalidTransactionProof, OpaqueBundle, SignedBundle, SignedExecutionReceipt,
 };
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::{
@@ -113,7 +113,7 @@ where
 	spawner: Box<dyn SpawnNamed + Send + Sync>,
 	overseer_handle: OverseerHandle<PBlock, Block::Hash>,
 	transaction_pool: Arc<TransactionPool>,
-	bundle_sender: Arc<TracingUnboundedSender<Bundle<Block::Extrinsic>>>,
+	bundle_sender: Arc<TracingUnboundedSender<SignedBundle<Block::Extrinsic>>>,
 	execution_receipt_sender: Arc<TracingUnboundedSender<SignedExecutionReceipt<Block::Hash>>>,
 	backend: Arc<Backend>,
 	code_executor: Arc<E>,
@@ -192,7 +192,7 @@ where
 		client: Arc<Client>,
 		spawner: Box<dyn SpawnNamed + Send + Sync>,
 		transaction_pool: Arc<TransactionPool>,
-		bundle_sender: Arc<TracingUnboundedSender<Bundle<Block::Extrinsic>>>,
+		bundle_sender: Arc<TracingUnboundedSender<SignedBundle<Block::Extrinsic>>>,
 		execution_receipt_sender: Arc<TracingUnboundedSender<SignedExecutionReceipt<Block::Hash>>>,
 		backend: Arc<Backend>,
 		code_executor: Arc<E>,
@@ -635,7 +635,10 @@ where
 {
 	type Error = GossipMessageError;
 
-	fn on_bundle(&self, bundle: &Bundle<Block::Extrinsic>) -> Result<Action, Self::Error> {
+	fn on_bundle(
+		&self,
+		SignedBundle { bundle, signature, signer }: &SignedBundle<Block::Extrinsic>,
+	) -> Result<Action, Self::Error> {
 		let check_equivocation = |_bundle: &Bundle<Block::Extrinsic>| {
 			// TODO: check bundle equivocation
 			let bundle_is_an_equivocation = false;

--- a/cumulus/client/cirrus-executor/src/overseer.rs
+++ b/cumulus/client/cirrus-executor/src/overseer.rs
@@ -25,7 +25,7 @@ use sp_blockchain::HeaderBackend;
 use sp_consensus_slots::Slot;
 use sp_executor::{
 	BundleEquivocationProof, ExecutorApi, FraudProof, InvalidTransactionProof, OpaqueBundle,
-	SignedExecutionReceipt,
+	SignedExecutionReceipt, SignedOpaqueBundle,
 };
 use sp_runtime::{
 	generic::{BlockId, DigestItem},
@@ -56,9 +56,12 @@ pub struct ExecutorSlotInfo {
 ///
 /// Will be called with each slot of the primary chain.
 ///
-/// Returns an optional [`OpaqueBundle`].
+/// Returns an optional [`SignedOpaqueBundle`].
 pub type BundlerFn = Box<
-	dyn Fn(PHash, ExecutorSlotInfo) -> Pin<Box<dyn Future<Output = Option<OpaqueBundle>> + Send>>
+	dyn Fn(
+			PHash,
+			ExecutorSlotInfo,
+		) -> Pin<Box<dyn Future<Output = Option<SignedOpaqueBundle>> + Send>>
 		+ Send
 		+ Sync,
 >;

--- a/cumulus/client/cirrus-executor/src/processor.rs
+++ b/cumulus/client/cirrus-executor/src/processor.rs
@@ -272,7 +272,7 @@ where
 					"This should not happen as the existence of key was just checked",
 				))),
 				Err(error) => Err(sp_blockchain::Error::Application(Box::from(format!(
-					"Error occurred when signing the execution receipt, error: {error}"
+					"Error occurred when signing the execution receipt: {error}"
 				)))),
 			}
 		} else {

--- a/cumulus/client/executor-gossip/src/lib.rs
+++ b/cumulus/client/executor-gossip/src/lib.rs
@@ -10,7 +10,7 @@ use sc_network_gossip::{
 };
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_core::hashing::twox_64;
-use sp_executor::{Bundle, SignedExecutionReceipt};
+use sp_executor::{SignedBundle, SignedExecutionReceipt};
 use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
 use std::{
 	collections::HashSet,
@@ -48,12 +48,12 @@ fn topic<Block: BlockT>() -> Block::Hash {
 /// This is the root type that gets encoded and sent on the network.
 #[derive(Debug, Encode, Decode)]
 pub enum GossipMessage<Block: BlockT> {
-	Bundle(Bundle<Block::Extrinsic>),
+	Bundle(SignedBundle<Block::Extrinsic>),
 	ExecutionReceipt(SignedExecutionReceipt<Block::Hash>),
 }
 
-impl<Block: BlockT> From<Bundle<Block::Extrinsic>> for GossipMessage<Block> {
-	fn from(bundle: Bundle<Block::Extrinsic>) -> Self {
+impl<Block: BlockT> From<SignedBundle<Block::Extrinsic>> for GossipMessage<Block> {
+	fn from(bundle: SignedBundle<Block::Extrinsic>) -> Self {
 		Self::Bundle(bundle)
 	}
 }
@@ -94,7 +94,7 @@ where
 	type Error: Debug;
 
 	/// Validates and applies when a transaction bundle was received.
-	fn on_bundle(&self, bundle: &Bundle<Block::Extrinsic>) -> Result<Action, Self::Error>;
+	fn on_bundle(&self, bundle: &SignedBundle<Block::Extrinsic>) -> Result<Action, Self::Error>;
 
 	/// Validates and applies when an execution receipt was received.
 	fn on_execution_receipt(
@@ -268,7 +268,7 @@ pub struct ExecutorGossipParams<Block: BlockT, Network, Executor> {
 	/// Executor instance.
 	pub executor: Executor,
 	/// Stream of transaction bundle produced locally.
-	pub bundle_receiver: TracingUnboundedReceiver<Bundle<Block::Extrinsic>>,
+	pub bundle_receiver: TracingUnboundedReceiver<SignedBundle<Block::Extrinsic>>,
 	/// Stream of execution receipt produced locally.
 	pub execution_receipt_receiver: TracingUnboundedReceiver<SignedExecutionReceipt<Block::Hash>>,
 }

--- a/cumulus/client/executor-gossip/src/worker.rs
+++ b/cumulus/client/executor-gossip/src/worker.rs
@@ -4,7 +4,7 @@ use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use sc_network_gossip::GossipEngine;
 use sc_utils::mpsc::TracingUnboundedReceiver;
-use sp_executor::{Bundle, SignedExecutionReceipt};
+use sp_executor::{SignedBundle, SignedExecutionReceipt};
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ where
 {
 	gossip_validator: Arc<GossipValidator<Block, Executor>>,
 	gossip_engine: Arc<Mutex<GossipEngine<Block>>>,
-	bundle_receiver: TracingUnboundedReceiver<Bundle<Block::Extrinsic>>,
+	bundle_receiver: TracingUnboundedReceiver<SignedBundle<Block::Extrinsic>>,
 	execution_receipt_receiver: TracingUnboundedReceiver<SignedExecutionReceipt<Block::Hash>>,
 }
 
@@ -28,13 +28,13 @@ where
 	pub(super) fn new(
 		gossip_validator: Arc<GossipValidator<Block, Executor>>,
 		gossip_engine: Arc<Mutex<GossipEngine<Block>>>,
-		bundle_receiver: TracingUnboundedReceiver<Bundle<Block::Extrinsic>>,
+		bundle_receiver: TracingUnboundedReceiver<SignedBundle<Block::Extrinsic>>,
 		execution_receipt_receiver: TracingUnboundedReceiver<SignedExecutionReceipt<Block::Hash>>,
 	) -> Self {
 		Self { gossip_validator, gossip_engine, bundle_receiver, execution_receipt_receiver }
 	}
 
-	fn gossip_bundle(&self, bundle: Bundle<Block::Extrinsic>) {
+	fn gossip_bundle(&self, bundle: SignedBundle<Block::Extrinsic>) {
 		let outgoing_message: GossipMessage<Block> = bundle.into();
 		let encoded_message = outgoing_message.encode();
 		self.gossip_validator.note_rebroadcasted(&encoded_message);

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -772,10 +772,10 @@ fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle> {
             match <UncheckedExtrinsic>::decode(&mut opaque_extrinsic.encode().as_slice()) {
                 Ok(uxt) => {
                     if let Call::Executor(pallet_executor::Call::submit_transaction_bundle {
-                        opaque_bundle,
+                        signed_opaque_bundle,
                     }) = uxt.function
                     {
-                        Some(opaque_bundle)
+                        Some(signed_opaque_bundle.opaque_bundle)
                     } else {
                         None
                     }
@@ -935,7 +935,7 @@ impl_runtime_apis! {
             Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
         }
 
-        fn submit_transaction_bundle_unsigned(opaque_bundle: OpaqueBundle) -> Option<()> {
+        fn submit_transaction_bundle_unsigned(opaque_bundle: sp_executor::SignedOpaqueBundle) -> Option<()> {
             Executor::submit_transaction_bundle_unsigned(opaque_bundle).ok()
         }
 


### PR DESCRIPTION
This PR is primarily for also allowing only the initial executor authority to produce a bundle on new slot, the signature and signer will be verified by both executors and farmers. `SignedBundle` will be gossiped over the executor network, `SignedOpaqueBundle` will be sent to the farmers.

There is obviously some room for improvement regarding the code quality, but it's a mere temporary solution for the initial version,  we could just take it for now as long as it's acceptable.