### PR TITLE
Add throughput printing for farmer benchmarking

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,6 +1,8 @@
+mod bench;
 mod farm;
 
-pub(crate) use farm::{bench, farm};
+pub(crate) use bench::bench;
+pub(crate) use farm::farm;
 use std::path::Path;
 use std::{fs, io};
 use tracing::info;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -212,8 +212,7 @@ pub(crate) async fn bench(
         * PIECE_SIZE as u64;
     let overhead = space_allocated - actual_space_pledged;
 
-    println!("Finished benchmarking.");
-    println!("");
+    println!("Finished benchmarking.\n");
     println!("{} allocated for farming", HumanReadable(space_allocated));
     println!(
         "{} actual space pledged (which is {:.2}%)",

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -135,10 +135,10 @@ pub(crate) async fn bench(
             archived_progress: ArchivedBlockProgress::Partial(0),
         };
 
-        for segment_index in 0..write_pieces_size / PIECE_SIZE as u64 / 1000 {
+        for segment_index in 0..write_pieces_size / PIECE_SIZE as u64 / 256 {
             last_archived_block
                 .archived_progress
-                .set_partial(segment_index as u32 * 1000 * PIECE_SIZE as u32);
+                .set_partial(segment_index as u32 * 256 * PIECE_SIZE as u32);
 
             let archived_segment = {
                 let root_block = RootBlock::V0 {
@@ -148,7 +148,7 @@ pub(crate) async fn bench(
                     last_archived_block,
                 };
 
-                let mut pieces = FlatPieces::new(1000);
+                let mut pieces = FlatPieces::new(256);
                 rand::thread_rng().fill(pieces.as_mut());
 
                 let objects = std::iter::repeat_with(|| PieceObject::V0 {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -1,0 +1,184 @@
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use rand::prelude::*;
+use tempfile::TempDir;
+use tracing::info;
+
+use subspace_archiving::archiver::ArchivedSegment;
+use subspace_core_primitives::objects::{PieceObject, PieceObjectMapping};
+use subspace_core_primitives::{
+    ArchivedBlockProgress, FlatPieces, LastArchivedBlock, PublicKey, RootBlock, Sha256Hash,
+    PIECE_SIZE,
+};
+use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
+use subspace_farmer::{ObjectMappings, PieceOffset, Plot, PlotFile, RpcClient};
+use subspace_rpc_primitives::FarmerMetadata;
+
+use crate::bench_rpc_client::BenchRpcClient;
+use crate::{utils, WriteToDisk};
+
+pub struct BenchPlotMock {
+    piece_count: u64,
+    max_piece_count: u64,
+}
+
+impl BenchPlotMock {
+    pub fn new(max_piece_count: u64) -> Self {
+        Self {
+            max_piece_count,
+            piece_count: 0,
+        }
+    }
+}
+
+impl PlotFile for BenchPlotMock {
+    fn piece_count(&mut self) -> io::Result<u64> {
+        Ok(self.piece_count)
+    }
+
+    fn write(&mut self, pieces: impl AsRef<[u8]>, _offset: PieceOffset) -> io::Result<()> {
+        self.piece_count = (self.piece_count + (pieces.as_ref().len() / PIECE_SIZE) as u64)
+            .max(self.max_piece_count);
+        Ok(())
+    }
+
+    fn read(&mut self, _offset: PieceOffset, mut buf: impl AsMut<[u8]>) -> io::Result<()> {
+        rand::thread_rng().fill(buf.as_mut());
+        Ok(())
+    }
+
+    fn sync_all(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+const BENCH_FARMER_METADATA: FarmerMetadata = FarmerMetadata {
+    record_size: PIECE_SIZE as u32 - 96, // PIECE_SIZE - WITNESS_SIZE
+    recorded_history_segment_size: PIECE_SIZE as u32 * 256 / 2, // PIECE_SIZE * MERKLE_NUM_LEAVES / 2
+    max_plot_size: 100 * 1024 * 1024 * 1024 / PIECE_SIZE as u64, // 100G
+};
+
+pub(crate) async fn bench(
+    custom_path: Option<PathBuf>,
+    plot_size: u64,
+    max_plot_size: Option<u64>,
+    best_block_number_check_interval: Duration,
+    write_to_disk: WriteToDisk,
+    write_pieces_size: u64,
+) -> anyhow::Result<()> {
+    utils::raise_fd_limit();
+
+    let (archived_segments_sender, archived_segments_receiver) = tokio::sync::mpsc::channel(10);
+    let client = BenchRpcClient::new(BENCH_FARMER_METADATA, archived_segments_receiver);
+
+    let base_directory = crate::utils::get_path(custom_path);
+    let base_directory = TempDir::new_in(base_directory)?;
+
+    let metadata = client
+        .farmer_metadata()
+        .await
+        .map_err(|error| anyhow!(error))?;
+
+    let max_plot_size = match max_plot_size.map(|max_plot_size| max_plot_size / PIECE_SIZE as u64) {
+        Some(max_plot_size) if max_plot_size > metadata.max_plot_size => {
+            tracing::warn!(
+                "Passed `max_plot_size` is too big. Fallback to the one from consensus."
+            );
+            metadata.max_plot_size
+        }
+        Some(max_plot_size) => max_plot_size,
+        None => metadata.max_plot_size,
+    };
+
+    info!("Opening object mapping");
+    let object_mappings = tokio::task::spawn_blocking({
+        let base_directory = base_directory.as_ref().to_owned();
+        move || ObjectMappings::open_or_create(&base_directory)
+    })
+    .await??;
+
+    let base_path = base_directory.as_ref().to_owned();
+    let plot_factory = move |plot_index, public_key, max_piece_count| {
+        let base_path = base_path.join(format!("plot{plot_index}"));
+        match write_to_disk {
+            WriteToDisk::Nothing => Plot::with_plot_file(
+                BenchPlotMock::new(max_piece_count),
+                base_path,
+                public_key,
+                max_piece_count,
+            ),
+            WriteToDisk::Everything => Plot::open_or_create(base_path, public_key, max_piece_count),
+        }
+    };
+
+    let multi_farming = MultiFarming::new(
+        MultiFarmingOptions {
+            base_directory: base_directory.as_ref().to_owned(),
+            client: client.clone(),
+            object_mappings: object_mappings.clone(),
+            reward_address: PublicKey::default(),
+            best_block_number_check_interval,
+        },
+        plot_size,
+        max_plot_size,
+        plot_factory,
+        false,
+    )
+    .await?;
+
+    tokio::spawn(async move {
+        let mut last_archived_block = LastArchivedBlock {
+            number: 0,
+            archived_progress: ArchivedBlockProgress::Partial(0),
+        };
+
+        for segment_index in 0..write_pieces_size / PIECE_SIZE as u64 / 1000 {
+            last_archived_block
+                .archived_progress
+                .set_partial(segment_index as u32 * 1000 * PIECE_SIZE as u32);
+
+            let archived_segment = {
+                let root_block = RootBlock::V0 {
+                    segment_index,
+                    records_root: Sha256Hash::default(),
+                    prev_root_block_hash: Sha256Hash::default(),
+                    last_archived_block,
+                };
+
+                let mut pieces = FlatPieces::new(1000);
+                rand::thread_rng().fill(pieces.as_mut());
+
+                let objects = std::iter::repeat_with(|| PieceObject::V0 {
+                    hash: rand::random(),
+                    offset: rand::random(),
+                })
+                .take(100)
+                .collect();
+
+                ArchivedSegment {
+                    root_block,
+                    pieces,
+                    object_mapping: vec![PieceObjectMapping { objects }],
+                }
+            };
+
+            if archived_segments_sender
+                .send(archived_segment)
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    })
+    .await?;
+
+    client.stop().await;
+
+    multi_farming.wait().await?;
+
+    Ok(())
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -1,67 +1,20 @@
 use anyhow::{anyhow, Result};
 use jsonrpsee::ws_server::WsServerBuilder;
-use rand::prelude::*;
-use std::path::PathBuf;
+use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{io, mem};
-use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::objects::{PieceObject, PieceObjectMapping};
-use subspace_core_primitives::{
-    ArchivedBlockProgress, FlatPieces, LastArchivedBlock, PublicKey, RootBlock, Sha256Hash,
-    PIECE_SIZE,
-};
+use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
-use subspace_farmer::{
-    retrieve_piece_from_plots, NodeRpcClient, ObjectMappings, PieceOffset, Plot, PlotFile,
-    RpcClient,
-};
+use subspace_farmer::{retrieve_piece_from_plots, NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::multihash::Multihash;
 use subspace_networking::multimess::MultihashCode;
 use subspace_networking::Config;
 use subspace_rpc_primitives::FarmerMetadata;
-use tempfile::TempDir;
 use tracing::{info, warn};
 
-use crate::bench_rpc_client::BenchRpcClient;
-use crate::{utils, FarmingArgs, WriteToDisk};
-
-pub struct BenchPlotMock {
-    piece_count: u64,
-    max_piece_count: u64,
-}
-
-impl BenchPlotMock {
-    pub fn new(max_piece_count: u64) -> Self {
-        Self {
-            max_piece_count,
-            piece_count: 0,
-        }
-    }
-}
-
-impl PlotFile for BenchPlotMock {
-    fn piece_count(&mut self) -> io::Result<u64> {
-        Ok(self.piece_count)
-    }
-
-    fn write(&mut self, pieces: impl AsRef<[u8]>, _offset: PieceOffset) -> io::Result<()> {
-        self.piece_count = (self.piece_count + (pieces.as_ref().len() / PIECE_SIZE) as u64)
-            .max(self.max_piece_count);
-        Ok(())
-    }
-
-    fn read(&mut self, _offset: PieceOffset, mut buf: impl AsMut<[u8]>) -> io::Result<()> {
-        rand::thread_rng().fill(buf.as_mut());
-        Ok(())
-    }
-
-    fn sync_all(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
+use crate::{utils, FarmingArgs};
 
 /// Start farming by using multiple replica plot in specified path and connecting to WebSocket
 /// server at specified address.
@@ -199,132 +152,6 @@ pub(crate) async fn farm(
     });
 
     multi_farming.wait().await
-}
-
-const BENCH_FARMER_METADATA: FarmerMetadata = FarmerMetadata {
-    record_size: PIECE_SIZE as u32 - 96, // PIECE_SIZE - WITNESS_SIZE
-    recorded_history_segment_size: PIECE_SIZE as u32 * 256 / 2, // PIECE_SIZE * MERKLE_NUM_LEAVES / 2
-    max_plot_size: 100 * 1024 * 1024 * 1024 / PIECE_SIZE as u64, // 100G
-};
-
-pub(crate) async fn bench(
-    custom_path: Option<PathBuf>,
-    plot_size: u64,
-    max_plot_size: Option<u64>,
-    best_block_number_check_interval: Duration,
-    write_to_disk: WriteToDisk,
-    write_pieces_size: u64,
-) -> anyhow::Result<()> {
-    utils::raise_fd_limit();
-
-    let (archived_segments_sender, archived_segments_receiver) = tokio::sync::mpsc::channel(10);
-    let client = BenchRpcClient::new(BENCH_FARMER_METADATA, archived_segments_receiver);
-
-    let base_directory = crate::utils::get_path(custom_path);
-    let base_directory = TempDir::new_in(base_directory)?;
-
-    let metadata = client
-        .farmer_metadata()
-        .await
-        .map_err(|error| anyhow!(error))?;
-
-    let max_plot_size = match max_plot_size.map(|max_plot_size| max_plot_size / PIECE_SIZE as u64) {
-        Some(max_plot_size) if max_plot_size > metadata.max_plot_size => {
-            warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
-            metadata.max_plot_size
-        }
-        Some(max_plot_size) => max_plot_size,
-        None => metadata.max_plot_size,
-    };
-
-    info!("Opening object mapping");
-    let object_mappings = tokio::task::spawn_blocking({
-        let base_directory = base_directory.as_ref().to_owned();
-        move || ObjectMappings::open_or_create(&base_directory)
-    })
-    .await??;
-
-    let base_path = base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index, public_key, max_piece_count| {
-        let base_path = base_path.join(format!("plot{plot_index}"));
-        match write_to_disk {
-            WriteToDisk::Nothing => Plot::with_plot_file(
-                BenchPlotMock::new(max_piece_count),
-                base_path,
-                public_key,
-                max_piece_count,
-            ),
-            WriteToDisk::Everything => Plot::open_or_create(base_path, public_key, max_piece_count),
-        }
-    };
-
-    let multi_farming = MultiFarming::new(
-        MultiFarmingOptions {
-            base_directory: base_directory.as_ref().to_owned(),
-            client: client.clone(),
-            object_mappings: object_mappings.clone(),
-            reward_address: PublicKey::default(),
-            best_block_number_check_interval,
-        },
-        plot_size,
-        max_plot_size,
-        plot_factory,
-        false,
-    )
-    .await?;
-
-    tokio::spawn(async move {
-        let mut last_archived_block = LastArchivedBlock {
-            number: 0,
-            archived_progress: ArchivedBlockProgress::Partial(0),
-        };
-
-        for segment_index in 0..write_pieces_size / PIECE_SIZE as u64 / 1000 {
-            last_archived_block
-                .archived_progress
-                .set_partial(segment_index as u32 * 1000 * PIECE_SIZE as u32);
-
-            let archived_segment = {
-                let root_block = RootBlock::V0 {
-                    segment_index,
-                    records_root: Sha256Hash::default(),
-                    prev_root_block_hash: Sha256Hash::default(),
-                    last_archived_block,
-                };
-
-                let mut pieces = FlatPieces::new(1000);
-                rand::thread_rng().fill(pieces.as_mut());
-
-                let objects = std::iter::repeat_with(|| PieceObject::V0 {
-                    hash: rand::random(),
-                    offset: rand::random(),
-                })
-                .take(100)
-                .collect();
-
-                ArchivedSegment {
-                    root_block,
-                    pieces,
-                    object_mapping: vec![PieceObjectMapping { objects }],
-                }
-            };
-
-            if archived_segments_sender
-                .send(archived_segment)
-                .await
-                .is_err()
-            {
-                break;
-            }
-        }
-    })
-    .await?;
-
-    client.stop().await;
-
-    multi_farming.wait().await?;
-
-    Ok(())
 }
 
 fn networking_getter(plots: &[Plot], key: &Multihash) -> Option<Vec<u8>> {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -23,10 +23,10 @@ use subspace_networking::multimess::MultihashCode;
 use subspace_networking::Config;
 use subspace_rpc_primitives::FarmerMetadata;
 use tempfile::TempDir;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::bench_rpc_client::BenchRpcClient;
-use crate::{FarmingArgs, WriteToDisk};
+use crate::{utils, FarmingArgs, WriteToDisk};
 
 pub struct BenchPlotMock {
     piece_count: u64,
@@ -63,23 +63,6 @@ impl PlotFile for BenchPlotMock {
     }
 }
 
-fn raise_fd_limit() {
-    match std::panic::catch_unwind(fdlimit::raise_fd_limit) {
-        Ok(Some(new_limit)) => info!(new_limit, "Increase file limit from soft to hard"),
-        Ok(None) => debug!("Failed to increase file limit"),
-        Err(err) => {
-            let err = if let Some(err) = err.downcast_ref::<&str>() {
-                *err
-            } else if let Some(err) = err.downcast_ref::<String>() {
-                err
-            } else {
-                unreachable!("Should be unreachable as `fdlimit` uses panic macro, which should return either `&str` or `String`.")
-            };
-            warn!(err, "Failed to increase file limit")
-        }
-    }
-}
-
 /// Start farming by using multiple replica plot in specified path and connecting to WebSocket
 /// server at specified address.
 pub(crate) async fn farm(
@@ -95,9 +78,9 @@ pub(crate) async fn farm(
     }: FarmingArgs,
     best_block_number_check_interval: Duration,
 ) -> Result<(), anyhow::Error> {
-    raise_fd_limit();
+    utils::raise_fd_limit();
 
-    let base_directory = crate::utils::get_path(custom_path);
+    let base_directory = utils::get_path(custom_path);
 
     info!("Connecting to node at {}", node_rpc_url);
     let client = NodeRpcClient::new(&node_rpc_url).await?;
@@ -232,7 +215,7 @@ pub(crate) async fn bench(
     write_to_disk: WriteToDisk,
     write_pieces_size: u64,
 ) -> anyhow::Result<()> {
-    raise_fd_limit();
+    utils::raise_fd_limit();
 
     let (archived_segments_sender, archived_segments_receiver) = tokio::sync::mpsc::channel(10);
     let client = BenchRpcClient::new(BENCH_FARMER_METADATA, archived_segments_receiver);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,5 +1,3 @@
-#![feature(bool_to_option)]
-
 mod bench_rpc_client;
 mod commands;
 mod utils;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,3 +1,5 @@
+#![feature(bool_to_option)]
+
 mod bench_rpc_client;
 mod commands;
 mod utils;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -132,14 +132,11 @@ fn parse_reward_address(s: &str) -> Result<PublicKey, PublicError> {
 async fn main() -> Result<()> {
     tracing_subscriber::registry()
         .with(
-            fmt::layer()
-                .with_span_events(FmtSpan::CLOSE)
-                .with_thread_ids(true)
-                .with_filter(
-                    EnvFilter::builder()
-                        .with_default_directive(LevelFilter::INFO.into())
-                        .from_env_lossy(),
-                ),
+            fmt::layer().with_span_events(FmtSpan::CLOSE).with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            ),
         )
         .init();
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
@@ -17,3 +17,22 @@ pub(crate) fn get_path(custom_path: Option<PathBuf>) -> PathBuf {
 
     path
 }
+
+pub(crate) fn raise_fd_limit() {
+    match std::panic::catch_unwind(fdlimit::raise_fd_limit) {
+        Ok(Some(limit)) => {
+            tracing::info!("Increase file limit from soft to hard (limit is {limit})")
+        }
+        Ok(None) => tracing::debug!("Failed to increase file limit"),
+        Err(err) => {
+            let err = if let Some(err) = err.downcast_ref::<&str>() {
+                *err
+            } else if let Some(err) = err.downcast_ref::<String>() {
+                err
+            } else {
+                unreachable!("Should be unreachable as `fdlimit` uses panic macro, which should return either `&str` or `String`.")
+            };
+            tracing::warn!("Failed to increase file limit: {err}")
+        }
+    }
+}


### PR DESCRIPTION
Some examples of the output:
```sh
$ ./farmer bench --plot-size 1G --write-pieces-size 2G
...
Finished benchmarking.

807.32M allocated for farming
762.94M actual space pledged (which is 94.50%)
44.38M of overhead (which is 5.50%)
21.26s plotting time
94.08M/s average plotting throughput
...
```