### PR TITLE
Switch from `merkletree` to fork of `merkle_light` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
+name = "merkle_light"
+version = "0.4.0"
+source = "git+https://github.com/subspace/merkle_light?rev=63e341d388209e1cb7f5c2f8880a36235905d1e6#63e341d388209e1cb7f5c2f8880a36235905d1e6"
+
+[[package]]
 name = "merkletree"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8442,7 +8447,7 @@ name = "subspace-archiving"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "merkletree",
+ "merkle_light",
  "parity-scale-codec",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -8450,7 +8455,6 @@ dependencies = [
  "sha2 0.10.2",
  "subspace-core-primitives",
  "thiserror",
- "typenum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,5 @@ codegen-units = 1
 [patch.crates-io]
 # TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies
 chacha20poly1305 = { git = "https://github.com/RustCrypto/AEADs", rev = "06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99" }
+# TODO: Remove once https://github.com/sitano/merkle_light/pull/8 is released
+merkle_light = { git = "https://github.com/subspace/merkle_light", rev = "63e341d388209e1cb7f5c2f8880a36235905d1e6" }

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -13,13 +13,12 @@ include = [
 ]
 
 [dependencies]
-merkletree = "0.21.0"
-parity-scale-codec = { version = "3.1.2", features = ["derive"], default-features = false }
+merkle_light = { version = "0.4.0", default-features = false }
+parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 reed-solomon-erasure = { version = "5.0.2", default-features = true }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 thiserror = { version = "1.0.30", optional = true }
-typenum = "1.14.0"
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -39,6 +38,7 @@ rand = { version = "0.8.5", features = ["min_const_gen"] }
 [features]
 default = ["std"]
 std = [
+    "merkle_light/std",
     "parity-scale-codec/std",
     "reed-solomon-erasure/simd-accel",
     "serde",


### PR DESCRIPTION
Old one wasn't no_std compatible. It was also a complex filecoin-specific fork of the original library that I have modified to support `no_std`, see https://github.com/sitano/merkle_light/pull/8