### PR TITLE
Secondary chain spec in primary chain spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8562,6 +8562,7 @@ dependencies = [
  "futures 0.3.21",
  "log",
  "parity-scale-codec",
+ "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
  "sc-consensus",

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -30,6 +30,7 @@ frame-support = { version = "4.0.0-dev", git = "https://github.com/paritytech/su
 futures = "0.3.21"
 log = "0.4.16"
 parity-scale-codec = "3.1.2"
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d", features = ["wasmtime"] }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -66,7 +66,7 @@ const TOKEN_GRANTS: &[(&str, u128)] = &[
     ("5FZwEgsvZz1vpeH7UsskmNmTpbfXvAcojjgVfShgbRqgC1nx", 27_800),
 ];
 
-/// The extensions for the [`ChainSpec`].
+/// The extensions for the [`ConsensusChainSpec`].
 #[derive(Clone, Serialize, Deserialize, ChainSpecExtension)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ChainSpecExtensions {

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -16,25 +16,25 @@
 
 //! Subspace chain configurations.
 
+use crate::chain_spec_utils::{
+    chain_spec_properties, get_account_id_from_seed, get_public_key_from_seed,
+};
 use crate::secondary_chain;
 use crate::secondary_chain::chain_spec::ExecutionChainSpec;
-use frame_support::traits::Get;
 use sc_chain_spec::{ChainSpecExtension, GenericChainSpec};
-use sc_service::{ChainType, Properties};
+use sc_service::ChainType;
 use sc_telemetry::TelemetryEndpoints;
 use serde::de::Visitor;
 use serde::ser::Error;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sp_core::crypto::Ss58Codec;
-use sp_core::{sr25519, Pair, Public};
 use sp_executor::ExecutorId;
-use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::fmt;
 use subspace_runtime::{
-    BalancesConfig, ExecutorConfig, GenesisConfig, SS58Prefix, SudoConfig, SystemConfig,
-    VestingConfig, DECIMAL_PLACES, MILLISECS_PER_BLOCK, SSC, WASM_BINARY,
+    BalancesConfig, ExecutorConfig, GenesisConfig, SudoConfig, SystemConfig, VestingConfig,
+    MILLISECS_PER_BLOCK, SSC, WASM_BINARY,
 };
-use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, Signature};
+use subspace_runtime_primitives::{AccountId, Balance, BlockNumber};
 
 const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.network/submit/";
@@ -123,29 +123,10 @@ where
 /// The `ChainSpec` parameterized for the consensus runtime.
 pub type ConsensusChainSpec = GenericChainSpec<GenesisConfig, ChainSpecExtensions>;
 
-/// Generate a crypto pair from seed.
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
-}
-
-type AccountPublic = <Signature as Verify>::Signer;
-
-/// Generate an account ID from seed.
-pub fn get_account_id_from_seed(seed: &str) -> AccountId {
-    AccountPublic::from(get_from_seed::<sr25519::Public>(seed)).into_account()
-}
-
 pub fn testnet_config_json() -> Result<ConsensusChainSpec, String> {
     ConsensusChainSpec::from_json_bytes(TESTNET_CHAIN_SPEC)
 }
 pub fn testnet_config_compiled() -> Result<ConsensusChainSpec, String> {
-    let mut properties = Properties::new();
-    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
-    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
-    properties.insert("tokenSymbol".into(), "tSSC".into());
-
     Ok(ConsensusChainSpec::from_genesis(
         // Name
         "Subspace testnet",
@@ -201,7 +182,7 @@ pub fn testnet_config_compiled() -> Result<ConsensusChainSpec, String> {
                 vesting_schedules,
                 (
                     get_account_id_from_seed("Alice"),
-                    get_from_seed::<ExecutorId>("Alice"),
+                    get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
             )
         },
@@ -221,7 +202,7 @@ pub fn testnet_config_compiled() -> Result<ConsensusChainSpec, String> {
         Some("subspace-substrate"),
         None,
         // Properties
-        Some(properties),
+        Some(chain_spec_properties()),
         // Extensions
         ChainSpecExtensions {
             execution_chain_spec: secondary_chain::chain_spec::local_testnet_config(),
@@ -230,11 +211,6 @@ pub fn testnet_config_compiled() -> Result<ConsensusChainSpec, String> {
 }
 
 pub fn dev_config() -> Result<ConsensusChainSpec, String> {
-    let mut properties = Properties::new();
-    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
-    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
-    properties.insert("tokenSymbol".into(), "tSSC".into());
-
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
     Ok(ConsensusChainSpec::from_genesis(
@@ -258,7 +234,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec, String> {
                 vec![],
                 (
                     get_account_id_from_seed("Alice"),
-                    get_from_seed::<ExecutorId>("Alice"),
+                    get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
             )
         },
@@ -270,7 +246,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec, String> {
         None,
         None,
         // Properties
-        Some(properties),
+        Some(chain_spec_properties()),
         // Extensions
         ChainSpecExtensions {
             execution_chain_spec: secondary_chain::chain_spec::development_config(),
@@ -279,11 +255,6 @@ pub fn dev_config() -> Result<ConsensusChainSpec, String> {
 }
 
 pub fn local_config() -> Result<ConsensusChainSpec, String> {
-    let mut properties = Properties::new();
-    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
-    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
-    properties.insert("tokenSymbol".into(), "tSSC".into());
-
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
     Ok(ConsensusChainSpec::from_genesis(
@@ -315,7 +286,7 @@ pub fn local_config() -> Result<ConsensusChainSpec, String> {
                 vec![],
                 (
                     get_account_id_from_seed("Alice"),
-                    get_from_seed::<ExecutorId>("Alice"),
+                    get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
             )
         },
@@ -327,7 +298,7 @@ pub fn local_config() -> Result<ConsensusChainSpec, String> {
         None,
         None,
         // Properties
-        Some(properties),
+        Some(chain_spec_properties()),
         // Extensions
         ChainSpecExtensions {
             execution_chain_spec: secondary_chain::chain_spec::local_testnet_config(),

--- a/crates/subspace-node/src/chain_spec_utils.rs
+++ b/crates/subspace-node/src/chain_spec_utils.rs
@@ -1,9 +1,23 @@
 use frame_support::traits::Get;
+use sc_chain_spec::{
+    ChainSpec, ChainType, GenericChainSpec, GetExtension, NoExtension, RuntimeGenesis,
+};
+use sc_service::config::MultiaddrWithPeerId;
 use sc_service::Properties;
+use sc_telemetry::TelemetryEndpoints;
+use serde::de::Visitor;
+use serde::ser::Error as _;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sp_core::crypto::AccountId32;
+use sp_core::storage::Storage;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::IdentifyAccount;
-use sp_runtime::MultiSigner;
+use sp_runtime::{BuildStorage, MultiSigner};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::marker::PhantomData;
+use std::path::PathBuf;
 use subspace_runtime::{SS58Prefix, DECIMAL_PLACES};
 
 /// Shared chain spec properties related to the coin.
@@ -29,4 +43,257 @@ pub(crate) fn get_public_key_from_seed<TPublic: Public>(
 /// Generate an account ID from seed.
 pub(crate) fn get_account_id_from_seed(seed: &'static str) -> AccountId32 {
     MultiSigner::from(get_public_key_from_seed::<sr25519::Public>(seed)).into_account()
+}
+
+pub struct SerializableChainSpec<GenesisConfig, Extensions = NoExtension> {
+    chain_spec: GenericChainSpec<GenesisConfig, Extensions>,
+}
+
+impl<GenesisConfig, Extensions> Clone for SerializableChainSpec<GenesisConfig, Extensions>
+where
+    Extensions: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            chain_spec: self.chain_spec.clone(),
+        }
+    }
+}
+
+impl<GenesisConfig, Extensions> Serialize for SerializableChainSpec<GenesisConfig, Extensions>
+where
+    GenesisConfig: RuntimeGenesis + 'static,
+    Extensions: GetExtension + Serialize + Clone + Send + Sync + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.as_json(true).map_err(S::Error::custom)?)
+    }
+}
+
+impl<'de, GenesisConfig, Extensions> Deserialize<'de>
+    for SerializableChainSpec<GenesisConfig, Extensions>
+where
+    Extensions: de::DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringVisitor<GenesisConfig, Extensions> {
+            _phantom_data: PhantomData<(GenesisConfig, Extensions)>,
+        }
+
+        impl<'de, GenesisConfig, Extensions> Visitor<'de> for StringVisitor<GenesisConfig, Extensions>
+        where
+            Extensions: de::DeserializeOwned,
+        {
+            type Value = SerializableChainSpec<GenesisConfig, Extensions>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("ExecutionChainSpec")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_string(value.to_string())
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Self::Value::from_json_bytes(value.into_bytes()).map_err(E::custom)
+            }
+        }
+        deserializer.deserialize_string(StringVisitor {
+            _phantom_data: PhantomData::default(),
+        })
+    }
+}
+
+impl<GenesisConfig, Extensions> BuildStorage for SerializableChainSpec<GenesisConfig, Extensions>
+where
+    GenesisConfig: RuntimeGenesis,
+{
+    fn assimilate_storage(&self, storage: &mut Storage) -> Result<(), String> {
+        self.chain_spec.assimilate_storage(storage)
+    }
+}
+
+impl<GenesisConfig, Extensions> ChainSpec for SerializableChainSpec<GenesisConfig, Extensions>
+where
+    GenesisConfig: RuntimeGenesis + 'static,
+    Extensions: GetExtension + Serialize + Clone + Send + Sync + 'static,
+{
+    fn name(&self) -> &str {
+        self.chain_spec.name()
+    }
+
+    fn id(&self) -> &str {
+        self.chain_spec.id()
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainSpec::chain_type(&self.chain_spec)
+    }
+
+    fn boot_nodes(&self) -> &[MultiaddrWithPeerId] {
+        self.chain_spec.boot_nodes()
+    }
+
+    fn telemetry_endpoints(&self) -> &Option<TelemetryEndpoints> {
+        self.chain_spec.telemetry_endpoints()
+    }
+
+    fn protocol_id(&self) -> Option<&str> {
+        self.chain_spec.protocol_id()
+    }
+
+    fn fork_id(&self) -> Option<&str> {
+        self.chain_spec.fork_id()
+    }
+
+    fn properties(&self) -> Properties {
+        self.chain_spec.properties()
+    }
+
+    fn extensions(&self) -> &dyn GetExtension {
+        self.chain_spec.extensions()
+    }
+
+    fn extensions_mut(&mut self) -> &mut dyn GetExtension {
+        self.chain_spec.extensions_mut()
+    }
+
+    fn add_boot_node(&mut self, addr: MultiaddrWithPeerId) {
+        self.chain_spec.add_boot_node(addr)
+    }
+
+    fn as_json(&self, raw: bool) -> Result<String, String> {
+        self.chain_spec.as_json(raw)
+    }
+
+    fn as_storage_builder(&self) -> &dyn BuildStorage {
+        self.chain_spec.as_storage_builder()
+    }
+
+    fn cloned_box(&self) -> Box<dyn ChainSpec> {
+        self.chain_spec.cloned_box()
+    }
+
+    fn set_storage(&mut self, storage: Storage) {
+        self.chain_spec.set_storage(storage)
+    }
+
+    fn code_substitutes(&self) -> BTreeMap<String, Vec<u8>> {
+        self.chain_spec.code_substitutes()
+    }
+}
+
+impl<GenesisConfig, Extensions> SerializableChainSpec<GenesisConfig, Extensions>
+where
+    GenesisConfig: RuntimeGenesis + 'static,
+    Extensions: GetExtension + Serialize + Clone + Send + Sync + 'static,
+{
+    /// A list of bootnode addresses.
+    pub fn boot_nodes(&self) -> &[MultiaddrWithPeerId] {
+        self.chain_spec.boot_nodes()
+    }
+
+    /// Spec name.
+    pub fn name(&self) -> &str {
+        self.chain_spec.name()
+    }
+
+    /// Spec id.
+    pub fn id(&self) -> &str {
+        self.chain_spec.id()
+    }
+
+    /// Telemetry endpoints (if any)
+    pub fn telemetry_endpoints(&self) -> &Option<TelemetryEndpoints> {
+        self.chain_spec.telemetry_endpoints()
+    }
+
+    /// Network protocol id.
+    pub fn protocol_id(&self) -> Option<&str> {
+        self.chain_spec.protocol_id()
+    }
+
+    /// Optional network fork identifier.
+    pub fn fork_id(&self) -> Option<&str> {
+        self.chain_spec.fork_id()
+    }
+
+    /// Additional loosly-typed properties of the chain.
+    ///
+    /// Returns an empty JSON object if 'properties' not defined in config
+    pub fn properties(&self) -> Properties {
+        self.chain_spec.properties()
+    }
+
+    /// Add a bootnode to the list.
+    pub fn add_boot_node(&mut self, addr: MultiaddrWithPeerId) {
+        self.chain_spec.add_boot_node(addr)
+    }
+
+    /// Returns a reference to the defined chain spec extensions.
+    pub fn extensions(&self) -> &Extensions {
+        self.chain_spec.extensions()
+    }
+
+    /// Returns a mutable reference to the defined chain spec extensions.
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        self.chain_spec.extensions_mut()
+    }
+
+    /// Create hardcoded spec.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_genesis<F: Fn() -> GenesisConfig + 'static + Send + Sync>(
+        name: &str,
+        id: &str,
+        chain_type: ChainType,
+        constructor: F,
+        boot_nodes: Vec<MultiaddrWithPeerId>,
+        telemetry_endpoints: Option<TelemetryEndpoints>,
+        protocol_id: Option<&str>,
+        fork_id: Option<&str>,
+        properties: Option<Properties>,
+        extensions: Extensions,
+    ) -> Self {
+        Self {
+            chain_spec: GenericChainSpec::from_genesis(
+                name,
+                id,
+                chain_type,
+                constructor,
+                boot_nodes,
+                telemetry_endpoints,
+                protocol_id,
+                fork_id,
+                properties,
+                extensions,
+            ),
+        }
+    }
+}
+
+impl<GenesisConfig, Extensions> SerializableChainSpec<GenesisConfig, Extensions>
+where
+    Extensions: de::DeserializeOwned,
+{
+    /// Parse json content into a `ChainSpec`
+    pub fn from_json_bytes(json: impl Into<Cow<'static, [u8]>>) -> Result<Self, String> {
+        GenericChainSpec::from_json_bytes(json).map(|chain_spec| Self { chain_spec })
+    }
+
+    /// Parse json file into a `ChainSpec`
+    pub fn from_json_file(path: PathBuf) -> Result<Self, String> {
+        GenericChainSpec::from_json_file(path).map(|chain_spec| Self { chain_spec })
+    }
 }

--- a/crates/subspace-node/src/chain_spec_utils.rs
+++ b/crates/subspace-node/src/chain_spec_utils.rs
@@ -1,0 +1,32 @@
+use frame_support::traits::Get;
+use sc_service::Properties;
+use sp_core::crypto::AccountId32;
+use sp_core::{sr25519, Pair, Public};
+use sp_runtime::traits::IdentifyAccount;
+use sp_runtime::MultiSigner;
+use subspace_runtime::{SS58Prefix, DECIMAL_PLACES};
+
+/// Shared chain spec properties related to the coin.
+pub(crate) fn chain_spec_properties() -> Properties {
+    let mut properties = Properties::new();
+
+    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
+    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
+    properties.insert("tokenSymbol".into(), "tSSC".into());
+
+    properties
+}
+
+/// Get public key from keypair seed.
+pub(crate) fn get_public_key_from_seed<TPublic: Public>(
+    seed: &'static str,
+) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(&format!("//{}", seed), None)
+        .expect("Static values are valid; qed")
+        .public()
+}
+
+/// Generate an account ID from seed.
+pub(crate) fn get_account_id_from_seed(seed: &'static str) -> AccountId32 {
+    MultiSigner::from(get_public_key_from_seed::<sr25519::Public>(seed)).into_account()
+}

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -18,12 +18,11 @@
 
 mod chain_spec;
 mod import_blocks_from_dsn;
-mod secondary_chain_cli;
-mod secondary_chain_spec;
+mod secondary_chain;
 
 use crate::chain_spec::SubspaceChainSpec;
 pub use crate::import_blocks_from_dsn::ImportBlocksFromDsnCmd;
-pub use crate::secondary_chain_cli::SecondaryChainCli;
+pub use crate::secondary_chain::cli::SecondaryChainCli;
 use crate::serde_json::Value;
 use clap::Parser;
 use sc_cli::SubstrateCli;
@@ -87,7 +86,7 @@ pub enum Subcommand {
 
     /// Run executor sub-commands.
     #[clap(subcommand)]
-    Executor(secondary_chain_cli::Subcommand),
+    Executor(secondary_chain::cli::Subcommand),
 
     /// Sub-commands concerned with benchmarking.
     #[clap(subcommand)]

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -20,8 +20,9 @@ mod chain_spec;
 mod import_blocks_from_dsn;
 mod secondary_chain;
 
-use crate::chain_spec::SubspaceChainSpec;
+pub use crate::chain_spec::{ChainSpecExtensions, ConsensusChainSpec};
 pub use crate::import_blocks_from_dsn::ImportBlocksFromDsnCmd;
+pub use crate::secondary_chain::chain_spec::ExecutionChainSpec;
 pub use crate::secondary_chain::cli::SecondaryChainCli;
 use crate::serde_json::Value;
 use clap::Parser;
@@ -164,7 +165,7 @@ impl SubstrateCli for Cli {
             "testnet-compiled" => chain_spec::testnet_config_compiled()?,
             "dev" => chain_spec::dev_config()?,
             "" | "local" => chain_spec::local_config()?,
-            path => SubspaceChainSpec::from_json_file(std::path::PathBuf::from(path))?,
+            path => ConsensusChainSpec::from_json_file(std::path::PathBuf::from(path))?,
         };
 
         // In case there are bootstrap nodes specified explicitly, ignore those that are in the
@@ -179,7 +180,7 @@ impl SubstrateCli for Cli {
                 }
             }
             chain_spec =
-                SubspaceChainSpec::from_json_bytes(chain_spec_value.to_string().into_bytes())?;
+                ConsensusChainSpec::from_json_bytes(chain_spec_value.to_string().into_bytes())?;
         }
         Ok(Box::new(chain_spec))
     }

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -17,6 +17,7 @@
 //! Subspace Node library.
 
 mod chain_spec;
+mod chain_spec_utils;
 mod import_blocks_from_dsn;
 mod secondary_chain;
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -25,7 +25,6 @@ pub use crate::chain_spec::{ChainSpecExtensions, ConsensusChainSpec};
 pub use crate::import_blocks_from_dsn::ImportBlocksFromDsnCmd;
 pub use crate::secondary_chain::chain_spec::ExecutionChainSpec;
 pub use crate::secondary_chain::cli::SecondaryChainCli;
-use crate::serde_json::Value;
 use clap::Parser;
 use sc_cli::SubstrateCli;
 use sc_executor::{NativeExecutionDispatch, RuntimeVersion};
@@ -173,15 +172,14 @@ impl SubstrateCli for Cli {
         // chain spec
         if !self.run.base.network_params.bootnodes.is_empty() {
             let mut chain_spec_value =
-                serde_json::from_str::<'_, Value>(&chain_spec.as_json(true)?)
-                    .map_err(|error| error.to_string())?;
+                serde_json::to_value(&chain_spec).map_err(|error| error.to_string())?;
             if let Some(boot_nodes) = chain_spec_value.get_mut("bootNodes") {
                 if let Some(boot_nodes) = boot_nodes.as_array_mut() {
                     boot_nodes.clear();
                 }
             }
             chain_spec =
-                ConsensusChainSpec::from_json_bytes(chain_spec_value.to_string().into_bytes())?;
+                serde_json::from_value(chain_spec_value).map_err(|error| error.to_string())?;
         }
         Ok(Box::new(chain_spec))
     }

--- a/crates/subspace-node/src/secondary_chain.rs
+++ b/crates/subspace-node/src/secondary_chain.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub(crate) mod chain_spec;
+pub(crate) mod cli;

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -1,14 +1,31 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Secondary chain configurations.
 
 use cirrus_runtime::{AccountId, Signature};
 use frame_support::traits::Get;
+use sc_chain_spec::GenericChainSpec;
 use sc_service::{ChainType, Properties};
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subspace_runtime::{SS58Prefix, DECIMAL_PLACES};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type ChainSpec = sc_service::GenericChainSpec<cirrus_runtime::GenesisConfig>;
+pub type ExecutionChainSpec = GenericChainSpec<cirrus_runtime::GenesisConfig>;
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_pair_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
@@ -27,13 +44,13 @@ where
     AccountPublic::from(get_pair_from_seed::<TPublic>(seed)).into_account()
 }
 
-pub fn development_config() -> ChainSpec {
+pub fn development_config() -> ExecutionChainSpec {
     let mut properties = Properties::new();
     properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
     properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
     properties.insert("tokenSymbol".into(), "tSSC".into());
 
-    ChainSpec::from_genesis(
+    ExecutionChainSpec::from_genesis(
         // Name
         "Development",
         // ID
@@ -64,13 +81,13 @@ pub fn development_config() -> ChainSpec {
     )
 }
 
-pub fn local_testnet_config() -> ChainSpec {
+pub fn local_testnet_config() -> ExecutionChainSpec {
     let mut properties = Properties::new();
     properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
     properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
     properties.insert("tokenSymbol".into(), "tSSC".into());
 
-    ChainSpec::from_genesis(
+    ExecutionChainSpec::from_genesis(
         // Name
         "Local Testnet",
         // ID

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -16,40 +16,16 @@
 
 //! Secondary chain configurations.
 
-use cirrus_runtime::{AccountId, Signature};
-use frame_support::traits::Get;
+use crate::chain_spec_utils::{chain_spec_properties, get_account_id_from_seed};
+use cirrus_runtime::AccountId;
 use sc_chain_spec::GenericChainSpec;
-use sc_service::{ChainType, Properties};
-use sp_core::{sr25519, Pair, Public};
-use sp_runtime::traits::{IdentifyAccount, Verify};
-use subspace_runtime::{SS58Prefix, DECIMAL_PLACES};
+use sc_service::ChainType;
+use subspace_runtime::SSC;
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ExecutionChainSpec = GenericChainSpec<cirrus_runtime::GenesisConfig>;
 
-/// Helper function to generate a crypto pair from seed
-pub fn get_pair_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
-}
-
-type AccountPublic = <Signature as Verify>::Signer;
-
-/// Helper function to generate an account ID from seed
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
-where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
-{
-    AccountPublic::from(get_pair_from_seed::<TPublic>(seed)).into_account()
-}
-
 pub fn development_config() -> ExecutionChainSpec {
-    let mut properties = Properties::new();
-    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
-    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
-    properties.insert("tokenSymbol".into(), "tSSC".into());
-
     ExecutionChainSpec::from_genesis(
         // Name
         "Development",
@@ -58,35 +34,22 @@ pub fn development_config() -> ExecutionChainSpec {
         ChainType::Development,
         move || {
             testnet_genesis(vec![
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
-                get_account_id_from_seed::<sr25519::Public>("Bob"),
-                get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                get_account_id_from_seed::<sr25519::Public>("Dave"),
-                get_account_id_from_seed::<sr25519::Public>("Eve"),
-                get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                get_account_id_from_seed("Alice"),
+                get_account_id_from_seed("Bob"),
+                get_account_id_from_seed("Alice//stash"),
+                get_account_id_from_seed("Bob//stash"),
             ])
         },
         vec![],
         None,
         None,
         None,
-        None,
+        Some(chain_spec_properties()),
         None,
     )
 }
 
 pub fn local_testnet_config() -> ExecutionChainSpec {
-    let mut properties = Properties::new();
-    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
-    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
-    properties.insert("tokenSymbol".into(), "tSSC".into());
-
     ExecutionChainSpec::from_genesis(
         // Name
         "Local Testnet",
@@ -95,18 +58,18 @@ pub fn local_testnet_config() -> ExecutionChainSpec {
         ChainType::Local,
         move || {
             testnet_genesis(vec![
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
-                get_account_id_from_seed::<sr25519::Public>("Bob"),
-                get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                get_account_id_from_seed::<sr25519::Public>("Dave"),
-                get_account_id_from_seed::<sr25519::Public>("Eve"),
-                get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+                get_account_id_from_seed("Alice"),
+                get_account_id_from_seed("Bob"),
+                get_account_id_from_seed("Charlie"),
+                get_account_id_from_seed("Dave"),
+                get_account_id_from_seed("Eve"),
+                get_account_id_from_seed("Ferdie"),
+                get_account_id_from_seed("Alice//stash"),
+                get_account_id_from_seed("Bob//stash"),
+                get_account_id_from_seed("Charlie//stash"),
+                get_account_id_from_seed("Dave//stash"),
+                get_account_id_from_seed("Eve//stash"),
+                get_account_id_from_seed("Ferdie//stash"),
             ])
         },
         // Bootnodes
@@ -117,7 +80,7 @@ pub fn local_testnet_config() -> ExecutionChainSpec {
         Some("template-local"),
         None,
         // Properties
-        Some(properties),
+        Some(chain_spec_properties()),
         // Extensions
         None,
     )
@@ -135,7 +98,7 @@ fn testnet_genesis(endowed_accounts: Vec<AccountId>) -> cirrus_runtime::GenesisC
             balances: endowed_accounts
                 .iter()
                 .cloned()
-                .map(|k| (k, 1 << 60))
+                .map(|k| (k, 1_000 * SSC))
                 .collect(),
         },
     }

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -16,14 +16,15 @@
 
 //! Secondary chain configurations.
 
-use crate::chain_spec_utils::{chain_spec_properties, get_account_id_from_seed};
+use crate::chain_spec_utils::{
+    chain_spec_properties, get_account_id_from_seed, SerializableChainSpec,
+};
 use cirrus_runtime::AccountId;
-use sc_chain_spec::GenericChainSpec;
 use sc_service::ChainType;
 use subspace_runtime::SSC;
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type ExecutionChainSpec = GenericChainSpec<cirrus_runtime::GenesisConfig>;
+pub type ExecutionChainSpec = SerializableChainSpec<cirrus_runtime::GenesisConfig>;
 
 pub fn development_config() -> ExecutionChainSpec {
     ExecutionChainSpec::from_genesis(

--- a/crates/subspace-node/src/secondary_chain/cli.rs
+++ b/crates/subspace-node/src/secondary_chain/cli.rs
@@ -1,4 +1,20 @@
-use crate::secondary_chain_spec;
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::secondary_chain::chain_spec;
 use clap::Parser;
 use sc_cli::{
     ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
@@ -94,9 +110,9 @@ impl SubstrateCli for SecondaryChainCli {
 
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
         Ok(match id {
-            "dev" => Box::new(secondary_chain_spec::development_config()),
-            "" | "local" => Box::new(secondary_chain_spec::local_testnet_config()),
-            path => Box::new(secondary_chain_spec::ChainSpec::from_json_file(
+            "dev" => Box::new(chain_spec::development_config()),
+            "" | "local" => Box::new(chain_spec::local_testnet_config()),
+            path => Box::new(chain_spec::ExecutionChainSpec::from_json_file(
                 std::path::PathBuf::from(path),
             )?),
         })

--- a/crates/subspace-node/src/secondary_chain/cli.rs
+++ b/crates/subspace-node/src/secondary_chain/cli.rs
@@ -22,7 +22,6 @@ use sc_cli::{
     NetworkParams, Result, RuntimeVersion, SharedParams, SubstrateCli,
 };
 use sc_service::{config::PrometheusConfig, BasePath};
-use serde_json::Value;
 use std::{net::SocketAddr, path::PathBuf};
 
 /// Sub-commands supported by the executor.
@@ -120,15 +119,14 @@ impl SubstrateCli for SecondaryChainCli {
         // chain spec
         if !self.run.base.network_params.bootnodes.is_empty() {
             let mut chain_spec_value =
-                serde_json::from_str::<'_, Value>(&chain_spec.as_json(true)?)
-                    .map_err(|error| error.to_string())?;
+                serde_json::to_value(&chain_spec).map_err(|error| error.to_string())?;
             if let Some(boot_nodes) = chain_spec_value.get_mut("bootNodes") {
                 if let Some(boot_nodes) = boot_nodes.as_array_mut() {
                     boot_nodes.clear();
                 }
             }
             chain_spec =
-                ExecutionChainSpec::from_json_bytes(chain_spec_value.to_string().into_bytes())?;
+                serde_json::from_value(chain_spec_value).map_err(|error| error.to_string())?;
         }
 
         Ok(Box::new(chain_spec))


### PR DESCRIPTION
This makes secondary chain specification be embedded into primary chain specification, making it easier to run chain, especially once we deploy decoupled execution.

Serializable chain spec wrapper is lengthy, but it makes other things easier, so IMO worth it.