### PR TITLE
Multi plots farm (part 3)

### DIFF
--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -229,7 +229,7 @@ async fn test_dsn_sync() {
             let _ = seeder_address_sender.unbounded_send(address.clone());
         }))
         .detach();
-    let node_runner = std::mem::take(&mut seeder_multi_farming.networking_node_runners)
+    let mut node_runner = std::mem::take(&mut seeder_multi_farming.networking_node_runners)
         .into_iter()
         .next()
         .unwrap();
@@ -287,7 +287,7 @@ async fn test_dsn_sync() {
     // HACK: farmer reserves 8% for its own needs, so we need to update piece count here
     let syncer_max_plot_size = syncer_max_plot_size * 92 / 100;
 
-    let node_runner = std::mem::take(&mut syncer_multi_farming.networking_node_runners)
+    let mut node_runner = std::mem::take(&mut syncer_multi_farming.networking_node_runners)
         .into_iter()
         .next()
         .unwrap();

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -7,7 +7,7 @@ use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::plot::Plot;
 use crate::rpc_client::RpcClient;
-use futures::future::{Either, Fuse};
+use futures::future::{Either, Fuse, FusedFuture};
 use futures::{future, FutureExt, StreamExt};
 use std::sync::mpsc;
 use std::time::Instant;
@@ -89,6 +89,9 @@ impl Farming {
 
     /// Waits for the background farming to finish
     pub async fn wait(&mut self) -> Result<(), FarmingError> {
+        if self.handle.is_terminated() {
+            return Ok(());
+        }
         (&mut self.handle).await.map_err(FarmingError::JoinTask)?
     }
 }

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -38,7 +38,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
     let client = MockRpcClient::new();
 
     // start the farming task
-    let farming_instance = Farming::start(
+    let mut farming_instance = Farming::start(
         plot.clone(),
         commitments.clone(),
         client.clone(),

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -129,7 +129,13 @@ impl LegacyMultiPlotsFarm {
             farmer_metadata,
             object_mappings,
             archiving_client,
-            enable_dsn_archiving.then(|| single_plot_farms[0].node.clone()),
+            enable_dsn_archiving.then(|| {
+                single_plot_farms
+                    .get(0)
+                    .expect("There is always at least one farm; qed")
+                    .node
+                    .clone()
+            }),
             {
                 let plotters = single_plot_farms
                     .iter()

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -193,8 +193,8 @@ impl LegacyMultiPlotsFarm {
             .single_plot_farms
             .iter_mut()
             .filter_map(|single_plot_farm| {
-                let farming = single_plot_farm.farming.take()?;
-                Some(farming.wait())
+                let mut farming = single_plot_farm.farming.take()?;
+                Some(async move { farming.wait().await })
             })
             .collect::<FuturesUnordered<_>>();
         let mut node_runners = self

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -199,7 +199,7 @@ impl LegacyMultiPlotsFarm {
             .collect::<FuturesUnordered<_>>();
         let mut node_runners = self
             .networking_node_runners
-            .into_iter()
+            .iter_mut()
             .map(NodeRunner::run)
             .collect::<FuturesUnordered<_>>();
 

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_core_primitives::{PublicKey, PIECE_SIZE};
 use subspace_networking::libp2p::Multiaddr;
-use subspace_networking::NodeRunner;
 use tracing::error;
 
 fn get_plot_sizes(total_plot_size: u64, max_plot_size: u64) -> Vec<u64> {
@@ -56,7 +55,6 @@ pub struct Options<C> {
 pub struct LegacyMultiPlotsFarm {
     pub single_plot_farms: Vec<SinglePlotFarm>,
     archiving: Archiving,
-    pub(crate) networking_node_runners: Vec<NodeRunner>,
 }
 
 impl LegacyMultiPlotsFarm {
@@ -93,61 +91,45 @@ impl LegacyMultiPlotsFarm {
         let max_plot_size = farmer_metadata.max_plot_size;
         let total_pieces = farmer_metadata.total_pieces;
 
-        let (single_plot_farms, networking_node_runners, node) =
-            tokio::task::spawn_blocking(move || {
-                let mut single_plot_farms = Vec::with_capacity(plot_sizes.len());
-                let mut networking_node_runners = Vec::with_capacity(plot_sizes.len());
-                let mut node = None;
+        let single_plot_farms = tokio::task::spawn_blocking(move || {
+            plot_sizes
+                .par_iter()
+                .enumerate()
+                .map(|(plot_index, &max_plot_pieces)| {
+                    let base_directory = base_directory.join(format!("plot{plot_index}"));
+                    let farming_client = farming_client.clone();
+                    let new_plot = new_plot.clone();
+                    let listen_on = listen_on.clone();
+                    let bootstrap_nodes = bootstrap_nodes.clone();
+                    let first_listen_on = Arc::clone(&first_listen_on);
 
-                let single_plot_farm_instantiations = plot_sizes
-                    .par_iter()
-                    .enumerate()
-                    .map(|(plot_index, &max_plot_pieces)| {
-                        let base_directory = base_directory.join(format!("plot{plot_index}"));
-                        let farming_client = farming_client.clone();
-                        let new_plot = new_plot.clone();
-                        let listen_on = listen_on.clone();
-                        let bootstrap_nodes = bootstrap_nodes.clone();
-                        let first_listen_on = Arc::clone(&first_listen_on);
-
-                        SinglePlotFarm::new(SinglePlotFarmOptions {
-                            base_directory,
-                            plot_index,
-                            max_plot_pieces,
-                            max_plot_size,
-                            total_pieces,
-                            farming_client,
-                            new_plot,
-                            listen_on,
-                            bootstrap_nodes,
-                            first_listen_on,
-                            enable_farming,
-                            reward_address,
-                            enable_dsn_sync,
-                        })
+                    SinglePlotFarm::new(SinglePlotFarmOptions {
+                        base_directory,
+                        plot_index,
+                        max_plot_pieces,
+                        max_plot_size,
+                        total_pieces,
+                        farming_client,
+                        new_plot,
+                        listen_on,
+                        bootstrap_nodes,
+                        first_listen_on,
+                        enable_farming,
+                        reward_address,
+                        enable_dsn_sync,
                     })
-                    .collect::<anyhow::Result<Vec<_>>>()?;
-
-                for (farm, node_runner) in single_plot_farm_instantiations {
-                    if node.is_none() {
-                        node = Some(farm.node.clone());
-                    }
-                    networking_node_runners.push(node_runner);
-                    single_plot_farms.push(farm);
-                }
-
-                Ok::<_, anyhow::Error>((single_plot_farms, networking_node_runners, node))
-            })
-            .await
-            .expect("Not supposed to panic, crash if it does")?;
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        })
+        .await
+        .expect("Not supposed to panic, crash if it does")?;
 
         // Start archiving task
         let archiving = Archiving::start(
             farmer_metadata,
             object_mappings,
             archiving_client,
-            enable_dsn_archiving
-                .then(|| node.expect("Always set, as we have at least one networking instance")),
+            enable_dsn_archiving.then(|| single_plot_farms[0].node.clone()),
             {
                 let plotters = single_plot_farms
                     .iter()
@@ -173,41 +155,21 @@ impl LegacyMultiPlotsFarm {
         Ok(Self {
             single_plot_farms,
             archiving,
-            networking_node_runners,
         })
     }
 
     /// Waits for farming and plotting completion (or errors)
-    pub async fn wait(mut self) -> anyhow::Result<()> {
-        if !self
+    pub async fn wait(self) -> anyhow::Result<()> {
+        let mut single_plot_farms = self
             .single_plot_farms
-            .iter()
-            .any(|single_plot_farm| single_plot_farm.farming.is_some())
-        {
-            return self.archiving.wait().await.map_err(Into::into);
-        }
-
-        // `.iter_mut()` so that we don't drop `SinglePlotFarm` and continue background tasks if
-        // there are any
-        let mut farming = self
-            .single_plot_farms
-            .iter_mut()
-            .filter_map(|single_plot_farm| {
-                let mut farming = single_plot_farm.farming.take()?;
-                Some(async move { farming.wait().await })
-            })
-            .collect::<FuturesUnordered<_>>();
-        let mut node_runners = self
-            .networking_node_runners
-            .iter_mut()
-            .map(NodeRunner::run)
+            .into_iter()
+            .map(|mut single_plot_farm| async move { single_plot_farm.run().await })
             .collect::<FuturesUnordered<_>>();
 
         tokio::select! {
-            res = farming.select_next_some() => {
+            res = single_plot_farms.select_next_some() => {
                 res?;
             },
-            () = node_runners.select_next_some() => {},
             res = self.archiving.wait() => {
                 res?;
             },

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -45,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
                 allow_non_globals_in_dht: true,
                 ..Config::with_keypair(Keypair::decode(hex::decode(keypair)?.as_mut_slice())?)
             };
-            let (node, node_runner) = subspace_networking::create(config).await.unwrap();
+            let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
 
             node.on_new_listener(Arc::new({
                 let node_id = node.id();

--- a/crates/subspace-networking/examples/get-pieces-complex.rs
+++ b/crates/subspace-networking/examples/get-pieces-complex.rs
@@ -49,7 +49,7 @@ async fn main() {
             }),
             ..Config::with_generated_keypair()
         };
-        let (node, node_runner) = subspace_networking::create(config).await.unwrap();
+        let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
 
         println!("Node {} ID is {}", i, node.id());
 
@@ -87,7 +87,7 @@ async fn main() {
         ..Config::with_generated_keypair()
     };
 
-    let (node, node_runner) = subspace_networking::create(config).await.unwrap();
+    let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
 
     println!("Source Node ID is {}", node.id());
     println!("Expected Peer ID:{}", expected_node_id);

--- a/crates/subspace-networking/examples/get-pieces.rs
+++ b/crates/subspace-networking/examples/get-pieces.rs
@@ -39,7 +39,7 @@ async fn main() {
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
     };
-    let (node_1, node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
 
     println!("Node 1 ID is {}", node_1.id());
 
@@ -67,7 +67,7 @@ async fn main() {
         ..Config::with_generated_keypair()
     };
 
-    let (node_2, node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -23,7 +23,7 @@ async fn main() {
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
     };
-    let (node_1, node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
 
     println!("Node 1 ID is {}", node_1.id());
 
@@ -53,7 +53,7 @@ async fn main() {
         ..Config::with_generated_keypair()
     };
 
-    let (node_2, node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -35,7 +35,7 @@ async fn main() {
         }),
         ..Config::with_generated_keypair()
     };
-    let (node_1, node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
 
     println!("Node 1 ID is {}", node_1.id());
 
@@ -63,7 +63,7 @@ async fn main() {
         ..Config::with_generated_keypair()
     };
 
-    let (node_2, node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
+++ b/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
@@ -38,7 +38,7 @@ async fn pieces_by_range_protocol_smoke() {
         }),
         ..Config::with_generated_keypair()
     };
-    let (node_1, node_runner_1) = crate::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = crate::create(config_1).await.unwrap();
 
     let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
     node_1
@@ -64,7 +64,7 @@ async fn pieces_by_range_protocol_smoke() {
         ..Config::with_generated_keypair()
     };
 
-    let (node_2, node_runner_2) = crate::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = crate::create(config_2).await.unwrap();
     tokio::spawn(async move {
         node_runner_2.run().await;
     });
@@ -132,7 +132,7 @@ async fn get_pieces_by_range_smoke() {
         }),
         ..Config::with_generated_keypair()
     };
-    let (node_1, node_runner_1) = crate::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = crate::create(config_1).await.unwrap();
 
     let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
     node_1
@@ -158,7 +158,7 @@ async fn get_pieces_by_range_smoke() {
         ..Config::with_generated_keypair()
     };
 
-    let (node_2, node_runner_2) = crate::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = crate::create(config_2).await.unwrap();
     tokio::spawn(async move {
         node_runner_2.run().await;
     });

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -135,7 +135,7 @@ where
     B: BlockT + for<'de> serde::Deserialize<'de>,
     IQ: ImportQueue<B> + 'static,
 {
-    let (node, node_runner) = subspace_networking::create(Config {
+    let (node, mut node_runner) = subspace_networking::create(Config {
         bootstrap_nodes,
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -19,14 +19,16 @@ where
 {
     trace!(target: "dsn", "Subspace networking starting.");
 
-    let (node, node_runner) = subspace_networking::create(networking_config).await?;
+    let (node, mut node_runner) = subspace_networking::create(networking_config).await?;
 
     info!(target: "dsn", "Subspace networking initialized: Node ID is {}", node.id());
 
     spawner.spawn_essential(
         "node-runner",
         Some("subspace-networking"),
-        Box::pin(node_runner.run()),
+        Box::pin(async move {
+            node_runner.run().await;
+        }),
     );
 
     let mut archived_segment_notification_stream = subspace_link


### PR DESCRIPTION
This builds on top of #646 and extends capabilities of `SinglePlotFarm` with ability to drive its internal farming and node runner components. Previously those components were exposed, making `LegacyMultiPlotFarm` more complex and API less elegant.

Both farming and node runner had to become resumable to make farm resumable as well, which while wasn't strictly necessary, allows to avoid a bunch of `Option<T>`s (due to `Drop` impl on `SinglePlotFarm`not allowing to move things out of it without dropping the whole thing, which we don't want and why we have `Drop` impl in the first place).

It also gives some nice abilities like calling `(&mut single_plot_farm).run().await` multiple times when racing with something for instance while calling other methods of `SinglePlotFarm` in between.

`LegacyMultiPlotsFarm` is quite simple and almost elegant now :slightly_smiling_face: 

Reviewing individual commits should be the easiest.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
