### PR TITLE
Snapshot build improvements

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -11,6 +11,10 @@ on:
     tags:
       - 'snapshot-*'
 
+# Incremental compilation here isn't helpful
+env:
+  CARGO_INCREMENTAL: 0
+
 jobs:
   container-linux:
     runs-on: ubuntu-20.04

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -16,6 +16,8 @@ jobs:
     # Only run for releases
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-20.04
+    # Aarch64 cross-compilation is very slow :(
+    timeout-minutes: 720
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -14,8 +14,6 @@ on:
 jobs:
   container-linux:
     runs-on: ubuntu-20.04
-    # Aarch64 cross-compilation is very slow :(
-    timeout-minutes: 720
     permissions:
       contents: write
       packages: write
@@ -26,8 +24,11 @@ jobs:
           - node
         platform:
           - arch: linux/amd64
+            profile: production
             suffix: ubuntu-x86_64-${{ github.ref_name }}
           - arch: linux/arm64
+            # Fewer optimizations on aarch64 to reduce CI time and make it not exceed 6 hours
+            profile: release
             suffix: ubuntu-aarch64-${{ github.ref_name }}
 
     steps:
@@ -67,6 +68,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
+            PROFILE=${{ matrix.platform.profile }}
 
       - name: Extract executable from container image
         # Using `steps.meta.outputs.tags` instead of `steps.build.outputs.digest` because of https://github.com/docker/build-push-action/issues/321

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -24,8 +24,17 @@ jobs:
         image:
           - node
           - farmer
+        platform:
+          - linux/amd64
+          - linux/arm64
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log into registry
         uses: docker/login-action@v1
         with:
@@ -49,6 +58,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile-${{ matrix.image }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -1,7 +1,7 @@
 # This action enables building container images and executables for farmer and node, can be triggered manually or by
 # release creation.
 #
-# Container images are only built for releases, pushed to GitHub Container Registry.
+# Container images are only pushed to GitHub Container Registry for releases.
 # Executables are built both for releases and for manually triggered runs, uploaded to artifacts and assets.
 name: Snapshot build
 
@@ -12,9 +12,7 @@ on:
       - 'snapshot-*'
 
 jobs:
-  container-images:
-    # Only run for releases
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+  container-linux:
     runs-on: ubuntu-20.04
     # Aarch64 cross-compilation is very slow :(
     timeout-minutes: 720
@@ -24,11 +22,13 @@ jobs:
     strategy:
       matrix:
         image:
-          - node
           - farmer
+          - node
         platform:
-          - linux/amd64
-          - linux/arm64
+          - arch: linux/amd64
+            suffix: ubuntu-x86_64-${{ github.ref_name }}
+          - arch: linux/arm64
+            suffix: ubuntu-aarch64-${{ github.ref_name }}
 
     steps:
       - name: Set up QEMU
@@ -60,19 +60,39 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: Dockerfile-${{ matrix.image }}
-          platforms: ${{ matrix.platform }}
-          push: true
+          platforms: ${{ matrix.platform.arch }}
+          # Only push for releases
+          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
 
+      - name: Extract executable from container image
+        # Using `steps.meta.outputs.tags` instead of `steps.build.outputs.digest` because of https://github.com/docker/build-push-action/issues/321
+        run: |
+          docker run --rm -u root --platform ${{ matrix.platform.arch }} --entrypoint /bin/cat ${{ steps.meta.outputs.tags }} /subspace-${{ matrix.image }} > subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
+
+      - name: Upload executable to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: executables
+          path: |
+            subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
+          if-no-files-found: error
+
+      - name: Upload executable to assets
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}"]'
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+
   executables:
     strategy:
       matrix:
         build:
-          - os: ubuntu-20.04
-            suffix: ubuntu-x86_64-${{ github.ref_name }}
           - os: macos-11
             suffix: macos-x86_64-${{ github.ref_name }}
           - os: windows-2022
@@ -146,6 +166,8 @@ jobs:
           # echo "Stapling node"
           # xcrun stapler staple target/production/subspace-node
           echo "Done!"
+        # Allow code signing to fail on non-release builds
+        continue-on-error: ${{ github.event_name != 'push' || github.ref_type != 'tag' }}
         if: runner.os == 'macOS'
 
       - name: Sign Application (Windows)
@@ -155,14 +177,9 @@ jobs:
           password: '${{ secrets.WINDOWS_CERTIFICATE_PW }}'
           certificatesha1: '00A427587B911908F59B6C42BA2863109C599C1C'
           folder: 'target/production'
+        # Allow code signing to fail on non-release builds
+        continue-on-error: ${{ github.event_name != 'push' || github.ref_type != 'tag' }}
         if: runner.os == 'Windows'
-
-      - name: Prepare executables for uploading Linux
-        run: |
-          mkdir executables
-          mv target/production/subspace-farmer executables/subspace-farmer-${{ matrix.build.suffix }}
-          mv target/production/subspace-node executables/subspace-node-${{ matrix.build.suffix }}
-        if: runner.os == 'Linux'
 
       - name: Prepare executables for uploading macOS
         run: |

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -30,10 +30,10 @@ jobs:
           - arch: linux/amd64
             profile: production
             suffix: ubuntu-x86_64-${{ github.ref_name }}
-          - arch: linux/arm64
-            # Fewer optimizations on aarch64 to reduce CI time and make it not exceed 6 hours
-            profile: release
-            suffix: ubuntu-aarch64-${{ github.ref_name }}
+#          - arch: linux/arm64
+#            # Fewer optimizations on aarch64 to reduce CI time
+#            profile: release
+#            suffix: ubuntu-aarch64-${{ github.ref_name }}
 
     steps:
       - name: Set up QEMU

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -99,7 +99,6 @@ jobs:
             suffix: macos-x86_64-${{ github.ref_name }}
           - os: windows-2022
             suffix: windows-x86_64-${{ github.ref_name }}
-
     runs-on: ${{ matrix.build.os }}
 
     steps:
@@ -168,8 +167,8 @@ jobs:
           # echo "Stapling node"
           # xcrun stapler staple target/production/subspace-node
           echo "Done!"
-        # Allow code signing to fail on non-release builds
-        continue-on-error: ${{ github.event_name != 'push' || github.ref_type != 'tag' }}
+        # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
+        continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
         if: runner.os == 'macOS'
 
       - name: Sign Application (Windows)
@@ -179,8 +178,8 @@ jobs:
           password: '${{ secrets.WINDOWS_CERTIFICATE_PW }}'
           certificatesha1: '00A427587B911908F59B6C42BA2863109C599C1C'
           folder: 'target/production'
-        # Allow code signing to fail on non-release builds
-        continue-on-error: ${{ github.event_name != 'push' || github.ref_type != 'tag' }}
+        # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
+        continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
         if: runner.os == 'Windows'
 
       - name: Prepare executables for uploading macOS

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -74,31 +74,35 @@ jobs:
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
             PROFILE=${{ matrix.platform.profile }}
 
-      - name: Extract executable from container image
+      - name: Extract executable from container image (aarch64)
         # Using `steps.meta.outputs.tags` instead of `steps.build.outputs.digest` because of https://github.com/docker/build-push-action/issues/321
         run: |
           docker run --rm -u root --platform ${{ matrix.platform.arch }} --entrypoint /bin/cat ${{ steps.meta.outputs.tags }} /subspace-${{ matrix.image }} > subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
+        if: matrix.platform.arch == 'linux/arm64'
 
-      - name: Upload executable to artifacts
+      - name: Upload executable to artifacts (aarch64)
         uses: actions/upload-artifact@v2
         with:
           name: executables
           path: |
             subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
           if-no-files-found: error
+        if: matrix.platform.arch == 'linux/arm64'
 
-      - name: Upload executable to assets
+      - name: Upload executable to assets (aarch64)
         uses: alexellis/upload-assets@0.3.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}"]'
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: matrix.platform.arch == 'linux/arm64' && github.event_name == 'push' && github.ref_type == 'tag'
 
   executables:
     strategy:
       matrix:
         build:
+          - os: ubuntu-20.04
+            suffix: ubuntu-x86_64-${{ github.ref_name }}
           - os: macos-11
             suffix: macos-x86_64-${{ github.ref_name }}
           - os: windows-2022
@@ -186,7 +190,14 @@ jobs:
         continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
         if: runner.os == 'Windows'
 
-      - name: Prepare executables for uploading macOS
+      - name: Prepare executables for uploading (Ubuntu)
+        run: |
+          mkdir executables
+          mv target/production/subspace-farmer executables/subspace-farmer-${{ matrix.build.suffix }}
+          mv target/production/subspace-node executables/subspace-node-${{ matrix.build.suffix }}
+        if: runner.os == 'Linux'
+
+      - name: Prepare executables for uploading (macOS)
         run: |
           mkdir executables
           mv target/production/subspace-farmer executables/subspace-farmer-${{ matrix.build.suffix }}

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 WORKDIR /code
 

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
+ARG PROFILE=production
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
 ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
@@ -31,8 +32,8 @@ COPY test /code/test
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 RUN \
-    /root/.cargo/bin/cargo build --profile production --bin subspace-farmer && \
-    mv target/production/subspace-farmer subspace-farmer && \
+    /root/.cargo/bin/cargo build --profile $PROFILE --bin subspace-farmer && \
+    mv target/$PROFILE/subspace-farmer subspace-farmer && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -3,7 +3,9 @@ FROM ubuntu:20.04
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
-ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
 
 WORKDIR /code
 

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 WORKDIR /code
 

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
+ARG PROFILE=production
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
 ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
@@ -33,8 +34,8 @@ COPY test /code/test
 ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
 
 RUN \
-    /root/.cargo/bin/cargo build --profile production --bin subspace-node && \
-    mv target/production/subspace-node subspace-node && \
+    /root/.cargo/bin/cargo build --profile $PROFILE --bin subspace-node && \
+    mv target/$PROFILE/subspace-node subspace-node && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -3,7 +3,9 @@ FROM ubuntu:20.04
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
-ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
 
 WORKDIR /code
 

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
+ARG PROFILE=production
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
 ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
@@ -32,11 +33,11 @@ COPY test /code/test
 
 # TODO: Re-enable cost of storage in future
 RUN \
-    /root/.cargo/bin/cargo build --profile production \
+    /root/.cargo/bin/cargo build --profile $PRODUCTION \
         --package subspace-runtime \
         --features=subspace-runtime/do-not-enforce-cost-of-storage && \
     mv \
-      target/production/wbuild/subspace-runtime/subspace_runtime.compact.compressed.wasm \
+      target/$PRODUCTION/wbuild/subspace-runtime/subspace_runtime.compact.compressed.wasm \
       subspace_runtime.compact.compressed.wasm && \
     rm -rf target
 

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 WORKDIR /code
 

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -3,7 +3,9 @@ FROM ubuntu:22.04
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
-ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
 
 WORKDIR /code
 


### PR DESCRIPTION
This was envisioned a while ago as aarch64 support branch, but then evolved with some other improvements like ability to build snapshots in forks without hitting errors during failed signing (binaries will be left unsigned instead if signature fails in a fork).

Unfortunately aarch64 builds take too long in CI with just 2 cores. Farmer takes 4+ hours to build, node exceeds 6 hours timeout, so aarch64 are commented out for now, but the logic is there already.