### PR TITLE
Fix subscription leakage on the farmer

### DIFF
--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,5 +1,6 @@
 use crate::object_mappings::ObjectMappings;
 use crate::rpc_client::RpcClient;
+use futures::StreamExt;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
 use subspace_core_primitives::{FlatPieces, Sha256Hash};
@@ -129,7 +130,7 @@ impl Archiving {
                         info!("Plotting stopped!");
                         break;
                     }
-                    result = archived_segments.recv() => {
+                    result = archived_segments.next() => {
                         match result {
                             Some(archived_segment) => {
                                 let segment_index = archived_segment.root_block.segment_index();

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -1,11 +1,11 @@
+use crate::bench_rpc_client::BenchRpcClient;
+use crate::{utils, WriteToDisk};
+use anyhow::anyhow;
+use futures::channel::mpsc;
+use futures::SinkExt;
+use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
-
-use anyhow::anyhow;
-use rand::prelude::*;
-use tempfile::TempDir;
-use tracing::info;
-
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{PieceObject, PieceObjectMapping};
 use subspace_core_primitives::{
@@ -15,10 +15,9 @@ use subspace_core_primitives::{
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::{ObjectMappings, PieceOffset, Plot, PlotFile, RpcClient};
 use subspace_rpc_primitives::FarmerMetadata;
+use tempfile::TempDir;
 use tokio::time::Instant;
-
-use crate::bench_rpc_client::BenchRpcClient;
-use crate::{utils, WriteToDisk};
+use tracing::info;
 
 pub struct BenchPlotMock {
     piece_count: u64,
@@ -90,7 +89,7 @@ pub(crate) async fn bench(
 ) -> anyhow::Result<()> {
     utils::raise_fd_limit();
 
-    let (archived_segments_sender, archived_segments_receiver) = tokio::sync::mpsc::channel(10);
+    let (mut archived_segments_sender, archived_segments_receiver) = mpsc::channel(10);
     let client = BenchRpcClient::new(BENCH_FARMER_METADATA, archived_segments_receiver);
 
     let base_directory = crate::utils::get_path(custom_path);

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -7,7 +7,7 @@ use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::plot::Plot;
 use crate::rpc_client::RpcClient;
-use futures::{future, future::Either};
+use futures::{future, future::Either, StreamExt};
 use std::sync::mpsc;
 use std::time::Instant;
 use subspace_core_primitives::{LocalChallenge, PublicKey, Salt, Solution};
@@ -123,7 +123,7 @@ async fn subscribe_to_slot_info<T: RpcClient>(
 
     let mut salts = Salts::default();
 
-    while let Some(slot_info) = slot_info_notifications.recv().await {
+    while let Some(slot_info) = slot_info_notifications.next().await {
         debug!(?slot_info, "New slot");
 
         update_commitments(plot, commitments, &mut salts, &slot_info);
@@ -184,7 +184,7 @@ async fn subscribe_to_slot_info<T: RpcClient>(
                     if let Some(BlockSigningInfo {
                         header_hash,
                         public_key,
-                    }) = block_signing_info_notifications.recv().await
+                    }) = block_signing_info_notifications.next().await
                     {
                         // Multiple plots might have solved, only sign with correct one
                         if identity.public_key().to_bytes() != public_key {

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -1,9 +1,10 @@
 use async_trait::async_trait;
+use futures::Stream;
+use std::pin::Pin;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
     BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
 };
-use tokio::sync::mpsc;
 
 /// To become error type agnostic
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -15,7 +16,9 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
     async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error>;
 
     /// Subscribe to slot
-    async fn subscribe_slot_info(&self) -> Result<mpsc::Receiver<SlotInfo>, Error>;
+    async fn subscribe_slot_info(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, Error>;
 
     /// Submit a slot solution
     async fn submit_solution_response(
@@ -24,13 +27,17 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
     ) -> Result<(), Error>;
 
     /// Subscribe to block signing request
-    async fn subscribe_block_signing(&self) -> Result<mpsc::Receiver<BlockSigningInfo>, Error>;
+    async fn subscribe_block_signing(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = BlockSigningInfo> + Send + 'static>>, Error>;
 
     /// Submit a block signature
     async fn submit_block_signature(&self, block_signature: BlockSignature) -> Result<(), Error>;
 
     /// Subscribe to archived segments
-    async fn subscribe_archived_segments(&self) -> Result<mpsc::Receiver<ArchivedSegment>, Error>;
+    async fn subscribe_archived_segments(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = ArchivedSegment> + Send + 'static>>, Error>;
 
     /// Acknowledge receiving of archived segments
     async fn acknowledge_archived_segment(&self, segment_index: u64) -> Result<(), Error>;


### PR DESCRIPTION
With `jsonrpsee` upgrade on Substrate side there is finally tracking for number of subscriptions and default limit it 1024, meaning in setups where farmer produces a lot of blocks it'll break once this number is reached. By turning `jsonrpsee`'s subscription into a stream we can drop it (unsubscribe) once no longer needed.