### PR TITLE
Remove log and add tracing to farmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8483,7 +8483,6 @@ dependencies = [
  "hex",
  "hex-buffer-serde",
  "jsonrpsee",
- "log",
  "lru 0.7.5",
  "num-traits",
  "parity-scale-codec",
@@ -8504,6 +8503,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 
@@ -8537,12 +8537,12 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "libp2p 0.44.0",
- "log",
  "nohash-hasher",
  "parking_lot 0.12.0",
  "subspace-core-primitives",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -8709,7 +8709,6 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
- "log",
  "num-traits",
  "num_cpus",
  "rand 0.8.5",
@@ -8719,6 +8718,7 @@ dependencies = [
  "sloth256-189",
  "subspace-core-primitives",
  "thiserror",
+ "tracing",
  "uint",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4326,6 +4326,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7108,7 +7117,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -8272,7 +8281,7 @@ dependencies = [
  "sp-std",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -8476,7 +8485,6 @@ dependencies = [
  "async-trait",
  "clap 3.1.8",
  "dirs",
- "env_logger",
  "event-listener-primitives",
  "fdlimit",
  "futures 0.3.21",
@@ -8504,6 +8512,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.11",
  "zeroize",
 ]
 
@@ -9411,7 +9420,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "parking_lot 0.11.2",
  "regex",
  "serde",
@@ -9423,6 +9432,24 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+dependencies = [
+ "ansi_term",
+ "lazy_static",
+ "matchers 0.1.0",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -18,7 +18,6 @@ async-oneshot = "0.5.0"
 async-trait = "0.1.53"
 clap = { version = "3.1.8", features = ["color", "derive"] }
 dirs = "4.0.0"
-env_logger = "0.9.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2"
 futures = "0.3.21"
@@ -26,6 +25,7 @@ hex = "0.4.3"
 hex-buffer-serde = "0.3.0"
 jsonrpsee = { version = "0.10.1", features = ["client", "macros", "server"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 lru = "0.7.5"
 num-traits = "0.2"
 parity-scale-codec = "3.1.2"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 hex-buffer-serde = "0.3.0"
 jsonrpsee = { version = "0.10.1", features = ["client", "macros", "server"] }
-log = "0.4.16"
+tracing = "0.1"
 lru = "0.7.5"
 num-traits = "0.2"
 parity-scale-codec = "3.1.2"

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -111,7 +111,7 @@ impl Archiving {
                         error!(%error, "Failed to store object mappings for pieces");
                     }
 
-                    info!(index = segment_index, "Plotted segment");
+                    info!(segment_index, "Plotted segment");
 
                     if let Err(()) = acknowledgement_sender.send(()) {
                         error!("Failed to send archived segment acknowledgement");

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -108,10 +108,10 @@ impl Archiving {
                         create_global_object_mapping(piece_index_offset, object_mapping);
 
                     if let Err(error) = object_mappings.store(&object_mapping) {
-                        error!("Failed to store object mappings for pieces: {}", error);
+                        error!(%error, "Failed to store object mappings for pieces");
                     }
 
-                    info!("Plotted segment {}", segment_index);
+                    info!(index = segment_index, "Plotted segment");
 
                     if let Err(()) = acknowledgement_sender.send(()) {
                         error!("Failed to send archived segment acknowledgement");
@@ -176,10 +176,10 @@ impl Archiving {
                                 // meantime. Ideally we'd acknowledge after, but it makes node wait
                                 // for it and the whole process very sequential.
                                 if let Err(error) = client.acknowledge_archived_segment(segment_index).await {
-                                    error!("Failed to send archived segment acknowledgement: {error}");
+                                    error!(%error, "Failed to send archived segment acknowledgement");
                                 }
                                 if let Err(error) = archived_segments_sync_sender.send((archived_segment, acknowledge_sender)) {
-                                    error!("Failed to send archived segment for plotting: {error}");
+                                    error!(%error, "Failed to send archived segment for plotting");
                                 }
                                 let _ = acknowledge_receiver.await;
                             },
@@ -192,15 +192,15 @@ impl Archiving {
                     maybe_result = best_block_number_receiver.next() => {
                         match maybe_result {
                             Some(Ok(Ok(best_block_number))) => {
-                                debug!("Best block number: {:#?}", best_block_number);
+                                debug!(best_block_number);
                                 last_best_block_number_error = false;
                             }
                             Some(Ok(Err(error))) => {
                                 if last_best_block_number_error {
-                                    error!("Request to get new best block failed second time: {error}");
+                                    error!(%error, "Request to get new best block failed second time");
                                     break;
                                 } else {
-                                    warn!("Request to get new best block failed: {error}");
+                                    warn!(%error, "Request to get new best block failed");
                                     last_best_block_number_error = true;
                                 }
                             }

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,7 +1,6 @@
 use crate::object_mappings::ObjectMappings;
 use crate::rpc_client::RpcClient;
 use futures::{SinkExt, StreamExt};
-use log::{debug, error, info, warn};
 use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
@@ -10,6 +9,7 @@ use subspace_rpc_primitives::FarmerMetadata;
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tracing::{debug, error, info, warn};
 
 const BEST_BLOCK_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -11,7 +11,7 @@ pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
         .map(|i| path.as_ref().join(format!("plot{i}")))
         .take_while(|path| path.is_dir())
         .try_for_each(|replica_path| {
-            info!("Erasing plot replica at path `{replica_path:?}'");
+            info!(path = ?replica_path, "Erasing plot replica");
             std::fs::remove_dir_all(replica_path)
         })?;
 
@@ -27,8 +27,8 @@ pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
 
     // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
     //  wipe old data from disks of our users
-    info!("Erasing identity");
     let identity = path.as_ref().join("identity.bin");
+    info!(path = ?identity, "Erasing identity");
     if identity.exists() {
         fs::remove_file(identity)?;
     }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,9 +1,9 @@
 mod farm;
 
 pub(crate) use farm::{bench, farm};
-use log::info;
 use std::path::Path;
 use std::{fs, io};
+use tracing::info;
 
 pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let _ = std::fs::remove_dir_all(path.as_ref().join("object-mappings"));

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -157,10 +157,10 @@ pub(crate) async fn farm(
         .await
     {
         Ok(ws_server) => ws_server,
-        Err(jsonrpsee::core::Error::Transport(ref error)) => {
+        Err(jsonrpsee::core::Error::Transport(error)) => {
             warn!(
                 address = %ws_server_listen_addr,
-                error = %error,
+                %error,
                 "Failed to start WebSocket RPC server on, trying random port"
             );
             ws_server_listen_addr.set_port(0);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 use jsonrpsee::ws_server::WsServerBuilder;
-use log::{info, warn};
 use rand::prelude::*;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -24,6 +23,7 @@ use subspace_networking::multimess::MultihashCode;
 use subspace_networking::Config;
 use subspace_rpc_primitives::FarmerMetadata;
 use tempfile::TempDir;
+use tracing::{debug, info, warn};
 
 use crate::bench_rpc_client::BenchRpcClient;
 use crate::{FarmingArgs, WriteToDisk};
@@ -65,8 +65,8 @@ impl PlotFile for BenchPlotMock {
 
 fn raise_fd_limit() {
     match std::panic::catch_unwind(fdlimit::raise_fd_limit) {
-        Ok(Some(limit)) => log::info!("Increase file limit from soft to hard (limit is {limit})"),
-        Ok(None) => log::debug!("Failed to increase file limit"),
+        Ok(Some(limit)) => info!("Increase file limit from soft to hard (limit is {limit})"),
+        Ok(None) => debug!("Failed to increase file limit"),
         Err(err) => {
             let err = if let Some(err) = err.downcast_ref::<&str>() {
                 *err
@@ -75,7 +75,7 @@ fn raise_fd_limit() {
             } else {
                 unreachable!("Should be unreachable as `fdlimit` uses panic macro, which should return either `&str` or `String`.")
             };
-            log::warn!("Failed to increase file limit: {err}")
+            warn!("Failed to increase file limit: {err}")
         }
     }
 }
@@ -109,7 +109,7 @@ pub(crate) async fn farm(
 
     let max_plot_size = match max_plot_size.map(|max_plot_size| max_plot_size / PIECE_SIZE as u64) {
         Some(max_plot_size) if max_plot_size > metadata.max_plot_size => {
-            log::warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
+            warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
             metadata.max_plot_size
         }
         Some(max_plot_size) => max_plot_size,
@@ -246,7 +246,7 @@ pub(crate) async fn bench(
 
     let max_plot_size = match max_plot_size.map(|max_plot_size| max_plot_size / PIECE_SIZE as u64) {
         Some(max_plot_size) if max_plot_size > metadata.max_plot_size => {
-            log::warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
+            warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
             metadata.max_plot_size
         }
         Some(max_plot_size) => max_plot_size,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -5,13 +5,13 @@ mod utils;
 use anyhow::Result;
 use clap::{ArgEnum, Parser, ValueHint};
 use env_logger::Env;
-use log::info;
 use sp_core::crypto::PublicError;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 use subspace_core_primitives::PublicKey;
 use subspace_networking::libp2p::Multiaddr;
+use tracing::info;
 
 const BEST_BLOCK_NUMBER_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_core_primitives::{Piece, Salt, Tag, PIECE_SIZE};
 use thiserror::Error;
-use tracing::{error, trace};
+use tracing::trace;
 
 const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;
 
@@ -327,9 +327,11 @@ impl<'a> SolutionIterator<'a> {
         let (upper, is_upper_overflowed) = u64::from_be_bytes(target).overflowing_add(range / 2);
 
         trace!(
-            "{} Lower overflow: {is_lower_overflowed} -- Upper overflow: {is_upper_overflowed}",
-            u64::from_be_bytes(target),
+            target = u64::from_be_bytes(target),
+            is_lower_overflowed,
+            is_upper_overflowed
         );
+
         let state = if is_lower_overflowed || is_upper_overflowed {
             iter.seek_to_first();
             SolutionIteratorState::OverflowStart

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -6,7 +6,6 @@ use crate::plot::{PieceOffset, Plot};
 use arc_swap::ArcSwapOption;
 use commitment_databases::{CommitmentDatabases, CreateDbEntryResult, DbEntry};
 use event_listener_primitives::{Bag, HandlerId};
-use log::{error, trace};
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use rocksdb::DB;
@@ -15,6 +14,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_core_primitives::{Piece, Salt, Tag, PIECE_SIZE};
 use thiserror::Error;
+use tracing::{error, trace};
 
 const BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;
 

--- a/crates/subspace-farmer/src/commitments/commitment_databases.rs
+++ b/crates/subspace-farmer/src/commitments/commitment_databases.rs
@@ -1,5 +1,4 @@
 use super::CommitmentError;
-use log::error;
 use lru::LruCache;
 use parking_lot::Mutex;
 use rocksdb::{Options, DB};
@@ -10,6 +9,7 @@ use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_core_primitives::Salt;
+use tracing::error;
 
 // Cache size is just enough for last 2 salts to be stored
 const COMMITMENTS_CACHE_SIZE: usize = 2;

--- a/crates/subspace-farmer/src/commitments/commitment_databases.rs
+++ b/crates/subspace-farmer/src/commitments/commitment_databases.rs
@@ -92,9 +92,9 @@ impl CommitmentDatabases {
                         std::fs::remove_dir_all(base_directory.join(hex::encode(salt)))
                     {
                         error!(
-                            "Failed to remove old in progress commitment {}: {}",
-                            hex::encode(salt),
-                            error
+                            salt = %hex::encode(salt),
+                            %error,
+                            "Failed to remove old in progress commitment",
                         );
                     }
                     true

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -7,7 +7,7 @@ use subspace_core_primitives::{FlatPieces, Salt, Tag, PIECE_SIZE};
 use tempfile::TempDir;
 
 fn init() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -8,13 +8,13 @@ use crate::identity::Identity;
 use crate::plot::Plot;
 use crate::rpc_client::RpcClient;
 use futures::{future, future::Either};
-use log::{debug, error, info, trace, warn};
 use std::sync::mpsc;
 use std::time::Instant;
 use subspace_core_primitives::{LocalChallenge, PublicKey, Salt, Solution};
 use subspace_rpc_primitives::{BlockSignature, BlockSigningInfo, SlotInfo, SolutionResponse};
 use thiserror::Error;
 use tokio::task::JoinHandle;
+use tracing::{debug, error, info, trace, warn};
 
 #[derive(Debug, Error)]
 pub enum FarmingError {

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -124,7 +124,7 @@ async fn subscribe_to_slot_info<T: RpcClient>(
     let mut salts = Salts::default();
 
     while let Some(slot_info) = slot_info_notifications.recv().await {
-        debug!("New slot: {:?}", slot_info);
+        debug!(?slot_info, "New slot");
 
         update_commitments(plot, commitments, &mut salts, &slot_info);
 
@@ -154,7 +154,7 @@ async fn subscribe_to_slot_info<T: RpcClient>(
                             tag,
                         };
                         debug!("Solution found");
-                        trace!("Solution found: {:?}", solution);
+                        trace!(?solution, "Solution found");
 
                         Ok(Some(solution))
                     }
@@ -201,9 +201,9 @@ async fn subscribe_to_slot_info<T: RpcClient>(
                             }
                             Err(error) => {
                                 warn!(
-                                    "Failed to send signature for block 0x{}: {}",
+                                    %error,
+                                    "Failed to send signature for block 0x{}",
                                     hex::encode(header_hash),
-                                    error
                                 );
                             }
                         }
@@ -251,21 +251,17 @@ fn update_commitments(
                 move || {
                     let started = Instant::now();
                     info!(
-                        "Salt updated to {}, recommitting in background",
-                        hex::encode(salt)
+                        new_salt = %hex::encode(salt),
+                        "Salt updated, recommitting in background",
                     );
 
                     if let Err(error) = commitments.create(salt, plot) {
-                        error!(
-                            "Failed to create commitment for {}: {}",
-                            hex::encode(salt),
-                            error
-                        );
+                        error!(salt = %hex::encode(salt), %error, "Failed to create commitment");
                     } else {
                         info!(
-                            "Finished recommitment for {} in {} seconds",
-                            hex::encode(salt),
-                            started.elapsed().as_secs_f32()
+                            salt = %hex::encode(salt),
+                            took_seconds = started.elapsed().as_secs_f32(),
+                            "Finished recommitment",
                         );
                     }
 
@@ -293,21 +289,21 @@ fn update_commitments(
 
                     let started = Instant::now();
                     info!(
-                        "Salt will update to {} soon, recommitting in background",
-                        hex::encode(new_next_salt)
+                        next_salt = %hex::encode(new_next_salt),
+                        "Salt will be updated, recommitting in background",
                     );
                     if let Err(error) = commitments.create(new_next_salt, plot) {
                         error!(
-                            "Recommitting salt in background failed for {}: {}",
-                            hex::encode(new_next_salt),
-                            error
+                            next_salt = %hex::encode(new_next_salt),
+                            %error,
+                            "Recommitting salt in background failed",
                         );
                         return;
                     }
                     info!(
-                        "Finished recommitment in background for {} in {} seconds",
-                        hex::encode(new_next_salt),
-                        started.elapsed().as_secs_f32()
+                        next_salt = %hex::encode(new_next_salt),
+                        took_seconds = started.elapsed().as_secs_f32(),
+                        "Finished recommitment in background",
                     );
                 }
             });

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
 
 fn init() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
 }
 
 async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {

--- a/crates/subspace-farmer/src/identity.rs
+++ b/crates/subspace-farmer/src/identity.rs
@@ -1,11 +1,11 @@
 use anyhow::Error;
-use log::debug;
 use parity_scale_codec::{Decode, Encode};
 use schnorrkel::{context::SigningContext, Keypair, PublicKey, SecretKey, Signature};
 use sp_core::sr25519::Pair;
 use std::fs;
 use std::path::Path;
 use subspace_solving::SOLUTION_SIGNING_CONTEXT;
+use tracing::debug;
 use zeroize::{Zeroize, Zeroizing};
 
 /// Signing context hardcoded in Substrate implementation and used for signing blocks.

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -3,11 +3,11 @@ use crate::{
 };
 use anyhow::anyhow;
 use futures::stream::{FuturesUnordered, StreamExt};
-use log::info;
 use rayon::prelude::*;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use subspace_core_primitives::{PublicKey, PIECE_SIZE};
 use subspace_solving::SubspaceCodec;
+use tracing::info;
 
 /// Abstraction around having multiple `Plot`s, `Farming`s and `Plotting`s.
 ///

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -914,14 +914,11 @@ impl<T: PlotFile> PlotWorker<T> {
         }
 
         if let Err(error) = self.plot.sync_all() {
-            error!("Failed to sync plot file before exit: {}", error);
+            error!(%error, "Failed to sync plot file before exit");
         }
 
         if let Err(error) = self.piece_offset_to_index.sync_all() {
-            error!(
-                "Failed to sync piece offset to index file before exit: {}",
-                error
-            );
+            error!(%error, "Failed to sync piece offset to index file before exit");
         }
 
         // Close the rest of databases

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -2,7 +2,6 @@
 mod tests;
 
 use event_listener_primitives::{Bag, HandlerId};
-use log::{error, info};
 use num_traits::{WrappingAdd, WrappingSub};
 use rocksdb::DB;
 use std::collections::{BTreeSet, VecDeque};
@@ -18,6 +17,7 @@ use subspace_core_primitives::{
 };
 use subspace_solving::{PieceDistance, SubspaceCodec};
 use thiserror::Error;
+use tracing::{error, info};
 
 /// Index of piece on disk
 pub type PieceOffset = u64;

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -6,7 +6,7 @@ use subspace_solving::PieceDistance;
 use tempfile::TempDir;
 
 fn init() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
 }
 
 fn generate_random_piece() -> Piece {

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -31,7 +31,7 @@ pub fn plot_pieces(
                 pieces_to_plot.piece_index_offset,
                 pieces_to_plot.pieces,
             ) {
-                error!("Failed to encode a piece: error: {}", error);
+                error!(%error, "Failed to encode a piece");
                 return false;
             }
         } else {
@@ -61,16 +61,16 @@ fn plot_pieces_internal(
     match plot.write_many(Arc::clone(&pieces), piece_indexes) {
         Ok(write_result) => {
             if let Err(error) = commitments.remove_pieces(write_result.evicted_pieces()) {
-                error!("Failed to remove old commitments for pieces: {}", error);
+                error!(%error, "Failed to remove old commitments for pieces");
             }
 
             if let Err(error) =
                 commitments.create_for_pieces(|| write_result.to_recommitment_iterator())
             {
-                error!("Failed to create commitments for pieces: {}", error);
+                error!(%error, "Failed to create commitments for pieces");
             }
         }
-        Err(error) => error!("Failed to write encoded pieces: {}", error),
+        Err(error) => error!(%error, "Failed to write encoded pieces"),
     }
 
     Ok(())

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -9,10 +9,10 @@ mod tests;
 use crate::commitments::Commitments;
 use crate::plot::Plot;
 use crate::PiecesToPlot;
-use tracing::error;
 use std::sync::Arc;
 use subspace_core_primitives::{FlatPieces, PieceIndex};
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
+use tracing::error;
 
 /// Generates a function that will plot pieces.
 pub fn plot_pieces(

--- a/crates/subspace-farmer/src/plotting.rs
+++ b/crates/subspace-farmer/src/plotting.rs
@@ -9,7 +9,7 @@ mod tests;
 use crate::commitments::Commitments;
 use crate::plot::Plot;
 use crate::PiecesToPlot;
-use log::error;
+use tracing::error;
 use std::sync::Arc;
 use subspace_core_primitives::{FlatPieces, PieceIndex};
 use subspace_solving::{BatchEncodeError, SubspaceCodec};

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -22,7 +22,7 @@ const SEGMENT_SIZE: usize = RECORD_SIZE * MERKLE_NUM_LEAVES / 2; // 16000
 const BEST_BLOCK_NUMBER_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 fn init() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use hex_buffer_serde::{Hex, HexForm};
 use jsonrpsee::core::error::Error;
 use jsonrpsee::proc_macros::rpc;
-use log::{debug, error};
 use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -13,6 +12,7 @@ use std::{
 };
 use subspace_archiving::archiver::{Segment, SegmentItem};
 use subspace_core_primitives::{Piece, PieceIndex, Sha256Hash, PIECE_SIZE};
+use tracing::{debug, error};
 
 /// Maximum expected size of one object in bytes
 const MAX_OBJECT_SIZE: usize = 5 * 1024 * 1024;

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -251,7 +251,7 @@ impl RpcServerImpl {
                     "Invalid data length prefix found: 0x{:02x}",
                     read_records_data[offset as usize]
                 );
-                error!("{}", error_string);
+                error!(error = %error_string);
 
                 return Err(Error::Custom(error_string));
             }
@@ -282,7 +282,7 @@ impl RpcServerImpl {
 
         let Compact(data_length) = data_length_result.map_err(|error| {
             let error_string = format!("Failed to read object data length: {}", error);
-            error!("{}", error_string);
+            error!(error = %error_string);
 
             Error::Custom(error_string)
         })?;
@@ -341,7 +341,7 @@ impl RpcServerImpl {
                         "Failed to find item at offset {} in segment {} for object {}",
                         offset_in_segment, segment_index, object_id
                     );
-                    error!("{}", error_string);
+                    error!(error = %error_string);
 
                     Error::Custom(error_string)
                 })?;
@@ -357,8 +357,8 @@ impl RpcServerImpl {
                 }
                 segment_item => {
                     error!(
-                        "Unexpected segment item {:?} at offset {} in segment {} for object {}",
-                        segment_item, offset_in_segment, segment_index, object_id
+                        ?segment_item,
+                        offset_in_segment, segment_index, object_id, "Unexpected segment item",
                     );
 
                     return Err(Error::Custom(format!(
@@ -390,10 +390,7 @@ impl RpcServerImpl {
             }
         }
 
-        error!(
-            "Read max object size for object {} without success",
-            object_id
-        );
+        error!(object_id, "Read max object size for object without success",);
 
         Err(Error::Custom(
             "Read max object size for object without success".to_string(),
@@ -413,8 +410,9 @@ impl RpcServerImpl {
 
         let segment = Segment::decode(&mut segment_bytes.as_slice()).map_err(|error| {
             error!(
-                "Failed to decode segment {} of archival history on retrieval: {}",
-                segment_index, error,
+                index = segment_index,
+                %error,
+                "Failed to decode segment of archival history on retrieval",
             );
 
             Error::Custom(format!(
@@ -466,16 +464,18 @@ impl RpcServer for RpcServerImpl {
             .await
             .map_err(|error| {
                 error!(
-                    "Object mapping retrieving panicked for {}: {}",
-                    object_id_string, error
+                    object_id = %object_id_string,
+                    %error,
+                    "Object mapping retrieving panicked",
                 );
 
                 Error::Custom("Failed to find an object due to internal error".to_string())
             })?
             .map_err(|error| {
                 error!(
-                    "Object mapping retrieving failed for {}: {}",
-                    object_id_string, error
+                    object_id = %object_id_string,
+                    %error,
+                    "Object mapping retrieving failed",
                 );
 
                 Error::Custom("Failed to find an object due to internal error".to_string())
@@ -484,7 +484,7 @@ impl RpcServer for RpcServerImpl {
         let global_object = match global_object {
             Some(global_object) => global_object,
             None => {
-                debug!("Object {} not found", object_id_string);
+                debug!(object_id = %object_id_string, "Object not found");
 
                 return Ok(None);
             }

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -17,12 +17,12 @@ event-listener-primitives = "2.0.1"
 bytes = "1.1.0"
 futures = "0.3.21"
 hex = "0.4.3"
-log = "0.4.16"
 nohash-hasher = "0.2.0"
 parking_lot = "0.12.0"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["macros", "parking_lot", "rt-multi-thread", "time"] }
+tracing = "0.1"
 
 [dependencies.libp2p]
 version = "0.44.0"

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -4,10 +4,10 @@ use clap::Parser;
 use env_logger::Env;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::Multiaddr;
-use tracing::info;
 use std::sync::Arc;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::Config;
+use tracing::info;
 
 #[derive(Debug, Parser)]
 #[clap(about, version)]

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use env_logger::Env;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::Multiaddr;
-use log::info;
+use tracing::info;
 use std::sync::Arc;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::Config;

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -17,12 +17,12 @@ use libp2p::tcp::TokioTcpConfig;
 use libp2p::websocket::WsConfig;
 use libp2p::yamux::{WindowUpdateMode, YamuxConfig};
 use libp2p::{core, identity, noise, Multiaddr, PeerId, Transport, TransportError};
-use tracing::info;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io};
 use subspace_core_primitives::crypto;
 use thiserror::Error;
+use tracing::info;
 
 const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL: &str = "/subspace/gossipsub/0.1.0";

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -17,7 +17,7 @@ use libp2p::tcp::TokioTcpConfig;
 use libp2p::websocket::WsConfig;
 use libp2p::yamux::{WindowUpdateMode, YamuxConfig};
 use libp2p::{core, identity, noise, Multiaddr, PeerId, Transport, TransportError};
-use log::info;
+use tracing::info;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io};

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -12,7 +12,7 @@ use libp2p::kad::{
 };
 use libp2p::swarm::SwarmEvent;
 use libp2p::{futures, PeerId, Swarm};
-use log::{debug, error, trace, warn};
+use tracing::{debug, error, trace, warn};
 use nohash_hasher::IntMap;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -12,13 +12,13 @@ use libp2p::kad::{
 };
 use libp2p::swarm::SwarmEvent;
 use libp2p::{futures, PeerId, Swarm};
-use tracing::{debug, error, trace, warn};
 use nohash_hasher::IntMap;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::{debug, error, trace, warn};
 
 enum QueryResultSender {
     GetValue {

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [dependencies]
-log = "0.4.16"
+tracing = "0.1"
 num_cpus = "1.13.0"
 num-traits = "0.2"
 rayon = "1.5.2"

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -16,13 +16,13 @@
 //! Codec for the [Subspace Network Blockchain](https://subspace.network) based on the
 //! [SLOTH permutation](https://eprint.iacr.org/2015/366).
 
-use log::error;
 use rayon::prelude::*;
 use sloth256_189::cpu;
 #[cfg(feature = "cuda")]
 use sloth256_189::cuda;
 use subspace_core_primitives::{crypto, Sha256Hash, PIECE_SIZE};
 use thiserror::Error;
+use tracing::error;
 
 /// Number of pieces for GPU should be multiples of 1024
 #[cfg(feature = "cuda")]


### PR DESCRIPTION
This pr substitutes `log` crate with `tracing` for observability usecases. Tracing has many interesting integrations like [opentelemetry](https://docs.rs/tracing-opentelemetry/0.17.2/tracing_opentelemetry/index.html) which can be used for benchmarking farmer.