### PR TITLE
Optimized AArch64 executables

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -77,30 +77,6 @@ jobs:
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
             PROFILE=${{ matrix.platform.profile }}
-            RUSTFLAGS=-C strip=debuginfo
-
-      - name: Extract executable from container image (aarch64)
-        # Using `steps.meta.outputs.tags` instead of `steps.build.outputs.digest` because of https://github.com/docker/build-push-action/issues/321
-        run: |
-          docker run --rm -u root --platform ${{ matrix.platform.arch }} --entrypoint /bin/cat ${{ steps.meta.outputs.tags }} /subspace-${{ matrix.image }} > subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
-        if: matrix.platform.arch == 'linux/arm64'
-
-      - name: Upload executable to artifacts (aarch64)
-        uses: actions/upload-artifact@v2
-        with:
-          name: executables-${{ matrix.platform.suffix }}
-          path: |
-            subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}
-          if-no-files-found: error
-        if: matrix.platform.arch == 'linux/arm64'
-
-      - name: Upload executable to assets (aarch64)
-        uses: alexellis/upload-assets@0.3.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["subspace-${{ matrix.image }}-${{ matrix.platform.suffix }}"]'
-        if: matrix.platform.arch == 'linux/arm64' && github.event_name == 'push' && github.ref_type == 'tag'
 
   executables:
     strategy:
@@ -109,18 +85,27 @@ jobs:
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-${{ github.ref_name }}
+            rustflags: ''
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            suffix: ubuntu-aarch64-${{ github.ref_name }}
+            rustflags: '-C linker=aarch64-linux-gnu-gcc'
           - os: macos-12
             target: x86_64-apple-darwin
             suffix: macos-x86_64-${{ github.ref_name }}
+            rustflags: ''
           - os: macos-12
             target: aarch64-apple-darwin
             suffix: macos-aarch64-${{ github.ref_name }}
+            rustflags: ''
           - os: windows-2022
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-${{ github.ref_name }}
+            rustflags: ''
     runs-on: ${{ matrix.build.os }}
     env:
       PRODUCTION_TARGET: target/${{ matrix.build.target }}/production
+      RUSTFLAGS: ${{ matrix.build.rustflags }}
 
     steps:
       - name: Checkout
@@ -138,6 +123,7 @@ jobs:
         with:
           toolchain: nightly-2022-05-16
           target: ${{ matrix.build.target }}
+          components: rust-src
           override: true
 
       - name: Rust toolchain (wasm32)
@@ -157,20 +143,24 @@ jobs:
         if: runner.os == 'Linux' || runner.os == 'Windows'
 
       - name: OpenCL
-        run: sudo apt-get install -y ocl-icd-opencl-dev
+        run: sudo apt-get install -y --no-install-recommends ocl-icd-opencl-dev
         if: runner.os == 'Linux'
+
+      - name: AArch64 cross-compile packages
+        run: sudo apt-get install -y --no-install-recommends g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+        if: matrix.build.target == 'aarch64-unknown-linux-gnu'
 
       - name: Build (farmer on Ubuntu or Windows with OpenCL)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features=subspace-farmer/opencl
-        if: runner.os == 'Linux' || runner.os == 'Windows'
+          args: -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features=subspace-farmer/opencl
+        if: (runner.os == 'Linux' || runner.os == 'Windows') && matrix.build.target != 'aarch64-unknown-linux-gnu'
 
       - name: Rename OpenCL farmer executable (Ubuntu)
         run: |
           mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.build.target != 'aarch64-unknown-linux-gnu'
 
       - name: Rename OpenCL farmer executable (Windows)
         run: |
@@ -181,7 +171,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target ${{ matrix.build.target }} --profile production --bin subspace-node --bin subspace-farmer
+          args: -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-node --bin subspace-farmer
 
       - name: Sign Application (macOS)
         run: |
@@ -227,7 +217,8 @@ jobs:
         run: |
           mkdir executables
           mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer executables/subspace-farmer-${{ matrix.build.suffix }}
-          mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl executables/subspace-farmer-opencl-${{ matrix.build.suffix }}
+          # AArch64 doesn't have OpenCL build (yet)
+          mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl executables/subspace-farmer-opencl-${{ matrix.build.suffix }} || true
           mv ${{ env.PRODUCTION_TARGET }}/subspace-node executables/subspace-node-${{ matrix.build.suffix }}
         if: runner.os == 'Linux'
 

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -29,12 +29,12 @@ jobs:
           - node
         platform:
           - arch: linux/amd64
-            profile: production
+            dockerfile-suffix: ''
             suffix: ubuntu-x86_64-${{ github.ref_name }}
             image-suffix: ''
-          - arch: linux/arm64
-            # Build at least something for aarch64 that doesn't exceed CI's time limit
-            profile: dev
+          # We build AArch64
+          - arch: linux/amd64
+            dockerfile-suffix: '.aarch64'
             suffix: ubuntu-aarch64-${{ github.ref_name }}
             image-suffix: '-aarch64'
 
@@ -68,7 +68,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v2
         with:
-          file: Dockerfile-${{ matrix.image }}
+          file: Dockerfile-${{ matrix.image }}${{ matrix.dockerfile-suffix }}
           platforms: ${{ matrix.platform.arch }}
           # Only push for releases
           push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
@@ -76,7 +76,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
-            PROFILE=${{ matrix.platform.profile }}
 
   executables:
     strategy:

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -37,8 +37,12 @@ COPY test /code/test
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 RUN \
-    /root/.cargo/bin/cargo build --profile $PROFILE --bin subspace-farmer && \
-    mv target/*/subspace-farmer subspace-farmer && \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-farmer \
+        --target x86_64-unknown-linux-gnu && \
+    mv target/*/*/subspace-farmer subspace-farmer && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -1,0 +1,70 @@
+FROM ubuntu:20.04
+
+ARG RUSTC_VERSION=nightly-2022-05-16
+ARG PROFILE=production
+ARG RUSTFLAGS
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
+
+WORKDIR /code
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        llvm \
+        clang \
+        cmake \
+        make && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
+
+RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+
+COPY Cargo.lock /code/Cargo.lock
+COPY Cargo.toml /code/Cargo.toml
+COPY rust-toolchain.toml /code/rust-toolchain.toml
+
+COPY crates /code/crates
+COPY cumulus /code/cumulus
+COPY orml /code/orml
+COPY substrate /code/substrate
+COPY test /code/test
+
+# Up until this line all Rust images in this repo should be the same to share the same layers
+
+ENV RUSTFLAGS="${RUSTFLAGS} -C linker=aarch64-linux-gnu-gcc"
+
+# Dependencies necessary for successful cross-compilation
+RUN \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        g++-aarch64-linux-gnu \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross
+
+# TODO: Following package is not necessary on Ubuntu 22.04, but RocksDb compilation fails otherwise on Ubuntu 20.04
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-9-multilib
+
+RUN \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-farmer \
+        --target aarch64-unknown-linux-gnu && \
+    mv target/*/*/subspace-farmer subspace-farmer && \
+    rm -rf target
+
+FROM arm64v8/ubuntu:20.04
+
+COPY --from=0 /code/subspace-farmer /subspace-farmer
+
+RUN mkdir /var/subspace && chown nobody:nogroup /var/subspace
+
+VOLUME /var/subspace
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/subspace-farmer"]

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -39,8 +39,12 @@ COPY test /code/test
 ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
 
 RUN \
-    /root/.cargo/bin/cargo build --profile $PROFILE --bin subspace-node && \
-    mv target/*/subspace-node subspace-node && \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-node \
+        --target x86_64-unknown-linux-gnu && \
+    mv target/*/*/subspace-node subspace-node && \
     rm -rf target
 
 FROM ubuntu:20.04

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -1,0 +1,80 @@
+FROM ubuntu:20.04
+
+ARG RUSTC_VERSION=nightly-2022-05-16
+ARG PROFILE=production
+ARG RUSTFLAGS
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
+
+WORKDIR /code
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        llvm \
+        clang \
+        cmake \
+        make && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
+
+RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+
+COPY Cargo.lock /code/Cargo.lock
+COPY Cargo.toml /code/Cargo.toml
+COPY rust-toolchain.toml /code/rust-toolchain.toml
+
+COPY crates /code/crates
+COPY cumulus /code/cumulus
+COPY orml /code/orml
+COPY substrate /code/substrate
+COPY test /code/test
+
+# Up until this line all Rust images in this repo should be the same to share the same layers
+
+ENV RUSTFLAGS="${RUSTFLAGS} -C linker=aarch64-linux-gnu-gcc"
+
+# Dependencies necessary for successful cross-compilation
+RUN \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        g++-aarch64-linux-gnu \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross
+
+RUN \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-node \
+        --target aarch64-unknown-linux-gnu && \
+    mv target/*/*/subspace-node subspace-node && \
+    rm -rf target
+
+ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
+
+FROM arm64v8/ubuntu:20.04
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+HEALTHCHECK CMD curl \
+                  -H "Content-Type: application/json" \
+                  -d '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }' \
+                  -f "http://localhost:9933"
+
+COPY --from=0 /code/subspace-node /subspace-node
+
+RUN mkdir /var/subspace && chown nobody:nogroup /var/subspace
+
+VOLUME /var/subspace
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/subspace-node"]

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -38,9 +38,12 @@ COPY test /code/test
 
 # TODO: Re-enable cost of storage in future
 RUN \
-    /root/.cargo/bin/cargo build --profile $PROFILE \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
         --package subspace-runtime \
-        --features=subspace-runtime/do-not-enforce-cost-of-storage && \
+        --features=subspace-runtime/do-not-enforce-cost-of-storage \
+        --target x86_64-unknown-linux-gnu && \
     mv \
       target/*/wbuild/subspace-runtime/subspace_runtime.compact.compressed.wasm \
       subspace_runtime.compact.compressed.wasm && \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
 channel = "nightly-2022-05-16"
+components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
This switches from `debug` AArch64 Linux builds that took 2.5 hours for farmer and 5.5 hours for node to `production` optimized builds that take 25 minutes to build for farmer and 50 minutes for node, cutting time for release publishing significantly :tada: 

This also makes all builds compile Rust's standard library as part of the build. Was only necessary for cross-compilation as standard library wasn't available for this target (might be just one rustc build, but still), but I decided to switch to that everywhere for consistency.

Workflow run: https://github.com/subspace/subspace/actions/runs/2573340931