### PR TITLE
Broadcast the signed execution receipt from the last seen receipt on primary chain

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -333,6 +333,7 @@ mod pallet {
 
     /// Latest execution chain block number.
     #[pallet::storage]
+    #[pallet::getter(fn best_execution_chain_number)]
     pub(super) type ExecutionChainBestNumber<T: Config> =
         StorageValue<_, T::BlockNumber, ValueQuery>;
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -400,6 +400,12 @@ sp_api::decl_runtime_apis! {
 
         /// Returns the authority id of current executor.
         fn executor_id() -> ExecutorId;
+
+        /// Returns the best execution chain number.
+        fn best_execution_chain_number() -> NumberFor<Block>;
+
+        /// Returns the maximum receipt drift.
+        fn maximum_receipt_drift() -> NumberFor<Block>;
     }
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1093,6 +1093,14 @@ impl_runtime_apis! {
                 .map(|(_account_id, executor_id)| executor_id)
                 .expect("Executor must be provided; qed")
         }
+
+        fn best_execution_chain_number() -> NumberFor<Block> {
+            Executor::best_execution_chain_number()
+        }
+
+        fn maximum_receipt_drift() -> NumberFor<Block> {
+            MaximumReceiptDrift::get()
+        }
     }
 
     impl sp_session::SessionKeys<Block> for Runtime {

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -164,10 +164,7 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Result<
-		Option<SignedExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>>,
-		sp_blockchain::Error,
-	> {
+	) -> Result<Option<SignedExecutionReceiptFor<PBlock, Block::Hash>>, sp_blockchain::Error> {
 		let parent_hash = self.client.info().best_hash;
 		let parent_number = self.client.info().best_number;
 
@@ -288,10 +285,10 @@ where
 			return Ok(None)
 		}
 
-		let executor_id = self.primary_chain_client.runtime_api().executor_id(&BlockId::Hash(
-			PBlock::Hash::decode(&mut primary_hash.encode().as_slice())
-				.expect("Primary block hash must be the correct type; qed"),
-		))?;
+		let executor_id = self
+			.primary_chain_client
+			.runtime_api()
+			.executor_id(&BlockId::Hash(primary_hash))?;
 
 		if self.is_authority &&
 			SyncCryptoStore::has_keys(

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -316,7 +316,7 @@ where
 			let max_allowed = (best_execution_chain_number + max_drift).min(header_number);
 
 			// TODO: parallelize and avoid spamming the missing receipts?
-			let mut to_send = best_execution_chain_number;
+			let mut to_send = best_execution_chain_number + One::one();
 			while to_send <= max_allowed {
 				let block_hash = self.client.hash(to_send)?.ok_or_else(|| {
 					sp_blockchain::Error::Backend(format!("Hash for Block {:?} not found", to_send))
@@ -336,7 +336,7 @@ where
 						//            - FraudProof might need to access the block body, hence all
 						//            the blocks have to be kept in the database. TODO: double check.
 						//        - Start publishing the correct ERs after the above corrected one.
-						todo!("Cache the invalid receipts without fraud proof");
+						println!("TODO: Cache the invalid receipts without fraud proof");
 					},
 				}
 

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -498,22 +498,18 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Option<SignedExecutionReceiptFor<PBlock, Block::Hash>> {
-		match self
+	) {
+		if let Err(err) = self
 			.bundle_processor
 			.process_bundles(primary_info, bundles, shuffling_seed, maybe_new_runtime)
 			.await
 		{
-			Ok(res) => res,
-			Err(err) => {
-				tracing::error!(
-					target: LOG_TARGET,
-					?primary_info,
-					error = ?err,
-					"Error at processing bundles.",
-				);
-				None
-			},
+			tracing::error!(
+				target: LOG_TARGET,
+				?primary_info,
+				error = ?err,
+				"Error at processing bundles.",
+			);
 		}
 	}
 }

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -498,7 +498,7 @@ where
 		bundles: Vec<OpaqueBundle>,
 		shuffling_seed: Randomness,
 		maybe_new_runtime: Option<Cow<'static, [u8]>>,
-	) -> Option<SignedExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>> {
+	) -> Option<SignedExecutionReceiptFor<PBlock, Block::Hash>> {
 		match self
 			.bundle_processor
 			.process_bundles(primary_info, bundles, shuffling_seed, maybe_new_runtime)
@@ -659,19 +659,10 @@ where
 	/// Checks the execution receipt from the executor peers.
 	fn on_execution_receipt(
 		&self,
-		signed_execution_receipt: &SignedExecutionReceipt<
-			NumberFor<PBlock>,
-			PBlock::Hash,
-			Block::Hash,
-		>,
+		signed_execution_receipt: &SignedExecutionReceiptFor<PBlock, Block::Hash>,
 	) -> Result<Action, Self::Error> {
 		let SignedExecutionReceipt { execution_receipt, signature, signer } =
 			signed_execution_receipt;
-
-		let block_hash = execution_receipt.secondary_hash;
-		let primary_hash =
-			PBlock::Hash::decode(&mut execution_receipt.primary_hash.encode().as_slice())
-				.expect("Hash type must be correct");
 
 		if !signer.verify(&execution_receipt.hash(), signature) {
 			return Err(Self::Error::BadExecutionReceiptSignature)
@@ -680,7 +671,7 @@ where
 		let expected_executor_id = self
 			.primary_chain_client
 			.runtime_api()
-			.executor_id(&BlockId::Hash(primary_hash))?;
+			.executor_id(&BlockId::Hash(execution_receipt.primary_hash))?;
 		if *signer != expected_executor_id {
 			// TODO: handle the misbehavior.
 
@@ -701,6 +692,7 @@ where
 			return Ok(Action::Empty)
 		}
 
+		let block_hash = execution_receipt.secondary_hash;
 		let block_number = <NumberFor<Block>>::decode(&mut primary_number.encode().as_slice())
 			.expect("Primary number and secondary number must use the same type; qed");
 
@@ -712,9 +704,7 @@ where
 		} else {
 			// Wait for the local execution receipt until it's ready.
 			let (tx, rx) = crossbeam::channel::bounded::<
-				sp_blockchain::Result<
-					ExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
-				>,
+				sp_blockchain::Result<ExecutionReceiptFor<PBlock, Block::Hash>>,
 			>(1);
 			let executor = self.clone();
 			self.spawner.spawn(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1020,6 +1020,14 @@ impl_runtime_apis! {
                 .map(|(_account_id, executor_id)| executor_id)
                 .expect("Executor must be provided; qed")
         }
+
+        fn best_execution_chain_number() -> NumberFor<Block> {
+            Executor::best_execution_chain_number()
+        }
+
+        fn maximum_receipt_drift() -> NumberFor<Block> {
+            MaximumReceiptDrift::get()
+        }
     }
 
     impl sp_session::SessionKeys<Block> for Runtime {


### PR DESCRIPTION
The main goal of this PR is to let the executor send the signed ER to other executors and farmers from the last seen ER on the primary chain instead of the execution chain tip, the maximum receipt drift is also considered.

The main part is almost done, but there are still some open questions there. I'd love to have some feedback before moving forward, especially to determine which are necessary for the initial executor deployment and should be implemented in this PR.