### PR TITLE
Check receipts included in primary block part 2

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -412,6 +412,7 @@ mod pallet {
                         }
                     }
 
+                    // TODO: is this check unnecessary as it's actually guaranteed by the above one?
                     // Ensure the parent receipt exists after block #1.
                     if primary_number > One::one() {
                         ensure!(

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -243,3 +243,20 @@ where
 		Ok((execution_proof, execution_phase))
 	}
 }
+
+/// Compares if the receipt `other` is the same with `local`, return a tuple of (local_index,
+/// local_trace_root) if there is a mismatch.
+pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PHash>(
+	local: &ExecutionReceipt<Number, PHash, Hash>,
+	other: &ExecutionReceipt<Number, PHash, Hash>,
+) -> Option<(usize, Hash)> {
+	local.trace.iter().enumerate().zip(other.trace.iter().enumerate()).find_map(
+		|((local_index, local_root), (_, other_root))| {
+			if local_root != other_root {
+				Some((local_index, *local_root))
+			} else {
+				None
+			}
+		},
+	)
+}

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -78,7 +78,7 @@ where
 	pub(crate) fn generate_proof<Number, PHash>(
 		&self,
 		block_number: NumberFor<Block>,
-		(local_trace_idx, local_root): (usize, Block::Hash),
+		local_trace_idx: usize,
 		local_receipt: &ExecutionReceipt<Number, PHash, Block::Hash>,
 		execution_receipt: &ExecutionReceipt<Number, PHash, Block::Hash>,
 	) -> Result<FraudProof, FraudProofError> {
@@ -99,6 +99,8 @@ where
 
 		let parent_number = TryInto::<BlockNumber>::try_into(*parent_header.number())
 			.unwrap_or_else(|_| panic!("Parent number must fit into u32; qed"));
+
+		let local_root = local_receipt.trace[local_trace_idx];
 
 		// TODO: abstract the execution proof impl to be reusable in the test.
 		let fraud_proof = if local_trace_idx == 0 {
@@ -249,11 +251,11 @@ where
 pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PHash>(
 	local: &ExecutionReceipt<Number, PHash, Hash>,
 	other: &ExecutionReceipt<Number, PHash, Hash>,
-) -> Option<(usize, Hash)> {
+) -> Option<usize> {
 	local.trace.iter().enumerate().zip(other.trace.iter().enumerate()).find_map(
 		|((local_index, local_root), (_, other_root))| {
 			if local_root != other_root {
-				Some((local_index, *local_root))
+				Some(local_index)
 			} else {
 				None
 			}

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -80,9 +80,8 @@ where
 		block_number: NumberFor<Block>,
 		local_trace_index: usize,
 		local_receipt: &ExecutionReceipt<Number, PHash, Block::Hash>,
-		execution_receipt: &ExecutionReceipt<Number, PHash, Block::Hash>,
 	) -> Result<FraudProof, FraudProofError> {
-		let block_hash = execution_receipt.secondary_hash;
+		let block_hash = local_receipt.secondary_hash;
 
 		let header = self.header(block_hash)?;
 		let parent_header = self.header(*header.parent_hash())?;
@@ -136,7 +135,7 @@ where
 			}
 		} else if local_trace_index == local_receipt.trace.len() - 1 {
 			// `finalize_block` execution proof.
-			let pre_state_root = as_h256(&execution_receipt.trace[local_trace_index - 1])?;
+			let pre_state_root = as_h256(&local_receipt.trace[local_trace_index - 1])?;
 			let post_state_root = as_h256(&local_root)?;
 			let execution_phase = ExecutionPhase::FinalizeBlock;
 
@@ -170,7 +169,7 @@ where
 			}
 		} else {
 			// Regular extrinsic execution proof.
-			let pre_state_root = as_h256(&execution_receipt.trace[local_trace_index - 1])?;
+			let pre_state_root = as_h256(&local_receipt.trace[local_trace_index - 1])?;
 			let post_state_root = as_h256(&local_root)?;
 
 			let (proof, execution_phase) = self.create_extrinsic_execution_proof(

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -18,7 +18,7 @@ use sp_trie::StorageProof;
 use std::{marker::PhantomData, sync::Arc};
 use subspace_core_primitives::BlockNumber;
 
-/// Error type for cirrus gossip handling.
+/// Error type for fraud proof generation.
 #[derive(Debug, thiserror::Error)]
 pub enum FraudProofError {
 	#[error("State root not using H256")]
@@ -250,8 +250,7 @@ where
 	}
 }
 
-/// Compares if the receipt `other` is the same with `local`, return a tuple of (local_index,
-/// local_trace_root) if there is a mismatch.
+/// Returns the index of first mismatch between the receipts `local` and `other` if any.
 pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PHash>(
 	local: &ExecutionReceipt<Number, PHash, Hash>,
 	other: &ExecutionReceipt<Number, PHash, Hash>,

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -1,0 +1,245 @@
+use crate::TransactionFor;
+use cirrus_block_builder::{BlockBuilder, RecordProof};
+use cirrus_primitives::{AccountId, SecondaryApi};
+use codec::{Decode, Encode};
+use sc_client_api::{AuxStore, BlockBackend};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_core::{
+	traits::{CodeExecutor, SpawnNamed},
+	H256,
+};
+use sp_executor::{ExecutionPhase, ExecutionReceipt, FraudProof};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, HashFor, Header as HeaderT, NumberFor},
+};
+use sp_trie::StorageProof;
+use std::{marker::PhantomData, sync::Arc};
+use subspace_core_primitives::BlockNumber;
+
+/// Error type for cirrus gossip handling.
+#[derive(Debug, thiserror::Error)]
+pub enum FraudProofError {
+	#[error("State root not using H256")]
+	InvalidStateRootType,
+	#[error("Invalid extrinsic index for creating the execution proof, got: {index}, max: {max}")]
+	InvalidExtrinsicIndex { index: usize, max: usize },
+	#[error(transparent)]
+	Blockchain(#[from] sp_blockchain::Error),
+	#[error(transparent)]
+	RuntimeApi(#[from] sp_api::ApiError),
+}
+
+pub(crate) struct FraudProofGenerator<Block, Client, Backend, E> {
+	client: Arc<Client>,
+	spawner: Box<dyn SpawnNamed + Send + Sync>,
+	backend: Arc<Backend>,
+	code_executor: Arc<E>,
+	_phantom: PhantomData<Block>,
+}
+
+impl<Block, Client, Backend, E> Clone for FraudProofGenerator<Block, Client, Backend, E> {
+	fn clone(&self) -> Self {
+		Self {
+			client: self.client.clone(),
+			spawner: self.spawner.clone(),
+			backend: self.backend.clone(),
+			code_executor: self.code_executor.clone(),
+			_phantom: self._phantom,
+		}
+	}
+}
+
+impl<Block, Client, Backend, E> FraudProofGenerator<Block, Client, Backend, E>
+where
+	Block: BlockT,
+	Client:
+		HeaderBackend<Block> + BlockBackend<Block> + AuxStore + ProvideRuntimeApi<Block> + 'static,
+	Client::Api: SecondaryApi<Block, AccountId>
+		+ sp_block_builder::BlockBuilder<Block>
+		+ sp_api::ApiExt<
+			Block,
+			StateBackend = sc_client_api::backend::StateBackendFor<Backend, Block>,
+		>,
+	Backend: sc_client_api::Backend<Block> + Send + Sync + 'static,
+	TransactionFor<Backend, Block>: sp_trie::HashDBT<HashFor<Block>, sp_trie::DBValue>,
+	E: CodeExecutor,
+{
+	pub(crate) fn new(
+		client: Arc<Client>,
+		spawner: Box<dyn SpawnNamed + Send + Sync>,
+		backend: Arc<Backend>,
+		code_executor: Arc<E>,
+	) -> Self {
+		Self { client, spawner, backend, code_executor, _phantom: Default::default() }
+	}
+
+	pub(crate) fn generate_proof<Number, PHash>(
+		&self,
+		block_number: NumberFor<Block>,
+		(local_trace_idx, local_root): (usize, Block::Hash),
+		local_receipt: &ExecutionReceipt<Number, PHash, Block::Hash>,
+		execution_receipt: &ExecutionReceipt<Number, PHash, Block::Hash>,
+	) -> Result<FraudProof, FraudProofError> {
+		let header = self.header(execution_receipt.secondary_hash)?;
+		let parent_header = self.header(*header.parent_hash())?;
+
+		// TODO: avoid the encode & decode?
+		let as_h256 = |state_root: &Block::Hash| {
+			H256::decode(&mut state_root.encode().as_slice())
+				.map_err(|_| FraudProofError::InvalidStateRootType)
+		};
+
+		let prover = subspace_fraud_proof::ExecutionProver::new(
+			self.backend.clone(),
+			self.code_executor.clone(),
+			self.spawner.clone() as Box<dyn SpawnNamed>,
+		);
+
+		let parent_number = TryInto::<BlockNumber>::try_into(*parent_header.number())
+			.unwrap_or_else(|_| panic!("Parent number must fit into u32; qed"));
+
+		// TODO: abstract the execution proof impl to be reusable in the test.
+		let fraud_proof = if local_trace_idx == 0 {
+			// `initialize_block` execution proof.
+			let pre_state_root = as_h256(parent_header.state_root())?;
+			let post_state_root = as_h256(&local_root)?;
+
+			let new_header = Block::Header::new(
+				block_number,
+				Default::default(),
+				Default::default(),
+				parent_header.hash(),
+				Default::default(),
+			);
+			let execution_phase =
+				ExecutionPhase::InitializeBlock { call_data: new_header.encode() };
+
+			let proof = prover.prove_execution::<TransactionFor<Backend, Block>>(
+				BlockId::Hash(parent_header.hash()),
+				&execution_phase,
+				None,
+			)?;
+
+			FraudProof {
+				parent_number,
+				parent_hash: as_h256(&parent_header.hash())?,
+				pre_state_root,
+				post_state_root,
+				proof,
+				execution_phase,
+			}
+		} else if local_trace_idx == local_receipt.trace.len() - 1 {
+			// `finalize_block` execution proof.
+			let pre_state_root = as_h256(&execution_receipt.trace[local_trace_idx - 1])?;
+			let post_state_root = as_h256(&local_root)?;
+			let execution_phase = ExecutionPhase::FinalizeBlock;
+
+			let block_builder = BlockBuilder::new(
+				&*self.client,
+				parent_header.hash(),
+				*parent_header.number(),
+				RecordProof::No,
+				Default::default(),
+				&*self.backend,
+				self.block_body(execution_receipt.secondary_hash)?,
+			)?;
+			let storage_changes = block_builder.prepare_storage_changes_before_finalize_block()?;
+
+			let delta = storage_changes.transaction;
+			let post_delta_root = storage_changes.transaction_storage_root;
+
+			let proof = prover.prove_execution(
+				BlockId::Hash(parent_header.hash()),
+				&execution_phase,
+				Some((delta, post_delta_root)),
+			)?;
+
+			FraudProof {
+				parent_number,
+				parent_hash: as_h256(&parent_header.hash())?,
+				pre_state_root,
+				post_state_root,
+				proof,
+				execution_phase,
+			}
+		} else {
+			// Regular extrinsic execution proof.
+			let pre_state_root = as_h256(&execution_receipt.trace[local_trace_idx - 1])?;
+			let post_state_root = as_h256(&local_root)?;
+
+			let (proof, execution_phase) = self.create_extrinsic_execution_proof(
+				local_trace_idx - 1,
+				&parent_header,
+				execution_receipt.secondary_hash,
+				&prover,
+			)?;
+
+			// TODO: proof should be a CompactProof.
+			FraudProof {
+				parent_number,
+				parent_hash: as_h256(&parent_header.hash())?,
+				pre_state_root,
+				post_state_root,
+				proof,
+				execution_phase,
+			}
+		};
+
+		Ok(fraud_proof)
+	}
+
+	fn header(&self, at: Block::Hash) -> Result<Block::Header, sp_blockchain::Error> {
+		self.client
+			.header(BlockId::Hash(at))?
+			.ok_or_else(|| sp_blockchain::Error::Backend(format!("Header not found for {:?}", at)))
+	}
+
+	fn block_body(&self, at: Block::Hash) -> Result<Vec<Block::Extrinsic>, sp_blockchain::Error> {
+		self.client.block_body(&BlockId::Hash(at))?.ok_or_else(|| {
+			sp_blockchain::Error::Backend(format!("Block body not found for {:?}", at))
+		})
+	}
+
+	fn create_extrinsic_execution_proof(
+		&self,
+		extrinsic_index: usize,
+		parent_header: &Block::Header,
+		current_hash: Block::Hash,
+		prover: &subspace_fraud_proof::ExecutionProver<Block, Backend, E>,
+	) -> Result<(StorageProof, ExecutionPhase), FraudProofError> {
+		let extrinsics = self.block_body(current_hash)?;
+
+		let encoded_extrinsic = extrinsics
+			.get(extrinsic_index)
+			.ok_or(FraudProofError::InvalidExtrinsicIndex {
+				index: extrinsic_index,
+				max: extrinsics.len() - 1,
+			})?
+			.encode();
+
+		let execution_phase = ExecutionPhase::ApplyExtrinsic { call_data: encoded_extrinsic };
+
+		let block_builder = BlockBuilder::new(
+			&*self.client,
+			parent_header.hash(),
+			*parent_header.number(),
+			RecordProof::No,
+			Default::default(),
+			&*self.backend,
+			extrinsics,
+		)?;
+		let storage_changes = block_builder.prepare_storage_changes_before(extrinsic_index)?;
+
+		let delta = storage_changes.transaction;
+		let post_delta_root = storage_changes.transaction_storage_root;
+		let execution_proof = prover.prove_execution(
+			BlockId::Hash(parent_header.hash()),
+			&execution_phase,
+			Some((delta, post_delta_root)),
+		)?;
+
+		Ok((execution_proof, execution_phase))
+	}
+}

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -690,11 +690,9 @@ where
 		if local_receipt.trace.len() != execution_receipt.trace.len() {}
 
 		if let Some(trace_mismatch_index) = find_trace_mismatch(&local_receipt, execution_receipt) {
-			let fraud_proof = self.fraud_proof_generator.generate_proof(
-				block_number,
-				trace_mismatch_index,
-				&local_receipt,
-			)?;
+			let fraud_proof = self
+				.fraud_proof_generator
+				.generate_proof::<PBlock>(trace_mismatch_index, &local_receipt)?;
 
 			self.submit_fraud_proof(fraud_proof);
 

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -59,15 +59,18 @@
 mod aux_schema;
 mod bundle_processor;
 mod bundle_producer;
+mod fraud_proof;
 mod merkle_tree;
 #[cfg(test)]
 mod tests;
 mod worker;
 
 use crate::{
-	bundle_processor::BundleProcessor, bundle_producer::BundleProducer, worker::BlockInfo,
+	bundle_processor::BundleProcessor,
+	bundle_producer::BundleProducer,
+	fraud_proof::{FraudProofError, FraudProofGenerator},
+	worker::BlockInfo,
 };
-use cirrus_block_builder::{BlockBuilder, RecordProof};
 use cirrus_client_executor_gossip::{Action, GossipMessageHandler};
 use cirrus_primitives::{AccountId, SecondaryApi};
 use codec::{Decode, Encode};
@@ -79,13 +82,10 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockStatus, SelectChain};
 use sp_consensus_slots::Slot;
-use sp_core::{
-	traits::{CodeExecutor, SpawnEssentialNamed, SpawnNamed},
-	H256,
-};
+use sp_core::traits::{CodeExecutor, SpawnEssentialNamed, SpawnNamed};
 use sp_executor::{
-	Bundle, BundleEquivocationProof, ExecutionPhase, ExecutionReceipt, ExecutorApi, ExecutorId,
-	FraudProof, InvalidTransactionProof, OpaqueBundle, SignedBundle, SignedExecutionReceipt,
+	Bundle, BundleEquivocationProof, ExecutionReceipt, ExecutorApi, ExecutorId, FraudProof,
+	InvalidTransactionProof, OpaqueBundle, SignedBundle, SignedExecutionReceipt,
 };
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::{
@@ -93,7 +93,6 @@ use sp_runtime::{
 	traits::{Block as BlockT, HashFor, Header as HeaderT, NumberFor, One, Saturating, Zero},
 	RuntimeAppPublic,
 };
-use sp_trie::StorageProof;
 use std::{borrow::Cow, sync::Arc};
 use subspace_core_primitives::{BlockNumber, Randomness, Sha256Hash};
 
@@ -112,7 +111,7 @@ where
 	spawner: Box<dyn SpawnNamed + Send + Sync>,
 	transaction_pool: Arc<TransactionPool>,
 	backend: Arc<Backend>,
-	code_executor: Arc<E>,
+	fraud_proof_generator: FraudProofGenerator<Block, Client, Backend, E>,
 	bundle_processor: BundleProcessor<Block, PBlock, Client, PClient, Backend>,
 }
 
@@ -129,7 +128,7 @@ where
 			spawner: self.spawner.clone(),
 			transaction_pool: self.transaction_pool.clone(),
 			backend: self.backend.clone(),
-			code_executor: self.code_executor.clone(),
+			fraud_proof_generator: self.fraud_proof_generator.clone(),
 			bundle_processor: self.bundle_processor.clone(),
 		}
 	}
@@ -214,6 +213,13 @@ where
 			keystore.clone(),
 		);
 
+		let fraud_proof_generator = FraudProofGenerator::new(
+			client.clone(),
+			spawner.clone(),
+			backend.clone(),
+			code_executor,
+		);
+
 		let bundle_processor = BundleProcessor::new(
 			primary_chain_client.clone(),
 			primary_network,
@@ -245,7 +251,7 @@ where
 			spawner,
 			transaction_pool,
 			backend,
-			code_executor,
+			fraud_proof_generator,
 			bundle_processor,
 		})
 	}
@@ -393,59 +399,6 @@ where
 		);
 	}
 
-	fn header(&self, at: Block::Hash) -> Result<Block::Header, sp_blockchain::Error> {
-		self.client
-			.header(BlockId::Hash(at))?
-			.ok_or_else(|| sp_blockchain::Error::Backend(format!("Header not found for {:?}", at)))
-	}
-
-	fn block_body(&self, at: Block::Hash) -> Result<Vec<Block::Extrinsic>, sp_blockchain::Error> {
-		self.client.block_body(&BlockId::Hash(at))?.ok_or_else(|| {
-			sp_blockchain::Error::Backend(format!("Block body not found for {:?}", at))
-		})
-	}
-
-	fn create_extrinsic_execution_proof(
-		&self,
-		extrinsic_index: usize,
-		parent_header: &Block::Header,
-		current_hash: Block::Hash,
-		prover: &subspace_fraud_proof::ExecutionProver<Block, Backend, E>,
-	) -> Result<(StorageProof, ExecutionPhase), GossipMessageError> {
-		let extrinsics = self.block_body(current_hash)?;
-
-		let encoded_extrinsic = extrinsics
-			.get(extrinsic_index)
-			.ok_or(GossipMessageError::InvalidExtrinsicIndex {
-				index: extrinsic_index,
-				max: extrinsics.len() - 1,
-			})?
-			.encode();
-
-		let execution_phase = ExecutionPhase::ApplyExtrinsic { call_data: encoded_extrinsic };
-
-		let block_builder = BlockBuilder::new(
-			&*self.client,
-			parent_header.hash(),
-			*parent_header.number(),
-			RecordProof::No,
-			Default::default(),
-			&*self.backend,
-			extrinsics,
-		)?;
-		let storage_changes = block_builder.prepare_storage_changes_before(extrinsic_index)?;
-
-		let delta = storage_changes.transaction;
-		let post_delta_root = storage_changes.transaction_storage_root;
-		let execution_proof = prover.prove_execution(
-			BlockId::Hash(parent_header.hash()),
-			&execution_phase,
-			Some((delta, post_delta_root)),
-		)?;
-
-		Ok((execution_proof, execution_phase))
-	}
-
 	/// The background is that a receipt received from the network points to a future block
 	/// from the local view, so we need to wait for the receipt for the block at the same
 	/// height to be produced locally in order to check the validity of the external receipt.
@@ -524,10 +477,8 @@ where
 pub enum GossipMessageError {
 	#[error("Bundle equivocation error")]
 	BundleEquivocation,
-	#[error("State root not using H256")]
-	InvalidStateRootType,
-	#[error("Invalid extrinsic index for creating the execution proof, got: {index}, max: {max}")]
-	InvalidExtrinsicIndex { index: usize, max: usize },
+	#[error(transparent)]
+	FraudProof(#[from] FraudProofError),
 	#[error(transparent)]
 	Client(Box<sp_blockchain::Error>),
 	#[error(transparent)]
@@ -758,111 +709,12 @@ where
 		if let Some((local_trace_idx, local_root)) =
 			find_trace_mismatch(&local_receipt, execution_receipt)
 		{
-			let header = self.header(execution_receipt.secondary_hash)?;
-			let parent_header = self.header(*header.parent_hash())?;
-
-			// TODO: avoid the encode & decode?
-			let as_h256 = |state_root: &Block::Hash| {
-				H256::decode(&mut state_root.encode().as_slice())
-					.map_err(|_| Self::Error::InvalidStateRootType)
-			};
-
-			let prover = subspace_fraud_proof::ExecutionProver::new(
-				self.backend.clone(),
-				self.code_executor.clone(),
-				self.spawner.clone() as Box<dyn SpawnNamed>,
-			);
-
-			let parent_number = TryInto::<BlockNumber>::try_into(*parent_header.number())
-				.unwrap_or_else(|_| panic!("Parent number must fit into u32; qed"));
-
-			// TODO: abstract the execution proof impl to be reusable in the test.
-			let fraud_proof = if local_trace_idx == 0 {
-				// `initialize_block` execution proof.
-				let pre_state_root = as_h256(parent_header.state_root())?;
-				let post_state_root = as_h256(&local_root)?;
-
-				let new_header = Block::Header::new(
-					block_number,
-					Default::default(),
-					Default::default(),
-					parent_header.hash(),
-					Default::default(),
-				);
-				let execution_phase =
-					ExecutionPhase::InitializeBlock { call_data: new_header.encode() };
-
-				let proof = prover.prove_execution::<TransactionFor<Backend, Block>>(
-					BlockId::Hash(parent_header.hash()),
-					&execution_phase,
-					None,
-				)?;
-
-				FraudProof {
-					parent_number,
-					parent_hash: as_h256(&parent_header.hash())?,
-					pre_state_root,
-					post_state_root,
-					proof,
-					execution_phase,
-				}
-			} else if local_trace_idx == local_receipt.trace.len() - 1 {
-				// `finalize_block` execution proof.
-				let pre_state_root = as_h256(&execution_receipt.trace[local_trace_idx - 1])?;
-				let post_state_root = as_h256(&local_root)?;
-				let execution_phase = ExecutionPhase::FinalizeBlock;
-
-				let block_builder = BlockBuilder::new(
-					&*self.client,
-					parent_header.hash(),
-					*parent_header.number(),
-					RecordProof::No,
-					Default::default(),
-					&*self.backend,
-					self.block_body(execution_receipt.secondary_hash)?,
-				)?;
-				let storage_changes =
-					block_builder.prepare_storage_changes_before_finalize_block()?;
-
-				let delta = storage_changes.transaction;
-				let post_delta_root = storage_changes.transaction_storage_root;
-
-				let proof = prover.prove_execution(
-					BlockId::Hash(parent_header.hash()),
-					&execution_phase,
-					Some((delta, post_delta_root)),
-				)?;
-
-				FraudProof {
-					parent_number,
-					parent_hash: as_h256(&parent_header.hash())?,
-					pre_state_root,
-					post_state_root,
-					proof,
-					execution_phase,
-				}
-			} else {
-				// Regular extrinsic execution proof.
-				let pre_state_root = as_h256(&execution_receipt.trace[local_trace_idx - 1])?;
-				let post_state_root = as_h256(&local_root)?;
-
-				let (proof, execution_phase) = self.create_extrinsic_execution_proof(
-					local_trace_idx - 1,
-					&parent_header,
-					execution_receipt.secondary_hash,
-					&prover,
-				)?;
-
-				// TODO: proof should be a CompactProof.
-				FraudProof {
-					parent_number,
-					parent_hash: as_h256(&parent_header.hash())?,
-					pre_state_root,
-					post_state_root,
-					proof,
-					execution_phase,
-				}
-			};
+			let fraud_proof = self.fraud_proof_generator.generate_proof(
+				block_number,
+				(local_trace_idx, local_root),
+				&local_receipt,
+				execution_receipt,
+			)?;
 
 			self.submit_fraud_proof(fraud_proof);
 

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -694,7 +694,6 @@ where
 				block_number,
 				trace_mismatch_index,
 				&local_receipt,
-				execution_receipt,
 			)?;
 
 			self.submit_fraud_proof(fraud_proof);

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -689,10 +689,10 @@ where
 		// TODO: What happens for this obvious error?
 		if local_receipt.trace.len() != execution_receipt.trace.len() {}
 
-		if let Some(trace_mismatch) = find_trace_mismatch(&local_receipt, execution_receipt) {
+		if let Some(trace_mismatch_index) = find_trace_mismatch(&local_receipt, execution_receipt) {
 			let fraud_proof = self.fraud_proof_generator.generate_proof(
 				block_number,
-				trace_mismatch,
+				trace_mismatch_index,
 				&local_receipt,
 				execution_receipt,
 			)?;

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -55,6 +55,7 @@
 //! - Secondary chain, execution layer.
 //!
 //! [Computation section]: https://subspace.network/news/subspace-network-whitepaper
+//! [`BlockBuilder`]: ../cirrus_block_builder/struct.BlockBuilder.html
 
 mod aux_schema;
 mod bundle_processor;

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -63,6 +63,9 @@ async fn test_executor_full_node_catching_up() {
 	);
 }
 
+// TODO: This is basically an unit test for the features provided by `subspace_fraud_proof`, move
+// it there and add a new test which simulates a situation that an executor produces a fraud proof
+// when an invalid receipt is received.
 #[substrate_test_utils::test(flavor = "multi_thread")]
 async fn execution_proof_creation_and_verification_should_work() {
 	let mut builder = sc_cli::LoggerBuilder::new("");


### PR DESCRIPTION
The first commit is a leftover from part 1, the other commits are primarily for abstracting out a component `FraudProofGenerator` which will be used by both `Executor` and `BundleProcessor` later. The body of each commit message details the motivation behind the change, please review commit by commit.

Part of #634