### PR TITLE
Skip processing the genesis primary block on executor

### DIFF
--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -849,6 +849,11 @@ where
 {
 	let best_block = select_chain.best_chain().await?;
 
+	// No leaves if starting from the genesis.
+	if best_block.number().is_zero() {
+		return Ok(Vec::new())
+	}
+
 	let mut leaves = select_chain
 		.leaves()
 		.await

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -45,6 +45,12 @@ async fn test_executor_full_node_catching_up() {
 	// dave is able to sync blocks.
 	futures::future::join(charlie.wait_for_blocks(10), dave.wait_for_blocks(10)).await;
 
+	assert_eq!(
+		alice.client.info().best_number,
+		charlie.client.info().best_number,
+		"Primary chain and secondary chain must be on the same best height"
+	);
+
 	let charlie_block_hash = charlie.client.expect_block_hash_from_id(&BlockId::Number(8)).unwrap();
 
 	let dave_block_hash = dave.client.expect_block_hash_from_id(&BlockId::Number(8)).unwrap();


### PR DESCRIPTION
Since
https://github.com/subspace/subspace/commit/2fc664a4ad2974bd81322623775d592c997046cf
the primary genesis block is also processed by executor on startup,
resulting in an issue that the block number of execution chain is always ahead of the
consensus chain block number by 1. The reason is that previously the
executor only processes the primary block after the config has been
initialized, hence the active leaves processing before the loop will be
actually skipped, but now the leaves will always be processed as the
config is ensured to be initialized.

For this specific case, it makes sense to me that there are actually no leaves for
the genesis block.