### PR TITLE
Replace chain id with genesis hash for Gemini 1b workaround

### DIFF
--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -61,8 +61,6 @@ pub(super) struct SubspaceSlotWorker<Block: BlockT, Client, E, I, SO, L, BS> {
     pub(super) block_proposal_slot_portion: SlotProportion,
     pub(super) max_block_proposal_slot_portion: Option<SlotProportion>,
     pub(super) telemetry: Option<TelemetryHandle>,
-    /// Chain ID from chain specification, needed to work around Gemini 1b launch issues.
-    pub(super) chain_id: String,
 }
 
 #[async_trait::async_trait]
@@ -123,7 +121,7 @@ where
     ) -> Option<Self::Claim> {
         // TODO: Hack for Gemini 1b launch. These blocks are already produced, avoid claiming them.
         if *parent_header.number() <= 33_671_u32.into()
-            && self.chain_id.as_str() == "subspace_gemini_1b"
+            && self.client.info().genesis_hash.as_ref() == crate::GEMINI_1B_GENESIS_HASH
         {
             return None;
         }

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -412,7 +412,6 @@ impl TestNetFactory for SubspaceTestNet {
                     REWARD_SIGNING_CONTEXT,
                 ),
                 block: PhantomData::default(),
-                chain_id: "".to_string(),
             },
             mutator: MUTATOR.with(|m| m.borrow().clone()),
         }
@@ -566,7 +565,6 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
             block_proposal_slot_portion: SlotProportion::new(0.5),
             max_block_proposal_slot_portion: None,
             telemetry: None,
-            chain_id: "".to_string(),
         })
         .expect("Starts Subspace");
 

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -260,7 +260,6 @@ where
         &task_manager.spawn_essential_handle(),
         config.prometheus_registry(),
         telemetry.as_ref().map(|x| x.handle()),
-        config.chain_spec.id().to_string(),
     )?;
 
     Ok(PartialComponents {
@@ -427,7 +426,6 @@ where
             block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
             max_block_proposal_slot_portion: None,
             telemetry: None,
-            chain_id: config.chain_spec.id().to_string(),
         };
 
         let subspace = sc_consensus_subspace::start_subspace(subspace_config)?;


### PR DESCRIPTION
As requested in https://github.com/subspace/subspace/pull/540#issuecomment-1145800306, please double check the genesis hash is `0x9ee86eefc3cc61c71a7751bba7f25e442da2512f408e6286153b3ccc055dccf0`