### PR TITLE
Move block verification logic from `sc-consensus-subspace` to `sp-consensus-subspace`

### DIFF
--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+
       - name: Build runtime
         id: build
         uses: docker/build-push-action@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -25,6 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved
@@ -61,6 +67,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
 
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -108,6 +120,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved
@@ -142,6 +160,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
 
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -15,30 +15,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly-2022-02-15
-        target: wasm32-unknown-unknown
-        profile: minimal
-        override: true
-        components: rustfmt, rust-src
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2022-02-15
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+          components: rustfmt, rust-src
 
       # Build the rust crate docs
       # Use `RUSTC_BOOTSTRAP` in order to use the `--enable-index-page` flag of rustdoc
       # This is needed in order to generate a landing page `index.html` for workspaces
-    - name: Build Documentation
-      run: cargo doc --all --no-deps --lib
-      env:
-        RUSTC_BOOTSTRAP: 1
-        RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
+      - name: Build Documentation
+        run: cargo doc --all --no-deps --lib
+        env:
+          RUSTC_BOOTSTRAP: 1
+          RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
 
-    - name: Deploy Docs
-      uses: JamesIves/github-pages-deploy-action@releases/v3
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: target/doc
+      - name: Deploy Docs
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: target/doc

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -72,6 +72,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1
         # TODO: Below can be removed when https://github.com/actions-rs/toolchain/issues/126 is resolved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,6 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "smallvec",
  "sp-api",
  "sp-block-builder",
@@ -1009,7 +1008,6 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "smallvec",
  "sp-api",
  "sp-block-builder",
@@ -7260,9 +7258,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "sloth256-189"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0965b23de228cef734baed2811ff783570d2cd5468b64268477e014b263ac72c"
+checksum = "e7b133a57a9d83343174c83a77be5dfbe5c7c4f2f49291967aee4cd53901e0bc"
 dependencies = [
  "cc",
  "glob",
@@ -7505,7 +7503,7 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "serde",
+ "schnorrkel",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -7515,7 +7513,10 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
+ "subspace-archiving",
  "subspace-core-primitives",
+ "subspace-solving",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/sc-consensus-subspace-rpc/Cargo.toml
+++ b/crates/sc-consensus-subspace-rpc/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.21"
 futures-timer = "3.0.2"
 jsonrpsee = { version = "0.13.1", features = ["server", "macros"] }
 log = "0.4.17"
-parity-scale-codec = { version = "3.1.2", default-features = false }
+parity-scale-codec = "3.1.2"
 parking_lot = "0.12.0"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 async-trait = { version = "0.1.53", optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.137", features = ["derive"], optional = true }
+schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-application-crypto = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-consensus = { version = "0.10.0-dev", optional = true, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
@@ -26,7 +26,10 @@ sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https:/
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831", default-features = false }
+subspace-archiving = { version = "0.1.0", path = "../subspace-archiving", default-features = false }
+subspace-solving = { version = "0.1.0", path = "../subspace-solving", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
+thiserror = { version = "1.0.31", optional = true }
 
 [features]
 default = ["std"]
@@ -34,7 +37,7 @@ std = [
 	"async-trait",
 	"codec/std",
 	"scale-info/std",
-	"serde",
+	"schnorrkel/std",
 	"sp-api/std",
 	"sp-application-crypto/std",
 	"sp-consensus",
@@ -44,5 +47,8 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-timestamp/std",
+	"subspace-archiving/std",
+	"subspace-solving/std",
 	"subspace-core-primitives/std",
+	"thiserror",
 ]

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -16,12 +16,13 @@
 
 //! Primitives for Subspace consensus.
 
-#![forbid(unsafe_code, missing_docs, unused_variables, unused_imports)]
+#![forbid(unsafe_code, missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod digests;
 pub mod inherents;
 pub mod offence;
+pub mod verification;
 
 use crate::digests::{
     CompatibleDigestItem, GlobalRandomnessDescriptor, PreDigest, SaltDescriptor,

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 [dependencies]
 merkle_light = { version = "0.4.0", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
-reed-solomon-erasure = { version = "5.0.2", default-features = true }
+reed-solomon-erasure = { version = "5.0.2", default-features = false }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 thiserror = { version = "1.0.31", optional = true }
@@ -41,6 +41,7 @@ std = [
     "merkle_light/std",
     "parity-scale-codec/std",
     "reed-solomon-erasure/simd-accel",
+    "reed-solomon-erasure/std",
     "serde",
     "sha2/std",
     "subspace-core-primitives/std",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
-serde_arrays = { version = "0.1", optional = true }
+serde_arrays = "0.1.0"
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -37,7 +37,6 @@ std = [
     "num-traits/std",
     "parity-scale-codec/std",
     "scale-info/std",
-    "serde/std",
-    "serde_arrays",
+    "serde",
     "sha2/std",
 ]

--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -29,7 +29,7 @@ default = ["std"]
 std = [
 	"parity-scale-codec/std",
 	"parity-util-mem/std",
-	"serde/std",
+	"serde",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,15 +12,15 @@ include = [
 ]
 
 [dependencies]
-tracing = "0.1"
-num_cpus = "1.13.0"
-num-traits = "0.2.15"
-rayon = "1.5.3"
-schnorrkel = "0.9.1"
-sloth256-189 = "0.3.1"
-subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
-thiserror = "1.0.31"
-uint = "0.9"
+num_cpus = { version = "1.13.0", optional = true }
+num-traits = { version = "0.2.15", default-features = false }
+rayon = { version = "1.5.3", optional = true }
+schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
+sloth256-189 = { version = "0.3.2", default-features = false }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
+thiserror = { version = "1.0.31", optional = true }
+tracing = { version = "0.1.34", default-features = false }
+uint = { version = "0.9", default-features = false }
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]
@@ -30,13 +30,28 @@ version = "0.10.2"
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 # `asm` feature is not supported on Windows except with GNU toolchain
 [target.'cfg(not(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu"))))'.dependencies.sha2]
+default-features = false
 version = "0.10.2"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 
 [features]
-default = []
+default = [
+    "std",
+]
+std = [
+    "num_cpus",
+    "num-traits/std",
+    "rayon",
+    "schnorrkel/std",
+    "sha2/std",
+    "sloth256-189/std",
+    "subspace-core-primitives/std",
+    "thiserror",
+    "tracing/std",
+    "uint/std"
+]
 # Compile with CUDA support and use it if compatible GPU is available
 cuda = [
     "sloth256-189/cuda",

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 mod codec;
 

--- a/cumulus/runtime/Cargo.toml
+++ b/cumulus/runtime/Cargo.toml
@@ -16,7 +16,6 @@ hex-literal = { version = '0.3.1', optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"]}
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.137", optional = true, features = ["derive"] }
 smallvec = "1.8.0"
 
 # Substrate Dependencies
@@ -58,7 +57,6 @@ default = [
 ]
 std = [
 	"codec/std",
-	"serde",
 	"scale-info/std",
 	"log/std",
 	"sp-api/std",

--- a/cumulus/test/runtime/Cargo.toml
+++ b/cumulus/test/runtime/Cargo.toml
@@ -19,7 +19,6 @@ hex-literal = { version = '0.3.1', optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"]}
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.137", optional = true, features = ["derive"] }
 smallvec = "1.8.0"
 
 # Substrate Dependencies
@@ -58,7 +57,6 @@ default = [
 ]
 std = [
 	"codec/std",
-	"serde",
 	"scale-info/std",
 	"log/std",
 	"sp-api/std",

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -180,7 +180,7 @@ parity_util_mem::malloc_size_of_is_0!(Extrinsic); // non-opaque extrinsic does n
 impl serde::Serialize for Extrinsic {
     fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error>
     where
-        S: ::serde::Serializer,
+        S: serde::Serializer,
     {
         self.using_encoded(|bytes| seq.serialize_bytes(bytes))
     }


### PR DESCRIPTION
This will be helpful for votes verification in the runtime.

I must admit I spent way too much time fighting no-std compilation errors due to missing `#![cfg_attr(not(feature = "std"), no_std)]` in two places and one `default-features = true` that should have been `default-features = false` :facepalm: 