### PR TITLE
Multi plots farm (part 6)

### DIFF
--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -77,7 +77,7 @@ impl BenchRpcClient {
 #[async_trait]
 impl RpcClient for BenchRpcClient {
     async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error> {
-        Ok(self.inner.metadata.clone())
+        Ok(self.inner.metadata)
     }
 
     async fn subscribe_slot_info(

--- a/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
@@ -1,197 +1,102 @@
 use crate::object_mappings::ObjectMappings;
-use crate::rpc_client::RpcClient;
+use crate::single_plot_farm::SinglePlotPlotter;
 use futures::StreamExt;
 use parity_scale_codec::Decode;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
 use subspace_core_primitives::Sha256Hash;
-use subspace_networking::{Node, PiecesToPlot};
-use subspace_rpc_primitives::FarmerMetadata;
-use thiserror::Error;
+use subspace_networking::{Node, PiecesToPlot, SubscribeError};
 use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
-use tracing::{debug, error, info};
+use tracing::{error, info, warn};
 
-#[derive(Debug, Error)]
-pub enum ArchivingError {
-    #[error("Plot is empty on restart, can't continue")]
-    ContinueError,
-    #[error("Failed to get block {0} from the chain, probably need to erase existing plot")]
-    GetBlockError(u32),
-    #[error("jsonrpsee error: {0}")]
-    RpcError(Box<dyn std::error::Error + Send + Sync>),
-    #[error("Last block retrieval from plot, rocksdb error: {0}")]
-    LastBlock(rocksdb::Error),
-    #[error("Error joining task: {0}")]
-    JoinTask(tokio::task::JoinError),
-    #[error("Archiver instantiation error: {0}")]
-    Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
-    #[error("Failed to subscribe to new segments: {0}")]
-    Subscribe(#[from] subspace_networking::SubscribeError),
-}
+// TODO: No verification whatsoever for now, must be added soon
+/// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
+pub(super) async fn start_archiving(
+    record_size: u32,
+    recorded_history_segment_size: u32,
+    object_mappings: ObjectMappings,
+    node: Node,
+    plotter: SinglePlotPlotter,
+) -> Result<(), SubscribeError> {
+    // TODO: This assumes fixed size segments, which might not be the case
+    let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
 
-/// Abstraction around archiving blocks and updating global object map
-pub struct Archiving {
-    stop_sender: Option<oneshot::Sender<()>>,
-    archiving_handle: Option<JoinHandle<()>>,
-}
+    let (archived_segments_sync_sender, archived_segments_sync_receiver) =
+        std::sync::mpsc::sync_channel::<(ArchivedSegment, oneshot::Sender<()>)>(5);
 
-impl Drop for Archiving {
-    fn drop(&mut self) {
-        let _ = self.stop_sender.take().unwrap().send(());
-    }
-}
+    // TODO: This must be sequentialized across single disk plot
+    // Erasure coding in archiver and piece encoding are CPU-intensive operations.
+    tokio::task::spawn_blocking({
+        move || {
+            let mut last_archived_segment_index = None;
+            while let Ok((archived_segment, acknowledgement_sender)) =
+                archived_segments_sync_receiver.recv()
+            {
+                let ArchivedSegment {
+                    root_block,
+                    pieces,
+                    object_mapping,
+                } = archived_segment;
+                let segment_index = root_block.segment_index();
+                if last_archived_segment_index == Some(segment_index) {
+                    continue;
+                }
+                last_archived_segment_index.replace(segment_index);
 
-impl Archiving {
-    // TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
-    //  don't want eventually
-    /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
-    pub async fn start<Client, OPTP>(
-        farmer_metadata: FarmerMetadata,
-        object_mappings: ObjectMappings,
-        client: Client,
-        node: Option<Node>,
-        mut on_pieces_to_plot: OPTP,
-    ) -> Result<Archiving, ArchivingError>
-    where
-        Client: RpcClient + Clone + Send + Sync + 'static,
-        OPTP: FnMut(PiecesToPlot) -> bool + Send + 'static,
-    {
-        // Oneshot channels, that will be used for interrupt/stop the process
-        let (stop_sender, mut stop_receiver) = oneshot::channel();
+                let piece_index_offset = merkle_num_leaves * segment_index;
 
-        let FarmerMetadata {
-            record_size,
-            recorded_history_segment_size,
-            ..
-        } = farmer_metadata;
+                let pieces_to_plot = PiecesToPlot {
+                    piece_indexes: (piece_index_offset..).take(pieces.count()).collect(),
+                    pieces,
+                };
+                if let Err(error) = plotter.plot_pieces(pieces_to_plot) {
+                    error!(%error, "Failed to plot pieces from DSN");
+                    break;
+                }
 
-        // TODO: This assumes fixed size segments, which might not be the case
-        let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
+                let object_mapping =
+                    create_global_object_mapping(piece_index_offset, object_mapping);
 
-        let (archived_segments_sync_sender, archived_segments_sync_receiver) =
-            std::sync::mpsc::sync_channel::<(ArchivedSegment, oneshot::Sender<()>)>(5);
+                if let Err(error) = object_mappings.store(&object_mapping) {
+                    error!(%error, "Failed to store object mappings for pieces");
+                }
 
-        // Erasure coding in archiver and piece encoding are CPU-intensive operations.
-        tokio::task::spawn_blocking({
-            move || {
-                let mut last_archived_segment_index = None;
-                while let Ok((archived_segment, acknowledgement_sender)) =
-                    archived_segments_sync_receiver.recv()
-                {
-                    let ArchivedSegment {
-                        root_block,
-                        pieces,
-                        object_mapping,
-                    } = archived_segment;
-                    let segment_index = root_block.segment_index();
-                    if last_archived_segment_index == Some(segment_index) {
-                        continue;
-                    }
-                    last_archived_segment_index.replace(segment_index);
+                info!(segment_index, "Plotted segment");
 
-                    let piece_index_offset = merkle_num_leaves * segment_index;
-
-                    let pieces_to_plot = PiecesToPlot {
-                        piece_indexes: (piece_index_offset..).take(pieces.count()).collect(),
-                        pieces,
-                    };
-                    if !on_pieces_to_plot(pieces_to_plot) {
-                        // No need to continue
-                        break;
-                    }
-
-                    let object_mapping =
-                        create_global_object_mapping(piece_index_offset, object_mapping);
-
-                    if let Err(error) = object_mappings.store(&object_mapping) {
-                        error!(%error, "Failed to store object mappings for pieces");
-                    }
-
-                    info!(segment_index, "Plotted segment");
-
-                    if let Err(()) = acknowledgement_sender.send(()) {
-                        error!("Failed to send archived segment acknowledgement");
-                    }
+                if let Err(()) = acknowledgement_sender.send(()) {
+                    error!("Failed to send archived segment acknowledgement");
                 }
             }
-        });
+        }
+    });
 
-        info!("Subscribing to archived segments");
-        let acknowledge_client = node.is_none();
-        let mut archived_segments = if let Some(node) = node {
-            tracing::trace!("Subscribing to pubsub archiving...");
-            let subscription = node
-                .subscribe(subspace_networking::PUB_SUB_ARCHIVING_TOPIC.clone())
-                .await?
-                .filter_map(|bytes| async move {
-                    match Decode::decode(&mut bytes.as_ref()) {
-                        Ok(archived_segment) => Some(archived_segment),
-                        Err(error) => {
-                            tracing::error!(%error, "Failed to decode archived segment");
-                            None
-                        }
-                    }
-                });
-            Box::pin(subscription)
-        } else {
-            client
-                .subscribe_archived_segments()
-                .await
-                .map_err(ArchivingError::RpcError)?
-        };
-
-        let archiving_handle = tokio::spawn(async move {
-            // Listen for new blocks produced on the network
-            loop {
-                tokio::select! {
-                    _ = &mut stop_receiver => {
-                        info!("Plotting stopped!");
-                        break;
-                    }
-                    result = archived_segments.next() => {
-                        match result {
-                            Some(archived_segment) => {
-                                let segment_index = archived_segment.root_block.segment_index();
-                                let (acknowledge_sender, acknowledge_receiver) = oneshot::channel();
-                                // Acknowledge immediately to allow node to continue sync quickly,
-                                // but this will miss some segments in case farmer crashed in the
-                                // meantime. Ideally we'd acknowledge after, but it makes node wait
-                                // for it and the whole process very sequential.
-                                if acknowledge_client {
-                                    if let Err(error) = client.acknowledge_archived_segment(segment_index).await {
-                                        error!(%error, "Failed to send archived segment acknowledgement");
-                                    }
-                                }
-                                if let Err(error) = archived_segments_sync_sender.try_send((archived_segment, acknowledge_sender)) {
-                                    tracing::warn!(%error, "Failed to send archived segment for plotting");
-                                }
-                                let _ = acknowledge_receiver.await;
-                            },
-                            None => {
-                                debug!("Subscription has forcefully closed from node side!");
-                                break;
-                            }
-                        }
-                    }
+    info!("Subscribing to pubsub archiving...");
+    let mut archived_segments = node
+        .subscribe(subspace_networking::PUB_SUB_ARCHIVING_TOPIC.clone())
+        .await?
+        .filter_map(|bytes| async move {
+            match ArchivedSegment::decode(&mut bytes.as_ref()) {
+                Ok(archived_segment) => Some(archived_segment),
+                Err(error) => {
+                    tracing::error!(%error, "Failed to decode archived segment");
+                    None
                 }
             }
-        });
-
-        Ok(Self {
-            stop_sender: Some(stop_sender),
-            archiving_handle: Some(archiving_handle),
         })
+        .boxed();
+
+    // Listen for new blocks produced on the network
+    while let Some(archived_segment) = archived_segments.next().await {
+        let (acknowledge_sender, acknowledge_receiver) = oneshot::channel();
+        if let Err(error) =
+            archived_segments_sync_sender.try_send((archived_segment, acknowledge_sender))
+        {
+            warn!(%error, "Failed to send archived segment for plotting");
+        }
+        let _ = acknowledge_receiver.await;
     }
 
-    /// Waits for the background archiving to finish
-    pub async fn wait(mut self) -> Result<(), ArchivingError> {
-        self.archiving_handle
-            .take()
-            .unwrap()
-            .await
-            .map_err(ArchivingError::JoinTask)
-    }
+    Ok(())
 }
 
 fn create_global_object_mapping(

--- a/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
@@ -1,0 +1,217 @@
+use crate::object_mappings::ObjectMappings;
+use crate::rpc_client::RpcClient;
+use futures::StreamExt;
+use parity_scale_codec::Decode;
+use subspace_archiving::archiver::ArchivedSegment;
+use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
+use subspace_core_primitives::Sha256Hash;
+use subspace_networking::{Node, PiecesToPlot};
+use subspace_rpc_primitives::FarmerMetadata;
+use thiserror::Error;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info};
+
+#[derive(Debug, Error)]
+pub enum ArchivingError {
+    #[error("Plot is empty on restart, can't continue")]
+    ContinueError,
+    #[error("Failed to get block {0} from the chain, probably need to erase existing plot")]
+    GetBlockError(u32),
+    #[error("jsonrpsee error: {0}")]
+    RpcError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Last block retrieval from plot, rocksdb error: {0}")]
+    LastBlock(rocksdb::Error),
+    #[error("Error joining task: {0}")]
+    JoinTask(tokio::task::JoinError),
+    #[error("Archiver instantiation error: {0}")]
+    Archiver(subspace_archiving::archiver::ArchiverInstantiationError),
+    #[error("Failed to subscribe to new segments: {0}")]
+    Subscribe(#[from] subspace_networking::SubscribeError),
+}
+
+/// Abstraction around archiving blocks and updating global object map
+pub struct Archiving {
+    stop_sender: Option<oneshot::Sender<()>>,
+    archiving_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for Archiving {
+    fn drop(&mut self) {
+        let _ = self.stop_sender.take().unwrap().send(());
+    }
+}
+
+impl Archiving {
+    // TODO: Blocks that are coming form substrate node are fully trusted right now, which we probably
+    //  don't want eventually
+    /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
+    pub async fn start<Client, OPTP>(
+        farmer_metadata: FarmerMetadata,
+        object_mappings: ObjectMappings,
+        client: Client,
+        node: Option<Node>,
+        mut on_pieces_to_plot: OPTP,
+    ) -> Result<Archiving, ArchivingError>
+    where
+        Client: RpcClient + Clone + Send + Sync + 'static,
+        OPTP: FnMut(PiecesToPlot) -> bool + Send + 'static,
+    {
+        // Oneshot channels, that will be used for interrupt/stop the process
+        let (stop_sender, mut stop_receiver) = oneshot::channel();
+
+        let FarmerMetadata {
+            record_size,
+            recorded_history_segment_size,
+            ..
+        } = farmer_metadata;
+
+        // TODO: This assumes fixed size segments, which might not be the case
+        let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
+
+        let (archived_segments_sync_sender, archived_segments_sync_receiver) =
+            std::sync::mpsc::sync_channel::<(ArchivedSegment, oneshot::Sender<()>)>(5);
+
+        // Erasure coding in archiver and piece encoding are CPU-intensive operations.
+        tokio::task::spawn_blocking({
+            move || {
+                let mut last_archived_segment_index = None;
+                while let Ok((archived_segment, acknowledgement_sender)) =
+                    archived_segments_sync_receiver.recv()
+                {
+                    let ArchivedSegment {
+                        root_block,
+                        pieces,
+                        object_mapping,
+                    } = archived_segment;
+                    let segment_index = root_block.segment_index();
+                    if last_archived_segment_index == Some(segment_index) {
+                        continue;
+                    }
+                    last_archived_segment_index.replace(segment_index);
+
+                    let piece_index_offset = merkle_num_leaves * segment_index;
+
+                    let pieces_to_plot = PiecesToPlot {
+                        piece_indexes: (piece_index_offset..).take(pieces.count()).collect(),
+                        pieces,
+                    };
+                    if !on_pieces_to_plot(pieces_to_plot) {
+                        // No need to continue
+                        break;
+                    }
+
+                    let object_mapping =
+                        create_global_object_mapping(piece_index_offset, object_mapping);
+
+                    if let Err(error) = object_mappings.store(&object_mapping) {
+                        error!(%error, "Failed to store object mappings for pieces");
+                    }
+
+                    info!(segment_index, "Plotted segment");
+
+                    if let Err(()) = acknowledgement_sender.send(()) {
+                        error!("Failed to send archived segment acknowledgement");
+                    }
+                }
+            }
+        });
+
+        info!("Subscribing to archived segments");
+        let acknowledge_client = node.is_none();
+        let mut archived_segments = if let Some(node) = node {
+            tracing::trace!("Subscribing to pubsub archiving...");
+            let subscription = node
+                .subscribe(subspace_networking::PUB_SUB_ARCHIVING_TOPIC.clone())
+                .await?
+                .filter_map(|bytes| async move {
+                    match Decode::decode(&mut bytes.as_ref()) {
+                        Ok(archived_segment) => Some(archived_segment),
+                        Err(error) => {
+                            tracing::error!(%error, "Failed to decode archived segment");
+                            None
+                        }
+                    }
+                });
+            Box::pin(subscription)
+        } else {
+            client
+                .subscribe_archived_segments()
+                .await
+                .map_err(ArchivingError::RpcError)?
+        };
+
+        let archiving_handle = tokio::spawn(async move {
+            // Listen for new blocks produced on the network
+            loop {
+                tokio::select! {
+                    _ = &mut stop_receiver => {
+                        info!("Plotting stopped!");
+                        break;
+                    }
+                    result = archived_segments.next() => {
+                        match result {
+                            Some(archived_segment) => {
+                                let segment_index = archived_segment.root_block.segment_index();
+                                let (acknowledge_sender, acknowledge_receiver) = oneshot::channel();
+                                // Acknowledge immediately to allow node to continue sync quickly,
+                                // but this will miss some segments in case farmer crashed in the
+                                // meantime. Ideally we'd acknowledge after, but it makes node wait
+                                // for it and the whole process very sequential.
+                                if acknowledge_client {
+                                    if let Err(error) = client.acknowledge_archived_segment(segment_index).await {
+                                        error!(%error, "Failed to send archived segment acknowledgement");
+                                    }
+                                }
+                                if let Err(error) = archived_segments_sync_sender.try_send((archived_segment, acknowledge_sender)) {
+                                    tracing::warn!(%error, "Failed to send archived segment for plotting");
+                                }
+                                let _ = acknowledge_receiver.await;
+                            },
+                            None => {
+                                debug!("Subscription has forcefully closed from node side!");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            stop_sender: Some(stop_sender),
+            archiving_handle: Some(archiving_handle),
+        })
+    }
+
+    /// Waits for the background archiving to finish
+    pub async fn wait(mut self) -> Result<(), ArchivingError> {
+        self.archiving_handle
+            .take()
+            .unwrap()
+            .await
+            .map_err(ArchivingError::JoinTask)
+    }
+}
+
+fn create_global_object_mapping(
+    piece_index_offset: u64,
+    object_mapping: Vec<PieceObjectMapping>,
+) -> Vec<(Sha256Hash, GlobalObject)> {
+    object_mapping
+        .iter()
+        .enumerate()
+        .flat_map(move |(position, object_mapping)| {
+            object_mapping.objects.iter().map(move |piece_object| {
+                let PieceObject::V0 { hash, offset } = piece_object;
+                (
+                    *hash,
+                    GlobalObject::V0 {
+                        piece_index: piece_index_offset + position as u64,
+                        offset: *offset,
+                    },
+                )
+            })
+        })
+        .collect()
+}

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -83,8 +83,7 @@ async fn plotting_happy_path() {
         farmer_metadata,
         object_mappings,
         client.clone(),
-        None,
-        move |pieces_to_plot| match single_plot_plotter.plot_pieces(&pieces_to_plot) {
+        move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
             Ok(()) => true,
             Err(error) => {
                 error!(%error, "Failed to plot pieces");
@@ -185,8 +184,7 @@ async fn plotting_piece_eviction() {
         farmer_metadata,
         object_mappings,
         client.clone(),
-        None,
-        move |pieces_to_plot| match single_plot_plotter.plot_pieces(&pieces_to_plot) {
+        move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
             Ok(()) => true,
             Err(error) => {
                 error!(%error, "Failed to plot pieces");

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -22,7 +22,7 @@ use subspace_core_primitives::{
 };
 
 /// Metadata necessary for farmer operation
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FarmerMetadata {
     /// The size of data in one piece (in bytes).


### PR DESCRIPTION
Before we can have single disk farm we also need to address the fact that object mappings are global right now, while keys each farmer stores are supposed to be tied to the identity (and similarly to plot's pieces those that don't fix within some limit will be evicted).

This PR creates individual object mappings databases for each plot. Global object mappings are still in place and used for PRC, but when DSN archiving is used, global object mappings are not updated and internal to the `SinglePlotFarm` archiving process (one per plot) and corresponding objects mapping database are used instead.

This means with DSN archiving some of the APIs of the farmer will break, but since DSN archiving is not enabled by default we can probably afford this (for now). Also RPC endpoints will be going away once we have DSN working, but that is a separate story.

Because RPC archiving will be going away long-term, I decided to just copy the code and not invent any special abstractions to share the code between it and DSN archiving.

Second commit is recommended to be reviewed with whitespaces ignored, `dsn_archiving.rs` file doesn't have too many changes actually.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
