### PR TITLE
Bump ExecutorApi version and check fraud proof after version 2

### DIFF
--- a/crates/sc-consensus-fraud-proof/src/lib.rs
+++ b/crates/sc-consensus-fraud-proof/src/lib.rs
@@ -18,7 +18,7 @@
 
 use codec::{Decode, Encode};
 use sc_consensus::block_import::{BlockCheckParams, BlockImport, BlockImportParams, ImportResult};
-use sp_api::{ProvideRuntimeApi, TransactionFor};
+use sp_api::{Core, ProvideRuntimeApi, RuntimeApiInfo, TransactionFor};
 use sp_consensus::{CacheKeyId, Error as ConsensusError};
 use sp_executor::ExecutorApi;
 use sp_runtime::generic::BlockId;
@@ -88,17 +88,41 @@ where
         let parent_hash = *block.header.parent_hash();
         let parent_block_id = BlockId::Hash(parent_hash);
 
-        if let Some(extrinsics) = &block.body {
-            for extrinsic in extrinsics.iter() {
-                if let Some(fraud_proof) = self
-                    .client
-                    .runtime_api()
-                    .extract_fraud_proof(&parent_block_id, extrinsic)
-                    .map_err(|e| ConsensusError::ClientImport(e.to_string()))?
-                {
-                    self.fraud_proof_verifier
-                        .verify_fraud_proof(&fraud_proof)
-                        .map_err(|e| ConsensusError::Other(Box::new(e)))?;
+        let runtime_version = self
+            .client
+            .runtime_api()
+            .version(&parent_block_id)
+            .map_err(|e| {
+                ConsensusError::ClientImport(format!(
+                    "Unable to retrieve current runtime version: {e}"
+                ))
+            })?;
+
+        let api_version = runtime_version
+            .api_version(&<dyn ExecutorApi<Block, SecondaryHash>>::ID)
+            .ok_or_else(|| {
+                ConsensusError::ClientImport(format!(
+                    "Unable to retrieve api version of ExecutorApi at block {parent_hash}"
+                ))
+            })?;
+
+        // `extract_fraud_proof` is added since ExecutorApi version 2
+        // TODO: reset the ExecutorApi api version and remove this check when the network is reset.
+        if api_version >= 2 {
+            if let Some(extrinsics) = &block.body {
+                for extrinsic in extrinsics.iter() {
+                    let api_result = self
+                        .client
+                        .runtime_api()
+                        .extract_fraud_proof(&parent_block_id, extrinsic);
+
+                    if let Some(fraud_proof) =
+                        api_result.map_err(|e| ConsensusError::ClientImport(e.to_string()))?
+                    {
+                        self.fraud_proof_verifier
+                            .verify_fraud_proof(&fraud_proof)
+                            .map_err(|e| ConsensusError::Other(Box::new(e)))?;
+                    }
                 }
             }
         }

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -419,6 +419,7 @@ pub struct InvalidTransactionProof;
 
 sp_api::decl_runtime_apis! {
     /// API necessary for executor pallet.
+    #[api_version(2)]
     pub trait ExecutorApi<SecondaryHash: Encode + Decode> {
         /// Submits the execution receipt via an unsigned extrinsic.
         fn submit_execution_receipt_unsigned(


### PR DESCRIPTION
This PR bumps the version of `ExecutorApi` due to the added `extract_fraud_proof` recently,
otherwise, the latest binary will not able to sync the gemini old blocks. For this newly added API, we can simply check if the API version is >= 2 as the fraud proof is not yet enabled.

Close #576