### PR TITLE
DSN. Update networking code to support the new libp2p branch with updated Kademlia.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,7 +3226,7 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 [[package]]
 name = "libp2p"
 version = "0.44.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "atomic",
  "bytes",
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.3.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.32.1"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "libp2p-deflate"
 version = "0.32.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "flate2",
  "futures 0.3.21",
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.32.1"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.21",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.35.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.37.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "asynchronous-codec",
  "base64",
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.35.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.36.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "arrayvec 0.5.2",
  "asynchronous-codec",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.36.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "libp2p-core",
  "libp2p-gossipsub",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.32.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.35.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.35.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -3521,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.32.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.22.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "futures 0.3.21",
  "log",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.8.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "libp2p-rendezvous"
 version = "0.5.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "asynchronous-codec",
  "bimap",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.17.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.35.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "either",
  "fnv",
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.27.1"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "quote",
  "syn",
@@ -3642,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.32.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "async-io",
  "futures 0.3.21",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.32.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "async-std",
  "futures 0.3.21",
@@ -3671,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.32.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "futures 0.3.21",
  "js-sys",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.34.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "either",
  "futures 0.3.21",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.36.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "futures 0.3.21",
  "libp2p-core",
@@ -4155,7 +4155,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "multistream-select"
 version = "0.11.0"
-source = "git+https://github.com/subspace/rust-libp2p?branch=add-sr25519-keys-v44#59a74b8038fadb430ec56f7771487cb9c6d3bbc0"
+source = "git+https://github.com/subspace/rust-libp2p?branch=subspace#ff6d9a15b71ae3524760ff952153093ed4d8710a"
 dependencies = [
  "bytes",
  "futures 0.3.21",
@@ -9105,7 +9105,7 @@ checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8126,6 +8126,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "rand 0.7.3",
+ "sha2 0.10.2",
  "subspace-core-primitives",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8119,6 +8119,7 @@ dependencies = [
  "env_logger",
  "event-listener-primitives",
  "futures 0.3.21",
+ "generic-array 0.14.5",
  "hex",
  "libp2p",
  "nohash-hasher",
@@ -8130,6 +8131,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.2.25",
+ "typenum",
  "unsigned-varint",
 ]
 
@@ -9105,7 +9107,7 @@ checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8126,7 +8126,6 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "rand 0.7.3",
- "sha2 0.10.2",
  "subspace-core-primitives",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,4 @@ codegen-units = 1
 chacha20poly1305 = { git = "https://github.com/RustCrypto/AEADs", rev = "06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99" }
 # TODO: Remove once https://github.com/sitano/merkle_light/pull/8 is released
 merkle_light = { git = "https://github.com/sitano/merkle_light", rev = "fe31d4ef27a1fbe54e82ab589b610ae4bfd2008e" }
-libp2p = { git = "https://github.com/subspace/rust-libp2p", branch = "add-sr25519-keys-v44" }
+libp2p = { git = "https://github.com/subspace/rust-libp2p", branch = "subspace" }

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -25,7 +25,6 @@ hex = "0.4.3"
 nohash-hasher = "0.2.0"
 parity-scale-codec = "3.1.2"
 parking_lot = "0.12.0"
-sha2 = "0.10.2"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["macros", "parking_lot", "rt-multi-thread", "time"] }

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4.3"
 nohash-hasher = "0.2.0"
 parity-scale-codec = "3.1.2"
 parking_lot = "0.12.0"
+sha2 = "0.10.2"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["macros", "parking_lot", "rt-multi-thread", "time"] }

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1.53"
 bytes = "1.1.0"
 event-listener-primitives = "2.0.1"
 futures = "0.3.21"
+generic-array = "0.14.5"
 hex = "0.4.3"
 nohash-hasher = "0.2.0"
 parity-scale-codec = "3.1.2"
@@ -28,6 +29,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["macros", "parking_lot", "rt-multi-thread", "time"] }
 tracing = "0.1"
+typenum = "1.15.0"
 unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_codec"] }
 
 [dependencies.libp2p]

--- a/crates/subspace-networking/examples/get-pieces-complex.rs
+++ b/crates/subspace-networking/examples/get-pieces-complex.rs
@@ -1,8 +1,7 @@
 use futures::channel::mpsc;
 use futures::StreamExt;
 use libp2p::multiaddr::Protocol;
-use libp2p::multihash::Multihash;
-use libp2p::PeerId;
+use libp2p::{identity, PeerId};
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{FlatPieces, Piece, PieceIndexHash};
@@ -99,9 +98,16 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let multihash: Multihash = expected_node_id.into();
-    let peer_id_public_key: [u8; 32] = multihash.digest()[0..32].try_into().unwrap();
+    let encoding = expected_node_id.as_ref().digest();
+    let public_key = identity::PublicKey::from_protobuf_encoding(&encoding)
+        .expect("Invalid public key from PeerId.");
+    let peer_id_public_key = if let identity::PublicKey::Sr25519(pk) = public_key {
+        pk.encode()
+    } else {
+        panic!("Expected PublicKey::Sr25519")
+    };
 
+    // create a range from expected peer's public key
     let from = {
         let mut buf = peer_id_public_key;
         buf[16] = 0;
@@ -116,11 +122,13 @@ async fn main() {
     let stream_future = node.get_pieces_by_range(from, to);
     let mut stream = stream_future.await.unwrap();
     if let Some(value) = stream.next().await {
-        assert_eq!(value, expected_response.pieces);
+        if value != expected_response.pieces {
+            panic!("UNEXPECTED RESPONSE")
+        }
 
         println!("Received expected response.");
     }
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
     println!("Exiting..");
 }

--- a/crates/subspace-networking/examples/get-pieces-complex.rs
+++ b/crates/subspace-networking/examples/get-pieces-complex.rs
@@ -99,7 +99,7 @@ async fn main() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let encoding = expected_node_id.as_ref().digest();
-    let public_key = identity::PublicKey::from_protobuf_encoding(&encoding)
+    let public_key = identity::PublicKey::from_protobuf_encoding(encoding)
         .expect("Invalid public key from PeerId.");
     let peer_id_public_key = if let identity::PublicKey::Sr25519(pk) = public_key {
         pk.encode()

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -5,6 +5,7 @@ use crate::request_responses::{
     Event as RequestResponseEvent, ProtocolConfig as RequestResponseConfig,
     RequestResponseHandlerRunner, RequestResponseInstanceConfig, RequestResponsesBehaviour,
 };
+use crate::shared::IdendityHash;
 use custom_record_store::CustomRecordStore;
 use libp2p::gossipsub::{Gossipsub, GossipsubConfig, GossipsubEvent, MessageAuthenticity};
 use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
@@ -36,7 +37,7 @@ pub(crate) struct BehaviorConfig {
 #[behaviour(event_process = false)]
 pub(crate) struct Behavior {
     pub(crate) identify: Identify,
-    pub(crate) kademlia: Kademlia<CustomRecordStore>,
+    pub(crate) kademlia: Kademlia<CustomRecordStore, IdendityHash>,
     pub(crate) gossipsub: Gossipsub,
     pub(crate) ping: Ping,
     pub(crate) request_response: RequestResponsesBehaviour,
@@ -46,7 +47,8 @@ impl Behavior {
     pub(crate) fn new(config: BehaviorConfig) -> Self {
         let kademlia = {
             let store = CustomRecordStore::new(config.value_getter);
-            let mut kademlia = Kademlia::with_config(config.peer_id, store, config.kademlia);
+            let mut kademlia =
+                Kademlia::<_, IdendityHash>::with_config(config.peer_id, store, config.kademlia);
 
             for (peer_id, address) in config.bootstrap_nodes {
                 kademlia.add_address(&peer_id, address);

--- a/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
+++ b/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
@@ -2,6 +2,7 @@ use crate::{Config, PiecesByRangeRequest, PiecesByRangeResponse, PiecesToPlot};
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use libp2p::multiaddr::Protocol;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use subspace_core_primitives::{crypto, FlatPieces, Piece, PieceIndexHash};
 
@@ -84,23 +85,50 @@ async fn pieces_by_range_protocol_smoke() {
 
 #[tokio::test]
 async fn get_pieces_by_range_smoke() {
-    let piece_bytes: Vec<u8> = Piece::default().into();
-    let flat_pieces = FlatPieces::try_from(piece_bytes).unwrap();
-    let pieces = PiecesToPlot {
-        piece_indexes: vec![1],
-        pieces: flat_pieces,
-    };
+    let piece_index_from = PieceIndexHash(crypto::sha256_hash(b"from"));
+    let piece_index_continue = PieceIndexHash(crypto::sha256_hash(b"continue"));
+    let piece_index_end = PieceIndexHash(crypto::sha256_hash(b"end"));
 
-    let expected_data = pieces.clone();
+    fn get_pieces_to_plot_mock(seed: u8) -> PiecesToPlot {
+        let piece_bytes: Vec<u8> = [seed; 4096].to_vec();
+        let flat_pieces = FlatPieces::try_from(piece_bytes).unwrap();
+
+        PiecesToPlot {
+            piece_indexes: vec![1],
+            pieces: flat_pieces,
+        }
+    }
+
+    static REQUEST_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    let expected_data = vec![get_pieces_to_plot_mock(0), get_pieces_to_plot_mock(1)];
+    let response_data = expected_data.clone();
 
     let config_1 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
-        pieces_by_range_request_handler: Arc::new(move |_| {
-            Some(PiecesByRangeResponse {
-                pieces: pieces.clone(),
-                next_piece_hash_index: None,
-            })
+        pieces_by_range_request_handler: Arc::new(move |req| {
+            let request_index = REQUEST_COUNT.fetch_add(1, Ordering::SeqCst);
+
+            // Only two responses
+            if request_index == 2 {
+                return None;
+            }
+
+            if request_index == 0 {
+                Some(PiecesByRangeResponse {
+                    pieces: response_data[request_index].clone(),
+                    next_piece_hash_index: Some(piece_index_continue),
+                })
+            } else {
+                // New request starts from from the previous response.
+                assert_eq!(req.from, piece_index_continue);
+
+                Some(PiecesByRangeResponse {
+                    pieces: response_data[request_index].clone(),
+                    next_piece_hash_index: None,
+                })
+            }
         }),
         ..Config::with_generated_keypair()
     };
@@ -135,14 +163,15 @@ async fn get_pieces_by_range_smoke() {
         node_runner_2.run().await;
     });
 
-    let hashed_peer_id = PieceIndexHash(crypto::sha256_hash(&node_1.id().to_bytes()));
-
     let mut stream = node_2
-        .get_pieces_by_range(hashed_peer_id, hashed_peer_id)
+        .get_pieces_by_range(piece_index_from, piece_index_end)
         .await
         .unwrap();
 
-    let result = stream.next().await;
+    let mut result = Vec::new();
+    while let Some(piece_plot) = stream.next().await {
+        result.push(piece_plot);
+    }
 
-    assert_eq!(result.unwrap(), expected_data);
+    assert_eq!(result, expected_data);
 }

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -4,15 +4,21 @@
 use crate::pieces_by_range_handler::PiecesByRangeRequest;
 use crate::request_responses::RequestFailure;
 use bytes::Bytes;
+use core::panic;
 use event_listener_primitives::Bag;
 use futures::channel::{mpsc, oneshot};
+use generic_array::GenericArray;
 use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::error::{PublishError, SubscriptionError};
 use libp2p::gossipsub::Sha256Topic;
-use libp2p::{Multiaddr, PeerId};
+use libp2p::kad::kbucket::{KeyBytes, PreimageIntoKeyBytes};
+use libp2p::kad::record;
+use libp2p::multihash::{Code, MultihashDigest};
+use libp2p::{identity, Multiaddr, PeerId};
 use parking_lot::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
+use typenum::U32;
 
 #[derive(Debug)]
 pub(crate) struct CreatedSubscription {
@@ -77,5 +83,63 @@ impl Shared {
             connected_peers_count: AtomicUsize::new(0),
             command_sender,
         }
+    }
+}
+
+// Supports exact keys for Kademlia. It uses the Multihash as the canonical type
+// and reduces all the conversions to Multihash conversion.
+// It supports only Sr25519 key pairs for PeerId and Identity multihashes.
+#[derive(Clone, Debug)]
+pub struct IdendityHash(GenericArray<u8, U32>);
+
+impl PreimageIntoKeyBytes<Multihash> for IdendityHash {
+    fn preimage_into_key_bytes(multihash: &Multihash) -> KeyBytes<Self> {
+        const SHA256_HASH_SIZE: usize = 32;
+
+        // Identity hasher for 32-bytes digest
+        if multihash.code() == u64::from(Code::Identity)
+            && multihash.digest().len() == SHA256_HASH_SIZE
+        {
+            let array = GenericArray::from_slice(multihash.digest());
+            return KeyBytes::from_unchecked(*array);
+        }
+
+        panic!(
+            "Unsupported multihash type. Expected Identity:{:?}",
+            multihash
+        )
+    }
+}
+
+impl PreimageIntoKeyBytes<PeerId> for IdendityHash {
+    fn preimage_into_key_bytes(peer_id: &PeerId) -> KeyBytes<Self> {
+        let multihash: Multihash = if let Ok(public_key) =
+            identity::PublicKey::from_protobuf_encoding(peer_id.as_ref().digest())
+        {
+            if let identity::PublicKey::Sr25519(pk) = public_key {
+                Code::Identity.digest(&pk.encode())
+            } else {
+                panic!("Unsupported public key type. Expected Sr25519")
+            }
+        } else {
+            // No protobuf encoding: it's PeerId::random()
+            *peer_id.as_ref()
+        };
+
+        PreimageIntoKeyBytes::<Multihash>::preimage_into_key_bytes(&multihash)
+    }
+}
+
+impl PreimageIntoKeyBytes<record::Key> for IdendityHash {
+    fn preimage_into_key_bytes(_record_key: &record::Key) -> KeyBytes<Self> {
+        panic!("Unsupported operation: record::Key to KeyBytes");
+    }
+}
+
+impl PreimageIntoKeyBytes<Vec<u8>> for IdendityHash {
+    fn preimage_into_key_bytes(bytes: &Vec<u8>) -> KeyBytes<Self> {
+        let multihash = Multihash::from_bytes(bytes).expect("Not multihash arrays not supported");
+
+        PreimageIntoKeyBytes::<Multihash>::preimage_into_key_bytes(&multihash)
     }
 }


### PR DESCRIPTION
### Changes
- code modification supporting the [new Subspace libp2p branch](https://github.com/subspace/rust-libp2p/tree/subspace), I added the new `IdendityHash`type  that uses the `Multihash` as a reference conversion method to `KeyBytes`  
- bugfix and changed test for the `get-pieces-by-range` method