### PR TITLE
Bootstrap nodes tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8568,6 +8568,7 @@ dependencies = [
  "sc-telemetry",
  "sc-tracing",
  "serde",
+ "serde_json",
  "sp-consensus",
  "sp-core",
  "sp-executor",

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -37,6 +37,7 @@ sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/subs
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-tracing = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 serde = "1.0.136"
+serde_json = "1.0.79"
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sp-executor = { version = "0.1.0", path = "../sp-executor" }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -32,7 +32,7 @@ use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, Signature};
 const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.network/submit/";
 const TESTNET_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-snapshot-2022-mar-09.json");
-const TESTNET_BOOTSTRAP_NODE: &str = "/dns/farm-rpc.subspace.network/tcp/30333/p2p/12D3KooWPjMZuSYj35ehced2MTJFf95upwpHKgKUrFRfHwohzJXr";
+// const TESTNET_BOOTSTRAP_NODE: &str = "/dns/farm-rpc.subspace.network/tcp/30333/p2p/12D3KooWPjMZuSYj35ehced2MTJFf95upwpHKgKUrFRfHwohzJXr";
 
 /// List of accounts which should receive token grants, amounts are specified in SSC.
 const TOKEN_GRANTS: &[(&str, u128)] = &[
@@ -147,9 +147,9 @@ pub fn testnet_config_compiled() -> Result<SubspaceChainSpec, String> {
             )
         },
         // Bootnodes
-        vec![TESTNET_BOOTSTRAP_NODE
-            .parse()
-            .expect("Bootstrap node must be correct")],
+        vec![
+            // TESTNET_BOOTSTRAP_NODE.parse().expect("Bootstrap node must be correct")
+        ],
         // Telemetry
         Some(
             TelemetryEndpoints::new(vec![


### PR DESCRIPTION
This will be helpful for avoiding CLI errors like this during testing:
```
Bootnode with peer id `12D3KooWPjMZuSYj35ehced2MTJFf95upwpHKgKUrFRfHwohzJXr` is on a different chain (our genesis: 0xd377…1f87 theirs: 0x332e…4a74)
```

It will also avoid trying to connect to farmnet from `testnet-compiled` chainspec.