### PR TITLE
Add farmer introspection

### DIFF
--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -44,4 +44,6 @@ pub use node_rpc_client::NodeRpcClient;
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
 pub use plot::{retrieve_piece_from_plots, PieceOffset, Plot, PlotError, PlotFile};
 pub use plotting::plot_pieces;
-pub use rpc_client::{Error as RpcClientError, RpcClient};
+pub use rpc_client::{
+    Error as RpcClientError, RpcClient, SegmentPipelineEvent, SegmentPipelineEventSender,
+};

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -140,14 +140,14 @@ impl MultiFarming {
                     })
                     .collect::<Vec<_>>();
 
-                move |pieces_to_plot| {
+                move |pieces_to_plot, segment_pipeline_event_sender| {
                     on_pieces_to_plots
                         .par_iter_mut()
                         .map(|on_pieces_to_plot| {
                             // TODO: It might be desirable to not clone it and instead pick just
                             //  unnecessary pieces and copy pieces once since different plots will
                             //  care about different pieces
-                            on_pieces_to_plot(pieces_to_plot.clone())
+                            on_pieces_to_plot(pieces_to_plot.clone(), segment_pipeline_event_sender)
                         })
                         .reduce(|| true, |result, should_continue| result && should_continue)
                 }

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -8,10 +8,11 @@ mod tests;
 
 use crate::commitments::Commitments;
 use crate::plot::Plot;
+use crate::rpc_client::{SegmentPipelineEvent, SegmentPipelineEventSender};
 use crate::PiecesToPlot;
 use log::error;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, PieceIndex};
+use subspace_core_primitives::{FlatPieces, PieceIndex, PIECE_SIZE};
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
 
 /// Generates a function that will plot pieces.
@@ -19,10 +20,10 @@ pub fn plot_pieces(
     mut subspace_codec: SubspaceCodec,
     plot: &Plot,
     commitments: Commitments,
-) -> impl FnMut(PiecesToPlot) -> bool + Send + 'static {
+) -> impl FnMut(PiecesToPlot, &'_ SegmentPipelineEventSender) -> bool + Send + 'static {
     let weak_plot = plot.downgrade();
 
-    move |pieces_to_plot| {
+    move |pieces_to_plot, segment_pipeline_event_sender| {
         if let Some(plot) = weak_plot.upgrade() {
             if let Err(error) = plot_pieces_internal(
                 &mut subspace_codec,
@@ -30,6 +31,7 @@ pub fn plot_pieces(
                 &commitments,
                 pieces_to_plot.piece_index_offset,
                 pieces_to_plot.pieces,
+                segment_pipeline_event_sender,
             ) {
                 error!("Failed to encode a piece: error: {}", error);
                 return false;
@@ -49,26 +51,44 @@ fn plot_pieces_internal(
     commitments: &Commitments,
     piece_index_offset: u64,
     mut pieces: FlatPieces,
+    segment_pipeline_event_sender: &'_ SegmentPipelineEventSender,
 ) -> Result<(), BatchEncodeError> {
     let piece_indexes = (piece_index_offset..)
         .take(pieces.count())
         .collect::<Vec<PieceIndex>>();
+    let pieces_amount = pieces.len() as u64 / PIECE_SIZE as u64;
 
     subspace_codec.batch_encode(&mut pieces, &piece_indexes)?;
+    segment_pipeline_event_sender.send(SegmentPipelineEvent::encoded(
+        piece_index_offset,
+        pieces_amount,
+    ));
 
     let pieces = Arc::new(pieces);
 
     match plot.write_many(Arc::clone(&pieces), piece_indexes) {
         Ok(write_result) => {
+            segment_pipeline_event_sender.send(SegmentPipelineEvent::writen_to_plot(
+                piece_index_offset,
+                pieces_amount,
+            ));
             if let Err(error) = commitments.remove_pieces(write_result.evicted_pieces()) {
                 error!("Failed to remove old commitments for pieces: {}", error);
             }
+            segment_pipeline_event_sender.send(SegmentPipelineEvent::evicted_pieces(
+                piece_index_offset,
+                pieces_amount,
+            ));
 
             if let Err(error) =
                 commitments.create_for_pieces(|| write_result.to_recommitment_iterator())
             {
                 error!("Failed to create commitments for pieces: {}", error);
             }
+            segment_pipeline_event_sender.send(SegmentPipelineEvent::created_commitments(
+                piece_index_offset,
+                pieces_amount,
+            ));
         }
         Err(error) => error!("Failed to write encoded pieces: {}", error),
     }

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -4,10 +4,130 @@ use subspace_core_primitives::BlockNumber;
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
-use tokio::sync::mpsc::Receiver;
+use tokio::{
+    sync::mpsc::{self, Receiver},
+    time::Instant,
+};
 
 /// To become error type agnostic
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub enum SegmentPipelineEventSender {
+    Some(mpsc::UnboundedSender<SegmentPipelineEvent>),
+    None,
+}
+
+impl SegmentPipelineEventSender {
+    pub fn send(&self, event: SegmentPipelineEvent) {
+        if let Self::Some(sender) = self {
+            let _ = sender.send(event);
+        }
+    }
+}
+
+/// Event of benchmarking of archiving
+pub enum SegmentPipelineEvent {
+    /// Segment was received
+    Received {
+        /// Starting index of pieces
+        pieces_start_index: u64,
+        /// Amount of pieces created
+        pieces_amount: u64,
+        /// Moment of time at which some stage was finished
+        at: Instant,
+    },
+    /// Last mentioned segment pieces were encoded
+    Encoded {
+        /// Starting index of pieces
+        pieces_start_index: u64,
+        /// Amount of pieces created
+        pieces_amount: u64,
+        at: Instant,
+    },
+    /// Last mentioned segment pieces were written to plot
+    WritenToPlot {
+        /// Starting index of pieces
+        pieces_start_index: u64,
+        /// Amount of pieces created
+        pieces_amount: u64,
+        at: Instant,
+    },
+    /// Evicted pieces were removed
+    EvictedPieces {
+        /// Starting index of pieces
+        pieces_start_index: u64,
+        /// Amount of pieces created
+        pieces_amount: u64,
+        at: Instant,
+    },
+    /// New commitments were created
+    CreatedCommitments {
+        /// Starting index of pieces
+        pieces_start_index: u64,
+        /// Amount of pieces created
+        pieces_amount: u64,
+        at: Instant,
+    },
+    /// Segment passed all stages
+    Done {
+        /// Starting index of pieces
+        pieces_start_index: u64,
+        /// Amount of pieces created
+        pieces_amount: u64,
+        /// Moment of time at which some stage was finished
+        at: Instant,
+    },
+}
+
+impl SegmentPipelineEvent {
+    pub fn received(pieces_start_index: u64, pieces_amount: u64) -> Self {
+        Self::Received {
+            pieces_start_index,
+            pieces_amount,
+            at: Instant::now(),
+        }
+    }
+
+    pub fn encoded(pieces_start_index: u64, pieces_amount: u64) -> Self {
+        Self::Encoded {
+            pieces_start_index,
+            pieces_amount,
+            at: Instant::now(),
+        }
+    }
+
+    pub fn writen_to_plot(pieces_start_index: u64, pieces_amount: u64) -> Self {
+        Self::WritenToPlot {
+            pieces_start_index,
+            pieces_amount,
+            at: Instant::now(),
+        }
+    }
+
+    pub fn evicted_pieces(pieces_start_index: u64, pieces_amount: u64) -> Self {
+        Self::EvictedPieces {
+            pieces_start_index,
+            pieces_amount,
+            at: Instant::now(),
+        }
+    }
+
+    pub fn created_commitments(pieces_start_index: u64, pieces_amount: u64) -> Self {
+        Self::CreatedCommitments {
+            pieces_start_index,
+            pieces_amount,
+            at: Instant::now(),
+        }
+    }
+
+    pub fn done(pieces_start_index: u64, pieces_amount: u64) -> Self {
+        Self::Done {
+            pieces_start_index,
+            pieces_amount,
+            at: Instant::now(),
+        }
+    }
+}
 
 /// Abstraction of the Remote Procedure Call Client
 #[async_trait]
@@ -38,4 +158,9 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
 
     /// Acknowledge receiving of archived segments
     async fn acknowledge_archived_segment(&self, segment_index: u64) -> Result<(), Error>;
+
+    /// Returns sender for segment pipeline event
+    fn segment_pipeline_event_sender(&self) -> SegmentPipelineEventSender {
+        SegmentPipelineEventSender::None
+    }
 }


### PR DESCRIPTION
This pr adds introduces introspection for each segment pipeline stage. It allows to see how much is taken by each stage and how much pieces were at each of those.

Depends on #442 

Creation of actual infographics is out of scope of this pr.