### PR TITLE
Build separate OpenCL-capable farmer executable to avoid unnecessary difficulties for those who do not care about it

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload executable to artifacts (aarch64)
         uses: actions/upload-artifact@v2
         with:
-          name: executables
+          name: executables-${{ matrix.platform.suffix }}
           path: |
             subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
           if-no-files-found: error
@@ -160,19 +160,28 @@ jobs:
         run: sudo apt-get install -y ocl-icd-opencl-dev
         if: runner.os == 'Linux'
 
-      - name: Build (Linux or Windows with OpenCL)
+      - name: Build (farmer on Ubuntu or Windows with OpenCL)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target ${{ matrix.build.target }} --profile production --bin subspace-node --bin subspace-farmer --features=subspace-farmer/opencl
+          args: --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features=subspace-farmer/opencl
         if: runner.os == 'Linux' || runner.os == 'Windows'
 
-      - name: Build (macOS without OpenCL)
+      - name: Rename OpenCL farmer executable (Ubuntu)
+        run: |
+          mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl
+        if: runner.os == 'Linux'
+
+      - name: Rename OpenCL farmer executable (Windows)
+        run: |
+          move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl.exe
+        if: runner.os == 'Windows'
+
+      - name: Build (farmer and node without OpenCL)
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --target ${{ matrix.build.target }} --profile production --bin subspace-node --bin subspace-farmer
-        if: runner.os == 'macOS'
 
       - name: Sign Application (macOS)
         run: |
@@ -218,6 +227,7 @@ jobs:
         run: |
           mkdir executables
           mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer executables/subspace-farmer-${{ matrix.build.suffix }}
+          mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl executables/subspace-farmer-opencl-${{ matrix.build.suffix }}
           mv ${{ env.PRODUCTION_TARGET }}/subspace-node executables/subspace-node-${{ matrix.build.suffix }}
         if: runner.os == 'Linux'
 
@@ -237,6 +247,7 @@ jobs:
         run: |
           mkdir executables
           move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe executables/subspace-farmer-${{ matrix.build.suffix }}.exe
+          move ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl.exe executables/subspace-farmer-opencl-${{ matrix.build.suffix }}.exe
           move ${{ env.PRODUCTION_TARGET }}/subspace-node.exe executables/subspace-node-${{ matrix.build.suffix }}.exe
         if: runner.os == 'Windows'
 

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -24,7 +24,7 @@ Our snapshots are categorized as the following:
 
 You need 2 executables, select whichever applies to your operating system
 * Node Executable - `subspace-node-...`
-* Farmer Executable - `subspace-farmer-...`
+* Farmer Executable - `subspace-farmer-...` or `subspace-farmer-opencl-...` (in case you have OpenCL-capable AMD, Intel or Nvidia GPU)
 
 You can find these executables in the [Releases](https://github.com/subspace/subspace/releases) section of this Repository.
 
@@ -43,6 +43,13 @@ On the desktop side if you have a router in front of your computer, you'll need 
 If you're connected directly without any router, then again nothing needs to be done in such case.
 
 ## 🖼️ Windows Instructions
+
+### OpenCL support
+If you use farmer executable starting with `subspace-farmer-opencl-` and see this error:
+> The code execution cannot proceed because OpenCL.dll was not found. Reinstalling the program may fix this problem.
+
+Or farmer exits in CLI without any messages, it means you don't have OpenCL-capable GPU or drivers installed.
+Installing OpenCL GPU drivers or using farmer executable without `opencl` in file name will fix the issue.
 
 1. Download the executables for your operating system from the [Releases](https://github.com/subspace/subspace/releases) tab.
 2. Open `Powershell` (we do not recommend using Command Prompt as it's syntax is slightly different)


### PR DESCRIPTION
Test CI run: https://github.com/subspace/subspace/actions/runs/2571791521

@ImmaZoni please pull documentation changes into upcoming snapshot.
@ozgunozerk I think on Windows we may have to add OpenCL to requirements in documentation or have separate builds too, on Ubuntu dependencies should be either bundled (AppImage) or specified in deb package (deb, but please confirm whether that is actually the case, we may need to add it manually there).

Fixes #611 by removing OpenCL from node builds completely and separating binaries for farmer.