### PR TITLE
General improvements

### DIFF
--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -267,7 +267,7 @@ fn create_custom_content_feed(
             // key should match the feed name spaced key
             assert_eq!(
                 mappings[i].key,
-                crypto::sha256_hash_pair(FEED_ID.encode(), key.as_slice())
+                crypto::sha256_hash_pair(&FEED_ID.encode(), key.as_slice())
             );
         });
 

--- a/crates/pallet-grandpa-finality-verifier/src/grandpa.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/grandpa.rs
@@ -16,7 +16,6 @@
 // GRANDPA verification is mostly taken from Parity's bridges https://github.com/paritytech/parity-bridges-common/tree/master/primitives/header-chain
 use codec::{Decode, Encode};
 use finality_grandpa::voter_set::VoterSet;
-use frame_support::RuntimeDebug;
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -47,7 +46,7 @@ pub struct GrandpaJustification<Header: HeaderT> {
 }
 
 /// A GRANDPA Authority List and ID.
-#[derive(Default, Encode, Decode, RuntimeDebug, PartialEq, Clone, TypeInfo)]
+#[derive(Debug, Default, Encode, Decode, PartialEq, Clone, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct AuthoritySet {
     /// List of GRANDPA authorities for the current round.
@@ -57,7 +56,7 @@ pub struct AuthoritySet {
 }
 
 /// Votes ancestries with useful methods.
-#[derive(RuntimeDebug)]
+#[derive(Debug)]
 struct AncestryChain<Header: HeaderT> {
     /// Header hash => parent header hash mapping.
     parents: BTreeMap<Header::Hash, Header::Hash>,
@@ -110,7 +109,7 @@ impl<Header: HeaderT> AncestryChain<Header> {
 }
 
 /// Justification verification error.
-#[derive(RuntimeDebug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Justification is finalizing unexpected header.
     InvalidJustificationTarget,

--- a/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
@@ -4,7 +4,6 @@ use codec::Encode;
 use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature};
 use finality_grandpa::voter_set::VoterSet;
 use sp_finality_grandpa::{AuthorityId, AuthorityList, AuthorityWeight};
-use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
 
 /// Set of test accounts with friendly names.
@@ -15,7 +14,7 @@ pub(crate) const DAVE: Account = Account(3);
 pub(crate) const EVE: Account = Account(4);
 
 /// A test account which can be used to sign messages.
-#[derive(RuntimeDebug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct Account(pub u16);
 
 impl Account {

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -904,16 +904,14 @@ impl<T: Config> Pallet<T> {
         eon_index: u64,
         randomness: &Randomness,
     ) -> subspace_core_primitives::Salt {
-        crypto::sha256_hash({
-            let mut input =
-                [0u8; SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH + mem::size_of::<u64>()];
-            input[..SALT_HASHING_PREFIX_LEN].copy_from_slice(SALT_HASHING_PREFIX);
-            input[SALT_HASHING_PREFIX_LEN..SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH]
-                .copy_from_slice(randomness);
-            input[SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH..]
-                .copy_from_slice(&eon_index.to_le_bytes());
-            input
-        })[..SALT_SIZE]
+        let mut input = [0u8; SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH + mem::size_of::<u64>()];
+        input[..SALT_HASHING_PREFIX_LEN].copy_from_slice(SALT_HASHING_PREFIX);
+        input[SALT_HASHING_PREFIX_LEN..SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH]
+            .copy_from_slice(randomness);
+        input[SALT_HASHING_PREFIX_LEN + RANDOMNESS_LENGTH..]
+            .copy_from_slice(&eon_index.to_le_bytes());
+
+        crypto::sha256_hash(&input)[..SALT_SIZE]
             .try_into()
             .expect("Slice has exactly the size needed; qed")
     }

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -191,7 +191,7 @@ pub fn go_to_block(
         System::parent_hash()
     };
 
-    let subspace_codec = SubspaceCodec::new(&keypair.public);
+    let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let piece_index = 0;
     let mut encoding = Piece::default();
@@ -353,7 +353,7 @@ pub fn extract_piece(
     archived_segment: &ArchivedSegment,
     piece_index: u64,
 ) -> Piece {
-    let codec = SubspaceCodec::new(&keypair.public);
+    let codec = SubspaceCodec::new(keypair.public.as_ref());
 
     let mut piece: [u8; PIECE_SIZE] = archived_segment
         .pieces
@@ -382,7 +382,8 @@ pub fn create_signed_vote(
     let solution_signing_context = schnorrkel::signing_context(SOLUTION_SIGNING_CONTEXT);
     let reward_signing_context = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
 
-    let global_challenge = subspace_solving::derive_global_challenge(global_randomnesses, slot);
+    let global_challenge =
+        subspace_solving::derive_global_challenge(global_randomnesses, slot.into());
     let local_challenge = keypair
         .sign(solution_signing_context.bytes(&global_challenge))
         .to_bytes()

--- a/crates/sc-consensus-subspace/src/aux_schema.rs
+++ b/crates/sc-consensus-subspace/src/aux_schema.rs
@@ -56,7 +56,7 @@ where
 }
 
 /// Load the cumulative chain-weight associated with a block.
-pub fn load_block_weight<H: Encode, B: AuxStore>(
+pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
     backend: &B,
     block_hash: H,
 ) -> ClientResult<Option<SubspaceBlockWeight>> {

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -132,7 +132,10 @@ where
 
         let new_slot_info = NewSlotInfo {
             slot,
-            global_challenge: subspace_solving::derive_global_challenge(&global_randomness, slot),
+            global_challenge: subspace_solving::derive_global_challenge(
+                &global_randomness,
+                slot.into(),
+            ),
             salt,
             next_salt,
             solution_range,

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -570,7 +570,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
         let mut new_slot_notification_stream = data.link.new_slot_notification_stream().subscribe();
         let subspace_farmer = async move {
             let keypair = Keypair::generate();
-            let subspace_codec = SubspaceCodec::new(&keypair.public);
+            let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
             let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
             let (piece_index, mut encoding) = archived_pieces_receiver
                 .await

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -21,12 +21,12 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
-use sp_runtime::{DigestItem, RuntimeDebug};
+use sp_runtime::DigestItem;
 use subspace_core_primitives::{Randomness, Salt, Solution};
 
 /// A Subspace pre-runtime digest. This contains all data required to validate a block and for the
 /// Subspace runtime module.
-#[derive(Clone, RuntimeDebug, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct PreDigest<PublicKey, RewardAddress> {
     /// Slot
     pub slot: Slot,
@@ -46,21 +46,21 @@ impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
 }
 
 /// Information about the global randomness for the block.
-#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, PartialEq, Eq, Clone)]
 pub struct GlobalRandomnessDescriptor {
     /// Global randomness used for deriving global slot challenges.
     pub global_randomness: Randomness,
 }
 
 /// Information about the solution range for the block.
-#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, PartialEq, Eq, Clone)]
 pub struct SolutionRangeDescriptor {
     /// Solution range used for challenges.
     pub solution_range: u64,
 }
 
 /// Salt for the block.
-#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, PartialEq, Eq, Clone)]
 pub struct SaltDescriptor {
     /// Salt used with challenges.
     pub salt: Salt,

--- a/crates/sp-consensus-subspace/src/inherents.rs
+++ b/crates/sp-consensus-subspace/src/inherents.rs
@@ -19,7 +19,6 @@
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
 use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
-use sp_runtime::RuntimeDebug;
 use sp_std::result::Result;
 use sp_std::vec::Vec;
 use subspace_core_primitives::RootBlock;
@@ -28,7 +27,7 @@ use subspace_core_primitives::RootBlock;
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"subspace";
 
 /// Errors that can occur while checking root blocks.
-#[derive(Encode, RuntimeDebug)]
+#[derive(Debug, Encode)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub enum InherentError {
     /// List of root blocks is not correct.
@@ -44,7 +43,7 @@ impl IsFatalError for InherentError {
 }
 
 /// The type of the Subspace inherent data.
-#[derive(Encode, Decode, RuntimeDebug)]
+#[derive(Debug, Encode, Decode)]
 pub struct InherentType {
     /// Slot at which block was created.
     pub slot: Slot,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -36,7 +36,7 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::KeyTypeId;
 use sp_core::H256;
 use sp_io::hashing;
-use sp_runtime::{ConsensusEngineId, RuntimeAppPublic, RuntimeDebug};
+use sp_runtime::{ConsensusEngineId, RuntimeAppPublic};
 use sp_std::vec::Vec;
 use subspace_core_primitives::{Randomness, RootBlock, Salt, Sha256Hash, Solution};
 
@@ -71,7 +71,7 @@ pub type EquivocationProof<Header> = sp_consensus_slots::EquivocationProof<Heade
 pub type SubspaceBlockWeight = u128;
 
 /// An consensus log item for Subspace.
-#[derive(Decode, Encode, Clone, PartialEq, Eq, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, Clone, PartialEq, Eq)]
 enum ConsensusLog {
     /// Global randomness for this block/interval.
     #[codec(index = 1)]
@@ -85,7 +85,7 @@ enum ConsensusLog {
 }
 
 /// Farmer vote.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, TypeInfo, RuntimeDebug)]
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, TypeInfo)]
 pub enum Vote<Number, Hash, RewardAddress> {
     /// V0 of the farmer vote.
     V0 {
@@ -121,7 +121,7 @@ where
 }
 
 /// Signed farmer vote.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, TypeInfo, RuntimeDebug)]
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode, TypeInfo)]
 pub struct SignedVote<Number, Hash, RewardAddress> {
     /// Farmer vote.
     pub vote: Vote<Number, Hash, RewardAddress>,

--- a/crates/sp-consensus-subspace/src/offence.rs
+++ b/crates/sp-consensus-subspace/src/offence.rs
@@ -65,7 +65,7 @@ pub trait Offence<Offender> {
 }
 
 /// Errors that may happen on offence reports.
-#[derive(PartialEq, sp_runtime::RuntimeDebug)]
+#[derive(Debug, PartialEq)]
 pub enum OffenceError {
     /// The report has already been submitted.
     DuplicateReport,
@@ -114,7 +114,7 @@ impl<Offender> OnOffenceHandler<Offender> for () {
 }
 
 /// A details about an offending authority for a particular kind of offence.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, sp_runtime::RuntimeDebug, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct OffenceDetails<Offender> {
     /// The offending authority id
     pub offender: Offender,

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -239,7 +239,7 @@ where
     let mut piece = solution.encoding.clone();
 
     // Ensure piece is decodable.
-    let subspace_codec = SubspaceCodec::new(&solution.public_key);
+    let subspace_codec = SubspaceCodec::new(solution.public_key.as_ref());
     subspace_codec
         .decode(&mut piece, solution.piece_index)
         .map_err(|_| VerificationError::InvalidEncoding(slot))?;
@@ -280,7 +280,7 @@ fn is_within_max_plot(
         return true;
     }
     let max_distance_one_direction = PieceDistance::MAX / total_pieces * max_plot_size / 2;
-    PieceDistance::distance(&piece_index.into(), key) <= max_distance_one_direction
+    PieceDistance::distance(&piece_index.into(), key.as_ref()) <= max_distance_one_direction
 }
 
 /// Parameters for checking piece validity
@@ -331,9 +331,9 @@ where
     } = params;
 
     if let Err(error) = is_local_challenge_valid(
-        derive_global_challenge(global_randomness, slot),
+        derive_global_challenge(global_randomness, slot.into()),
         &solution.local_challenge,
-        &solution.public_key,
+        solution.public_key.as_ref(),
     ) {
         return Err(VerificationError::BadLocalChallenge(slot, error));
     }

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -23,7 +23,7 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::KeyTypeId;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT, NumberFor};
-use sp_runtime::{OpaqueExtrinsic, RuntimeDebug};
+use sp_runtime::OpaqueExtrinsic;
 use sp_runtime_interface::pass_by::PassBy;
 use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
@@ -60,7 +60,7 @@ impl sp_runtime::BoundToRuntimeAppPublic for ExecutorKey {
 }
 
 /// Header of transaction bundle.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct BundleHeader {
     /// The hash of primary block at which the bundle was created.
     pub primary_hash: PHash,
@@ -78,7 +78,7 @@ impl BundleHeader {
 }
 
 /// Transaction bundle
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct Bundle<Extrinsic> {
     /// The bundle header.
     pub header: BundleHeader,
@@ -94,7 +94,7 @@ impl<Extrinsic> Bundle<Extrinsic> {
 }
 
 /// Signed version of [`Bundle`].
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SignedBundle<Extrinsic> {
     /// The bundle header.
     pub bundle: Bundle<Extrinsic>,
@@ -105,7 +105,7 @@ pub struct SignedBundle<Extrinsic> {
 }
 
 /// Bundle with opaque extrinsics.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct OpaqueBundle {
     /// The bundle header.
     pub header: BundleHeader,
@@ -138,7 +138,7 @@ impl<Extrinsic: Encode> From<Bundle<Extrinsic>> for OpaqueBundle {
 }
 
 /// Signed version of [`OpaqueBundle`].
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SignedOpaqueBundle {
     /// The bundle header.
     pub opaque_bundle: OpaqueBundle,
@@ -172,7 +172,7 @@ impl<Extrinsic: Encode> From<SignedBundle<Extrinsic>> for SignedOpaqueBundle {
 }
 
 /// Receipt of state execution.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct ExecutionReceipt<Number, Hash, SecondaryHash> {
     /// Primary block number.
     pub primary_number: Number,
@@ -196,7 +196,7 @@ impl<Number: Encode, Hash: Encode, SecondaryHash: Encode>
 }
 
 /// Signed version of [`ExecutionReceipt`] which will be gossiped over the executors network.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SignedExecutionReceipt<Number, Hash, SecondaryHash> {
     /// Execution receipt
     pub execution_receipt: ExecutionReceipt<Number, Hash, SecondaryHash>,
@@ -218,7 +218,7 @@ impl<Number: Encode, Hash: Encode, SecondaryHash: Encode>
 /// Execution phase along with an optional encoded call data.
 ///
 /// Each execution phase has a different method for the runtime call.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub enum ExecutionPhase {
     /// Executes the `initialize_block` hook.
     InitializeBlock { call_data: Vec<u8> },
@@ -284,7 +284,7 @@ impl ExecutionPhase {
 }
 
 /// Error type of fraud proof verification on primary node.
-#[derive(RuntimeDebug)]
+#[derive(Debug)]
 pub enum VerificationError {
     /// Failed to pass the execution proof check.
     BadProof(sp_std::boxed::Box<dyn sp_state_machine::Error>),
@@ -299,7 +299,7 @@ pub enum VerificationError {
 }
 
 /// Fraud proof for the state computation.
-#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct FraudProof {
     /// Parent number.
     pub parent_number: BlockNumber,

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -269,11 +269,11 @@ impl Archiver {
     /// Create a new instance of the archiver with initial state in case of restart.
     ///
     /// `block` corresponds to `last_archived_block` and will be processed accordingly to its state.
-    pub fn with_initial_state<B: AsRef<[u8]>>(
+    pub fn with_initial_state(
         record_size: usize,
         segment_size: usize,
         root_block: RootBlock,
-        encoded_block: B,
+        encoded_block: &[u8],
         mut object_mapping: BlockObjectMapping,
     ) -> Result<Self, ArchiverInstantiationError> {
         let mut archiver = Self::new(record_size, segment_size)?;
@@ -288,7 +288,6 @@ impl Archiver {
             .push_back(SegmentItem::RootBlock(root_block));
 
         if let Some(archived_block_bytes) = archiver.last_archived_block.partial_archived() {
-            let encoded_block = encoded_block.as_ref();
             let encoded_block_bytes = u32::try_from(encoded_block.len())
                 .expect("Blocks length is never bigger than u32; qed");
 
@@ -720,7 +719,7 @@ pub fn is_piece_valid(piece: &[u8], root: Sha256Hash, position: usize, record_si
             return false;
         }
     };
-    let leaf_hash = crypto::sha256_hash(&record);
+    let leaf_hash = crypto::sha256_hash(record);
 
     witness.is_valid(root, position, leaf_hash)
 }

--- a/crates/subspace-archiving/src/merkle_tree.rs
+++ b/crates/subspace-archiving/src/merkle_tree.rs
@@ -90,7 +90,7 @@ impl<'a> Witness<'a> {
 
         // Hash one more time as Merkle Tree implementation does
         // Merkle Tree leaf hash prefix is `0x00`
-        let leaf_hash = crypto::sha256_hash_pair(&[0x00], leaf_hash);
+        let leaf_hash = crypto::sha256_hash_pair(&[0x00], &leaf_hash);
 
         // Reconstruct lemma for verification
         let lemma = iter::once(leaf_hash)
@@ -174,7 +174,10 @@ impl MerkleTree {
         T: AsRef<[u8]>,
         I: IntoIterator<Item = T>,
     {
-        Self::new(data.into_iter().map(crypto::sha256_hash))
+        Self::new(
+            data.into_iter()
+                .map(|item| crypto::sha256_hash(item.as_ref())),
+        )
     }
 
     /// Get Merkle Root

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -159,7 +159,7 @@ fn archiver() {
             RECORD_SIZE,
             SEGMENT_SIZE,
             first_archived_segment.root_block,
-            block_1.clone(),
+            &block_1,
             block_1_object_mapping.clone(),
         )
         .unwrap();
@@ -248,7 +248,7 @@ fn archiver() {
             RECORD_SIZE,
             SEGMENT_SIZE,
             last_root_block,
-            block_2,
+            &block_2,
             BlockObjectMapping::default(),
         )
         .unwrap();
@@ -316,7 +316,7 @@ fn invalid_usage() {
                     archived_progress: ArchivedBlockProgress::Partial(10),
                 },
             },
-            &vec![0u8; 10],
+            &[0u8; 10],
             BlockObjectMapping::default(),
         );
 
@@ -343,7 +343,7 @@ fn invalid_usage() {
                     archived_progress: ArchivedBlockProgress::Partial(10),
                 },
             },
-            &vec![0u8; 6],
+            &[0u8; 6],
             BlockObjectMapping::default(),
         );
 

--- a/crates/subspace-archiving/tests/integration/merkle_tree.rs
+++ b/crates/subspace-archiving/tests/integration/merkle_tree.rs
@@ -8,7 +8,10 @@ fn merkle_tree() {
     let pieces: Vec<Piece> = iter::repeat_with(|| rand::random::<[u8; PIECE_SIZE]>().into())
         .take(number_of_pieces)
         .collect();
-    let hashes: Vec<Sha256Hash> = pieces.iter().map(crypto::sha256_hash).collect();
+    let hashes: Vec<Sha256Hash> = pieces
+        .iter()
+        .map(|item| crypto::sha256_hash(item.as_ref()))
+        .collect();
 
     let merkle_tree_data = MerkleTree::from_data(&pieces);
     let merkle_tree_hashes = MerkleTree::new(hashes.iter().copied());

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -20,9 +20,9 @@ use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
 /// Simple Sha2-256 hashing.
-pub fn sha256_hash<D: AsRef<[u8]>>(data: D) -> Sha256Hash {
+pub fn sha256_hash(data: &[u8]) -> Sha256Hash {
     let mut hasher = Sha256::new();
-    hasher.update(data.as_ref());
+    hasher.update(data);
     hasher
         .finalize()
         .as_slice()
@@ -31,10 +31,10 @@ pub fn sha256_hash<D: AsRef<[u8]>>(data: D) -> Sha256Hash {
 }
 
 /// Simple Sha2-256 hashing of a pair of values.
-pub fn sha256_hash_pair(a: impl AsRef<[u8]>, b: impl AsRef<[u8]>) -> Sha256Hash {
+pub fn sha256_hash_pair(a: &[u8], b: &[u8]) -> Sha256Hash {
     let mut hasher = Sha256::new();
-    hasher.update(a.as_ref());
-    hasher.update(b.as_ref());
+    hasher.update(a);
+    hasher.update(b);
     hasher
         .finalize()
         .as_slice()
@@ -43,10 +43,10 @@ pub fn sha256_hash_pair(a: impl AsRef<[u8]>, b: impl AsRef<[u8]>) -> Sha256Hash 
 }
 
 /// Hmac with Sha2-256 hash function.
-pub fn hmac_sha256<K: AsRef<[u8]>, P: AsRef<[u8]>>(key: K, piece: P) -> Sha256Hash {
-    let mut mac = Hmac::<Sha256>::new_from_slice(key.as_ref())
-        .expect("Sha256 HMAC can take key of any size; qed");
-    mac.update(piece.as_ref());
+pub fn hmac_sha256(key: &[u8], piece: &[u8]) -> Sha256Hash {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(key).expect("Sha256 HMAC can take key of any size; qed");
+    mac.update(piece);
 
     // `result` has type `Output` which is a thin wrapper around array of
     // bytes for providing constant time equality check

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -91,7 +91,7 @@ impl MultiFarming {
                     info!("Opening commitments");
                     let plot_commitments = Commitments::new(base_directory.join("commitments"))?;
 
-                    let subspace_codec = SubspaceCodec::new(identity.public_key());
+                    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
 
                     // Start the farming task
                     let farming = start_farmings.then(|| {

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -139,7 +139,8 @@ pub fn retrieve_piece_from_plots(
 ) -> io::Result<Option<Piece>> {
     let piece_index_hash = PieceIndexHash::from(piece_index);
     let mut plots = plots.iter().collect::<Vec<_>>();
-    plots.sort_by_key(|plot| PieceDistance::distance(&piece_index_hash, plot.public_key()));
+    plots
+        .sort_by_key(|plot| PieceDistance::distance(&piece_index_hash, plot.public_key().as_ref()));
 
     plots
         .iter()
@@ -566,7 +567,7 @@ impl IndexHashToOffsetDB {
                 subspace_core_primitives::bidirectional_distance(
                     &max_distance_key,
                     &PieceDistance::MIDDLE,
-                ) >= PieceDistance::distance(index_hash, self.address)
+                ) >= PieceDistance::distance(index_hash, self.address.as_ref())
             })
             .unwrap_or(true)
     }

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -64,7 +64,7 @@ async fn plotting_happy_path() {
         }
     }
 
-    let subspace_codec = SubspaceCodec::new(identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
 
     // Start archiving task
     let archiving_instance = Archiving::start(
@@ -148,7 +148,7 @@ async fn plotting_piece_eviction() {
         }
     }
 
-    let subspace_codec = SubspaceCodec::new(identity.public_key());
+    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
 
     // Start archiving task
     let archiving_instance = Archiving::start(

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -98,7 +98,6 @@ pub mod opaque {
     use parity_scale_codec::{Decode, Encode};
     #[cfg(feature = "std")]
     use serde::{Deserialize, Serialize};
-    use sp_core::RuntimeDebug;
     use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Header as HeaderT};
     use sp_runtime::{generic, DigestItem, OpaqueExtrinsic};
     use sp_std::prelude::*;
@@ -108,7 +107,7 @@ pub mod opaque {
     /// Opaque block type.
 
     /// Abstraction over a substrate block.
-    #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+    #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
     #[cfg_attr(
         feature = "std",
         derive(Serialize, Deserialize, parity_util_mem::MallocSizeOf)

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -182,7 +182,7 @@ fn get_successful_calls(block: Block) -> Vec<Hash> {
 }
 
 fn key(feed_id: u64, data: &[u8]) -> Sha256Hash {
-    crypto::sha256_hash_pair(feed_id.encode(), data)
+    crypto::sha256_hash_pair(&feed_id.encode(), data)
 }
 
 #[test]

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -83,7 +83,7 @@ pub struct SubspaceCodec {
 
 impl SubspaceCodec {
     /// New instance with 256-bit prime and 4096-byte genesis piece size
-    pub fn new<P: AsRef<[u8]>>(farmer_public_key: &P) -> Self {
+    pub fn new(farmer_public_key: &[u8]) -> Self {
         #[cfg(feature = "cuda")]
         let cuda_available = cuda::is_cuda_available();
 

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -35,7 +35,7 @@ use scale_info::TypeInfo;
 use sp_api::{decl_runtime_apis, impl_runtime_apis};
 use sp_application_crypto::{ecdsa, ed25519, sr25519, RuntimeAppPublic};
 pub use sp_core::hash::H256;
-use sp_core::{offchain::KeyTypeId, OpaqueMetadata, RuntimeDebug};
+use sp_core::{offchain::KeyTypeId, OpaqueMetadata};
 use sp_inherents::{CheckInherentsResult, InherentData};
 use sp_runtime::traits::NumberFor;
 use sp_runtime::{
@@ -120,7 +120,7 @@ pub fn native_version() -> NativeVersion {
 }
 
 /// Calls in transactions.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct Transfer {
     pub from: AccountId,
     pub to: AccountId,
@@ -159,7 +159,7 @@ impl Transfer {
 }
 
 /// Extrinsic for test-runtime.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum Extrinsic {
     AuthoritiesChange(Vec<AuthorityId>),
     Transfer {
@@ -437,7 +437,7 @@ impl GetRuntimeBlockType for Runtime {
     type RuntimeBlock = Block;
 }
 
-#[derive(Clone, RuntimeDebug, Encode, Decode, PartialEq, Eq, TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
 pub struct Origin;
 
 impl From<frame_system::Origin<Runtime>> for Origin {
@@ -494,7 +494,7 @@ impl frame_support::traits::OriginTrait for Origin {
     }
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct Event;
 
 impl From<frame_system::Event<Runtime>> for Event {

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -140,7 +140,7 @@ async fn start_farming<Client>(
         }
     });
 
-    let subspace_codec = SubspaceCodec::new(&keypair.public);
+    let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
     let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let (piece_index, mut encoding) = archived_pieces_receiver
         .await


### PR DESCRIPTION
Turns out replacing `RuntimeDebug` with `Debug` reduces the size of the bundle even though supposedly it should have been the same. Not entirely sure why.

Second commit removes generics on the crate boundary. This should improve compile times a bit since every crate that depends on previously generic functions will no longer have to do monomorphization.

Both commits reduce the size of the runtime bundle a bit.