### PR TITLE
Upgrade CI and builds

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   chains-spec:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   runtime:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-11
+          - macos-12
           - windows-2022
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   cargo-fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-11
           - windows-2022
 
@@ -116,7 +116,7 @@ jobs:
         if: runner.os == 'macOS'
 
   cargo-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -152,8 +152,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
-          - macos-11
+          - ubuntu-22.04
+          - macos-12
           - windows-2022
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rustdoc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   container-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write
@@ -106,13 +106,13 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-${{ github.ref_name }}
-          - os: macos-11
+          - os: macos-12
             target: x86_64-apple-darwin
             suffix: macos-x86_64-${{ github.ref_name }}
-          - os: macos-11
+          - os: macos-12
             target: aarch64-apple-darwin
             suffix: macos-aarch64-${{ github.ref_name }}
           - os: windows-2022

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-22.04
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-${{ github.ref_name }}
           - os: macos-12

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -18,6 +18,7 @@ RUN \
         git \
         llvm \
         clang \
+        cmake \
         make && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
 

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -18,6 +18,7 @@ RUN \
         git \
         llvm \
         clang \
+        cmake \
         make && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
 

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -18,6 +18,7 @@ RUN \
         git \
         llvm \
         clang \
+        cmake \
         make && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
 

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG RUSTC_VERSION=nightly-2022-05-16
 ARG PROFILE=production

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -353,9 +353,9 @@ If you're running unsupported Linux distribution or CPU architecture, you may tr
 NOTE: This is primarily targeted at tech-savvy users and not recommended unless you know what you're doing.
 Please try to find answer to your question online before reaching out to maintainers.
 
-You'll have to have [Rust toolchain](https://rustup.rs/) installed as well as LLVM and Clang in addition to usual developer tooling (Ubuntu example):
+You'll have to have [Rust toolchain](https://rustup.rs/) installed as well as LLVM, Clang and CMake in addition to usual developer tooling (Ubuntu example):
 ```bash
-sudo apt-get install llvm clang
+sudo apt-get install llvm clang cmake
 ```
 
 Now clone the source and build snapshot `snapshot-2022-apr-29` (replace occurrences with the snapshot you want to build):


### PR DESCRIPTION
This primarily switches to newer versions of operating systems by default.

If someone can test on Ubuntu 20.04 and macOS 11 that things still work as expected, that'll be helpful, there are builds here: https://github.com/nazar-pc/subspace/releases/tag/snapshot-test-upgrades