### PR TITLE
Refactor cirrus executor (part 3)

### DIFF
--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -9,7 +9,8 @@ use sc_consensus::{
 };
 use sc_network::NetworkService;
 use sc_utils::mpsc::TracingUnboundedSender;
-use sp_api::{NumberFor, ProvideRuntimeApi};
+use sp_api::{NumberFor, ProvideRuntimeApi, TransactionFor};
+use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockOrigin;
 use sp_core::ByteArray;
 use sp_executor::{
@@ -117,10 +118,7 @@ impl<Block, PBlock, Client, PClient, Backend>
 where
 	Block: BlockT,
 	PBlock: BlockT,
-	Client: sp_blockchain::HeaderBackend<Block>
-		+ BlockBackend<Block>
-		+ AuxStore
-		+ ProvideRuntimeApi<Block>,
+	Client: HeaderBackend<Block> + BlockBackend<Block> + AuxStore + ProvideRuntimeApi<Block>,
 	Client::Api: SecondaryApi<Block, AccountId>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ sp_api::ApiExt<
@@ -129,7 +127,7 @@ where
 		>,
 	for<'b> &'b Client: BlockImport<
 		Block,
-		Transaction = sp_api::TransactionFor<Client, Block>,
+		Transaction = TransactionFor<Client, Block>,
 		Error = sp_consensus::Error,
 	>,
 	PClient: ProvideRuntimeApi<PBlock>,

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -158,7 +158,7 @@ where
 	}
 
 	pub(crate) async fn process_bundles(
-		&self,
+		self,
 		(primary_hash, primary_number): (PBlock::Hash, NumberFor<PBlock>),
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,

--- a/cumulus/client/cirrus-executor/src/bundle_producer.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_producer.rs
@@ -1,4 +1,4 @@
-use crate::overseer::ExecutorSlotInfo;
+use crate::worker::ExecutorSlotInfo;
 use cirrus_primitives::{AccountId, SecondaryApi};
 use codec::{Decode, Encode};
 use futures::{select, FutureExt};

--- a/cumulus/client/cirrus-executor/src/bundle_producer.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_producer.rs
@@ -6,6 +6,8 @@ use sc_client_api::BlockBackend;
 use sc_transaction_pool_api::InPoolTransaction;
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::ProvideRuntimeApi;
+use sp_block_builder::BlockBuilder;
+use sp_blockchain::HeaderBackend;
 use sp_core::ByteArray;
 use sp_executor::{
 	Bundle, BundleHeader, ExecutorApi, ExecutorId, ExecutorSignature, SignedBundle,
@@ -58,8 +60,8 @@ impl<Block, PBlock, Client, PClient, TransactionPool>
 where
 	Block: BlockT,
 	PBlock: BlockT,
-	Client: sp_blockchain::HeaderBackend<Block> + BlockBackend<Block> + ProvideRuntimeApi<Block>,
-	Client::Api: SecondaryApi<Block, AccountId> + sp_block_builder::BlockBuilder<Block>,
+	Client: HeaderBackend<Block> + BlockBackend<Block> + ProvideRuntimeApi<Block>,
+	Client::Api: SecondaryApi<Block, AccountId> + BlockBuilder<Block>,
 	PClient: ProvideRuntimeApi<PBlock>,
 	PClient::Api: ExecutorApi<PBlock, Block::Hash>,
 	TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block>,

--- a/cumulus/client/cirrus-executor/src/worker.rs
+++ b/cumulus/client/cirrus-executor/src/worker.rs
@@ -36,15 +36,15 @@ use std::{
 use subspace_core_primitives::{Randomness, Tag};
 use subspace_runtime_primitives::Hash as PHash;
 
-const LOG_TARGET: &str = "overseer";
+const LOG_TARGET: &str = "executor-worker";
 
 /// Data required to produce bundles on executor node.
 #[derive(PartialEq, Clone, Debug)]
-pub struct ExecutorSlotInfo {
+pub(super) struct ExecutorSlotInfo {
 	/// Slot
-	pub slot: Slot,
+	pub(super) slot: Slot,
 	/// Global slot challenge
-	pub global_challenge: Tag,
+	pub(super) global_challenge: Tag,
 }
 
 /// An event telling the `Overseer` on the particular block

--- a/cumulus/node/src/service.rs
+++ b/cumulus/node/src/service.rs
@@ -1,9 +1,9 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
-use cirrus_client_executor::{Executor, ExecutorSlotInfo};
+use cirrus_client_executor::Executor;
 use cirrus_client_executor_gossip::ExecutorGossipParams;
 use cirrus_runtime::{opaque::Block, Hash, RuntimeApi};
-use futures::{Stream, StreamExt};
+use futures::Stream;
 use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_network::NetworkService;
@@ -235,9 +235,7 @@ where
 			&spawn_essential,
 			select_chain,
 			imported_block_notification_stream,
-			new_slot_notification_stream.then(|(slot, global_challenge)| async move {
-				ExecutorSlotInfo { slot, global_challenge }
-			}),
+			new_slot_notification_stream,
 			client.clone(),
 			Box::new(task_manager.spawn_handle()),
 			transaction_pool,

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -20,7 +20,6 @@
 
 pub mod chain_spec;
 
-use cirrus_client_executor::ExecutorSlotInfo;
 use cirrus_client_executor_gossip::ExecutorGossipParams;
 use cirrus_test_runtime::{opaque::Block, Hash, RuntimeApi};
 use futures::StreamExt;
@@ -242,10 +241,8 @@ async fn start_node_impl(
 			primary_chain_full_node.new_slot_notification_stream.subscribe().then(
 				|slot_notification| async move {
 					let slot_info = slot_notification.new_slot_info;
-					ExecutorSlotInfo {
-						slot: slot_info.slot,
-						global_challenge: slot_info.global_challenge,
-					}
+
+					(slot_info.slot, slot_info.global_challenge)
 				},
 			),
 			client.clone(),


### PR DESCRIPTION
This concludes series of refactoring with introduction of `start_worker` function that does background work for executor.