### PR TITLE
Fix voting equivocation persistence

### DIFF
--- a/crates/pallet-subspace/src/equivocation.rs
+++ b/crates/pallet-subspace/src/equivocation.rs
@@ -214,6 +214,7 @@ fn is_known_offence<T: Config>(
 /// A Subspace equivocation offence report.
 ///
 /// When a farmer released two or more blocks at the same slot.
+#[derive(Debug, Eq, PartialEq)]
 pub struct SubspaceEquivocationOffence<PublicKey> {
     /// A Subspace slot in which this incident happened.
     pub slot: Slot,


### PR DESCRIPTION
While equivocation validation was correct, due to returning of an error from `ValidateUnsigned::pre_dispatch()` insertion into block list wasn't actually persisted and equivocation effectively didn't work.

Fixed that and updated test cases with not only validation check, but also actual results of the method call to make sure things work properly.