### PR TITLE
Farmer voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,6 +4688,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "sp-std",
  "subspace-runtime-primitives",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
 name = "pallet-subspace"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "frame-support",
  "frame-system",
  "hex",
@@ -4725,6 +4726,7 @@ dependencies = [
  "pallet-offences-subspace",
  "pallet-timestamp",
  "parity-scale-codec",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel",
  "sp-consensus-slots",
@@ -4733,6 +4735,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "subspace-archiving",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "subspace-solving",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "hex",
  "log",
  "num-traits",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,7 +4720,6 @@ dependencies = [
  "env_logger",
  "frame-support",
  "frame-system",
- "hex",
  "log",
  "pallet-balances",
  "pallet-offences-subspace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7510,6 +7510,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-timestamp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4722,7 +4722,6 @@ dependencies = [
  "frame-system",
  "hex",
  "log",
- "num-traits",
  "pallet-balances",
  "pallet-offences-subspace",
  "pallet-timestamp",

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -267,7 +267,7 @@ fn create_custom_content_feed(
             // key should match the feed name spaced key
             assert_eq!(
                 mappings[i].key,
-                crypto::sha256_hash_pair(FEED_ID.encode(), key.as_slice())
+                crypto::sha256_hash_pair(&FEED_ID.encode(), key.as_slice())
             );
         });
 

--- a/crates/pallet-grandpa-finality-verifier/src/grandpa.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/grandpa.rs
@@ -16,7 +16,6 @@
 // GRANDPA verification is mostly taken from Parity's bridges https://github.com/paritytech/parity-bridges-common/tree/master/primitives/header-chain
 use codec::{Decode, Encode};
 use finality_grandpa::voter_set::VoterSet;
-use frame_support::RuntimeDebug;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -47,7 +46,7 @@ pub struct GrandpaJustification<Header: HeaderT> {
 }
 
 /// A GRANDPA Authority List and ID.
-#[derive(Default, Encode, Decode, RuntimeDebug, PartialEq, Clone, TypeInfo)]
+#[derive(Debug, Default, Encode, Decode, PartialEq, Clone, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct AuthoritySet {
     /// List of GRANDPA authorities for the current round.
@@ -57,7 +56,7 @@ pub struct AuthoritySet {
 }
 
 /// Votes ancestries with useful methods.
-#[derive(RuntimeDebug)]
+#[derive(Debug)]
 struct AncestryChain<Header: HeaderT> {
     /// Header hash => parent header hash mapping.
     parents: BTreeMap<Header::Hash, Header::Hash>,
@@ -110,7 +109,7 @@ impl<Header: HeaderT> AncestryChain<Header> {
 }
 
 /// Justification verification error.
-#[derive(RuntimeDebug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Justification is finalizing unexpected header.
     InvalidJustificationTarget,

--- a/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
@@ -4,7 +4,6 @@ use codec::Encode;
 use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature};
 use finality_grandpa::voter_set::VoterSet;
 use sp_finality_grandpa::{AuthorityId, AuthorityList, AuthorityWeight};
-use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
 
 /// Set of test accounts with friendly names.
@@ -15,7 +14,7 @@ pub(crate) const DAVE: Account = Account(3);
 pub(crate) const EVE: Account = Account(4);
 
 /// A test account which can be used to sign messages.
-#[derive(RuntimeDebug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct Account(pub u16);
 
 impl Account {

--- a/crates/pallet-rewards/Cargo.toml
+++ b/crates/pallet-rewards/Cargo.toml
@@ -22,6 +22,7 @@ codec = { package = "parity-scale-codec", version = "3.1.2", default-features = 
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [features]
@@ -31,5 +32,7 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "scale-info/std",
+  "sp-std/std",
+  "subspace-runtime-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
@@ -44,7 +43,6 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",
-	"hex/std",
 	"log/std",
 	"pallet-timestamp/std",
 	"scale-info/std",

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -18,7 +18,6 @@ frame-support = { version = "4.0.0-dev", default-features = false, git = "https:
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
@@ -47,7 +46,6 @@ std = [
 	"frame-system/std",
 	"hex/std",
 	"log/std",
-	"num-traits/std",
 	"pallet-timestamp/std",
 	"scale-info/std",
 	"schnorrkel/std",

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -16,10 +16,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../sp-consensus-subspace" }
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
@@ -27,13 +29,12 @@ sp-runtime = { version = "6.0.0", default-features = false, git = "https://githu
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
+subspace-solving = { version = "0.1.0", default-features = false, path = "../subspace-solving" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 pallet-offences-subspace = { version = "0.1.0", path = "../pallet-offences-subspace" }
-schnorrkel = "0.9.1"
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
-subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 
 [features]
 default = ["std"]
@@ -41,16 +42,19 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",
+	"hex/std",
 	"log/std",
 	"num-traits/std",
 	"pallet-timestamp/std",
 	"scale-info/std",
+	"schnorrkel/std",
 	"sp-consensus-subspace/std",
 	"sp-consensus-slots/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"subspace-core-primitives/std",
-	"subspace-runtime-primitives/std"
+	"subspace-runtime-primitives/std",
+	"subspace-solving/std"
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -32,9 +32,12 @@ subspace-runtime-primitives = { version = "0.1.0", default-features = false, pat
 subspace-solving = { version = "0.1.0", default-features = false, path = "../subspace-solving" }
 
 [dev-dependencies]
+env_logger = "0.9.0"
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 pallet-offences-subspace = { version = "0.1.0", path = "../pallet-offences-subspace" }
+rand = { version = "0.8.5", features = ["min_const_gen"] }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
+subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-subspace/src/equivocation.rs
+++ b/crates/pallet-subspace/src/equivocation.rs
@@ -214,20 +214,18 @@ fn is_known_offence<T: Config>(
 /// A Subspace equivocation offence report.
 ///
 /// When a farmer released two or more blocks at the same slot.
-pub struct SubspaceEquivocationOffence<FullIdentification> {
+pub struct SubspaceEquivocationOffence<PublicKey> {
     /// A Subspace slot in which this incident happened.
     pub slot: Slot,
-    /// The authority that produced the equivocation.
-    pub offender: FullIdentification,
+    /// Identity of the farmer that produced the equivocation.
+    pub offender: PublicKey,
 }
 
-impl<FullIdentification: Clone> Offence<FullIdentification>
-    for SubspaceEquivocationOffence<FullIdentification>
-{
+impl<PublicKey: Clone> Offence<PublicKey> for SubspaceEquivocationOffence<PublicKey> {
     const ID: Kind = *b"sub:equivocation";
     type TimeSlot = Slot;
 
-    fn offenders(&self) -> Vec<FullIdentification> {
+    fn offenders(&self) -> Vec<PublicKey> {
         vec![self.offender.clone()]
     }
 

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -904,16 +904,14 @@ impl<T: Config> Pallet<T> {
         eon_index: u64,
         randomness: &Randomness,
     ) -> subspace_core_primitives::Salt {
-        crypto::sha256_hash({
-            let mut input =
-                [0u8; SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH + mem::size_of::<u64>()];
-            input[..SALT_HASHING_PREFIX_LEN].copy_from_slice(SALT_HASHING_PREFIX);
-            input[SALT_HASHING_PREFIX_LEN..SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH]
-                .copy_from_slice(randomness);
-            input[SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH..]
-                .copy_from_slice(&eon_index.to_le_bytes());
-            input
-        })[..SALT_SIZE]
+        let mut input = [0u8; SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH + mem::size_of::<u64>()];
+        input[..SALT_HASHING_PREFIX_LEN].copy_from_slice(SALT_HASHING_PREFIX);
+        input[SALT_HASHING_PREFIX_LEN..SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH]
+            .copy_from_slice(randomness);
+        input[SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH..]
+            .copy_from_slice(&eon_index.to_le_bytes());
+
+        crypto::sha256_hash(&input)[..SALT_SIZE]
             .try_into()
             .expect("Slice has exactly the size needed; qed")
     }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1169,6 +1169,13 @@ impl<T: Config> subspace_runtime_primitives::FindBlockRewardAddress<T::AccountId
     }
 }
 
+impl<T: Config> subspace_runtime_primitives::FindVotingRewardAddresses<T::AccountId> for Pallet<T> {
+    fn find_voting_reward_addresses() -> Vec<T::AccountId> {
+        // TODO: Implement
+        Vec::new()
+    }
+}
+
 impl<T: Config> frame_support::traits::Randomness<T::Hash, T::BlockNumber> for Pallet<T> {
     fn random(subject: &[u8]) -> (T::Hash, T::BlockNumber) {
         let mut subject = subject.to_vec();

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1174,7 +1174,7 @@ fn check_vote<T: Config>(
         // New time slot is already set, whatever time slot is in the vote it must be smaller or the
         // same (for votes produced locally)
         let current_slot = Pallet::<T>::current_slot();
-        if slot > current_slot {
+        if slot > current_slot || (slot == current_slot && height != current_block_number) {
             debug!(
                 target: "runtime::subspace",
                 "Vote slot {slot:?} must be before current slot {current_slot:?}",

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1112,7 +1112,6 @@ where
     }
 }
 
-// TODO: Equivocation test case
 fn check_vote<T: Config>(
     signed_vote: &SignedVote<T::BlockNumber, T::Hash, T::AccountId>,
     pre_dispatch: bool,
@@ -1133,7 +1132,7 @@ fn check_vote<T: Config>(
     let current_block_number = frame_system::Pallet::<T>::current_block_number();
 
     if current_block_number <= One::one() || height <= One::one() {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Votes are not expected at height below 2"
         );
@@ -1145,7 +1144,7 @@ fn check_vote<T: Config>(
     //
     // Subtraction will not panic due to check above.
     if !(height == current_block_number || height == current_block_number - One::one()) {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Vote verification error: bad height {height:?}, current block number is \
             {current_block_number:?}"
@@ -1161,7 +1160,7 @@ fn check_vote<T: Config>(
     //
     // Subtraction will not panic due to check above.
     if *parent_hash != frame_system::Pallet::<T>::block_hash(height - One::one()) {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Vote verification error: parent hash {}",
             hex::encode(parent_hash)
@@ -1177,7 +1176,7 @@ fn check_vote<T: Config>(
         // New time slot is already set, whatever time slot is in the vote it must be smaller
         let current_slot = Pallet::<T>::current_slot();
         if slot >= current_slot {
-            warn!(
+            debug!(
                 target: "runtime::subspace",
                 "Vote slot {slot:?} must be before current slot {current_slot:?}",
             );
@@ -1208,7 +1207,7 @@ fn check_vote<T: Config>(
     };
 
     if slot <= parent_slot {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Vote slot {slot:?} must be after parent slot {parent_slot:?}",
         );
@@ -1221,7 +1220,7 @@ fn check_vote<T: Config>(
         &solution.public_key,
         &schnorrkel::signing_context(REWARD_SIGNING_CONTEXT),
     ) {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Vote verification error: {error:?}"
         );
@@ -1244,7 +1243,7 @@ fn check_vote<T: Config>(
     let records_root = if let Some(records_root) = Pallet::<T>::records_root(segment_index) {
         records_root
     } else {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Vote verification error: no records root for segment index {segment_index}"
         );
@@ -1268,7 +1267,7 @@ fn check_vote<T: Config>(
             solution_signing_context: &schnorrkel::signing_context(SOLUTION_SIGNING_CONTEXT),
         },
     ) {
-        warn!(
+        debug!(
             target: "runtime::subspace",
             "Vote verification error: {error:?}"
         );
@@ -1307,7 +1306,7 @@ fn check_vote<T: Config>(
 
         // Report equivocation, we don't care about duplicate report here
         if let Err(OffenceError::Other(code)) = T::HandleEquivocation::report_offence(offence) {
-            warn!(
+            debug!(
                 target: "runtime::subspace",
                 "Failed to submit voter offence report with code {code}"
             );

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1171,9 +1171,10 @@ fn check_vote<T: Config>(
         .expect("Above check for block number ensures that this value is always present");
 
     if pre_dispatch {
-        // New time slot is already set, whatever time slot is in the vote it must be smaller
+        // New time slot is already set, whatever time slot is in the vote it must be smaller or the
+        // same (for votes produced locally)
         let current_slot = Pallet::<T>::current_slot();
-        if slot >= current_slot {
+        if slot > current_slot {
             debug!(
                 target: "runtime::subspace",
                 "Vote slot {slot:?} must be before current slot {current_slot:?}",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -132,7 +132,7 @@ pub const INITIAL_SOLUTION_RANGE: u64 =
 parameter_types! {
     pub const GlobalRandomnessUpdateInterval: u64 = 10;
     pub const EraDuration: u32 = 4;
-    pub const EonDuration: u32 = 5;
+    pub const EonDuration: u32 = 6;
     pub const EonNextSaltReveal: u64 = 3;
     // 1GB
     pub const InitialSolutionRange: u64 = INITIAL_SOLUTION_RANGE;

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -140,7 +140,7 @@ parameter_types! {
     pub const ConfirmationDepthK: u32 = 10;
     pub const RecordSize: u32 = 3840;
     pub const RecordedHistorySegmentSize: u32 = 3840 * 256 / 2;
-    pub const ExpectedVotesPerBlock: u32 = 10;
+    pub const ExpectedVotesPerBlock: u32 = 9;
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
     pub const MaxPlotSize: u64 = 10 * 2u64.pow(18);

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -191,7 +191,7 @@ pub fn go_to_block(
         System::parent_hash()
     };
 
-    let subspace_codec = SubspaceCodec::new(&keypair.public);
+    let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let piece_index = 0;
     let mut encoding = Piece::default();
@@ -353,7 +353,7 @@ pub fn extract_piece(
     archived_segment: &ArchivedSegment,
     piece_index: u64,
 ) -> Piece {
-    let codec = SubspaceCodec::new(&keypair.public);
+    let codec = SubspaceCodec::new(keypair.public.as_ref());
 
     let mut piece: [u8; PIECE_SIZE] = archived_segment
         .pieces
@@ -382,7 +382,8 @@ pub fn create_signed_vote(
     let solution_signing_context = schnorrkel::signing_context(SOLUTION_SIGNING_CONTEXT);
     let reward_signing_context = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
 
-    let global_challenge = subspace_solving::derive_global_challenge(global_randomnesses, slot);
+    let global_challenge =
+        subspace_solving::derive_global_challenge(global_randomnesses, slot.into());
     let local_challenge = keypair
         .sign(solution_signing_context.bytes(&global_challenge))
         .to_bytes()

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -182,11 +182,11 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
         System::parent_hash()
     };
 
-    let subspace_solving = SubspaceCodec::new(&keypair.public);
+    let subspace_codec = SubspaceCodec::new(&keypair.public);
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let piece_index = 0;
     let mut encoding = Piece::default();
-    subspace_solving.encode(&mut encoding, piece_index).unwrap();
+    subspace_codec.encode(&mut encoding, piece_index).unwrap();
     let tag: Tag = subspace_solving::create_tag(&encoding, {
         let salts = Subspace::salts();
         if salts.switch_next_block {
@@ -259,7 +259,7 @@ pub fn generate_equivocation_proof(
                 public_key: public_key.clone(),
                 reward_address: public_key.clone(),
                 piece_index,
-                encoding,
+                encoding: encoding.clone(),
                 signature: signature.into(),
                 local_challenge: LocalChallenge::default(),
                 tag,

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -139,6 +139,7 @@ parameter_types! {
     pub const ConfirmationDepthK: u32 = 10;
     pub const RecordSize: u32 = 3840;
     pub const RecordedHistorySegmentSize: u32 = 3840 * 256 / 2;
+    pub const ExpectedVotesPerBlock: u32 = 10;
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
     pub const MaxPlotSize: u64 = 10 * 2u64.pow(18);
@@ -158,6 +159,7 @@ impl Config for Test {
     type ConfirmationDepthK = ConfirmationDepthK;
     type RecordSize = RecordSize;
     type RecordedHistorySegmentSize = RecordedHistorySegmentSize;
+    type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type GlobalRandomnessIntervalTrigger = NormalGlobalRandomnessInterval;
     type EraChangeTrigger = NormalEraChange;
     type EonChangeTrigger = NormalEonChange;

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -96,6 +96,9 @@ fn can_update_solution_range_on_era_change() {
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,
+            voting_current: INITIAL_SOLUTION_RANGE
+                .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+            voting_next: None,
         };
         assert_eq!(Subspace::solution_ranges(), initial_solution_ranges);
         // enable solution range adjustment
@@ -122,7 +125,12 @@ fn can_update_solution_range_on_era_change() {
             Subspace::solution_ranges(),
             SolutionRanges {
                 current: updated_solution_ranges.next.unwrap(),
-                next: None
+                next: None,
+                voting_current: updated_solution_ranges
+                    .next
+                    .unwrap()
+                    .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+                voting_next: None,
             }
         );
 
@@ -156,6 +164,9 @@ fn solution_range_should_not_update_when_disabled() {
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,
+            voting_current: INITIAL_SOLUTION_RANGE
+                .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+            voting_next: None,
         };
         assert_eq!(Subspace::solution_ranges(), initial_solution_ranges);
 
@@ -180,7 +191,12 @@ fn solution_range_should_not_update_when_disabled() {
             Subspace::solution_ranges(),
             SolutionRanges {
                 current: updated_solution_ranges.next.unwrap(),
-                next: None
+                next: None,
+                voting_current: updated_solution_ranges
+                    .next
+                    .unwrap()
+                    .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+                voting_next: None,
             }
         );
 

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -96,8 +96,7 @@ fn can_update_solution_range_on_era_change() {
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,
-            voting_current: INITIAL_SOLUTION_RANGE
-                .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+            voting_current: INITIAL_SOLUTION_RANGE,
             voting_next: None,
         };
         assert_eq!(Subspace::solution_ranges(), initial_solution_ranges);
@@ -164,8 +163,7 @@ fn solution_range_should_not_update_when_disabled() {
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,
-            voting_current: INITIAL_SOLUTION_RANGE
-                .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+            voting_current: INITIAL_SOLUTION_RANGE,
             voting_next: None,
         };
         assert_eq!(Subspace::solution_ranges(), initial_solution_ranges);
@@ -192,10 +190,7 @@ fn solution_range_should_not_update_when_disabled() {
             SolutionRanges {
                 current: updated_solution_ranges.next.unwrap(),
                 next: None,
-                voting_current: updated_solution_ranges
-                    .next
-                    .unwrap()
-                    .saturating_mul(u64::from(<Test as Config>::ExpectedVotesPerBlock::get()) + 1),
+                voting_current: updated_solution_ranges.next.unwrap(),
                 voting_next: None,
             }
         );

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -174,15 +174,10 @@ where
     BalanceOf<T>: From<u64>,
 {
     fn do_initialize(_n: T::BlockNumber) {
-        let block_author = T::FindBlockRewardAddress::find_block_reward_address(
-            frame_system::Pallet::<T>::digest()
-                .logs
-                .iter()
-                .filter_map(|d| d.as_pre_runtime()),
-        )
-        .expect("Block author must always be present; qed");
-
-        BlockAuthor::<T>::put(block_author);
+        // Block author may equivocate, in which case they'll not be present here
+        if let Some(block_author) = T::FindBlockRewardAddress::find_block_reward_address() {
+            BlockAuthor::<T>::put(block_author);
+        }
 
         CollectedBlockFees::<T>::put(CollectedFees {
             storage: BalanceOf::<T>::zero(),
@@ -195,67 +190,77 @@ where
     fn do_finalize(_n: T::BlockNumber) {
         TransactionByteFee::<T>::take();
 
-        let block_author =
-            BlockAuthor::<T>::take().expect("`BlockAuthor` was set in `on_initialize`; qed");
-
-        let original_storage_fees_escrow = CollectedStorageFeesEscrow::<T>::get();
         let collected_fees = CollectedBlockFees::<T>::take()
             .expect("`CollectedBlockFees` was set in `on_initialize`; qed");
 
-        let mut storage_fees_escrow = original_storage_fees_escrow;
+        // Block author may equivocate, in which case they'll not be present here
+        if let Some(block_author) = BlockAuthor::<T>::take() {
+            let original_storage_fees_escrow = CollectedStorageFeesEscrow::<T>::get();
+            let mut storage_fees_escrow = original_storage_fees_escrow;
 
-        // Take a portion of storage fees escrow as a farmer reward.
-        let storage_fees_escrow_reward = storage_fees_escrow
-            / T::StorageFeesEscrowBlockReward::get().1.into()
-            * T::StorageFeesEscrowBlockReward::get().0.into();
-        storage_fees_escrow -= storage_fees_escrow_reward;
+            // Take a portion of storage fees escrow as a farmer reward.
+            let storage_fees_escrow_reward = storage_fees_escrow
+                / T::StorageFeesEscrowBlockReward::get().1.into()
+                * T::StorageFeesEscrowBlockReward::get().0.into();
+            storage_fees_escrow -= storage_fees_escrow_reward;
 
-        // Take a portion of storage fees collected in this block as a farmer reward.
-        let collected_storage_fees_reward = collected_fees.storage
-            / T::StorageFeesEscrowBlockTax::get().1.into()
-            * (T::StorageFeesEscrowBlockTax::get().1 - T::StorageFeesEscrowBlockTax::get().0)
-                .into();
-        storage_fees_escrow += collected_fees.storage - collected_storage_fees_reward;
+            // Take a portion of storage fees collected in this block as a farmer reward.
+            let collected_storage_fees_reward = collected_fees.storage
+                / T::StorageFeesEscrowBlockTax::get().1.into()
+                * (T::StorageFeesEscrowBlockTax::get().1 - T::StorageFeesEscrowBlockTax::get().0)
+                    .into();
+            storage_fees_escrow += collected_fees.storage - collected_storage_fees_reward;
 
-        // Update storage fees escrow.
-        if storage_fees_escrow != original_storage_fees_escrow {
+            // Update storage fees escrow.
+            if storage_fees_escrow != original_storage_fees_escrow {
+                CollectedStorageFeesEscrow::<T>::put(storage_fees_escrow);
+                Self::deposit_event(Event::<T>::StorageFeesEscrowChange {
+                    before: original_storage_fees_escrow,
+                    after: storage_fees_escrow,
+                });
+            }
+
+            // Issue storage fees reward.
+            let storage_fees_reward = storage_fees_escrow_reward + collected_storage_fees_reward;
+            if !storage_fees_reward.is_zero() {
+                T::Currency::deposit_creating(&block_author, storage_fees_reward);
+                Self::deposit_event(Event::<T>::StorageFeesReward {
+                    who: block_author.clone(),
+                    amount: storage_fees_reward,
+                });
+            }
+
+            // Issue compute fees reward.
+            if !collected_fees.compute.is_zero() {
+                T::Currency::deposit_creating(&block_author, collected_fees.compute);
+                Self::deposit_event(Event::<T>::ComputeFeesReward {
+                    who: block_author.clone(),
+                    amount: collected_fees.compute,
+                });
+            }
+
+            // Issue tips reward.
+            if !collected_fees.tips.is_zero() {
+                T::Currency::deposit_creating(&block_author, collected_fees.tips);
+                Self::deposit_event(Event::<T>::TipsReward {
+                    who: block_author,
+                    amount: collected_fees.tips,
+                });
+            }
+        } else {
+            // If farmer equivocated, all fees go into storage escrow.
+            let original_storage_fees_escrow = CollectedStorageFeesEscrow::<T>::get();
+            let mut storage_fees_escrow = original_storage_fees_escrow;
+
+            storage_fees_escrow += collected_fees.storage;
+            storage_fees_escrow += collected_fees.compute;
+            storage_fees_escrow += collected_fees.tips;
+
             CollectedStorageFeesEscrow::<T>::put(storage_fees_escrow);
+
             Self::deposit_event(Event::<T>::StorageFeesEscrowChange {
                 before: original_storage_fees_escrow,
                 after: storage_fees_escrow,
-            });
-        }
-
-        // Issue storage fees reward.
-        let storage_fees_reward = storage_fees_escrow_reward + collected_storage_fees_reward;
-        if !storage_fees_reward.is_zero() {
-            T::Currency::deposit_into_existing(&block_author, storage_fees_reward).expect(
-                "Farmer account must have already received the block reward before fees are \
-                collected; qed",
-            );
-            Self::deposit_event(Event::<T>::StorageFeesReward {
-                who: block_author.clone(),
-                amount: storage_fees_reward,
-            });
-        }
-
-        // Issue compute fees reward.
-        if !collected_fees.compute.is_zero() {
-            T::Currency::deposit_into_existing(&block_author, collected_fees.compute)
-                .expect("Executor account must already exist before they execute the block; qed");
-            Self::deposit_event(Event::<T>::ComputeFeesReward {
-                who: block_author.clone(),
-                amount: collected_fees.compute,
-            });
-        }
-
-        // Issue tips reward.
-        if !collected_fees.tips.is_zero() {
-            T::Currency::deposit_into_existing(&block_author, collected_fees.tips)
-                .expect("Executor account must already exist before they execute the block; qed");
-            Self::deposit_event(Event::<T>::TipsReward {
-                who: block_author,
-                amount: collected_fees.tips,
             });
         }
     }

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -306,6 +306,7 @@ where
                         salt: new_slot_info.salt,
                         next_salt: new_slot_info.next_salt,
                         solution_range: new_slot_info.solution_range,
+                        voting_solution_range: new_slot_info.voting_solution_range,
                     }
                 });
 

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -52,7 +52,8 @@ use subspace_rpc_primitives::{
     FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
-const SOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
+const SOLUTION_TIMEOUT: Duration = Duration::from_secs(2);
+const REWARD_SIGNING_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Provides rpc methods for interacting with Subspace.
 #[rpc(client, server)]
@@ -373,7 +374,7 @@ where
                     "subspace-block-signing-forward",
                     Some("rpc"),
                     future::select(
-                        futures_timer::Delay::new(SOLUTION_TIMEOUT),
+                        futures_timer::Delay::new(REWARD_SIGNING_TIMEOUT),
                         Box::pin(forward_signature_fut),
                     )
                     .map(|_| ())

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -142,7 +142,7 @@ where
         + Send
         + Sync
         + 'static,
-    Client::Api: SubspaceRuntimeApi<Block>,
+    Client::Api: SubspaceRuntimeApi<Block, FarmerPublicKey>,
 {
     /// Creates a new instance of the `SubspaceRpc` handler.
     pub fn new(
@@ -178,7 +178,7 @@ where
         + Send
         + Sync
         + 'static,
-    Client::Api: SubspaceRuntimeApi<Block>,
+    Client::Api: SubspaceRuntimeApi<Block, FarmerPublicKey>,
 {
     fn get_farmer_metadata(&self) -> RpcResult<FarmerMetadata> {
         let best_block_id = BlockId::Hash(self.client.info().best_hash);

--- a/crates/sc-consensus-subspace/src/aux_schema.rs
+++ b/crates/sc-consensus-subspace/src/aux_schema.rs
@@ -56,7 +56,7 @@ where
 }
 
 /// Load the cumulative chain-weight associated with a block.
-pub fn load_block_weight<H: Encode, B: AuxStore>(
+pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
     backend: &B,
     block_hash: H,
 ) -> ClientResult<Option<SubspaceBlockWeight>> {

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -922,8 +922,8 @@ where
         let solution_range = find_solution_range_descriptor(&header)?
             .ok_or(Error::MissingSolutionRange(block_hash))?
             .solution_range;
-        let correct_solution_range =
-            slot_worker::extract_solution_range_for_block(self.client.as_ref(), &parent_block_id)?;
+        let (correct_solution_range, _) =
+            slot_worker::extract_solution_ranges_for_block(self.client.as_ref(), &parent_block_id)?;
         if solution_range != correct_solution_range {
             return Err(Error::InvalidSolutionRange(block_hash));
         }

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -90,8 +90,10 @@ pub struct NewSlotInfo {
     pub salt: Salt,
     /// Salt for the next eon
     pub next_salt: Option<Salt>,
-    /// Acceptable solution range
+    /// Acceptable solution range for block authoring
     pub solution_range: u64,
+    /// Acceptable solution range for voting
+    pub voting_solution_range: u64,
 }
 
 /// New slot notification with slot information and sender for solution for the slot.

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -232,11 +232,13 @@ where
 
                 // If solution is of high enough quality, block reward is claimed
                 if verification::is_within_solution_range(&pre_digest.solution, solution_range) {
-                    info!(target: "subspace", "Claimed block at slot {slot}");
+                    info!(target: "subspace", "🚜 Claimed block at slot {slot}");
 
                     return Some(pre_digest);
-                } else {
-                    info!(target: "subspace", "Claimed vote at slot {slot}");
+                } else if !parent_header.number().is_zero() {
+                    // Not sending vote on top of genesis bloc since root blocks since piece
+                    // verification wouldn't be possible due to empty records root
+                    info!(target: "subspace", "🗳️ Claimed vote at slot {slot}");
 
                     self.create_vote(pre_digest, parent_header, &parent_block_id)
                         .await;

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use futures::StreamExt;
 use futures::TryFutureExt;
-use log::{debug, warn};
+use log::{debug, error, info, warn};
 use sc_consensus::block_import::{BlockImport, BlockImportParams, StateAction};
 use sc_consensus::{JustificationSyncLink, StorageChanges};
 use sc_consensus_slots::{
@@ -36,12 +36,12 @@ use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata};
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SyncOracle};
 use sp_consensus_slots::Slot;
 use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest};
-use sp_consensus_subspace::{FarmerPublicKey, SubspaceApi};
+use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature, SubspaceApi};
 use sp_core::crypto::ByteArray;
 use sp_core::H256;
 use sp_runtime::generic::BlockId;
-use sp_runtime::traits::{AppVerify, Block as BlockT, Header, Zero};
-use sp_runtime::DigestItem;
+use sp_runtime::traits::{AppVerify, Block as BlockT, Header, One, Saturating, Zero};
+use sp_runtime::{Digest, DigestItem};
 use std::future::Future;
 use std::{pin::Pin, sync::Arc};
 use subspace_core_primitives::{Randomness, Salt};
@@ -120,8 +120,8 @@ where
 
         let global_randomness =
             extract_global_randomness_for_block(self.client.as_ref(), &parent_block_id).ok()?;
-        let solution_range =
-            extract_solution_range_for_block(self.client.as_ref(), &parent_block_id).ok()?;
+        let (solution_range, voting_solution_range) =
+            extract_solution_ranges_for_block(self.client.as_ref(), &parent_block_id).ok()?;
         let (salt, next_salt) =
             extract_salt_for_block(self.client.as_ref(), &parent_block_id).ok()?;
 
@@ -130,7 +130,7 @@ where
             global_challenge: subspace_solving::derive_global_challenge(&global_randomness, slot),
             salt,
             next_salt,
-            solution_range,
+            solution_range: voting_solution_range,
         };
         let (solution_sender, mut solution_receiver) =
             tracing_unbounded("subspace_slot_solution_stream");
@@ -201,12 +201,12 @@ where
                 }
             };
 
-            match verification::verify_solution::<B::Header>(
+            let solution_verification_result = verification::verify_solution::<B::Header>(
                 &solution,
                 slot,
                 verification::VerifySolutionParams {
                     global_randomness: &global_randomness,
-                    solution_range,
+                    solution_range: voting_solution_range,
                     salt,
                     piece_check_params: Some(PieceCheckParams {
                         records_root,
@@ -217,14 +217,23 @@ where
                     }),
                     signing_context: &self.signing_context,
                 },
-            ) {
-                Ok(_) => {
-                    debug!(target: "subspace", "Claimed slot {}", slot);
+            );
 
-                    return Some(PreDigest { solution, slot });
-                }
-                Err(error) => {
-                    warn!(target: "subspace", "Invalid solution received for slot {}: {:?}", slot, error);
+            if let Err(error) = solution_verification_result {
+                warn!(target: "subspace", "Invalid solution received for slot {slot}: {error:?}");
+            } else {
+                let pre_digest = PreDigest { solution, slot };
+
+                // If solution is of high enough quality, block reward is claimed
+                if verification::is_within_solution_range(&pre_digest.solution, solution_range) {
+                    info!(target: "subspace", "Claimed block at slot {slot}");
+
+                    return Some(pre_digest);
+                } else {
+                    info!(target: "subspace", "Claimed vote at slot {slot}");
+
+                    self.create_vote(pre_digest, parent_header, &parent_block_id)
+                        .await;
                 }
             }
         }
@@ -245,43 +254,22 @@ where
         pre_digest: Self::Claim,
         _epoch_data: Self::EpochData,
     ) -> Result<BlockImportParams<B, I::Transaction>, ConsensusError> {
-        let (signature_sender, mut signature_receiver) =
-            tracing_unbounded("subspace_signature_signing_stream");
+        let signature = self
+            .sign_pre_header(
+                H256::from_slice(header_hash.as_ref()),
+                &pre_digest.solution.public_key,
+            )
+            .await?;
 
-        // Sign the pre-sealed header of the block and then add it to a digest item.
-        self.subspace_link
-            .block_signing_notification_sender
-            .notify(|| BlockSigningNotification {
-                header_hash: H256::from_slice(header_hash.as_ref()),
-                public_key: pre_digest.solution.public_key.clone(),
-                signature_sender,
-            });
+        let digest_item = DigestItem::subspace_seal(signature);
 
-        while let Some(signature) = signature_receiver.next().await {
-            if !signature.verify(header_hash.as_ref(), &pre_digest.solution.public_key) {
-                warn!(
-                    target: "subspace",
-                    "Received invalid signature for block header {:?}",
-                    header_hash
-                );
-                continue;
-            }
+        let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+        import_block.post_digests.push(digest_item);
+        import_block.body = Some(body);
+        import_block.state_action =
+            StateAction::ApplyChanges(StorageChanges::Changes(storage_changes));
 
-            let digest_item = DigestItem::subspace_seal(signature);
-
-            let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
-            import_block.post_digests.push(digest_item);
-            import_block.body = Some(body);
-            import_block.state_action =
-                StateAction::ApplyChanges(StorageChanges::Changes(storage_changes));
-
-            return Ok(import_block);
-        }
-
-        Err(ConsensusError::CannotSign(
-            pre_digest.solution.public_key.to_raw_vec(),
-            "Farmer didn't sign header".to_string(),
-        ))
+        Ok(import_block)
     }
 
     fn force_authoring(&self) -> bool {
@@ -343,6 +331,108 @@ where
     }
 }
 
+impl<B, C, E, I, Error, SO, L, BS> SubspaceSlotWorker<B, C, E, I, SO, L, BS>
+where
+    B: BlockT,
+    C: ProvideRuntimeApi<B> + HeaderBackend<B> + HeaderMetadata<B, Error = ClientError> + 'static,
+    C::Api: SubspaceApi<B>,
+    E: Environment<B, Error = Error> + Send + Sync,
+    E::Proposer: Proposer<B, Error = Error, Transaction = TransactionFor<C, B>>,
+    I: BlockImport<B, Transaction = TransactionFor<C, B>> + Send + Sync + 'static,
+    SO: SyncOracle + Send + Sync + Clone,
+    L: JustificationSyncLink<B>,
+    BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync,
+    Error: std::error::Error + Send + From<ConsensusError> + From<I::Error> + 'static,
+{
+    async fn create_vote(
+        &self,
+        pre_digest: PreDigest<FarmerPublicKey>,
+        parent_header: &B::Header,
+        parent_block_id: &BlockId<B>,
+    ) {
+        let slot = pre_digest.slot;
+        let runtime_api = self.client.runtime_api();
+
+        if self.should_backoff(slot, parent_header) {
+            return;
+        }
+
+        // Vote doesn't have extrinsics or state, hence dummy values
+        let mut vote = B::Header::new(
+            parent_header.number().saturating_add(One::one()),
+            <B::Header as Header>::Hash::default(),
+            <B::Header as Header>::Hash::default(),
+            parent_header.hash(),
+            Digest {
+                logs: vec![DigestItem::subspace_pre_digest(&pre_digest)],
+            },
+        );
+
+        let signature = match self
+            .sign_pre_header(
+                H256::from_slice(vote.hash().as_ref()),
+                &pre_digest.solution.public_key,
+            )
+            .await
+        {
+            Ok(signature) => signature,
+            Err(error) => {
+                error!(
+                    target: "subspace",
+                    "Failed to submit vote at slot {slot}: {error:?}",
+                );
+                return;
+            }
+        };
+
+        vote.digest_mut()
+            .logs
+            .push(DigestItem::subspace_seal(signature));
+
+        if let Err(error) = runtime_api.submit_vote_extrinsic(parent_block_id, vote) {
+            error!(
+                target: "subspace",
+                "Failed to submit vote at slot {slot}: {error:?}",
+            );
+        }
+    }
+
+    async fn sign_pre_header(
+        &self,
+        header_hash: H256,
+        public_key: &FarmerPublicKey,
+    ) -> Result<FarmerSignature, ConsensusError> {
+        let (signature_sender, mut signature_receiver) =
+            tracing_unbounded("subspace_signature_signing_stream");
+
+        // Sign the pre-sealed header of the block and then add it to a digest item.
+        self.subspace_link
+            .block_signing_notification_sender
+            .notify(|| BlockSigningNotification {
+                header_hash,
+                public_key: public_key.clone(),
+                signature_sender,
+            });
+
+        while let Some(signature) = signature_receiver.next().await {
+            if !signature.verify(header_hash.as_ref(), public_key) {
+                warn!(
+                    target: "subspace",
+                    "Received invalid signature for pre-header {header_hash:?}"
+                );
+                continue;
+            }
+
+            return Ok(signature);
+        }
+
+        Err(ConsensusError::CannotSign(
+            public_key.to_raw_vec(),
+            "Farmer didn't sign header".to_string(),
+        ))
+    }
+}
+
 /// Extract global randomness for block, given ID of the parent block.
 pub(crate) fn extract_global_randomness_for_block<Block, Client>(
     client: &Client,
@@ -359,11 +449,11 @@ where
         .map(|randomnesses| randomnesses.next.unwrap_or(randomnesses.current))
 }
 
-/// Extract solution range for block, given ID of the parent block.
-pub(crate) fn extract_solution_range_for_block<Block, Client>(
+/// Extract solution ranges for block and votes, given ID of the parent block.
+pub(crate) fn extract_solution_ranges_for_block<Block, Client>(
     client: &Client,
     parent_block_id: &BlockId<Block>,
-) -> Result<u64, ApiError>
+) -> Result<(u64, u64), ApiError>
 where
     Block: BlockT,
     Client: ProvideRuntimeApi<Block>,
@@ -372,7 +462,14 @@ where
     client
         .runtime_api()
         .solution_ranges(parent_block_id)
-        .map(|solution_ranges| solution_ranges.next.unwrap_or(solution_ranges.current))
+        .map(|solution_ranges| {
+            (
+                solution_ranges.next.unwrap_or(solution_ranges.current),
+                solution_ranges
+                    .voting_next
+                    .unwrap_or(solution_ranges.voting_current),
+            )
+        })
 }
 
 /// Extract salt and next salt for block, given ID of the parent block.

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -17,8 +17,8 @@
 
 use crate::verification::PieceCheckParams;
 use crate::{
-    find_pre_digest, subspace_err, verification, NewSlotInfo, NewSlotNotification,
-    RewardSigningNotification, SubspaceLink,
+    find_pre_digest, verification, NewSlotInfo, NewSlotNotification, RewardSigningNotification,
+    SubspaceLink,
 };
 use futures::StreamExt;
 use futures::TryFutureExt;
@@ -286,10 +286,7 @@ where
 
     fn should_backoff(&self, slot: Slot, chain_head: &Block::Header) -> bool {
         if let Some(ref strategy) = self.backoff_authoring_blocks {
-            if let Ok(chain_head_slot) = find_pre_digest(chain_head)
-                .map(|digest| digest.slot)
-                .map_err(subspace_err)
-            {
+            if let Ok(chain_head_slot) = find_pre_digest(chain_head).map(|digest| digest.slot) {
                 return strategy.should_backoff(
                     *chain_head.number(),
                     chain_head_slot,
@@ -323,10 +320,7 @@ where
     }
 
     fn proposing_remaining_duration(&self, slot_info: &SlotInfo<Block>) -> std::time::Duration {
-        let parent_slot = find_pre_digest(&slot_info.chain_head)
-            .map_err(subspace_err)
-            .ok()
-            .map(|d| d.slot);
+        let parent_slot = find_pre_digest(&slot_info.chain_head).ok().map(|d| d.slot);
 
         sc_consensus_slots::proposing_remaining_duration(
             parent_slot,

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -135,7 +135,8 @@ where
             global_challenge: subspace_solving::derive_global_challenge(&global_randomness, slot),
             salt,
             next_salt,
-            solution_range: voting_solution_range,
+            solution_range,
+            voting_solution_range,
         };
         let (solution_sender, mut solution_receiver) =
             tracing_unbounded("subspace_slot_solution_stream");

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -132,7 +132,10 @@ where
 
         let new_slot_info = NewSlotInfo {
             slot,
-            global_challenge: subspace_solving::derive_global_challenge(&global_randomness, slot),
+            global_challenge: subspace_solving::derive_global_challenge(
+                &global_randomness,
+                slot.into(),
+            ),
             salt,
             next_salt,
             solution_range,

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -570,7 +570,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
         let mut new_slot_notification_stream = data.link.new_slot_notification_stream().subscribe();
         let subspace_farmer = async move {
             let keypair = Keypair::generate();
-            let subspace_codec = SubspaceCodec::new(&keypair.public);
+            let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
             let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
             let (piece_index, mut encoding) = archived_pieces_receiver
                 .await

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -69,7 +69,7 @@ use std::{cell::RefCell, task::Poll, time::Duration};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{FlatPieces, LocalChallenge, Piece, Signature, Solution, Tag};
-use subspace_solving::{SubspaceCodec, SOLUTION_SIGNING_CONTEXT};
+use subspace_solving::{SubspaceCodec, REWARD_SIGNING_CONTEXT, SOLUTION_SIGNING_CONTEXT};
 use substrate_test_runtime::{Block as TestBlock, Hash};
 
 type TestClient = substrate_test_runtime_client::client::Client<
@@ -404,7 +404,12 @@ impl TestNetFactory for SubspaceTestNet {
                     Slot::from_timestamp(*timestamp, SlotDuration::from_millis(6000))
                 }),
                 telemetry: None,
-                signing_context: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
+                solution_signing_context: schnorrkel::context::signing_context(
+                    SOLUTION_SIGNING_CONTEXT,
+                ),
+                reward_signing_context: schnorrkel::context::signing_context(
+                    REWARD_SIGNING_CONTEXT,
+                ),
                 block: PhantomData::default(),
             },
             mutator: MUTATOR.with(|m| m.borrow().clone()),

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -698,7 +698,9 @@ fn sig_is_not_pre_digest() {
 }
 
 /// Claims the given slot number. always returning a dummy block.
-pub fn dummy_claim_slot(slot: Slot) -> Option<(PreDigest<FarmerPublicKey>, FarmerPublicKey)> {
+pub fn dummy_claim_slot(
+    slot: Slot,
+) -> Option<(PreDigest<FarmerPublicKey, FarmerPublicKey>, FarmerPublicKey)> {
     Some((
         PreDigest {
             solution: Solution {

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -570,7 +570,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
         let mut new_slot_notification_stream = data.link.new_slot_notification_stream().subscribe();
         let subspace_farmer = async move {
             let keypair = Keypair::generate();
-            let subspace_solving = SubspaceCodec::new(&keypair.public);
+            let subspace_codec = SubspaceCodec::new(&keypair.public);
             let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
             let (piece_index, mut encoding) = archived_pieces_receiver
                 .await
@@ -581,7 +581,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
                 .choose(&mut rand::thread_rng())
                 .map(|(piece_index, piece)| (piece_index as u64, Piece::try_from(piece).unwrap()))
                 .unwrap();
-            subspace_solving.encode(&mut encoding, piece_index).unwrap();
+            subspace_codec.encode(&mut encoding, piece_index).unwrap();
 
             while let Some(NewSlotNotification {
                 new_slot_info,
@@ -598,7 +598,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
                                 keypair.public.to_bytes(),
                             ),
                             piece_index,
-                            encoding,
+                            encoding: encoding.clone(),
                             signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),
                             local_challenge: keypair
                                 .sign(ctx.bytes(&new_slot_info.global_challenge))

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -23,6 +23,7 @@ sp-consensus = { version = "0.10.0-dev", optional = true, git = "https://github.
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
+sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831" }
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "5d3e7c4ee9f5c8e370022d5f3fa9723185710831", default-features = false }
@@ -44,6 +45,7 @@ std = [
 	"sp-consensus-slots/std",
 	"sp-core/std",
 	"sp-inherents/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-timestamp/std",

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -16,7 +16,9 @@
 
 //! Private implementation details of Subspace consensus digests.
 
-use crate::{ConsensusLog, FarmerSignature, SubspaceBlockWeight, SUBSPACE_ENGINE_ID};
+use crate::{
+    ConsensusLog, FarmerPublicKey, FarmerSignature, SubspaceBlockWeight, SUBSPACE_ENGINE_ID,
+};
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
 use sp_runtime::generic::DigestItemRef;
@@ -26,14 +28,14 @@ use subspace_core_primitives::{Randomness, Salt, Solution};
 /// A Subspace pre-runtime digest. This contains all data required to validate a block and for the
 /// Subspace runtime module.
 #[derive(Clone, RuntimeDebug, Encode, Decode)]
-pub struct PreDigest<AccountId> {
+pub struct PreDigest<PublicKey, RewardAddress> {
     /// Slot
     pub slot: Slot,
     /// Solution (includes PoR)
-    pub solution: Solution<AccountId>,
+    pub solution: Solution<PublicKey, RewardAddress>,
 }
 
-impl<AccountId> PreDigest<AccountId> {
+impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
     /// Returns the weight _added_ by this digest, not the cumulative weight
     /// of the chain.
     pub fn added_weight(&self) -> SubspaceBlockWeight {
@@ -68,10 +70,14 @@ pub struct SaltDescriptor {
 /// A digest item which is usable with Subspace consensus.
 pub trait CompatibleDigestItem: Sized {
     /// Construct a digest item which contains a Subspace pre-digest.
-    fn subspace_pre_digest<AccountId: Encode>(pre_digest: &PreDigest<AccountId>) -> Self;
+    fn subspace_pre_digest<AccountId: Encode>(
+        pre_digest: &PreDigest<FarmerPublicKey, AccountId>,
+    ) -> Self;
 
     /// If this item is an Subspace pre-digest, return it.
-    fn as_subspace_pre_digest<AccountId: Decode>(&self) -> Option<PreDigest<AccountId>>;
+    fn as_subspace_pre_digest<AccountId: Decode>(
+        &self,
+    ) -> Option<PreDigest<FarmerPublicKey, AccountId>>;
 
     /// Construct a digest item which contains a Subspace seal.
     fn subspace_seal(signature: FarmerSignature) -> Self;
@@ -99,11 +105,15 @@ pub trait CompatibleDigestItem: Sized {
 }
 
 impl CompatibleDigestItem for DigestItem {
-    fn subspace_pre_digest<AccountId: Encode>(pre_digest: &PreDigest<AccountId>) -> Self {
+    fn subspace_pre_digest<RewardAddress: Encode>(
+        pre_digest: &PreDigest<FarmerPublicKey, RewardAddress>,
+    ) -> Self {
         Self::PreRuntime(SUBSPACE_ENGINE_ID, pre_digest.encode())
     }
 
-    fn as_subspace_pre_digest<AccountId: Decode>(&self) -> Option<PreDigest<AccountId>> {
+    fn as_subspace_pre_digest<RewardAddress: Decode>(
+        &self,
+    ) -> Option<PreDigest<FarmerPublicKey, RewardAddress>> {
         self.pre_runtime_try_to(&SUBSPACE_ENGINE_ID)
     }
 
@@ -169,14 +179,18 @@ impl CompatibleDigestItem for DigestItem {
 /// A digest item which is usable with Subspace consensus.
 pub trait CompatibleDigestItemRef: Sized {
     /// If this item is an Subspace pre-digest, return it.
-    fn as_subspace_pre_digest<AccountId: Decode>(&self) -> Option<PreDigest<AccountId>>;
+    fn as_subspace_pre_digest<RewardAddress: Decode>(
+        &self,
+    ) -> Option<PreDigest<FarmerPublicKey, RewardAddress>>;
 
     /// Construct a digest item which contains a Subspace seal.
     fn as_subspace_seal(&self) -> Option<FarmerSignature>;
 }
 
 impl CompatibleDigestItemRef for DigestItemRef<'_> {
-    fn as_subspace_pre_digest<AccountId: Decode>(&self) -> Option<PreDigest<AccountId>> {
+    fn as_subspace_pre_digest<RewardAddress: Decode>(
+        &self,
+    ) -> Option<PreDigest<FarmerPublicKey, RewardAddress>> {
         self.pre_runtime_try_to(&SUBSPACE_ENGINE_ID)
     }
 

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -21,12 +21,12 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
-use sp_runtime::{DigestItem, RuntimeDebug};
+use sp_runtime::DigestItem;
 use subspace_core_primitives::{Randomness, Salt, Solution};
 
 /// A Subspace pre-runtime digest. This contains all data required to validate a block and for the
 /// Subspace runtime module.
-#[derive(Clone, RuntimeDebug, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct PreDigest<PublicKey, RewardAddress> {
     /// Slot
     pub slot: Slot,
@@ -46,21 +46,21 @@ impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
 }
 
 /// Information about the global randomness for the block.
-#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, PartialEq, Eq, Clone)]
 pub struct GlobalRandomnessDescriptor {
     /// Global randomness used for deriving global slot challenges.
     pub global_randomness: Randomness,
 }
 
 /// Information about the solution range for the block.
-#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, PartialEq, Eq, Clone)]
 pub struct SolutionRangeDescriptor {
     /// Solution range used for challenges.
     pub solution_range: u64,
 }
 
 /// Salt for the block.
-#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, PartialEq, Eq, Clone)]
 pub struct SaltDescriptor {
     /// Salt used with challenges.
     pub salt: Salt,

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
-use sp_runtime::generic::DigestItemRef;
 use sp_runtime::{DigestItem, RuntimeDebug};
 use subspace_core_primitives::{Randomness, Salt, Solution};
 
@@ -173,28 +172,5 @@ impl CompatibleDigestItem for DigestItem {
                 None
             }
         })
-    }
-}
-
-/// A digest item which is usable with Subspace consensus.
-pub trait CompatibleDigestItemRef: Sized {
-    /// If this item is an Subspace pre-digest, return it.
-    fn as_subspace_pre_digest<RewardAddress: Decode>(
-        &self,
-    ) -> Option<PreDigest<FarmerPublicKey, RewardAddress>>;
-
-    /// Construct a digest item which contains a Subspace seal.
-    fn as_subspace_seal(&self) -> Option<FarmerSignature>;
-}
-
-impl CompatibleDigestItemRef for DigestItemRef<'_> {
-    fn as_subspace_pre_digest<RewardAddress: Decode>(
-        &self,
-    ) -> Option<PreDigest<FarmerPublicKey, RewardAddress>> {
-        self.pre_runtime_try_to(&SUBSPACE_ENGINE_ID)
-    }
-
-    fn as_subspace_seal(&self) -> Option<FarmerSignature> {
-        self.seal_try_to(&SUBSPACE_ENGINE_ID)
     }
 }

--- a/crates/sp-consensus-subspace/src/inherents.rs
+++ b/crates/sp-consensus-subspace/src/inherents.rs
@@ -19,7 +19,6 @@
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
 use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
-use sp_runtime::RuntimeDebug;
 use sp_std::result::Result;
 use sp_std::vec::Vec;
 use subspace_core_primitives::RootBlock;
@@ -28,7 +27,7 @@ use subspace_core_primitives::RootBlock;
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"subspace";
 
 /// Errors that can occur while checking root blocks.
-#[derive(Encode, RuntimeDebug)]
+#[derive(Debug, Encode)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub enum InherentError {
     /// List of root blocks is not correct.
@@ -44,7 +43,7 @@ impl IsFatalError for InherentError {
 }
 
 /// The type of the Subspace inherent data.
-#[derive(Encode, Decode, RuntimeDebug)]
+#[derive(Debug, Encode, Decode)]
 pub struct InherentType {
     /// Slot at which block was created.
     pub slot: Slot,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -36,7 +36,7 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::KeyTypeId;
 use sp_core::H256;
 use sp_io::hashing;
-use sp_runtime::{ConsensusEngineId, RuntimeAppPublic, RuntimeDebug};
+use sp_runtime::{ConsensusEngineId, RuntimeAppPublic};
 use sp_std::vec::Vec;
 use subspace_core_primitives::{Randomness, RootBlock, Salt, Sha256Hash, Solution};
 
@@ -71,7 +71,7 @@ pub type EquivocationProof<Header> = sp_consensus_slots::EquivocationProof<Heade
 pub type SubspaceBlockWeight = u128;
 
 /// An consensus log item for Subspace.
-#[derive(Decode, Encode, Clone, PartialEq, Eq, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, Clone, PartialEq, Eq)]
 enum ConsensusLog {
     /// Global randomness for this block/interval.
     #[codec(index = 1)]
@@ -85,7 +85,7 @@ enum ConsensusLog {
 }
 
 /// Farmer vote.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, TypeInfo, RuntimeDebug)]
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, TypeInfo)]
 pub enum Vote<Number, Hash, RewardAddress> {
     /// V0 of the farmer vote.
     V0 {
@@ -121,7 +121,7 @@ where
 }
 
 /// Signed farmer vote.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, TypeInfo, RuntimeDebug)]
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, TypeInfo)]
 pub struct SignedVote<Number, Hash, RewardAddress> {
     /// Farmer vote.
     pub vote: Vote<Number, Hash, RewardAddress>,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -238,6 +238,10 @@ sp_api::decl_runtime_apis! {
             equivocation_proof: EquivocationProof<Block::Header>,
         ) -> Option<()>;
 
+        /// Submit farmer vote vote that is essentially a header with bigger solution range than
+        /// acceptable for block authoring. Only useful in an offchain context.
+        fn submit_vote_extrinsic(vote: Block::Header);
+
         /// Check if `farmer_public_key` is in block list (due to equivocation)
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool;
 

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -171,6 +171,10 @@ pub struct SolutionRanges {
     pub current: u64,
     /// Solution range that will be used in the next block/era.
     pub next: Option<u64>,
+    /// Voting solution range in current block/era.
+    pub voting_current: u64,
+    /// Voting solution range that will be used in the next block/era.
+    pub voting_next: Option<u64>,
 }
 
 impl Default for SolutionRanges {
@@ -178,6 +182,8 @@ impl Default for SolutionRanges {
         Self {
             current: u64::MAX,
             next: None,
+            voting_current: u64::MAX,
+            voting_next: None,
         }
     }
 }

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -31,9 +31,7 @@ use crate::digests::{
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::time::Duration;
 use scale_info::TypeInfo;
-use schnorrkel::{PublicKey, Signature};
 use sp_api::{BlockT, HeaderT};
-use sp_application_crypto::ByteArray;
 use sp_consensus_slots::Slot;
 use sp_core::crypto::KeyTypeId;
 use sp_core::H256;
@@ -41,7 +39,6 @@ use sp_io::hashing;
 use sp_runtime::{ConsensusEngineId, RuntimeAppPublic, RuntimeDebug};
 use sp_std::vec::Vec;
 use subspace_core_primitives::{Randomness, RootBlock, Salt, Sha256Hash, Solution};
-use subspace_solving::REWARD_SIGNING_CONTEXT;
 
 /// Key type for Subspace pallet.
 const KEY_TYPE: KeyTypeId = KeyTypeId(*b"sub_");
@@ -130,26 +127,6 @@ pub struct SignedVote<Number, Hash, RewardAddress> {
     pub vote: Vote<Number, Hash, RewardAddress>,
     /// Signature.
     pub signature: FarmerSignature,
-}
-
-impl<Number, Hash, RewardAddress> SignedVote<Number, Hash, RewardAddress>
-where
-    Number: Encode,
-    Hash: Encode,
-    RewardAddress: Encode,
-{
-    /// Whether vote signature is valid
-    pub fn is_valid(&self) -> bool {
-        let ctx = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
-        PublicKey::from_bytes(self.vote.public_key().as_slice())
-            .expect("Public key always uses the same crypto; qed")
-            .verify(
-                ctx.bytes(&self.vote.encode()),
-                &Signature::from_bytes(&self.signature)
-                    .expect("Signature always uses the same crypto; qed"),
-            )
-            .is_ok()
-    }
 }
 
 fn find_pre_digest<Header, RewardAddress>(

--- a/crates/sp-consensus-subspace/src/offence.rs
+++ b/crates/sp-consensus-subspace/src/offence.rs
@@ -65,7 +65,7 @@ pub trait Offence<Offender> {
 }
 
 /// Errors that may happen on offence reports.
-#[derive(PartialEq, sp_runtime::RuntimeDebug)]
+#[derive(Debug, PartialEq)]
 pub enum OffenceError {
     /// The report has already been submitted.
     DuplicateReport,
@@ -114,7 +114,7 @@ impl<Offender> OnOffenceHandler<Offender> for () {
 }
 
 /// A details about an offending authority for a particular kind of offence.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, sp_runtime::RuntimeDebug, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct OffenceDetails<Offender> {
     /// The offending authority id
     pub offender: Offender,

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -32,7 +32,7 @@ use subspace_solving::{
 };
 
 /// Errors encountered by the Subspace authorship task.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum VerificationError<Header: HeaderT> {
     /// No Subspace pre-runtime digest found

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -225,7 +225,7 @@ where
 }
 
 /// Returns true if `solution.tag` is within the solution range.
-fn is_within_solution_range(solution: &Solution<FarmerPublicKey>, solution_range: u64) -> bool {
+pub fn is_within_solution_range(solution: &Solution<FarmerPublicKey>, solution_range: u64) -> bool {
     let solution_tag = u64::from_be_bytes(solution.tag);
     let target = u64::from_be_bytes(solution.local_challenge.derive_target());
 

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -227,7 +227,7 @@ pub fn check_piece<Header>(
 where
     Header: HeaderT,
 {
-    let mut piece = solution.encoding;
+    let mut piece = solution.encoding.clone();
 
     // Ensure piece is decodable.
     let subspace_codec = SubspaceCodec::new(&solution.public_key);

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -239,7 +239,7 @@ where
     let mut piece = solution.encoding.clone();
 
     // Ensure piece is decodable.
-    let subspace_codec = SubspaceCodec::new(&solution.public_key);
+    let subspace_codec = SubspaceCodec::new(solution.public_key.as_ref());
     subspace_codec
         .decode(&mut piece, solution.piece_index)
         .map_err(|_| VerificationError::InvalidEncoding(slot))?;
@@ -280,7 +280,7 @@ fn is_within_max_plot(
         return true;
     }
     let max_distance_one_direction = PieceDistance::MAX / total_pieces * max_plot_size / 2;
-    PieceDistance::distance(&piece_index.into(), key) <= max_distance_one_direction
+    PieceDistance::distance(&piece_index.into(), key.as_ref()) <= max_distance_one_direction
 }
 
 /// Parameters for checking piece validity
@@ -331,9 +331,9 @@ where
     } = params;
 
     if let Err(error) = is_local_challenge_valid(
-        derive_global_challenge(global_randomness, slot),
+        derive_global_challenge(global_randomness, slot.into()),
         &solution.local_challenge,
-        &solution.public_key,
+        solution.public_key.as_ref(),
     ) {
         return Err(VerificationError::BadLocalChallenge(slot, error));
     }

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -411,6 +411,7 @@ sp_api::decl_runtime_apis! {
 
 // TODO: remove once the fraud proof verification is moved into the client.
 pub mod fraud_proof_ext {
+    #[cfg(feature = "std")]
     use sp_externalities::ExternalitiesExt;
     use sp_runtime_interface::runtime_interface;
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -23,7 +23,7 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::KeyTypeId;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT, NumberFor};
-use sp_runtime::{OpaqueExtrinsic, RuntimeDebug};
+use sp_runtime::OpaqueExtrinsic;
 use sp_runtime_interface::pass_by::PassBy;
 use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
@@ -60,7 +60,7 @@ impl sp_runtime::BoundToRuntimeAppPublic for ExecutorKey {
 }
 
 /// Header of transaction bundle.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct BundleHeader {
     /// The hash of primary block at which the bundle was created.
     pub primary_hash: PHash,
@@ -78,7 +78,7 @@ impl BundleHeader {
 }
 
 /// Transaction bundle
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct Bundle<Extrinsic> {
     /// The bundle header.
     pub header: BundleHeader,
@@ -94,7 +94,7 @@ impl<Extrinsic> Bundle<Extrinsic> {
 }
 
 /// Signed version of [`Bundle`].
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SignedBundle<Extrinsic> {
     /// The bundle header.
     pub bundle: Bundle<Extrinsic>,
@@ -105,7 +105,7 @@ pub struct SignedBundle<Extrinsic> {
 }
 
 /// Bundle with opaque extrinsics.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct OpaqueBundle {
     /// The bundle header.
     pub header: BundleHeader,
@@ -138,7 +138,7 @@ impl<Extrinsic: Encode> From<Bundle<Extrinsic>> for OpaqueBundle {
 }
 
 /// Signed version of [`OpaqueBundle`].
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SignedOpaqueBundle {
     /// The bundle header.
     pub opaque_bundle: OpaqueBundle,
@@ -172,7 +172,7 @@ impl<Extrinsic: Encode> From<SignedBundle<Extrinsic>> for SignedOpaqueBundle {
 }
 
 /// Receipt of state execution.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct ExecutionReceipt<Number, Hash, SecondaryHash> {
     /// Primary block number.
     pub primary_number: Number,
@@ -196,7 +196,7 @@ impl<Number: Encode, Hash: Encode, SecondaryHash: Encode>
 }
 
 /// Signed version of [`ExecutionReceipt`] which will be gossiped over the executors network.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SignedExecutionReceipt<Number, Hash, SecondaryHash> {
     /// Execution receipt
     pub execution_receipt: ExecutionReceipt<Number, Hash, SecondaryHash>,
@@ -218,7 +218,7 @@ impl<Number: Encode, Hash: Encode, SecondaryHash: Encode>
 /// Execution phase along with an optional encoded call data.
 ///
 /// Each execution phase has a different method for the runtime call.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub enum ExecutionPhase {
     /// Executes the `initialize_block` hook.
     InitializeBlock { call_data: Vec<u8> },
@@ -284,7 +284,7 @@ impl ExecutionPhase {
 }
 
 /// Error type of fraud proof verification on primary node.
-#[derive(RuntimeDebug)]
+#[derive(Debug)]
 pub enum VerificationError {
     /// Failed to pass the execution proof check.
     BadProof(sp_std::boxed::Box<dyn sp_state_machine::Error>),
@@ -299,7 +299,7 @@ pub enum VerificationError {
 }
 
 /// Fraud proof for the state computation.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct FraudProof {
     /// Parent number.
     pub parent_number: BlockNumber,

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -269,11 +269,11 @@ impl Archiver {
     /// Create a new instance of the archiver with initial state in case of restart.
     ///
     /// `block` corresponds to `last_archived_block` and will be processed accordingly to its state.
-    pub fn with_initial_state<B: AsRef<[u8]>>(
+    pub fn with_initial_state(
         record_size: usize,
         segment_size: usize,
         root_block: RootBlock,
-        encoded_block: B,
+        encoded_block: &[u8],
         mut object_mapping: BlockObjectMapping,
     ) -> Result<Self, ArchiverInstantiationError> {
         let mut archiver = Self::new(record_size, segment_size)?;
@@ -288,7 +288,6 @@ impl Archiver {
             .push_back(SegmentItem::RootBlock(root_block));
 
         if let Some(archived_block_bytes) = archiver.last_archived_block.partial_archived() {
-            let encoded_block = encoded_block.as_ref();
             let encoded_block_bytes = u32::try_from(encoded_block.len())
                 .expect("Blocks length is never bigger than u32; qed");
 
@@ -720,7 +719,7 @@ pub fn is_piece_valid(piece: &[u8], root: Sha256Hash, position: usize, record_si
             return false;
         }
     };
-    let leaf_hash = crypto::sha256_hash(&record);
+    let leaf_hash = crypto::sha256_hash(record);
 
     witness.is_valid(root, position, leaf_hash)
 }

--- a/crates/subspace-archiving/src/merkle_tree.rs
+++ b/crates/subspace-archiving/src/merkle_tree.rs
@@ -90,7 +90,7 @@ impl<'a> Witness<'a> {
 
         // Hash one more time as Merkle Tree implementation does
         // Merkle Tree leaf hash prefix is `0x00`
-        let leaf_hash = crypto::sha256_hash_pair(&[0x00], leaf_hash);
+        let leaf_hash = crypto::sha256_hash_pair(&[0x00], &leaf_hash);
 
         // Reconstruct lemma for verification
         let lemma = iter::once(leaf_hash)
@@ -174,7 +174,10 @@ impl MerkleTree {
         T: AsRef<[u8]>,
         I: IntoIterator<Item = T>,
     {
-        Self::new(data.into_iter().map(crypto::sha256_hash))
+        Self::new(
+            data.into_iter()
+                .map(|item| crypto::sha256_hash(item.as_ref())),
+        )
     }
 
     /// Get Merkle Root

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -159,7 +159,7 @@ fn archiver() {
             RECORD_SIZE,
             SEGMENT_SIZE,
             first_archived_segment.root_block,
-            block_1.clone(),
+            &block_1,
             block_1_object_mapping.clone(),
         )
         .unwrap();
@@ -248,7 +248,7 @@ fn archiver() {
             RECORD_SIZE,
             SEGMENT_SIZE,
             last_root_block,
-            block_2,
+            &block_2,
             BlockObjectMapping::default(),
         )
         .unwrap();
@@ -316,7 +316,7 @@ fn invalid_usage() {
                     archived_progress: ArchivedBlockProgress::Partial(10),
                 },
             },
-            &vec![0u8; 10],
+            &[0u8; 10],
             BlockObjectMapping::default(),
         );
 
@@ -343,7 +343,7 @@ fn invalid_usage() {
                     archived_progress: ArchivedBlockProgress::Partial(10),
                 },
             },
-            &vec![0u8; 6],
+            &[0u8; 6],
             BlockObjectMapping::default(),
         );
 

--- a/crates/subspace-archiving/tests/integration/merkle_tree.rs
+++ b/crates/subspace-archiving/tests/integration/merkle_tree.rs
@@ -8,7 +8,10 @@ fn merkle_tree() {
     let pieces: Vec<Piece> = iter::repeat_with(|| rand::random::<[u8; PIECE_SIZE]>().into())
         .take(number_of_pieces)
         .collect();
-    let hashes: Vec<Sha256Hash> = pieces.iter().map(crypto::sha256_hash).collect();
+    let hashes: Vec<Sha256Hash> = pieces
+        .iter()
+        .map(|item| crypto::sha256_hash(item.as_ref()))
+        .collect();
 
     let merkle_tree_data = MerkleTree::from_data(&pieces);
     let merkle_tree_hashes = MerkleTree::new(hashes.iter().copied());

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -22,7 +22,7 @@ fn flat_pieces_to_regular(pieces: &FlatPieces) -> Vec<Piece> {
 }
 
 fn pieces_to_option_of_pieces(pieces: &[Piece]) -> Vec<Option<Piece>> {
-    pieces.iter().copied().map(Some).collect()
+    pieces.iter().cloned().map(Some).collect()
 }
 
 #[test]
@@ -250,7 +250,7 @@ fn partial_data() {
                 &pieces
                     .iter()
                     .take(MERKLE_NUM_LEAVES / 2)
-                    .copied()
+                    .cloned()
                     .map(Some)
                     .chain(iter::repeat(None).take(MERKLE_NUM_LEAVES / 2))
                     .collect::<Vec<_>>(),
@@ -267,7 +267,7 @@ fn partial_data() {
             .add_segment(
                 &iter::repeat(None)
                     .take(MERKLE_NUM_LEAVES / 2)
-                    .chain(pieces.iter().skip(MERKLE_NUM_LEAVES / 2).copied().map(Some))
+                    .chain(pieces.iter().skip(MERKLE_NUM_LEAVES / 2).cloned().map(Some))
                     .collect::<Vec<_>>(),
             )
             .unwrap();
@@ -330,7 +330,7 @@ fn invalid_usage() {
                 &flat_pieces_to_regular(&archived_segments[0].pieces)
                     .iter()
                     .take(MERKLE_NUM_LEAVES / 2 - 1)
-                    .copied()
+                    .cloned()
                     .map(Some)
                     .chain(iter::repeat(None).take(MERKLE_NUM_LEAVES / 2 + 1))
                     .collect::<Vec<_>>(),

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -20,9 +20,9 @@ use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
 /// Simple Sha2-256 hashing.
-pub fn sha256_hash<D: AsRef<[u8]>>(data: D) -> Sha256Hash {
+pub fn sha256_hash(data: &[u8]) -> Sha256Hash {
     let mut hasher = Sha256::new();
-    hasher.update(data.as_ref());
+    hasher.update(data);
     hasher
         .finalize()
         .as_slice()
@@ -31,10 +31,10 @@ pub fn sha256_hash<D: AsRef<[u8]>>(data: D) -> Sha256Hash {
 }
 
 /// Simple Sha2-256 hashing of a pair of values.
-pub fn sha256_hash_pair(a: impl AsRef<[u8]>, b: impl AsRef<[u8]>) -> Sha256Hash {
+pub fn sha256_hash_pair(a: &[u8], b: &[u8]) -> Sha256Hash {
     let mut hasher = Sha256::new();
-    hasher.update(a.as_ref());
-    hasher.update(b.as_ref());
+    hasher.update(a);
+    hasher.update(b);
     hasher
         .finalize()
         .as_slice()
@@ -43,10 +43,10 @@ pub fn sha256_hash_pair(a: impl AsRef<[u8]>, b: impl AsRef<[u8]>) -> Sha256Hash 
 }
 
 /// Hmac with Sha2-256 hash function.
-pub fn hmac_sha256<K: AsRef<[u8]>, P: AsRef<[u8]>>(key: K, piece: P) -> Sha256Hash {
-    let mut mac = Hmac::<Sha256>::new_from_slice(key.as_ref())
-        .expect("Sha256 HMAC can take key of any size; qed");
-    mac.update(piece.as_ref());
+pub fn hmac_sha256(key: &[u8], piece: &[u8]) -> Sha256Hash {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(key).expect("Sha256 HMAC can take key of any size; qed");
+    mac.update(piece);
 
     // `result` has type `Output` which is a thin wrapper around array of
     // bytes for providing constant time equality check

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -198,24 +198,23 @@ impl LocalChallenge {
 /// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
 /// the segment this piece belongs to can be used to verify that a piece belongs to the actual
 /// archival history of the blockchain.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct Piece(#[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; PIECE_SIZE]);
+pub struct Piece(Vec<u8>);
 
 impl Default for Piece {
     fn default() -> Self {
-        Self([0u8; PIECE_SIZE])
+        Self(vec![0u8; PIECE_SIZE])
     }
 }
 
 impl From<[u8; PIECE_SIZE]> for Piece {
     fn from(inner: [u8; PIECE_SIZE]) -> Self {
-        Self(inner)
+        Self(inner.to_vec())
     }
 }
 
-impl From<Piece> for [u8; PIECE_SIZE] {
+impl From<Piece> for Vec<u8> {
     fn from(piece: Piece) -> Self {
         piece.0
     }
@@ -224,10 +223,11 @@ impl From<Piece> for [u8; PIECE_SIZE] {
 impl TryFrom<&[u8]> for Piece {
     type Error = &'static str;
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        slice
-            .try_into()
-            .map(Self)
-            .map_err(|_| "Wrong piece size, expected: 4096")
+        if slice.len() != PIECE_SIZE {
+            Err("Wrong piece size, expected: 4096")
+        } else {
+            Ok(Self(slice.to_vec()))
+        }
     }
 }
 
@@ -259,7 +259,6 @@ impl AsMut<[u8]> for Piece {
 /// Flat representation of multiple pieces concatenated for higher efficient for processing.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct FlatPieces(Vec<u8>);
 
 impl FlatPieces {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -209,8 +209,8 @@ impl Default for Piece {
 }
 
 impl From<[u8; PIECE_SIZE]> for Piece {
-    fn from(inner: [u8; PIECE_SIZE]) -> Self {
-        Self(inner.to_vec())
+    fn from(piece: [u8; PIECE_SIZE]) -> Self {
+        Self(piece.to_vec())
     }
 }
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -477,7 +477,7 @@ impl PieceIndexHash {
 }
 
 /// Farmer solution for slot challenge.
-#[derive(Clone, Debug, Encode, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct Solution<AccountId> {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_farmer::{RpcClient, RpcClientError as MockError};
 use subspace_rpc_primitives::{
-    BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -83,15 +83,15 @@ impl RpcClient for BenchRpcClient {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }
 
-    async fn subscribe_block_signing(
+    async fn subscribe_reward_signing(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = BlockSigningInfo> + Send + 'static>>, MockError> {
+    ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, MockError> {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }
 
-    async fn submit_block_signature(
+    async fn submit_reward_signature(
         &self,
-        _block_signature: BlockSignature,
+        _reward_signature: RewardSignature,
     ) -> Result<(), MockError> {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -202,14 +202,14 @@ async fn subscribe_to_slot_info<T: RpcClient>(
                         {
                             Ok(_) => {
                                 info!(
-                                    "Successfully signed block 0x{} and sent signature to node",
+                                    "Successfully signed pre-header hash 0x{} and sent to node",
                                     hex::encode(header_hash)
                                 );
                             }
                             Err(error) => {
                                 warn!(
                                     %error,
-                                    "Failed to send signature for block 0x{}",
+                                    "Failed to send signature for pre-header hash 0x{}",
                                     hex::encode(header_hash),
                                 );
                             }

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -104,6 +104,7 @@ async fn farming_happy_path() {
         salt: [1, 1, 1, 1, 1, 1, 1, 1],
         next_salt: Some([1, 1, 1, 1, 1, 1, 1, 2]),
         solution_range: u64::MAX,
+        voting_solution_range: u64::MAX,
     };
     let slots = vec![slot_info];
 
@@ -121,6 +122,7 @@ async fn farming_salt_change() {
         salt: [1, 1, 1, 1, 1, 1, 1, 1],
         next_salt: Some([1, 1, 1, 1, 1, 1, 1, 2]),
         solution_range: u64::MAX,
+        voting_solution_range: u64::MAX,
     };
     let second_slot = SlotInfo {
         slot_number: 2,
@@ -128,6 +130,7 @@ async fn farming_salt_change() {
         salt: [1, 1, 1, 1, 1, 1, 1, 1],
         next_salt: Some([1, 1, 1, 1, 1, 1, 1, 2]),
         solution_range: u64::MAX,
+        voting_solution_range: u64::MAX,
     };
     let third_slot = SlotInfo {
         slot_number: 3,
@@ -135,6 +138,7 @@ async fn farming_salt_change() {
         salt: [1, 1, 1, 1, 1, 1, 1, 2],
         next_salt: Some([1, 1, 1, 1, 1, 1, 1, 2]),
         solution_range: u64::MAX,
+        voting_solution_range: u64::MAX,
     };
     let slots = vec![first_slot, second_slot, third_slot];
 

--- a/crates/subspace-farmer/src/identity.rs
+++ b/crates/subspace-farmer/src/identity.rs
@@ -4,12 +4,10 @@ use schnorrkel::{context::SigningContext, Keypair, PublicKey, SecretKey, Signatu
 use sp_core::sr25519::Pair;
 use std::fs;
 use std::path::Path;
-use subspace_solving::SOLUTION_SIGNING_CONTEXT;
+use subspace_solving::{REWARD_SIGNING_CONTEXT, SOLUTION_SIGNING_CONTEXT};
 use tracing::debug;
 use zeroize::{Zeroize, Zeroizing};
 
-/// Signing context hardcoded in Substrate implementation and used for signing blocks.
-const SUBSTRATE_SIGNING_CONTEXT: &[u8] = b"substrate";
 /// Entropy used for identity generation.
 const ENTROPY_LENGTH: usize = 32;
 
@@ -56,7 +54,7 @@ impl Identity {
                 keypair: Zeroizing::new(pair.into()),
                 entropy: Zeroizing::new(entropy),
                 farmer_solution_ctx: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
-                substrate_ctx: schnorrkel::context::signing_context(SUBSTRATE_SIGNING_CONTEXT),
+                substrate_ctx: schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT),
             }))
         } else {
             debug!("Existing keypair not found");
@@ -81,7 +79,7 @@ impl Identity {
             keypair: Zeroizing::new(pair.into()),
             entropy: Zeroizing::new(entropy),
             farmer_solution_ctx: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
-            substrate_ctx: schnorrkel::context::signing_context(SUBSTRATE_SIGNING_CONTEXT),
+            substrate_ctx: schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT),
         })
     }
 
@@ -107,7 +105,7 @@ impl Identity {
             keypair: Zeroizing::new(pair.into()),
             entropy: Zeroizing::new(entropy),
             farmer_solution_ctx: schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT),
-            substrate_ctx: schnorrkel::context::signing_context(SUBSTRATE_SIGNING_CONTEXT),
+            substrate_ctx: schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT),
         })
     }
 
@@ -131,8 +129,8 @@ impl Identity {
         self.keypair.sign(self.farmer_solution_ctx.bytes(data))
     }
 
-    /// Sign substrate block.
-    pub fn sign_block_header_hash(&self, header_hash: &[u8]) -> Signature {
+    /// Sign reward hash.
+    pub fn sign_reward_hash(&self, header_hash: &[u8]) -> Signature {
         self.keypair.sign(self.substrate_ctx.bytes(header_hash))
     }
 }

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -91,7 +91,7 @@ impl MultiFarming {
                     info!("Opening commitments");
                     let plot_commitments = Commitments::new(base_directory.join("commitments"))?;
 
-                    let subspace_codec = SubspaceCodec::new(identity.public_key());
+                    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
 
                     // Start the farming task
                     let farming = start_farmings.then(|| {

--- a/crates/subspace-farmer/src/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_rpc_client.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// `WsClient` wrapper.
@@ -65,33 +65,33 @@ impl RpcClient for NodeRpcClient {
             .await?)
     }
 
-    async fn subscribe_block_signing(
+    async fn subscribe_reward_signing(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = BlockSigningInfo> + Send + 'static>>, RpcError> {
+    ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, RpcError> {
         let subscription = self
             .client
             .subscribe(
-                "subspace_subscribeBlockSigning",
+                "subspace_subscribeRewardSigning",
                 rpc_params![],
-                "subspace_unsubscribeBlockSigning",
+                "subspace_unsubscribeRewardSigning",
             )
             .await?;
 
         Ok(Box::pin(subscription.filter_map(
-            |block_signing_info_result| async move { block_signing_info_result.ok() },
+            |reward_signing_info_result| async move { reward_signing_info_result.ok() },
         )))
     }
 
     /// Submit a block signature
-    async fn submit_block_signature(
+    async fn submit_reward_signature(
         &self,
-        block_signature: BlockSignature,
+        reward_signature: RewardSignature,
     ) -> Result<(), RpcError> {
         Ok(self
             .client
             .request(
-                "subspace_submitBlockSignature",
-                rpc_params![&block_signature],
+                "subspace_submitRewardSignature",
+                rpc_params![&reward_signature],
             )
             .await?)
     }

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -139,7 +139,8 @@ pub fn retrieve_piece_from_plots(
 ) -> io::Result<Option<Piece>> {
     let piece_index_hash = PieceIndexHash::from(piece_index);
     let mut plots = plots.iter().collect::<Vec<_>>();
-    plots.sort_by_key(|plot| PieceDistance::distance(&piece_index_hash, plot.public_key()));
+    plots
+        .sort_by_key(|plot| PieceDistance::distance(&piece_index_hash, plot.public_key().as_ref()));
 
     plots
         .iter()
@@ -566,7 +567,7 @@ impl IndexHashToOffsetDB {
                 subspace_core_primitives::bidirectional_distance(
                     &max_distance_key,
                     &PieceDistance::MIDDLE,
-                ) >= PieceDistance::distance(index_hash, self.address)
+                ) >= PieceDistance::distance(index_hash, self.address.as_ref())
             })
             .unwrap_or(true)
     }

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -323,8 +323,7 @@ impl Plot {
     }
 
     pub fn read_piece(&self, index_hash: impl Into<PieceIndexHash>) -> io::Result<Vec<u8>> {
-        self.read(index_hash)
-            .map(|piece| <[u8; PIECE_SIZE]>::from(piece).to_vec())
+        self.read(index_hash).map(Into::into)
     }
 
     pub(crate) fn read_piece_with_index(

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -64,7 +64,7 @@ async fn plotting_happy_path() {
         }
     }
 
-    let subspace_codec = SubspaceCodec::new(identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
 
     // Start archiving task
     let archiving_instance = Archiving::start(
@@ -148,7 +148,7 @@ async fn plotting_piece_eviction() {
         }
     }
 
-    let subspace_codec = SubspaceCodec::new(identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
 
     // Start archiving task
     let archiving_instance = Archiving::start(

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use std::pin::Pin;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    BlockSignature, BlockSigningInfo, FarmerMetadata, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// To become error type agnostic
@@ -27,12 +27,13 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
     ) -> Result<(), Error>;
 
     /// Subscribe to block signing request
-    async fn subscribe_block_signing(
+    async fn subscribe_reward_signing(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = BlockSigningInfo> + Send + 'static>>, Error>;
+    ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, Error>;
 
     /// Submit a block signature
-    async fn submit_block_signature(&self, block_signature: BlockSignature) -> Result<(), Error>;
+    async fn submit_reward_signature(&self, reward_signature: RewardSignature)
+        -> Result<(), Error>;
 
     /// Subscribe to archived segments
     async fn subscribe_archived_segments(

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -11,15 +11,15 @@ use std::{
     sync::Arc,
 };
 use subspace_archiving::archiver::{Segment, SegmentItem};
-use subspace_core_primitives::{Piece, PieceIndex, Sha256Hash, PIECE_SIZE};
+use subspace_core_primitives::{Piece, PieceIndex, Sha256Hash};
 use tracing::{debug, error};
 
 /// Maximum expected size of one object in bytes
 const MAX_OBJECT_SIZE: usize = 5 * 1024 * 1024;
 
 /// Same as [`Piece`], but serializes/deserialized to/from hex string
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct HexPiece(#[serde(with = "HexForm")] [u8; PIECE_SIZE]);
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HexPiece(#[serde(with = "HexForm")] Vec<u8>);
 
 impl From<Piece> for HexPiece {
     fn from(piece: Piece) -> Self {
@@ -29,7 +29,11 @@ impl From<Piece> for HexPiece {
 
 impl From<HexPiece> for Piece {
     fn from(piece: HexPiece) -> Self {
-        piece.0.into()
+        piece
+            .0
+            .as_slice()
+            .try_into()
+            .expect("Internal piece is always has correct length; qed")
     }
 }
 

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -60,25 +60,25 @@ pub struct SolutionResponse {
     pub maybe_solution: Option<Solution<PublicKey>>,
 }
 
-/// Block header hash that needs to be signed.
+/// Reward info that needs to be signed.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BlockSigningInfo {
-    /// Header hash of the block to be signed.
+pub struct RewardSigningInfo {
+    /// Hash to be signed.
     #[serde(with = "HexForm")]
-    pub header_hash: [u8; 32],
+    pub hash: [u8; 32],
     /// Public key of the plot identity that should create signature.
     #[serde(with = "HexForm")]
     pub public_key: [u8; 32],
 }
 
-/// Signature in response to block header hash signing request.
+/// Signature in response to reward hash signing request.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BlockSignature {
-    /// Header hash of the block to be signed.
+pub struct RewardSignature {
+    /// Hash that was signed.
     #[serde(with = "HexForm")]
-    pub header_hash: [u8; 32],
-    /// Block header hash signature.
+    pub hash: [u8; 32],
+    /// Pre-header or vote hash signature.
     pub signature: Option<Signature>,
 }

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -57,7 +57,7 @@ pub struct SolutionResponse {
     /// Optional solution.
     ///
     /// Derived from the farmer's plot corresponding to `slot_number` above.
-    pub maybe_solution: Option<Solution<PublicKey>>,
+    pub maybe_solution: Option<Solution<PublicKey, PublicKey>>,
 }
 
 /// Reward info that needs to be signed.

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -43,8 +43,10 @@ pub struct SlotInfo {
     pub salt: Salt,
     /// Salt for the next eon
     pub next_salt: Option<Salt>,
-    /// Acceptable solution range
+    /// Acceptable solution range for block authoring
     pub solution_range: u64,
+    /// Acceptable solution range for voting
+    pub voting_solution_range: u64,
 }
 
 /// Response of a slot challenge consisting of an optional solution and

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -159,9 +159,7 @@ pub mod opaque {
 /// A trait for finding the address for a block reward based on the `PreRuntime` digests contained within it.
 pub trait FindBlockRewardAddress<RewardAddress> {
     /// Find the address for a block rewards based on the pre-runtime digests.
-    fn find_block_reward_address<'a, I>(digests: I) -> Option<RewardAddress>
-    where
-        I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>;
+    fn find_block_reward_address() -> Option<RewardAddress>;
 }
 
 /// A trait for finding the addresses for voting reward based on transactions found in the block.

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -21,6 +21,7 @@
 
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::MultiSignature;
+use sp_std::vec::Vec;
 pub use subspace_core_primitives::BlockNumber;
 use subspace_core_primitives::{PIECE_SIZE, SHA256_HASH_SIZE};
 
@@ -161,4 +162,10 @@ pub trait FindBlockRewardAddress<RewardAddress> {
     fn find_block_reward_address<'a, I>(digests: I) -> Option<RewardAddress>
     where
         I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>;
+}
+
+/// A trait for finding the addresses for voting reward based on transactions found in the block.
+pub trait FindVotingRewardAddresses<RewardAddress> {
+    /// Find the addresses for voting rewards based on transactions found in the block.
+    fn find_voting_reward_addresses() -> Vec<RewardAddress>;
 }

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -98,7 +98,6 @@ pub mod opaque {
     use parity_scale_codec::{Decode, Encode};
     #[cfg(feature = "std")]
     use serde::{Deserialize, Serialize};
-    use sp_core::RuntimeDebug;
     use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Header as HeaderT};
     use sp_runtime::{generic, DigestItem, OpaqueExtrinsic};
     use sp_std::prelude::*;
@@ -108,7 +107,7 @@ pub mod opaque {
     /// Opaque block type.
 
     /// Abstraction over a substrate block.
-    #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+    #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
     #[cfg_attr(
         feature = "std",
         derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -156,9 +156,9 @@ pub mod opaque {
 }
 
 /// A trait for finding the address for a block reward based on the `PreRuntime` digests contained within it.
-pub trait FindBlockRewardAddress<Address> {
+pub trait FindBlockRewardAddress<RewardAddress> {
     /// Find the address for a block rewards based on the pre-runtime digests.
-    fn find_block_reward_address<'a, I>(digests: I) -> Option<Address>
+    fn find_block_reward_address<'a, I>(digests: I) -> Option<RewardAddress>
     where
         I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>;
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -151,6 +151,11 @@ const INITIAL_SOLUTION_RANGE: u64 =
     u64::MAX / (RECORDED_HISTORY_SEGMENT_SIZE * 2 / RECORD_SIZE as u32) as u64 * SLOT_PROBABILITY.0
         / SLOT_PROBABILITY.1;
 
+/// Number of votes expected per block.
+///
+/// This impacts solution range for votes in consensus.
+const EXPECTED_VOTES_PER_BLOCK: u32 = 10;
+
 /// A ratio of `Normal` dispatch class within block, for `BlockWeight` and `BlockLength`.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
@@ -261,6 +266,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
+    type ExpectedVotesPerBlock = ConstU32<EXPECTED_VOTES_PER_BLOCK>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -251,6 +251,7 @@ impl frame_system::Config for Runtime {
 parameter_types! {
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
+    pub const ExpectedVotesPerBlock: u32 = EXPECTED_VOTES_PER_BLOCK;
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
@@ -269,7 +270,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
-    type ExpectedVotesPerBlock = ConstU32<EXPECTED_VOTES_PER_BLOCK>;
+    type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
@@ -500,14 +501,17 @@ impl pallet_executor::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BlockReward: Balance = SSC;
+    pub const BlockReward: Balance = SSC / (ExpectedVotesPerBlock::get() as Balance + 1);
+    pub const VoteReward: Balance = SSC / (ExpectedVotesPerBlock::get() as Balance + 1);
 }
 
 impl pallet_rewards::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type BlockReward = BlockReward;
+    type VoteReward = VoteReward;
     type FindBlockRewardAddress = Subspace;
+    type FindVotingRewardAddresses = Subspace;
     type WeightInfo = ();
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -157,7 +157,7 @@ const INITIAL_SOLUTION_RANGE: u64 =
 /// Number of votes expected per block.
 ///
 /// This impacts solution range for votes in consensus.
-const EXPECTED_VOTES_PER_BLOCK: u32 = 10;
+const EXPECTED_VOTES_PER_BLOCK: u32 = 9;
 
 /// A ratio of `Normal` dispatch class within block, for `BlockWeight` and `BlockLength`.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -322,22 +322,25 @@ impl Get<Balance> for CreditSupply {
 
 pub struct TotalSpacePledged;
 
-impl Get<u64> for TotalSpacePledged {
-    fn get() -> u64 {
-        let piece_size = u64::try_from(PIECE_SIZE)
-            .expect("Piece size is definitely small enough to fit into u64; qed");
-        // Operations reordered to avoid u64 overflow, but essentially are:
+impl Get<u128> for TotalSpacePledged {
+    fn get() -> u128 {
+        let piece_size = u128::try_from(PIECE_SIZE)
+            .expect("Piece size is definitely small enough to fit into u128; qed");
+        // Operations reordered to avoid data loss, but essentially are:
         // u64::MAX * SlotProbability / (solution_range / PIECE_SIZE)
-        u64::MAX / Subspace::solution_ranges().current * piece_size * SlotProbability::get().0
-            / SlotProbability::get().1
+        u128::from(u64::MAX)
+            .saturating_mul(piece_size)
+            .saturating_mul(u128::from(SlotProbability::get().0))
+            / u128::from(Subspace::solution_ranges().current)
+            / u128::from(SlotProbability::get().1)
     }
 }
 
 pub struct BlockchainHistorySize;
 
-impl Get<u64> for BlockchainHistorySize {
-    fn get() -> u64 {
-        Subspace::archived_history_size()
+impl Get<u128> for BlockchainHistorySize {
+    fn get() -> u128 {
+        u128::from(Subspace::archived_history_size())
     }
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1032,6 +1032,10 @@ impl_runtime_apis! {
             Subspace::submit_equivocation_report(equivocation_proof)
         }
 
+        fn submit_vote_extrinsic(vote: <Block as BlockT>::Header) {
+            Subspace::submit_vote(vote)
+        }
+
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool {
             // TODO: Either check tx pool too for pending equivocations or replace equivocation
             //  mechanism with an alternative one, so that blocking happens faster

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -51,7 +51,7 @@ use scale_info::TypeInfo;
 use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
 use sp_consensus_subspace::{
     digests::CompatibleDigestItem, EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts,
-    SolutionRanges,
+    SignedVote, SolutionRanges,
 };
 use sp_core::{crypto::KeyTypeId, Hasher, OpaqueMetadata};
 use sp_executor::{FraudProof, OpaqueBundle};
@@ -1032,8 +1032,10 @@ impl_runtime_apis! {
             Subspace::submit_equivocation_report(equivocation_proof)
         }
 
-        fn submit_vote_extrinsic(vote: <Block as BlockT>::Header) {
-            Subspace::submit_vote(vote)
+        fn submit_vote_extrinsic(
+            signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+        ) {
+            Subspace::submit_vote(signed_vote)
         }
 
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool {

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -182,7 +182,7 @@ fn get_successful_calls(block: Block) -> Vec<Hash> {
 }
 
 fn key(feed_id: u64, data: &[u8]) -> Sha256Hash {
-    crypto::sha256_hash_pair(feed_id.encode(), data)
+    crypto::sha256_hash_pair(&feed_id.encode(), data)
 }
 
 #[test]

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -42,7 +42,7 @@ use sp_api::{ApiExt, ConstructRuntimeApi, Metadata, NumberFor, TransactionFor};
 use sp_block_builder::BlockBuilder;
 use sp_consensus::{CanAuthorWithNativeVersion, Error as ConsensusError};
 use sp_consensus_slots::Slot;
-use sp_consensus_subspace::SubspaceApi;
+use sp_consensus_subspace::{FarmerPublicKey, SubspaceApi};
 use sp_executor::ExecutorApi;
 use sp_objects::ObjectsApi;
 use sp_offchain::OffchainWorkerApi;
@@ -145,7 +145,7 @@ where
         + ExecutorApi<Block, SecondaryHash>
         + OffchainWorkerApi<Block>
         + SessionKeys<Block>
-        + SubspaceApi<Block>
+        + SubspaceApi<Block, FarmerPublicKey>
         + ObjectsApi<Block>
         + TaggedTransactionQueue<Block>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
@@ -327,7 +327,7 @@ where
         + ExecutorApi<Block, SecondaryHash>
         + OffchainWorkerApi<Block>
         + SessionKeys<Block>
-        + SubspaceApi<Block>
+        + SubspaceApi<Block, FarmerPublicKey>
         + ObjectsApi<Block>
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, AccountId, Nonce>

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -29,8 +29,8 @@ use sc_client_api::{BlockBackend, ExecutorProvider, HeaderBackend, StateBackendF
 use sc_consensus::{BlockImport, DefaultImportQueue};
 use sc_consensus_slots::SlotProportion;
 use sc_consensus_subspace::{
-    notification::SubspaceNotificationStream, ArchivedSegmentNotification,
-    BlockSigningNotification, NewSlotNotification, SubspaceLink, SubspaceParams,
+    notification::SubspaceNotificationStream, ArchivedSegmentNotification, NewSlotNotification,
+    RewardSigningNotification, SubspaceLink, SubspaceParams,
 };
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_service::{error::Error as ServiceError, Configuration, PartialComponents, TaskManager};
@@ -298,7 +298,7 @@ where
     /// New slot stream.
     pub new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     /// Block signing stream.
-    pub block_signing_notification_stream: SubspaceNotificationStream<BlockSigningNotification>,
+    pub reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
     /// Imported block stream.
     pub imported_block_notification_stream:
         SubspaceNotificationStream<(NumberFor<Block>, mpsc::Sender<RootBlock>)>,
@@ -369,7 +369,7 @@ where
     let prometheus_registry = config.prometheus_registry().cloned();
 
     let new_slot_notification_stream = subspace_link.new_slot_notification_stream();
-    let block_signing_notification_stream = subspace_link.block_signing_notification_stream();
+    let reward_signing_notification_stream = subspace_link.reward_signing_notification_stream();
     let imported_block_notification_stream = subspace_link.imported_block_notification_stream();
     let archived_segment_notification_stream = subspace_link.archived_segment_notification_stream();
 
@@ -447,7 +447,7 @@ where
         rpc_builder: if enable_rpc_extensions {
             let client = client.clone();
             let new_slot_notification_stream = new_slot_notification_stream.clone();
-            let block_signing_notification_stream = block_signing_notification_stream.clone();
+            let reward_signing_notification_stream = reward_signing_notification_stream.clone();
             let archived_segment_notification_stream = archived_segment_notification_stream.clone();
             let transaction_pool = transaction_pool.clone();
 
@@ -458,7 +458,7 @@ where
                     deny_unsafe,
                     subscription_executor,
                     new_slot_notification_stream: new_slot_notification_stream.clone(),
-                    block_signing_notification_stream: block_signing_notification_stream.clone(),
+                    reward_signing_notification_stream: reward_signing_notification_stream.clone(),
                     archived_segment_notification_stream: archived_segment_notification_stream
                         .clone(),
                 };
@@ -482,7 +482,7 @@ where
         rpc_handlers,
         backend,
         new_slot_notification_stream,
-        block_signing_notification_stream,
+        reward_signing_notification_stream,
         imported_block_notification_stream,
         archived_segment_notification_stream,
         network_starter,

--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -26,7 +26,7 @@ use pallet_transaction_payment_rpc::{TransactionPaymentApiServer, TransactionPay
 use sc_client_api::BlockBackend;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::{
-    ArchivedSegmentNotification, BlockSigningNotification, NewSlotNotification,
+    ArchivedSegmentNotification, NewSlotNotification, RewardSigningNotification,
 };
 use sc_consensus_subspace_rpc::{SubspaceRpc, SubspaceRpcApiServer};
 use sc_rpc::SubscriptionTaskExecutor;
@@ -54,7 +54,7 @@ pub struct FullDeps<C, P> {
     pub new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     /// A stream with notifications about headers that need to be signed with ability to send
     /// signature back.
-    pub block_signing_notification_stream: SubspaceNotificationStream<BlockSigningNotification>,
+    pub reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
     /// A stream with notifications about archived segment creation.
     pub archived_segment_notification_stream:
         SubspaceNotificationStream<ArchivedSegmentNotification>,
@@ -85,7 +85,7 @@ where
         deny_unsafe,
         subscription_executor,
         new_slot_notification_stream,
-        block_signing_notification_stream,
+        reward_signing_notification_stream,
         archived_segment_notification_stream,
     } = deps;
 
@@ -97,7 +97,7 @@ where
             client,
             subscription_executor,
             new_slot_notification_stream,
-            block_signing_notification_stream,
+            reward_signing_notification_stream,
             archived_segment_notification_stream,
         )
         .into_rpc(),

--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -35,6 +35,7 @@ use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_consensus_subspace::FarmerPublicKey;
 use std::sync::Arc;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Index};
@@ -75,7 +76,7 @@ where
     C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>
         + pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
         + BlockBuilder<Block>
-        + sp_consensus_subspace::SubspaceApi<Block>,
+        + sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey>,
     P: TransactionPool + 'static,
 {
     let mut module = RpcModule::new(());

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -83,7 +83,7 @@ pub struct SubspaceCodec {
 
 impl SubspaceCodec {
     /// New instance with 256-bit prime and 4096-byte genesis piece size
-    pub fn new<P: AsRef<[u8]>>(farmer_public_key: &P) -> Self {
+    pub fn new(farmer_public_key: &[u8]) -> Self {
         #[cfg(feature = "cuda")]
         let cuda_available = cuda::is_cuda_available();
 

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -29,8 +29,11 @@ use subspace_core_primitives::{
     crypto, LocalChallenge, Piece, Randomness, Salt, Sha256Hash, Tag, TAG_SIZE,
 };
 
-/// Signing context used for creating solution signatures by farmer
+/// Signing context used for creating solution signatures by farmers.
 pub const SOLUTION_SIGNING_CONTEXT: &[u8] = b"farmer_solution";
+
+/// Signing context used for creating reward signatures by farmers.
+pub const REWARD_SIGNING_CONTEXT: &[u8] = b"farmer_reward";
 
 #[allow(clippy::assign_op_pattern, clippy::ptr_offset_with_cast)]
 mod construct_uint {

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -987,6 +987,10 @@ cfg_if! {
                     )
                 }
 
+                fn submit_vote_extrinsic(_vote: <Block as BlockT>::Header) {
+                    unimplemented!()
+                }
+
                 fn is_in_block_list(farmer_public_key: &sp_consensus_subspace::FarmerPublicKey) -> bool {
                     <pallet_subspace::Pallet<Runtime>>::is_in_block_list(farmer_public_key)
                 }
@@ -1313,6 +1317,10 @@ cfg_if! {
                     <pallet_subspace::Pallet<Runtime>>::submit_test_equivocation_report(
                         equivocation_proof,
                     )
+                }
+
+                fn submit_vote_extrinsic(_vote: <Block as BlockT>::Header) {
+                    unimplemented!()
                 }
 
                 fn is_in_block_list(farmer_public_key: &sp_consensus_subspace::FarmerPublicKey) -> bool {

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -667,7 +667,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<3840>;
     type MaxPlotSize = ConstU64<{ 10 * 1024 * 1024 * 1024 / PIECE_SIZE as u64 }>;
     type RecordedHistorySegmentSize = ConstU32<{ 3840 * 256 / 2 }>;
-    type ExpectedVotesPerBlock = ConstU32<10>;
+    type ExpectedVotesPerBlock = ConstU32<9>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -503,8 +503,8 @@ impl From<frame_system::Event<Runtime>> for Event {
     }
 }
 
-impl From<pallet_subspace::Event> for Event {
-    fn from(_evt: pallet_subspace::Event) -> Self {
+impl From<pallet_subspace::Event<Runtime>> for Event {
+    fn from(_evt: pallet_subspace::Event<Runtime>) -> Self {
         unimplemented!("Not required in tests!")
     }
 }

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -58,7 +58,7 @@ use sp_version::RuntimeVersion;
 use subspace_core_primitives::PIECE_SIZE;
 use trie_db::{Trie, TrieMut};
 // bench on latest state.
-use sp_consensus_subspace::SignedVote;
+use sp_consensus_subspace::{FarmerPublicKey, SignedVote};
 use sp_trie::trie_types::TrieDBMutV1 as TrieDBMut;
 
 // Ensure Babe and Aura use the same crypto to simplify things a bit.
@@ -938,7 +938,7 @@ cfg_if! {
                 }
             }
 
-            impl sp_consensus_subspace::SubspaceApi<Block> for Runtime {
+            impl sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey> for Runtime {
                 fn confirmation_depth_k() -> <<Block as BlockT>::Header as HeaderT>::Number {
                     <Self as pallet_subspace::Config>::ConfirmationDepthK::get()
                 }
@@ -988,7 +988,11 @@ cfg_if! {
                 }
 
                 fn submit_vote_extrinsic(
-                    _signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+                    _signed_vote: SignedVote<
+                        NumberFor<Block>,
+                        <Block as BlockT>::Hash,
+                        FarmerPublicKey,
+                    >,
                 ) {
                     unimplemented!()
                 }
@@ -1272,7 +1276,7 @@ cfg_if! {
                 }
             }
 
-            impl sp_consensus_subspace::SubspaceApi<Block> for Runtime {
+            impl sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey> for Runtime {
                 fn confirmation_depth_k() -> <<Block as BlockT>::Header as HeaderT>::Number {
                     <Self as pallet_subspace::Config>::ConfirmationDepthK::get()
                 }
@@ -1322,7 +1326,11 @@ cfg_if! {
                 }
 
                 fn submit_vote_extrinsic(
-                    _signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+                    _signed_vote: SignedVote<
+                        NumberFor<Block>,
+                        <Block as BlockT>::Hash,
+                        FarmerPublicKey,
+                    >,
                 ) {
                     unimplemented!()
                 }

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -667,6 +667,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<3840>;
     type MaxPlotSize = ConstU64<{ 10 * 1024 * 1024 * 1024 / PIECE_SIZE as u64 }>;
     type RecordedHistorySegmentSize = ConstU32<{ 3840 * 256 / 2 }>;
+    type ExpectedVotesPerBlock = ConstU32<10>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -37,7 +37,6 @@ use sp_application_crypto::{ecdsa, ed25519, sr25519, RuntimeAppPublic};
 pub use sp_core::hash::H256;
 use sp_core::{offchain::KeyTypeId, OpaqueMetadata, RuntimeDebug};
 use sp_inherents::{CheckInherentsResult, InherentData};
-#[cfg(feature = "std")]
 use sp_runtime::traits::NumberFor;
 use sp_runtime::{
     create_runtime_str, impl_opaque_keys,
@@ -59,6 +58,7 @@ use sp_version::RuntimeVersion;
 use subspace_core_primitives::PIECE_SIZE;
 use trie_db::{Trie, TrieMut};
 // bench on latest state.
+use sp_consensus_subspace::SignedVote;
 use sp_trie::trie_types::TrieDBMutV1 as TrieDBMut;
 
 // Ensure Babe and Aura use the same crypto to simplify things a bit.
@@ -987,7 +987,9 @@ cfg_if! {
                     )
                 }
 
-                fn submit_vote_extrinsic(_vote: <Block as BlockT>::Header) {
+                fn submit_vote_extrinsic(
+                    _signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+                ) {
                     unimplemented!()
                 }
 
@@ -1319,7 +1321,9 @@ cfg_if! {
                     )
                 }
 
-                fn submit_vote_extrinsic(_vote: <Block as BlockT>::Header) {
+                fn submit_vote_extrinsic(
+                    _signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+                ) {
                     unimplemented!()
                 }
 

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -35,7 +35,7 @@ use scale_info::TypeInfo;
 use sp_api::{decl_runtime_apis, impl_runtime_apis};
 use sp_application_crypto::{ecdsa, ed25519, sr25519, RuntimeAppPublic};
 pub use sp_core::hash::H256;
-use sp_core::{offchain::KeyTypeId, OpaqueMetadata, RuntimeDebug};
+use sp_core::{offchain::KeyTypeId, OpaqueMetadata};
 use sp_inherents::{CheckInherentsResult, InherentData};
 use sp_runtime::traits::NumberFor;
 use sp_runtime::{
@@ -120,7 +120,7 @@ pub fn native_version() -> NativeVersion {
 }
 
 /// Calls in transactions.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct Transfer {
     pub from: AccountId,
     pub to: AccountId,
@@ -159,7 +159,7 @@ impl Transfer {
 }
 
 /// Extrinsic for test-runtime.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum Extrinsic {
     AuthoritiesChange(Vec<AuthorityId>),
     Transfer {
@@ -437,7 +437,7 @@ impl GetRuntimeBlockType for Runtime {
     type RuntimeBlock = Block;
 }
 
-#[derive(Clone, RuntimeDebug, Encode, Decode, PartialEq, Eq, TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct Origin;
 
 impl From<frame_system::Origin<Runtime>> for Origin {
@@ -494,7 +494,7 @@ impl frame_support::traits::OriginTrait for Origin {
     }
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct Event;
 
 impl From<frame_system::Event<Runtime>> for Event {

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -140,7 +140,7 @@ async fn start_farming<Client>(
         }
     });
 
-    let subspace_codec = SubspaceCodec::new(&keypair.public);
+    let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let (piece_index, mut encoding) = archived_pieces_receiver
         .await

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -140,7 +140,7 @@ async fn start_farming<Client>(
         }
     });
 
-    let subspace_solving = SubspaceCodec::new(&keypair.public);
+    let subspace_codec = SubspaceCodec::new(&keypair.public);
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let (piece_index, mut encoding) = archived_pieces_receiver
         .await
@@ -151,7 +151,7 @@ async fn start_farming<Client>(
         .choose(&mut rand::thread_rng())
         .map(|(piece_index, piece)| (piece_index as u64, Piece::try_from(piece).unwrap()))
         .unwrap();
-    subspace_solving.encode(&mut encoding, piece_index).unwrap();
+    subspace_codec.encode(&mut encoding, piece_index).unwrap();
 
     let mut new_slot_notification_stream = new_slot_notification_stream.subscribe();
 
@@ -168,7 +168,7 @@ async fn start_farming<Client>(
                     public_key: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     reward_address: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     piece_index,
-                    encoding,
+                    encoding: encoding.clone(),
                     signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),
                     local_challenge: keypair
                         .sign(ctx.bytes(&new_slot_info.global_challenge))

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -129,7 +129,7 @@ async fn start_farming<Client>(
     new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
 ) where
     Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + Send + Sync + 'static,
-    Client::Api: SubspaceApi<Block>,
+    Client::Api: SubspaceApi<Block, FarmerPublicKey>,
 {
     let (archived_pieces_sender, archived_pieces_receiver) = futures::channel::oneshot::channel();
 
@@ -184,7 +184,7 @@ async fn start_farming<Client>(
 fn get_archived_pieces<Client>(client: &Arc<Client>) -> Vec<FlatPieces>
 where
     Client: ProvideRuntimeApi<Block> + BlockBackend<Block>,
-    Client::Api: SubspaceApi<Block>,
+    Client::Api: SubspaceApi<Block, FarmerPublicKey>,
 {
     let genesis_block_id = BlockId::Number(sp_runtime::traits::Zero::zero());
     let runtime_api = client.runtime_api();

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -248,6 +248,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
+    type ExpectedVotesPerBlock = ConstU32<10>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -45,7 +45,7 @@ use pallet_grandpa_finality_verifier::chain::Chain;
 use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::{
-    EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts, SolutionRanges,
+    EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts, SignedVote, SolutionRanges,
 };
 use sp_core::{crypto::KeyTypeId, Hasher, OpaqueMetadata};
 use sp_executor::{FraudProof, OpaqueBundle};
@@ -963,8 +963,10 @@ impl_runtime_apis! {
             Subspace::submit_equivocation_report(equivocation_proof)
         }
 
-        fn submit_vote_extrinsic(vote: <Block as BlockT>::Header) {
-            Subspace::submit_vote(vote)
+        fn submit_vote_extrinsic(
+            signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+        ) {
+            Subspace::submit_vote(signed_vote)
         }
 
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -963,6 +963,10 @@ impl_runtime_apis! {
             Subspace::submit_equivocation_report(equivocation_proof)
         }
 
+        fn submit_vote_extrinsic(vote: <Block as BlockT>::Header) {
+            Subspace::submit_vote(vote)
+        }
+
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool {
             // TODO: Either check tx pool too for pending equivocations or replace equivocation
             //  mechanism with an alternative one, so that blocking happens faster

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -304,22 +304,25 @@ impl Get<Balance> for CreditSupply {
 
 pub struct TotalSpacePledged;
 
-impl Get<u64> for TotalSpacePledged {
-    fn get() -> u64 {
-        let piece_size = u64::try_from(PIECE_SIZE)
-            .expect("Piece size is definitely small enough to fit into u64; qed");
-        // Operations reordered to avoid u64 overflow, but essentially are:
+impl Get<u128> for TotalSpacePledged {
+    fn get() -> u128 {
+        let piece_size = u128::try_from(PIECE_SIZE)
+            .expect("Piece size is definitely small enough to fit into u128; qed");
+        // Operations reordered to avoid data loss, but essentially are:
         // u64::MAX * SlotProbability / (solution_range / PIECE_SIZE)
-        u64::MAX / Subspace::solution_ranges().current * piece_size * SlotProbability::get().0
-            / SlotProbability::get().1
+        u128::from(u64::MAX)
+            .saturating_mul(piece_size)
+            .saturating_mul(u128::from(SlotProbability::get().0))
+            / u128::from(Subspace::solution_ranges().current)
+            / u128::from(SlotProbability::get().1)
     }
 }
 
 pub struct BlockchainHistorySize;
 
-impl Get<u64> for BlockchainHistorySize {
-    fn get() -> u64 {
-        Subspace::archived_history_size()
+impl Get<u128> for BlockchainHistorySize {
+    fn get() -> u128 {
+        u128::from(Subspace::archived_history_size())
     }
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -45,9 +45,10 @@ use pallet_grandpa_finality_verifier::chain::Chain;
 use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::{
-    EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts, SignedVote, SolutionRanges,
+    EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts, SignedVote, SolutionRanges, Vote,
 };
-use sp_core::{crypto::KeyTypeId, Hasher, OpaqueMetadata};
+use sp_core::crypto::{ByteArray, KeyTypeId};
+use sp_core::{Hasher, OpaqueMetadata};
 use sp_executor::{FraudProof, OpaqueBundle};
 use sp_runtime::traits::{
     AccountIdLookup, BlakeTwo256, DispatchInfoOf, NumberFor, PostDispatchInfoOf, Zero,
@@ -55,8 +56,10 @@ use sp_runtime::traits::{
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
 };
-use sp_runtime::{create_runtime_str, generic, ApplyExtrinsicResult, Perbill};
-use sp_runtime::{DispatchError, OpaqueExtrinsic};
+use sp_runtime::{
+    create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, DispatchError, OpaqueExtrinsic,
+    Perbill,
+};
 use sp_std::borrow::Cow;
 use sp_std::iter::Peekable;
 use sp_std::marker::PhantomData;
@@ -852,6 +855,25 @@ fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness
     }
 }
 
+struct RewardAddress([u8; 32]);
+
+impl From<FarmerPublicKey> for RewardAddress {
+    fn from(farmer_public_key: FarmerPublicKey) -> Self {
+        Self(
+            farmer_public_key
+                .as_slice()
+                .try_into()
+                .expect("Public key is always of correct size; qed"),
+        )
+    }
+}
+
+impl From<RewardAddress> for AccountId32 {
+    fn from(reward_address: RewardAddress) -> Self {
+        reward_address.0.into()
+    }
+}
+
 impl_runtime_apis! {
     impl sp_api::Core<Block> for Runtime {
         fn version() -> RuntimeVersion {
@@ -920,7 +942,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_consensus_subspace::SubspaceApi<Block> for Runtime {
+    impl sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey> for Runtime {
         fn confirmation_depth_k() -> <<Block as BlockT>::Header as HeaderT>::Number {
             <Self as pallet_subspace::Config>::ConfirmationDepthK::get()
         }
@@ -964,9 +986,25 @@ impl_runtime_apis! {
         }
 
         fn submit_vote_extrinsic(
-            signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash>,
+            signed_vote: SignedVote<NumberFor<Block>, <Block as BlockT>::Hash, FarmerPublicKey>,
         ) {
-            Subspace::submit_vote(signed_vote)
+            let SignedVote { vote, signature } = signed_vote;
+            let Vote::V0 {
+                height,
+                parent_hash,
+                slot,
+                solution,
+            } = vote;
+
+            Subspace::submit_vote(SignedVote {
+                vote: Vote::V0 {
+                    height,
+                    parent_hash,
+                    slot,
+                    solution: solution.into_reward_address_format::<RewardAddress, AccountId32>(),
+                },
+                signature,
+            })
         }
 
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -236,6 +236,7 @@ parameter_types! {
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
     pub const ShouldAdjustSolutionRange: bool = false;
+    pub const ExpectedVotesPerBlock: u32 = 10;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -251,7 +252,7 @@ impl pallet_subspace::Config for Runtime {
     type RecordSize = ConstU32<RECORD_SIZE>;
     type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
-    type ExpectedVotesPerBlock = ConstU32<10>;
+    type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type GlobalRandomnessIntervalTrigger = pallet_subspace::NormalGlobalRandomnessInterval;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
@@ -482,14 +483,17 @@ impl pallet_executor::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BlockReward: Balance = SSC;
+    pub const BlockReward: Balance = SSC / (ExpectedVotesPerBlock::get() as Balance + 1);
+    pub const VoteReward: Balance = SSC / (ExpectedVotesPerBlock::get() as Balance + 1);
 }
 
 impl pallet_rewards::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type BlockReward = BlockReward;
+    type VoteReward = VoteReward;
     type FindBlockRewardAddress = Subspace;
+    type FindVotingRewardAddresses = Subspace;
     type WeightInfo = ();
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -236,7 +236,7 @@ parameter_types! {
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
     pub const ShouldAdjustSolutionRange: bool = false;
-    pub const ExpectedVotesPerBlock: u32 = 10;
+    pub const ExpectedVotesPerBlock: u32 = 9;
 }
 
 impl pallet_subspace::Config for Runtime {


### PR DESCRIPTION
Brace yourself, this is a big one!

Unfortunately a few refactorings were necessary along the way and it was painful to move them out, so they are part of this PR.

The primary goal of this PR is to introduce initial concept of voting. Farmers can solve with a reduced difficulty in additional to regular difficulty to have a chance of creating a vote on top of the parent block. Vote currently is just a transaction, there is no incentive (yet) for farmers to include it, but we'll change that later. For such vote farmer will also get a reward. Votes are also subject to equivocation just like block producers, though all of the logic is contained within runtime.

Votes on top of block N can only be included in block N+1 or N+2 (this is because delay between N and N+1 might be too small for vote to actually propagate over the network, which would result in many votes lost).

Voting is disabled (as useless) when solution range adjustment isn't active.

Since there are new ways to equivocate it is possible that block author itself equivocates, in which case they don't get block reward or fees, all that instead goes to storage escrow for future farmers.

While implementing voting signatures I decided to finally create a separate reward signing context for Sr25519 crypto that is separate from Substrate's, just like we have a separate context for solutions.

Along the way when working on tests I noticed that the way reward address was implemented was incorrect and it shouldn't have treated public key of the farmer and reward address as the same type. Those are distinct and in fact different in tests (there we use `u64` as account ID instead), so that had to change, which involved a lot of changes throughout the codebase on all levels.

Some other tweaks like avoiding floats in solution range adjustment or making `Piece` contain `Vec<u8>` instead of `[u8; 4096]` (such that Polkadot.js API doesn't complain about arrays over 256 bytes and doesn't break explorer) were done as well.

I recommend to go through individual commits to see what changes were done and look at refactoring, but for actual logic and test checks final diff would be the most helpful IMO.