### PR TITLE
Recommitments improvements

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -167,7 +167,8 @@ pub(crate) async fn bench(
     let multi_farming = MultiFarming::new(
         MultiFarmingOptions {
             base_directory: base_directory.as_ref().to_owned(),
-            client: client.clone(),
+            archiving_client: client.clone(),
+            farming_client: client.clone(),
             object_mappings: object_mappings.clone(),
             reward_address: PublicKey::default(),
             bootstrap_nodes: vec![],

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -34,9 +34,10 @@ pub(crate) async fn farm(
     }
 
     info!("Connecting to node at {}", node_rpc_url);
-    let client = NodeRpcClient::new(&node_rpc_url).await?;
+    let archiving_client = NodeRpcClient::new(&node_rpc_url).await?;
+    let farming_client = NodeRpcClient::new(&node_rpc_url).await?;
 
-    let metadata = client
+    let metadata = farming_client
         .farmer_metadata()
         .await
         .map_err(|error| anyhow!(error))?;
@@ -67,7 +68,8 @@ pub(crate) async fn farm(
     let multi_farming = MultiFarming::new(
         MultiFarmingOptions {
             base_directory: base_directory.clone(),
-            client,
+            archiving_client,
+            farming_client,
             object_mappings: object_mappings.clone(),
             reward_address,
             bootstrap_nodes,

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -53,7 +53,10 @@ fn get_plot_sizes(total_plot_size: u64, max_plot_size: u64) -> Vec<u64> {
 /// Options for `MultiFarming` creation
 pub struct Options<C> {
     pub base_directory: PathBuf,
-    pub client: C,
+    /// Client used for archiving subscriptions
+    pub archiving_client: C,
+    /// Independent client used for farming, such that it is not blocked by archiving
+    pub farming_client: C,
     pub object_mappings: ObjectMappings,
     pub reward_address: PublicKey,
     pub bootstrap_nodes: Vec<Multiaddr>,
@@ -65,7 +68,8 @@ impl MultiFarming {
     pub async fn new<C: RpcClient>(
         Options {
             base_directory,
-            client,
+            archiving_client,
+            farming_client,
             object_mappings,
             reward_address,
             mut bootstrap_nodes,
@@ -89,7 +93,7 @@ impl MultiFarming {
             .enumerate()
             .map(|(plot_index, max_plot_pieces)| {
                 let base_directory = base_directory.to_owned();
-                let client = client.clone();
+                let farming_client = farming_client.clone();
                 let new_plot = new_plot.clone();
 
                 tokio::task::spawn_blocking(move || {
@@ -112,7 +116,7 @@ impl MultiFarming {
                         Farming::start(
                             plot.clone(),
                             plot_commitments.clone(),
-                            client.clone(),
+                            farming_client.clone(),
                             identity.clone(),
                             reward_address,
                         )
@@ -201,7 +205,7 @@ impl MultiFarming {
             }
         }
 
-        let farmer_metadata = client
+        let farmer_metadata = farming_client
             .farmer_metadata()
             .await
             .map_err(|error| anyhow!(error))?;
@@ -250,7 +254,7 @@ impl MultiFarming {
         });
 
         // Start archiving task
-        let archiving = Archiving::start(farmer_metadata, object_mappings, client.clone(), {
+        let archiving = Archiving::start(farmer_metadata, object_mappings, archiving_client, {
             let mut on_pieces_to_plots = plots
                 .iter()
                 .zip(&commitments)

--- a/crates/subspace-farmer/src/multi_farming.rs
+++ b/crates/subspace-farmer/src/multi_farming.rs
@@ -187,7 +187,11 @@ impl MultiFarming {
             }))
             .detach();
 
-            bootstrap_nodes.extend(listen_on);
+            bootstrap_nodes.extend(
+                listen_on
+                    .into_iter()
+                    .map(|listen_on| listen_on.with(Protocol::P2p(node.id().into()))),
+            );
             networking_node_runners.push(node_runner);
             plots.push(plot);
             commitments.push(plot_commitments);


### PR DESCRIPTION
This isn't a perfect solution as it doesn't distinguish between what farmer has acknowledged segment and which didn't (old code didn't either, so :man_shrugging:).

Also back-pressure should ideally be implemented on the farmer side, so regardless of what node sends it'll not leak memory, but that is more complex and current sync process will be replaced with DSN sync anyway, so I went with the simplest working approach possible.

Fixes https://github.com/subspace/subspace/issues/569 where node was sending segments to farmers that are busy with recommitments over and over again, consuming more and more RAM over time.