### PR TITLE
Fix voting transaction propagation

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -389,7 +389,7 @@ mod pallet {
             .priority(TransactionPriority::MAX)
             .and_provides(tag)
             .longevity(TransactionLongevity::MAX)
-            // We need this extrinsic to be propagted to the farmer nodes.
+            // We need this extrinsic to be propagated to the farmer nodes.
             .propagate(true)
             .build()
     }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1173,7 +1173,8 @@ impl<T: Config> Pallet<T> {
         ValidTransaction::with_tag_prefix("SubspaceRootBlock")
             // We assign the maximum priority for any root block.
             .priority(TransactionPriority::MAX)
-            // Should be included immediately into the upcoming block with no exceptions.
+            // Should be included immediately into the current block (this is an inherent
+            // extrinsic) with no exceptions.
             .longevity(0)
             // We don't propagate this. This can never be included on a remote node.
             .propagate(false)
@@ -1193,7 +1194,8 @@ impl<T: Config> Pallet<T> {
             // We assign the maximum priority for any vote.
             .priority(TransactionPriority::MAX)
             // Should be included in the next block or block after that, but not later
-            .longevity(1)
+            .longevity(2)
+            .and_provides(&signed_vote.signature)
             .build()
     }
 


### PR DESCRIPTION
Made another unexpected discovery today.

Turns out that without any tags provided transaction is effectively non-propagatable. I mean it will be physically propagated, but will end up failing on the receiving side with this `NoTagsProvided`:
https://github.com/paritytech/substrate/blob/e0ccd008fe8bfaf29357ea87561e60f3baaae08c/client/transaction-pool/api/src/error.rs#L38-L43