### PR TITLE
Fix for vote built on top of the previous block incorrectly rejected in some cases

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1066,7 +1066,13 @@ fn current_vote_verification_data<T: Config>(is_block_initialized: bool) -> Vote
         total_pieces: Pallet::<T>::total_pieces(),
         current_slot: Pallet::<T>::current_slot(),
         parent_slot: ParentVoteVerificationData::<T>::get()
-            .map(|parent_vote_verification_data| parent_vote_verification_data.current_slot)
+            .map(|parent_vote_verification_data| {
+                if is_block_initialized {
+                    parent_vote_verification_data.current_slot
+                } else {
+                    parent_vote_verification_data.parent_slot
+                }
+            })
             .unwrap_or_else(Pallet::<T>::current_slot),
     }
 }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -855,17 +855,7 @@ impl<T: Config> Pallet<T> {
             ParentBlockAuthorInfo::<T>::put((public_key, slot));
         }
 
-        let current_vote_verification_data = current_vote_verification_data::<T>(true);
-        match ParentVoteVerificationData::<T>::get() {
-            Some(parent_vote_verification_data) => {
-                if current_vote_verification_data != parent_vote_verification_data {
-                    ParentVoteVerificationData::<T>::put(current_vote_verification_data);
-                }
-            }
-            None => {
-                ParentVoteVerificationData::<T>::put(current_vote_verification_data);
-            }
-        }
+        ParentVoteVerificationData::<T>::put(current_vote_verification_data::<T>(true));
 
         ParentBlockVoters::<T>::put(CurrentBlockVoters::<T>::take().unwrap_or_default());
     }
@@ -1178,7 +1168,7 @@ fn check_vote<T: Config>(
     if pre_dispatch {
         // New time slot is already set, whatever time slot is in the vote it must be smaller or the
         // same (for votes produced locally)
-        let current_slot = Pallet::<T>::current_slot();
+        let current_slot = current_vote_verification_data.current_slot;
         if slot > current_slot || (slot == current_slot && height != current_block_number) {
             debug!(
                 target: "runtime::subspace",


### PR DESCRIPTION
I noticed that in some cases votes built on top of the previous block were rejected with incorrect time slot.

The reason was that parent block during call from transaction pool wasn't retrieved properly (`current_slot` in `ParentVoteVerificationData` in that case is the same as `CurrentSlot` because parent block has already finalized and updated `ParentVoteVerificationData`, I forgot that it wasn't called against the state at the beginning of that block as runtime API calls are).

I fixed it and added test that covers the case of vote built on top of the parent block.