### PR TITLE
Skip submitting equivocation extrinsic if node is not authoring blocks

### DIFF
--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -411,6 +411,7 @@ impl TestNetFactory for SubspaceTestNet {
                 reward_signing_context: schnorrkel::context::signing_context(
                     REWARD_SIGNING_CONTEXT,
                 ),
+                is_authoring_blocks: true,
                 block: PhantomData::default(),
             },
             mutator: MUTATOR.with(|m| m.borrow().clone()),

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -274,6 +274,7 @@ where
         &task_manager.spawn_essential_handle(),
         config.prometheus_registry(),
         telemetry.as_ref().map(|x| x.handle()),
+        config.role.is_authority(),
     )?;
 
     Ok(PartialComponents {


### PR DESCRIPTION
Since this extrinsics is non-propagatable, it is considered to be unactionable by transaction pool and just causes unnecessary error on non-validator nodes.