### PR TITLE
Fix `execute_block` of cirrus-pallet-executive

### DIFF
--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -213,9 +213,7 @@ where
 		// TODO: handle the import result properly.
 		match import_result {
 			ImportResult::Imported(..) => {},
-			ImportResult::AlreadyInChain => {
-				panic!("Block already in chain {}: {:?}", header_number, header_hash);
-			},
+			ImportResult::AlreadyInChain => {},
 			ImportResult::KnownBad => {
 				panic!("Bad block {}: {:?}", header_number, header_hash);
 			},

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -40,7 +40,6 @@ async fn test_executor_full_node_catching_up() {
 
 	// run cirrus dave (a secondary chain full node)
 	let dave = cirrus_test_service::TestNodeBuilder::new(tokio_handle, Dave)
-		.connect_to_parachain_node(&charlie)
 		.connect_to_relay_chain_node(&alice)
 		.build(Role::Full)
 		.await;
@@ -86,7 +85,6 @@ async fn execution_proof_creation_and_verification_should_work() {
 
 	// run cirrus dave (a secondary chain full node)
 	let dave = cirrus_test_service::TestNodeBuilder::new(tokio_handle, Dave)
-		.connect_to_parachain_node(&charlie)
 		.connect_to_relay_chain_node(&alice)
 		.build(Role::Full)
 		.await;
@@ -347,7 +345,6 @@ async fn invalid_execution_proof_should_not_work() {
 
 	// run cirrus dave (a secondary chain full node)
 	let dave = cirrus_test_service::TestNodeBuilder::new(tokio_handle, Dave)
-		.connect_to_parachain_node(&charlie)
 		.connect_to_relay_chain_node(&alice)
 		.build(Role::Full)
 		.await;

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -613,8 +613,9 @@ async fn pallet_executor_unsigned_extrinsics_should_work() {
 	};
 
 	assert_eq!(vec![tx1, tx2, tx3], ready_txs());
-	alice_executor.wait_for_blocks(1).await;
-	// The ready txs will be consumed and included in the next block.
+
+	// Wait for a few more blocks to ensure the ready txs can be consumed.
+	alice_executor.wait_for_blocks(5).await;
 	assert!(ready_txs().is_empty());
 
 	alice_executor.wait_for_blocks(4).await;
@@ -657,16 +658,19 @@ async fn pallet_executor_unsigned_extrinsics_should_work() {
 	// )
 	// );
 
-	alice_executor.wait_for_blocks(1).await;
+	// Wait for a few more blocks to ensure the ready txs can be consumed.
+	alice_executor.wait_for_blocks(5).await;
 	assert!(ready_txs().is_empty());
 	assert_eq!(HashSet::from([tx5, tx6, tx7]), future_txs());
+
 	let tx4 = create_and_send_submit_execution_receipt(4)
 		.await
 		.expect("Submit receipt successfully");
 	// All future txs become ready once the required tx is ready.
 	assert_eq!(vec![tx4, tx5, tx6, tx7], ready_txs());
 	assert!(future_txs().is_empty());
-	alice_executor.wait_for_blocks(1).await;
-	// The ready txs will be consumed and included in the next block.
+
+	// Wait for a few more blocks to ensure the ready txs can be consumed.
+	alice_executor.wait_for_blocks(5).await;
 	assert!(ready_txs().is_empty());
 }

--- a/cumulus/pallets/executive/src/lib.rs
+++ b/cumulus/pallets/executive/src/lib.rs
@@ -328,6 +328,11 @@ impl<
 			}
 		});
 
+		// Note the storage root before finalizing the block so that the block imported during the
+		// syncing processs produces the same storage root with the one processed based on
+		// the primary block.
+		Pallet::<ExecutiveConfig>::push_root(Self::storage_root());
+
 		// post-extrinsics book-keeping
 		<frame_system::Pallet<System>>::note_finished_extrinsics();
 

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -188,7 +188,9 @@ async fn start_node_impl(
 			subspace_test_runtime::RuntimeApi,
 			subspace_test_client::TestExecutorDispatch,
 		>(primary_chain_config.into(), false)
-		.map_err(|_| sc_service::Error::Other("Failed to build a full subspace node".into()))?
+		.map_err(|e| {
+			sc_service::Error::Other(format!("Failed to build a full subspace node: {e}"))
+		})?
 	};
 
 	let client = params.client.clone();


### PR DESCRIPTION
The main purpose of this PR is to fix the syncing issue between the executors, previously if an executor is connected to another one and tries to sync from it, it'll run into the issue of storage root does not match, which is caused by the `execute_block` missing the step of storage root recording after applying all the extrinsics. More details are expanded in the commit message.

```
2022-05-15 08:48:02 [//Charlie (parachain)] Block prepare storage changes error: Error at calling runtime api: Execution failed: Runtime panicked: Storage root must match that calculated.    
2022-05-15 08:48:02 [//Charlie (parachain)] 💔 Error importing block 0x71d89a3dd61fee4cc5587113e1c0319d2a5f584ba5a3b77263e690e397e9436a: consensus error: Import failed: Error at calling runtime api: Execution failed: Runtime panicked: Storage root must match that calculated.      
```

After this PR, the syncing between the executors works again, and both the traditional syncing and primary block processing are supported now, even though we might don't want to use them at the same time. As long as the executor don't connect to  any other executors, then the syncing can be saved automatically.