### PR TITLE
Replace non-canonical signatures with canonical for local challenge and PoR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8361,6 +8361,7 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
+ "merlin",
  "num-traits",
  "num_cpus",
  "rand 0.8.5",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -41,7 +41,8 @@ use subspace_core_primitives::{
     Sha256Hash, Solution, Tag, PIECE_SIZE,
 };
 use subspace_solving::{
-    create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
+    create_tag, create_tag_signature, derive_global_challenge, derive_local_challenge,
+    SubspaceCodec, REWARD_SIGNING_CONTEXT,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -195,7 +196,7 @@ pub fn go_to_block(
     let piece_index = 0;
     let mut encoding = Piece::default();
     subspace_codec.encode(&mut encoding, piece_index).unwrap();
-    let tag: Tag = subspace_solving::create_tag(&encoding, {
+    let tag: Tag = create_tag(&encoding, {
         let salts = Subspace::salts();
         if salts.switch_next_block {
             salts.next.unwrap()
@@ -388,10 +389,9 @@ pub fn create_signed_vote(
 ) -> SignedVote<u64, <Block as BlockT>::Hash, <Test as frame_system::Config>::AccountId> {
     let reward_signing_context = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
 
-    let global_challenge =
-        subspace_solving::derive_global_challenge(global_randomnesses, slot.into());
+    let global_challenge = derive_global_challenge(global_randomnesses, slot.into());
 
-    let tag = subspace_solving::create_tag(&encoding, salt);
+    let tag = create_tag(&encoding, salt);
 
     let vote = Vote::<u64, <Block as BlockT>::Hash, _>::V0 {
         height,

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -40,7 +40,9 @@ use subspace_core_primitives::{
     ArchivedBlockProgress, LastArchivedBlock, LocalChallenge, Piece, Randomness, RootBlock, Salt,
     Sha256Hash, Solution, Tag, PIECE_SIZE,
 };
-use subspace_solving::{SubspaceCodec, REWARD_SIGNING_CONTEXT, SOLUTION_SIGNING_CONTEXT};
+use subspace_solving::{
+    create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
+};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -190,7 +192,6 @@ pub fn go_to_block(
     };
 
     let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
-    let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let piece_index = 0;
     let mut encoding = Piece::default();
     subspace_codec.encode(&mut encoding, piece_index).unwrap();
@@ -210,8 +211,11 @@ pub fn go_to_block(
             reward_address,
             piece_index: 0,
             encoding,
-            signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),
-            local_challenge: LocalChallenge::default(),
+            tag_signature: create_tag_signature(keypair, tag),
+            local_challenge: LocalChallenge {
+                output: [0; 32],
+                proof: [0; 64],
+            },
             tag,
         },
     );
@@ -267,12 +271,10 @@ pub fn generate_equivocation_proof(
     let current_block = System::block_number();
     let current_slot = CurrentSlot::<Test>::get();
 
-    let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let encoding = Piece::default();
     let tag: Tag = [(current_block % 8) as u8; 8];
 
     let public_key = FarmerPublicKey::unchecked_from(keypair.public.to_bytes());
-    let signature = keypair.sign(ctx.bytes(&tag)).to_bytes();
 
     let make_header = |piece_index, reward_address: <Test as frame_system::Config>::AccountId| {
         let parent_hash = System::parent_hash();
@@ -283,8 +285,11 @@ pub fn generate_equivocation_proof(
                 reward_address,
                 piece_index,
                 encoding: encoding.clone(),
-                signature: signature.into(),
-                local_challenge: LocalChallenge::default(),
+                tag_signature: create_tag_signature(keypair, tag),
+                local_challenge: LocalChallenge {
+                    output: [0; 32],
+                    proof: [0; 64],
+                },
                 tag,
             },
         );
@@ -381,15 +386,10 @@ pub fn create_signed_vote(
     encoding: Piece,
     reward_address: <Test as frame_system::Config>::AccountId,
 ) -> SignedVote<u64, <Block as BlockT>::Hash, <Test as frame_system::Config>::AccountId> {
-    let solution_signing_context = schnorrkel::signing_context(SOLUTION_SIGNING_CONTEXT);
     let reward_signing_context = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
 
     let global_challenge =
         subspace_solving::derive_global_challenge(global_randomnesses, slot.into());
-    let local_challenge = keypair
-        .sign(solution_signing_context.bytes(&global_challenge))
-        .to_bytes()
-        .into();
 
     let tag = subspace_solving::create_tag(&encoding, salt);
 
@@ -402,11 +402,8 @@ pub fn create_signed_vote(
             reward_address,
             piece_index: 0,
             encoding,
-            signature: keypair
-                .sign(solution_signing_context.bytes(&tag))
-                .to_bytes()
-                .into(),
-            local_challenge,
+            tag_signature: create_tag_signature(keypair, tag),
+            local_challenge: derive_local_challenge(keypair, global_challenge),
             tag,
         },
     };

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -1108,7 +1108,7 @@ fn vote_invalid_solution_signature() {
         );
 
         let Vote::V0 { solution, .. } = &mut signed_vote.vote;
-        solution.signature = rand::random::<[u8; 64]>().into();
+        solution.tag_signature.output = rand::random();
 
         // Fix signed vote signature after changed contents
         signed_vote.signature = FarmerSignature::unchecked_from(

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -47,7 +47,7 @@ use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::Solution;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 const SOLUTION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -80,7 +80,7 @@ pub trait SubspaceRpcApi {
     fn subscribe_reward_signing(&self);
 
     #[method(name = "subspace_submitRewardSignature")]
-    fn submit_reward_signature(&self, reward_signature: RewardSignature) -> RpcResult<()>;
+    fn submit_reward_signature(&self, reward_signature: RewardSignatureResponse) -> RpcResult<()>;
 
     /// Archived segment subscription
     #[subscription(
@@ -103,7 +103,7 @@ struct SolutionResponseSenders {
 #[derive(Default)]
 struct BlockSignatureSenders {
     current_hash: H256,
-    senders: Vec<async_oneshot::Sender<RewardSignature>>,
+    senders: Vec<async_oneshot::Sender<RewardSignatureResponse>>,
 }
 
 #[derive(Default)]
@@ -248,35 +248,18 @@ where
                     let forward_solution_fut = async move {
                         if let Ok(solution_response) = response_receiver.await {
                             if let Some(solution) = solution_response.maybe_solution {
-                                let public_key =
-                                    match FarmerPublicKey::from_slice(&solution.public_key) {
-                                        Ok(public_key) => public_key,
-                                        Err(()) => {
-                                            warn!(
-                                                "Failed to convert public key: {:?}",
-                                                solution.public_key
-                                            );
-                                            return;
-                                        }
-                                    };
+                                let public_key = FarmerPublicKey::from_slice(&solution.public_key)
+                                    .expect("Always correct length; qed");
                                 let reward_address =
-                                    match FarmerPublicKey::from_slice(&solution.reward_address) {
-                                        Ok(public_key) => public_key,
-                                        Err(()) => {
-                                            warn!(
-                                                "Failed to convert reward address: {:?}",
-                                                solution.reward_address,
-                                            );
-                                            return;
-                                        }
-                                    };
+                                    FarmerPublicKey::from_slice(&solution.reward_address)
+                                        .expect("Always correct length; qed");
 
                                 let solution = Solution {
                                     public_key,
                                     reward_address,
                                     piece_index: solution.piece_index,
                                     encoding: solution.encoding,
-                                    signature: solution.signature,
+                                    tag_signature: solution.tag_signature,
                                     local_challenge: solution.local_challenge,
                                     tag: solution.tag,
                                 };
@@ -403,7 +386,7 @@ where
         );
     }
 
-    fn submit_reward_signature(&self, reward_signature: RewardSignature) -> RpcResult<()> {
+    fn submit_reward_signature(&self, reward_signature: RewardSignatureResponse) -> RpcResult<()> {
         let reward_signature_senders = self.reward_signature_senders.clone();
 
         // TODO: This doesn't track what client sent a solution, allowing some clients to send

--- a/crates/sc-consensus-subspace/src/aux_schema.rs
+++ b/crates/sc-consensus-subspace/src/aux_schema.rs
@@ -21,7 +21,12 @@ use codec::{Decode, Encode};
 
 use sc_client_api::backend::AuxStore;
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
-use sp_consensus_subspace::SubspaceBlockWeight;
+
+/// The cumulative weight of a Subspace block, i.e. sum of block weights starting
+/// at this block until the genesis block.
+///
+/// The closer solution's tag is to the target, the heavier it is.
+type SubspaceBlockWeight = u128;
 
 /// The aux storage key used to store the block weight of the given block hash.
 fn block_weight_key<H: Encode>(block_hash: H) -> Vec<u8> {

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -30,6 +30,7 @@ use sc_consensus_slots::{
 use sc_telemetry::TelemetryHandle;
 use sc_utils::mpsc::tracing_unbounded;
 use schnorrkel::context::SigningContext;
+use schnorrkel::PublicKey;
 use sp_api::{ApiError, NumberFor, ProvideRuntimeApi, TransactionFor};
 use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata};
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SyncOracle};
@@ -45,6 +46,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_core_primitives::{Randomness, Salt, Solution};
+use subspace_solving::{derive_global_challenge, derive_target};
 
 pub(super) struct SubspaceSlotWorker<Block: BlockT, Client, E, I, SO, L, BS> {
     pub(super) client: Arc<Client>,
@@ -55,7 +57,6 @@ pub(super) struct SubspaceSlotWorker<Block: BlockT, Client, E, I, SO, L, BS> {
     pub(super) force_authoring: bool,
     pub(super) backoff_authoring_blocks: Option<BS>,
     pub(super) subspace_link: SubspaceLink<Block>,
-    pub(super) solution_signing_context: SigningContext,
     pub(super) reward_signing_context: SigningContext,
     pub(super) block_proposal_slot_portion: SlotProportion,
     pub(super) max_block_proposal_slot_portion: Option<SlotProportion>,
@@ -129,13 +130,11 @@ where
             extract_solution_ranges_for_block(self.client.as_ref(), &parent_block_id).ok()?;
         let (salt, next_salt) =
             extract_salt_for_block(self.client.as_ref(), &parent_block_id).ok()?;
+        let global_challenge = derive_global_challenge(&global_randomness, slot.into());
 
         let new_slot_info = NewSlotInfo {
             slot,
-            global_challenge: subspace_solving::derive_global_challenge(
-                &global_randomness,
-                slot.into(),
-            ),
+            global_challenge,
             salt,
             next_salt,
             solution_range,
@@ -227,17 +226,24 @@ where
                             max_plot_size,
                             total_pieces,
                         }),
-                        solution_signing_context: &self.solution_signing_context,
                     },
                 );
 
             if let Err(error) = solution_verification_result {
                 warn!(target: "subspace", "Invalid solution received for slot {slot}: {error:?}");
             } else {
+                // Verification of the local challenge was done before this
+                let target = derive_target(
+                    &PublicKey::from_bytes(solution.public_key.as_ref())
+                        .expect("Always correct length; qed"),
+                    global_challenge,
+                    &solution.local_challenge,
+                )
+                .expect("Verification of the local challenge was done before this; qed");
                 // If solution is of high enough quality and block pre-digest wasn't produced yet,
                 // block reward is claimed
                 if maybe_pre_digest.is_none()
-                    && verification::is_within_solution_range(&solution, solution_range)
+                    && verification::is_within_solution_range(target, solution.tag, solution_range)
                 {
                     info!(target: "subspace", "🚜 Claimed block at slot {slot}");
 

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -72,7 +72,7 @@ use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{FlatPieces, LocalChallenge, Piece, Solution, Tag, TagSignature};
 use subspace_solving::{
-    create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
+    create_tag, create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
 };
 use substrate_test_runtime::{Block as TestBlock, Hash};
 
@@ -589,7 +589,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
             }) = new_slot_notification_stream.next().await
             {
                 if Into::<u64>::into(new_slot_info.slot) % 3 == (*peer_id) as u64 {
-                    let tag: Tag = subspace_solving::create_tag(&encoding, new_slot_info.salt);
+                    let tag: Tag = create_tag(&encoding, new_slot_info.salt);
 
                     let _ = solution_sender
                         .send(Solution {

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -16,9 +16,7 @@
 
 //! Private implementation details of Subspace consensus digests.
 
-use crate::{
-    ConsensusLog, FarmerPublicKey, FarmerSignature, SubspaceBlockWeight, SUBSPACE_ENGINE_ID,
-};
+use crate::{ConsensusLog, FarmerPublicKey, FarmerSignature, SUBSPACE_ENGINE_ID};
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
 use sp_runtime::DigestItem;
@@ -32,17 +30,6 @@ pub struct PreDigest<PublicKey, RewardAddress> {
     pub slot: Slot,
     /// Solution (includes PoR)
     pub solution: Solution<PublicKey, RewardAddress>,
-}
-
-impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
-    /// Returns the weight _added_ by this digest, not the cumulative weight
-    /// of the chain.
-    pub fn added_weight(&self) -> SubspaceBlockWeight {
-        let target = u64::from_be_bytes(self.solution.local_challenge.derive_target());
-        let tag = u64::from_be_bytes(self.solution.tag);
-
-        u128::from(u64::MAX - subspace_core_primitives::bidirectional_distance(&target, &tag))
-    }
 }
 
 /// Information about the global randomness for the block.

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -27,8 +27,8 @@ use sp_runtime::DigestItem;
 use subspace_archiving::archiver;
 use subspace_core_primitives::{PieceIndex, Randomness, Salt, Sha256Hash, Solution, Tag};
 use subspace_solving::{
-    derive_global_challenge, derive_target, verify_local_challenge, verify_tag_signature,
-    PieceDistance, SubspaceCodec,
+    derive_global_challenge, derive_target, is_tag_valid, verify_local_challenge,
+    verify_tag_signature, PieceDistance, SubspaceCodec,
 };
 
 /// Errors encountered by the Subspace authorship task.
@@ -206,7 +206,7 @@ fn check_piece_tag<Header, RewardAddress>(
 where
     Header: HeaderT,
 {
-    if !subspace_solving::is_tag_valid(&solution.encoding, salt, solution.tag) {
+    if !is_tag_valid(&solution.encoding, salt, solution.tag) {
         return Err(VerificationError::InvalidTag(slot));
     }
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/bench_rpc_client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_farmer::{RpcClient, RpcClientError as MockError};
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -91,7 +91,7 @@ impl RpcClient for BenchRpcClient {
 
     async fn submit_reward_signature(
         &self,
-        _reward_signature: RewardSignature,
+        _reward_signature: RewardSignatureResponse,
     ) -> Result<(), MockError> {
         unreachable!("Unreachable, as we don't start farming for benchmarking")
     }

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_core_primitives::{Piece, Salt, Tag, PIECE_SIZE};
+use subspace_solving::create_tag;
 use thiserror::Error;
 use tracing::trace;
 
@@ -136,7 +137,7 @@ impl Commitments {
 
                 let tags: Vec<Tag> = pieces
                     .par_chunks_exact(PIECE_SIZE)
-                    .map(|piece| subspace_solving::create_tag(piece, salt))
+                    .map(|piece| create_tag(piece, salt))
                     .collect();
 
                 for (tag, offset) in tags.iter().zip(batch_start..) {
@@ -198,7 +199,7 @@ impl Commitments {
 
             if let Some(db) = db_guard.as_ref() {
                 for piece in pieces {
-                    let tag = subspace_solving::create_tag(piece, salt);
+                    let tag = create_tag(piece, salt);
                     db.delete(tag).map_err(CommitmentError::CommitmentDb)?;
                 }
             }
@@ -236,9 +237,7 @@ impl Commitments {
 
             if let Some(db) = db_guard.as_ref() {
                 let tags_with_offset: Vec<(PieceOffset, Tag)> = pieces_with_offsets()
-                    .map(|(piece_offset, piece)| {
-                        (piece_offset, subspace_solving::create_tag(piece, salt))
-                    })
+                    .map(|(piece_offset, piece)| (piece_offset, create_tag(piece, salt)))
                     .collect();
 
                 for (piece_offset, tag) in tags_with_offset {

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -11,8 +11,10 @@ use futures::future::Either;
 use futures::{future, StreamExt};
 use std::sync::mpsc;
 use std::time::Instant;
-use subspace_core_primitives::{LocalChallenge, PublicKey, Salt, Solution};
-use subspace_rpc_primitives::{RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse};
+use subspace_core_primitives::{PublicKey, Salt, Solution};
+use subspace_rpc_primitives::{
+    RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+};
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace, warn};
@@ -151,7 +153,7 @@ async fn subscribe_to_slot_info<T: RpcClient>(
                 let signature = identity.sign_reward_hash(&hash);
 
                 match client
-                    .submit_reward_signature(RewardSignature {
+                    .submit_reward_signature(RewardSignatureResponse {
                         hash,
                         signature: Some(signature.to_bytes().into()),
                     })
@@ -185,21 +187,19 @@ async fn subscribe_to_slot_info<T: RpcClient>(
             let plot = plot.clone();
 
             move || {
-                let local_challenge = derive_local_challenge(slot_info.global_challenge, &identity);
+                let (local_challenge, target) =
+                    identity.derive_local_challenge_and_target(slot_info.global_challenge);
+
                 // Try to first find a block authoring solution, then if not found try to find a vote
                 let maybe_tag = commitments
-                    .find_by_range(
-                        local_challenge.derive_target(),
-                        slot_info.solution_range,
-                        slot_info.salt,
-                    )
+                    .find_by_range(target, slot_info.solution_range, slot_info.salt)
                     .or_else(|| {
                         if slot_info.solution_range == slot_info.voting_solution_range {
                             return None;
                         }
 
                         commitments.find_by_range(
-                            local_challenge.derive_target(),
+                            target,
                             slot_info.voting_solution_range,
                             slot_info.salt,
                         )
@@ -214,7 +214,7 @@ async fn subscribe_to_slot_info<T: RpcClient>(
                             reward_address,
                             piece_index,
                             encoding,
-                            signature: identity.sign_farmer_solution(&tag).to_bytes().into(),
+                            tag_signature: identity.create_tag_signature(tag),
                             local_challenge,
                             tag,
                         };
@@ -330,15 +330,4 @@ fn update_commitments(
             });
         }
     }
-}
-
-/// Derive local challenge for farmer's identity from the global challenge.
-fn derive_local_challenge<C: AsRef<[u8]>>(
-    global_challenge: C,
-    identity: &Identity,
-) -> LocalChallenge {
-    identity
-        .sign_farmer_solution(global_challenge.as_ref())
-        .to_bytes()
-        .into()
 }

--- a/crates/subspace-farmer/src/mock_rpc_client.rs
+++ b/crates/subspace-farmer/src/mock_rpc_client.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 use tokio::sync::Mutex;
 
@@ -28,10 +28,10 @@ pub struct Inner {
     #[allow(dead_code)]
     reward_signing_info_sender: Mutex<Option<mpsc::Sender<RewardSigningInfo>>>,
     reward_signing_info_receiver: Arc<Mutex<mpsc::Receiver<RewardSigningInfo>>>,
-    reward_signature_sender: mpsc::Sender<RewardSignature>,
+    reward_signature_sender: mpsc::Sender<RewardSignatureResponse>,
     // TODO: Use this
     #[allow(dead_code)]
-    reward_signature_receiver: Arc<Mutex<mpsc::Receiver<RewardSignature>>>,
+    reward_signature_receiver: Arc<Mutex<mpsc::Receiver<RewardSignatureResponse>>>,
     archived_segments_sender: Mutex<Option<mpsc::Sender<ArchivedSegment>>>,
     archived_segments_receiver: Arc<Mutex<mpsc::Receiver<ArchivedSegment>>>,
     acknowledge_archived_segment_sender: mpsc::Sender<u64>,
@@ -193,7 +193,10 @@ impl RpcClient for MockRpcClient {
         Ok(Box::pin(receiver))
     }
 
-    async fn submit_reward_signature(&self, signature: RewardSignature) -> Result<(), MockError> {
+    async fn submit_reward_signature(
+        &self,
+        signature: RewardSignatureResponse,
+    ) -> Result<(), MockError> {
         self.inner
             .reward_signature_sender
             .clone()

--- a/crates/subspace-farmer/src/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_rpc_client.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// `WsClient` wrapper.
@@ -85,7 +85,7 @@ impl RpcClient for NodeRpcClient {
     /// Submit a block signature
     async fn submit_reward_signature(
         &self,
-        reward_signature: RewardSignature,
+        reward_signature: RewardSignatureResponse,
     ) -> Result<(), RpcError> {
         Ok(self
             .client

--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -11,7 +11,7 @@ use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{PieceIndexHash, Salt, PIECE_SIZE, SHA256_HASH_SIZE};
 use subspace_rpc_primitives::FarmerMetadata;
-use subspace_solving::SubspaceCodec;
+use subspace_solving::{create_tag, SubspaceCodec};
 use tempfile::TempDir;
 
 const MERKLE_NUM_LEAVES: usize = 8_usize;
@@ -181,7 +181,7 @@ async fn plotting_piece_eviction() {
                 //  allow `None` and not errors once that is the case
                 if let Ok(mut read_piece) = plot.read_piece(PieceIndexHash::from_index(piece_index))
                 {
-                    let correct_tag = subspace_solving::create_tag(&read_piece, salt);
+                    let correct_tag = create_tag(&read_piece, salt);
 
                     subspace_codec.decode(&mut read_piece, piece_index).unwrap();
 

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use std::pin::Pin;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignature, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// To become error type agnostic
@@ -32,8 +32,10 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
     ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, Error>;
 
     /// Submit a block signature
-    async fn submit_reward_signature(&self, reward_signature: RewardSignature)
-        -> Result<(), Error>;
+    async fn submit_reward_signature(
+        &self,
+        reward_signature: RewardSignatureResponse,
+    ) -> Result<(), Error>;
 
     /// Subscribe to archived segments
     async fn subscribe_archived_segments(

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -17,7 +17,9 @@
 
 use hex_buffer_serde::{Hex, HexForm};
 use serde::{Deserialize, Serialize};
-use subspace_core_primitives::{PublicKey, Salt, Sha256Hash, Signature, SlotNumber, Solution};
+use subspace_core_primitives::{
+    PublicKey, RewardSignature, Salt, Sha256Hash, SlotNumber, Solution,
+};
 
 /// Metadata necessary for farmer operation
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -77,10 +79,10 @@ pub struct RewardSigningInfo {
 /// Signature in response to reward hash signing request.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RewardSignature {
+pub struct RewardSignatureResponse {
     /// Hash that was signed.
     #[serde(with = "HexForm")]
     pub hash: [u8; 32],
     /// Pre-header or vote hash signature.
-    pub signature: Option<Signature>,
+    pub signature: Option<RewardSignature>,
 }

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+merlin = { version = "2.0.1", default-features = false }
 num_cpus = { version = "1.13.0", optional = true }
 num-traits = { version = "0.2.15", default-features = false }
 rayon = { version = "1.5.3", optional = true }
@@ -30,6 +31,7 @@ default = [
     "std",
 ]
 std = [
+    "merlin/std",
     "num_cpus",
     "num-traits/std",
     "rayon",

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -24,16 +24,19 @@ mod codec;
 
 pub use codec::{BatchEncodeError, SubspaceCodec};
 pub use construct_uint::PieceDistance;
-use schnorrkel::SignatureResult;
+use merlin::Transcript;
+use schnorrkel::vrf::{VRFInOut, VRFOutput, VRFProof};
+use schnorrkel::{Keypair, PublicKey, SignatureResult};
 use subspace_core_primitives::{
-    crypto, LocalChallenge, Piece, Randomness, Salt, Sha256Hash, Tag, TAG_SIZE,
+    crypto, LocalChallenge, Piece, Randomness, Salt, Sha256Hash, Tag, TagSignature, TAG_SIZE,
 };
 
-/// Signing context used for creating solution signatures by farmers.
-pub const SOLUTION_SIGNING_CONTEXT: &[u8] = b"farmer_solution";
+const LOCAL_CHALLENGE_LABEL: &[u8] = b"subspace_local_challenge";
+const PLOT_TARGET_CONTEXT: &[u8] = b"subspace_plot_target";
+const TAG_SIGNATURE_LABEL: &[u8] = b"subspace_tag_signature";
 
 /// Signing context used for creating reward signatures by farmers.
-pub const REWARD_SIGNING_CONTEXT: &[u8] = b"farmer_reward";
+pub const REWARD_SIGNING_CONTEXT: &[u8] = b"subspace_reward";
 
 #[allow(clippy::assign_op_pattern, clippy::ptr_offset_with_cast)]
 mod construct_uint {
@@ -95,20 +98,104 @@ pub fn create_tag(piece: &[u8], salt: Salt) -> Tag {
         .expect("Slice is always of correct size; qed")
 }
 
+// TODO: Separate type for global challenge
 /// Derive global slot challenge from global randomness.
 pub fn derive_global_challenge(global_randomness: &Randomness, slot: u64) -> Sha256Hash {
     crypto::sha256_hash_pair(global_randomness, &slot.to_le_bytes())
 }
 
+fn create_local_challenge_transcript(global_challenge: &Sha256Hash) -> Transcript {
+    let mut transcript = Transcript::new(LOCAL_CHALLENGE_LABEL);
+    transcript.append_message(b"global challenge", global_challenge);
+    transcript
+}
+
+/// Derive local challenge for farmer from keypair and global challenge.
+pub fn derive_local_challenge(keypair: &Keypair, global_challenge: Sha256Hash) -> LocalChallenge {
+    let (in_out, proof, _) = keypair.vrf_sign(create_local_challenge_transcript(&global_challenge));
+
+    LocalChallenge {
+        output: in_out.output.to_bytes(),
+        proof: proof.to_bytes(),
+    }
+}
+
+/// Derive local challenge and target for farmer from keypair and global challenge.
+pub fn derive_local_challenge_and_target(
+    keypair: &Keypair,
+    global_challenge: Sha256Hash,
+) -> (LocalChallenge, Tag) {
+    let (in_out, proof, _) = keypair.vrf_sign(create_local_challenge_transcript(&global_challenge));
+
+    let local_challenge = LocalChallenge {
+        output: in_out.output.to_bytes(),
+        proof: proof.to_bytes(),
+    };
+    let target = in_out.make_bytes(PLOT_TARGET_CONTEXT);
+
+    (local_challenge, target)
+}
+
 /// Verify local challenge for farmer's public key that was derived from the global challenge.
-pub fn is_local_challenge_valid(
+pub fn verify_local_challenge(
+    public_key: &PublicKey,
     global_challenge: Sha256Hash,
     local_challenge: &LocalChallenge,
-    public_key: &[u8],
-) -> SignatureResult<()> {
-    let signature = schnorrkel::Signature::from_bytes(local_challenge)?;
-    let public_key = schnorrkel::PublicKey::from_bytes(public_key)?;
+) -> SignatureResult<VRFInOut> {
+    public_key
+        .vrf_verify(
+            create_local_challenge_transcript(&global_challenge),
+            &VRFOutput(local_challenge.output),
+            &VRFProof::from_bytes(&local_challenge.proof)?,
+        )
+        .map(|(in_out, _)| in_out)
+}
 
-    let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
-    public_key.verify(ctx.bytes(&global_challenge), &signature)
+/// Derive challenge target from public key and local challenge.
+///
+/// NOTE: If you are not the signer then you must verify the local challenge before calling this
+/// function.
+pub fn derive_target(
+    public_key: &PublicKey,
+    global_challenge: Sha256Hash,
+    local_challenge: &LocalChallenge,
+) -> SignatureResult<Tag> {
+    let in_out = VRFOutput(local_challenge.output).attach_input_hash(
+        public_key,
+        create_local_challenge_transcript(&global_challenge),
+    )?;
+
+    Ok(in_out.make_bytes(PLOT_TARGET_CONTEXT))
+}
+
+/// Transcript used for creation and verification of VRF signatures for tags.
+pub fn create_tag_signature_transcript(tag: Tag) -> Transcript {
+    let mut transcript = Transcript::new(TAG_SIGNATURE_LABEL);
+    transcript.append_message(b"tag", &tag);
+    transcript
+}
+
+/// Create tag signature using farmer's keypair.
+pub fn create_tag_signature(keypair: &Keypair, tag: Tag) -> TagSignature {
+    let (in_out, proof, _) = keypair.vrf_sign(create_tag_signature_transcript(tag));
+
+    TagSignature {
+        output: in_out.output.to_bytes(),
+        proof: proof.to_bytes(),
+    }
+}
+
+/// Verify that tag signature was created correctly.
+pub fn verify_tag_signature(
+    tag: Tag,
+    tag_signature: &TagSignature,
+    public_key: &PublicKey,
+) -> SignatureResult<VRFInOut> {
+    public_key
+        .vrf_verify(
+            create_tag_signature_transcript(tag),
+            &VRFOutput(tag_signature.output),
+            &VRFProof::from_bytes(&tag_signature.proof)?,
+        )
+        .map(|(in_out, _)| in_out)
 }

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -34,7 +34,9 @@ use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{FlatPieces, Piece, Solution, Tag};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_service::{FullClient, NewFull};
-use subspace_solving::{SubspaceCodec, REWARD_SIGNING_CONTEXT, SOLUTION_SIGNING_CONTEXT};
+use subspace_solving::{
+    create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
+};
 use zeroize::Zeroizing;
 
 /// Subspace native executor instance.
@@ -107,10 +109,10 @@ pub fn start_farmer(new_full: &NewFull<Client>) {
             }) = reward_signing_notification_stream.next().await
             {
                 let header_hash: [u8; 32] = header_hash.into();
-                let reward_signature: schnorrkel::Signature =
-                    signing_pair.sign(substrate_ctx.bytes(&header_hash));
-                let signature: subspace_core_primitives::Signature =
-                    reward_signature.to_bytes().into();
+                let signature: subspace_core_primitives::RewardSignature = signing_pair
+                    .sign(substrate_ctx.bytes(&header_hash))
+                    .to_bytes()
+                    .into();
                 signature_sender
                     .send(
                         FarmerSignature::decode(&mut signature.encode().as_ref())
@@ -140,7 +142,6 @@ async fn start_farming<Client>(
     });
 
     let subspace_codec = SubspaceCodec::new(keypair.public.as_ref());
-    let ctx = schnorrkel::context::signing_context(SOLUTION_SIGNING_CONTEXT);
     let (piece_index, mut encoding) = archived_pieces_receiver
         .await
         .unwrap()
@@ -168,11 +169,11 @@ async fn start_farming<Client>(
                     reward_address: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     piece_index,
                     encoding: encoding.clone(),
-                    signature: keypair.sign(ctx.bytes(&tag)).to_bytes().into(),
-                    local_challenge: keypair
-                        .sign(ctx.bytes(&new_slot_info.global_challenge))
-                        .to_bytes()
-                        .into(),
+                    tag_signature: create_tag_signature(&keypair, tag),
+                    local_challenge: derive_local_challenge(
+                        &keypair,
+                        new_slot_info.global_challenge,
+                    ),
                     tag,
                 })
                 .await;

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -35,7 +35,7 @@ use subspace_core_primitives::{FlatPieces, Piece, Solution, Tag};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_service::{FullClient, NewFull};
 use subspace_solving::{
-    create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
+    create_tag, create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
 };
 use zeroize::Zeroizing;
 
@@ -161,7 +161,7 @@ async fn start_farming<Client>(
     }) = new_slot_notification_stream.next().await
     {
         if Into::<u64>::into(new_slot_info.slot) % 2 == 0 {
-            let tag: Tag = subspace_solving::create_tag(&encoding, new_slot_info.salt);
+            let tag: Tag = create_tag(&encoding, new_slot_info.salt);
 
             let _ = solution_sender
                 .send(Solution {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -43,7 +43,8 @@ use pallet_grandpa_finality_verifier::chain::Chain;
 use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::{
-    EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts, SignedVote, SolutionRanges, Vote,
+    derive_randomness, EquivocationProof, FarmerPublicKey, GlobalRandomnesses, Salts, SignedVote,
+    SolutionRanges, Vote,
 };
 use sp_core::crypto::{ByteArray, KeyTypeId};
 use sp_core::{Hasher, OpaqueMetadata};
@@ -856,7 +857,18 @@ fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness
 
         let pre_digest = pre_digest.expect("Header must contain one pre-runtime digest; qed");
 
-        BlakeTwo256::hash_of(&pre_digest.solution.signature).into()
+        let seed: &[u8] = b"extrinsics-shuffling-seed";
+        let randomness = derive_randomness(
+            &pre_digest.solution.public_key,
+            pre_digest.solution.tag,
+            &pre_digest.solution.tag_signature,
+        )
+        .expect("Tag signature is verified by the client and must always be valid; qed");
+        let mut data = Vec::with_capacity(seed.len() + randomness.len());
+        data.extend_from_slice(seed);
+        data.extend_from_slice(&randomness);
+
+        BlakeTwo256::hash_of(&data).into()
     }
 }
 


### PR DESCRIPTION
During this fix I also introduced a bunch of utility functions in `subspace-solving` crate for use cases of challenge/signature generation/verification such that less copy-paste is needed in other places and it is generally nice to have all that in one place.