### PR TITLE
Multi plots farm (part 7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -4387,6 +4387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7903,6 +7912,7 @@ dependencies = [
  "base58",
  "blake2-rfc",
  "clap 3.1.18",
+ "derive_more",
  "dirs",
  "event-listener-primitives",
  "fdlimit",
@@ -7932,6 +7942,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.11",
+ "ulid",
  "zeroize",
 ]
 
@@ -8652,6 +8663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+dependencies = [
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8998,6 +9019,17 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "ulid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be932d774bfad49722da2c4915ac7cc77b77dd223890739a0240de2b2a15957"
+dependencies = [
+ "rand 0.8.5",
+ "serde",
+ "time 0.3.11",
 ]
 
 [[package]]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1.53"
 base58 = "0.2.0"
 blake2-rfc = "0.2.18"
 clap = { version = "3.1.18", features = ["color", "derive"] }
+derive_more = "0.99.17"
 dirs = "4.0.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2"
@@ -47,6 +48,7 @@ substrate-bip39 = "0.4.4"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["macros", "parking_lot", "rt-multi-thread"] }
+ulid = { version = "0.6.0", features = ["serde"] }
 zeroize = "1.5.5"
 
 # OpenBSD and MSVC are unteested and shouldn't enable jemalloc:

--- a/crates/subspace-farmer/benches/plot-write.rs
+++ b/crates/subspace-farmer/benches/plot-write.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
-
 use rand::prelude::*;
+use std::sync::Arc;
 use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::Plot;
 use tempfile::TempDir;
@@ -12,10 +11,11 @@ async fn main() {
     let base_directory = TempDir::new_in(std::env::current_dir().unwrap()).unwrap();
 
     let mut pieces = vec![0u8; batch_size as usize * PIECE_SIZE];
-    rand::thread_rng().fill(&mut pieces[..]);
+    thread_rng().fill(&mut pieces[..]);
     let pieces = Arc::new(pieces.try_into().unwrap());
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -1,7 +1,7 @@
 use crate::rpc_client::{Error, RpcClient};
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::{SinkExt, Stream, StreamExt};
+use futures::{stream, SinkExt, Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
@@ -21,6 +21,7 @@ pub struct BenchRpcClient {
 #[derive(Debug)]
 pub struct Inner {
     metadata: FarmerMetadata,
+    slot_info_receiver: Arc<Mutex<mpsc::Receiver<SlotInfo>>>,
     acknowledge_archived_segment_sender: mpsc::Sender<u64>,
     archived_segments_receiver: Arc<Mutex<mpsc::Receiver<ArchivedSegment>>>,
     segment_producer_handle: Mutex<JoinHandle<()>>,
@@ -39,20 +40,17 @@ impl BenchRpcClient {
     /// Create a new instance of [`BenchRpcClient`].
     pub fn new(
         metadata: FarmerMetadata,
+        slot_info_receiver: mpsc::Receiver<SlotInfo>,
         mut archived_segments_receiver: mpsc::Receiver<ArchivedSegment>,
+        acknowledge_archived_segment_sender: mpsc::Sender<u64>,
     ) -> Self {
         let (mut inner_archived_segments_sender, inner_archived_segments_receiver) =
             mpsc::channel(10);
-        let (acknowledge_archived_segment_sender, mut acknowledge_archived_segment_receiver) =
-            mpsc::channel(1);
 
         let segment_producer_handle = tokio::spawn({
             async move {
                 while let Some(segment) = archived_segments_receiver.next().await {
                     if inner_archived_segments_sender.send(segment).await.is_err() {
-                        break;
-                    }
-                    if acknowledge_archived_segment_receiver.next().await.is_none() {
                         break;
                     }
                 }
@@ -62,6 +60,7 @@ impl BenchRpcClient {
         Self {
             inner: Arc::new(Inner {
                 metadata,
+                slot_info_receiver: Arc::new(Mutex::new(slot_info_receiver)),
                 archived_segments_receiver: Arc::new(Mutex::new(inner_archived_segments_receiver)),
                 acknowledge_archived_segment_sender,
                 segment_producer_handle: Mutex::new(segment_producer_handle),
@@ -83,20 +82,31 @@ impl RpcClient for BenchRpcClient {
     async fn subscribe_slot_info(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, Error> {
-        unreachable!("Unreachable, as we don't start farming for benchmarking")
+        let (mut sender, receiver) = mpsc::channel(10);
+        let slot_receiver = self.inner.slot_info_receiver.clone();
+        tokio::spawn(async move {
+            while let Some(slot_info) = slot_receiver.lock().await.next().await {
+                if sender.send(slot_info).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(Box::pin(receiver))
     }
 
     async fn submit_solution_response(
         &self,
         _solution_response: SolutionResponse,
     ) -> Result<(), Error> {
-        unreachable!("Unreachable, as we don't start farming for benchmarking")
+        // Bench RPC client doesn't care
+        Ok(())
     }
 
     async fn subscribe_reward_signing(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, Error> {
-        unreachable!("Unreachable, as we don't start farming for benchmarking")
+        Ok(Box::pin(stream::empty()))
     }
 
     async fn submit_reward_signature(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -145,18 +145,23 @@ pub(crate) async fn bench(
     .await??;
 
     let base_path = base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index, public_key, max_piece_count| {
+    let plot_factory = move |plot_index: usize, public_key, max_piece_count| {
         let base_path = base_path.join(format!("plot{plot_index}"));
         match write_to_disk {
             WriteToDisk::Nothing => Plot::with_plot_file(
+                plot_index.into(),
                 BenchPlotMock::new(max_piece_count),
                 &base_path,
                 public_key,
                 max_piece_count,
             ),
-            WriteToDisk::Everything => {
-                Plot::open_or_create(&base_path, &base_path, public_key, max_piece_count)
-            }
+            WriteToDisk::Everything => Plot::open_or_create(
+                plot_index.into(),
+                &base_path,
+                &base_path,
+                public_key,
+                max_piece_count,
+            ),
         }
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -90,6 +90,7 @@ pub(crate) async fn farm(
         move |plot_index, public_key, max_piece_count| {
             let plot_directory = base_directory.join(format!("plot{plot_index}"));
             Plot::open_or_create(
+                plot_index.into(),
                 &plot_directory,
                 &plot_directory,
                 public_key,

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -21,6 +21,7 @@ async fn create() {
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -47,6 +48,7 @@ async fn find_by_tag() {
     let salt: Salt = [1u8; 8];
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -135,6 +137,7 @@ async fn remove_commitments() {
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -159,9 +159,15 @@ async fn test_dsn_sync() {
     .unwrap();
 
     let base_path = seeder_base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index, public_key, max_piece_count| {
+    let plot_factory = move |plot_index: usize, public_key, max_piece_count| {
         let base_path = base_path.join(format!("plot{plot_index}"));
-        Plot::open_or_create(&base_path, &base_path, public_key, max_piece_count)
+        Plot::open_or_create(
+            plot_index.into(),
+            &base_path,
+            &base_path,
+            public_key,
+            max_piece_count,
+        )
     };
 
     let seeder_multi_farming = LegacyMultiPlotsFarm::new(
@@ -271,9 +277,15 @@ async fn test_dsn_sync() {
     .unwrap();
 
     let base_path = syncer_base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index, public_key, max_piece_count| {
+    let plot_factory = move |plot_index: usize, public_key, max_piece_count| {
         let base_path = base_path.join(format!("plot{plot_index}"));
-        Plot::open_or_create(&base_path, &base_path, public_key, max_piece_count)
+        Plot::open_or_create(
+            plot_index.into(),
+            &base_path,
+            &base_path,
+            public_key,
+            max_piece_count,
+        )
     };
 
     let syncer_multi_farming = LegacyMultiPlotsFarm::new(

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -2,7 +2,7 @@ use super::{sync, DSNSync, NoSync, PieceIndexHashNumber, SyncOptions};
 use crate::bench_rpc_client::{BenchRpcClient, BENCH_FARMER_METADATA};
 use crate::legacy_multi_plots_farm::{LegacyMultiPlotsFarm, Options as MultiFarmingOptions};
 use crate::{ObjectMappings, Plot};
-use futures::channel::oneshot;
+use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
 use num_traits::{WrappingAdd, WrappingSub};
 use rand::Rng;
@@ -144,10 +144,16 @@ async fn test_dsn_sync() {
 
     let seeder_base_directory = TempDir::new().unwrap();
 
-    let (mut seeder_archived_segments_sender, seeder_archived_segments_receiver) =
-        futures::channel::mpsc::channel(0);
-    let seeder_client =
-        BenchRpcClient::new(BENCH_FARMER_METADATA, seeder_archived_segments_receiver);
+    let (_seeder_slot_info_sender, seeder_slot_info_receiver) = mpsc::channel(10);
+    let (mut seeder_archived_segments_sender, seeder_archived_segments_receiver) = mpsc::channel(0);
+    let (seeder_acknowledge_archived_segment_sender, _seeder_acknowledge_archived_segment_receiver) =
+        mpsc::channel(1);
+    let seeder_client = BenchRpcClient::new(
+        BENCH_FARMER_METADATA,
+        seeder_slot_info_receiver,
+        seeder_archived_segments_receiver,
+        seeder_acknowledge_archived_segment_sender,
+    );
 
     let object_mappings = tokio::task::spawn_blocking({
         let path = seeder_base_directory.as_ref().join("object-mappings");
@@ -234,7 +240,7 @@ async fn test_dsn_sync() {
             .collect::<BTreeMap<_, _>>()
     };
 
-    let (seeder_address_sender, mut seeder_address_receiver) = futures::channel::mpsc::unbounded();
+    let (seeder_address_sender, mut seeder_address_receiver) = mpsc::unbounded();
     seeder_multi_farming.single_plot_farms[0]
         .node()
         .on_new_listener(Arc::new(move |address| {
@@ -263,9 +269,16 @@ async fn test_dsn_sync() {
     drop(seeder_address_receiver);
 
     let syncer_base_directory = TempDir::new().unwrap();
-    let (_sender, syncer_archived_segments_receiver) = futures::channel::mpsc::channel(10);
-    let syncer_client =
-        BenchRpcClient::new(BENCH_FARMER_METADATA, syncer_archived_segments_receiver);
+    let (_syncer_slot_info_sender, syncer_slot_info_receiver) = mpsc::channel(10);
+    let (_syncer_archived_segments_sender, syncer_archived_segments_receiver) = mpsc::channel(10);
+    let (syncer_acknowledge_archived_segment_sender, _syncer_acknowledge_archived_segment_receiver) =
+        mpsc::channel(1);
+    let syncer_client = BenchRpcClient::new(
+        BENCH_FARMER_METADATA,
+        syncer_slot_info_receiver,
+        syncer_archived_segments_receiver,
+        syncer_acknowledge_archived_segment_sender,
+    );
 
     let object_mappings = tokio::task::spawn_blocking({
         let path = syncer_base_directory.as_ref().join("object-mappings");

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -28,6 +28,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
 
     let public_key = identity.public_key().to_bytes().into();
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -45,6 +46,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
 
     // start the farming task
     let mut farming_instance = Farming::start(
+        0usize.into(),
         plot.clone(),
         commitments.clone(),
         client.clone(),

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -106,6 +106,7 @@ impl LegacyMultiPlotsFarm {
                     let first_listen_on = Arc::clone(&first_listen_on);
 
                     SinglePlotFarm::new(SinglePlotFarmOptions {
+                        id: plot_index.into(),
                         metadata_directory,
                         plot_index,
                         max_plot_pieces,

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -29,6 +29,7 @@ async fn read_write() {
     let piece_index_start = 0;
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -49,6 +50,7 @@ async fn read_write() {
 
     // Make sure it is still not empty on reopen
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -64,6 +66,7 @@ async fn piece_retrievable() {
     let base_directory = TempDir::new().unwrap();
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -106,6 +109,7 @@ async fn partial_plot() {
     let public_key = random::<[u8; 32]>().into();
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -152,6 +156,7 @@ async fn sequential_pieces_iterator() {
     let public_key = random::<[u8; 32]>().into();
 
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -248,6 +253,7 @@ async fn test_read_sequential_pieces() {
         bytes
     };
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key_bytes.into(),

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -173,7 +173,13 @@ impl Drop for SinglePlotFarm {
 
 impl SinglePlotFarm {
     pub(crate) fn new<C, NewPlot>(
-        SinglePlotFarmOptions {
+        options: SinglePlotFarmOptions<C, NewPlot>,
+    ) -> anyhow::Result<Self>
+    where
+        C: RpcClient,
+        NewPlot: Fn(usize, PublicKey, u64) -> Result<Plot, PlotError> + Clone + Send + 'static,
+    {
+        let SinglePlotFarmOptions {
             metadata_directory,
             plot_index,
             max_plot_pieces,
@@ -187,12 +193,7 @@ impl SinglePlotFarm {
             reward_address,
             enable_dsn_archiving,
             enable_dsn_sync,
-        }: SinglePlotFarmOptions<C, NewPlot>,
-    ) -> anyhow::Result<Self>
-    where
-        C: RpcClient,
-        NewPlot: Fn(usize, PublicKey, u64) -> Result<Plot, PlotError> + Clone + Send + 'static,
-    {
+        } = options;
         std::fs::create_dir_all(&metadata_directory)?;
 
         let identity = Identity::open_or_create(&metadata_directory)?;

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -185,7 +185,7 @@ pub struct SinglePlotFarm {
     public_key: PublicKey,
     codec: SubspaceCodec,
     plot: Plot,
-    pub commitments: Commitments,
+    commitments: Commitments,
     farming: Option<Farming>,
     node: Node,
     node_runner: NodeRunner,
@@ -452,6 +452,11 @@ impl SinglePlotFarm {
     /// Access plot instance of the farm
     pub fn plot(&self) -> &Plot {
         &self.plot
+    }
+
+    /// Access commitments instance of the farm
+    pub fn commitments(&self) -> &Commitments {
+        &self.commitments
     }
 
     /// Access network node instance of the farm

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -36,6 +36,7 @@ async fn plotting_happy_path() {
 
     let public_key = identity.public_key().to_bytes().into();
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -124,6 +125,7 @@ async fn plotting_piece_eviction() {
     let public_key = identity.public_key().to_bytes().into();
     let salt = Salt::default();
     let plot = Plot::open_or_create(
+        0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -149,7 +149,13 @@ pub trait Rpc {
 ///
 /// let identity = Identity::open_or_create(&base_directory)?;
 /// let public_key = identity.public_key().to_bytes().into();
-/// let plot = Plot::open_or_create(&base_directory, &base_directory, public_key, u64::MAX)?;
+/// let plot = Plot::open_or_create(
+///     0usize.into(),
+///     &base_directory,
+///     &base_directory,
+///     public_key,
+///     u64::MAX,
+/// )?;
 /// let object_mappings = ObjectMappings::open_or_create(base_directory.join("object-mappings"))?;
 /// let ws_server = WsServerBuilder::default().build(ws_server_listen_addr).await?;
 /// let rpc_server = RpcServerImpl::new(


### PR DESCRIPTION
I was looking at how to limit threading on the same disk and noticed that we have a problem because for some of the long-running tasks we're spawning threads with `tokio::task::spawn_blocking()` that uses thread pool of a limited size (512 threads by default), which means with big enough plot it'll block and some plots will never make any progress waiting for thread pool to get free threads.

In order to fix that I changes spawning to standard threads with custom thread names for better debugging and tracing's spans. That required introduction of ID for `SinglePlotFarm`. Ulid will be used with `SingleDiskFarm` once we have it, decided to add it to the enum right away even though it is not used yet.

Then I looked at whether we can remove `commitments` property from `SinglePlotFarm` and decided that we still need to expose it because it has some useful events library users might want to subscribe to, hence we need to still expose it anyway (but as a method now). While doing so I initially wanted to remove recommitments from the bench, but instead extended it with support for recommitments that happen during plotting (that was missing before) in addition to full recommitment.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
