### PR TITLE
Check receipts included in primary block part 3

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -341,6 +341,7 @@ mod pallet {
 
     /// Number of the block that the oldest execution receipt points to.
     #[pallet::storage]
+    #[pallet::getter(fn oldest_receipt_number)]
     pub(super) type OldestReceiptNumber<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
 
     #[pallet::hooks]

--- a/crates/pallet-executor/src/tests.rs
+++ b/crates/pallet-executor/src/tests.rs
@@ -231,6 +231,7 @@ fn submit_fraud_proof_should_work() {
         .collect::<Vec<_>>();
 
     let dummy_proof = FraudProof {
+        bad_signed_receipt_hash: Hash::random(),
         parent_number: 99,
         parent_hash: H256::random(),
         pre_state_root: H256::random(),

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -352,6 +352,8 @@ pub enum VerificationError {
 /// Fraud proof for the state computation.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct FraudProof {
+    /// Hash of the signed execution receipt in which an invalid state transition occurred.
+    pub bad_signed_receipt_hash: H256,
     /// Parent number.
     pub parent_number: BlockNumber,
     /// Parent hash of the block at which the invalid execution occurred.

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -231,9 +231,9 @@ pub struct SignedExecutionReceipt<Number, Hash, SecondaryHash> {
 impl<Number: Encode, Hash: Encode, SecondaryHash: Encode>
     SignedExecutionReceipt<Number, Hash, SecondaryHash>
 {
-    /// Returns the hash of inner execution receipt.
+    /// Returns the hash of signed execution receipt.
     pub fn hash(&self) -> H256 {
-        self.execution_receipt.hash()
+        BlakeTwo256::hash_of(self)
     }
 }
 

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -466,6 +466,9 @@ sp_api::decl_runtime_apis! {
         /// Returns the best execution chain number.
         fn best_execution_chain_number() -> NumberFor<Block>;
 
+        /// Returns the block number of oldest execution receipt.
+        fn oldest_receipt_number() -> NumberFor<Block>;
+
         /// Returns the maximum receipt drift.
         fn maximum_receipt_drift() -> NumberFor<Block>;
     }

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -224,6 +224,7 @@ async fn execution_proof_creation_and_verification_should_work() {
     let parent_number_alice = ferdie.client.info().best_number;
 
     let fraud_proof = FraudProof {
+        bad_signed_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
         pre_state_root: *parent_header.state_root(),
@@ -280,6 +281,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         );
 
         let fraud_proof = FraudProof {
+            bad_signed_receipt_hash: Hash::random(),
             parent_number: parent_number_alice,
             parent_hash: parent_hash_alice,
             pre_state_root: intermediate_roots[target_extrinsic_index].into(),
@@ -325,6 +327,7 @@ async fn execution_proof_creation_and_verification_should_work() {
     assert_eq!(post_execution_root, *header.state_root());
 
     let fraud_proof = FraudProof {
+        bad_signed_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
         pre_state_root: intermediate_roots.last().unwrap().into(),
@@ -486,6 +489,7 @@ async fn invalid_execution_proof_should_not_work() {
     let parent_number_alice = ferdie.client.info().best_number;
 
     let fraud_proof = FraudProof {
+        bad_signed_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
         pre_state_root: post_delta_root0,
@@ -496,6 +500,7 @@ async fn invalid_execution_proof_should_not_work() {
     assert!(proof_verifier.verify(&fraud_proof).is_err());
 
     let fraud_proof = FraudProof {
+        bad_signed_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
         pre_state_root: post_delta_root0,
@@ -506,6 +511,7 @@ async fn invalid_execution_proof_should_not_work() {
     assert!(proof_verifier.verify(&fraud_proof).is_err());
 
     let fraud_proof = FraudProof {
+        bad_signed_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
         pre_state_root: post_delta_root0,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -850,6 +850,10 @@ impl_runtime_apis! {
             Executor::best_execution_chain_number()
         }
 
+        fn oldest_receipt_number() -> NumberFor<Block> {
+            Executor::oldest_receipt_number()
+        }
+
         fn maximum_receipt_drift() -> NumberFor<Block> {
             MaximumReceiptDrift::get()
         }

--- a/cumulus/client/cirrus-executor/src/aux_schema.rs
+++ b/cumulus/client/cirrus-executor/src/aux_schema.rs
@@ -304,7 +304,7 @@ where
 				)
 			})?;
 
-			// Ensure the block from which the trace mismatch index was generated is still on the
+			// TODO: Ensure the block from which the trace mismatch index was generated is still on the
 			// canonical chain.
 			if backend.header(BlockId::Hash(block_hash))?.is_some() {
 				if !fork_receipt_hashes.is_empty() {

--- a/cumulus/client/cirrus-executor/src/aux_schema.rs
+++ b/cumulus/client/cirrus-executor/src/aux_schema.rs
@@ -150,9 +150,7 @@ where
 	// The first bad receipt detected at this block number.
 	if !bad_receipt_numbers.contains(&bad_receipt_number) {
 		bad_receipt_numbers.push(bad_receipt_number);
-
-		assert!(bad_receipt_numbers.is_sorted(), "Bad receipt numbers must be sorted");
-
+		bad_receipt_numbers.sort_unstable();
 		to_insert.push((BAD_RECEIPT_NUMBERS.encode(), bad_receipt_numbers.encode()));
 	}
 

--- a/cumulus/client/cirrus-executor/src/aux_schema.rs
+++ b/cumulus/client/cirrus-executor/src/aux_schema.rs
@@ -276,7 +276,12 @@ pub(super) fn load_first_unconfirmed_bad_receipt_info<
 		let bad_signed_receipt_hashes: Vec<H256> =
 			load_decode(backend, bad_signed_receipt_hashes_key.as_slice())?.unwrap_or_default();
 
-		let first_bad_signed_receipt_hash = bad_signed_receipt_hashes[0];
+		let first_bad_signed_receipt_hash =
+			bad_signed_receipt_hashes.get(0).copied().ok_or_else(|| {
+				ClientError::Backend(format!(
+					"No bad signed receipt hashes found for block {bad_receipt_number:?}"
+				))
+			})?;
 
 		let trace_mismatch_index = load_decode(
 			backend,

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -513,7 +513,7 @@ where
 					// on the primary chain points to an invalid secondary block.
 					crate::aux_schema::write_bad_receipt::<_, PBlock, _>(
 						&*self.client,
-						block_number.into(),
+						signed_receipt.execution_receipt.primary_number,
 						signed_receipt.hash(),
 						(0u32, block_hash),
 					)?;

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -503,6 +503,10 @@ where
 						.try_into()
 						.unwrap_or_else(|_| panic!("Primary number must fit into u32; qed"));
 
+					// TODO: Ensure the `block_hash` aligns with the one returned in
+					// `aux_schema::find_first_unconfirmed_bad_receipt_info`. Assuming there are
+					// multiple forks at present, `block_hash` is on one of them, but another fork
+					// becomes the canonical chain later.
 					let block_hash = self.client.hash(block_number.into())?.ok_or_else(|| {
 						sp_blockchain::Error::Backend(format!(
 							"Header hash not found for number {block_number}"

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -501,8 +501,13 @@ where
 			.runtime_api()
 			.extract_fraud_proofs(&BlockId::Hash(primary_hash), extrinsics)?;
 
-		for _fraud_proof in fraud_proofs {
-			// TODO: Remove the corresponding invalid receipt entry from cache.
+		for fraud_proof in fraud_proofs {
+			let bad_receipt_number = fraud_proof.parent_number + 1;
+			crate::aux_schema::delete_bad_receipt(
+				&*self.client,
+				bad_receipt_number,
+				fraud_proof.bad_signed_receipt_hash,
+			)?;
 		}
 
 		Ok(())

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -484,10 +484,6 @@ where
 					if let Some(trace_mismatch_index) =
 						find_trace_mismatch(&local_receipt, &signed_receipt.execution_receipt)
 					{
-						let trace_mismatch_index = trace_mismatch_index
-							.try_into()
-							.expect("Trace mismatch index must fit into u32; qed");
-
 						crate::aux_schema::write_bad_receipt::<_, PBlock, _>(
 							&*self.client,
 							signed_receipt.execution_receipt.primary_number,
@@ -574,7 +570,7 @@ where
 			let fraud_proof = self
 				.fraud_proof_generator
 				.generate_proof::<PBlock>(
-					trace_mismatch_index as usize,
+					trace_mismatch_index,
 					&local_receipt,
 					bad_signed_receipt_hash,
 				)

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -149,6 +149,7 @@ where
 	TransactionFor<Backend, Block>: sp_trie::HashDBT<HashFor<Block>, sp_trie::DBValue>,
 	E: CodeExecutor,
 {
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn new(
 		primary_chain_client: Arc<PClient>,
 		primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -343,7 +343,8 @@ where
 			.primary_chain_client
 			.runtime_api()
 			.oldest_receipt_number(&BlockId::Hash(primary_hash))?;
-		self.try_submit_fraud_proof_for_first_unconfirmed_bad_receipt(oldest_receipt_number)?;
+		crate::aux_schema::prune_expired_bad_receipts(&*self.client, oldest_receipt_number)?;
+		self.try_submit_fraud_proof_for_first_unconfirmed_bad_receipt()?;
 
 		// Ideally, the receipt of current block will be included in the next block, i.e., no
 		// missing receipts.
@@ -537,12 +538,10 @@ where
 
 	fn try_submit_fraud_proof_for_first_unconfirmed_bad_receipt(
 		&self,
-		oldest_receipt_number: NumberFor<PBlock>,
 	) -> Result<(), sp_blockchain::Error> {
 		if let Some((bad_receipt_number, bad_signed_receipt_hash, trace_mismatch_index)) =
 			crate::aux_schema::load_first_unconfirmed_bad_receipt_info::<_, NumberFor<PBlock>>(
 				&*self.client,
-				oldest_receipt_number,
 			)? {
 			let block_number: BlockNumber = bad_receipt_number
 				.try_into()

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -79,6 +79,7 @@ where
 		&self,
 		local_trace_index: usize,
 		local_receipt: &ExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
+		bad_signed_receipt_hash: H256,
 	) -> Result<FraudProof, FraudProofError> {
 		let block_hash = local_receipt.secondary_hash;
 		let block_number: BlockNumber = local_receipt
@@ -129,6 +130,7 @@ where
 			)?;
 
 			FraudProof {
+				bad_signed_receipt_hash,
 				parent_number,
 				parent_hash: as_h256(&parent_header.hash())?,
 				pre_state_root,
@@ -163,6 +165,7 @@ where
 			)?;
 
 			FraudProof {
+				bad_signed_receipt_hash,
 				parent_number,
 				parent_hash: as_h256(&parent_header.hash())?,
 				pre_state_root,
@@ -184,6 +187,7 @@ where
 
 			// TODO: proof should be a CompactProof.
 			FraudProof {
+				bad_signed_receipt_hash,
 				parent_number,
 				parent_hash: as_h256(&parent_header.hash())?,
 				pre_state_root,

--- a/cumulus/client/cirrus-executor/src/fraud_proof.rs
+++ b/cumulus/client/cirrus-executor/src/fraud_proof.rs
@@ -23,6 +23,8 @@ use subspace_core_primitives::BlockNumber;
 pub enum FraudProofError {
 	#[error("State root not using H256")]
 	InvalidStateRootType,
+	#[error("Invalid trace index, got: {index}, max: {max}")]
+	InvalidTraceIndex { index: usize, max: usize },
 	#[error("Invalid extrinsic index for creating the execution proof, got: {index}, max: {max}")]
 	InvalidExtrinsicIndex { index: usize, max: usize },
 	#[error(transparent)]
@@ -77,7 +79,7 @@ where
 
 	pub(crate) fn generate_proof<PBlock: BlockT>(
 		&self,
-		local_trace_index: usize,
+		local_trace_index: u32,
 		local_receipt: &ExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
 		bad_signed_receipt_hash: H256,
 	) -> Result<FraudProof, FraudProofError> {
@@ -105,13 +107,18 @@ where
 		let parent_number = TryInto::<BlockNumber>::try_into(*parent_header.number())
 			.unwrap_or_else(|_| panic!("Parent number must fit into u32; qed"));
 
-		let local_root = local_receipt.trace[local_trace_index];
+		let local_root = local_receipt.trace.get(local_trace_index as usize).ok_or(
+			FraudProofError::InvalidTraceIndex {
+				index: local_trace_index as usize,
+				max: local_receipt.trace.len() - 1,
+			},
+		)?;
 
 		// TODO: abstract the execution proof impl to be reusable in the test.
 		let fraud_proof = if local_trace_index == 0 {
 			// `initialize_block` execution proof.
 			let pre_state_root = as_h256(parent_header.state_root())?;
-			let post_state_root = as_h256(&local_root)?;
+			let post_state_root = as_h256(local_root)?;
 
 			let new_header = Block::Header::new(
 				block_number.into(),
@@ -138,10 +145,10 @@ where
 				proof,
 				execution_phase,
 			}
-		} else if local_trace_index == local_receipt.trace.len() - 1 {
+		} else if local_trace_index as usize == local_receipt.trace.len() - 1 {
 			// `finalize_block` execution proof.
-			let pre_state_root = as_h256(&local_receipt.trace[local_trace_index - 1])?;
-			let post_state_root = as_h256(&local_root)?;
+			let pre_state_root = as_h256(&local_receipt.trace[local_trace_index as usize - 1])?;
+			let post_state_root = as_h256(local_root)?;
 			let execution_phase = ExecutionPhase::FinalizeBlock;
 
 			let block_builder = BlockBuilder::new(
@@ -175,11 +182,11 @@ where
 			}
 		} else {
 			// Regular extrinsic execution proof.
-			let pre_state_root = as_h256(&local_receipt.trace[local_trace_index - 1])?;
-			let post_state_root = as_h256(&local_root)?;
+			let pre_state_root = as_h256(&local_receipt.trace[local_trace_index as usize - 1])?;
+			let post_state_root = as_h256(local_root)?;
 
 			let (proof, execution_phase) = self.create_extrinsic_execution_proof(
-				local_trace_index - 1,
+				local_trace_index as usize - 1,
 				&parent_header,
 				block_hash,
 				&prover,
@@ -258,11 +265,11 @@ where
 pub(crate) fn find_trace_mismatch<Number, Hash: Copy + Eq, PHash>(
 	local: &ExecutionReceipt<Number, PHash, Hash>,
 	other: &ExecutionReceipt<Number, PHash, Hash>,
-) -> Option<usize> {
+) -> Option<u32> {
 	local.trace.iter().enumerate().zip(other.trace.iter().enumerate()).find_map(
 		|((local_index, local_root), (_, other_root))| {
 			if local_root != other_root {
-				Some(local_index)
+				Some(local_index.try_into().expect("Trace mismatch index must fit into u32; qed"))
 			} else {
 				None
 			}

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -616,6 +616,8 @@ where
 		&self,
 		signed_execution_receipt: &SignedExecutionReceiptFor<PBlock, Block::Hash>,
 	) -> Result<Action, Self::Error> {
+		let signed_receipt_hash = signed_execution_receipt.hash();
+
 		let SignedExecutionReceipt { execution_receipt, signature, signer } =
 			signed_execution_receipt;
 
@@ -693,9 +695,11 @@ where
 		if local_receipt.trace.len() != execution_receipt.trace.len() {}
 
 		if let Some(trace_mismatch_index) = find_trace_mismatch(&local_receipt, execution_receipt) {
-			let fraud_proof = self
-				.fraud_proof_generator
-				.generate_proof::<PBlock>(trace_mismatch_index, &local_receipt)?;
+			let fraud_proof = self.fraud_proof_generator.generate_proof::<PBlock>(
+				trace_mismatch_index,
+				&local_receipt,
+				signed_receipt_hash,
+			)?;
 
 			self.submit_fraud_proof(fraud_proof);
 

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -58,6 +58,7 @@
 //! [`BlockBuilder`]: ../cirrus_block_builder/struct.BlockBuilder.html
 
 #![feature(is_sorted)]
+#![feature(drain_filter)]
 
 mod aux_schema;
 mod bundle_processor;

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -116,7 +116,7 @@ where
 	transaction_pool: Arc<TransactionPool>,
 	backend: Arc<Backend>,
 	fraud_proof_generator: FraudProofGenerator<Block, Client, Backend, E>,
-	bundle_processor: BundleProcessor<Block, PBlock, Client, PClient, Backend>,
+	bundle_processor: BundleProcessor<Block, PBlock, Client, PClient, Backend, E>,
 }
 
 impl<Block, PBlock, Client, PClient, TransactionPool, Backend, E> Clone
@@ -232,6 +232,8 @@ where
 			backend.clone(),
 			is_authority,
 			keystore,
+			spawner.clone(),
+			fraud_proof_generator.clone(),
 		);
 
 		spawn_essential.spawn_essential_blocking(

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -57,7 +57,6 @@
 //! [Computation section]: https://subspace.network/news/subspace-network-whitepaper
 //! [`BlockBuilder`]: ../cirrus_block_builder/struct.BlockBuilder.html
 
-#![feature(is_sorted)]
 #![feature(drain_filter)]
 
 mod aux_schema;

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -57,6 +57,8 @@
 //! [Computation section]: https://subspace.network/news/subspace-network-whitepaper
 //! [`BlockBuilder`]: ../cirrus_block_builder/struct.BlockBuilder.html
 
+#![feature(is_sorted)]
+
 mod aux_schema;
 mod bundle_processor;
 mod bundle_producer;

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -118,6 +118,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
 	let parent_number_ferdie = *header_ferdie.number();
 
 	let valid_fraud_proof = FraudProof {
+		bad_signed_receipt_hash: Hash::random(),
 		parent_number: parent_number_ferdie,
 		parent_hash: parent_hash_ferdie,
 		pre_state_root: *parent_header.state_root(),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1146,6 +1146,10 @@ impl_runtime_apis! {
             Executor::best_execution_chain_number()
         }
 
+        fn oldest_receipt_number() -> NumberFor<Block> {
+            Executor::oldest_receipt_number()
+        }
+
         fn maximum_receipt_drift() -> NumberFor<Block> {
             MaximumReceiptDrift::get()
         }


### PR DESCRIPTION
Last piece of new features in #634.

3 storage items are added to the executor's aux db:

- `bad_receipt_numbers`(Vec<Number>), all block numbers associated with at least one bad receipt, we need to find the first unconfirmed bad receipt.
- A map of `bad_receipt_block_number` => all_bad_signed_receipt_hashes_detected_aginest_this_block, there is one receipt per block at present, but we'll support multiple receipts per block in the future, hence this one to many mapping.
- `bad_signed_receipt_hash` => `trace_mismatch_index`, necessary info for building a fraud proof later.

Only some basic tests for caching the bad receipts are added in this PR, more features testing will be added later. Before that, I'd love to have another look at https://github.com/subspace/subspace/issues/545 as the increasing tests in executor will make it a bigger issue.

Should be easiest to review commit by commit.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
