### PR TITLE
Check the receipts included in primary block part 1

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -147,6 +147,7 @@ mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
+        // TODO: We do not rely on this event to collect the receipts included in a block, perhaps can be removed later.
         /// A new execution receipt was backed.
         NewExecutionReceipt {
             primary_number: T::BlockNumber,

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -448,6 +448,7 @@ sp_api::decl_runtime_apis! {
         /// Extract the fraud proofs from the given extrinsics.
         fn extract_fraud_proofs(extrinsics: Vec<Block::Extrinsic>) -> Vec<FraudProof>;
 
+        // TODO: remove and replace the usages with `extract_fraud_proofs` once api version is reset.
         /// Extract a fraud proof from given extrinsic if any.
         fn extract_fraud_proof(ext: &Block::Extrinsic) -> Option<FraudProof>;
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -437,8 +437,8 @@ sp_api::decl_runtime_apis! {
             invalid_transaction_proof: InvalidTransactionProof,
         );
 
-        /// Extract the bundles from extrinsics in a block.
-        fn extract_bundles(extrinsics: Vec<OpaqueExtrinsic>) -> Vec<OpaqueBundle>;
+        /// Extract the bundles from the given extrinsics.
+        fn extract_bundles(extrinsics: Vec<Block::Extrinsic>) -> Vec<OpaqueBundle>;
 
         /// Extract a fraud proof from given extrinsic if any.
         fn extract_fraud_proof(ext: &Block::Extrinsic) -> Option<FraudProof>;

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -414,7 +414,7 @@ pub struct InvalidTransactionProof;
 
 sp_api::decl_runtime_apis! {
     /// API necessary for executor pallet.
-    #[api_version(2)]
+    #[api_version(3)]
     pub trait ExecutorApi<SecondaryHash: Encode + Decode> {
         /// Submits the execution receipt via an unsigned extrinsic.
         fn submit_execution_receipt_unsigned(

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -440,6 +440,14 @@ sp_api::decl_runtime_apis! {
         /// Extract the bundles from the given extrinsics.
         fn extract_bundles(extrinsics: Vec<Block::Extrinsic>) -> Vec<OpaqueBundle>;
 
+        /// Extract the receipts from the given extrinsics.
+        fn extract_receipts(
+            extrinsics: Vec<Block::Extrinsic>,
+        ) -> Vec<SignedExecutionReceipt<NumberFor<Block>, Block::Hash, SecondaryHash>>;
+
+        /// Extract the fraud proofs from the given extrinsics.
+        fn extract_fraud_proofs(extrinsics: Vec<Block::Extrinsic>) -> Vec<FraudProof>;
+
         /// Extract a fraud proof from given extrinsic if any.
         fn extract_fraud_proof(ext: &Block::Extrinsic) -> Option<FraudProof>;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -541,6 +541,39 @@ fn extract_bundles(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<OpaqueBundle> {
         .collect()
 }
 
+fn extract_receipts(
+    extrinsics: Vec<UncheckedExtrinsic>,
+) -> Vec<SignedExecutionReceipt<BlockNumber, Hash, cirrus_primitives::Hash>> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| {
+            if let Call::Executor(pallet_executor::Call::submit_execution_receipt {
+                signed_execution_receipt,
+            }) = uxt.function
+            {
+                Some(signed_execution_receipt)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| {
+            if let Call::Executor(pallet_executor::Call::submit_fraud_proof { fraud_proof }) =
+                uxt.function
+            {
+                Some(fraud_proof)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 fn extract_fraud_proof(ext: &UncheckedExtrinsic) -> Option<sp_executor::FraudProof> {
     match &ext.function {
         Call::Executor(pallet_executor::Call::submit_fraud_proof { fraud_proof }) => {
@@ -783,6 +816,16 @@ impl_runtime_apis! {
 
         fn extract_bundles(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<OpaqueBundle> {
             extract_bundles(extrinsics)
+        }
+
+        fn extract_receipts(
+            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+        ) -> Vec<SignedExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, cirrus_primitives::Hash>> {
+            extract_receipts(extrinsics)
+        }
+
+        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<FraudProof> {
+            extract_fraud_proofs(extrinsics)
         }
 
         fn extrinsics_shuffling_seed(header: <Block as BlockT>::Header) -> Randomness {

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -321,6 +321,8 @@ where
 			return Ok(())
 		}
 
+		// TODO: Generate FraudProof for the first incorrect ER which is still not _confirmed_.
+
 		// Ideally, the receipt of current block will be included in the next block, i.e., no
 		// missing receipts.
 		if header_number == best_execution_chain_number + One::one() {

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -10,7 +10,7 @@ use sc_consensus::{
 };
 use sc_network::NetworkService;
 use sc_utils::mpsc::TracingUnboundedSender;
-use sp_api::{NumberFor, ProvideRuntimeApi, TransactionFor};
+use sp_api::{ApiExt, NumberFor, ProvideRuntimeApi, TransactionFor};
 use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockOrigin;
 use sp_core::ByteArray;
@@ -301,7 +301,17 @@ where
 
 		// TODO: The applied txs can be fully removed from the transaction pool
 
-		self.check_receipts_in_primary_block(primary_number.into())?;
+		// TODO: Remove once the network is reset.
+		if self
+			.primary_chain_client
+			.runtime_api()
+			.api_version::<dyn ExecutorApi<PBlock, Block::Hash>>(&BlockId::Number(
+				primary_number.into(),
+			))?
+			.map_or(false, |v| v >= 3)
+		{
+			self.check_receipts_in_primary_block(primary_number.into())?;
+		}
 
 		if self.primary_network.is_major_syncing() {
 			tracing::debug!(

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -552,6 +552,23 @@ impl From<sp_blockchain::Error> for GossipMessageError {
 	}
 }
 
+/// Compares if the receipt `other` is the same with `local`, return a tuple of (local_index,
+/// local_trace_root) if there is a mismatch.
+pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PNumber, PHash>(
+	local: &ExecutionReceipt<Number, PHash, Hash>,
+	other: &ExecutionReceipt<PNumber, PHash, Hash>,
+) -> Option<(usize, Hash)> {
+	local.trace.iter().enumerate().zip(other.trace.iter().enumerate()).find_map(
+		|((local_index, local_root), (_, other_root))| {
+			if local_root != other_root {
+				Some((local_index, *local_root))
+			} else {
+				None
+			}
+		},
+	)
+}
+
 impl<Block, PBlock, Client, PClient, TransactionPool, Backend, E>
 	GossipMessageHandler<PBlock, Block>
 	for Executor<Block, PBlock, Client, PClient, TransactionPool, Backend, E>
@@ -738,18 +755,9 @@ where
 		// TODO: What happens for this obvious error?
 		if local_receipt.trace.len() != execution_receipt.trace.len() {}
 
-		if let Some((local_trace_idx, local_root)) = local_receipt
-			.trace
-			.iter()
-			.enumerate()
-			.zip(execution_receipt.trace.iter().enumerate())
-			.find_map(|((local_idx, local_root), (_, external_root))| {
-				if local_root != external_root {
-					Some((local_idx, local_root))
-				} else {
-					None
-				}
-			}) {
+		if let Some((local_trace_idx, local_root)) =
+			find_trace_mismatch(&local_receipt, execution_receipt)
+		{
 			let header = self.header(execution_receipt.secondary_hash)?;
 			let parent_header = self.header(*header.parent_hash())?;
 
@@ -772,7 +780,7 @@ where
 			let fraud_proof = if local_trace_idx == 0 {
 				// `initialize_block` execution proof.
 				let pre_state_root = as_h256(parent_header.state_root())?;
-				let post_state_root = as_h256(local_root)?;
+				let post_state_root = as_h256(&local_root)?;
 
 				let new_header = Block::Header::new(
 					block_number,
@@ -801,7 +809,7 @@ where
 			} else if local_trace_idx == local_receipt.trace.len() - 1 {
 				// `finalize_block` execution proof.
 				let pre_state_root = as_h256(&execution_receipt.trace[local_trace_idx - 1])?;
-				let post_state_root = as_h256(local_root)?;
+				let post_state_root = as_h256(&local_root)?;
 				let execution_phase = ExecutionPhase::FinalizeBlock;
 
 				let block_builder = BlockBuilder::new(
@@ -836,7 +844,7 @@ where
 			} else {
 				// Regular extrinsic execution proof.
 				let pre_state_root = as_h256(&execution_receipt.trace[local_trace_idx - 1])?;
-				let post_state_root = as_h256(local_root)?;
+				let post_state_root = as_h256(&local_root)?;
 
 				let (proof, execution_phase) = self.create_extrinsic_execution_proof(
 					local_trace_idx - 1,

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -554,9 +554,9 @@ impl From<sp_blockchain::Error> for GossipMessageError {
 
 /// Compares if the receipt `other` is the same with `local`, return a tuple of (local_index,
 /// local_trace_root) if there is a mismatch.
-pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PNumber, PHash>(
+pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PHash>(
 	local: &ExecutionReceipt<Number, PHash, Hash>,
-	other: &ExecutionReceipt<PNumber, PHash, Hash>,
+	other: &ExecutionReceipt<Number, PHash, Hash>,
 ) -> Option<(usize, Hash)> {
 	local.trace.iter().enumerate().zip(other.trace.iter().enumerate()).find_map(
 		|((local_index, local_root), (_, other_root))| {

--- a/cumulus/client/cirrus-executor/src/worker.rs
+++ b/cumulus/client/cirrus-executor/src/worker.rs
@@ -28,7 +28,6 @@ use sp_executor::{ExecutorApi, OpaqueBundle, SignedOpaqueBundle};
 use sp_runtime::{
 	generic::{BlockId, DigestItem},
 	traits::{Header as HeaderT, NumberFor, One, Saturating},
-	OpaqueExtrinsic,
 };
 use std::{
 	borrow::Cow,
@@ -396,15 +395,7 @@ where
 		Ok(Some(body)) => body,
 	};
 
-	let bundles = primary_chain_client.runtime_api().extract_bundles(
-		&block_id,
-		extrinsics
-			.into_iter()
-			.map(|xt| {
-				OpaqueExtrinsic::from_bytes(&xt.encode()).expect("Certainly a correct extrinsic")
-			})
-			.collect(),
-	)?;
+	let bundles = primary_chain_client.runtime_api().extract_bundles(&block_id, extrinsics)?;
 
 	let header = match primary_chain_client.header(block_id) {
 		Err(err) => {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -837,6 +837,39 @@ fn extract_bundles(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<OpaqueBundle> {
         .collect()
 }
 
+fn extract_receipts(
+    extrinsics: Vec<UncheckedExtrinsic>,
+) -> Vec<SignedExecutionReceipt<BlockNumber, Hash, cirrus_primitives::Hash>> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| {
+            if let Call::Executor(pallet_executor::Call::submit_execution_receipt {
+                signed_execution_receipt,
+            }) = uxt.function
+            {
+                Some(signed_execution_receipt)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| {
+            if let Call::Executor(pallet_executor::Call::submit_fraud_proof { fraud_proof }) =
+                uxt.function
+            {
+                Some(fraud_proof)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 fn extract_fraud_proof(ext: &UncheckedExtrinsic) -> Option<sp_executor::FraudProof> {
     match &ext.function {
         Call::Executor(pallet_executor::Call::submit_fraud_proof { fraud_proof }) => {
@@ -1079,6 +1112,16 @@ impl_runtime_apis! {
 
         fn extract_bundles(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<OpaqueBundle> {
             extract_bundles(extrinsics)
+        }
+
+        fn extract_receipts(
+            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+        ) -> Vec<SignedExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, cirrus_primitives::Hash>> {
+            extract_receipts(extrinsics)
+        }
+
+        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<FraudProof> {
+            extract_fraud_proofs(extrinsics)
         }
 
         fn extract_fraud_proof(ext: &<Block as BlockT>::Extrinsic) -> Option<FraudProof> {


### PR DESCRIPTION
Part 1 of # #634. This PR is primarily for adding the overall workflow to check the receipts included in each primary block, the TODOs about primary receipts checking will be addressed in the next PR.