### PR TITLE
Add llvm installation to rustdoc too

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
I thought it wouldn't be necessary, but looks like we only skip build in docs.rs environment and not during regular building of docs