### PR TITLE
Prune the receipts relative to the best execution chain number

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -182,8 +182,6 @@ mod pallet {
                 signed_execution_receipt
             );
 
-            // TODO: ensure the receipt is ready to be applied
-
             let SignedExecutionReceipt {
                 execution_receipt, ..
             } = signed_execution_receipt;

--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -675,18 +675,25 @@ where
     pub fn submit_execution_receipt_unsigned(
         signed_execution_receipt: SignedExecutionReceipt<T::BlockNumber, T::Hash, T::SecondaryHash>,
     ) {
+        let primary_number = signed_execution_receipt.execution_receipt.primary_number;
+
         let call = Call::submit_execution_receipt {
             signed_execution_receipt,
         };
 
         match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
             Ok(()) => {
-                log::info!(target: "runtime::subspace::executor", "Submitted execution receipt");
+                log::info!(
+                    target: "runtime::subspace::executor",
+                    "Execution receipt for block #{:?} submitted to the tx pool",
+                    primary_number,
+                );
             }
             Err(()) => {
                 log::error!(
                     target: "runtime::subspace::executor",
-                    "Error submitting execution receipt",
+                    "Error submitting execution receipt for block #{:?} to the tx pool",
+                    primary_number,
                 );
             }
         }

--- a/cumulus/client/cirrus-executor/src/aux_schema.rs
+++ b/cumulus/client/cirrus-executor/src/aux_schema.rs
@@ -4,9 +4,7 @@ use codec::{Decode, Encode};
 use sc_client_api::backend::AuxStore;
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_executor::ExecutionReceipt;
-use sp_runtime::traits::{
-	Block as BlockT, Header as HeaderT, NumberFor, One, SaturatedConversion, Saturating,
-};
+use sp_runtime::traits::{Block as BlockT, NumberFor, One, SaturatedConversion, Saturating};
 use subspace_core_primitives::BlockNumber;
 
 const EXECUTION_RECEIPT_KEY: &[u8] = b"execution_receipt";
@@ -38,6 +36,7 @@ fn load_decode<Backend: AuxStore, T: Decode>(
 pub(super) fn write_execution_receipt<Backend: AuxStore, Block: BlockT, PBlock: BlockT>(
 	backend: &Backend,
 	(block_hash, block_number): (Block::Hash, NumberFor<Block>),
+	best_execution_chain_number: NumberFor<Block>,
 	execution_receipt: &ExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
 ) -> Result<(), sp_blockchain::Error> {
 	let block_number_key = (EXECUTION_RECEIPT_BLOCK_NUMBER, block_number).encode();
@@ -51,29 +50,31 @@ pub(super) fn write_execution_receipt<Backend: AuxStore, Block: BlockT, PBlock: 
 
 	let mut new_first_saved_receipt = first_saved_receipt;
 
-	let keys_to_delete = if block_number - first_saved_receipt >= PRUNING_DEPTH.saturated_into() {
-		new_first_saved_receipt = block_number.saturating_sub((PRUNING_DEPTH - 1).saturated_into());
+	let keys_to_delete =
+		if best_execution_chain_number >= first_saved_receipt + PRUNING_DEPTH.saturated_into() {
+			new_first_saved_receipt =
+				best_execution_chain_number.saturating_sub((PRUNING_DEPTH - 1).saturated_into());
 
-		let mut keys_to_delete = vec![];
-		let mut to_delete_start = first_saved_receipt;
-		while to_delete_start < new_first_saved_receipt {
-			let delete_block_number_key =
-				(EXECUTION_RECEIPT_BLOCK_NUMBER, to_delete_start).encode();
-			if let Some(hashes_to_delete) =
-				load_decode::<_, Vec<Block::Hash>>(backend, delete_block_number_key.as_slice())?
-			{
-				keys_to_delete.extend(
-					hashes_to_delete.into_iter().map(|h| (EXECUTION_RECEIPT_KEY, h).encode()),
-				);
-				keys_to_delete.push(delete_block_number_key);
+			let mut keys_to_delete = vec![];
+			let mut to_delete_start = first_saved_receipt;
+			while to_delete_start < new_first_saved_receipt {
+				let delete_block_number_key =
+					(EXECUTION_RECEIPT_BLOCK_NUMBER, to_delete_start).encode();
+				if let Some(hashes_to_delete) =
+					load_decode::<_, Vec<Block::Hash>>(backend, delete_block_number_key.as_slice())?
+				{
+					keys_to_delete.extend(
+						hashes_to_delete.into_iter().map(|h| (EXECUTION_RECEIPT_KEY, h).encode()),
+					);
+					keys_to_delete.push(delete_block_number_key);
+				}
+				to_delete_start = to_delete_start.saturating_add(One::one());
 			}
-			to_delete_start = to_delete_start.saturating_add(One::one());
-		}
 
-		keys_to_delete
-	} else {
-		vec![]
-	};
+			keys_to_delete
+		} else {
+			vec![]
+		};
 
 	backend.insert_aux(
 		&[
@@ -100,10 +101,10 @@ where
 }
 
 pub(super) fn target_receipt_is_pruned(
-	current_block: BlockNumber,
+	best_execution_chain_number: BlockNumber,
 	target_block: BlockNumber,
 ) -> bool {
-	current_block.checked_sub(target_block + PRUNING_DEPTH).is_some()
+	best_execution_chain_number.checked_sub(target_block + PRUNING_DEPTH).is_some()
 }
 
 #[cfg(test)]
@@ -127,7 +128,7 @@ mod tests {
 	}
 
 	#[test]
-	fn prune_execution_receipt_works() {
+	fn normal_prune_execution_receipt_works() {
 		let client = substrate_test_runtime_client::new();
 
 		let receipt_start = || {
@@ -146,7 +147,13 @@ mod tests {
 		let receipt_at = |block_hash: Hash| load_execution_receipt(&client, block_hash).unwrap();
 
 		let write_receipt_at = |hash: Hash, number: BlockNumber, receipt: &ExecutionReceipt| {
-			write_execution_receipt::<_, Block, PBlock>(&client, (hash, number), receipt).unwrap()
+			write_execution_receipt::<_, Block, PBlock>(
+				&client,
+				(hash, number),
+				number - 1, // Ideally, the receipt of previous block has been included when writing the receipt of current block.
+				receipt,
+			)
+			.unwrap()
 		};
 
 		assert_eq!(receipt_start(), None);
@@ -166,7 +173,7 @@ mod tests {
 
 		assert!(!target_receipt_is_pruned(PRUNING_DEPTH, 1));
 
-		// Create PRUNING_DEPTH + 1 receipt.
+		// Create PRUNING_DEPTH + 1 receipt, best_execution_chain_number is PRUNING_DEPTH.
 		let block_hash = Hash::random();
 		assert!(receipt_at(block_hash).is_none());
 		write_receipt_at(
@@ -175,6 +182,16 @@ mod tests {
 			&create_execution_receipt(PRUNING_DEPTH + 1),
 		);
 		assert!(receipt_at(block_hash).is_some());
+
+		// Create PRUNING_DEPTH + 2 receipt, best_execution_chain_number is PRUNING_DEPTH + 1.
+		let block_hash = Hash::random();
+		write_receipt_at(
+			block_hash,
+			PRUNING_DEPTH + 2,
+			&create_execution_receipt(PRUNING_DEPTH + 2),
+		);
+		assert!(receipt_at(block_hash).is_some());
+
 		// ER of block #1 should be pruned.
 		assert!(receipt_at(block_hash_list[0]).is_none());
 		// block number mapping should be pruned as well.
@@ -182,12 +199,12 @@ mod tests {
 		assert!(target_receipt_is_pruned(PRUNING_DEPTH + 1, 1));
 		assert_eq!(receipt_start(), Some(2));
 
-		// Create PRUNING_DEPTH + 2 receipt.
+		// Create PRUNING_DEPTH + 3 receipt, best_execution_chain_number is PRUNING_DEPTH + 2.
 		let block_hash = Hash::random();
 		write_receipt_at(
 			block_hash,
-			PRUNING_DEPTH + 2,
-			&create_execution_receipt(PRUNING_DEPTH + 2),
+			PRUNING_DEPTH + 3,
+			&create_execution_receipt(PRUNING_DEPTH + 3),
 		);
 		assert!(receipt_at(block_hash).is_some());
 		// ER of block #2 should be pruned.
@@ -196,14 +213,111 @@ mod tests {
 		assert!(!target_receipt_is_pruned(PRUNING_DEPTH + 2, 3));
 		assert_eq!(receipt_start(), Some(3));
 
-		// Multiple hashes attached to the block #(PRUNING_DEPTH + 2)
+		// Multiple hashes attached to the block #(PRUNING_DEPTH + 3)
 		let block_hash2 = Hash::random();
 		write_receipt_at(
 			block_hash2,
-			PRUNING_DEPTH + 2,
-			&create_execution_receipt(PRUNING_DEPTH + 2),
+			PRUNING_DEPTH + 3,
+			&create_execution_receipt(PRUNING_DEPTH + 3),
 		);
 		assert!(receipt_at(block_hash2).is_some());
-		assert_eq!(hashes_at(PRUNING_DEPTH + 2), Some(vec![block_hash, block_hash2]));
+		assert_eq!(hashes_at(PRUNING_DEPTH + 3), Some(vec![block_hash, block_hash2]));
+	}
+
+	#[test]
+	fn execution_receipts_should_be_kept_against_best_execution_chain_number() {
+		let client = substrate_test_runtime_client::new();
+
+		let receipt_start = || {
+			load_decode::<_, BlockNumber>(&client, EXECUTION_RECEIPT_START.to_vec().as_slice())
+				.unwrap()
+		};
+
+		let hashes_at = |number: BlockNumber| {
+			load_decode::<_, Vec<Hash>>(
+				&client,
+				(EXECUTION_RECEIPT_BLOCK_NUMBER, number).encode().as_slice(),
+			)
+			.unwrap()
+		};
+
+		let receipt_at = |block_hash: Hash| load_execution_receipt(&client, block_hash).unwrap();
+
+		let write_receipt_at = |(hash, number): (Hash, BlockNumber),
+		                        best_execution_chain_number: BlockNumber,
+		                        receipt: &ExecutionReceipt| {
+			write_execution_receipt::<_, Block, PBlock>(
+				&client,
+				(hash, number),
+				best_execution_chain_number,
+				receipt,
+			)
+			.unwrap()
+		};
+
+		assert_eq!(receipt_start(), None);
+
+		// Create PRUNING_DEPTH receipts, best_execution_chain_number is 0, i.e., no receipt
+		// has ever been included on primary chain.
+		let block_hash_list = (1..=PRUNING_DEPTH)
+			.map(|block_number| {
+				let receipt = create_execution_receipt(block_number);
+				let block_hash = Hash::random();
+				write_receipt_at((block_hash, block_number), 0, &receipt);
+				assert_eq!(receipt_at(block_hash), Some(receipt));
+				assert_eq!(hashes_at(block_number), Some(vec![block_hash]));
+				assert_eq!(receipt_start(), Some(1));
+				block_hash
+			})
+			.collect::<Vec<_>>();
+
+		assert!(!target_receipt_is_pruned(PRUNING_DEPTH, 1));
+
+		// Create PRUNING_DEPTH + 1 receipt, best_execution_chain_number is 0.
+		let block_hash = Hash::random();
+		assert!(receipt_at(block_hash).is_none());
+		write_receipt_at(
+			(block_hash, PRUNING_DEPTH + 1),
+			0,
+			&create_execution_receipt(PRUNING_DEPTH + 1),
+		);
+
+		// Create PRUNING_DEPTH + 2 receipt, best_execution_chain_number is 0.
+		let block_hash = Hash::random();
+		write_receipt_at(
+			(block_hash, PRUNING_DEPTH + 2),
+			0,
+			&create_execution_receipt(PRUNING_DEPTH + 2),
+		);
+
+		// ER of block #1 should not be pruned even the size of stored receipts exceeds the pruning depth.
+		assert!(receipt_at(block_hash_list[0]).is_some());
+		// block number mapping for #1 should not be pruned neither.
+		assert!(hashes_at(1).is_some());
+		assert!(!target_receipt_is_pruned(0, 1));
+		assert_eq!(receipt_start(), Some(1));
+
+		// Create PRUNING_DEPTH + 3 receipt, best_execution_chain_number is 0.
+		let block_hash = Hash::random();
+		write_receipt_at(
+			(block_hash, PRUNING_DEPTH + 3),
+			0,
+			&create_execution_receipt(PRUNING_DEPTH + 3),
+		);
+
+		// Create PRUNING_DEPTH + 3 receipt, best_execution_chain_number is PRUNING_DEPTH + 3.
+		let block_hash = Hash::random();
+		write_receipt_at(
+			(block_hash, PRUNING_DEPTH + 4),
+			PRUNING_DEPTH + 3, // Now assuming all the missing receipts are included.
+			&create_execution_receipt(PRUNING_DEPTH + 4),
+		);
+		assert!(receipt_at(block_hash_list[0]).is_none());
+		// receipt and block number mapping for [1, 2, 3] should be pruned.
+		(1..=3).for_each(|pruned| {
+			assert!(hashes_at(pruned).is_none());
+			assert!(target_receipt_is_pruned(PRUNING_DEPTH + 3, pruned));
+		});
+		assert_eq!(receipt_start(), Some(4));
 	}
 }

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -268,8 +268,7 @@ where
 
 		crate::aux_schema::write_execution_receipt::<_, Block, PBlock>(
 			&*self.client,
-			header_hash,
-			header_number,
+			(header_hash, header_number),
 			&execution_receipt,
 		)?;
 

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -266,22 +266,6 @@ where
 			trace_root,
 		};
 
-		crate::aux_schema::write_execution_receipt::<_, Block, PBlock>(
-			&*self.client,
-			(header_hash, header_number),
-			&execution_receipt,
-		)?;
-
-		// TODO: The applied txs can be fully removed from the transaction pool
-
-		if self.primary_network.is_major_syncing() {
-			tracing::debug!(
-				target: LOG_TARGET,
-				"Skip generating signed execution receipt as the primary node is still major syncing..."
-			);
-			return Ok(())
-		}
-
 		let best_execution_chain_number = self
 			.primary_chain_client
 			.runtime_api()
@@ -295,6 +279,23 @@ where
 			header_number > best_execution_chain_number,
 			"Consensus chain number must larger than execution chain number by at least 1"
 		);
+
+		crate::aux_schema::write_execution_receipt::<_, Block, PBlock>(
+			&*self.client,
+			(header_hash, header_number),
+			best_execution_chain_number,
+			&execution_receipt,
+		)?;
+
+		// TODO: The applied txs can be fully removed from the transaction pool
+
+		if self.primary_network.is_major_syncing() {
+			tracing::debug!(
+				target: LOG_TARGET,
+				"Skip generating signed execution receipt as the primary node is still major syncing..."
+			);
+			return Ok(())
+		}
 
 		// Ideally, the receipt of current block will be included in the next block, i.e., no
 		// missing receipts.

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -678,6 +678,7 @@ where
 		}
 
 		let primary_number = execution_receipt.primary_number;
+		// TODO: best_execution_chain_number?
 		let best_number = self.client.info().best_number;
 
 		// Just ignore it if the receipt is too old and has been pruned.

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -597,7 +597,7 @@ async fn pallet_executor_unsigned_extrinsics_should_work() {
 		.expect("Submit receipt successfully");
 	let tx3 = create_and_send_submit_execution_receipt(3)
 		.await
-		.expect("Best block receipt must be able be included in the next block");
+		.expect("Best block receipt must be able to be included in the next block");
 
 	let ready_txs = || {
 		alice


### PR DESCRIPTION
The second and third commits are the core of this PR. Previously the local receipts on executor are pruned against the best number of primary chain, resulting in an issue that if the execution chain gets stuck somehow because no receipts are able to be submitted to the primary chain for a long time, these ancient receipts will be pruned by the executor and they will never be submitted to the primary chain. Now the receipts pruning on executor is relative to the best execution chain number on the primary chain so that even if the execution chain discontinues for a long time, it can still be recovered and resumed.