### PR TITLE
Build aarch64

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -31,10 +31,12 @@ jobs:
           - arch: linux/amd64
             profile: production
             suffix: ubuntu-x86_64-${{ github.ref_name }}
-#          - arch: linux/arm64
-#            # Fewer optimizations on aarch64 to reduce CI time
-#            profile: release
-#            suffix: ubuntu-aarch64-${{ github.ref_name }}
+            image-suffix: ''
+          - arch: linux/arm64
+            # Build at least something for aarch64 that doesn't exceed CI's time limit
+            profile: dev
+            suffix: ubuntu-aarch64-${{ github.ref_name }}
+            image-suffix: '-aarch64'
 
     steps:
       - name: Set up QEMU
@@ -60,6 +62,7 @@ jobs:
             type=ref,event=tag
           flavor: |
             latest=false
+            suffix=${{ matrix.platform.image-suffix }}
 
       - name: Build and push ${{ matrix.image }} image
         id: build
@@ -74,6 +77,7 @@ jobs:
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
             PROFILE=${{ matrix.platform.profile }}
+            RUSTFLAGS=-C strip=debuginfo
 
       - name: Extract executable from container image (aarch64)
         # Using `steps.meta.outputs.tags` instead of `steps.build.outputs.digest` because of https://github.com/docker/build-push-action/issues/321

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production
+ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Incremental compilation here isn't helpful
@@ -35,7 +36,7 @@ COPY test /code/test
 
 RUN \
     /root/.cargo/bin/cargo build --profile $PROFILE --bin subspace-farmer && \
-    mv target/$PROFILE/subspace-farmer subspace-farmer && \
+    mv target/*/subspace-farmer subspace-farmer && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production
+ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Incremental compilation here isn't helpful
@@ -37,7 +38,7 @@ ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
 
 RUN \
     /root/.cargo/bin/cargo build --profile $PROFILE --bin subspace-node && \
-    mv target/$PROFILE/subspace-node subspace-node && \
+    mv target/*/subspace-node subspace-node && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production
+ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Incremental compilation here isn't helpful
@@ -39,7 +40,7 @@ RUN \
         --package subspace-runtime \
         --features=subspace-runtime/do-not-enforce-cost-of-storage && \
     mv \
-      target/$PROFILE/wbuild/subspace-runtime/subspace_runtime.compact.compressed.wasm \
+      target/*/wbuild/subspace-runtime/subspace_runtime.compact.compressed.wasm \
       subspace_runtime.compact.compressed.wasm && \
     rm -rf target
 

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -185,6 +185,7 @@ version: "3.7"
 services:
   node:
     # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+    # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/node:snapshot-DATE
     volumes:
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can
@@ -221,7 +222,8 @@ services:
     depends_on:
       node:
         condition: service_healthy
-# Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+    # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+    # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/farmer:snapshot-DATE
 # Un-comment following 2 lines to unlock farmer's RPC
 #    ports:


### PR DESCRIPTION
This isn't great, but it does allow us to have aarch64 build (both container images and regular executables) at least in some form.

It is a bit of a stretch with build taking 5 hours 49 minutes out of 6 hours timeout, but it does work. With some effort I'm sure we can make build even faster, but this is not a high priority right now.