### PR TITLE
Support restricting authoring of blocks and votes

### DIFF
--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -330,5 +330,8 @@ sp_api::decl_runtime_apis! {
 
         /// Returns `Vec<RootBlock>` if a given extrinsic has them.
         fn extract_root_blocks(ext: &Block::Extrinsic) -> Option<Vec<RootBlock>>;
+
+        /// Returns root plot public key in case block authoring is restricted.
+        fn root_plot_public_key() -> Option<FarmerPublicKey>;
     }
 }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -142,6 +142,7 @@ pub fn gemini_config_compiled() -> Result<ConsensusChainSpec, String> {
                 ),
                 false,
                 false,
+                false,
             )
         },
         // Bootnodes
@@ -194,6 +195,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec, String> {
                 ),
                 false,
                 false,
+                true,
             )
         },
         // Bootnodes
@@ -248,6 +250,7 @@ pub fn local_config() -> Result<ConsensusChainSpec, String> {
                 ),
                 false,
                 false,
+                true,
             )
         },
         // Bootnodes
@@ -267,6 +270,7 @@ pub fn local_config() -> Result<ConsensusChainSpec, String> {
 }
 
 /// Configure initial storage state for FRAME modules.
+#[allow(clippy::too_many_arguments)]
 fn subspace_genesis_config(
     wasm_binary: &[u8],
     sudo_account: AccountId,
@@ -276,6 +280,7 @@ fn subspace_genesis_config(
     executor_authority: (AccountId, ExecutorId),
     enable_rewards: bool,
     enable_storage_access: bool,
+    allow_authoring_by_anyone: bool,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -291,6 +296,7 @@ fn subspace_genesis_config(
         subspace: SubspaceConfig {
             enable_rewards,
             enable_storage_access,
+            allow_authoring_by_anyone,
         },
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -740,6 +740,10 @@ impl_runtime_apis! {
         fn extract_root_blocks(ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<RootBlock>> {
             extract_root_blocks(ext)
         }
+
+        fn root_plot_public_key() -> Option<FarmerPublicKey> {
+            Subspace::root_plot_public_key()
+        }
     }
 
     impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -1010,6 +1010,10 @@ cfg_if! {
                 ) -> Option<Vec<subspace_core_primitives::RootBlock>> {
                     panic!("Not needed in tests")
                 }
+
+                fn root_plot_public_key() -> Option<FarmerPublicKey> {
+                    <pallet_subspace::Pallet<Runtime>>::root_plot_public_key()
+                }
             }
 
             impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
@@ -1347,6 +1351,10 @@ cfg_if! {
                     _ext: &<Block as BlockT>::Extrinsic
                 ) -> Option<Vec<subspace_core_primitives::RootBlock>> {
                     panic!("Not needed in tests")
+                }
+
+                fn root_plot_public_key() -> Option<FarmerPublicKey> {
+                    <pallet_subspace::Pallet<Runtime>>::root_plot_public_key()
                 }
             }
 

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -93,6 +93,7 @@ fn create_genesis_config(
         subspace: SubspaceConfig {
             enable_rewards: false,
             enable_storage_access: false,
+            allow_authoring_by_anyone: true,
         },
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1037,6 +1037,10 @@ impl_runtime_apis! {
         fn extract_root_blocks(ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<RootBlock>> {
             extract_root_blocks(ext)
         }
+
+        fn root_plot_public_key() -> Option<FarmerPublicKey> {
+            Subspace::root_plot_public_key()
+        }
     }
 
     impl sp_executor::ExecutorApi<Block, cirrus_primitives::Hash> for Runtime {


### PR DESCRIPTION
This will allow us to make sure we don't create forks until the network is synced to the same tip of the chain.