### PR TITLE
Make recommitment not block other operations

### DIFF
--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -185,6 +185,10 @@ impl Commitments {
     }
 
     pub(crate) fn remove_pieces(&self, pieces: &[Piece]) -> Result<(), CommitmentError> {
+        if pieces.is_empty() {
+            return Ok(());
+        }
+
         for db_entry in self.get_db_entries() {
             let salt = db_entry.salt();
             let db_guard = db_entry.lock();
@@ -209,6 +213,10 @@ impl Commitments {
         F: Fn() -> Iter,
         Iter: Iterator<Item = (PieceOffset, &'iter [u8])>,
     {
+        if pieces_with_offsets().next().is_none() {
+            return Ok(());
+        }
+
         for db_entry in self.get_db_entries() {
             let salt = db_entry.salt();
             let db_guard = db_entry.lock();


### PR DESCRIPTION
This builds on top of refactoring and makes recommitment not block other processes, including concurrent plotting and farming (which means node should be able to farm with partial commitment database at least to some capacity).

Review with whitespace ignore turned on, the changes are actually pretty small here.

Fixes #580, fixes #586