### PR TITLE
Switch to upstream merkle tree library revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,7 +4069,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle_light"
 version = "0.4.0"
-source = "git+https://github.com/subspace/merkle_light?rev=63e341d388209e1cb7f5c2f8880a36235905d1e6#63e341d388209e1cb7f5c2f8880a36235905d1e6"
+source = "git+https://github.com/sitano/merkle_light?rev=fe31d4ef27a1fbe54e82ab589b610ae4bfd2008e#fe31d4ef27a1fbe54e82ab589b610ae4bfd2008e"
 
 [[package]]
 name = "merkletree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,4 +86,4 @@ codegen-units = 1
 # TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies
 chacha20poly1305 = { git = "https://github.com/RustCrypto/AEADs", rev = "06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99" }
 # TODO: Remove once https://github.com/sitano/merkle_light/pull/8 is released
-merkle_light = { git = "https://github.com/subspace/merkle_light", rev = "63e341d388209e1cb7f5c2f8880a36235905d1e6" }
+merkle_light = { git = "https://github.com/sitano/merkle_light", rev = "fe31d4ef27a1fbe54e82ab589b610ae4bfd2008e" }


### PR DESCRIPTION
It is not released yet, but at least I don't have to keep it in my downstream fork going forward