### PR TITLE
Control non-root storage access

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -300,6 +300,8 @@ mod pallet {
     pub struct GenesisConfig {
         /// Whether rewards should be enabled.
         pub enable_rewards: bool,
+        /// Whether storage access should be enabled.
+        pub enable_storage_access: bool,
     }
 
     #[cfg(feature = "std")]
@@ -307,6 +309,7 @@ mod pallet {
         fn default() -> Self {
             Self {
                 enable_rewards: true,
+                enable_storage_access: true,
             }
         }
     }
@@ -315,8 +318,9 @@ mod pallet {
     impl<T: Config> GenesisBuild<T> for GenesisConfig {
         fn build(&self) {
             if self.enable_rewards {
-                EnableRewards::<T>::put::<T::BlockNumber>(One::one())
+                EnableRewards::<T>::put::<T::BlockNumber>(One::one());
             }
+            IsStorageAccessEnabled::<T>::put(self.enable_storage_access);
         }
     }
 
@@ -436,7 +440,7 @@ mod pallet {
     #[pallet::storage]
     pub(super) type PorRandomness<T> = StorageValue<_, Randomness>;
 
-    /// Enable storage access for al users.
+    /// Enable storage access for all users.
     #[pallet::storage]
     #[pallet::getter(fn is_storage_access_enabled)]
     pub(super) type IsStorageAccessEnabled<T> = StorageValue<_, bool, ValueQuery>;

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -436,6 +436,11 @@ mod pallet {
     #[pallet::storage]
     pub(super) type PorRandomness<T> = StorageValue<_, Randomness>;
 
+    /// Enable storage access for al users.
+    #[pallet::storage]
+    #[pallet::getter(fn is_storage_access_enabled)]
+    pub(super) type IsStorageAccessEnabled<T> = StorageValue<_, bool, ValueQuery>;
+
     #[pallet::hooks]
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
         fn on_initialize(block_number: T::BlockNumber) -> Weight {
@@ -480,7 +485,7 @@ mod pallet {
             Self::do_store_root_blocks(root_blocks)
         }
 
-        /// Enables solution range adjustment after every era.
+        /// Enable solution range adjustment after every era.
         /// Note: No effect on the solution range for the current era
         #[pallet::weight(T::DbWeight::get().writes(1))]
         pub fn enable_solution_range_adjustment(
@@ -527,7 +532,7 @@ mod pallet {
             Ok(())
         }
 
-        /// Enables rewards for blocks and votes at specified block height.
+        /// Enable rewards for blocks and votes at specified block height.
         #[pallet::weight(T::DbWeight::get().writes(1))]
         pub fn enable_rewards(
             origin: OriginFor<T>,
@@ -536,6 +541,16 @@ mod pallet {
             ensure_root(origin)?;
 
             Self::do_enable_rewards(height)
+        }
+
+        /// Enable storage access for all users.
+        #[pallet::weight(T::DbWeight::get().writes(1))]
+        pub fn enable_storage_access(origin: OriginFor<T>) -> DispatchResult {
+            ensure_root(origin)?;
+
+            IsStorageAccessEnabled::<T>::put(true);
+
+            Ok(())
         }
     }
 

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -141,6 +141,7 @@ pub fn gemini_config_compiled() -> Result<ConsensusChainSpec, String> {
                         .expect("Wrong Executor authority address"),
                 ),
                 false,
+                false,
             )
         },
         // Bootnodes
@@ -191,6 +192,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec, String> {
                     get_account_id_from_seed("Alice"),
                     get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
+                false,
                 false,
             )
         },
@@ -245,6 +247,7 @@ pub fn local_config() -> Result<ConsensusChainSpec, String> {
                     get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
                 false,
+                false,
             )
         },
         // Bootnodes
@@ -272,6 +275,7 @@ fn subspace_genesis_config(
     vesting: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
     executor_authority: (AccountId, ExecutorId),
     enable_rewards: bool,
+    enable_storage_access: bool,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -284,7 +288,10 @@ fn subspace_genesis_config(
             // Assign network admin rights.
             key: Some(sudo_account),
         },
-        subspace: SubspaceConfig { enable_rewards },
+        subspace: SubspaceConfig {
+            enable_rewards,
+            enable_storage_access,
+        },
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {
             executor: Some(executor_authority),

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -694,9 +694,9 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 
 /// Controls non-root access to feeds and object store
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
-pub struct ControlNonRootStorageAccess;
+pub struct CheckStorageAccess;
 
-impl SignedExtension for ControlNonRootStorageAccess {
+impl SignedExtension for CheckStorageAccess {
     const IDENTIFIER: &'static str = "ControlNonRootStorageAccess";
     type AccountId = <Runtime as frame_system::Config>::AccountId;
     type Call = <Runtime as frame_system::Config>::Call;
@@ -742,7 +742,7 @@ pub type SignedExtra = (
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-    ControlNonRootStorageAccess,
+    CheckStorageAccess,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -92,6 +92,7 @@ fn create_genesis_config(
         },
         subspace: SubspaceConfig {
             enable_rewards: false,
+            enable_storage_access: false,
         },
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {


### PR DESCRIPTION
We don't want regular users to upload any data to the network (submit any signed transaction basically) until we have enable cost of storage adjustment