### PR TITLE
Introduce pallet-runtime-configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4625,6 +4625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-runtime-configs"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=5f0aa1feb7250ac7b8c1b9928f87b2420b530e22#5f0aa1feb7250ac7b8c1b9928f87b2420b530e22"
@@ -8176,6 +8186,7 @@ dependencies = [
  "pallet-object-store",
  "pallet-offences-subspace",
  "pallet-rewards",
+ "pallet-runtime-configs",
  "pallet-subspace",
  "pallet-sudo",
  "pallet-timestamp",

--- a/crates/pallet-runtime-configs/Cargo.toml
+++ b/crates/pallet-runtime-configs/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "pallet-runtime-configs"
+version = "0.1.0"
+authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace"
+description = "Pallet for tweaking the runtime configs for multiple network"
+include = [
+  "/src",
+  "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false, features = ["derive"] }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "frame-support/std",
+  "frame-system/std",
+  "scale-info/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -22,56 +22,32 @@ pub use pallet::*;
 #[frame_support::pallet]
 mod pallet {
     use frame_support::pallet_prelude::*;
-    use frame_system::pallet_prelude::*;
 
     #[pallet::pallet]
     #[pallet::generate_store(pub trait Store)]
     pub struct Pallet<T>(_);
 
-    /// Enable the signed extension `DisablePallets`.
+    /// Sets this value to `true` to enable the signed extension `DisablePallets` which
+    /// disallowes the Call from pallet-executor.
     #[pallet::storage]
-    #[pallet::getter(fn enable_disable_pallets)]
-    pub type EnableDisablePallets<T> = StorageValue<_, bool, ValueQuery>;
+    #[pallet::getter(fn enable_executor)]
+    pub type EnableExecutor<T> = StorageValue<_, bool, ValueQuery>;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {}
 
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {
-        /// Set new value of [`EnableDisablePallets`].
-        #[pallet::weight(T::DbWeight::get().writes(1))]
-        pub fn set_enable_disable_pallets(origin: OriginFor<T>, new: bool) -> DispatchResult {
-            ensure_root(origin)?;
-
-            EnableDisablePallets::<T>::put(new);
-
-            Ok(())
-        }
-    }
-
     #[pallet::genesis_config]
+    #[derive(Default)]
     pub struct GenesisConfig {
-        pub enable_disable_pallets: bool,
-    }
-
-    #[cfg(feature = "std")]
-    impl Default for GenesisConfig {
-        fn default() -> Self {
-            Self {
-                // Enable the pallet Call filter by default.
-                enable_disable_pallets: true,
-            }
-        }
+        pub enable_executor: bool,
     }
 
     #[pallet::genesis_build]
     impl<T: Config> GenesisBuild<T> for GenesisConfig {
         fn build(&self) {
-            let Self {
-                enable_disable_pallets,
-            } = self;
+            let Self { enable_executor } = self;
 
-            <EnableDisablePallets<T>>::put(enable_disable_pallets);
+            <EnableExecutor<T>>::put(enable_executor);
         }
     }
 }

--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -22,18 +22,32 @@ pub use pallet::*;
 #[frame_support::pallet]
 mod pallet {
     use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::generate_store(pub trait Store)]
     pub struct Pallet<T>(_);
 
     /// Enable the signed extension `DisablePallets`.
     #[pallet::storage]
     #[pallet::getter(fn enable_disable_pallets)]
-    pub(super) type EnableDisablePallets<T> = StorageValue<_, bool, ValueQuery>;
+    pub type EnableDisablePallets<T> = StorageValue<_, bool, ValueQuery>;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {}
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Set new value of [`EnableDisablePallets`].
+        #[pallet::weight(T::DbWeight::get().writes(1))]
+        pub fn set_enable_disable_pallets(origin: OriginFor<T>, new: bool) -> DispatchResult {
+            ensure_root(origin)?;
+
+            EnableDisablePallets::<T>::put(new);
+
+            Ok(())
+        }
+    }
 
     #[pallet::genesis_config]
     pub struct GenesisConfig {

--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 Subspace Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pallet for tweaking the runtime configs for multiple network.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+mod pallet {
+    use frame_support::pallet_prelude::*;
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+    /// Enable the signed extension `DisablePallets`.
+    #[pallet::storage]
+    #[pallet::getter(fn enable_disable_pallets)]
+    pub(super) type EnableDisablePallets<T> = StorageValue<_, bool, ValueQuery>;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {}
+
+    #[pallet::genesis_config]
+    pub struct GenesisConfig {
+        pub enable_disable_pallets: bool,
+    }
+
+    #[cfg(feature = "std")]
+    impl Default for GenesisConfig {
+        fn default() -> Self {
+            Self {
+                // Enable the pallet Call filter by default.
+                enable_disable_pallets: true,
+            }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig {
+        fn build(&self) {
+            let Self {
+                enable_disable_pallets,
+            } = self;
+
+            <EnableDisablePallets<T>>::put(enable_disable_pallets);
+        }
+    }
+}

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -63,6 +63,14 @@ const TOKEN_GRANTS: &[(&str, u128)] = &[
     ("5FZwEgsvZz1vpeH7UsskmNmTpbfXvAcojjgVfShgbRqgC1nx", 27_800),
 ];
 
+/// Additional subspace specific genesis parameters.
+struct GenesisParams {
+    enable_rewards: bool,
+    enable_storage_access: bool,
+    allow_authoring_by_anyone: bool,
+    enable_disable_pallets: bool,
+}
+
 pub fn gemini_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenesisConfig>, String>
 {
     ConsensusChainSpec::from_json_bytes(GEMINI_1_CHAIN_SPEC)
@@ -129,10 +137,12 @@ pub fn gemini_config_compiled(
                     ExecutorId::from_ss58check("5FuuXk1TL8DKQMvg7mcqmP8t9FhxUdzTcYC9aFmebiTLmASx")
                         .expect("Wrong Executor authority address"),
                 ),
-                false,
-                false,
-                false,
-                false,
+                GenesisParams {
+                    enable_rewards: false,
+                    enable_storage_access: false,
+                    allow_authoring_by_anyone: false,
+                    enable_disable_pallets: false,
+                },
             )
         },
         // Bootnodes
@@ -183,10 +193,12 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenesis
                     get_account_id_from_seed("Alice"),
                     get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
-                false,
-                false,
-                true,
-                false,
+                GenesisParams {
+                    enable_rewards: false,
+                    enable_storage_access: false,
+                    allow_authoring_by_anyone: true,
+                    enable_disable_pallets: false,
+                },
             )
         },
         // Bootnodes
@@ -239,10 +251,12 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenes
                     get_account_id_from_seed("Alice"),
                     get_public_key_from_seed::<ExecutorId>("Alice"),
                 ),
-                false,
-                false,
-                true,
-                false,
+                GenesisParams {
+                    enable_rewards: false,
+                    enable_storage_access: false,
+                    allow_authoring_by_anyone: true,
+                    enable_disable_pallets: false,
+                },
             )
         },
         // Bootnodes
@@ -270,11 +284,15 @@ fn subspace_genesis_config(
     // who, start, period, period_count, per_period
     vesting: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
     executor_authority: (AccountId, ExecutorId),
-    enable_rewards: bool,
-    enable_storage_access: bool,
-    allow_authoring_by_anyone: bool,
-    enable_disable_pallets: bool,
+    genesis_params: GenesisParams,
 ) -> GenesisConfig {
+    let GenesisParams {
+        enable_rewards,
+        enable_storage_access,
+        allow_authoring_by_anyone,
+        enable_disable_pallets,
+    } = genesis_params;
+
     GenesisConfig {
         system: SystemConfig {
             // Add Wasm runtime to storage.

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -27,8 +27,8 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_core::crypto::Ss58Codec;
 use sp_executor::ExecutorId;
 use subspace_runtime::{
-    BalancesConfig, ExecutorConfig, GenesisConfig, SubspaceConfig, SudoConfig, SystemConfig,
-    VestingConfig, MILLISECS_PER_BLOCK, WASM_BINARY,
+    BalancesConfig, ExecutorConfig, GenesisConfig, RuntimeConfigsConfig, SubspaceConfig,
+    SudoConfig, SystemConfig, VestingConfig, MILLISECS_PER_BLOCK, WASM_BINARY,
 };
 use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, SSC};
 
@@ -132,6 +132,7 @@ pub fn gemini_config_compiled(
                 false,
                 false,
                 false,
+                false,
             )
         },
         // Bootnodes
@@ -185,6 +186,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenesis
                 false,
                 false,
                 true,
+                false,
             )
         },
         // Bootnodes
@@ -240,6 +242,7 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenes
                 false,
                 false,
                 true,
+                false,
             )
         },
         // Bootnodes
@@ -270,6 +273,7 @@ fn subspace_genesis_config(
     enable_rewards: bool,
     enable_storage_access: bool,
     allow_authoring_by_anyone: bool,
+    enable_disable_pallets: bool,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -290,6 +294,9 @@ fn subspace_genesis_config(
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {
             executor: Some(executor_authority),
+        },
+        runtime_configs: RuntimeConfigsConfig {
+            enable_disable_pallets,
         },
     }
 }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -68,7 +68,7 @@ struct GenesisParams {
     enable_rewards: bool,
     enable_storage_access: bool,
     allow_authoring_by_anyone: bool,
-    enable_disable_pallets: bool,
+    enable_executor: bool,
 }
 
 pub fn gemini_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenesisConfig>, String>
@@ -141,7 +141,7 @@ pub fn gemini_config_compiled(
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by_anyone: false,
-                    enable_disable_pallets: false,
+                    enable_executor: false,
                 },
             )
         },
@@ -197,7 +197,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenesis
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by_anyone: true,
-                    enable_disable_pallets: false,
+                    enable_executor: true,
                 },
             )
         },
@@ -255,7 +255,7 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenes
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by_anyone: true,
-                    enable_disable_pallets: false,
+                    enable_executor: true,
                 },
             )
         },
@@ -276,7 +276,6 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenes
 }
 
 /// Configure initial storage state for FRAME modules.
-#[allow(clippy::too_many_arguments)]
 fn subspace_genesis_config(
     wasm_binary: &[u8],
     sudo_account: AccountId,
@@ -290,7 +289,7 @@ fn subspace_genesis_config(
         enable_rewards,
         enable_storage_access,
         allow_authoring_by_anyone,
-        enable_disable_pallets,
+        enable_executor,
     } = genesis_params;
 
     GenesisConfig {
@@ -313,8 +312,6 @@ fn subspace_genesis_config(
         executor: ExecutorConfig {
             executor: Some(executor_authority),
         },
-        runtime_configs: RuntimeConfigsConfig {
-            enable_disable_pallets,
-        },
+        runtime_configs: RuntimeConfigsConfig { enable_executor },
     }
 }

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -31,6 +31,7 @@ pallet-grandpa-finality-verifier = { version = "0.1.0", default-features = false
 pallet-object-store = { version = "0.1.0", default-features = false, path = "../pallet-object-store" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../pallet-offences-subspace" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../pallet-rewards" }
+pallet-runtime-configs = { version = "0.1.0", default-features = false, path = "../pallet-runtime-configs" }
 pallet-subspace = { version = "0.1.0", default-features = false, path = "../pallet-subspace" }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
@@ -89,6 +90,7 @@ std = [
 	"pallet-object-store/std",
 	"pallet-offences-subspace/std",
 	"pallet-rewards/std",
+	"pallet-runtime-configs/std",
 	"pallet-subspace/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -436,6 +436,8 @@ impl pallet_object_store::Config for Runtime {
     type Event = Event;
 }
 
+impl pallet_runtime_configs::Config for Runtime {}
+
 parameter_types! {
     // This value doesn't matter, we don't use it (`VestedTransferOrigin = EnsureNever` below).
     pub const MinVestedTransfer: Balance = 0;
@@ -473,6 +475,7 @@ construct_runtime!(
         GrandpaFinalityVerifier: pallet_grandpa_finality_verifier = 10,
         ObjectStore: pallet_object_store = 11,
         Executor: pallet_executor = 12,
+        RuntimeConfigs: pallet_runtime_configs = 14,
 
         Vesting: orml_vesting = 13,
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -513,17 +513,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    OnRuntimeUpgrade,
 >;
-
-pub struct OnRuntimeUpgrade;
-impl frame_support::traits::OnRuntimeUpgrade for OnRuntimeUpgrade {
-    fn on_runtime_upgrade() -> u64 {
-        // Gemini 1b still disallowes the pallet executor.
-        <RuntimeConfigs as pallet_runtime_configs::Store>::EnableDisablePallets::put(true);
-        RocksDbWeight::get().writes(1)
-    }
-}
 
 fn extract_root_blocks(ext: &UncheckedExtrinsic) -> Option<Vec<RootBlock>> {
     match &ext.function {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -513,7 +513,17 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    OnRuntimeUpgrade,
 >;
+
+pub struct OnRuntimeUpgrade;
+impl frame_support::traits::OnRuntimeUpgrade for OnRuntimeUpgrade {
+    fn on_runtime_upgrade() -> u64 {
+        // Gemini 1b still disallowes the pallet executor.
+        <RuntimeConfigs as pallet_runtime_configs::Store>::EnableDisablePallets::put(true);
+        RocksDbWeight::get().writes(1)
+    }
+}
 
 fn extract_root_blocks(ext: &UncheckedExtrinsic) -> Option<Vec<RootBlock>> {
     match &ext.function {

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -76,7 +76,7 @@ impl SignedExtension for DisablePallets {
         _info: &DispatchInfoOf<Self::Call>,
         _len: usize,
     ) -> TransactionValidity {
-        if RuntimeConfigs::enable_disable_pallets() && matches!(call, Call::Executor(_)) {
+        if matches!(call, Call::Executor(_)) && !RuntimeConfigs::enable_executor() {
             InvalidTransaction::Call.into()
         } else {
             Ok(ValidTransaction::default())

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -1,4 +1,4 @@
-use crate::{Call, Runtime, Subspace, Sudo};
+use crate::{Call, Runtime, RuntimeConfigs, Subspace, Sudo};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::traits::{DispatchInfoOf, SignedExtension};
@@ -76,7 +76,7 @@ impl SignedExtension for DisablePallets {
         _info: &DispatchInfoOf<Self::Call>,
         _len: usize,
     ) -> TransactionValidity {
-        if matches!(call, Call::Executor(_)) {
+        if RuntimeConfigs::enable_disable_pallets() && matches!(call, Call::Executor(_)) {
             InvalidTransaction::Call.into()
         } else {
             Ok(ValidTransaction::default())


### PR DESCRIPTION
This PR adds a new pallet used for tweaking some runtime configs for multiple networks. In order to continue to disallow the pallet executor Call for the current Gemini, `OnRuntimeUpgrade` is added to initialize the new pallet on the next runtime upgrade. New network can disable the signed extension from the genesis config, `OnRuntimeUpgrade` won't be invoked when the new network is launched. After the new runtime upgrade is applied on Gemini, `OnRuntimeUpgrade` will be removed so it should also be fine for the new network.

I already feel that using a pallet has more mental cost in comparison to maintaining multiple runtimes along the way.