### PR TITLE
Update max distance cache size

### DIFF
--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -480,7 +480,11 @@ struct IndexHashToOffsetDB {
 }
 
 impl IndexHashToOffsetDB {
-    const MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP: usize = 100;
+    /// Max distance cache size.
+    ///
+    /// You can find discussion of derivation of this number here:
+    /// https://github.com/subspace/subspace/pull/449
+    const MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP: usize = 8000;
 
     fn open_default(path: impl AsRef<Path>, address: PublicKey) -> Result<Self, PlotError> {
         let inner = DB::open_default(path.as_ref()).map_err(PlotError::IndexDbOpen)?;


### PR DESCRIPTION
After doing some benchmarks on my hdd with patches from #445 it seems that the most performant number for max distance cache for farmer's database for evicting pieces is around 8000. Here is some info about that:
```
   100: Average time for writing pieces to plot: 144.597µs which is 80.34% of total time
   200: Average time for writing pieces to plot: 70.145µs which is 67.35% of total time
   300: Average time for writing pieces to plot: 54.54µs which is 60.28% of total time
   400: Average time for writing pieces to plot: 40.612µs which is 52.61% of total time
   500: Average time for writing pieces to plot: 32.055µs which is 48.46% of total time
   600: Average time for writing pieces to plot: 27.429µs which is 44.53% of total time
   700: Average time for writing pieces to plot: 24.615µs which is 41.76% of total time
   800: Average time for writing pieces to plot: 21.328µs which is 38.41% of total time
   900: Average time for writing pieces to plot: 19.352µs which is 36.10% of total time
  1000: Average time for writing pieces to plot: 17.5µs which is 33.62% of total time
  1500: Average time for writing pieces to plot: 13.671µs which is 28.00% of total time
  2000: Average time for writing pieces to plot: 10.686µs which is 23.61% of total time
  2500: Average time for writing pieces to plot: 9.174µs which is 21.11% of total time
  3000: Average time for writing pieces to plot: 8.459µs which is 19.67% of total time
  4000: Average time for writing pieces to plot: 7.14µs which is 15.12% of total time
  8000: Average time for writing pieces to plot: 5.148µs which is 13.03% of total time
 12000: Average time for writing pieces to plot: 4.934µs which is 12.55% of total time
```

Or we can look at the graphs of time which it took to write pieces to plot:
<details>
<summary>Graphs (On x axis - cache size, on y - average time)</summary>

Regular graph

![image](https://user-images.githubusercontent.com/22083325/168495181-b9bd5af4-1777-48cf-a00d-d482dfeed947.png)

Y axis is log scaled

![log-scale](https://user-images.githubusercontent.com/22083325/168495161-19b3579c-b7e0-40db-8108-980d4d68f66d.png)
</details>

So I guess 8000 should be more than enough even considering other hard drives which might be faster, as 8000 is not the elbow point on my graph.

In terms of performance it should be at least `2 * 32 * 8000` which should be around 0.5M, which I believe is not that big of a price.

From benchmarking info it seems that overall piece writing with eviction should be 4.5 times faster.