### PR TITLE
Remove farmer workarounds for node's RPC

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -47,7 +47,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{BlockNumber, Solution};
+use subspace_core_primitives::Solution;
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
@@ -60,10 +60,6 @@ pub trait SubspaceRpcApi {
     /// Ger metadata necessary for farmer operation
     #[method(name = "subspace_getFarmerMetadata")]
     fn get_farmer_metadata(&self) -> RpcResult<FarmerMetadata>;
-
-    /// Get best block number
-    #[method(name = "subspace_getBestBlockNumber")]
-    fn get_best_block_number(&self) -> RpcResult<BlockNumber>;
 
     #[method(name = "subspace_submitSolutionResponse")]
     fn submit_solution_response(&self, solution_response: SolutionResponse) -> RpcResult<()>;
@@ -207,15 +203,6 @@ where
             error!("Failed to get data from runtime API: {}", error);
             JsonRpseeError::Custom("Internal error".to_string())
         })
-    }
-
-    fn get_best_block_number(&self) -> RpcResult<BlockNumber> {
-        let best_number = TryInto::<BlockNumber>::try_into(self.client.info().best_number)
-            .unwrap_or_else(|_| {
-                panic!("Block number can't be converted into BlockNumber");
-            });
-
-        Ok(best_number)
     }
 
     fn submit_solution_response(&self, solution_response: SolutionResponse) -> RpcResult<()> {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
@@ -1,16 +1,12 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
+use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::BlockNumber;
+use subspace_farmer::{RpcClient, RpcClientError as MockError};
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
-use tokio::sync::mpsc::Receiver;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
-
-use subspace_farmer::{RpcClient, RpcClientError as MockError};
 
 /// Client mock for benching purpose
 #[derive(Clone, Debug)]
@@ -70,11 +66,6 @@ impl RpcClient for BenchRpcClient {
         Ok(self.inner.metadata.clone())
     }
 
-    async fn best_block_number(&self) -> Result<BlockNumber, MockError> {
-        // Doesn't matter for tests (at least yet)
-        Ok(BlockNumber::MAX)
-    }
-
     async fn subscribe_slot_info(&self) -> Result<mpsc::Receiver<SlotInfo>, MockError> {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }
@@ -86,7 +77,7 @@ impl RpcClient for BenchRpcClient {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }
 
-    async fn subscribe_block_signing(&self) -> Result<Receiver<BlockSigningInfo>, MockError> {
+    async fn subscribe_block_signing(&self) -> Result<mpsc::Receiver<BlockSigningInfo>, MockError> {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }
 
@@ -97,7 +88,9 @@ impl RpcClient for BenchRpcClient {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }
 
-    async fn subscribe_archived_segments(&self) -> Result<Receiver<ArchivedSegment>, MockError> {
+    async fn subscribe_archived_segments(
+        &self,
+    ) -> Result<mpsc::Receiver<ArchivedSegment>, MockError> {
         let (sender, receiver) = mpsc::channel(10);
         let archived_segments_receiver = self.inner.archived_segments_receiver.clone();
         tokio::spawn(async move {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -3,7 +3,6 @@ use jsonrpsee::ws_server::WsServerBuilder;
 use rand::prelude::*;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use std::{io, mem};
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{PieceObject, PieceObjectMapping};
@@ -93,7 +92,6 @@ pub(crate) async fn farm(
         plot_size,
         max_plot_size,
     }: FarmingArgs,
-    best_block_number_check_interval: Duration,
 ) -> Result<(), anyhow::Error> {
     raise_fd_limit();
 
@@ -136,7 +134,6 @@ pub(crate) async fn farm(
             client,
             object_mappings: object_mappings.clone(),
             reward_address,
-            best_block_number_check_interval,
         },
         plot_size,
         max_plot_size,
@@ -228,7 +225,6 @@ pub(crate) async fn bench(
     custom_path: Option<PathBuf>,
     plot_size: u64,
     max_plot_size: Option<u64>,
-    best_block_number_check_interval: Duration,
     write_to_disk: WriteToDisk,
     write_pieces_size: u64,
 ) -> anyhow::Result<()> {
@@ -281,7 +277,6 @@ pub(crate) async fn bench(
             client: client.clone(),
             object_mappings: object_mappings.clone(),
             reward_address: PublicKey::default(),
-            best_block_number_check_interval,
         },
         plot_size,
         max_plot_size,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -7,7 +7,6 @@ use clap::{ArgEnum, Parser, ValueHint};
 use sp_core::crypto::PublicError;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::time::Duration;
 use subspace_core_primitives::PublicKey;
 use subspace_networking::libp2p::Multiaddr;
 use tracing::info;
@@ -17,8 +16,6 @@ use tracing_subscriber::{
     prelude::*,
     EnvFilter,
 };
-
-const BEST_BLOCK_NUMBER_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Arguments for farmer
 #[derive(Debug, Parser)]
@@ -150,7 +147,7 @@ async fn main() -> Result<()> {
             info!("Done");
         }
         Command::Farm(args) => {
-            commands::farm(args, BEST_BLOCK_NUMBER_CHECK_INTERVAL).await?;
+            commands::farm(args).await?;
         }
         Command::Bench {
             custom_path,
@@ -163,7 +160,6 @@ async fn main() -> Result<()> {
                 custom_path,
                 plot_size,
                 max_plot_size,
-                BEST_BLOCK_NUMBER_CHECK_INTERVAL,
                 write_to_disk,
                 write_pieces_size,
             )

--- a/crates/subspace-farmer/src/mock_rpc_client.rs
+++ b/crates/subspace-farmer/src/mock_rpc_client.rs
@@ -2,11 +2,9 @@ use crate::rpc_client::{Error as MockError, RpcClient};
 use async_trait::async_trait;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::BlockNumber;
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
-use tokio::sync::mpsc::Receiver;
 use tokio::sync::{mpsc, Mutex};
 
 /// `MockRpc` wrapper.
@@ -135,11 +133,6 @@ impl RpcClient for MockRpcClient {
         Ok(self.inner.metadata_receiver.lock().await.try_recv()?)
     }
 
-    async fn best_block_number(&self) -> Result<BlockNumber, MockError> {
-        // Doesn't matter for tests (at least yet)
-        Ok(0)
-    }
-
     async fn subscribe_slot_info(&self) -> Result<mpsc::Receiver<SlotInfo>, MockError> {
         let (sender, receiver) = mpsc::channel(10);
         let slot_receiver = self.inner.slot_info_receiver.clone();
@@ -164,7 +157,7 @@ impl RpcClient for MockRpcClient {
         Ok(())
     }
 
-    async fn subscribe_block_signing(&self) -> Result<Receiver<BlockSigningInfo>, MockError> {
+    async fn subscribe_block_signing(&self) -> Result<mpsc::Receiver<BlockSigningInfo>, MockError> {
         let (sender, receiver) = mpsc::channel(10);
         let block_signing_receiver = self.inner.block_signing_info_receiver.clone();
         tokio::spawn(async move {
@@ -188,7 +181,9 @@ impl RpcClient for MockRpcClient {
         Ok(())
     }
 
-    async fn subscribe_archived_segments(&self) -> Result<Receiver<ArchivedSegment>, MockError> {
+    async fn subscribe_archived_segments(
+        &self,
+    ) -> Result<mpsc::Receiver<ArchivedSegment>, MockError> {
         let (sender, receiver) = mpsc::channel(10);
         let archived_segments_receiver = self.inner.archived_segments_receiver.clone();
         tokio::spawn(async move {

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -4,7 +4,8 @@ use crate::{
 use anyhow::anyhow;
 use futures::stream::{FuturesUnordered, StreamExt};
 use rayon::prelude::*;
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::path::PathBuf;
+use std::sync::Arc;
 use subspace_core_primitives::{PublicKey, PIECE_SIZE};
 use subspace_solving::SubspaceCodec;
 use tracing::info;
@@ -43,7 +44,6 @@ pub struct Options<C: RpcClient> {
     pub client: C,
     pub object_mappings: ObjectMappings,
     pub reward_address: PublicKey,
-    pub best_block_number_check_interval: Duration,
 }
 
 impl MultiFarming {
@@ -54,7 +54,6 @@ impl MultiFarming {
             client,
             object_mappings,
             reward_address,
-            best_block_number_check_interval,
         }: Options<C>,
         total_plot_size: u64,
         max_plot_size: u64,
@@ -125,34 +124,28 @@ impl MultiFarming {
             .map_err(|error| anyhow!(error))?;
 
         // Start archiving task
-        let archiving = Archiving::start(
-            farmer_metadata,
-            object_mappings,
-            client.clone(),
-            best_block_number_check_interval,
-            {
-                let mut on_pieces_to_plots = plots
-                    .iter()
-                    .zip(subspace_codecs)
-                    .zip(&commitments)
-                    .map(|((plot, subspace_codec), commitments)| {
-                        plotting::plot_pieces(subspace_codec, plot, commitments.clone())
-                    })
-                    .collect::<Vec<_>>();
+        let archiving = Archiving::start(farmer_metadata, object_mappings, client.clone(), {
+            let mut on_pieces_to_plots = plots
+                .iter()
+                .zip(subspace_codecs)
+                .zip(&commitments)
+                .map(|((plot, subspace_codec), commitments)| {
+                    plotting::plot_pieces(subspace_codec, plot, commitments.clone())
+                })
+                .collect::<Vec<_>>();
 
-                move |pieces_to_plot| {
-                    on_pieces_to_plots
-                        .par_iter_mut()
-                        .map(|on_pieces_to_plot| {
-                            // TODO: It might be desirable to not clone it and instead pick just
-                            //  unnecessary pieces and copy pieces once since different plots will
-                            //  care about different pieces
-                            on_pieces_to_plot(pieces_to_plot.clone())
-                        })
-                        .reduce(|| true, |result, should_continue| result && should_continue)
-                }
-            },
-        )
+            move |pieces_to_plot| {
+                on_pieces_to_plots
+                    .par_iter_mut()
+                    .map(|on_pieces_to_plot| {
+                        // TODO: It might be desirable to not clone it and instead pick just
+                        //  unnecessary pieces and copy pieces once since different plots will
+                        //  care about different pieces
+                        on_pieces_to_plot(pieces_to_plot.clone())
+                    })
+                    .reduce(|| true, |result, should_continue| result && should_continue)
+            }
+        })
         .await?;
 
         Ok(Self {

--- a/crates/subspace-farmer/src/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_rpc_client.rs
@@ -6,12 +6,10 @@ use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::BlockNumber;
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::Receiver;
 
 /// `WsClient` wrapper.
 #[derive(Clone, Debug)]
@@ -33,13 +31,6 @@ impl RpcClient for NodeRpcClient {
         Ok(self
             .client
             .request("subspace_getFarmerMetadata", rpc_params![])
-            .await?)
-    }
-
-    async fn best_block_number(&self) -> Result<BlockNumber, RpcError> {
-        Ok(self
-            .client
-            .request("subspace_getBestBlockNumber", rpc_params![])
             .await?)
     }
 
@@ -112,7 +103,9 @@ impl RpcClient for NodeRpcClient {
             .await?)
     }
 
-    async fn subscribe_archived_segments(&self) -> Result<Receiver<ArchivedSegment>, RpcError> {
+    async fn subscribe_archived_segments(
+        &self,
+    ) -> Result<mpsc::Receiver<ArchivedSegment>, RpcError> {
         let mut subscription = self
             .client
             .subscribe(

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -7,7 +7,6 @@ use crate::rpc_client::RpcClient;
 use crate::{plotting, Archiving};
 use rand::prelude::*;
 use rand::Rng;
-use std::time::Duration;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{PieceIndexHash, Salt, PIECE_SIZE, SHA256_HASH_SIZE};
@@ -19,7 +18,6 @@ const MERKLE_NUM_LEAVES: usize = 8_usize;
 const WITNESS_SIZE: usize = SHA256_HASH_SIZE * MERKLE_NUM_LEAVES.log2() as usize; // 96
 const RECORD_SIZE: usize = PIECE_SIZE - WITNESS_SIZE; // 4000
 const SEGMENT_SIZE: usize = RECORD_SIZE * MERKLE_NUM_LEAVES / 2; // 16000
-const BEST_BLOCK_NUMBER_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 fn init() {
     let _ = tracing_subscriber::fmt::try_init();
@@ -73,7 +71,6 @@ async fn plotting_happy_path() {
         farmer_metadata,
         object_mappings,
         client.clone(),
-        BEST_BLOCK_NUMBER_CHECK_INTERVAL,
         plotting::plot_pieces(subspace_codec, &plot, commitments),
     )
     .await
@@ -158,7 +155,6 @@ async fn plotting_piece_eviction() {
         farmer_metadata,
         object_mappings,
         client.clone(),
-        BEST_BLOCK_NUMBER_CHECK_INTERVAL,
         plotting::plot_pieces(subspace_codec, &plot, commitments.clone()),
     )
     .await

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -1,10 +1,9 @@
 use async_trait::async_trait;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::BlockNumber;
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc;
 
 /// To become error type agnostic
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -15,11 +14,8 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
     /// Get farmer metadata
     async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error>;
 
-    /// Get a block by number
-    async fn best_block_number(&self) -> Result<BlockNumber, Error>;
-
     /// Subscribe to slot
-    async fn subscribe_slot_info(&self) -> Result<Receiver<SlotInfo>, Error>;
+    async fn subscribe_slot_info(&self) -> Result<mpsc::Receiver<SlotInfo>, Error>;
 
     /// Submit a slot solution
     async fn submit_solution_response(
@@ -28,13 +24,13 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
     ) -> Result<(), Error>;
 
     /// Subscribe to block signing request
-    async fn subscribe_block_signing(&self) -> Result<Receiver<BlockSigningInfo>, Error>;
+    async fn subscribe_block_signing(&self) -> Result<mpsc::Receiver<BlockSigningInfo>, Error>;
 
     /// Submit a block signature
     async fn submit_block_signature(&self, block_signature: BlockSignature) -> Result<(), Error>;
 
     /// Subscribe to archived segments
-    async fn subscribe_archived_segments(&self) -> Result<Receiver<ArchivedSegment>, Error>;
+    async fn subscribe_archived_segments(&self) -> Result<mpsc::Receiver<ArchivedSegment>, Error>;
 
     /// Acknowledge receiving of archived segments
     async fn acknowledge_archived_segment(&self, segment_index: u64) -> Result<(), Error>;


### PR DESCRIPTION
We were pinging node due to RPC connection being potentially broken, this shouldn't be necessary as RPC server in Substrate doesn't have the issue after switching to `jsonrpsee`.