### PR TITLE
Initial benchmarking support for the farmer

### DIFF
--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -42,6 +42,7 @@ subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
+tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["macros", "parking_lot", "rt-multi-thread"] }
 zeroize = "1.5.4"
@@ -57,9 +58,6 @@ version = "0.18.0"
 default-features = false
 features = ["snappy", "jemalloc"]
 version = "0.18.0"
-
-[dev-dependencies]
-tempfile = "3.3.0"
 
 [features]
 default = []

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -1,0 +1,201 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rand::prelude::*;
+use subspace_archiving::archiver::ArchivedSegment;
+use subspace_core_primitives::objects::{PieceObject, PieceObjectMapping};
+use subspace_core_primitives::{
+    ArchivedBlockProgress, BlockNumber, FlatPieces, LastArchivedBlock, RootBlock, Sha256Hash,
+};
+use subspace_rpc_primitives::{
+    BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
+};
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinHandle;
+
+use crate::rpc_client::{Error as MockError, RpcClient};
+
+/// Client mock for benching purpose
+#[derive(Clone, Debug)]
+pub struct BenchRpcClient {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+pub struct Inner {
+    metadata: FarmerMetadata,
+    slot_info_receiver: Arc<Mutex<mpsc::Receiver<SlotInfo>>>,
+    acknowledge_archived_segment_sender: mpsc::Sender<u64>,
+    archived_segments_receiver: Arc<Mutex<mpsc::Receiver<ArchivedSegment>>>,
+    slot_info_handler: Mutex<JoinHandle<()>>,
+    segment_producer_handle: Mutex<JoinHandle<()>>,
+}
+
+impl BenchRpcClient {
+    /// Create a new instance of [`BenchRpcClient`].
+    pub fn new(metadata: FarmerMetadata) -> Self {
+        let (slot_info_sender, slot_info_receiver) = mpsc::channel(10);
+        let (archived_segments_sender, archived_segments_receiver) = mpsc::channel(10);
+        let (acknowledge_archived_segment_sender, mut acknowledge_archived_segment_receiver) =
+            mpsc::channel(1);
+
+        let slot_info_handler = tokio::spawn(async move {
+            let mut slot_number = 0;
+            let mut next_salt = rand::random();
+            loop {
+                let global_challenge = rand::random();
+                next_salt = {
+                    let (salt, next_salt) = (next_salt, rand::random());
+                    let slot_info = SlotInfo {
+                        slot_number,
+                        global_challenge,
+                        salt: next_salt,
+                        next_salt: salt,
+                        solution_range: rand::random(),
+                    };
+                    if slot_info_sender.send(slot_info).await.is_err() {
+                        break;
+                    };
+                    Some(next_salt)
+                };
+
+                tokio::time::sleep(Duration::from_secs(2 * 60)).await;
+
+                slot_number += 1;
+            }
+        });
+
+        let segment_producer_handle = tokio::spawn(async move {
+            let mut segment_index = 0;
+            let mut last_archived_block = LastArchivedBlock {
+                number: 0,
+                archived_progress: ArchivedBlockProgress::Partial(0),
+            };
+            loop {
+                last_archived_block
+                    .archived_progress
+                    .set_partial(segment_index as u32);
+
+                let archived_segment = {
+                    let root_block = RootBlock::V0 {
+                        segment_index,
+                        records_root: Sha256Hash::default(),
+                        prev_root_block_hash: Sha256Hash::default(),
+                        last_archived_block,
+                    };
+
+                    let mut pieces = FlatPieces::new(100);
+                    rand::thread_rng().fill(pieces.as_mut());
+
+                    let objects = std::iter::repeat_with(|| PieceObject::V0 {
+                        hash: rand::random(),
+                        offset: rand::random(),
+                    })
+                    .take(100)
+                    .collect();
+
+                    ArchivedSegment {
+                        root_block,
+                        pieces,
+                        object_mapping: vec![PieceObjectMapping { objects }],
+                    }
+                };
+
+                if archived_segments_sender
+                    .send(archived_segment)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                if acknowledge_archived_segment_receiver.recv().await.is_none() {
+                    break;
+                }
+
+                segment_index += 1;
+            }
+        });
+
+        Self {
+            inner: Arc::new(Inner {
+                metadata,
+                slot_info_receiver: Arc::new(Mutex::new(slot_info_receiver)),
+                archived_segments_receiver: Arc::new(Mutex::new(archived_segments_receiver)),
+                acknowledge_archived_segment_sender,
+                slot_info_handler: Mutex::new(slot_info_handler),
+                segment_producer_handle: Mutex::new(segment_producer_handle),
+            }),
+        }
+    }
+
+    pub async fn stop(self) {
+        self.inner.slot_info_handler.lock().await.abort();
+        self.inner.segment_producer_handle.lock().await.abort();
+    }
+}
+
+#[async_trait]
+impl RpcClient for BenchRpcClient {
+    async fn farmer_metadata(&self) -> Result<FarmerMetadata, MockError> {
+        Ok(self.inner.metadata.clone())
+    }
+
+    async fn best_block_number(&self) -> Result<BlockNumber, MockError> {
+        // Doesn't matter for tests (at least yet)
+        Ok(BlockNumber::MAX)
+    }
+
+    async fn subscribe_slot_info(&self) -> Result<mpsc::Receiver<SlotInfo>, MockError> {
+        let (sender, receiver) = mpsc::channel(10);
+        let slot_receiver = self.inner.slot_info_receiver.clone();
+        tokio::spawn(async move {
+            while let Some(slot_info) = slot_receiver.lock().await.recv().await {
+                sender.send(slot_info).await.unwrap();
+            }
+        });
+
+        Ok(receiver)
+    }
+
+    async fn submit_solution_response(
+        &self,
+        _solution_response: SolutionResponse,
+    ) -> Result<(), MockError> {
+        unreachable!("Unreachable, as we don't start farming for benchmarking")
+    }
+
+    async fn subscribe_block_signing(&self) -> Result<Receiver<BlockSigningInfo>, MockError> {
+        unreachable!("Unreachable, as we don't start farming for benchmarking")
+    }
+
+    async fn submit_block_signature(
+        &self,
+        _block_signature: BlockSignature,
+    ) -> Result<(), MockError> {
+        unreachable!("Unreachable, as we don't start farming for benchmarking")
+    }
+
+    async fn subscribe_archived_segments(&self) -> Result<Receiver<ArchivedSegment>, MockError> {
+        let (sender, receiver) = mpsc::channel(10);
+        let archived_segments_receiver = self.inner.archived_segments_receiver.clone();
+        tokio::spawn(async move {
+            while let Some(archived_segment) = archived_segments_receiver.lock().await.recv().await
+            {
+                sender.send(archived_segment).await.unwrap();
+            }
+        });
+
+        Ok(receiver)
+    }
+
+    async fn acknowledge_archived_segment(&self, segment_index: u64) -> Result<(), MockError> {
+        self.inner
+            .acknowledge_archived_segment_sender
+            .send(segment_index)
+            .await
+            .unwrap();
+        Ok(())
+    }
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 
-use crate::rpc_client::{Error as MockError, RpcClient};
+use subspace_farmer::{RpcClient, RpcClientError as MockError};
 
 /// Client mock for benching purpose
 #[derive(Clone, Debug)]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,6 +1,6 @@
 mod farm;
 
-pub(crate) use farm::farm;
+pub(crate) use farm::{bench, farm};
 use log::info;
 use std::path::Path;
 use std::{fs, io};

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -136,10 +136,10 @@ pub(crate) async fn farm(
         },
         plot_size,
         max_plot_size,
-        move |plot_index, address, max_piece_count| {
+        move |plot_index, public_key, max_piece_count| {
             Plot::open_or_create(
                 base_directory.join(format!("plot{plot_index}")),
-                address,
+                public_key,
                 max_piece_count,
             )
         },
@@ -256,16 +256,16 @@ pub(crate) async fn bench(
     .await??;
 
     let base_path = base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index, address, max_piece_count| {
+    let plot_factory = move |plot_index, public_key, max_piece_count| {
         let base_path = base_path.join(format!("plot{plot_index}"));
         match write_to_disk {
             WriteToDisk::Nothing => Plot::with_plot_file(
                 BenchPlotMock::new(max_piece_count),
                 base_path,
-                address,
+                public_key,
                 max_piece_count,
             ),
-            WriteToDisk::Everything => Plot::open_or_create(base_path, address, max_piece_count),
+            WriteToDisk::Everything => Plot::open_or_create(base_path, public_key, max_piece_count),
         }
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{PublicKey, PIECE_SIZE};
 use subspace_farmer::bench_rpc_client::BenchRpcClient;
-use subspace_farmer::multi_farming::{self, MultiFarming};
+use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{retrieve_piece_from_plots, NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use subspace_networking::libp2p::multiaddr::Protocol;
@@ -17,7 +17,7 @@ use subspace_networking::Config;
 use subspace_rpc_primitives::FarmerMetadata;
 use tempfile::TempDir;
 
-use crate::FarmingArgs;
+use crate::{FarmingArgs, WriteToDisk};
 
 fn raise_fd_limit() {
     match std::panic::catch_unwind(fdlimit::raise_fd_limit) {
@@ -87,7 +87,7 @@ pub(crate) async fn farm(
     .await??;
 
     let multi_farming = MultiFarming::new(
-        multi_farming::Options {
+        MultiFarmingOptions {
             base_directory,
             client,
             object_mappings: object_mappings.clone(),
@@ -176,7 +176,7 @@ pub(crate) async fn bench(
     plot_size: u64,
     max_plot_size: Option<u64>,
     best_block_number_check_interval: Duration,
-    mock_plot: bool,
+    write_to_disk: WriteToDisk,
     write_pieces_size: u64,
 ) -> anyhow::Result<()> {
     raise_fd_limit();
@@ -208,7 +208,7 @@ pub(crate) async fn bench(
     .await??;
 
     let multi_farming = MultiFarming::benchmarking(
-        multi_farming::Options {
+        MultiFarmingOptions {
             base_directory: base_directory.as_ref().to_owned(),
             client: client.clone(),
             object_mappings: object_mappings.clone(),
@@ -217,7 +217,7 @@ pub(crate) async fn bench(
         },
         plot_size,
         max_plot_size,
-        mock_plot,
+        matches!(write_to_disk, WriteToDisk::Nothing),
     )
     .await?;
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::PIECE_SIZE;
-use subspace_farmer::multi_farming::MultiFarming;
+use subspace_farmer::multi_farming::{self, MultiFarming};
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{retrieve_piece_from_plots, NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use subspace_networking::libp2p::multiaddr::Protocol;
@@ -80,11 +80,13 @@ pub(crate) async fn farm(
     .await??;
 
     let multi_farming = MultiFarming::new(
-        base_directory,
-        client,
-        object_mappings.clone(),
-        reward_address,
-        best_block_number_check_interval,
+        multi_farming::Options {
+            base_directory,
+            client,
+            object_mappings: object_mappings.clone(),
+            reward_address,
+            best_block_number_check_interval,
+        },
         plot_size,
         max_plot_size,
     )

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{io, mem};
 use subspace_core_primitives::{PublicKey, PIECE_SIZE};
-use subspace_farmer::bench_rpc_client::BenchRpcClient;
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{
@@ -20,6 +19,7 @@ use subspace_networking::Config;
 use subspace_rpc_primitives::FarmerMetadata;
 use tempfile::TempDir;
 
+use crate::bench_rpc_client::BenchRpcClient;
 use crate::{FarmingArgs, WriteToDisk};
 
 pub struct BenchPlotMock {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -171,6 +171,7 @@ pub(crate) async fn bench(
     plot_size: u64,
     max_plot_size: Option<u64>,
     best_block_number_check_interval: Duration,
+    mock_plot: bool,
 ) -> anyhow::Result<()> {
     let client = BenchRpcClient::new(BENCH_FARMER_METADATA);
 
@@ -222,6 +223,7 @@ pub(crate) async fn bench(
         },
         plot_size,
         max_plot_size,
+        mock_plot,
     )
     .await?;
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -61,7 +61,7 @@ enum Command {
     },
     /// Start a farmer using previously created plot
     Farm(FarmingArgs),
-    /// Benchmark disk in order to see a throughput of the disk for farming
+    /// Benchmark disk in order to see a throughput of the disk for plotting
     Bench {
         /// Custom path for data storage instead of platform-specific default
         #[clap(long, value_hint = ValueHint::FilePath)]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -52,10 +52,15 @@ struct FarmingArgs {
 }
 
 #[derive(Debug, Clone, Copy, ArgEnum)]
-#[clap(default_value = "nothing")]
 enum WriteToDisk {
     Nothing,
     Everything,
+}
+
+impl Default for WriteToDisk {
+    fn default() -> Self {
+        Self::Nothing
+    }
 }
 
 #[derive(Debug, Parser)]
@@ -88,7 +93,7 @@ enum Command {
         max_plot_size: Option<u64>,
         /// How much things to write on disk (the more we write during benchmark, the more accurate
         /// it is)
-        #[clap(arg_enum, long)]
+        #[clap(arg_enum, long, default_value_t)]
         write_to_disk: WriteToDisk,
         /// Amount of data to plot for benchmarking.
         ///

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,3 +1,4 @@
+mod bench_rpc_client;
 mod commands;
 mod utils;
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -68,8 +68,6 @@ enum Command {
         custom_path: Option<PathBuf>,
         /// Maximum plot size in human readable format (e.g. 10G, 2T) or just bytes (e.g. 4096).
         ///
-        /// Not all disk space will be used, but please give some precise numbers for your setup.
-        ///
         /// Only `G` and `T` endings are supported.
         #[clap(long, parse(try_from_str = parse_human_readable_size))]
         plot_size: u64,
@@ -80,9 +78,15 @@ enum Command {
         /// Only a developer testing flag, as it might be needed for testing.
         #[clap(long, parse(try_from_str = parse_human_readable_size))]
         max_plot_size: Option<u64>,
-        /// Actually write pieces to disk while benchmarking (might be more accurate)
+        /// Actually write pieces to disk while benchmarking (might be more accurate, but uses more
+        /// space)
         #[clap(long)]
         plot: bool,
+        /// Amount of data to plot for benchmarking.
+        ///
+        /// Only `G` and `T` endings are supported.
+        #[clap(long, parse(try_from_str = parse_human_readable_size))]
+        write_pieces_size: u64,
     },
 }
 
@@ -124,6 +128,7 @@ async fn main() -> Result<()> {
             plot_size,
             max_plot_size,
             plot,
+            write_pieces_size,
         } => {
             commands::bench(
                 custom_path,
@@ -131,6 +136,7 @@ async fn main() -> Result<()> {
                 max_plot_size,
                 BEST_BLOCK_NUMBER_CHECK_INTERVAL,
                 !plot,
+                write_pieces_size,
             )
             .await?
         }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -80,6 +80,9 @@ enum Command {
         /// Only a developer testing flag, as it might be needed for testing.
         #[clap(long, parse(try_from_str = parse_human_readable_size))]
         max_plot_size: Option<u64>,
+        /// Actually write pieces to disk while benchmarking (might be more accurate)
+        #[clap(long)]
+        plot: bool,
     },
 }
 
@@ -120,12 +123,14 @@ async fn main() -> Result<()> {
             custom_path,
             plot_size,
             max_plot_size,
+            plot,
         } => {
             commands::bench(
                 custom_path,
                 plot_size,
                 max_plot_size,
                 BEST_BLOCK_NUMBER_CHECK_INTERVAL,
+                !plot,
             )
             .await?
         }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -59,7 +59,7 @@ enum WriteToDisk {
 
 impl Default for WriteToDisk {
     fn default() -> Self {
-        Self::Nothing
+        Self::Everything
     }
 }
 

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -22,7 +22,6 @@
 //! 64-bit unsigned integers.
 
 pub(crate) mod archiving;
-pub mod bench_rpc_client;
 pub(crate) mod commitments;
 pub(crate) mod farming;
 pub(crate) mod identity;
@@ -45,4 +44,4 @@ pub use node_rpc_client::NodeRpcClient;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
 pub use plot::{retrieve_piece_from_plots, PieceOffset, Plot, PlotError, PlotFile};
 pub use plotting::plot_pieces;
-pub use rpc_client::RpcClient;
+pub use rpc_client::{Error as RpcClientError, RpcClient};

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -43,6 +43,6 @@ pub use identity::Identity;
 pub use jsonrpsee;
 pub use node_rpc_client::NodeRpcClient;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
-pub use plot::{retrieve_piece_from_plots, Plot, PlotError};
+pub use plot::{retrieve_piece_from_plots, PieceOffset, Plot, PlotError, PlotFile};
 pub use plotting::plot_pieces;
 pub use rpc_client::RpcClient;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -22,6 +22,7 @@
 //! 64-bit unsigned integers.
 
 pub(crate) mod archiving;
+pub mod bench_rpc_client;
 pub(crate) mod commitments;
 pub(crate) mod farming;
 pub(crate) mod identity;

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -49,8 +49,8 @@ pub struct Options<C: RpcClient> {
 
 impl MultiFarming {
     /// Starts multiple farmers with any plot sizes which user gives
-    pub async fn new(
-        options: Options<impl RpcClient>,
+    pub async fn new<C: RpcClient>(
+        options: Options<C>,
         total_plot_size: u64,
         max_plot_size: u64,
     ) -> anyhow::Result<Self> {
@@ -73,8 +73,8 @@ impl MultiFarming {
 
     /// Starts multiple farmers for benchmarking (basically disables farming, just plots pieces
     /// from the archiver)
-    pub async fn benchmarking(
-        options: Options<impl RpcClient>,
+    pub async fn benchmarking<C: RpcClient>(
+        options: Options<C>,
         total_plot_size: u64,
         max_plot_size: u64,
         mock_plot: bool,
@@ -114,14 +114,14 @@ impl MultiFarming {
         }
     }
 
-    async fn new_inner(
+    async fn new_inner<C: RpcClient>(
         Options {
             base_directory,
             client,
             object_mappings,
             reward_address,
             best_block_number_check_interval,
-        }: Options<impl RpcClient>,
+        }: Options<C>,
         plot_sizes: Vec<u64>,
         new_plot: impl Fn(usize, PublicKey, u64) -> Result<Plot, PlotError> + Clone + Send + 'static,
         start_farmings: bool,

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -1,6 +1,5 @@
 use crate::{
-    plotting, Archiving, Commitments, Farming, Identity, NodeRpcClient, ObjectMappings, Plot,
-    PlotError, RpcClient,
+    plotting, Archiving, Commitments, Farming, Identity, ObjectMappings, Plot, PlotError, RpcClient,
 };
 use anyhow::anyhow;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -46,7 +45,7 @@ impl MultiFarming {
     /// Starts multiple farmers with any plot sizes which user gives
     pub async fn new(
         base_directory: PathBuf,
-        client: NodeRpcClient,
+        client: impl RpcClient,
         object_mappings: ObjectMappings,
         reward_address: PublicKey,
         best_block_number_check_interval: Duration,
@@ -74,7 +73,7 @@ impl MultiFarming {
 
     async fn new_inner(
         base_directory: impl AsRef<Path>,
-        client: NodeRpcClient,
+        client: impl RpcClient,
         object_mappings: ObjectMappings,
         reward_address: PublicKey,
         best_block_number_check_interval: Duration,

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -20,7 +20,7 @@ use subspace_solving::{PieceDistance, SubspaceCodec};
 use thiserror::Error;
 
 /// Index of piece on disk
-pub(crate) type PieceOffset = u64;
+pub type PieceOffset = u64;
 
 #[derive(Debug, Error)]
 pub enum PlotError {
@@ -641,43 +641,6 @@ impl PlotFile for File {
 
     fn sync_all(&mut self) -> io::Result<()> {
         File::sync_all(&*self)
-    }
-}
-
-pub struct BenchPlotMock {
-    piece_count: u64,
-    max_piece_count: u64,
-}
-
-impl BenchPlotMock {
-    pub fn new(max_piece_count: u64) -> Self {
-        Self {
-            max_piece_count,
-            piece_count: 0,
-        }
-    }
-}
-
-impl PlotFile for BenchPlotMock {
-    fn piece_count(&mut self) -> io::Result<u64> {
-        Ok(self.piece_count)
-    }
-
-    fn write(&mut self, pieces: impl AsRef<[u8]>, _offset: PieceOffset) -> io::Result<()> {
-        self.piece_count = (self.piece_count + (pieces.as_ref().len() / PIECE_SIZE) as u64)
-            .max(self.max_piece_count);
-        Ok(())
-    }
-
-    fn read(&mut self, _offset: PieceOffset, mut buf: impl AsMut<[u8]>) -> io::Result<()> {
-        use rand::Rng;
-
-        rand::thread_rng().fill(buf.as_mut());
-        Ok(())
-    }
-
-    fn sync_all(&mut self) -> io::Result<()> {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This pr introduces the base for future work on benchmarking. The main purpose of this pr is to:
- introduce benchmarking mock rpc
- introduce command

Creation of some benchmark introspection and statistics is out of scope here.

Things to think about:
- Should we remove cli arguments for:
 - Writing actual plot
 - `write_pieces_size` (calculate it using other arguments)