### PR TITLE
Add max plot size flag

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -40,9 +40,15 @@ pub(crate) async fn farm(
         .farmer_metadata()
         .await
         .map_err(|error| anyhow!(error))?;
-    let max_plot_size = max_plot_size
-        .map(|max_plot_size| max_plot_size / PIECE_SIZE as u64)
-        .unwrap_or(metadata.max_plot_size);
+
+    let max_plot_size = match max_plot_size.map(|max_plot_size| max_plot_size / PIECE_SIZE as u64) {
+        Some(max_plot_size) if max_plot_size > metadata.max_plot_size => {
+            log::warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
+            metadata.max_plot_size
+        }
+        Some(max_plot_size) => max_plot_size,
+        None => metadata.max_plot_size,
+    };
 
     let FarmerMetadata {
         record_size,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -41,6 +41,13 @@ struct FarmingArgs {
     /// Only `G` and `T` endings are supported.
     #[clap(long, parse(try_from_str = parse_human_readable_size))]
     plot_size: u64,
+    /// Maximum single plot size in bytes human readable format (e.g. 10G, 2T) or just bytes (e.g. 4096).
+    ///
+    /// Only `G` and `T` endings are supported.
+    ///
+    /// Only a developer testing flag, as it might be needed for testing.
+    #[clap(long, parse(try_from_str = parse_human_readable_size))]
+    max_plot_size: Option<u64>,
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
This pr adds a flag for setting the maximum size of an individual plot. It might be needed for testing purposes.