### PR TITLE
Multi plots farm (part 8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7845,6 +7845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "std-semaphore"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7931,6 +7937,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ss58-registry",
+ "std-semaphore",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-networking",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -38,6 +38,7 @@ rayon = "1.5.3"
 schnorrkel = "0.9.1"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
+std-semaphore = "0.1.0"
 ss58-registry = "1.18.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving" }

--- a/crates/subspace-farmer/benches/plot-write.rs
+++ b/crates/subspace-farmer/benches/plot-write.rs
@@ -15,7 +15,7 @@ async fn main() {
     let pieces = Arc::new(pieces.try_into().unwrap());
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -257,7 +257,7 @@ pub(crate) async fn bench(
 
     let space_allocated = get_size(base_directory)?;
     let actual_space_pledged = multi_farming
-        .single_plot_farms
+        .single_plot_farms()
         .iter()
         .map(|single_plot_farm| single_plot_farm.plot().piece_count())
         .sum::<u64>()
@@ -289,7 +289,7 @@ pub(crate) async fn bench(
         let start = Instant::now();
 
         let mut tasks = multi_farming
-            .single_plot_farms
+            .single_plot_farms()
             .iter()
             .map(|single_plot_farm| {
                 (

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -17,6 +17,7 @@ use subspace_farmer::bench_rpc_client::{BenchRpcClient, BENCH_FARMER_METADATA};
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
 };
+use subspace_farmer::single_plot_farm::PlotFactoryOptions;
 use subspace_farmer::{ObjectMappings, PieceOffset, Plot, PlotFile, RpcClient};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
@@ -153,25 +154,21 @@ pub(crate) async fn bench(
     })
     .await??;
 
-    let base_path = base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index: usize, public_key, max_piece_count| {
-        let base_path = base_path.join(format!("plot{plot_index}"));
-        match write_to_disk {
-            WriteToDisk::Nothing => Plot::with_plot_file(
-                plot_index.into(),
-                BenchPlotMock::new(max_piece_count),
-                &base_path,
-                public_key,
-                max_piece_count,
-            ),
-            WriteToDisk::Everything => Plot::open_or_create(
-                plot_index.into(),
-                &base_path,
-                &base_path,
-                public_key,
-                max_piece_count,
-            ),
-        }
+    let plot_factory = move |options: PlotFactoryOptions<'_>| match write_to_disk {
+        WriteToDisk::Nothing => Plot::with_plot_file(
+            options.single_plot_farm_id,
+            BenchPlotMock::new(options.max_piece_count),
+            options.metadata_directory,
+            options.public_key,
+            options.max_piece_count,
+        ),
+        WriteToDisk::Everything => Plot::open_or_create(
+            options.single_plot_farm_id,
+            options.plot_directory,
+            options.metadata_directory,
+            options.public_key,
+            options.max_piece_count,
+        ),
     };
 
     let multi_farming = LegacyMultiPlotsFarm::new(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -254,6 +254,7 @@ pub(crate) async fn bench(
             break;
         }
     }
+    drop(archived_segments_sender);
 
     let took = start.elapsed();
 
@@ -314,7 +315,7 @@ pub(crate) async fn bench(
         );
     }
 
-    client.stop().await;
+    drop(client);
     multi_farming.wait().await?;
 
     Ok(())

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -6,6 +6,7 @@ use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
 };
+use subspace_farmer::single_plot_farm::PlotFactoryOptions;
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use subspace_rpc_primitives::FarmerMetadata;
@@ -74,7 +75,7 @@ pub(crate) async fn farm(
 
     let multi_plots_farm = LegacyMultiPlotsFarm::new(
         MultiFarmingOptions {
-            base_directory: base_directory.clone(),
+            base_directory,
             archiving_client,
             farming_client,
             object_mappings: object_mappings.clone(),
@@ -87,14 +88,13 @@ pub(crate) async fn farm(
         },
         plot_size,
         max_plot_size,
-        move |plot_index, public_key, max_piece_count| {
-            let plot_directory = base_directory.join(format!("plot{plot_index}"));
+        move |options: PlotFactoryOptions<'_>| {
             Plot::open_or_create(
-                plot_index.into(),
-                &plot_directory,
-                &plot_directory,
-                public_key,
-                max_piece_count,
+                options.single_plot_farm_id,
+                options.plot_directory,
+                options.metadata_directory,
+                options.public_key,
+                options.max_piece_count,
             )
         },
     )

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -21,7 +21,7 @@ async fn create() {
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -48,7 +48,7 @@ async fn find_by_tag() {
     let salt: Salt = [1u8; 8];
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -137,7 +137,7 @@ async fn remove_commitments() {
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -240,14 +240,17 @@ async fn test_dsn_sync() {
     };
 
     let (seeder_address_sender, mut seeder_address_receiver) = mpsc::unbounded();
-    seeder_multi_farming.single_plot_farms[0]
+    seeder_multi_farming.single_plot_farms()[0]
         .node()
         .on_new_listener(Arc::new(move |address| {
             let _ = seeder_address_sender.unbounded_send(address.clone());
         }))
         .detach();
 
-    let peer_id = seeder_multi_farming.single_plot_farms[0].node().id().into();
+    let peer_id = seeder_multi_farming.single_plot_farms()[0]
+        .node()
+        .id()
+        .into();
 
     let (seeder_multi_farming_finished_sender, seeder_multi_farming_finished_receiver) =
         oneshot::channel();
@@ -321,14 +324,14 @@ async fn test_dsn_sync() {
     let syncer_max_plot_size = syncer_max_plot_size * 92 / 100;
 
     let range_size = PieceIndexHashNumber::MAX / seeder_max_plot_size * request_pieces_size;
-    let plot = syncer_multi_farming.single_plot_farms[0].plot().clone();
-    let dsn_sync = syncer_multi_farming.single_plot_farms[0].dsn_sync(
+    let plot = syncer_multi_farming.single_plot_farms()[0].plot().clone();
+    let dsn_sync = syncer_multi_farming.single_plot_farms()[0].dsn_sync(
         syncer_max_plot_size,
         seeder_max_plot_size,
         range_size,
     );
     let public_key = U256::from_big_endian(
-        syncer_multi_farming.single_plot_farms[0]
+        syncer_multi_farming.single_plot_farms()[0]
             .public_key()
             .as_ref(),
     );

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -405,9 +405,9 @@ async fn test_dsn_sync() {
         ),
     };
 
-    syncer_client.stop().await;
+    drop(syncer_client);
 
     drop(seeder_archived_segments_sender);
-    seeder_client.stop().await;
+    drop(seeder_client);
     seeder_multi_farming_finished_receiver.await.unwrap();
 }

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -1,6 +1,7 @@
 use super::{sync, DSNSync, NoSync, PieceIndexHashNumber, SyncOptions};
 use crate::bench_rpc_client::{BenchRpcClient, BENCH_FARMER_METADATA};
 use crate::legacy_multi_plots_farm::{LegacyMultiPlotsFarm, Options as MultiFarmingOptions};
+use crate::single_plot_farm::PlotFactoryOptions;
 use crate::{ObjectMappings, Plot};
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
@@ -164,15 +165,13 @@ async fn test_dsn_sync() {
     .unwrap()
     .unwrap();
 
-    let base_path = seeder_base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index: usize, public_key, max_piece_count| {
-        let base_path = base_path.join(format!("plot{plot_index}"));
+    let plot_factory = move |options: PlotFactoryOptions<'_>| {
         Plot::open_or_create(
-            plot_index.into(),
-            &base_path,
-            &base_path,
-            public_key,
-            max_piece_count,
+            options.single_plot_farm_id,
+            options.plot_directory,
+            options.metadata_directory,
+            options.public_key,
+            options.max_piece_count,
         )
     };
 
@@ -289,15 +288,13 @@ async fn test_dsn_sync() {
     .unwrap()
     .unwrap();
 
-    let base_path = syncer_base_directory.as_ref().to_owned();
-    let plot_factory = move |plot_index: usize, public_key, max_piece_count| {
-        let base_path = base_path.join(format!("plot{plot_index}"));
+    let plot_factory = move |options: PlotFactoryOptions<'_>| {
         Plot::open_or_create(
-            plot_index.into(),
-            &base_path,
-            &base_path,
-            public_key,
-            max_piece_count,
+            options.single_plot_farm_id,
+            options.plot_directory,
+            options.metadata_directory,
+            options.public_key,
+            options.max_piece_count,
         )
     };
 

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -3,6 +3,7 @@ use crate::farming::Farming;
 use crate::identity::Identity;
 use crate::mock_rpc_client::MockRpcClient;
 use crate::plot::Plot;
+use crate::single_disk_farm::SingleDiskSemaphore;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
 use std::sync::Arc;
@@ -50,6 +51,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
         plot.clone(),
         commitments.clone(),
         client.clone(),
+        SingleDiskSemaphore::new(1),
         identity.clone(),
         public_key,
     );

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -28,7 +28,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
 
     let public_key = identity.public_key().to_bytes().into();
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -153,7 +153,7 @@ impl LegacyMultiPlotsFarm {
         })
     }
 
-    pub fn single_plot_farms(&self) -> &'_ [SinglePlotFarm] {
+    pub fn single_plot_farms(&self) -> &[SinglePlotFarm] {
         &self.single_plot_farms
     }
 

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -56,7 +56,7 @@ pub struct Options<C> {
 /// It is needed because of the limit of a single plot size from the consensus
 /// (`pallet_subspace::MaxPlotSize`) in order to support any amount of disk space from user.
 pub struct LegacyMultiPlotsFarm {
-    pub single_plot_farms: Vec<SinglePlotFarm>,
+    single_plot_farms: Vec<SinglePlotFarm>,
     archiving: Option<Archiving>,
 }
 
@@ -164,6 +164,10 @@ impl LegacyMultiPlotsFarm {
             single_plot_farms,
             archiving,
         })
+    }
+
+    pub fn single_plot_farms(&self) -> &'_ [SinglePlotFarm] {
+        &self.single_plot_farms
     }
 
     pub fn piece_getter(&self) -> SingleDiskFarmPieceGetter {

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -3,6 +3,7 @@ use crate::object_mappings::ObjectMappings;
 use crate::rpc_client::RpcClient;
 use crate::single_disk_farm::SingleDiskFarmPieceGetter;
 use crate::single_plot_farm::{PlotFactory, SinglePlotFarm, SinglePlotFarmOptions};
+use crate::utils::get_plot_sizes;
 use anyhow::anyhow;
 use futures::stream::{FuturesUnordered, StreamExt};
 use parking_lot::Mutex;
@@ -13,26 +14,6 @@ use subspace_core_primitives::{PublicKey, PIECE_SIZE};
 use subspace_networking::libp2p::Multiaddr;
 use tokio::runtime::Handle;
 use tracing::error;
-
-fn get_plot_sizes(allocated_space: u64, max_plot_size: u64) -> Vec<u64> {
-    // TODO: we need to remember plot size in order to prune unused plots in future if plot size is
-    //  less than it was specified before.
-    // TODO: Piece count should account for database overhead of various additional databases.
-    //  For now assume 92% will go for plot itself
-    let usable_space_for_plots = allocated_space * 92 / 100;
-
-    let plot_sizes =
-        std::iter::repeat(max_plot_size).take((usable_space_for_plots / max_plot_size) as usize);
-    if usable_space_for_plots / max_plot_size == 0
-        || usable_space_for_plots % max_plot_size > max_plot_size / 2
-    {
-        plot_sizes
-            .chain(std::iter::once(usable_space_for_plots % max_plot_size))
-            .collect::<Vec<_>>()
-    } else {
-        plot_sizes.collect()
-    }
-}
 
 /// Options for `MultiFarming` creation
 pub struct Options<C> {

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -1,4 +1,11 @@
-#![feature(try_blocks, hash_drain_filter, int_log, io_error_other, map_first_last)]
+#![feature(
+    hash_drain_filter,
+    int_log,
+    io_error_other,
+    map_first_last,
+    trait_alias,
+    try_blocks
+)]
 
 //! # `subspace-farmer` library implementation overview
 //!

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -36,6 +36,7 @@ pub(crate) mod plot;
 pub(crate) mod rpc_client;
 pub mod single_disk_farm;
 pub mod single_plot_farm;
+mod utils;
 pub mod ws_rpc_server;
 
 pub use archiving::{Archiving, ArchivingError};

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -132,7 +132,7 @@ impl fmt::Debug for Plot {
 impl Plot {
     /// Creates a new plot for persisting encoded pieces to disk
     pub fn open_or_create(
-        single_plot_farm_id: SinglePlotFarmId,
+        single_plot_farm_id: &SinglePlotFarmId,
         plot_directory: &Path,
         metadata_directory: &Path,
         public_key: PublicKey,
@@ -156,7 +156,7 @@ impl Plot {
 
     /// Creates a new plot from any kind of plot file
     pub fn with_plot_file<P>(
-        single_plot_farm_id: SinglePlotFarmId,
+        single_plot_farm_id: &SinglePlotFarmId,
         plot: P,
         metadata_directory: &Path,
         public_key: PublicKey,

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -29,7 +29,7 @@ async fn read_write() {
     let piece_index_start = 0;
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -50,7 +50,7 @@ async fn read_write() {
 
     // Make sure it is still not empty on reopen
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -66,7 +66,7 @@ async fn piece_retrievable() {
     let base_directory = TempDir::new().unwrap();
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
@@ -109,7 +109,7 @@ async fn partial_plot() {
     let public_key = random::<[u8; 32]>().into();
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -156,7 +156,7 @@ async fn sequential_pieces_iterator() {
     let public_key = random::<[u8; 32]>().into();
 
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -253,7 +253,7 @@ async fn test_read_sequential_pieces() {
         bytes
     };
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key_bytes.into(),

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1,5 +1,8 @@
 use crate::single_plot_farm::SinglePlotPieceGetter;
 use crate::ws_rpc_server::PieceGetter;
+use std::fmt;
+use std::sync::Arc;
+use std_semaphore::{Semaphore, SemaphoreGuard};
 use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
 
 /// Abstraction that can get pieces out of internal plots
@@ -28,5 +31,34 @@ impl PieceGetter for SingleDiskFarmPieceGetter {
             .find_map(|single_plot_piece_getter| {
                 single_plot_piece_getter.get_piece(piece_index, piece_index_hash)
             })
+    }
+}
+
+/// Semaphore that limits disk access concurrency in strategic places to the number specified during
+/// initialization
+#[derive(Clone)]
+pub struct SingleDiskSemaphore {
+    inner: Arc<Semaphore>,
+}
+
+impl fmt::Debug for SingleDiskSemaphore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SingleDiskSemaphore").finish()
+    }
+}
+
+impl SingleDiskSemaphore {
+    /// Create new semaphore for limiting concurrency of the major processes working with the same
+    /// disk
+    pub fn new(concurrency: u16) -> Self {
+        Self {
+            inner: Arc::new(Semaphore::new(concurrency as isize)),
+        }
+    }
+
+    /// Acquire access, will block current thread until previously acquired guards are dropped and
+    /// access is released
+    pub fn acquire(&self) -> SemaphoreGuard<'_> {
+        self.inner.access()
     }
 }

--- a/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
@@ -37,7 +37,6 @@ pub(super) async fn start_archiving(
     let (archived_segments_sync_sender, archived_segments_sync_receiver) =
         std::sync::mpsc::sync_channel::<(ArchivedSegment, oneshot::Sender<()>)>(5);
 
-    // TODO: This must be sequentialized across single disk plot
     let span = Span::current();
     // Piece encoding are CPU-intensive operations.
     thread::Builder::new()

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -4,6 +4,7 @@ use crate::mock_rpc_client::MockRpcClient;
 use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::rpc_client::RpcClient;
+use crate::single_disk_farm::SingleDiskSemaphore;
 use crate::single_plot_farm::SinglePlotPlotter;
 use crate::Archiving;
 use rand::prelude::*;
@@ -77,7 +78,12 @@ async fn plotting_happy_path() {
 
     let subspace_codec = SubspaceCodec::new_with_gpu(identity.public_key().as_ref());
 
-    let single_plot_plotter = SinglePlotPlotter::new(subspace_codec, plot.clone(), commitments);
+    let single_plot_plotter = SinglePlotPlotter::new(
+        subspace_codec,
+        plot.clone(),
+        commitments,
+        SingleDiskSemaphore::new(1),
+    );
 
     // Start archiving task
     let archiving_instance = Archiving::start(
@@ -178,8 +184,12 @@ async fn plotting_piece_eviction() {
 
     let subspace_codec = SubspaceCodec::new_with_gpu(identity.public_key().as_ref());
 
-    let single_plot_plotter =
-        SinglePlotPlotter::new(subspace_codec.clone(), plot.clone(), commitments.clone());
+    let single_plot_plotter = SinglePlotPlotter::new(
+        subspace_codec.clone(),
+        plot.clone(),
+        commitments.clone(),
+        SingleDiskSemaphore::new(1),
+    );
 
     // Start archiving task
     let archiving_instance = Archiving::start(

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -36,7 +36,7 @@ async fn plotting_happy_path() {
 
     let public_key = identity.public_key().to_bytes().into();
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
@@ -125,7 +125,7 @@ async fn plotting_piece_eviction() {
     let public_key = identity.public_key().to_bytes().into();
     let salt = Salt::default();
     let plot = Plot::open_or_create(
-        0usize.into(),
+        &0usize.into(),
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -26,3 +26,23 @@ impl<T> AbortingJoinHandle<T> {
         Self(handle)
     }
 }
+
+pub(crate) fn get_plot_sizes(allocated_space: u64, max_plot_size: u64) -> Vec<u64> {
+    // TODO: we need to remember plot size in order to prune unused plots in future if plot size is
+    //  less than it was specified before.
+    // TODO: Piece count should account for database overhead of various additional databases.
+    //  For now assume 92% will go for plot itself
+    let usable_space_for_plots = allocated_space * 92 / 100;
+
+    let plot_sizes =
+        std::iter::repeat(max_plot_size).take((usable_space_for_plots / max_plot_size) as usize);
+    if usable_space_for_plots / max_plot_size == 0
+        || usable_space_for_plots % max_plot_size > max_plot_size / 2
+    {
+        plot_sizes
+            .chain(std::iter::once(usable_space_for_plots % max_plot_size))
+            .collect::<Vec<_>>()
+    } else {
+        plot_sizes.collect()
+    }
+}

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -1,0 +1,28 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::task::{JoinError, JoinHandle};
+
+/// Abort Tokio task on drop
+#[derive(Debug)]
+pub(crate) struct AbortingJoinHandle<T>(JoinHandle<T>);
+
+impl<T> Drop for AbortingJoinHandle<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl<T> Future for AbortingJoinHandle<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+impl<T> AbortingJoinHandle<T> {
+    pub(crate) fn new(handle: JoinHandle<T>) -> Self {
+        Self(handle)
+    }
+}

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -150,7 +150,7 @@ pub trait Rpc {
 /// let identity = Identity::open_or_create(&base_directory)?;
 /// let public_key = identity.public_key().to_bytes().into();
 /// let plot = Plot::open_or_create(
-///     0usize.into(),
+///     &0usize.into(),
 ///     &base_directory,
 ///     &base_directory,
 ///     public_key,


### PR DESCRIPTION
Probably last PR with preparations for `SingleDiskPlot`.

There are a few abstractions crated, concurrency limiting is already in place, logs have spans used more consistently, so it is clear which plot is recommitting for instance and which plot has solved successfully.

Reviewing separate commits will make most sense as usual.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
