### PR TITLE
Multi plots farm (part 4)

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -231,7 +231,7 @@ pub(crate) async fn bench(
     let actual_space_pledged = multi_farming
         .single_plot_farms
         .iter()
-        .map(|single_plot_farm| single_plot_farm.plot.piece_count())
+        .map(|single_plot_farm| single_plot_farm.plot().piece_count())
         .sum::<u64>()
         * PIECE_SIZE as u64;
     let overhead = space_allocated - actual_space_pledged;
@@ -266,7 +266,7 @@ pub(crate) async fn bench(
             .map(|single_plot_farm| {
                 (
                     single_plot_farm.commitments.clone(),
-                    single_plot_farm.plot.clone(),
+                    single_plot_farm.plot().clone(),
                 )
             })
             .map(|(commitments, plot)| move || commitments.create(rand::random(), plot))

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use jsonrpsee::ws_server::WsServerBuilder;
 use std::path::PathBuf;
+use std::sync::Arc;
 use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
@@ -119,7 +120,7 @@ pub(crate) async fn farm(
     let rpc_server = RpcServerImpl::new(
         record_size,
         recorded_history_segment_size,
-        multi_plots_farm.piece_getter(),
+        Arc::new(multi_plots_farm.piece_getter()),
         object_mappings.clone(),
     );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -69,7 +69,7 @@ pub(crate) async fn farm(
     })
     .await??;
 
-    let multi_farming = LegacyMultiPlotsFarm::new(
+    let multi_plots_farm = LegacyMultiPlotsFarm::new(
         MultiFarmingOptions {
             base_directory: base_directory.clone(),
             archiving_client,
@@ -119,12 +119,12 @@ pub(crate) async fn farm(
     let rpc_server = RpcServerImpl::new(
         record_size,
         recorded_history_segment_size,
-        multi_farming.piece_getter(),
+        multi_plots_farm.piece_getter(),
         object_mappings.clone(),
     );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;
 
     info!("WS RPC server listening on {ws_server_addr}");
 
-    multi_farming.wait().await
+    multi_plots_farm.wait().await
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Result};
 use jsonrpsee::ws_server::WsServerBuilder;
 use std::path::PathBuf;
-use std::sync::Arc;
 use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
@@ -120,13 +119,7 @@ pub(crate) async fn farm(
     let rpc_server = RpcServerImpl::new(
         record_size,
         recorded_history_segment_size,
-        Arc::new(
-            multi_farming
-                .single_plot_farms
-                .iter()
-                .map(|single_plot_farm| single_plot_farm.plot.clone())
-                .collect(),
-        ),
+        multi_farming.piece_getter(),
         object_mappings.clone(),
     );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -294,7 +294,7 @@ async fn test_dsn_sync() {
     let syncer_max_plot_size = syncer_max_plot_size * 92 / 100;
 
     let range_size = PieceIndexHashNumber::MAX / seeder_max_plot_size * request_pieces_size;
-    let plot = syncer_multi_farming.single_plot_farms[0].plot.clone();
+    let plot = syncer_multi_farming.single_plot_farms[0].plot().clone();
     let dsn_sync = syncer_multi_farming.single_plot_farms[0].dsn_sync(
         syncer_max_plot_size,
         seeder_max_plot_size,

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -225,13 +225,13 @@ async fn test_dsn_sync() {
 
     let (seeder_address_sender, mut seeder_address_receiver) = futures::channel::mpsc::unbounded();
     seeder_multi_farming.single_plot_farms[0]
-        .node
+        .node()
         .on_new_listener(Arc::new(move |address| {
             let _ = seeder_address_sender.unbounded_send(address.clone());
         }))
         .detach();
 
-    let peer_id = seeder_multi_farming.single_plot_farms[0].node.id().into();
+    let peer_id = seeder_multi_farming.single_plot_farms[0].node().id().into();
 
     let (seeder_multi_farming_finished_sender, seeder_multi_farming_finished_receiver) =
         oneshot::channel();

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -140,7 +140,7 @@ impl LegacyMultiPlotsFarm {
             {
                 let plotters = single_plot_farms
                     .iter()
-                    .map(|single_plot_farm| single_plot_farm.get_plotter())
+                    .map(|single_plot_farm| single_plot_farm.plotter())
                     .collect::<Vec<_>>();
 
                 move |pieces_to_plot| {

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -133,7 +133,7 @@ impl LegacyMultiPlotsFarm {
                 single_plot_farms
                     .get(0)
                     .expect("There is always at least one farm; qed")
-                    .node
+                    .node()
                     .clone()
             }),
             {

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -2,6 +2,7 @@ use crate::archiving::Archiving;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::{Plot, PlotError};
 use crate::rpc_client::RpcClient;
+use crate::single_disk_farm::SingleDiskFarmPieceGetter;
 use crate::single_plot_farm::{SinglePlotFarm, SinglePlotFarmOptions};
 use anyhow::anyhow;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -162,6 +163,15 @@ impl LegacyMultiPlotsFarm {
             single_plot_farms,
             archiving,
         })
+    }
+
+    pub fn piece_getter(&self) -> SingleDiskFarmPieceGetter {
+        SingleDiskFarmPieceGetter::new(
+            self.single_plot_farms
+                .iter()
+                .map(|single_plot_farm| single_plot_farm.piece_getter())
+                .collect(),
+        )
     }
 
     /// Waits for farming and plotting completion (or errors)

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) mod node_rpc_client;
 pub(crate) mod object_mappings;
 pub(crate) mod plot;
 pub(crate) mod rpc_client;
+pub mod single_disk_farm;
 pub mod single_plot_farm;
 pub mod ws_rpc_server;
 

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -284,10 +284,11 @@ impl Plot {
         })?
     }
 
+    // TODO: De-duplicate this method
     /// Reads a piece from plot by index
-    pub(crate) fn read(&self, index_hash: impl Into<PieceIndexHash>) -> io::Result<Piece> {
+    pub(crate) fn read(&self, piece_index_hash: impl Into<PieceIndexHash>) -> io::Result<Piece> {
         let (result_sender, result_receiver) = mpsc::channel();
-        let index_hash = index_hash.into();
+        let index_hash = piece_index_hash.into();
 
         self.inner
             .requests_sender
@@ -353,8 +354,8 @@ impl Plot {
         })?
     }
 
-    pub fn read_piece(&self, index_hash: impl Into<PieceIndexHash>) -> io::Result<Vec<u8>> {
-        self.read(index_hash).map(Into::into)
+    pub fn read_piece(&self, piece_index_hash: PieceIndexHash) -> io::Result<Piece> {
+        self.read(piece_index_hash)
     }
 
     pub(crate) fn read_piece_with_index(

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1,0 +1,30 @@
+use crate::single_plot_farm::SinglePlotPieceGetter;
+use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
+
+/// Abstraction that can get pieces out of internal plots
+#[derive(Debug, Clone)]
+pub struct SingleDiskFarmPieceGetter {
+    single_plot_piece_getters: Vec<SinglePlotPieceGetter>,
+}
+
+impl SingleDiskFarmPieceGetter {
+    /// Create new piece getter for many single plot farms
+    pub fn new(single_plot_piece_getter: Vec<SinglePlotPieceGetter>) -> Self {
+        Self {
+            single_plot_piece_getters: single_plot_piece_getter,
+        }
+    }
+
+    pub fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+        piece_index_hash: PieceIndexHash,
+    ) -> Option<Piece> {
+        self.single_plot_piece_getters
+            .iter()
+            .filter_map(|single_plot_piece_getter| {
+                single_plot_piece_getter.get_piece(piece_index, piece_index_hash)
+            })
+            .next()
+    }
+}

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -10,9 +10,9 @@ pub struct SingleDiskFarmPieceGetter {
 
 impl SingleDiskFarmPieceGetter {
     /// Create new piece getter for many single plot farms
-    pub fn new(single_plot_piece_getter: Vec<SinglePlotPieceGetter>) -> Self {
+    pub fn new(single_plot_piece_getters: Vec<SinglePlotPieceGetter>) -> Self {
         Self {
-            single_plot_piece_getters: single_plot_piece_getter,
+            single_plot_piece_getters,
         }
     }
 }
@@ -25,9 +25,8 @@ impl PieceGetter for SingleDiskFarmPieceGetter {
     ) -> Option<Piece> {
         self.single_plot_piece_getters
             .iter()
-            .filter_map(|single_plot_piece_getter| {
+            .find_map(|single_plot_piece_getter| {
                 single_plot_piece_getter.get_piece(piece_index, piece_index_hash)
             })
-            .next()
     }
 }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1,4 +1,5 @@
 use crate::single_plot_farm::SinglePlotPieceGetter;
+use crate::ws_rpc_server::PieceGetter;
 use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
 
 /// Abstraction that can get pieces out of internal plots
@@ -14,8 +15,10 @@ impl SingleDiskFarmPieceGetter {
             single_plot_piece_getters: single_plot_piece_getter,
         }
     }
+}
 
-    pub fn get_piece(
+impl PieceGetter for SingleDiskFarmPieceGetter {
+    fn get_piece(
         &self,
         piece_index: PieceIndex,
         piece_index_hash: PieceIndexHash,

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -7,6 +7,7 @@ use crate::farming::Farming;
 use crate::identity::Identity;
 use crate::plot::{Plot, PlotError};
 use crate::rpc_client::RpcClient;
+use crate::ws_rpc_server::PieceGetter;
 use crate::{dsn, CommitmentError};
 use futures::future::try_join;
 use parking_lot::Mutex;
@@ -39,8 +40,10 @@ impl SinglePlotPieceGetter {
     pub fn new(codec: SubspaceCodec, plot: Plot) -> Self {
         Self { codec, plot }
     }
+}
 
-    pub fn get_piece(
+impl PieceGetter for SinglePlotPieceGetter {
+    fn get_piece(
         &self,
         piece_index: PieceIndex,
         piece_index_hash: PieceIndexHash,

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -56,7 +56,8 @@ impl PieceGetter for SinglePlotPieceGetter {
                 Err(error) => {
                     trace!(
                         %error,
-                        "Piece with piece index {piece_index} not found in plot"
+                        "Failed to decode piece with piece index hash {}",
+                        hex::encode(piece_index_hash)
                     );
                 }
             },

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -385,8 +385,8 @@ impl SinglePlotFarm {
         SinglePlotPieceGetter::new(self.codec.clone(), self.plot.clone())
     }
 
-    /// Get plotter for this plot
-    pub fn get_plotter(&self) -> SinglePlotPlotter {
+    /// Plotter for this plot
+    pub fn plotter(&self) -> SinglePlotPlotter {
         SinglePlotPlotter::new(
             self.codec.clone(),
             self.plot.clone(),
@@ -422,7 +422,7 @@ impl SinglePlotFarm {
             total_pieces,
         };
 
-        let single_plot_plotter = self.get_plotter();
+        let single_plot_plotter = self.plotter();
 
         dsn::sync(self.node.clone(), options, move |pieces, piece_indexes| {
             single_plot_plotter

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -110,7 +110,7 @@ pub struct SinglePlotFarm {
     pub plot: Plot,
     pub commitments: Commitments,
     farming: Option<Farming>,
-    pub(crate) node: Node,
+    node: Node,
     node_runner: NodeRunner,
     background_task_handles: Vec<JoinHandle<()>>,
 }
@@ -328,6 +328,11 @@ impl SinglePlotFarm {
     /// Public key associated with this farm
     pub fn public_key(&self) -> &PublicKey {
         &self.public_key
+    }
+
+    /// Access network node instance of the farm
+    pub fn node(&self) -> &Node {
+        &self.node
     }
 
     /// Get plotter for this plot

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -216,7 +216,7 @@ async fn plotting_piece_eviction() {
                         .is_some());
 
                     assert!(
-                        read_piece.as_slice() == piece,
+                        read_piece.as_ref() == piece,
                         "Read incorrect piece for piece index {}",
                         piece_index
                     );


### PR DESCRIPTION
This builds on top of #647 and primarily introduces `PieceGetter` trait in RPC server so that there could be different sources of pieces providing such functionality. Eventually we'll probably move this trait somewhere else though.

`single_disk_farm` module was created as well, it'll be used for new disk-aware implementation, seemed like a better name than `multi_plots_farm`.

Expect more PRs focused on different things.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
