### PR TITLE
Add number of pieces type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7882,6 +7882,7 @@ dependencies = [
 name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "hmac 0.12.1",
  "num-traits",
  "parity-scale-codec",

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -61,7 +61,7 @@ use sp_runtime::DispatchError;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::prelude::*;
 use subspace_core_primitives::{
-    crypto, Randomness, RootBlock, Salt, PIECE_SIZE, RANDOMNESS_LENGTH, SALT_SIZE,
+    crypto, NPieces, Randomness, RootBlock, Salt, PIECE_SIZE, RANDOMNESS_LENGTH, SALT_SIZE,
 };
 use subspace_solving::REWARD_SIGNING_CONTEXT;
 
@@ -135,8 +135,8 @@ struct VoteVerificationData {
     salt: Salt,
     record_size: u32,
     recorded_history_segment_size: u32,
-    max_plot_size: u64,
-    total_pieces: u64,
+    max_plot_size: NPieces,
+    total_pieces: NPieces,
     current_slot: Slot,
     parent_slot: Slot,
 }
@@ -156,7 +156,7 @@ mod pallet {
     use sp_runtime::traits::One;
     use sp_std::collections::btree_map::BTreeMap;
     use sp_std::prelude::*;
-    use subspace_core_primitives::{Randomness, RootBlock, Sha256Hash};
+    use subspace_core_primitives::{NPieces, Randomness, RootBlock, Sha256Hash};
 
     pub(super) struct InitialSolutionRanges<T: Config> {
         _config: T,
@@ -253,7 +253,7 @@ mod pallet {
 
         /// Maximum number of pieces in each plot
         #[pallet::constant]
-        type MaxPlotSize: Get<u64>;
+        type MaxPlotSize: Get<NPieces>;
 
         // TODO: This will probably become configurable later
         /// Recorded history is encoded and plotted in segments of this size (in bytes).
@@ -663,10 +663,10 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Total number of pieces in the blockchain
-    pub fn total_pieces() -> u64 {
+    pub fn total_pieces() -> NPieces {
         // TODO: This assumes fixed size segments, which might not be the case
         let merkle_num_leaves = T::RecordedHistorySegmentSize::get() / T::RecordSize::get() * 2;
-        u64::from(RecordsRoot::<T>::count()) * u64::from(merkle_num_leaves)
+        NPieces(u64::from(RecordsRoot::<T>::count()) * u64::from(merkle_num_leaves))
     }
 
     /// Determine whether a randomness update should take place at this block.

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -36,8 +36,8 @@ use sp_runtime::Perbill;
 use std::sync::Once;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
 use subspace_core_primitives::{
-    ArchivedBlockProgress, LastArchivedBlock, LocalChallenge, Piece, Randomness, RootBlock, Salt,
-    Sha256Hash, Solution, Tag, PIECE_SIZE,
+    ArchivedBlockProgress, LastArchivedBlock, LocalChallenge, NPieces, Piece, Randomness,
+    RootBlock, Salt, Sha256Hash, Solution, Tag, PIECE_SIZE,
 };
 use subspace_solving::{
     create_tag, create_tag_signature, derive_global_challenge, derive_local_challenge,
@@ -146,7 +146,7 @@ parameter_types! {
     pub const ExpectedVotesPerBlock: u32 = 9;
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
-    pub const MaxPlotSize: u64 = 10 * 2u64.pow(18);
+    pub const MaxPlotSize: NPieces = NPieces::from_bytes(10 * 2u64.pow(30));
     pub const ShouldAdjustSolutionRange: bool = false;
 }
 

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -43,7 +43,7 @@ use sp_io::hashing;
 use sp_runtime::ConsensusEngineId;
 use sp_std::vec::Vec;
 use subspace_core_primitives::{
-    Randomness, RootBlock, Salt, Sha256Hash, Solution, Tag, TagSignature,
+    NPieces, Randomness, RootBlock, Salt, Sha256Hash, Solution, Tag, TagSignature,
 };
 use subspace_solving::{create_tag_signature_transcript, REWARD_SIGNING_CONTEXT};
 
@@ -293,7 +293,7 @@ sp_api::decl_runtime_apis! {
         fn recorded_history_segment_size() -> u32;
 
         /// Maximum number of pieces in each plot
-        fn max_plot_size() -> u64;
+        fn max_plot_size() -> NPieces;
 
         /// The slot duration in milliseconds for Subspace.
         fn slot_duration() -> Duration;
@@ -331,7 +331,7 @@ sp_api::decl_runtime_apis! {
         fn is_in_block_list(farmer_public_key: &FarmerPublicKey) -> bool;
 
         /// Total number of pieces in a blockchain
-        fn total_pieces() -> u64;
+        fn total_pieces() -> NPieces;
 
         /// Get the merkle tree root of records for specified segment index
         fn records_root(segment_index: u64) -> Option<Sha256Hash>;

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -26,7 +26,7 @@ use sp_consensus_slots::Slot;
 use sp_runtime::DigestItem;
 use subspace_archiving::archiver;
 use subspace_core_primitives::{
-    PieceIndex, PieceIndexHash, Randomness, Salt, Sha256Hash, Solution, Tag, U256,
+    NPieces, PieceIndex, PieceIndexHash, Randomness, Salt, Sha256Hash, Solution, Tag, U256,
 };
 use subspace_solving::{
     derive_global_challenge, derive_target, is_tag_valid, verify_local_challenge,
@@ -260,13 +260,13 @@ pub fn is_within_solution_range(target: Tag, tag: Tag, solution_range: u64) -> b
 fn is_within_max_plot(
     piece_index: PieceIndex,
     key: &FarmerPublicKey,
-    total_pieces: u64,
-    max_plot_size: u64,
+    total_pieces: NPieces,
+    max_plot_size: NPieces,
 ) -> bool {
     if total_pieces < max_plot_size {
         return true;
     }
-    let max_distance_one_direction = U256::MAX / total_pieces * max_plot_size / 2;
+    let max_distance_one_direction = U256::MAX / *total_pieces * *max_plot_size / 2;
     U256::distance(&PieceIndexHash::from_index(piece_index), key.as_ref())
         <= max_distance_one_direction
 }
@@ -280,9 +280,9 @@ pub struct PieceCheckParams {
     /// Record size, system parameter
     pub record_size: u32,
     /// Max plot size in pieces, system parameter
-    pub max_plot_size: u64,
+    pub max_plot_size: NPieces,
     /// Total number of pieces in the whole archival history
-    pub total_pieces: u64,
+    pub total_pieces: NPieces,
 }
 
 /// Parameters for solution verification

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -19,6 +19,7 @@ scale-info = { version = "2.1.1", default-features = false, features = ["derive"
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
 serde_arrays = "0.1.0"
 uint = { version = "0.9", default-features = false }
+derive_more = "0.99"
 
 # Ugly workaround for https://github.com/rust-lang/cargo/issues/1197
 [target.'cfg(any(target_os = "linux", target_os = "macos", all(target_os = "windows", target_env = "gnu")))'.dependencies.sha2]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -33,6 +33,12 @@ use alloc::vec::Vec;
 pub use construct_uint::U256;
 use core::convert::AsRef;
 use core::ops::{Deref, DerefMut};
+use derive_more::{
+    Add, AddAssign, Deref, DerefMut, Display, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub,
+    SubAssign,
+};
+#[cfg(feature = "std")]
+use parity_scale_codec::MaxEncodedLen;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
@@ -79,6 +85,77 @@ pub const PUBLIC_KEY_LENGTH: usize = 32;
 const REWARD_SIGNATURE_LENGTH: usize = 64;
 const VRF_OUTPUT_LENGTH: usize = 32;
 const VRF_PROOF_LENGTH: usize = 64;
+
+/// Measure of number of pieces. (Just a smart wrapper around `u64`)
+#[derive(
+    Add,
+    AddAssign,
+    Clone,
+    Copy,
+    Debug,
+    Deref,
+    DerefMut,
+    Display,
+    DivAssign,
+    Eq,
+    Hash,
+    MulAssign,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Sub,
+    SubAssign,
+    Rem,
+    RemAssign,
+    Div,
+    Mul,
+    Decode,
+    Encode,
+    TypeInfo,
+)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, MaxEncodedLen))]
+#[cfg_attr(feature = "std", serde(transparent))]
+pub struct NPieces(pub u64);
+
+impl core::ops::Mul<NPieces> for u64 {
+    type Output = u64;
+    fn mul(self, NPieces(n): NPieces) -> u64 {
+        self * n
+    }
+}
+
+impl core::ops::Div<NPieces> for u64 {
+    type Output = u64;
+    fn div(self, NPieces(n): NPieces) -> u64 {
+        self / n
+    }
+}
+
+impl core::ops::Rem<NPieces> for u64 {
+    type Output = u64;
+    fn rem(self, NPieces(n): NPieces) -> u64 {
+        self % n
+    }
+}
+
+impl NPieces {
+    /// Zero
+    pub const ZERO: Self = Self(0);
+    /// Minimal value
+    pub const MIN: Self = Self(u64::MIN);
+    /// Maximum value
+    pub const MAX: Self = Self(u64::MAX);
+
+    /// Construct number of pieces from number of bytes
+    pub const fn from_bytes(nbytes: u64) -> Self {
+        Self(nbytes / PIECE_SIZE as u64)
+    }
+
+    /// Export to bytes
+    pub const fn to_bytes(&self) -> u64 {
+        self.0 * PIECE_SIZE as u64
+    }
+}
 
 /// A Ristretto Schnorr public key as bytes produced by `schnorrkel` crate.
 #[derive(

--- a/crates/subspace-farmer/benches/plot-write.rs
+++ b/crates/subspace-farmer/benches/plot-write.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 #[tokio::main]
 async fn main() {
     let batch_size = 4096; // 16M
-    let piece_count = 2u64.pow(20); // 4G
+    let piece_count = subspace_core_primitives::NPieces::from_bytes(4 * 2u64.pow(20)); // 4G
     let base_directory = TempDir::new_in(std::env::current_dir().unwrap()).unwrap();
 
     let mut pieces = vec![0u8; batch_size as usize * PIECE_SIZE];
@@ -25,14 +25,14 @@ async fn main() {
 
     let start = std::time::Instant::now();
 
-    for index in (0..piece_count / batch_size).map(|i| i * batch_size) {
+    for index in (0..*piece_count / batch_size).map(|i| i * batch_size) {
         plot.write_many(Arc::clone(&pieces), (index..index + batch_size).collect())
             .unwrap();
     }
     drop(plot);
 
     let took = start.elapsed();
-    let write_size = piece_count * PIECE_SIZE as u64 / 1024 / 1024;
+    let write_size = *piece_count * PIECE_SIZE as u64 / 1024 / 1024;
     eprintln!(
         "Writing {write_size}M to disk took {took:?}. Speed is around {:.2} M/s",
         write_size as f64 / took.as_secs_f64()

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -5,7 +5,7 @@ use futures::{SinkExt, Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::PIECE_SIZE;
+use subspace_core_primitives::NPieces;
 use subspace_rpc_primitives::{
     FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -30,9 +30,9 @@ pub struct Inner {
 pub const BENCH_FARMER_METADATA: FarmerMetadata = FarmerMetadata {
     record_size: 3840,                     // PIECE_SIZE - WITNESS_SIZE
     recorded_history_segment_size: 491520, // RECORD_SIZE * MERKLE_NUM_LEAVES / 2
-    max_plot_size: 100 * 1024 * 1024 * 1024 / PIECE_SIZE as u64, // 100G
+    max_plot_size: NPieces::from_bytes(100 * 1024 * 1024 * 1024), // 100G
     // Doesn't matter, as we don't start sync
-    total_pieces: 0,
+    total_pieces: NPieces::from_bytes(0),
 };
 
 impl BenchRpcClient {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use jsonrpsee::ws_server::WsServerBuilder;
 use std::path::PathBuf;
 use std::sync::Arc;
-use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
 };
@@ -47,15 +46,13 @@ pub(crate) async fn farm(
         .await
         .map_err(|error| anyhow!(error))?;
 
-    // TODO: `max_plot_size` in the protocol must change to bytes as well
-    let consensus_max_plot_size = metadata.max_plot_size * PIECE_SIZE as u64;
     let max_plot_size = match max_plot_size {
-        Some(max_plot_size) if max_plot_size > consensus_max_plot_size => {
+        Some(max_plot_size) if max_plot_size > metadata.max_plot_size => {
             warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
-            consensus_max_plot_size
+            metadata.max_plot_size
         }
         Some(max_plot_size) => max_plot_size,
-        None => consensus_max_plot_size,
+        None => metadata.max_plot_size,
     };
 
     let FarmerMetadata {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -8,7 +8,7 @@ use ss58::parse_ss58_reward_address;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use subspace_core_primitives::PublicKey;
+use subspace_core_primitives::{NPieces, PublicKey};
 use subspace_networking::libp2p::Multiaddr;
 use tempfile::TempDir;
 use tracing::info;
@@ -60,8 +60,8 @@ struct FarmingArgs {
     /// Only `G` and `T` endings are supported.
     ///
     /// Only a developer testing flag, as it might be needed for testing.
-    #[clap(long, parse(try_from_str = parse_human_readable_size))]
-    max_plot_size: Option<u64>,
+    #[clap(long, parse(try_from_str = parse_npieces))]
+    max_plot_size: Option<NPieces>,
     /// Archive data from
     #[clap(arg_enum, long, default_value_t)]
     archiving: ArchivingFrom,
@@ -103,8 +103,8 @@ enum Subcommand {
         /// Only `G` and `T` endings are supported.
         ///
         /// Only a developer testing flag, as it might be needed for testing.
-        #[clap(long, parse(try_from_str = parse_human_readable_size))]
-        max_plot_size: Option<u64>,
+        #[clap(long, parse(try_from_str = parse_npieces))]
+        max_plot_size: Option<NPieces>,
         /// How much things to write on disk (the more we write during benchmark, the more accurate
         /// it is)
         #[clap(arg_enum, long, default_value_t)]
@@ -112,8 +112,8 @@ enum Subcommand {
         /// Amount of data to plot for benchmarking.
         ///
         /// Only `G` and `T` endings are supported.
-        #[clap(long, parse(try_from_str = parse_human_readable_size))]
-        write_pieces_size: u64,
+        #[clap(long, parse(try_from_str = parse_npieces))]
+        write_pieces_size: NPieces,
         /// Skip recommitment benchmark
         #[clap(long)]
         no_recommitments: bool,
@@ -147,6 +147,10 @@ fn parse_human_readable_size(s: &str) -> Result<u64, std::num::ParseIntError> {
         .find_map(|(suf, mul)| s.strip_suffix(suf).map(|s| (s, mul)))
         .map(|(s, mul)| s.parse::<u64>().map(|num| num * mul))
         .unwrap_or_else(|| s.parse::<u64>())
+}
+
+fn parse_npieces(s: &str) -> Result<NPieces, std::num::ParseIntError> {
+    parse_human_readable_size(s).map(NPieces::from_bytes)
 }
 
 // TODO: Add graceful shutdown handling, without it temporary directory may be left not deleted

--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -126,8 +126,8 @@ impl Commitments {
         }
 
         let piece_count = plot.piece_count();
-        for batch_start in (0..piece_count).step_by(BATCH_SIZE as usize) {
-            let pieces_to_process = (batch_start + BATCH_SIZE).min(piece_count) - batch_start;
+        for batch_start in (0..*piece_count).step_by(BATCH_SIZE as usize) {
+            let pieces_to_process = (batch_start + BATCH_SIZE).min(*piece_count) - batch_start;
             // TODO: Read next batch while creating tags for the previous one for faster
             //  recommitment.
             let pieces = plot

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -3,7 +3,7 @@ use crate::plot::Plot;
 use rand::prelude::*;
 use rand::rngs::StdRng;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Salt, Tag, PIECE_SIZE};
+use subspace_core_primitives::{FlatPieces, NPieces, Salt, Tag};
 use tempfile::TempDir;
 
 fn init() {
@@ -24,7 +24,7 @@ async fn create() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
-        u64::MAX,
+        NPieces::MAX,
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
@@ -50,14 +50,14 @@ async fn find_by_tag() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
-        u64::MAX,
+        NPieces::MAX,
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
 
     // Generate deterministic pieces, such that we don't have random errors in CI
     let mut rng = StdRng::seed_from_u64(0);
-    let mut pieces: FlatPieces = vec![0u8; 1024 * PIECE_SIZE].try_into().unwrap();
+    let mut pieces = FlatPieces::new(1024);
     rng.fill(pieces.as_mut());
     let piece_indexes = (0..).take(pieces.count()).collect();
     plot.write_many(Arc::new(pieces), piece_indexes).unwrap();
@@ -138,7 +138,7 @@ async fn remove_commitments() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
-        u64::MAX,
+        NPieces::MAX,
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();

--- a/crates/subspace-farmer/src/dsn.rs
+++ b/crates/subspace-farmer/src/dsn.rs
@@ -2,7 +2,7 @@ use futures::{Stream, StreamExt};
 use num_traits::{WrappingAdd, WrappingSub};
 use std::ops::Range;
 use subspace_core_primitives::{
-    FlatPieces, PieceIndex, PieceIndexHash, PublicKey, Sha256Hash, PIECE_SIZE, U256,
+    FlatPieces, NPieces, PieceIndex, PieceIndexHash, PublicKey, Sha256Hash, U256,
 };
 use subspace_networking::PiecesToPlot;
 
@@ -13,10 +13,10 @@ pub type PieceIndexHashNumber = U256;
 
 /// Options for syncing
 pub struct SyncOptions {
-    /// Max plot size from node (in bytes)
-    pub max_plot_size: u64,
+    /// Max plot size from node
+    pub max_plot_size: NPieces,
     /// Total number of pieces in the network
-    pub total_pieces: u64,
+    pub total_pieces: NPieces,
     /// The size of range which we request
     pub range_size: PieceIndexHashNumber,
     /// Public key of our plot
@@ -84,10 +84,10 @@ where
     } = options;
     let public_key = PieceIndexHashNumber::from(Sha256Hash::from(public_key));
 
-    let sync_sector_size = if total_pieces < max_plot_size / PIECE_SIZE as u64 {
+    let sync_sector_size = if total_pieces < max_plot_size {
         PieceIndexHashNumber::MAX
     } else {
-        PieceIndexHashNumber::MAX / total_pieces * max_plot_size / PIECE_SIZE as u64
+        PieceIndexHashNumber::MAX / total_pieces.0 * max_plot_size.0
     };
     let from = public_key.wrapping_sub(&(sync_sector_size / 2));
 

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -6,7 +6,7 @@ use crate::plot::Plot;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Salt, Tag, SHA256_HASH_SIZE};
+use subspace_core_primitives::{FlatPieces, NPieces, Salt, Tag, SHA256_HASH_SIZE};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
@@ -31,7 +31,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
-        u64::MAX,
+        NPieces::MAX,
     )
     .unwrap();
 

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -10,7 +10,7 @@ use rand::prelude::*;
 use rand::Rng;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
-use subspace_core_primitives::{PieceIndexHash, Salt, PIECE_SIZE, SHA256_HASH_SIZE};
+use subspace_core_primitives::{NPieces, PieceIndexHash, Salt, PIECE_SIZE, SHA256_HASH_SIZE};
 use subspace_rpc_primitives::FarmerMetadata;
 use subspace_solving::{create_tag, SubspaceCodec};
 use tempfile::TempDir;
@@ -39,7 +39,7 @@ async fn plotting_happy_path() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
-        u64::MAX,
+        NPieces::MAX,
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
@@ -52,8 +52,8 @@ async fn plotting_happy_path() {
     let farmer_metadata = FarmerMetadata {
         record_size: RECORD_SIZE as u32,
         recorded_history_segment_size: SEGMENT_SIZE as u32,
-        max_plot_size: u64::MAX,
-        total_pieces: 0,
+        max_plot_size: NPieces::MAX,
+        total_pieces: NPieces(0),
     };
 
     client.send_metadata(farmer_metadata).await;
@@ -127,7 +127,7 @@ async fn plotting_piece_eviction() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
-        5,
+        NPieces(5),
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
@@ -144,8 +144,8 @@ async fn plotting_piece_eviction() {
     let farmer_metadata = FarmerMetadata {
         record_size: RECORD_SIZE as u32,
         recorded_history_segment_size: SEGMENT_SIZE as u32,
-        max_plot_size: u64::MAX,
-        total_pieces: 0,
+        max_plot_size: NPieces::MAX,
+        total_pieces: NPieces(0),
     };
 
     client.send_metadata(farmer_metadata).await;

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -141,6 +141,7 @@ pub trait Rpc {
 /// use subspace_farmer::single_plot_farm::SinglePlotPieceGetter;
 /// use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 /// use subspace_solving::SubspaceCodec;
+/// use subspace_core_primitives::NPieces;
 /// use std::path::PathBuf;
 /// use std::sync::Arc;
 ///
@@ -149,7 +150,7 @@ pub trait Rpc {
 ///
 /// let identity = Identity::open_or_create(&base_directory)?;
 /// let public_key = identity.public_key().to_bytes().into();
-/// let plot = Plot::open_or_create(&base_directory, &base_directory, public_key, u64::MAX)?;
+/// let plot = Plot::open_or_create(&base_directory, &base_directory, public_key, NPieces::MAX)?;
 /// let object_mappings = ObjectMappings::open_or_create(base_directory.join("object-mappings"))?;
 /// let ws_server = WsServerBuilder::default().build(ws_server_listen_addr).await?;
 /// let rpc_server = RpcServerImpl::new(

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -18,7 +18,7 @@
 use hex_buffer_serde::{Hex, HexForm};
 use serde::{Deserialize, Serialize};
 use subspace_core_primitives::{
-    PublicKey, RewardSignature, Salt, Sha256Hash, SlotNumber, Solution,
+    NPieces, PublicKey, RewardSignature, Salt, Sha256Hash, SlotNumber, Solution,
 };
 
 /// Metadata necessary for farmer operation
@@ -30,9 +30,9 @@ pub struct FarmerMetadata {
     /// Recorded history is encoded and plotted in segments of this size (in bytes).
     pub recorded_history_segment_size: u32,
     /// Maximum number of pieces in each plot
-    pub max_plot_size: u64,
+    pub max_plot_size: NPieces,
     /// Total number of pieces stored on the network
-    pub total_pieces: u64,
+    pub total_pieces: NPieces,
 }
 
 /// Information about new slot that just arrived

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -23,7 +23,7 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::MultiSignature;
 use sp_std::vec::Vec;
 pub use subspace_core_primitives::BlockNumber;
-use subspace_core_primitives::{PIECE_SIZE, SHA256_HASH_SIZE};
+use subspace_core_primitives::{NPieces, PIECE_SIZE, SHA256_HASH_SIZE};
 
 // TODO: Proper value here
 pub const CONFIRMATION_DEPTH_K: BlockNumber = 100;
@@ -44,9 +44,9 @@ const MERKLE_NUM_LEAVES: u32 = 256;
 const WITNESS_SIZE: u32 = SHA256_HASH_SIZE as u32 * MERKLE_NUM_LEAVES.log2();
 /// Size of a segment record given the global piece size (in bytes).
 pub const RECORD_SIZE: u32 = PIECE_SIZE as u32 - WITNESS_SIZE;
-///Maximum number of pieces in each plot
+/// Maximum number of pieces in each plot
 // TODO: Proper value here
-pub const MAX_PLOT_SIZE: u64 = 100 * 1024 * 1024 * 1024 / PIECE_SIZE as u64;
+pub const MAX_PLOT_SIZE: NPieces = NPieces::from_bytes(100 * 1024 * 1024 * 1024);
 /// Recorded History Segment Size includes half of the records (just data records) that will later
 /// be erasure coded and together with corresponding witnesses will result in `MERKLE_NUM_LEAVES`
 /// pieces of archival history.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -65,7 +65,7 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use subspace_core_primitives::objects::BlockObjectMapping;
-use subspace_core_primitives::{Randomness, RootBlock, Sha256Hash, PIECE_SIZE};
+use subspace_core_primitives::{NPieces, Randomness, RootBlock, Sha256Hash, PIECE_SIZE};
 use subspace_runtime_primitives::{
     opaque, AccountId, Balance, BlockNumber, Hash, Index, Moment, Signature, CONFIRMATION_DEPTH_K,
     MAX_PLOT_SIZE, MIN_REPLICATION_FACTOR, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE, SHANNON,
@@ -246,6 +246,7 @@ parameter_types! {
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
+    pub const MaxPlotSize: NPieces = MAX_PLOT_SIZE;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -259,7 +260,7 @@ impl pallet_subspace::Config for Runtime {
     type ExpectedBlockTime = ExpectedBlockTime;
     type ConfirmationDepthK = ConstU32<CONFIRMATION_DEPTH_K>;
     type RecordSize = ConstU32<RECORD_SIZE>;
-    type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
+    type MaxPlotSize = MaxPlotSize;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
@@ -708,11 +709,11 @@ impl_runtime_apis! {
             <Self as pallet_subspace::Config>::ConfirmationDepthK::get()
         }
 
-        fn total_pieces() -> u64 {
+        fn total_pieces() -> NPieces {
             <pallet_subspace::Pallet<Runtime>>::total_pieces()
         }
 
-        fn max_plot_size() -> u64 {
+        fn max_plot_size() -> NPieces {
             <Self as pallet_subspace::Config>::MaxPlotSize::get()
         }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -69,7 +69,7 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping};
-use subspace_core_primitives::{Randomness, RootBlock, Sha256Hash, PIECE_SIZE};
+use subspace_core_primitives::{NPieces, Randomness, RootBlock, Sha256Hash, PIECE_SIZE};
 use subspace_runtime_primitives::{
     opaque, AccountId, Balance, BlockNumber, Hash, Index, Moment, Signature, CONFIRMATION_DEPTH_K,
     MAX_PLOT_SIZE, MIN_REPLICATION_FACTOR, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
@@ -238,6 +238,7 @@ parameter_types! {
     pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
     pub const ShouldAdjustSolutionRange: bool = false;
     pub const ExpectedVotesPerBlock: u32 = 9;
+    pub const MaxPlotSize: NPieces = MAX_PLOT_SIZE;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -251,7 +252,7 @@ impl pallet_subspace::Config for Runtime {
     type ExpectedBlockTime = ExpectedBlockTime;
     type ConfirmationDepthK = ConstU32<CONFIRMATION_DEPTH_K>;
     type RecordSize = ConstU32<RECORD_SIZE>;
-    type MaxPlotSize = ConstU64<MAX_PLOT_SIZE>;
+    type MaxPlotSize = MaxPlotSize;
     type RecordedHistorySegmentSize = ConstU32<RECORDED_HISTORY_SEGMENT_SIZE>;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
@@ -1004,7 +1005,7 @@ impl_runtime_apis! {
             <Self as pallet_subspace::Config>::ConfirmationDepthK::get()
         }
 
-        fn total_pieces() -> u64 {
+        fn total_pieces() -> NPieces {
             <pallet_subspace::Pallet<Runtime>>::total_pieces()
         }
 
@@ -1012,7 +1013,7 @@ impl_runtime_apis! {
             <Self as pallet_subspace::Config>::RecordSize::get()
         }
 
-        fn max_plot_size() -> u64 {
+        fn max_plot_size() -> NPieces {
             <Self as pallet_subspace::Config>::MaxPlotSize::get()
         }
 


### PR DESCRIPTION
This pr introduces new type `NPieces` which is essentially a smart wrapper around `u64` with a bunch of methods.

It is better to start reviewing from `subspace_core_primitives::NPieces` definition and then go forward. The changes are mostly syntactical, but on a farmer side I pushed `NPieces` even to the cli, so that we could have homogeneous types in calculations.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
