### PR TITLE
Support additional naming conventions for Gemini snapshots

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -9,6 +9,7 @@ on:
   push:
     tags:
       - 'chain-spec-snapshot-*'
+      - 'gemini-*'
 
 jobs:
   chains-spec:

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -9,6 +9,7 @@ on:
   push:
     tags:
       - 'runtime-snapshot-*'
+      - 'gemini-*'
 
 jobs:
   runtime:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -10,6 +10,7 @@ on:
   push:
     tags:
       - 'snapshot-*'
+      - 'gemini-*'
 
 # Incremental compilation here isn't helpful
 env:


### PR DESCRIPTION
We'll follow `gemini-1a-DATE`, `gemini-1b-DATE` and so on convention going forward