### PR TITLE
Make GPU support optional in `SubspaceCodec`

### DIFF
--- a/crates/subspace-farmer/src/plotting/tests.rs
+++ b/crates/subspace-farmer/src/plotting/tests.rs
@@ -66,7 +66,7 @@ async fn plotting_happy_path() {
         }
     }
 
-    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
+    let subspace_codec = SubspaceCodec::new_with_gpu(identity.public_key().as_ref());
 
     // Start archiving task
     let archiving_instance = Archiving::start(
@@ -152,7 +152,7 @@ async fn plotting_piece_eviction() {
         }
     }
 
-    let subspace_codec = SubspaceCodec::new(identity.public_key().as_ref());
+    let subspace_codec = SubspaceCodec::new_with_gpu(identity.public_key().as_ref());
 
     // Start archiving task
     let archiving_instance = Archiving::start(

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -125,7 +125,7 @@ impl SinglePlotFarm {
             }
         }
 
-        let codec = SubspaceCodec::new(&plot.public_key());
+        let codec = SubspaceCodec::new_with_gpu(&plot.public_key());
         let create_networking_fut = subspace_networking::create(Config {
             bootstrap_nodes,
             // TODO: Do we still need it?

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -87,8 +87,22 @@ pub struct SubspaceCodec {
 impl SubspaceCodec {
     /// New instance with 256-bit prime and 4096-byte genesis piece size
     pub fn new(farmer_public_key: &[u8]) -> Self {
+        Self {
+            farmer_public_key_hash: crypto::sha256_hash(farmer_public_key),
+            #[cfg(feature = "opencl")]
+            opencl_encoder: None,
+            #[cfg(feature = "std")]
+            cpu_cores: num_cpus::get(),
+            #[cfg(not(feature = "std"))]
+            cpu_cores: 1,
+        }
+    }
+
+    /// New instance with 256-bit prime and 4096-byte genesis piece size, try to use GPU if
+    /// available
+    pub fn new_with_gpu(farmer_public_key: &[u8]) -> Self {
         #[cfg(feature = "opencl")]
-        let opencl_encoder = opencl::OpenClEncoder::new(Some(OpenClBatch {
+        let opencl_encoder = OpenClEncoder::new(Some(OpenClBatch {
             size: GPU_PIECE_BLOCK * PIECE_SIZE,
             layers: ENCODE_ROUNDS,
         }))

--- a/crates/subspace-solving/tests/integration/codec.rs
+++ b/crates/subspace-solving/tests/integration/codec.rs
@@ -8,7 +8,7 @@ fn single_piece() {
     let original_piece = rand::random::<[u8; PIECE_SIZE]>();
     let piece_index = rand::random();
 
-    let subspace_codec = SubspaceCodec::new(&public_key);
+    let subspace_codec = SubspaceCodec::new_with_gpu(&public_key);
     let mut piece = original_piece;
 
     subspace_codec.encode(&mut piece, piece_index).unwrap();
@@ -21,7 +21,7 @@ fn single_piece() {
 #[test]
 fn batch() {
     let public_key = rand::random::<[u8; 32]>();
-    let mut subspace_codec = SubspaceCodec::new(&public_key);
+    let mut subspace_codec = SubspaceCodec::new_with_gpu(&public_key);
     // Use 2.5 batches worth of pieces
     let piece_count = subspace_codec.batch_size() * 2 + subspace_codec.batch_size() / 2;
 


### PR DESCRIPTION
GPU initialization isn't free. In most cases we don't even take advantage of GPU (encode one piece in tests or only use decoding for verification), but with Cargo's feature unification node can be built with OpenCL feature enabled for codec, which meant we initialize GPU support every time we have a block to decode, this is not good.

This PR introduces a separate method that will try to take advantage of GPU where it is applicable, in most other cases GPU support will be ignored completely even if `opencl` feature is enabled.