### PR TITLE
Multi plots farm (part 9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7890,6 +7890,7 @@ dependencies = [
 name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "hmac 0.12.1",
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,14 +2612,7 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-buffer-serde"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f52012c160668b4494727f3588045aa00429849fcae51de70d68fa98228039"
 dependencies = [
- "hex",
  "serde",
 ]
 
@@ -7924,7 +7917,6 @@ dependencies = [
  "fdlimit",
  "futures 0.3.21",
  "hex",
- "hex-buffer-serde",
  "jsonrpsee",
  "lru",
  "num-traits",
@@ -8051,7 +8043,7 @@ dependencies = [
 name = "subspace-rpc-primitives"
 version = "0.1.0"
 dependencies = [
- "hex-buffer-serde",
+ "hex",
  "serde",
  "subspace-core-primitives",
 ]

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -48,7 +48,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::Solution;
+use subspace_core_primitives::{Solution, PIECE_SIZE};
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -205,7 +205,8 @@ where
                 record_size: runtime_api.record_size(&best_block_id)?,
                 recorded_history_segment_size: runtime_api
                     .recorded_history_segment_size(&best_block_id)?,
-                max_plot_size: runtime_api.max_plot_size(&best_block_id)?,
+                // TODO: `max_plot_size` in the protocol must change to bytes as well
+                max_plot_size: runtime_api.max_plot_size(&best_block_id)? * PIECE_SIZE as u64,
                 total_pieces: runtime_api.total_pieces(&best_block_id)?,
             }
         };

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -50,7 +50,7 @@ use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::Solution;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 const SOLUTION_TIMEOUT: Duration = Duration::from_secs(2);
@@ -60,8 +60,8 @@ const REWARD_SIGNING_TIMEOUT: Duration = Duration::from_millis(500);
 #[rpc(client, server)]
 pub trait SubspaceRpcApi {
     /// Ger metadata necessary for farmer operation
-    #[method(name = "subspace_getFarmerMetadata")]
-    fn get_farmer_metadata(&self) -> RpcResult<FarmerMetadata>;
+    #[method(name = "subspace_getFarmerProtocolInfo")]
+    fn get_farmer_protocol_info(&self) -> RpcResult<FarmerProtocolInfo>;
 
     #[method(name = "subspace_submitSolutionResponse")]
     fn submit_solution_response(&self, solution_response: SolutionResponse) -> RpcResult<()>;
@@ -184,7 +184,7 @@ where
         + 'static,
     Client::Api: SubspaceRuntimeApi<Block, FarmerPublicKey>,
 {
-    fn get_farmer_metadata(&self) -> RpcResult<FarmerMetadata> {
+    fn get_farmer_protocol_info(&self) -> RpcResult<FarmerProtocolInfo> {
         let best_block_id = BlockId::Hash(self.client.info().best_hash);
         let runtime_api = self.client.runtime_api();
 
@@ -199,8 +199,8 @@ where
                 JsonRpseeError::Custom("Internal error".to_string())
             })?;
 
-        let farmer_metadata: Result<FarmerMetadata, ApiError> = try {
-            FarmerMetadata {
+        let farmer_protocol_info: Result<FarmerProtocolInfo, ApiError> = try {
+            FarmerProtocolInfo {
                 genesis_hash,
                 record_size: runtime_api.record_size(&best_block_id)?,
                 recorded_history_segment_size: runtime_api
@@ -210,7 +210,7 @@ where
             }
         };
 
-        farmer_metadata.map_err(|error| {
+        farmer_protocol_info.map_err(|error| {
             error!("Failed to get data from runtime API: {}", error);
             JsonRpseeError::Custom("Internal error".to_string())
         })

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -188,8 +188,20 @@ where
         let best_block_id = BlockId::Hash(self.client.info().best_hash);
         let runtime_api = self.client.runtime_api();
 
+        let genesis_hash = self
+            .client
+            .info()
+            .genesis_hash
+            .as_ref()
+            .try_into()
+            .map_err(|error| {
+                error!("Failed to convert genesis hash: {error}");
+                JsonRpseeError::Custom("Internal error".to_string())
+            })?;
+
         let farmer_metadata: Result<FarmerMetadata, ApiError> = try {
             FarmerMetadata {
+                genesis_hash,
                 record_size: runtime_api.record_size(&best_block_id)?,
                 recorded_history_segment_size: runtime_api
                     .recorded_history_segment_size(&best_block_id)?,

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+hex = { version  = "0.4.3", default-features = false }
 hmac = { version  = "0.12.1", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.1.2", default-features = false, features = ["derive"] }
@@ -34,6 +35,8 @@ version = "0.10.2"
 [features]
 default = ["std"]
 std = [
+    "hex/serde",
+    "hex/std",
     "hmac/std",
     "num-traits/std",
     "parity-scale-codec/std",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -85,7 +85,9 @@ const VRF_PROOF_LENGTH: usize = 64;
     Debug, Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct PublicKey([u8; PUBLIC_KEY_LENGTH]);
+pub struct PublicKey(
+    #[cfg_attr(feature = "std", serde(with = "hex::serde"))] [u8; PUBLIC_KEY_LENGTH],
+);
 
 impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
     fn from(bytes: [u8; PUBLIC_KEY_LENGTH]) -> Self {

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -24,8 +24,7 @@ dirs = "4.0.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2"
 futures = "0.3.21"
-hex = "0.4.3"
-hex-buffer-serde = "0.3.0"
+hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.14.0", features = ["client", "macros", "server"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -40,7 +40,7 @@ impl Archiving {
     /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
     pub async fn start<Client, OPTP>(
         farmer_protocol_info: FarmerProtocolInfo,
-        object_mappings: ObjectMappings,
+        object_mappings: Vec<ObjectMappings>,
         client: Client,
         mut on_pieces_to_plot: OPTP,
     ) -> Result<Archiving, ArchivingError>
@@ -92,8 +92,10 @@ impl Archiving {
                     let object_mapping =
                         create_global_object_mapping(piece_index_offset, object_mapping);
 
-                    if let Err(error) = object_mappings.store(&object_mapping) {
-                        error!(%error, "Failed to store object mappings for pieces");
+                    for object_mappings in &object_mappings {
+                        if let Err(error) = object_mappings.store(&object_mapping) {
+                            error!(%error, "Failed to store object mappings for pieces");
+                        }
                     }
 
                     info!(segment_index, "Plotted segment");

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -6,7 +6,7 @@ use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::objects::{GlobalObject, PieceObject, PieceObjectMapping};
 use subspace_core_primitives::Sha256Hash;
 use subspace_networking::PiecesToPlot;
-use subspace_rpc_primitives::FarmerMetadata;
+use subspace_rpc_primitives::FarmerProtocolInfo;
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info};
@@ -39,7 +39,7 @@ impl Archiving {
     //  don't want eventually
     /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
     pub async fn start<Client, OPTP>(
-        farmer_metadata: FarmerMetadata,
+        farmer_protocol_info: FarmerProtocolInfo,
         object_mappings: ObjectMappings,
         client: Client,
         mut on_pieces_to_plot: OPTP,
@@ -48,11 +48,11 @@ impl Archiving {
         Client: RpcClient + Clone + Send + Sync + 'static,
         OPTP: FnMut(PiecesToPlot) -> bool + Send + 'static,
     {
-        let FarmerMetadata {
+        let FarmerProtocolInfo {
             record_size,
             recorded_history_segment_size,
             ..
-        } = farmer_metadata;
+        } = farmer_protocol_info;
 
         // TODO: This assumes fixed size segments, which might not be the case
         let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -29,6 +29,7 @@ pub struct Inner {
 
 /// Default farmer metadata for benchmarking
 pub const BENCH_FARMER_METADATA: FarmerMetadata = FarmerMetadata {
+    genesis_hash: [0; 32],
     record_size: 3840,                     // PIECE_SIZE - WITNESS_SIZE
     recorded_history_segment_size: 491520, // RECORD_SIZE * MERKLE_NUM_LEAVES / 2
     max_plot_size: 100 * 1024 * 1024 * 1024 / PIECE_SIZE as u64, // 100G

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -6,7 +6,6 @@ use futures::{stream, SinkExt, Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::PIECE_SIZE;
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -30,9 +29,9 @@ pub struct Inner {
 /// Default farmer metadata for benchmarking
 pub const BENCH_FARMER_METADATA: FarmerProtocolInfo = FarmerProtocolInfo {
     genesis_hash: [0; 32],
-    record_size: 3840,                     // PIECE_SIZE - WITNESS_SIZE
-    recorded_history_segment_size: 491520, // RECORD_SIZE * MERKLE_NUM_LEAVES / 2
-    max_plot_size: 100 * 1024 * 1024 * 1024 / PIECE_SIZE as u64, // 100G
+    record_size: 3840,                       // PIECE_SIZE - WITNESS_SIZE
+    recorded_history_segment_size: 491520,   // RECORD_SIZE * MERKLE_NUM_LEAVES / 2
+    max_plot_size: 100 * 1024 * 1024 * 1024, // 100G
     // Doesn't matter, as we don't start sync
     total_pieces: 0,
 };

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -27,7 +27,7 @@ pub struct Inner {
 }
 
 /// Default farmer metadata for benchmarking
-pub const BENCH_FARMER_METADATA: FarmerProtocolInfo = FarmerProtocolInfo {
+pub const BENCH_FARMER_PROTOCOL_INFO: FarmerProtocolInfo = FarmerProtocolInfo {
     genesis_hash: [0; 32],
     record_size: 3840,                       // PIECE_SIZE - WITNESS_SIZE
     recorded_history_segment_size: 491520,   // RECORD_SIZE * MERKLE_NUM_LEAVES / 2

--- a/crates/subspace-farmer/src/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/bench_rpc_client.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::PIECE_SIZE;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 use tokio::sync::Mutex;
 
@@ -20,7 +20,7 @@ pub struct BenchRpcClient {
 
 #[derive(Debug)]
 pub struct Inner {
-    metadata: FarmerMetadata,
+    metadata: FarmerProtocolInfo,
     slot_info_receiver: Arc<Mutex<mpsc::Receiver<SlotInfo>>>,
     acknowledge_archived_segment_sender: mpsc::Sender<u64>,
     archived_segments_receiver: Arc<Mutex<mpsc::Receiver<ArchivedSegment>>>,
@@ -28,7 +28,7 @@ pub struct Inner {
 }
 
 /// Default farmer metadata for benchmarking
-pub const BENCH_FARMER_METADATA: FarmerMetadata = FarmerMetadata {
+pub const BENCH_FARMER_METADATA: FarmerProtocolInfo = FarmerProtocolInfo {
     genesis_hash: [0; 32],
     record_size: 3840,                     // PIECE_SIZE - WITNESS_SIZE
     recorded_history_segment_size: 491520, // RECORD_SIZE * MERKLE_NUM_LEAVES / 2
@@ -40,7 +40,7 @@ pub const BENCH_FARMER_METADATA: FarmerMetadata = FarmerMetadata {
 impl BenchRpcClient {
     /// Create a new instance of [`BenchRpcClient`].
     pub fn new(
-        metadata: FarmerMetadata,
+        metadata: FarmerProtocolInfo,
         slot_info_receiver: mpsc::Receiver<SlotInfo>,
         mut archived_segments_receiver: mpsc::Receiver<ArchivedSegment>,
         acknowledge_archived_segment_sender: mpsc::Sender<u64>,
@@ -72,7 +72,7 @@ impl BenchRpcClient {
 
 #[async_trait]
 impl RpcClient for BenchRpcClient {
-    async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error> {
+    async fn farmer_protocol_info(&self) -> Result<FarmerProtocolInfo, Error> {
         Ok(self.inner.metadata)
     }
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -128,13 +128,13 @@ pub(crate) async fn bench(
 
     let base_directory = TempDir::new_in(base_directory)?;
 
-    let metadata = client
-        .farmer_metadata()
+    let farmer_protocol_info = client
+        .farmer_protocol_info()
         .await
         .map_err(|error| anyhow!(error))?;
 
     // TODO: `max_plot_size` in the protocol must change to bytes as well
-    let consensus_max_plot_size = metadata.max_plot_size * PIECE_SIZE as u64;
+    let consensus_max_plot_size = farmer_protocol_info.max_plot_size * PIECE_SIZE as u64;
     let max_plot_size = match max_plot_size {
         Some(max_plot_size) if max_plot_size > consensus_max_plot_size => {
             tracing::warn!(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -133,8 +133,7 @@ pub(crate) async fn bench(
         .await
         .map_err(|error| anyhow!(error))?;
 
-    // TODO: `max_plot_size` in the protocol must change to bytes as well
-    let consensus_max_plot_size = farmer_protocol_info.max_plot_size * PIECE_SIZE as u64;
+    let consensus_max_plot_size = farmer_protocol_info.max_plot_size;
     let max_plot_size = match max_plot_size {
         Some(max_plot_size) if max_plot_size > consensus_max_plot_size => {
             tracing::warn!(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use jsonrpsee::ws_server::WsServerBuilder;
 use std::path::PathBuf;
 use std::sync::Arc;
-use subspace_core_primitives::PIECE_SIZE;
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
 };
@@ -48,8 +47,7 @@ pub(crate) async fn farm(
         .await
         .map_err(|error| anyhow!(error))?;
 
-    // TODO: `max_plot_size` in the protocol must change to bytes as well
-    let consensus_max_plot_size = farmer_protocol_info.max_plot_size * PIECE_SIZE as u64;
+    let consensus_max_plot_size = farmer_protocol_info.max_plot_size;
     let max_plot_size = match max_plot_size {
         Some(max_plot_size) if max_plot_size > consensus_max_plot_size => {
             warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -42,7 +42,7 @@ pub struct LegacyMultiPlotsFarm {
 }
 
 impl LegacyMultiPlotsFarm {
-    /// Starts multiple farmers with any plot sizes which user gives
+    /// Creates multiple single plot farms with user-provided total plot size
     pub async fn new<RC, PF>(
         options: Options<RC>,
         allocated_space: u64,
@@ -69,8 +69,8 @@ impl LegacyMultiPlotsFarm {
 
         let first_listen_on: Arc<Mutex<Option<Vec<Multiaddr>>>> = Arc::default();
 
-        let farmer_metadata = farming_client
-            .farmer_metadata()
+        let farmer_protocol_info = farming_client
+            .farmer_protocol_info()
             .await
             .map_err(|error| anyhow!(error))?;
 
@@ -101,7 +101,7 @@ impl LegacyMultiPlotsFarm {
                         metadata_directory,
                         plot_index,
                         max_piece_count,
-                        farmer_metadata,
+                        farmer_protocol_info,
                         farming_client,
                         plot_factory: &plot_factory,
                         listen_on,
@@ -122,7 +122,7 @@ impl LegacyMultiPlotsFarm {
         // Start archiving task
         let archiving = if !enable_dsn_archiving {
             let archiving_start_fut =
-                Archiving::start(farmer_metadata, object_mappings, archiving_client, {
+                Archiving::start(farmer_protocol_info, object_mappings, archiving_client, {
                     let plotters = single_plot_farms
                         .iter()
                         .map(|single_plot_farm| single_plot_farm.plotter())

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -122,7 +122,11 @@ impl LegacyMultiPlotsFarm {
         let archiving = if !enable_dsn_archiving {
             let archiving_start_fut = Archiving::start(
                 farmer_protocol_info,
-                vec![object_mappings],
+                single_plot_farms
+                    .iter()
+                    .map(|single_plot_farm| single_plot_farm.object_mappings().clone())
+                    .chain([object_mappings])
+                    .collect(),
                 archiving_client,
                 {
                     let plotters = single_plot_farms

--- a/crates/subspace-farmer/src/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_rpc_client.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// `WsClient` wrapper.
@@ -28,10 +28,10 @@ impl NodeRpcClient {
 
 #[async_trait]
 impl RpcClient for NodeRpcClient {
-    async fn farmer_metadata(&self) -> Result<FarmerMetadata, RpcError> {
+    async fn farmer_protocol_info(&self) -> Result<FarmerProtocolInfo, RpcError> {
         Ok(self
             .client
-            .request("subspace_getFarmerMetadata", rpc_params![])
+            .request("subspace_getFarmerProtocolInfo", rpc_params![])
             .await?)
     }
 

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use std::pin::Pin;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_rpc_primitives::{
-    FarmerMetadata, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// To become error type agnostic
@@ -13,7 +13,7 @@ pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[async_trait]
 pub trait RpcClient: Clone + Send + Sync + 'static {
     /// Get farmer metadata
-    async fn farmer_metadata(&self) -> Result<FarmerMetadata, Error>;
+    async fn farmer_protocol_info(&self) -> Result<FarmerProtocolInfo, Error>;
 
     /// Subscribe to slot
     async fn subscribe_slot_info(

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1,9 +1,13 @@
-use crate::single_plot_farm::SinglePlotPieceGetter;
+use crate::single_plot_farm::{SinglePlotFarmId, SinglePlotPieceGetter};
 use crate::ws_rpc_server::PieceGetter;
-use std::fmt;
+use derive_more::From;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::sync::Arc;
+use std::{fmt, fs, io};
 use std_semaphore::{Semaphore, SemaphoreGuard};
 use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
+use ulid::Ulid;
 
 /// Abstraction that can get pieces out of internal plots
 #[derive(Debug, Clone)]
@@ -60,5 +64,68 @@ impl SingleDiskSemaphore {
     /// access is released
     pub fn acquire(&self) -> SemaphoreGuard<'_> {
         self.inner.access()
+    }
+}
+
+/// An identifier for single plot farm, can be used for in logs, thread names, etc.
+#[derive(
+    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, From,
+)]
+pub struct SingleDiskFarmId(Ulid);
+
+impl fmt::Display for SingleDiskFarmId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Metadata for `SingleDiskFarm`, stores important information about the contents of the farm
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SingleDiskFarmMetadata {
+    /// V0 of the metadata
+    #[serde(rename_all = "camelCase")]
+    V0 {
+        /// ID of the farm
+        id: SingleDiskFarmId,
+        /// Genesis hash of the chain used for farm creation
+        #[serde(with = "hex::serde")]
+        genesis_hash: [u8; 32],
+        /// Allocated space in bytes used during latest start
+        allocated_space: u64,
+        /// IDs of single plot farms contained within
+        single_plot_farms: Vec<SinglePlotFarmId>,
+    },
+}
+
+impl SingleDiskFarmMetadata {
+    const FILE_NAME: &'static str = "single_disk_farm.json";
+
+    /// Load `SingleDiskFarm` metadata from path where metadata is supposed to be stored, `None`
+    /// means no metadata was found, happens during first start.
+    pub fn load_from(metadata_path: &Path) -> io::Result<Option<Self>> {
+        let bytes = match fs::read(metadata_path.join(Self::FILE_NAME)) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return if error.kind() == io::ErrorKind::NotFound {
+                    Ok(None)
+                } else {
+                    Err(error)
+                };
+            }
+        };
+
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    /// Store `SingleDiskFarm` metadata to path where metadata is supposed to be stored so it can be
+    /// loaded again upon restart.
+    pub fn store_to(&self, metadata_path: &Path) -> io::Result<()> {
+        fs::write(
+            metadata_path.join(Self::FILE_NAME),
+            serde_json::to_vec(self).expect("Metadata serialization never fails; qed"),
+        )
     }
 }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1,12 +1,27 @@
-use crate::single_plot_farm::{SinglePlotFarmId, SinglePlotPieceGetter};
+use crate::archiving::Archiving;
+use crate::rpc_client::RpcClient;
+use crate::single_plot_farm::{
+    PlotFactory, SinglePlotFarm, SinglePlotFarmId, SinglePlotFarmOptions, SinglePlotPieceGetter,
+};
+use crate::utils::get_plot_sizes;
 use crate::ws_rpc_server::PieceGetter;
+use anyhow::anyhow;
 use derive_more::From;
+use futures::future::{select, Either};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use parking_lot::Mutex;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs, io};
 use std_semaphore::{Semaphore, SemaphoreGuard};
-use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
+use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash, PublicKey, PIECE_SIZE};
+use subspace_networking::libp2p::Multiaddr;
+use subspace_rpc_primitives::FarmerProtocolInfo;
+use tokio::runtime::Handle;
+use tracing::error;
 use ulid::Ulid;
 
 /// Abstraction that can get pieces out of internal plots
@@ -79,6 +94,14 @@ impl fmt::Display for SingleDiskFarmId {
     }
 }
 
+#[allow(clippy::new_without_default)]
+impl SingleDiskFarmId {
+    /// Creates new ID
+    pub fn new() -> Self {
+        Self(Ulid::new())
+    }
+}
+
 /// Metadata for `SingleDiskFarm`, stores important information about the contents of the farm
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -91,8 +114,8 @@ pub enum SingleDiskFarmMetadata {
         /// Genesis hash of the chain used for farm creation
         #[serde(with = "hex::serde")]
         genesis_hash: [u8; 32],
-        /// Allocated space in bytes used during latest start
-        allocated_space: u64,
+        /// How much space in bytes can farm use for plots (metadata space is not included)
+        usable_plotting_space: u64,
         /// IDs of single plot farms contained within
         single_plot_farms: Vec<SinglePlotFarmId>,
     },
@@ -101,10 +124,23 @@ pub enum SingleDiskFarmMetadata {
 impl SingleDiskFarmMetadata {
     const FILE_NAME: &'static str = "single_disk_farm.json";
 
+    pub fn new(
+        genesis_hash: [u8; 32],
+        usable_plotting_space: u64,
+        single_plot_farms: Vec<SinglePlotFarmId>,
+    ) -> Self {
+        Self::V0 {
+            id: SingleDiskFarmId::new(),
+            genesis_hash,
+            usable_plotting_space,
+            single_plot_farms,
+        }
+    }
+
     /// Load `SingleDiskFarm` metadata from path where metadata is supposed to be stored, `None`
     /// means no metadata was found, happens during first start.
-    pub fn load_from(metadata_path: &Path) -> io::Result<Option<Self>> {
-        let bytes = match fs::read(metadata_path.join(Self::FILE_NAME)) {
+    pub fn load_from(metadata_directory: &Path) -> io::Result<Option<Self>> {
+        let bytes = match fs::read(metadata_directory.join(Self::FILE_NAME)) {
             Ok(bytes) => bytes,
             Err(error) => {
                 return if error.kind() == io::ErrorKind::NotFound {
@@ -122,10 +158,291 @@ impl SingleDiskFarmMetadata {
 
     /// Store `SingleDiskFarm` metadata to path where metadata is supposed to be stored so it can be
     /// loaded again upon restart.
-    pub fn store_to(&self, metadata_path: &Path) -> io::Result<()> {
+    pub fn store_to(&self, metadata_directory: &Path) -> io::Result<()> {
         fs::write(
-            metadata_path.join(Self::FILE_NAME),
+            metadata_directory.join(Self::FILE_NAME),
             serde_json::to_vec(self).expect("Metadata serialization never fails; qed"),
         )
+    }
+
+    // ID of the farm
+    pub fn id(&self) -> &SingleDiskFarmId {
+        let Self::V0 { id, .. } = self;
+        id
+    }
+
+    // Genesis hash of the chain used for farm creation
+    pub fn genesis_hash(&self) -> &[u8; 32] {
+        let Self::V0 { genesis_hash, .. } = self;
+        genesis_hash
+    }
+
+    // How much space in bytes can farm use for plots (metadata space is not included)
+    pub fn usable_plotting_space(&self) -> u64 {
+        let Self::V0 {
+            usable_plotting_space,
+            ..
+        } = self;
+        *usable_plotting_space
+    }
+
+    // IDs of single plot farms contained within
+    pub fn single_plot_farms(&self) -> &[SinglePlotFarmId] {
+        let Self::V0 {
+            single_plot_farms, ..
+        } = self;
+        single_plot_farms
+    }
+}
+
+/// Options for `SingleDiskFarm` creation
+pub struct SingleDiskFarmOptions<RC, PF> {
+    /// Path to directory where plots are stored, typically HDD.
+    pub plot_directory: PathBuf,
+    /// Path to directory for storing metadata, typically SSD.
+    pub metadata_directory: PathBuf,
+    /// How much space in bytes can farm use for plots (metadata space is not included)
+    pub usable_plotting_space: u64,
+    pub farmer_protocol_info: FarmerProtocolInfo,
+    /// Client used for archiving subscriptions
+    pub archiving_client: RC,
+    /// Independent client used for farming, such that it is not blocked by archiving
+    pub farming_client: RC,
+    /// Factory that'll create/open plot using given options
+    pub plot_factory: PF,
+    pub reward_address: PublicKey,
+    pub bootstrap_nodes: Vec<Multiaddr>,
+    pub listen_on: Vec<Multiaddr>,
+    /// Enable DSN subscription for archiving segments.
+    pub enable_dsn_archiving: bool,
+    pub enable_dsn_sync: bool,
+    pub enable_farming: bool,
+}
+
+/// Abstraction on top of `SinglePlotFarm` instances contained within the same physical disk (or
+/// what appears to be one disk).
+///
+/// It primarily constraints some of the disk access concurrency to achieve higher performance by
+/// avoiding unnecessary random disk access and preferring sequential reads/writes whenever possible
+/// instead of doing a large amount of random I/O that is bad for HDDs (intended storage medium for
+/// plots).
+pub struct SingleDiskFarm {
+    single_plot_farms: Vec<SinglePlotFarm>,
+    archiving: Option<Archiving>,
+}
+
+impl SingleDiskFarm {
+    /// Creates single disk farm with user-provided total plot size
+    pub async fn new<RC, PF>(options: SingleDiskFarmOptions<RC, PF>) -> anyhow::Result<Self>
+    where
+        RC: RpcClient,
+        PF: PlotFactory,
+    {
+        let SingleDiskFarmOptions {
+            plot_directory,
+            metadata_directory,
+            usable_plotting_space,
+            farmer_protocol_info,
+            plot_factory,
+            archiving_client,
+            farming_client,
+            reward_address,
+            bootstrap_nodes,
+            listen_on,
+            enable_dsn_archiving,
+            enable_dsn_sync,
+            enable_farming,
+        } = options;
+
+        let plot_sizes = get_plot_sizes(usable_plotting_space, farmer_protocol_info.max_plot_size);
+
+        let single_disk_farm_metadata =
+            match SingleDiskFarmMetadata::load_from(&metadata_directory)? {
+                Some(single_disk_farm_metadata) => {
+                    if usable_plotting_space != single_disk_farm_metadata.usable_plotting_space() {
+                        error!(
+                            id = %single_disk_farm_metadata.id(),
+                            plot_directory = %plot_directory.display(),
+                            metadata_directory = %metadata_directory.display(),
+                            "Usable plotting space {} is different from {} when farm was created, \
+                            resizing isn't supported yet",
+                            usable_plotting_space,
+                            single_disk_farm_metadata.usable_plotting_space(),
+                        );
+
+                        return Err(anyhow!("Can't resize farm after creation"));
+                    }
+
+                    if &farmer_protocol_info.genesis_hash
+                        != single_disk_farm_metadata.genesis_hash()
+                    {
+                        error!(
+                            id = %single_disk_farm_metadata.id(),
+                            "Genesis hash {} is different from {} when farm was created, is is not \
+                            possible to use farm on a different chain",
+                            hex::encode(farmer_protocol_info.genesis_hash),
+                            hex::encode(single_disk_farm_metadata.genesis_hash()),
+                        );
+
+                        return Err(anyhow!("Wrong chain (genesis hash)"));
+                    }
+                    single_disk_farm_metadata
+                }
+                None => {
+                    let single_disk_farm_metadata = SingleDiskFarmMetadata::new(
+                        farmer_protocol_info.genesis_hash,
+                        usable_plotting_space,
+                        plot_sizes
+                            .iter()
+                            .map(|_plot_size| SinglePlotFarmId::new())
+                            .collect(),
+                    );
+
+                    single_disk_farm_metadata.store_to(&metadata_directory)?;
+
+                    single_disk_farm_metadata
+                }
+            };
+
+        let first_listen_on: Arc<Mutex<Option<Vec<Multiaddr>>>> = Arc::default();
+
+        // Somewhat arbitrary number (we don't know if this is RAID or anything), but at least not
+        // unbounded.
+        let single_disk_semaphore = SingleDiskSemaphore::new(16);
+
+        let single_plot_farms = tokio::task::spawn_blocking(move || {
+            let handle = Handle::current();
+            single_disk_farm_metadata
+                .single_plot_farms()
+                .into_par_iter()
+                .zip(
+                    plot_sizes
+                        .par_iter()
+                        .map(|&plot_size| plot_size / PIECE_SIZE as u64),
+                )
+                .enumerate()
+                .map(
+                    move |(plot_index, (single_farm_plot_id, max_piece_count))| {
+                        let _guard = handle.enter();
+
+                        let plot_directory = plot_directory.join(single_farm_plot_id.to_string());
+                        let metadata_directory =
+                            metadata_directory.join(single_farm_plot_id.to_string());
+                        let farming_client = farming_client.clone();
+                        let listen_on = listen_on.clone();
+                        let bootstrap_nodes = bootstrap_nodes.clone();
+                        let first_listen_on = Arc::clone(&first_listen_on);
+                        let single_disk_semaphore = single_disk_semaphore.clone();
+
+                        SinglePlotFarm::new(SinglePlotFarmOptions {
+                            id: *single_farm_plot_id,
+                            plot_directory,
+                            metadata_directory,
+                            plot_index,
+                            max_piece_count,
+                            farmer_protocol_info,
+                            farming_client,
+                            plot_factory: &plot_factory,
+                            listen_on,
+                            bootstrap_nodes,
+                            first_listen_on,
+                            single_disk_semaphore,
+                            enable_farming,
+                            reward_address,
+                            enable_dsn_archiving,
+                            enable_dsn_sync,
+                        })
+                    },
+                )
+                .collect::<anyhow::Result<Vec<_>>>()
+        })
+        .await
+        .expect("Not supposed to panic, crash if it does")?;
+
+        // Start archiving task
+        let archiving = if !enable_dsn_archiving {
+            let archiving_start_fut = Archiving::start(
+                farmer_protocol_info,
+                single_plot_farms
+                    .iter()
+                    .map(|single_plot_farm| single_plot_farm.object_mappings().clone())
+                    .collect(),
+                archiving_client,
+                {
+                    let plotters = single_plot_farms
+                        .iter()
+                        .map(|single_plot_farm| single_plot_farm.plotter())
+                        .collect::<Vec<_>>();
+
+                    move |pieces_to_plot| {
+                        if let Some(Err(error)) = plotters
+                            .par_iter()
+                            .map(|plotter| plotter.plot_pieces(pieces_to_plot.clone()))
+                            .find_first(|result| result.is_err())
+                        {
+                            error!(%error, "Failed to plot pieces");
+                            false
+                        } else {
+                            true
+                        }
+                    }
+                },
+            );
+
+            Some(archiving_start_fut.await?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            single_plot_farms,
+            archiving,
+        })
+    }
+
+    pub fn single_plot_farms(&self) -> &'_ [SinglePlotFarm] {
+        &self.single_plot_farms
+    }
+
+    pub fn piece_getter(&self) -> SingleDiskFarmPieceGetter {
+        SingleDiskFarmPieceGetter::new(
+            self.single_plot_farms
+                .iter()
+                .map(|single_plot_farm| single_plot_farm.piece_getter())
+                .collect(),
+        )
+    }
+
+    /// Waits for farming and plotting completion (or errors)
+    pub async fn wait(self) -> anyhow::Result<()> {
+        let mut single_plot_farms = self
+            .single_plot_farms
+            .into_iter()
+            .map(|mut single_plot_farm| async move { single_plot_farm.run().await })
+            .collect::<FuturesUnordered<_>>();
+
+        if let Some(archiving) = self.archiving {
+            let fut = select(
+                Box::pin(archiving.wait()),
+                Box::pin(async move {
+                    while let Some(result) = single_plot_farms.next().await {
+                        result?;
+                    }
+
+                    anyhow::Ok(())
+                }),
+            );
+
+            match fut.await {
+                Either::Left((result, _)) => result?,
+                Either::Right((result, _)) => result?,
+            }
+        } else {
+            while let Some(result) = single_plot_farms.next().await {
+                result?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -6,7 +6,7 @@ use crate::single_plot_farm::{
 use crate::utils::get_plot_sizes;
 use crate::ws_rpc_server::PieceGetter;
 use anyhow::anyhow;
-use derive_more::From;
+use derive_more::{Display, From};
 use futures::future::{select, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
@@ -84,15 +84,9 @@ impl SingleDiskSemaphore {
 
 /// An identifier for single plot farm, can be used for in logs, thread names, etc.
 #[derive(
-    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, From,
+    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Display, From,
 )]
 pub struct SingleDiskFarmId(Ulid);
-
-impl fmt::Display for SingleDiskFarmId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 #[allow(clippy::new_without_default)]
 impl SingleDiskFarmId {

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -18,7 +18,6 @@ use futures::future::try_join;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Formatter;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -53,7 +52,7 @@ pub enum SinglePlotFarmId {
 }
 
 impl fmt::Display for SinglePlotFarmId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SinglePlotFarmId::Index(id) => id.fmt(f),
             SinglePlotFarmId::Ulid(id) => id.fmt(f),

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -60,6 +60,14 @@ impl fmt::Display for SinglePlotFarmId {
     }
 }
 
+#[allow(clippy::new_without_default)]
+impl SinglePlotFarmId {
+    /// Creates new ID
+    pub fn new() -> Self {
+        Self::Ulid(Ulid::new())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SinglePlotPieceGetter {
     codec: SubspaceCodec,
@@ -206,6 +214,7 @@ pub struct SinglePlotFarm {
     codec: SubspaceCodec,
     plot: Plot,
     commitments: Commitments,
+    object_mappings: ObjectMappings,
     farming: Option<Farming>,
     node: Node,
     node_runner: NodeRunner,
@@ -406,6 +415,7 @@ impl SinglePlotFarm {
             codec,
             plot,
             commitments,
+            object_mappings,
             farming,
             node: node.clone(),
             node_runner,
@@ -420,7 +430,7 @@ impl SinglePlotFarm {
                 id,
                 farmer_protocol_info.record_size,
                 farmer_protocol_info.recorded_history_segment_size,
-                object_mappings,
+                farm.object_mappings().clone(),
                 node,
                 farm.plotter(),
             );
@@ -483,6 +493,11 @@ impl SinglePlotFarm {
     /// Access commitments instance of the farm
     pub fn commitments(&self) -> &Commitments {
         &self.commitments
+    }
+
+    /// Access object mappings instance of the farm
+    pub fn object_mappings(&self) -> &ObjectMappings {
+        &self.object_mappings
     }
 
     /// Access network node instance of the farm

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -29,7 +29,7 @@ use subspace_networking::multimess::MultihashCode;
 use subspace_networking::{
     libp2p, Config, Node, NodeRunner, PiecesByRangeRequest, PiecesByRangeResponse, PiecesToPlot,
 };
-use subspace_rpc_primitives::FarmerMetadata;
+use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
 use thiserror::Error;
 use tokio::runtime::Handle;
@@ -182,7 +182,7 @@ pub(crate) struct SinglePlotFarmOptions<'a, RC, PF> {
     pub(crate) metadata_directory: PathBuf,
     pub(crate) plot_index: usize,
     pub(crate) max_piece_count: u64,
-    pub(crate) farmer_metadata: FarmerMetadata,
+    pub(crate) farmer_protocol_info: FarmerProtocolInfo,
     pub(crate) farming_client: RC,
     pub(crate) plot_factory: &'a PF,
     pub(crate) listen_on: Vec<Multiaddr>,
@@ -226,7 +226,7 @@ impl SinglePlotFarm {
             metadata_directory,
             plot_index,
             max_piece_count,
-            farmer_metadata,
+            farmer_protocol_info,
             farming_client,
             plot_factory,
             mut listen_on,
@@ -418,8 +418,8 @@ impl SinglePlotFarm {
         if enable_dsn_archiving {
             let archiving_fut = start_archiving(
                 id,
-                farmer_metadata.record_size,
-                farmer_metadata.recorded_history_segment_size,
+                farmer_protocol_info.record_size,
+                farmer_protocol_info.recorded_history_segment_size,
                 object_mappings,
                 node,
                 farm.plotter(),
@@ -439,10 +439,11 @@ impl SinglePlotFarm {
         // Start DSN syncing
         if enable_dsn_sync {
             // TODO: operate with number of pieces to fetch, instead of range calculations
-            let sync_range_size = PieceIndexHashNumber::MAX / farmer_metadata.total_pieces * 1024; // 4M per stream
+            let sync_range_size =
+                PieceIndexHashNumber::MAX / farmer_protocol_info.total_pieces * 1024; // 4M per stream
             let dsn_sync_fut = farm.dsn_sync(
-                farmer_metadata.max_plot_size,
-                farmer_metadata.total_pieces,
+                farmer_protocol_info.max_plot_size,
+                farmer_protocol_info.total_pieces,
                 sync_range_size,
             );
 

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -14,14 +14,14 @@ use crate::utils::AbortingJoinHandle;
 use crate::ws_rpc_server::PieceGetter;
 use crate::{dsn, CommitmentError, ObjectMappings};
 use anyhow::anyhow;
-use derive_more::From;
+use derive_more::{Display, From};
 use futures::future::try_join;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::{fmt, fs, io, mem};
+use std::{fs, io, mem};
 use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash, PublicKey, PIECE_SIZE};
 use subspace_networking::libp2p::identity::sr25519;
 use subspace_networking::libp2p::multiaddr::Protocol;
@@ -41,7 +41,7 @@ const SYNC_PIECES_AT_ONCE: u64 = 5000;
 
 /// An identifier for single plot farm, can be used for in logs, thread names, etc.
 #[derive(
-    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, From,
+    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Display, From,
 )]
 #[serde(untagged)]
 pub enum SinglePlotFarmId {
@@ -50,15 +50,6 @@ pub enum SinglePlotFarmId {
     Index(usize),
     /// New farm ID
     Ulid(Ulid),
-}
-
-impl fmt::Display for SinglePlotFarmId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SinglePlotFarmId::Index(id) => id.fmt(f),
-            SinglePlotFarmId::Ulid(id) => id.fmt(f),
-        }
-    }
 }
 
 #[allow(clippy::new_without_default)]

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -12,7 +12,7 @@ use rand::Rng;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{PieceIndexHash, Salt, PIECE_SIZE, SHA256_HASH_SIZE};
-use subspace_rpc_primitives::FarmerMetadata;
+use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::{create_tag, SubspaceCodec};
 use tempfile::TempDir;
 use tracing::error;
@@ -51,7 +51,7 @@ async fn plotting_happy_path() {
     let client = MockRpcClient::new();
 
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE).unwrap();
-    let farmer_metadata = FarmerMetadata {
+    let farmer_protocol_info = FarmerProtocolInfo {
         genesis_hash: [0; 32],
         record_size: RECORD_SIZE as u32,
         recorded_history_segment_size: SEGMENT_SIZE as u32,
@@ -59,12 +59,12 @@ async fn plotting_happy_path() {
         total_pieces: 0,
     };
 
-    client.send_metadata(farmer_metadata).await;
+    client.send_farmer_protocol_info(farmer_protocol_info).await;
 
-    let farmer_metadata = client
-        .farmer_metadata()
+    let farmer_protocol_info = client
+        .farmer_protocol_info()
         .await
-        .expect("Could not retrieve farmer_metadata");
+        .expect("Could not retrieve farmer_protocol_info");
 
     let encoded_block0 = vec![0u8; SEGMENT_SIZE / 2];
     let encoded_block1 = vec![1u8; SEGMENT_SIZE / 2];
@@ -88,7 +88,7 @@ async fn plotting_happy_path() {
 
     // Start archiving task
     let archiving_instance = Archiving::start(
-        farmer_metadata,
+        farmer_protocol_info,
         object_mappings,
         client.clone(),
         move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
@@ -150,7 +150,7 @@ async fn plotting_piece_eviction() {
     let client = MockRpcClient::new();
 
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE).unwrap();
-    let farmer_metadata = FarmerMetadata {
+    let farmer_protocol_info = FarmerProtocolInfo {
         genesis_hash: [0; 32],
         record_size: RECORD_SIZE as u32,
         recorded_history_segment_size: SEGMENT_SIZE as u32,
@@ -158,12 +158,12 @@ async fn plotting_piece_eviction() {
         total_pieces: 0,
     };
 
-    client.send_metadata(farmer_metadata).await;
+    client.send_farmer_protocol_info(farmer_protocol_info).await;
 
-    let farmer_metadata = client
-        .farmer_metadata()
+    let farmer_protocol_info = client
+        .farmer_protocol_info()
         .await
-        .expect("Could not retrieve farmer_metadata");
+        .expect("Could not retrieve farmer_protocol_info");
 
     let encoded_block0 = {
         let mut block = vec![0u8; SEGMENT_SIZE];
@@ -195,7 +195,7 @@ async fn plotting_piece_eviction() {
 
     // Start archiving task
     let archiving_instance = Archiving::start(
-        farmer_metadata,
+        farmer_protocol_info,
         object_mappings,
         client.clone(),
         move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -89,7 +89,7 @@ async fn plotting_happy_path() {
     // Start archiving task
     let archiving_instance = Archiving::start(
         farmer_protocol_info,
-        object_mappings,
+        vec![object_mappings],
         client.clone(),
         move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
             Ok(()) => true,
@@ -196,7 +196,7 @@ async fn plotting_piece_eviction() {
     // Start archiving task
     let archiving_instance = Archiving::start(
         farmer_protocol_info,
-        object_mappings,
+        vec![object_mappings],
         client.clone(),
         move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
             Ok(()) => true,

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -52,6 +52,7 @@ async fn plotting_happy_path() {
 
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE).unwrap();
     let farmer_metadata = FarmerMetadata {
+        genesis_hash: [0; 32],
         record_size: RECORD_SIZE as u32,
         recorded_history_segment_size: SEGMENT_SIZE as u32,
         max_plot_size: u64::MAX,
@@ -150,6 +151,7 @@ async fn plotting_piece_eviction() {
 
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE).unwrap();
     let farmer_metadata = FarmerMetadata {
+        genesis_hash: [0; 32],
         record_size: RECORD_SIZE as u32,
         recorded_history_segment_size: SEGMENT_SIZE as u32,
         max_plot_size: u64::MAX,

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -27,20 +27,19 @@ impl<T> AbortingJoinHandle<T> {
     }
 }
 
-pub(crate) fn get_plot_sizes(allocated_space: u64, max_plot_size: u64) -> Vec<u64> {
-    // TODO: we need to remember plot size in order to prune unused plots in future if plot size is
-    //  less than it was specified before.
-    // TODO: Piece count should account for database overhead of various additional databases.
+pub(crate) fn get_usable_plot_space(allocated_space: u64) -> u64 {
+    // TODO: Should account for database overhead of various additional databases.
     //  For now assume 92% will go for plot itself
-    let usable_space_for_plots = allocated_space * 92 / 100;
+    allocated_space * 92 / 100
+}
 
-    let plot_sizes =
-        std::iter::repeat(max_plot_size).take((usable_space_for_plots / max_plot_size) as usize);
-    if usable_space_for_plots / max_plot_size == 0
-        || usable_space_for_plots % max_plot_size > max_plot_size / 2
-    {
+pub(crate) fn get_plot_sizes(usable_space: u64, max_plot_size: u64) -> Vec<u64> {
+    let plot_sizes = std::iter::repeat(max_plot_size).take((usable_space / max_plot_size) as usize);
+    // TODO: Remove restriction for >50% of max plot size for last plot once it no longer causes
+    //  performance issues
+    if usable_space / max_plot_size == 0 || usable_space % max_plot_size > max_plot_size / 2 {
         plot_sizes
-            .chain(std::iter::once(usable_space_for_plots % max_plot_size))
+            .chain(std::iter::once(usable_space % max_plot_size))
             .collect::<Vec<_>>()
     } else {
         plot_sizes.collect()

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -1,6 +1,5 @@
 use crate::object_mappings::ObjectMappings;
 use async_trait::async_trait;
-use hex_buffer_serde::{Hex, HexForm};
 use jsonrpsee::core::error::Error;
 use jsonrpsee::proc_macros::rpc;
 use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
@@ -23,7 +22,7 @@ pub trait PieceGetter {
 
 /// Same as [`Piece`], but serializes/deserialized to/from hex string
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HexPiece(#[serde(with = "HexForm")] Vec<u8>);
+pub struct HexPiece(#[serde(with = "hex::serde")] Vec<u8>);
 
 impl From<Piece> for HexPiece {
     fn from(piece: Piece) -> Self {
@@ -68,7 +67,7 @@ impl AsMut<[u8]> for HexPiece {
 
 /// Similar to [`Sha256Hash`], but serializes/deserialized to/from hex string
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct HexSha256Hash(#[serde(with = "HexForm")] Sha256Hash);
+pub struct HexSha256Hash(#[serde(with = "hex::serde")] Sha256Hash);
 
 impl From<Sha256Hash> for HexSha256Hash {
     fn from(hash: Sha256Hash) -> Self {
@@ -116,7 +115,7 @@ pub struct Object {
     /// Offset of the object
     offset: u16,
     /// The data object contains for convenience
-    #[serde(with = "HexForm")]
+    #[serde(with = "hex::serde")]
     data: Vec<u8>,
 }
 

--- a/crates/subspace-rpc-primitives/Cargo.toml
+++ b/crates/subspace-rpc-primitives/Cargo.toml
@@ -13,6 +13,6 @@ include = [
 ]
 
 [dependencies]
-hex-buffer-serde = "0.3.0"
+hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.137", features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -31,7 +31,7 @@ pub struct FarmerProtocolInfo {
     pub record_size: u32,
     /// Recorded history is encoded and plotted in segments of this size (in bytes).
     pub recorded_history_segment_size: u32,
-    /// Maximum number of pieces in each plot
+    /// Maximum plot size in bytes
     pub max_plot_size: u64,
     /// Total number of pieces stored on the network
     pub total_pieces: u64,

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -15,7 +15,6 @@
 
 //! Primitives for Subspace RPC.
 
-use hex_buffer_serde::{Hex, HexForm};
 use serde::{Deserialize, Serialize};
 use subspace_core_primitives::{
     PublicKey, RewardSignature, Salt, Sha256Hash, SlotNumber, Solution,
@@ -71,10 +70,10 @@ pub struct SolutionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct RewardSigningInfo {
     /// Hash to be signed.
-    #[serde(with = "HexForm")]
+    #[serde(with = "hex::serde")]
     pub hash: [u8; 32],
     /// Public key of the plot identity that should create signature.
-    #[serde(with = "HexForm")]
+    #[serde(with = "hex::serde")]
     pub public_key: [u8; 32],
 }
 
@@ -83,7 +82,7 @@ pub struct RewardSigningInfo {
 #[serde(rename_all = "camelCase")]
 pub struct RewardSignatureResponse {
     /// Hash that was signed.
-    #[serde(with = "HexForm")]
+    #[serde(with = "hex::serde")]
     pub hash: [u8; 32],
     /// Pre-header or vote hash signature.
     pub signature: Option<RewardSignature>,

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -20,10 +20,10 @@ use subspace_core_primitives::{
     PublicKey, RewardSignature, Salt, Sha256Hash, SlotNumber, Solution,
 };
 
-/// Metadata necessary for farmer operation
+/// Information about the protocol necessary for farmer operation
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FarmerMetadata {
+pub struct FarmerProtocolInfo {
     /// Genesis hash of the chain
     #[serde(with = "hex::serde")]
     pub genesis_hash: [u8; 32],

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -24,6 +24,9 @@ use subspace_core_primitives::{
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FarmerMetadata {
+    /// Genesis hash of the chain
+    #[serde(with = "hex::serde")]
+    pub genesis_hash: [u8; 32],
     /// The size of data in one piece (in bytes).
     pub record_size: u32,
     /// Recorded history is encoded and plotted in segments of this size (in bytes).


### PR DESCRIPTION
The primary goal of this PR is to introduce `SingleDiskFarm` abstraction in addition to `LegacyMultiPlotsFarm`.

It is based on the latter (and quite a bit of refactoring went into aligning it to the former quite closely), however there are a few new important features that fix some of the long-standing issues and open possibility for new features in the future too:
* metadata introduced for both `SinglePlotFarm` and `SingleDiskFarm`, so that they remember some important parameters like genesis hash or plot size specified during previous start, refusing to start when some of the data changes incompatibly
* global object mapping is not used anymore, object mappings of individual plots are use instead

`max_plot_size` was changed on RPC level to be in bytes instead of pieces, also `FarmerMetadata` was renamed to `FarmerProtocolInfo`, which farms now take as an argument.

There is a bit of design space to farmer's CLI, so this PR only introduces internal data structure, but doesn't expose any CLI interface just yet.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
