### PR TITLE
Multi plots farm (part 10)

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,66 +1,7 @@
 mod bench;
 mod farm;
+mod wipe;
 
 pub(crate) use bench::bench;
 pub(crate) use farm::farm;
-use std::path::Path;
-use std::{fs, io};
-use tracing::info;
-
-pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
-    let _ = std::fs::remove_dir_all(path.as_ref().join("object-mappings"));
-    (0..)
-        .map(|i| path.as_ref().join(format!("plot{i}")))
-        .take_while(|path| path.is_dir())
-        .try_for_each(|replica_path| {
-            info!(path = ?replica_path, "Erasing plot replica");
-            std::fs::remove_dir_all(replica_path)
-        })?;
-
-    // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
-    //  wipe old data from disks of our users
-    if let Some(base_dir) = dirs::data_local_dir() {
-        let _ = std::fs::remove_dir_all(base_dir.join("subspace"));
-    }
-
-    // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
-    //  wipe old data from disks of our users
-    erase_legacy_plot(path.as_ref())?;
-
-    // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
-    //  wipe old data from disks of our users
-    let identity = path.as_ref().join("identity.bin");
-    info!(path = ?identity, "Erasing identity");
-    if identity.exists() {
-        fs::remove_file(identity)?;
-    }
-
-    Ok(())
-}
-
-/// Helper function for ignoring the error that given file/directory does not exist.
-fn try_remove<P: AsRef<Path>>(path: P, remove: impl FnOnce(P) -> io::Result<()>) -> io::Result<()> {
-    if path.as_ref().exists() {
-        remove(path)?;
-    }
-    Ok(())
-}
-
-// TODO: Remove with the next snapshot (as it is unused by now)
-/// Erases plot in specific directory
-pub fn erase_legacy_plot(path: &Path) -> io::Result<()> {
-    info!("Erasing the plot");
-    try_remove(&path.join("plot.bin"), fs::remove_file)?;
-    info!("Erasing the plot offset to index db");
-    try_remove(&path.join("plot-offset-to-index.bin"), fs::remove_file)?;
-    info!("Erasing the plot index to offset db");
-    try_remove(&path.join("plot-index-to-offset"), fs::remove_dir_all)?;
-    info!("Erasing plot metadata");
-    try_remove(&path.join("plot-metadata"), fs::remove_dir_all)?;
-    info!("Erasing plot commitments");
-    try_remove(&path.join("commitments"), fs::remove_dir_all)?;
-    info!("Erasing object mappings");
-    try_remove(&path.join("object-mappings"), fs::remove_dir_all)?;
-
-    Ok(())
-}
+pub(crate) use wipe::wipe;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -3,5 +3,5 @@ mod farm;
 mod wipe;
 
 pub(crate) use bench::bench;
-pub(crate) use farm::farm;
+pub(crate) use farm::{farm_legacy, farm_multi_disk};
 pub(crate) use wipe::wipe;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -46,6 +46,8 @@ pub(crate) async fn farm_multi_disk(
     let mut record_size = None;
     let mut recorded_history_segment_size = None;
 
+    // TODO: Check plot and metadata sizes to ensure there is enough space for farmer to not
+    //  fail later (note that multiple farms can use the same location for metadata)
     for disk_farm in disk_farms {
         if plot_size < 1024 * 1024 {
             return Err(anyhow::anyhow!(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -1,23 +1,34 @@
 use anyhow::{anyhow, Result};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use jsonrpsee::ws_server::WsServerBuilder;
 use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
 };
+use subspace_farmer::single_disk_farm::{SingleDiskFarm, SingleDiskFarmOptions};
 use subspace_farmer::single_plot_farm::PlotFactoryOptions;
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use tracing::{info, warn};
 
-use crate::{utils, ArchivingFrom, FarmingArgs};
+use crate::{utils, ArchivingFrom, DiskFarm, FarmingArgs};
 
 /// Start farming by using multiple replica plot in specified path and connecting to WebSocket
 /// server at specified address.
-pub(crate) async fn farm(
-    base_directory: PathBuf,
-    FarmingArgs {
+pub(crate) async fn farm_multi_disk(
+    disk_farms: Vec<DiskFarm>,
+    farming_args: FarmingArgs,
+) -> Result<(), anyhow::Error> {
+    if disk_farms.is_empty() {
+        return Err(anyhow!("There must be at least one disk farm provided"));
+    }
+
+    utils::raise_fd_limit();
+
+    let FarmingArgs {
         bootstrap_nodes,
         listen_on,
         node_rpc_url,
@@ -25,12 +36,160 @@ pub(crate) async fn farm(
         reward_address,
         plot_size,
         max_plot_size,
+        disk_concurrency,
         dsn_sync,
         archiving,
         disable_farming,
-    }: FarmingArgs,
+    } = farming_args;
+
+    let mut single_disk_farms = Vec::with_capacity(disk_farms.len());
+    let mut record_size = None;
+    let mut recorded_history_segment_size = None;
+
+    for disk_farm in disk_farms {
+        if plot_size < 1024 * 1024 {
+            return Err(anyhow::anyhow!(
+                "Plot size is too low ({plot_size} bytes). Did you mean {plot_size}G or {plot_size}T?"
+            ));
+        }
+
+        info!("Connecting to node at {}", node_rpc_url);
+        let archiving_client = NodeRpcClient::new(&node_rpc_url).await?;
+        let farming_client = NodeRpcClient::new(&node_rpc_url).await?;
+
+        let mut farmer_protocol_info = farming_client
+            .farmer_protocol_info()
+            .await
+            .map_err(|error| anyhow!(error))?;
+
+        if let Some(max_plot_size) = max_plot_size {
+            if max_plot_size > farmer_protocol_info.max_plot_size {
+                warn!("Passed `max_plot_size` is too big. Fallback to the one from consensus.");
+            } else {
+                farmer_protocol_info.max_plot_size = max_plot_size;
+            }
+        }
+
+        record_size.replace(farmer_protocol_info.record_size);
+        recorded_history_segment_size.replace(farmer_protocol_info.recorded_history_segment_size);
+
+        // TODO: listen_on should not be specified here, common networking instance should be used
+        //  instead once we have circuit relay
+        let single_disk_farm = SingleDiskFarm::new(SingleDiskFarmOptions {
+            plot_directory: disk_farm.plot_directory,
+            metadata_directory: disk_farm.metadata_directory,
+            allocated_plotting_space: disk_farm.allocated_plotting_space,
+            farmer_protocol_info,
+            disk_concurrency,
+            archiving_client,
+            farming_client,
+            reward_address,
+            bootstrap_nodes: bootstrap_nodes.clone(),
+            listen_on: listen_on.clone(),
+            enable_dsn_archiving: matches!(archiving, ArchivingFrom::Dsn),
+            enable_dsn_sync: dsn_sync,
+            enable_farming: !disable_farming,
+            plot_factory: move |options: PlotFactoryOptions<'_>| {
+                Plot::open_or_create(
+                    options.single_plot_farm_id,
+                    options.plot_directory,
+                    options.metadata_directory,
+                    options.public_key,
+                    options.max_piece_count,
+                )
+            },
+        })
+        .await?;
+
+        single_disk_farms.push(single_disk_farm);
+    }
+
+    let record_size = record_size.expect("At least one farm is always present, checked above; qed");
+    let recorded_history_segment_size = recorded_history_segment_size
+        .expect("At least one farm is always present, checked above; qed");
+
+    // Start RPC server
+    let ws_server = match WsServerBuilder::default()
+        .build(ws_server_listen_addr)
+        .await
+    {
+        Ok(ws_server) => ws_server,
+        Err(jsonrpsee::core::Error::Transport(error)) => {
+            warn!(
+                address = %ws_server_listen_addr,
+                %error,
+                "Failed to start WebSocket RPC server on, trying random port"
+            );
+            ws_server_listen_addr.set_port(0);
+            WsServerBuilder::default()
+                .build(ws_server_listen_addr)
+                .await?
+        }
+        Err(error) => {
+            return Err(error.into());
+        }
+    };
+    let ws_server_addr = ws_server.local_addr()?;
+    let rpc_server = RpcServerImpl::new(
+        record_size,
+        recorded_history_segment_size,
+        Arc::new(
+            single_disk_farms
+                .iter()
+                .map(|single_disk_farm| single_disk_farm.piece_getter())
+                .collect::<Vec<_>>(),
+        ),
+        Arc::new(
+            single_disk_farms
+                .iter()
+                .flat_map(|single_disk_farm| {
+                    single_disk_farm
+                        .single_plot_farms()
+                        .iter()
+                        .map(|single_plot_farm| single_plot_farm.object_mappings().clone())
+                })
+                .collect::<Vec<_>>(),
+        ),
+    );
+    let _stop_handle = ws_server.start(rpc_server.into_rpc())?;
+
+    info!("WS RPC server listening on {ws_server_addr}");
+
+    let mut single_disk_farms_stream = single_disk_farms
+        .into_iter()
+        .map(|single_disk_farm| single_disk_farm.wait())
+        .collect::<FuturesUnordered<_>>();
+
+    while let Some(result) = single_disk_farms_stream.next().await {
+        result?;
+
+        info!("Farm exited successfully");
+    }
+
+    Ok(())
+}
+
+/// Start farming by using multiple replica plot in specified path and connecting to WebSocket
+/// server at specified address.
+pub(crate) async fn farm_legacy(
+    base_directory: PathBuf,
+    farm_args: FarmingArgs,
 ) -> Result<(), anyhow::Error> {
     utils::raise_fd_limit();
+
+    let FarmingArgs {
+        bootstrap_nodes,
+        listen_on,
+        node_rpc_url,
+        mut ws_server_listen_addr,
+        reward_address,
+        plot_size,
+        max_plot_size,
+        disk_concurrency: _,
+        dsn_sync,
+        archiving,
+        disable_farming,
+    } = farm_args;
 
     if plot_size < 1024 * 1024 {
         return Err(anyhow::anyhow!(
@@ -122,7 +281,7 @@ pub(crate) async fn farm(
         record_size,
         recorded_history_segment_size,
         Arc::new(multi_plots_farm.piece_getter()),
-        object_mappings.clone(),
+        Arc::new(vec![object_mappings]),
     );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/wipe.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/wipe.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+use std::{fs, io};
+use tracing::info;
+
+pub(crate) fn wipe<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let _ = std::fs::remove_dir_all(path.as_ref().join("object-mappings"));
+    (0..)
+        .map(|i| path.as_ref().join(format!("plot{i}")))
+        .take_while(|path| path.is_dir())
+        .try_for_each(|replica_path| {
+            info!(path = ?replica_path, "Erasing plot replica");
+            std::fs::remove_dir_all(replica_path)
+        })?;
+
+    // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
+    //  wipe old data from disks of our users
+    if let Some(base_dir) = dirs::data_local_dir() {
+        let _ = std::fs::remove_dir_all(base_dir.join("subspace"));
+    }
+
+    // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
+    //  wipe old data from disks of our users
+    erase_legacy_plot(path.as_ref())?;
+
+    // TODO: Remove this after next snapshot, this is a compatibility layer to make sure we
+    //  wipe old data from disks of our users
+    let identity = path.as_ref().join("identity.bin");
+    info!(path = ?identity, "Erasing identity");
+    if identity.exists() {
+        fs::remove_file(identity)?;
+    }
+
+    Ok(())
+}
+
+/// Helper function for ignoring the error that given file/directory does not exist.
+fn try_remove<P: AsRef<Path>>(path: P, remove: impl FnOnce(P) -> io::Result<()>) -> io::Result<()> {
+    if path.as_ref().exists() {
+        remove(path)?;
+    }
+    Ok(())
+}
+
+// TODO: Remove with the next snapshot (as it is unused by now)
+/// Erases plot in specific directory
+fn erase_legacy_plot(path: &Path) -> io::Result<()> {
+    info!("Erasing the plot");
+    try_remove(&path.join("plot.bin"), fs::remove_file)?;
+    info!("Erasing the plot offset to index db");
+    try_remove(&path.join("plot-offset-to-index.bin"), fs::remove_file)?;
+    info!("Erasing the plot index to offset db");
+    try_remove(&path.join("plot-index-to-offset"), fs::remove_dir_all)?;
+    info!("Erasing plot metadata");
+    try_remove(&path.join("plot-metadata"), fs::remove_dir_all)?;
+    info!("Erasing plot commitments");
+    try_remove(&path.join("commitments"), fs::remove_dir_all)?;
+    info!("Erasing object mappings");
+    try_remove(&path.join("object-mappings"), fs::remove_dir_all)?;
+
+    Ok(())
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
+use utils::parse_human_readable_size;
 
 #[derive(Debug, Clone, Copy, ArgEnum)]
 enum ArchivingFrom {
@@ -132,21 +133,6 @@ struct Command {
     /// will be delete at the end of the process
     #[clap(long, conflicts_with = "base-path")]
     tmp: bool,
-}
-
-fn parse_human_readable_size(s: &str) -> Result<u64, std::num::ParseIntError> {
-    const SUFFIXES: &[(&str, u64)] = &[
-        ("G", 10u64.pow(9)),
-        ("GB", 10u64.pow(9)),
-        ("T", 10u64.pow(12)),
-        ("TB", 10u64.pow(12)),
-    ];
-
-    SUFFIXES
-        .iter()
-        .find_map(|(suf, mul)| s.strip_suffix(suf).map(|s| (s, mul)))
-        .map(|(s, mul)| s.parse::<u64>().map(|num| num * mul))
-        .unwrap_or_else(|| s.parse::<u64>())
 }
 
 // TODO: Add graceful shutdown handling, without it temporary directory may be left not deleted

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -11,6 +11,7 @@ use std::num::NonZeroU16;
 use std::path::PathBuf;
 use std::str::FromStr;
 use subspace_core_primitives::PublicKey;
+use subspace_farmer::single_disk_farm::SingleDiskFarm;
 use subspace_networking::libp2p::Multiaddr;
 use tempfile::TempDir;
 use tracing::info;
@@ -267,7 +268,9 @@ async fn main() -> Result<()> {
             if command.farm.is_empty() {
                 commands::wipe(&base_path)?;
             } else {
-                unimplemented!()
+                for farm in &command.farm {
+                    SingleDiskFarm::wipe(&farm.plot_directory, &farm.metadata_directory)?;
+                }
             }
 
             info!("Done");

--- a/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
@@ -6,6 +6,21 @@ pub(crate) fn default_base_path() -> PathBuf {
         .join("subspace-farmer")
 }
 
+pub(crate) fn parse_human_readable_size(s: &str) -> Result<u64, std::num::ParseIntError> {
+    const SUFFIXES: &[(&str, u64)] = &[
+        ("G", 10u64.pow(9)),
+        ("GB", 10u64.pow(9)),
+        ("T", 10u64.pow(12)),
+        ("TB", 10u64.pow(12)),
+    ];
+
+    SUFFIXES
+        .iter()
+        .find_map(|(suf, mul)| s.strip_suffix(suf).map(|s| (s, mul)))
+        .map(|(s, mul)| s.parse::<u64>().map(|num| num * mul))
+        .unwrap_or_else(|| s.parse::<u64>())
+}
+
 pub(crate) fn raise_fd_limit() {
     match std::panic::catch_unwind(fdlimit::raise_fd_limit) {
         Ok(Some(limit)) => {

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -6,6 +6,7 @@ use crate::plot::Plot;
 use crate::single_disk_farm::SingleDiskSemaphore;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
+use std::num::NonZeroU16;
 use std::sync::Arc;
 use subspace_core_primitives::{FlatPieces, Salt, Tag, SHA256_HASH_SIZE};
 use subspace_rpc_primitives::SlotInfo;
@@ -51,7 +52,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
         plot.clone(),
         commitments.clone(),
         client.clone(),
-        SingleDiskSemaphore::new(1),
+        SingleDiskSemaphore::new(NonZeroU16::try_from(1).unwrap()),
         identity.clone(),
         public_key,
     );

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -618,7 +618,7 @@ impl SinglePlotFarm {
         &self.node
     }
 
-    pub fn piece_getter(&self) -> SinglePlotPieceGetter {
+    pub fn piece_getter(&self) -> impl PieceGetter {
         SinglePlotPieceGetter::new(self.codec.clone(), self.plot.clone())
     }
 

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -9,6 +9,7 @@ use crate::single_plot_farm::SinglePlotPlotter;
 use crate::Archiving;
 use rand::prelude::*;
 use rand::Rng;
+use std::num::NonZeroU16;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{PieceIndexHash, Salt, PIECE_SIZE, SHA256_HASH_SIZE};
@@ -83,7 +84,7 @@ async fn plotting_happy_path() {
         subspace_codec,
         plot.clone(),
         commitments,
-        SingleDiskSemaphore::new(1),
+        SingleDiskSemaphore::new(NonZeroU16::try_from(1).unwrap()),
     );
 
     // Start archiving task
@@ -190,7 +191,7 @@ async fn plotting_piece_eviction() {
         subspace_codec.clone(),
         plot.clone(),
         commitments.clone(),
-        SingleDiskSemaphore::new(1),
+        SingleDiskSemaphore::new(NonZeroU16::try_from(1).unwrap()),
     );
 
     // Start archiving task


### PR DESCRIPTION
Building on top of #660 this finally implements support for farming on multiple disks.

I was thinking about readable syntax more and came up with this:
```
subspace-farmer
    --farm hdd=/hdd1,ssd=/ssd,size=5T \
    --farm hdd=/hdd2,ssd=/ssd,size=5T \
    farm \
    --reward-address xyz
```

The idea is that we operate on farms, they can be located on different disks. Some disks are HDDs for plots, some are SSDs for metadata, so we need to separate them clearly. I decided to just call them HDD and SSD, though help message elaborates on this some.

Note that size of the farm now only reflects size of the plot (100% of it), extra 8% of the space needs to be reserved for metadata by the user.

I'm open for feedback on CLI arguments.

In upcoming updates we'll reserve space for plot to make sure it is not used by anything else (https://github.com/subspace/subspace/issues/656). As to metadata I did some research on how we can pre-allocate some amount of space and didn't find a good solution. We can try to estimate how much space we need for metadata, how much space we already use for metadata and how much space is left on the disk to identify whether there is sufficient amount of space there for farm to even start.

Once we test this and confirm it works fine, we'll switch to `SingleDiskFarm` even for `--base-path`, but for now logic there is left untouched.

There is no benching support for `--farm` right now, though performance shouldn't be any different.

Outside of that some refactoring was necessary. Notably I looked at `PieceGetter` and decided to implement this trait on `Vec<PieceGetter>` too, so we can aggregate them in multiple layers (`Vec<Vec<SinglePlotFarmPieceGetter>>` also implements `PieceGetter`, though types are erased due to irrelevance). This was necessary to keep WS RPC working.

Fixes #636

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
