### PR TITLE
Refactor cirrus executor (part 2)

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -509,62 +509,61 @@ where
     }
 
     /// Submits an unsigned extrinsic [`Call::submit_fraud_proof`].
-    pub fn submit_fraud_proof_unsigned(
-        fraud_proof: FraudProof,
-    ) -> frame_support::pallet_prelude::DispatchResult {
+    pub fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) {
         let call = Call::submit_fraud_proof { fraud_proof };
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
-            Ok(()) => log::info!(target: "runtime::subspace::executor", "Submitted fraud proof."),
-            Err(e) => {
-                log::error!(target: "runtime::subspace::executor", "Error submitting fraud proof: {:?}", e,)
+            Ok(()) => {
+                log::info!(target: "runtime::subspace::executor", "Submitted fraud proof");
+            }
+            Err(()) => {
+                log::error!(target: "runtime::subspace::executor", "Error submitting fraud proof");
             }
         }
-
-        Ok(())
     }
 
     /// Submits an unsigned extrinsic [`Call::submit_bundle_equivocation_proof`].
     pub fn submit_bundle_equivocation_proof_unsigned(
         bundle_equivocation_proof: BundleEquivocationProof,
-    ) -> frame_support::pallet_prelude::DispatchResult {
+    ) {
         let call = Call::submit_bundle_equivocation_proof {
             bundle_equivocation_proof,
         };
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
             Ok(()) => {
-                log::info!(target: "runtime::subspace::executor", "Submitted bundle equivocation proof.")
+                log::info!(
+                    target: "runtime::subspace::executor",
+                    "Submitted bundle equivocation proof"
+                );
             }
-            Err(e) => log::error!(
-                target: "runtime::subspace::executor",
-                "Error submitting bundle equivocation proof: {:?}",
-                e,
-            ),
+            Err(()) => {
+                log::error!(
+                    target: "runtime::subspace::executor",
+                    "Error submitting bundle equivocation proof",
+                );
+            }
         }
-
-        Ok(())
     }
 
     /// Submits an unsigned extrinsic [`Call::submit_invalid_transaction_proof`].
     pub fn submit_invalid_transaction_proof_unsigned(
         invalid_transaction_proof: InvalidTransactionProof,
-    ) -> frame_support::pallet_prelude::DispatchResult {
+    ) {
         let call = Call::submit_invalid_transaction_proof {
             invalid_transaction_proof,
         };
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
             Ok(()) => {
-                log::info!(target: "runtime::subspace::executor", "Submitted invalid transaction proof.")
+                log::info!(target: "runtime::subspace::executor", "Submitted invalid transaction proof")
             }
-            Err(e) => log::error!(
-                target: "runtime::subspace::executor",
-                "Error submitting invalid transaction proof: {:?}",
-                e,
-            ),
+            Err(()) => {
+                log::error!(
+                    target: "runtime::subspace::executor",
+                    "Error submitting invalid transaction proof",
+                );
+            }
         }
-
-        Ok(())
     }
 }

--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -467,45 +467,41 @@ where
     /// Submits an unsigned extrinsic [`Call::submit_execution_receipt`].
     pub fn submit_execution_receipt_unsigned(
         signed_execution_receipt: SignedExecutionReceipt<T::SecondaryHash>,
-    ) -> frame_support::pallet_prelude::DispatchResult {
+    ) {
         let call = Call::submit_execution_receipt {
             signed_execution_receipt,
         };
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
             Ok(()) => {
-                log::info!(target: "runtime::subspace::executor", "Submitted execution receipt.")
+                log::info!(target: "runtime::subspace::executor", "Submitted execution receipt");
             }
-            Err(e) => log::error!(
-                target: "runtime::subspace::executor",
-                "Error submitting execution receipt: {:?}",
-                e
-            ),
+            Err(()) => {
+                log::error!(
+                    target: "runtime::subspace::executor",
+                    "Error submitting execution receipt",
+                );
+            }
         }
-
-        Ok(())
     }
 
     /// Submits an unsigned extrinsic [`Call::submit_transaction_bundle`].
-    pub fn submit_transaction_bundle_unsigned(
-        signed_opaque_bundle: SignedOpaqueBundle,
-    ) -> frame_support::pallet_prelude::DispatchResult {
+    pub fn submit_transaction_bundle_unsigned(signed_opaque_bundle: SignedOpaqueBundle) {
         let call = Call::submit_transaction_bundle {
             signed_opaque_bundle,
         };
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
             Ok(()) => {
-                log::info!(target: "runtime::subspace::executor", "Submitted transaction bundle.")
+                log::info!(target: "runtime::subspace::executor", "Submitted transaction bundle");
             }
-            Err(e) => log::error!(
-                target: "runtime::subspace::executor",
-                "Error submitting transaction bundle: {:?}",
-                e,
-            ),
+            Err(()) => {
+                log::error!(
+                    target: "runtime::subspace::executor",
+                    "Error submitting transaction bundle",
+                );
+            }
         }
-
-        Ok(())
     }
 
     /// Submits an unsigned extrinsic [`Call::submit_fraud_proof`].

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -366,10 +366,10 @@ sp_api::decl_runtime_apis! {
         /// Submits the execution receipt via an unsigned extrinsic.
         fn submit_execution_receipt_unsigned(
             execution_receipt: SignedExecutionReceipt<SecondaryHash>,
-        ) -> Option<()>;
+        );
 
         /// Submits the transaction bundle via an unsigned extrinsic.
-        fn submit_transaction_bundle_unsigned(opaque_bundle: SignedOpaqueBundle) -> Option<()>;
+        fn submit_transaction_bundle_unsigned(opaque_bundle: SignedOpaqueBundle);
 
         /// Submits the fraud proof via an unsigned extrinsic.
         fn submit_fraud_proof_unsigned(fraud_proof: FraudProof);

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -372,17 +372,17 @@ sp_api::decl_runtime_apis! {
         fn submit_transaction_bundle_unsigned(opaque_bundle: SignedOpaqueBundle) -> Option<()>;
 
         /// Submits the fraud proof via an unsigned extrinsic.
-        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) -> Option<()>;
+        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof);
 
         /// Submits the bundle equivocation proof via an unsigned extrinsic.
         fn submit_bundle_equivocation_proof_unsigned(
             bundle_equivocation_proof: BundleEquivocationProof,
-        ) -> Option<()>;
+        );
 
         /// Submits the invalid transaction proof via an unsigned extrinsic.
         fn submit_invalid_transaction_proof_unsigned(
             invalid_transaction_proof: InvalidTransactionProof,
-        ) -> Option<()>;
+        );
 
         /// Extract the bundles from extrinsics in a block.
         fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle>;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1013,12 +1013,12 @@ impl_runtime_apis! {
     impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {
         fn submit_execution_receipt_unsigned(
             execution_receipt: sp_executor::SignedExecutionReceipt<cirrus_primitives::Hash>,
-        ) -> Option<()> {
-            Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
+        ) {
+            Executor::submit_execution_receipt_unsigned(execution_receipt)
         }
 
-        fn submit_transaction_bundle_unsigned(opaque_bundle: sp_executor::SignedOpaqueBundle) -> Option<()> {
-            Executor::submit_transaction_bundle_unsigned(opaque_bundle).ok()
+        fn submit_transaction_bundle_unsigned(opaque_bundle: sp_executor::SignedOpaqueBundle) {
+            Executor::submit_transaction_bundle_unsigned(opaque_bundle)
         }
 
         fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1021,20 +1021,20 @@ impl_runtime_apis! {
             Executor::submit_transaction_bundle_unsigned(opaque_bundle).ok()
         }
 
-        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) -> Option<()> {
-            Executor::submit_fraud_proof_unsigned(fraud_proof).ok()
+        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) {
+            Executor::submit_fraud_proof_unsigned(fraud_proof)
         }
 
         fn submit_bundle_equivocation_proof_unsigned(
             bundle_equivocation_proof: sp_executor::BundleEquivocationProof,
-        ) -> Option<()> {
-            Executor::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof).ok()
+        ) {
+            Executor::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof)
         }
 
         fn submit_invalid_transaction_proof_unsigned(
             invalid_transaction_proof: sp_executor::InvalidTransactionProof,
-        ) -> Option<()> {
-            Executor::submit_invalid_transaction_proof_unsigned(invalid_transaction_proof).ok()
+        ) {
+            Executor::submit_invalid_transaction_proof_unsigned(invalid_transaction_proof)
         }
 
         fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle> {

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -401,8 +401,9 @@ where
 	}
 
 	fn submit_bundle_equivocation_proof(&self, bundle_equivocation_proof: BundleEquivocationProof) {
-		let mut overseer_handle = self.overseer_handle.clone();
-		self.spawner.spawn(
+		let primary_chain_client = self.primary_chain_client.clone();
+		// TODO: No backpressure
+		self.spawner.spawn_blocking(
 			"cirrus-submit-bundle-equivocation-proof",
 			None,
 			async move {
@@ -410,21 +411,26 @@ where
 					target: LOG_TARGET,
 					"Submitting bundle equivocation proof in a background task..."
 				);
-				overseer_handle
-					.submit_bundle_equivocation_proof(bundle_equivocation_proof)
-					.await;
-				tracing::debug!(
-					target: LOG_TARGET,
-					"Bundle equivocation proof submission finished"
-				);
+				if let Err(error) =
+					primary_chain_client.runtime_api().submit_bundle_equivocation_proof_unsigned(
+						&BlockId::Hash(primary_chain_client.info().best_hash),
+						bundle_equivocation_proof,
+					) {
+					tracing::debug!(
+						target: LOG_TARGET,
+						error = ?error,
+						"Failed to submit bundle equivocation proof"
+					);
+				}
 			}
 			.boxed(),
 		);
 	}
 
 	fn submit_fraud_proof(&self, fraud_proof: FraudProof) {
-		let mut overseer_handle = self.overseer_handle.clone();
-		self.spawner.spawn(
+		let primary_chain_client = self.primary_chain_client.clone();
+		// TODO: No backpressure
+		self.spawner.spawn_blocking(
 			"cirrus-submit-fraud-proof",
 			None,
 			async move {
@@ -432,16 +438,25 @@ where
 					target: LOG_TARGET,
 					"Submitting fraud proof in a background task..."
 				);
-				overseer_handle.submit_fraud_proof(fraud_proof).await;
-				tracing::debug!(target: LOG_TARGET, "Fraud proof submission finished");
+				if let Err(error) = primary_chain_client.runtime_api().submit_fraud_proof_unsigned(
+					&BlockId::Hash(primary_chain_client.info().best_hash),
+					fraud_proof,
+				) {
+					tracing::debug!(
+						target: LOG_TARGET,
+						error = ?error,
+						"Failed to submit fraud proof"
+					);
+				}
 			}
 			.boxed(),
 		);
 	}
 
 	fn submit_invalid_transaction_proof(&self, invalid_transaction_proof: InvalidTransactionProof) {
-		let mut overseer_handle = self.overseer_handle.clone();
-		self.spawner.spawn(
+		let primary_chain_client = self.primary_chain_client.clone();
+		// TODO: No backpressure
+		self.spawner.spawn_blocking(
 			"cirrus-submit-invalid-transaction-proof",
 			None,
 			async move {
@@ -449,13 +464,17 @@ where
 					target: LOG_TARGET,
 					"Submitting invalid transaction proof in a background task..."
 				);
-				overseer_handle
-					.submit_invalid_transaction_proof(invalid_transaction_proof)
-					.await;
-				tracing::debug!(
-					target: LOG_TARGET,
-					"Invalid transaction proof submission finished"
-				);
+				if let Err(error) =
+					primary_chain_client.runtime_api().submit_invalid_transaction_proof_unsigned(
+						&BlockId::Hash(primary_chain_client.info().best_hash),
+						invalid_transaction_proof,
+					) {
+					tracing::debug!(
+						target: LOG_TARGET,
+						error = ?error,
+						"Failed to submit invalid transaction proof"
+					);
+				}
 			}
 			.boxed(),
 		);

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -66,15 +66,13 @@ mod tests;
 
 pub use crate::overseer::ExecutorSlotInfo;
 use crate::{
-	bundle_processor::BundleProcessor,
-	bundle_producer::BundleProducer,
-	overseer::{BlockInfo, CollationGenerationConfig, Overseer, OverseerHandle},
+	bundle_processor::BundleProcessor, bundle_producer::BundleProducer, overseer::BlockInfo,
 };
 use cirrus_block_builder::{BlockBuilder, RecordProof};
 use cirrus_client_executor_gossip::{Action, GossipMessageHandler};
 use cirrus_primitives::{AccountId, SecondaryApi};
 use codec::{Decode, Encode};
-use futures::{pin_mut, select, FutureExt, Stream, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use sc_client_api::{AuxStore, BlockBackend};
 use sc_network::NetworkService;
 use sc_utils::mpsc::TracingUnboundedSender;
@@ -114,7 +112,6 @@ where
 	primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
 	client: Arc<Client>,
 	spawner: Box<dyn SpawnNamed + Send + Sync>,
-	overseer_handle: OverseerHandle<PBlock>,
 	transaction_pool: Arc<TransactionPool>,
 	backend: Arc<Backend>,
 	code_executor: Arc<E>,
@@ -134,7 +131,6 @@ where
 			primary_network: self.primary_network.clone(),
 			client: self.client.clone(),
 			spawner: self.spawner.clone(),
-			overseer_handle: self.overseer_handle.clone(),
 			transaction_pool: self.transaction_pool.clone(),
 			backend: self.backend.clone(),
 			code_executor: self.code_executor.clone(),
@@ -225,111 +221,84 @@ where
 			keystore,
 		);
 
-		let overseer_handle = {
+		{
 			let span = tracing::Span::current();
-			let overseer_config = CollationGenerationConfig {
-				processor: {
-					let span = span.clone();
-					let bundle_processor = bundle_processor.clone();
+			let primary_chain_client = primary_chain_client.clone();
+			let bundle_processor = bundle_processor.clone();
 
-					Box::new(move |primary_hash, bundles, shuffling_seed, maybe_new_runtime| {
-						let bundle_processor = bundle_processor.clone();
-						let span = span.clone();
+			spawn_essential.spawn_essential_blocking(
+				"collation-generation-subsystem",
+				Some("collation-generation-subsystem"),
+				async move {
+					overseer::forward_events(
+						primary_chain_client.as_ref(),
+						{
+							let span = span.clone();
 
-						Box::pin(async move {
-							let process_bundles_fut = bundle_processor
-								.process_bundles(
-									primary_hash,
-									bundles,
-									shuffling_seed,
-									maybe_new_runtime,
-								)
-								.instrument(span.clone());
+							move |primary_hash, slot_info| {
+								let bundle_producer = bundle_producer.clone();
+								let produce_bundle_fut = bundle_producer
+									.produce_bundle(primary_hash, slot_info)
+									.instrument(span.clone());
 
-							process_bundles_fut.await.unwrap_or_else(|error| {
-								tracing::error!(
-									target: LOG_TARGET,
-									relay_parent = ?primary_hash,
-									error = ?error,
-									"Error at processing bundles.",
-								);
-								None
-							})
-						})
-					})
-				},
-			};
-
-			let (overseer, overseer_handle) = Overseer::new(
-				primary_chain_client.clone(),
-				active_leaves
-					.into_iter()
-					.map(|BlockInfo { hash, parent_hash: _, number }| (hash, number))
-					.collect(),
-				Default::default(),
-				overseer_config,
-			);
-
-			{
-				let primary_chain_client = primary_chain_client.clone();
-				let overseer_handle = overseer_handle.clone();
-				spawn_essential.spawn_essential_blocking(
-					"collation-generation-subsystem",
-					Some("collation-generation-subsystem"),
-					Box::pin(async move {
-						let forward = overseer::forward_events(
-							primary_chain_client.as_ref(),
-							{
+								Box::pin(async move {
+									produce_bundle_fut.await.unwrap_or_else(|error| {
+										tracing::error!(
+											target: LOG_TARGET,
+											relay_parent = ?primary_hash,
+											error = ?error,
+											"Error at producing bundle.",
+										);
+										None
+									})
+								})
+							}
+						},
+						{
+							&move |primary_hash, bundles, shuffling_seed, maybe_new_runtime| {
+								let bundle_processor = bundle_processor.clone();
 								let span = span.clone();
 
-								move |primary_hash, slot_info| {
-									let bundle_producer = bundle_producer.clone();
-									let produce_bundle_fut = bundle_producer
-										.produce_bundle(primary_hash, slot_info)
+								Box::pin(async move {
+									let process_bundles_fut = bundle_processor
+										.process_bundles(
+											primary_hash,
+											bundles,
+											shuffling_seed,
+											maybe_new_runtime,
+										)
 										.instrument(span.clone());
 
-									Box::pin(async move {
-										produce_bundle_fut.await.unwrap_or_else(|error| {
-											tracing::error!(
-												target: LOG_TARGET,
-												relay_parent = ?primary_hash,
-												error = ?error,
-												"Error at producing bundle.",
-											);
-											None
-										})
+									process_bundles_fut.await.unwrap_or_else(|error| {
+										tracing::error!(
+											target: LOG_TARGET,
+											relay_parent = ?primary_hash,
+											error = ?error,
+											"Error at processing bundles.",
+										);
+										None
 									})
-								}
-							},
-							Box::pin(imported_block_notification_stream.fuse()),
-							Box::pin(new_slot_notification_stream.fuse()),
-							overseer_handle,
-						);
-
-						let forward = forward.fuse();
-						let overseer_fut = overseer.run().fuse();
-
-						pin_mut!(overseer_fut);
-						pin_mut!(forward);
-
-						select! {
-							_ = forward => (),
-							_ = overseer_fut => (),
-							complete => (),
-						}
-					}),
-				);
-			}
-
-			overseer_handle
-		};
+								})
+							}
+						},
+						active_leaves
+							.into_iter()
+							.map(|BlockInfo { hash, parent_hash: _, number }| (hash, number))
+							.collect(),
+						Box::pin(imported_block_notification_stream.fuse()),
+						Box::pin(new_slot_notification_stream.fuse()),
+					)
+					.await
+				}
+				.boxed(),
+			);
+		}
 
 		Ok(Self {
 			primary_chain_client,
 			primary_network,
 			client,
 			spawner,
-			overseer_handle,
 			transaction_pool,
 			backend,
 			code_executor,

--- a/cumulus/client/cirrus-executor/src/overseer.rs
+++ b/cumulus/client/cirrus-executor/src/overseer.rs
@@ -143,7 +143,7 @@ where
 
 	let best_hash = primary_chain_client.info().best_hash;
 
-	let () = primary_chain_client
+	primary_chain_client
 		.runtime_api()
 		.submit_execution_receipt_unsigned(&BlockId::Hash(best_hash), execution_receipt)?;
 
@@ -295,7 +295,7 @@ where
 		},
 	};
 
-	let () = primary_chain_client
+	primary_chain_client
 		.runtime_api()
 		.submit_transaction_bundle_unsigned(&BlockId::Hash(best_hash), opaque_bundle)?;
 

--- a/cumulus/client/cirrus-executor/src/overseer.rs
+++ b/cumulus/client/cirrus-executor/src/overseer.rs
@@ -187,8 +187,7 @@ where
 
 	let best_hash = client.info().best_hash;
 
-	// TODO: Handle returned result?
-	client
+	let () = client
 		.runtime_api()
 		.submit_execution_receipt_unsigned(&BlockId::Hash(best_hash), execution_receipt)?;
 
@@ -436,8 +435,7 @@ where
 				},
 			};
 
-		// TODO: Handle returned result?
-		let _ = client
+		let () = client
 			.runtime_api()
 			.submit_transaction_bundle_unsigned(&BlockId::Hash(best_hash), opaque_bundle)?;
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -936,12 +936,12 @@ impl_runtime_apis! {
     impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {
         fn submit_execution_receipt_unsigned(
             execution_receipt: sp_executor::SignedExecutionReceipt<cirrus_primitives::Hash>,
-        ) -> Option<()> {
-            Executor::submit_execution_receipt_unsigned(execution_receipt).ok()
+        ) {
+            Executor::submit_execution_receipt_unsigned(execution_receipt)
         }
 
-        fn submit_transaction_bundle_unsigned(opaque_bundle: sp_executor::SignedOpaqueBundle) -> Option<()> {
-            Executor::submit_transaction_bundle_unsigned(opaque_bundle).ok()
+        fn submit_transaction_bundle_unsigned(opaque_bundle: sp_executor::SignedOpaqueBundle) {
+            Executor::submit_transaction_bundle_unsigned(opaque_bundle)
         }
 
         fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -944,20 +944,20 @@ impl_runtime_apis! {
             Executor::submit_transaction_bundle_unsigned(opaque_bundle).ok()
         }
 
-        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) -> Option<()> {
-            Executor::submit_fraud_proof_unsigned(fraud_proof).ok()
+        fn submit_fraud_proof_unsigned(fraud_proof: FraudProof) {
+            Executor::submit_fraud_proof_unsigned(fraud_proof)
         }
 
         fn submit_bundle_equivocation_proof_unsigned(
             bundle_equivocation_proof: sp_executor::BundleEquivocationProof,
-        ) -> Option<()> {
-            Executor::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof).ok()
+        ) {
+            Executor::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof)
         }
 
         fn submit_invalid_transaction_proof_unsigned(
             invalid_transaction_proof: sp_executor::InvalidTransactionProof,
-        ) -> Option<()> {
-            Executor::submit_invalid_transaction_proof_unsigned(invalid_transaction_proof).ok()
+        ) {
+            Executor::submit_invalid_transaction_proof_unsigned(invalid_transaction_proof)
         }
 
         fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle> {


### PR DESCRIPTION
`Overseer` struct is gone, there is just a few functions left of it.

Naming and other things will be cleaned up in upcoming PR(s).

Reviewing commit by commit should make sense, hopefully the reason refactoring in #429 was necessary is also clearer now.