### PR TITLE
deprecate SubspaceAPI object mapping

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -127,25 +127,25 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
             .expect("Older blocks must always exist")
             .expect("Older blocks must always exist");
 
-        let validated_object_calls = client
+        let block_object_mappings = client
             .runtime_api()
             .validated_object_call_hashes(&BlockId::Number(last_archived_block_number.into()))
-            .expect("Block state must exist");
-
-        let block_object_mapping = ObjectsApi::extract_block_object_mapping(
-            client.runtime_api().deref(),
-            &BlockId::Number(last_archived_block_number.saturating_sub(1).into()),
-            last_archived_block.block.clone(),
-            validated_object_calls,
-        )
-        .expect("Must be able to make runtime call");
+            .and_then(|calls| {
+                ObjectsApi::extract_block_object_mapping(
+                    client.runtime_api().deref(),
+                    &BlockId::Number(last_archived_block_number.saturating_sub(1).into()),
+                    last_archived_block.block.clone(),
+                    calls,
+                )
+            })
+            .unwrap_or_default();
 
         Archiver::with_initial_state(
             record_size as usize,
             recorded_history_segment_size as usize,
             last_root_block,
             &last_archived_block.encode(),
-            block_object_mapping,
+            block_object_mappings,
         )
         .expect("Incorrect parameters for archiver")
     } else {
@@ -194,18 +194,18 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
                     .expect("Older block by number must always exist")
                     .expect("Older block by number must always exist");
 
-                let validated_object_calls = client
+                let block_object_mappings = client
                     .runtime_api()
                     .validated_object_call_hashes(&BlockId::Number(block_to_archive.into()))
-                    .expect("Block state must exist");
-
-                let block_object_mapping = ObjectsApi::extract_block_object_mapping(
-                    client.runtime_api().deref(),
-                    &BlockId::Number(block_to_archive.saturating_sub(1).into()),
-                    block.block.clone(),
-                    validated_object_calls,
-                )
-                .expect("Must be able to make runtime call");
+                    .and_then(|calls| {
+                        ObjectsApi::extract_block_object_mapping(
+                            client.runtime_api().deref(),
+                            &BlockId::Number(block_to_archive.saturating_sub(1).into()),
+                            block.block.clone(),
+                            calls,
+                        )
+                    })
+                    .unwrap_or_default();
 
                 let encoded_block = block.encode();
                 debug!(
@@ -215,7 +215,7 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
                     encoded_block.len() as f32 / 1024.0
                 );
 
-                let archived_segments = archiver.add_block(encoded_block, block_object_mapping);
+                let archived_segments = archiver.add_block(encoded_block, block_object_mappings);
                 let new_root_blocks: Vec<RootBlock> = archived_segments
                     .iter()
                     .map(|archived_segment| archived_segment.root_block)
@@ -296,18 +296,18 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
                         .expect("Older block by number must always exist")
                         .expect("Older block by number must always exist");
 
-                    let validated_object_calls = client
+                    let block_object_mappings = client
                         .runtime_api()
                         .validated_object_call_hashes(&BlockId::Number(block_to_archive))
-                        .expect("Block state must exist");
-
-                    let block_object_mapping = ObjectsApi::extract_block_object_mapping(
-                        client.runtime_api().deref(),
-                        &BlockId::Number(block_to_archive.saturating_sub(One::one())),
-                        block.block.clone(),
-                        validated_object_calls,
-                    )
-                    .expect("Must be able to make runtime call");
+                        .and_then(|calls| {
+                            ObjectsApi::extract_block_object_mapping(
+                                client.runtime_api().deref(),
+                                &BlockId::Number(block_to_archive.saturating_sub(One::one())),
+                                block.block.clone(),
+                                calls,
+                            )
+                        })
+                        .unwrap_or_default();
 
                     let encoded_block = block.encode();
                     debug!(
@@ -316,7 +316,7 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
                         block_to_archive,
                         encoded_block.len() as f32 / 1024.0
                     );
-                    for archived_segment in archiver.add_block(encoded_block, block_object_mapping)
+                    for archived_segment in archiver.add_block(encoded_block, block_object_mappings)
                     {
                         let root_block = archived_segment.root_block;
 

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -26,6 +26,7 @@ use sp_consensus_subspace::SubspaceApi;
 use sp_objects::ObjectsApi;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, CheckedSub, Header, One, Saturating, Zero};
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
@@ -130,14 +131,14 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
             .runtime_api()
             .validated_object_call_hashes(&BlockId::Number(last_archived_block_number.into()))
             .expect("Block state must exist");
-        let block_object_mapping = client
-            .runtime_api()
-            .extract_block_object_mapping(
-                &BlockId::Number(last_archived_block_number.saturating_sub(1).into()),
-                last_archived_block.block.clone(),
-                validated_object_calls,
-            )
-            .expect("Must be able to make runtime call");
+
+        let block_object_mapping = ObjectsApi::extract_block_object_mapping(
+            client.runtime_api().deref(),
+            &BlockId::Number(last_archived_block_number.saturating_sub(1).into()),
+            last_archived_block.block.clone(),
+            validated_object_calls,
+        )
+        .expect("Must be able to make runtime call");
 
         Archiver::with_initial_state(
             record_size as usize,
@@ -198,14 +199,13 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
                     .validated_object_call_hashes(&BlockId::Number(block_to_archive.into()))
                     .expect("Block state must exist");
 
-                let block_object_mapping = client
-                    .runtime_api()
-                    .extract_block_object_mapping(
-                        &BlockId::Number(block_to_archive.saturating_sub(1).into()),
-                        block.block.clone(),
-                        validated_object_calls,
-                    )
-                    .expect("Must be able to make runtime call");
+                let block_object_mapping = ObjectsApi::extract_block_object_mapping(
+                    client.runtime_api().deref(),
+                    &BlockId::Number(block_to_archive.saturating_sub(1).into()),
+                    block.block.clone(),
+                    validated_object_calls,
+                )
+                .expect("Must be able to make runtime call");
 
                 let encoded_block = block.encode();
                 debug!(
@@ -301,14 +301,13 @@ pub fn start_subspace_archiver<Block: BlockT, Client>(
                         .validated_object_call_hashes(&BlockId::Number(block_to_archive))
                         .expect("Block state must exist");
 
-                    let block_object_mapping = client
-                        .runtime_api()
-                        .extract_block_object_mapping(
-                            &BlockId::Number(block_to_archive.saturating_sub(One::one())),
-                            block.block.clone(),
-                            validated_object_calls,
-                        )
-                        .expect("Must be able to make runtime call");
+                    let block_object_mapping = ObjectsApi::extract_block_object_mapping(
+                        client.runtime_api().deref(),
+                        &BlockId::Number(block_to_archive.saturating_sub(One::one())),
+                        block.block.clone(),
+                        validated_object_calls,
+                    )
+                    .expect("Must be able to make runtime call");
 
                     let encoded_block = block.encode();
                     debug!(

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -34,6 +34,7 @@ use sp_api::{BlockT, HeaderT};
 use sp_core::crypto::KeyTypeId;
 use sp_runtime::{ConsensusEngineId, RuntimeAppPublic, RuntimeDebug};
 use sp_std::vec::Vec;
+use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{Randomness, RootBlock, Salt, Sha256Hash};
 
 /// Key type for Subspace pallet.
@@ -242,5 +243,10 @@ sp_api::decl_runtime_apis! {
 
         /// Returns `Vec<RootBlock>` if a given extrinsic has them.
         fn extract_root_blocks(ext: &Block::Extrinsic) -> Option<Vec<RootBlock>>;
+
+        /// Extract block object mapping for a given block
+        /// TODO: remove once the node is upgraded
+        #[deprecated = "Use ObjectsApi function with same name"]
+        fn extract_block_object_mapping(block: Block) -> BlockObjectMapping;
     }
 }

--- a/crates/sp-objects/src/lib.rs
+++ b/crates/sp-objects/src/lib.rs
@@ -28,6 +28,6 @@ sp_api::decl_runtime_apis! {
 
 
         /// Extract block object mapping for a given block
-        fn extract_block_object_mapping(block: Block, successful_calls: Vec<Hash>) -> BlockObjectMapping;
+        fn extract_block_object_mapping(block: Block, validated_object_calls: Vec<Hash>) -> BlockObjectMapping;
     }
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -720,18 +720,21 @@ fn extract_feeds_block_object_mapping<I: Iterator<Item = Hash>>(
     base_offset: u32,
     objects: &mut Vec<BlockObject>,
     call: &pallet_feeds::Call<Runtime>,
-    successful_calls: &mut Peekable<I>,
+    successful_calls: &mut Option<Peekable<I>>,
 ) {
-    let call_hash = successful_calls.peek();
-    match call_hash {
-        Some(hash) => {
-            if <BlakeTwo256 as HashT>::hash(call.encode().as_slice()) != *hash {
-                return;
-            }
+    if let Some(successful_calls) = successful_calls {
+        let call_hash = successful_calls.peek();
+        match call_hash {
+            Some(hash) => {
+                if <BlakeTwo256 as HashT>::hash(call.encode().as_slice()) != *hash {
+                    return;
+                }
 
-            successful_calls.next();
+                // remove the hash and fetch the object mapping for this call
+                successful_calls.next();
+            }
+            None => return,
         }
-        None => return,
     }
     call.extract_call_objects()
         .into_iter()
@@ -761,7 +764,7 @@ fn extract_utility_block_object_mapping<I: Iterator<Item = Hash>>(
     objects: &mut Vec<BlockObject>,
     call: &pallet_utility::Call<Runtime>,
     mut recursion_depth_left: u16,
-    successful_calls: &mut Peekable<I>,
+    successful_calls: &mut Option<Peekable<I>>,
 ) {
     if recursion_depth_left == 0 {
         return;
@@ -821,7 +824,7 @@ fn extract_call_block_object_mapping<I: Iterator<Item = Hash>>(
     objects: &mut Vec<BlockObject>,
     call: &Call,
     recursion_depth_left: u16,
-    successful_calls: &mut Peekable<I>,
+    successful_calls: &mut Option<Peekable<I>>,
 ) {
     // Add enum variant to the base offset.
     base_offset += 1;
@@ -846,9 +849,12 @@ fn extract_call_block_object_mapping<I: Iterator<Item = Hash>>(
     }
 }
 
-fn extract_block_object_mapping(block: Block, successful_calls: Vec<Hash>) -> BlockObjectMapping {
+fn extract_block_object_mapping(
+    block: Block,
+    successful_calls: Option<Vec<Hash>>,
+) -> BlockObjectMapping {
     let mut block_object_mapping = BlockObjectMapping::default();
-    let mut successful_calls = successful_calls.into_iter().peekable();
+    let mut successful_calls = successful_calls.map(|calls| calls.into_iter().peekable());
     let mut base_offset =
         block.header.encoded_size() + Compact::compact_len(&(block.extrinsics.len() as u32));
     for extrinsic in block.extrinsics {
@@ -983,7 +989,7 @@ impl_runtime_apis! {
 
     impl sp_objects::ObjectsApi<Block> for Runtime {
         fn extract_block_object_mapping(block: Block, successful_calls: Vec<Hash>) -> BlockObjectMapping {
-            extract_block_object_mapping(block, successful_calls)
+            extract_block_object_mapping(block, Some(successful_calls))
         }
 
         fn validated_object_call_hashes() -> Vec<Hash> {
@@ -1046,6 +1052,10 @@ impl_runtime_apis! {
 
         fn extract_root_blocks(ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<RootBlock>> {
             extract_root_blocks(ext)
+        }
+
+        fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
+            extract_block_object_mapping(block, None)
         }
     }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -988,8 +988,12 @@ impl_runtime_apis! {
     }
 
     impl sp_objects::ObjectsApi<Block> for Runtime {
-        fn extract_block_object_mapping(block: Block, successful_calls: Vec<Hash>) -> BlockObjectMapping {
-            extract_block_object_mapping(block, Some(successful_calls))
+        fn extract_block_object_mapping(block: Block, _successful_calls: Vec<Hash>) -> BlockObjectMapping {
+            // TODO: this is breaking change and cannot be updated without a fork in one step
+            // We first fallback to subspace API
+            // Once client upgrades node, the new node will use the object API with same logic path
+            // Then we do another runtime upgrade that removes SubspaceApi and accepts successful puts instead of None
+            extract_block_object_mapping(block, None)
         }
 
         fn validated_object_call_hashes() -> Vec<Hash> {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -64,7 +64,6 @@ use sp_runtime::{
     ApplyExtrinsicResult, DispatchError, OpaqueExtrinsic, Perbill,
 };
 use sp_std::iter::Peekable;
-use sp_std::vec;
 use sp_std::{borrow::Cow, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -735,6 +734,7 @@ fn extract_feeds_block_object_mapping<I: Iterator<Item = Hash>>(
         }
         None => return,
     }
+
     call.extract_call_objects()
         .into_iter()
         .for_each(|object_map| {
@@ -1050,7 +1050,7 @@ impl_runtime_apis! {
             extract_root_blocks(ext)
         }
 
-        fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
+        fn extract_block_object_mapping(_block: Block) -> BlockObjectMapping {
             BlockObjectMapping::default()
         }
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1051,7 +1051,7 @@ impl_runtime_apis! {
         }
 
         fn extract_block_object_mapping(block: Block) -> BlockObjectMapping {
-            extract_block_object_mapping(block, vec![])
+            BlockObjectMapping::default()
         }
     }
 

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -40,13 +40,13 @@ fn object_mapping() {
                 }),
             },
             // assuming this call fails, we will remove the 3rd hash from calls
-            UncheckedExtrinsic {
-                signature: None,
-                function: Call::Feeds(pallet_feeds::Call::put {
-                    feed_id: 0,
-                    object: data0.clone(),
-                }),
-            },
+            // UncheckedExtrinsic {
+            //     signature: None,
+            //     function: Call::Feeds(pallet_feeds::Call::put {
+            //         feed_id: 0,
+            //         object: data0.clone(),
+            //     }),
+            // },
             UncheckedExtrinsic {
                 signature: None,
                 function: Call::Utility(pallet_utility::Call::batch {
@@ -90,10 +90,12 @@ fn object_mapping() {
         ],
     };
 
-    let mut successful_calls = get_successful_calls(block.clone());
-    assert_eq!(successful_calls.len(), 8);
+    let successful_calls = get_successful_calls(block.clone());
+    assert_eq!(successful_calls.len(), 7);
     // remove third call signifying that it failed
-    successful_calls.remove(2);
+    // TODO: remove when subspace_api `extract_object_mappings` is removed
+    // successful_calls.remove(2);
+
     let encoded_block = block.encode();
     let BlockObjectMapping { objects } = new_test_ext().execute_with(|| {
         // init feed

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -40,13 +40,13 @@ fn object_mapping() {
                 }),
             },
             // assuming this call fails, we will remove the 3rd hash from calls
-            // UncheckedExtrinsic {
-            //     signature: None,
-            //     function: Call::Feeds(pallet_feeds::Call::put {
-            //         feed_id: 0,
-            //         object: data0.clone(),
-            //     }),
-            // },
+            UncheckedExtrinsic {
+                signature: None,
+                function: Call::Feeds(pallet_feeds::Call::put {
+                    feed_id: 0,
+                    object: data0.clone(),
+                }),
+            },
             UncheckedExtrinsic {
                 signature: None,
                 function: Call::Utility(pallet_utility::Call::batch {
@@ -90,11 +90,11 @@ fn object_mapping() {
         ],
     };
 
-    let successful_calls = get_successful_calls(block.clone());
-    assert_eq!(successful_calls.len(), 7);
+    let mut successful_calls = get_successful_calls(block.clone());
+    assert_eq!(successful_calls.len(), 8);
     // remove third call signifying that it failed
     // TODO: remove when subspace_api `extract_object_mappings` is removed
-    // successful_calls.remove(2);
+    successful_calls.remove(2);
 
     let encoded_block = block.encode();
     let BlockObjectMapping { objects } = new_test_ext().execute_with(|| {

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -93,7 +93,6 @@ fn object_mapping() {
     let mut successful_calls = get_successful_calls(block.clone());
     assert_eq!(successful_calls.len(), 8);
     // remove third call signifying that it failed
-    // TODO: remove when subspace_api `extract_object_mappings` is removed
     successful_calls.remove(2);
 
     let encoded_block = block.encode();

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -999,6 +999,12 @@ cfg_if! {
                 ) -> Option<Vec<subspace_core_primitives::RootBlock>> {
                     panic!("Not needed in tests")
                 }
+
+                fn extract_block_object_mapping(
+                    _block: Block
+                ) -> subspace_core_primitives::objects::BlockObjectMapping {
+                    Default::default()
+                }
             }
 
             impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
@@ -1326,6 +1332,12 @@ cfg_if! {
                     _ext: &<Block as BlockT>::Extrinsic
                 ) -> Option<Vec<subspace_core_primitives::RootBlock>> {
                     panic!("Not needed in tests")
+                }
+
+                fn extract_block_object_mapping(
+                    _block: Block
+                ) -> subspace_core_primitives::objects::BlockObjectMapping {
+                    subspace_core_primitives::objects::BlockObjectMapping::default()
                 }
             }
 

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -933,7 +933,7 @@ cfg_if! {
                 fn extract_block_object_mapping(
                     _block: Block, _successful_calls: Vec<Hash>
                 ) -> subspace_core_primitives::objects::BlockObjectMapping {
-                    Default::default()
+                    subspace_core_primitives::objects::BlockObjectMapping::default()
                 }
             }
 
@@ -1003,7 +1003,7 @@ cfg_if! {
                 fn extract_block_object_mapping(
                     _block: Block
                 ) -> subspace_core_primitives::objects::BlockObjectMapping {
-                    Default::default()
+                    subspace_core_primitives::objects::BlockObjectMapping::default()
                 }
             }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -914,8 +914,8 @@ impl_runtime_apis! {
     }
 
     impl sp_objects::ObjectsApi<Block> for Runtime {
-        fn extract_block_object_mapping(block: Block, successful_calls: Vec<Hash>) -> BlockObjectMapping {
-            extract_block_object_mapping(block, Some(successful_calls))
+        fn extract_block_object_mapping(block: Block, _successful_calls: Vec<Hash>) -> BlockObjectMapping {
+            extract_block_object_mapping(block, None)
         }
 
         fn validated_object_call_hashes() -> Vec<Hash> {


### PR DESCRIPTION
This PR deprecates Subspace API object mapping and instead Defaults to ObjectAPI. 
Deprecation notice is for current nodes expecting object mapping in SubspaceAPI. The runtime in itself still doesn't relay on the successful call vector sent by the new nodes as that would cause different object mappings sometimes. So we would need to do a another runtime upgrade after sufficient time for the nodes to upgrade to latest snpshot to remove the old api