### PR TITLE
Reading sequential pieces and indexes from the plot

### DIFF
--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -921,10 +921,13 @@ impl<T: PlotFile> PlotWorker<T> {
             if iter.key().is_none() {
                 break;
             }
-            let offset =
-                <[u8; std::mem::size_of::<PieceOffset>()]>::try_from(iter.value().unwrap())
-                    .map(PieceOffset::from_le_bytes)
-                    .expect("Failed to decode piece offsets from rocksdb");
+
+            let offset = PieceOffset::from_le_bytes(
+                iter.value()
+                    .unwrap()
+                    .try_into()
+                    .expect("Failed to decode piece offsets from rocksdb"),
+            );
             iter.next();
 
             piece_indexes.push(self.piece_offset_to_index.get_piece_index(offset)?)

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -389,6 +389,47 @@ impl Plot {
             ))
         })?
     }
+
+    /// Returns sequential piece indexes for piece retrieval
+    pub(crate) fn read_sequential_piece_indexes(
+        &self,
+        from_index_hash: PieceIndexHash,
+        count: u64,
+    ) -> io::Result<Vec<PieceIndex>> {
+        let (result_sender, result_receiver) = mpsc::channel();
+
+        self.inner
+            .requests_sender
+            .send(RequestWithPriority {
+                request: Request::ReadPieceIndexes {
+                    from_index_hash,
+                    count,
+                    result_sender,
+                },
+                priority: RequestPriority::High,
+            })
+            .map_err(|error| {
+                io::Error::other(format!(
+                    "Failed sending read piece indexes request: {error}"
+                ))
+            })?;
+
+        result_receiver.recv().map_err(|error| {
+            io::Error::other(format!(
+                "Read piece indexes result sender was dropped: {error}",
+            ))
+        })?
+    }
+
+    #[allow(dead_code)]
+    /// Returns iterator which would return piece starting from supplied piece index hash (`from`)
+    pub(crate) fn sequential_pieces_iterator(
+        &self,
+        from: PieceIndexHash,
+    ) -> io::Result<SequentialPieceIterator> {
+        SequentialPieceIterator::new(self.clone(), from, 32)
+    }
+
     pub fn on_progress_change(
         &self,
         callback: Arc<dyn Fn(&PlottedPieces) + Send + Sync + 'static>,
@@ -430,6 +471,54 @@ impl Plot {
         Self::try_remove(path.as_ref().join("object-mappings"), fs::remove_dir_all)?;
 
         Ok(())
+    }
+}
+
+pub struct SequentialPieceIterator {
+    plot: Plot,
+    indexes: VecDeque<PieceIndex>,
+    batch_size: u64,
+}
+
+impl SequentialPieceIterator {
+    pub fn new(plot: Plot, from: PieceIndexHash, batch_size: u64) -> io::Result<Self> {
+        let mut me = Self {
+            plot,
+            indexes: VecDeque::new(),
+            batch_size,
+        };
+        me.update_indexes(from)?;
+        Ok(me)
+    }
+
+    fn update_indexes(&mut self, from: PieceIndexHash) -> io::Result<()> {
+        self.indexes.extend(
+            self.plot
+                .read_sequential_piece_indexes(from, self.batch_size)?,
+        );
+        Ok(())
+    }
+}
+
+impl Iterator for SequentialPieceIterator {
+    type Item = io::Result<(PieceIndex, Piece)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.indexes.len() == 1 {
+            let last_index = *self.indexes.front().unwrap();
+            if let Err(error) = self.update_indexes(last_index.into()) {
+                return Some(Err(error));
+            }
+            // We have 2 same indexes in the `self.indexes`
+            self.indexes.pop_front();
+        }
+
+        if self.indexes.is_empty() {
+            return None;
+        }
+
+        let index = self.indexes.pop_front().unwrap();
+        Some(try { (index, self.plot.read(index)?) })
     }
 }
 
@@ -540,7 +629,12 @@ impl IndexHashToOffsetDB {
         let mut iter = self.inner.raw_iterator();
         iter.seek(&self.get_key(from).to_bytes());
         std::iter::from_fn(move || match iter.key() {
-            Some(_) => {
+            Some(key) => {
+                let key = PieceIndexHash(key.try_into().unwrap());
+                let key = PieceDistance::from_big_endian(&key.0)
+                    .wrapping_sub(&PieceDistance::MIDDLE)
+                    .to_bytes();
+                dbg!(format!("{:?}", &key[..4]));
                 let value = iter.value().unwrap();
                 let value = <[u8; 8]>::try_from(value)
                     .map(PieceOffset::from_le_bytes)

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -125,11 +125,11 @@ async fn sequential_pieces_iterator() {
     piece_indexes.sort_by_key(|i| PieceIndexHash::from(*i));
 
     let got_indexes = plot
-        .sequential_pieces_iterator(PieceIndexHash([0; 32]))
+        .get_sequential_pieces(PieceIndexHash([0; 32]), 100)
         .unwrap()
-        .map(|result| result.map(|(index, _)| index))
+        .into_iter()
+        .map(|(index, _)| index)
         .take(100)
-        .collect::<std::io::Result<Vec<_>>>()
-        .unwrap();
+        .collect::<Vec<_>>();
     assert_eq!(got_indexes, piece_indexes[..got_indexes.len()]);
 }


### PR DESCRIPTION
This pr adds sequential pieces and indexes fetching for the DSN.

It works as follows:
1. queries plot for piece offsets
2. queries plot for each piece index from piece offset
3. fetch pieces from corresponding piece index and offset