### PR TITLE
Add caching for removing the furthest pieces

### DIFF
--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(try_blocks, hash_drain_filter, int_log, io_error_other)]
+#![feature(try_blocks, hash_drain_filter, int_log, io_error_other, map_first_last)]
 
 //! # `subspace-farmer` library implementation overview
 //!

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -411,10 +411,16 @@ impl WeakPlot {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord)]
 struct BidirectionalDistanceSorted<T> {
     distance: T,
     value: T,
+}
+
+impl<T: PartialOrd> PartialOrd for BidirectionalDistanceSorted<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.distance.partial_cmp(&other.distance)
+    }
 }
 
 impl BidirectionalDistanceSorted<PieceDistance> {
@@ -445,7 +451,7 @@ impl IndexHashToOffsetDB {
         let mut me = Self {
             inner,
             address,
-            max_distance_cache: Default::default(),
+            max_distance_cache: BTreeSet::new(),
         };
         me.update_max_distance_cache();
         Ok(me)
@@ -557,8 +563,7 @@ impl IndexHashToOffsetDB {
             let key = BidirectionalDistanceSorted::new(key);
             if key > *first {
                 self.max_distance_cache.insert(key);
-                if self.max_distance_cache.len() == 2 * Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP + 1
-                {
+                if self.max_distance_cache.len() > 2 * Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP {
                     self.max_distance_cache.pop_first();
                 }
             }

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -5,7 +5,7 @@ use event_listener_primitives::{Bag, HandlerId};
 use log::{error, info};
 use num_traits::{WrappingAdd, WrappingSub};
 use rocksdb::DB;
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -411,6 +411,20 @@ impl WeakPlot {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct BidirectionalDistanceSorted<T> {
+    distance: T,
+    value: T,
+}
+
+impl BidirectionalDistanceSorted<PieceDistance> {
+    pub fn new(value: PieceDistance) -> Self {
+        let distance =
+            subspace_core_primitives::bidirectional_distance(&value, &PieceDistance::MIDDLE);
+        Self { value, distance }
+    }
+}
+
 /// Mapping from piece index hash to piece offset.
 ///
 /// Piece index hashes are transformed in the following manner:
@@ -420,42 +434,60 @@ impl WeakPlot {
 struct IndexHashToOffsetDB {
     inner: DB,
     address: PublicKey,
-    max_distance_key: Option<PieceDistance>,
+    max_distance_cache: BTreeSet<BidirectionalDistanceSorted<PieceDistance>>,
 }
 
 impl IndexHashToOffsetDB {
+    const MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP: usize = 100;
+
     fn open_default(path: impl AsRef<Path>, address: PublicKey) -> Result<Self, PlotError> {
         let inner = DB::open_default(path.as_ref()).map_err(PlotError::IndexDbOpen)?;
         let mut me = Self {
             inner,
             address,
-            max_distance_key: None,
+            max_distance_cache: Default::default(),
         };
-        me.update_max_distance();
+        me.update_max_distance_cache();
         Ok(me)
     }
 
-    fn update_max_distance(&mut self) {
-        self.max_distance_key = try {
-            let mut iter = self.inner.raw_iterator();
-            iter.seek_to_first();
-            let lower_bound = iter.key().map(PieceDistance::from_big_endian)?;
-            iter.seek_to_last();
-            let upper_bound = iter.key().map(PieceDistance::from_big_endian)?;
+    fn update_max_distance_cache(&mut self) {
+        let mut iter = self.inner.raw_iterator();
 
-            // Pick key which has maximum distance to our key
-            if subspace_core_primitives::bidirectional_distance(
-                &lower_bound,
-                &PieceDistance::MIDDLE,
-            ) < subspace_core_primitives::bidirectional_distance(
-                &upper_bound,
-                &PieceDistance::MIDDLE,
-            ) {
-                upper_bound
-            } else {
-                lower_bound
-            }
-        };
+        iter.seek_to_first();
+        self.max_distance_cache.extend(
+            std::iter::from_fn(|| {
+                let piece_index_hash = iter.key().map(PieceDistance::from_big_endian);
+                if piece_index_hash.is_some() {
+                    iter.next();
+                }
+                piece_index_hash
+            })
+            .take(Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP)
+            .map(BidirectionalDistanceSorted::new),
+        );
+
+        iter.seek_to_last();
+        self.max_distance_cache.extend(
+            std::iter::from_fn(|| {
+                let piece_index_hash = iter.key().map(PieceDistance::from_big_endian);
+                if piece_index_hash.is_some() {
+                    iter.prev();
+                }
+                piece_index_hash
+            })
+            .take(Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP)
+            .map(BidirectionalDistanceSorted::new),
+        );
+    }
+
+    fn max_distance_key(&mut self) -> Option<PieceDistance> {
+        if self.max_distance_cache.is_empty() {
+            self.update_max_distance_cache()
+        }
+        self.max_distance_cache
+            .last()
+            .map(|distance| distance.value)
     }
 
     fn get_key(&self, index_hash: &PieceIndexHash) -> PieceDistance {
@@ -480,8 +512,8 @@ impl IndexHashToOffsetDB {
 
     /// Returns `true` if piece plot will not result in exceeding plot size and doesn't exist
     /// already
-    fn should_store(&self, index_hash: &PieceIndexHash) -> bool {
-        self.max_distance_key
+    fn should_store(&mut self, index_hash: &PieceIndexHash) -> bool {
+        self.max_distance_key()
             .map(|max_distance_key| {
                 subspace_core_primitives::bidirectional_distance(
                     &max_distance_key,
@@ -492,7 +524,7 @@ impl IndexHashToOffsetDB {
     }
 
     fn remove_furthest(&mut self) -> io::Result<Option<PieceOffset>> {
-        let max_distance = match self.max_distance_key {
+        let max_distance = match self.max_distance_key() {
             Some(max_distance) => max_distance,
             None => return Ok(None),
         };
@@ -506,8 +538,8 @@ impl IndexHashToOffsetDB {
         self.inner
             .delete(&max_distance.to_bytes())
             .map_err(io::Error::other)?;
-
-        self.update_max_distance();
+        self.max_distance_cache
+            .remove(&BidirectionalDistanceSorted::new(max_distance));
 
         Ok(result)
     }
@@ -518,21 +550,16 @@ impl IndexHashToOffsetDB {
             .put(&key.to_bytes(), offset.to_le_bytes())
             .map_err(io::Error::other)?;
 
-        self.max_distance_key = match self.max_distance_key {
-            Some(max_distance_key) => {
-                if PieceDistance::distance(index_hash, self.address)
-                    > subspace_core_primitives::bidirectional_distance(
-                        &max_distance_key,
-                        &PieceDistance::MIDDLE,
-                    )
+        if let Some(first) = self.max_distance_cache.first() {
+            let key = BidirectionalDistanceSorted::new(key);
+            if key > *first {
+                self.max_distance_cache.insert(key);
+                if self.max_distance_cache.len() == 2 * Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP + 1
                 {
-                    Some(key)
-                } else {
-                    Some(max_distance_key)
+                    self.max_distance_cache.pop_first();
                 }
             }
-            None => Some(key),
-        };
+        }
 
         Ok(())
     }

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -411,7 +411,7 @@ impl WeakPlot {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct BidirectionalDistanceSorted<T> {
     distance: T,
     value: T,
@@ -420,6 +420,12 @@ struct BidirectionalDistanceSorted<T> {
 impl<T: PartialOrd> PartialOrd for BidirectionalDistanceSorted<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.distance.partial_cmp(&other.distance)
+    }
+}
+
+impl<T: Ord> Ord for BidirectionalDistanceSorted<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.distance.cmp(&other.distance)
     }
 }
 

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -479,6 +479,9 @@ impl IndexHashToOffsetDB {
             .take(Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP)
             .map(BidirectionalDistanceSorted::new),
         );
+        while self.max_distance_cache.len() > Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP {
+            self.max_distance_cache.pop_first();
+        }
     }
 
     fn max_distance_key(&mut self) -> Option<PieceDistance> {


### PR DESCRIPTION
This pr adds cache for `IndexHashToOffsetDB` which is used for removing the furthest pieces, as it seems that it is a hot path.

~~Not sure about this change, as sometimes I get errors in `plot::tests::partial_plot` test if I set `max_plot_pieces` to `10_000`. If I add some introspection or logs they seem to go away, which is weird as all code is supposed to run sequentially.~~
Will post flamegraphs from before and after this change.