### PR TITLE
Fix impl for `ExecuteBlock` trait

### DIFF
--- a/cumulus/pallets/executive/src/lib.rs
+++ b/cumulus/pallets/executive/src/lib.rs
@@ -151,7 +151,7 @@ impl<
 			+ OnIdle<System::BlockNumber>
 			+ OnFinalize<System::BlockNumber>
 			+ OffchainWorker<System::BlockNumber>,
-		ExecutiveConfig,
+		ExecutiveConfig: Config,
 		COnRuntimeUpgrade: OnRuntimeUpgrade,
 	> ExecuteBlock<Block>
 	for Executive<
@@ -170,7 +170,6 @@ impl<
 	OriginOf<Block::Extrinsic, Context>: From<Option<System::AccountId>>,
 	UnsignedValidator: ValidateUnsigned<Call = CallOf<Block::Extrinsic, Context>>,
 {
-	#[allow(unconditional_recursion)]
 	fn execute_block(block: Block) {
 		Executive::<
 			System,


### PR DESCRIPTION
Simple app that reproduces recursion stack overflow:
```rust
pub struct Struct<Generic>(std::marker::PhantomData<Generic>);

pub trait Trait {
    fn print();
}

impl<Generic> Trait for Struct<Generic> {
    fn print() {
        Struct::<Generic>::print();
    }
}

pub trait Bound {}

impl Bound for () {}

impl<Generic: Bound> Struct<Generic> {
    pub fn print() {
        println!("Hello");
    }
}

fn main() {
    Struct::<()>::print();
    <Struct<()> as Trait>::print();
}
```

Output:
```
Hello

thread 'main' has overflowed its stack
fatal runtime error: stack overflow
```

The reason that https://github.com/paritytech/substrate/pull/9399 didn't have issues is because it didn't have the same typo in bounds that forced compiler to do recursion.

This replaces https://github.com/subspace/subspace/pull/422