### PR TITLE
Fix the primary block existence check in pallet-executor

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -459,7 +459,7 @@ mod pallet {
                     if let Err(e) = Self::validate_execution_receipt(signed_execution_receipt) {
                         log::error!(
                             target: "runtime::subspace::executor",
-                            "[validate_unsigned] Invalid execution receipt: {:?}, error: {:?}",
+                            "Invalid execution receipt: {:?}, error: {:?}",
                             signed_execution_receipt, e
                         );
                         return InvalidTransactionCode::ExecutionReceipt.into();
@@ -490,7 +490,7 @@ mod pallet {
                     if let Err(e) = Self::validate_bundle(signed_opaque_bundle) {
                         log::error!(
                             target: "runtime::subspace::executor",
-                            "[validate_unsigned] Invalid signed opaque bundle: {:?}, error: {:?}",
+                            "Invalid signed opaque bundle: {:?}, error: {:?}",
                             signed_opaque_bundle, e
                         );
                         return InvalidTransactionCode::Bundle.into();
@@ -504,7 +504,7 @@ mod pallet {
                     if let Err(e) = Self::validate_fraud_proof(fraud_proof) {
                         log::error!(
                             target: "runtime::subspace::executor",
-                            "[validate_unsigned] Invalid fraud proof: {:?}, error: {:?}",
+                            "Invalid fraud proof: {:?}, error: {:?}",
                             fraud_proof, e
                         );
                         return InvalidTransactionCode::FraudProof.into();
@@ -521,7 +521,7 @@ mod pallet {
                     {
                         log::error!(
                             target: "runtime::subspace::executor",
-                            "[validate_unsigned] Invalid bundle equivocation proof: {:?}, error: {:?}",
+                            "Invalid bundle equivocation proof: {:?}, error: {:?}",
                             bundle_equivocation_proof, e
                         );
                         return InvalidTransactionCode::BundleEquivicationProof.into();
@@ -540,7 +540,7 @@ mod pallet {
                     {
                         log::error!(
                             target: "runtime::subspace::executor",
-                            "[validate_unsigned] Wrong InvalidTransactionProof: {:?}, error: {:?}",
+                            "Wrong InvalidTransactionProof: {:?}, error: {:?}",
                             invalid_transaction_proof, e
                         );
                         return InvalidTransactionCode::TrasactionProof.into();

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -559,7 +559,7 @@ async fn pallet_executor_unsigned_extrinsics_should_work() {
 		.build(Role::Full)
 		.await;
 
-	alice_executor.wait_for_blocks(3).await;
+	alice_executor.wait_for_blocks(4).await;
 
 	let create_and_send_submit_execution_receipt = |primary_number: BlockNumber| {
 		let pool = alice.transaction_pool.pool();


### PR DESCRIPTION
This PR is primary for fixing the check of primary block existence https://github.com/subspace/subspace/compare/cirrus-fixes?expand=1#diff-8d1c28c28055fbaa7e46a4dddbe6fa4ddebd330bbdbc82d032d806c089983413L552-R574 . Previously, I just used the block hash mapping in frame system and didn't realize that it will be pruned once its size exceeds the `T::BlockHashCount`. Now we also store the block hash mapping relative to the best execution chain number in pallet-executor, which will be bounded by `ReceiptsPruningDepth` ideally, but if somehow the execution chain stalls, this mapping will grow indefinitely, but once the execution chain recovers, the mapping will be pruned again and become bounded. The second commit is to improve the error log to display detailed error info.