### PR TITLE
Disable pallet executor on transaction pool level

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -697,7 +697,7 @@ impl SignedExtension for CheckStorageAccess {
     type AdditionalSigned = ();
     type Pre = ();
 
-    fn additional_signed(&self) -> Result<Self::Pre, TransactionValidityError> {
+    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
 
@@ -737,7 +737,7 @@ impl SignedExtension for DisablePallets {
     type AdditionalSigned = ();
     type Pre = ();
 
-    fn additional_signed(&self) -> Result<Self::Pre, TransactionValidityError> {
+    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
         Ok(())
     }
 


### PR DESCRIPTION
The fact that pallet was disabled didn't mean you couldn't fill blocks with transactions that will fail later. Rejecting it at transaction pool level should prevent that fro happening.