### PR TITLE
Plain file tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,9 +3181,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -7919,6 +7919,7 @@ dependencies = [
  "futures 0.3.21",
  "hex",
  "jsonrpsee",
+ "libc",
  "lru",
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7916,6 +7916,7 @@ dependencies = [
  "dirs",
  "event-listener-primitives",
  "fdlimit",
+ "fs2",
  "futures 0.3.21",
  "hex",
  "jsonrpsee",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -23,6 +23,7 @@ derive_more = "0.99.17"
 dirs = "4.0.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2"
+fs2 = "0.4.3"
 futures = "0.3.21"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.14.0", features = ["client", "macros", "server"] }

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -26,8 +26,7 @@ fdlimit = "0.2"
 futures = "0.3.21"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.14.0", features = ["client", "macros", "server"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+libc = "0.2.126"
 lru = "0.7.5"
 num-traits = "0.2.15"
 parity-scale-codec = "3.1.2"
@@ -48,6 +47,8 @@ substrate-bip39 = "0.4.4"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["macros", "parking_lot", "rt-multi-thread"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = { version = "0.6.0", features = ["serde"] }
 zeroize = "1.5.5"
 

--- a/crates/subspace-farmer/benches/plot-write.rs
+++ b/crates/subspace-farmer/benches/plot-write.rs
@@ -19,7 +19,7 @@ async fn main() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         [0; 32].into(),
-        piece_count,
+        piece_count * PIECE_SIZE as u64,
     )
     .unwrap();
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -24,24 +24,11 @@ use tempfile::TempDir;
 use tokio::time::Instant;
 use tracing::{info, warn};
 
-pub struct BenchPlotMock {
-    piece_count: u64,
-    max_piece_count: u64,
-}
-
-impl BenchPlotMock {
-    pub fn new(max_piece_count: u64) -> Self {
-        Self {
-            max_piece_count,
-            piece_count: 0,
-        }
-    }
-}
+#[derive(Default)]
+pub struct BenchPlotMock;
 
 impl PlotFile for BenchPlotMock {
-    fn write(&mut self, pieces: impl AsRef<[u8]>, _offset: PieceOffset) -> io::Result<()> {
-        self.piece_count = (self.piece_count + (pieces.as_ref().len() / PIECE_SIZE) as u64)
-            .max(self.max_piece_count);
+    fn write(&mut self, _pieces: impl AsRef<[u8]>, _offset: PieceOffset) -> io::Result<()> {
         Ok(())
     }
 
@@ -148,17 +135,17 @@ pub(crate) async fn bench(
     let plot_factory = move |options: PlotFactoryOptions<'_>| match write_to_disk {
         WriteToDisk::Nothing => Plot::with_plot_file(
             options.single_plot_farm_id,
-            BenchPlotMock::new(options.max_piece_count),
+            BenchPlotMock::default(),
             options.metadata_directory,
             options.public_key,
-            options.max_piece_count,
+            options.max_plot_size,
         ),
         WriteToDisk::Everything => Plot::open_or_create(
             options.single_plot_farm_id,
             options.plot_directory,
             options.metadata_directory,
             options.public_key,
-            options.max_piece_count,
+            options.max_plot_size,
         ),
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -39,10 +39,6 @@ impl BenchPlotMock {
 }
 
 impl PlotFile for BenchPlotMock {
-    fn piece_count(&mut self) -> io::Result<u64> {
-        Ok(self.piece_count)
-    }
-
     fn write(&mut self, pieces: impl AsRef<[u8]>, _offset: PieceOffset) -> io::Result<()> {
         self.piece_count = (self.piece_count + (pieces.as_ref().len() / PIECE_SIZE) as u64)
             .max(self.max_piece_count);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -97,7 +97,7 @@ pub(crate) async fn farm_multi_disk(
                     options.plot_directory,
                     options.metadata_directory,
                     options.public_key,
-                    options.max_piece_count,
+                    options.max_plot_size,
                 )
             },
         })
@@ -251,7 +251,7 @@ pub(crate) async fn farm_legacy(
                 options.plot_directory,
                 options.metadata_directory,
                 options.public_key,
-                options.max_piece_count,
+                options.max_plot_size,
             )
         },
     )

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -171,7 +171,7 @@ async fn test_dsn_sync() {
             options.plot_directory,
             options.metadata_directory,
             options.public_key,
-            options.max_piece_count,
+            options.max_plot_size,
         )
     };
 
@@ -297,7 +297,7 @@ async fn test_dsn_sync() {
             options.plot_directory,
             options.metadata_directory,
             options.public_key,
-            options.max_piece_count,
+            options.max_plot_size,
         )
     };
 

--- a/crates/subspace-farmer/src/file_ext.rs
+++ b/crates/subspace-farmer/src/file_ext.rs
@@ -2,6 +2,9 @@ use std::fs::File;
 use std::io::Result;
 
 pub(crate) trait FileExt {
+    /// Make sure file has specified number of bytes allocated for it
+    fn preallocate(&self, len: u64) -> Result<()>;
+
     /// Advise OS/file system that file will use random access and read-ahead behavior is
     /// undesirable
     fn advise_random_access(&self) -> Result<()>;
@@ -14,6 +17,10 @@ pub(crate) trait FileExt {
 }
 
 impl FileExt for File {
+    fn preallocate(&self, len: u64) -> Result<()> {
+        fs2::FileExt::allocate(self, len)
+    }
+
     #[cfg(target_os = "linux")]
     fn advise_random_access(&self) -> Result<()> {
         use std::os::unix::io::AsRawFd;

--- a/crates/subspace-farmer/src/file_ext.rs
+++ b/crates/subspace-farmer/src/file_ext.rs
@@ -1,0 +1,109 @@
+use std::fs::File;
+use std::io::Result;
+
+pub(crate) trait FileExt {
+    /// Advise OS/file system that file will use random access and read-ahead behavior is
+    /// undesirable
+    fn advise_random_access(&self) -> Result<()>;
+
+    /// Read exact number of bytes at a specific offset
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> Result<()>;
+
+    /// Write all provided bytes at a specific offset
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> Result<()>;
+}
+
+impl FileExt for File {
+    #[cfg(target_os = "linux")]
+    fn advise_random_access(&self) -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+        let err = unsafe { libc::posix_fadvise(self.as_raw_fd(), 0, 0, libc::POSIX_FADV_RANDOM) };
+        if err != 0 {
+            Err(std::io::Error::from_raw_os_error(err))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn advise_random_access(&self) -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+        if unsafe { libc::fcntl(self.as_raw_fd(), libc::F_RDAHEAD, 0) } != 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    fn advise_random_access(&self) -> Result<()> {
+        // Not supported
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> Result<()> {
+        std::os::unix::fs::FileExt::read_exact_at(self, buf, offset)
+    }
+
+    #[cfg(unix)]
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> Result<()> {
+        std::os::unix::fs::FileExt::write_all_at(self, buf, offset)
+    }
+
+    #[cfg(windows)]
+    fn read_exact_at(&self, mut buf: &mut [u8], mut offset: u64) -> Result<()> {
+        while !buf.is_empty() {
+            match std::os::windows::fs::FileExt::seek_read(self, buf, offset) {
+                Ok(0) => {
+                    break;
+                }
+                Ok(n) => {
+                    buf = &mut buf[n..];
+                    offset += n as u64;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                    // Try again
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+
+        if !buf.is_empty() {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(windows)]
+    fn write_all_at(&self, mut buf: &[u8], mut offset: u64) -> Result<()> {
+        while !buf.is_empty() {
+            match std::os::windows::fs::FileExt::seek_write(self, buf, offset) {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
+                Ok(n) => {
+                    buf = &buf[n..];
+                    offset += n as u64;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                    // Try again
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -33,6 +33,7 @@ pub mod bench_rpc_client;
 pub(crate) mod commitments;
 pub(crate) mod dsn;
 pub(crate) mod farming;
+mod file_ext;
 pub(crate) mod identity;
 pub mod legacy_multi_plots_farm;
 #[cfg(test)]

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -133,6 +133,8 @@ impl Plot {
             .open(plot_directory.join("plot.bin"))
             .map_err(PlotError::PlotOpen)?;
 
+        plot.preallocate(max_piece_count * PIECE_SIZE as u64)
+            .map_err(PlotError::PlotOpen)?;
         plot.advise_random_access().map_err(PlotError::PlotOpen)?;
 
         Self::with_plot_file(

--- a/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
@@ -1,10 +1,12 @@
 use crate::plot::{PieceDistance, PieceOffset, PlotError};
 use num_traits::{WrappingAdd, WrappingSub};
-use rocksdb::DB;
+use rocksdb::{Options, DB};
 use std::collections::BTreeSet;
 use std::io;
 use std::ops::RangeInclusive;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use subspace_core_primitives::{PieceIndexHash, PublicKey, SHA256_HASH_SIZE};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,6 +45,7 @@ pub(super) struct IndexHashToOffsetDB {
     inner: DB,
     public_key: PublicKey,
     max_distance_cache: BTreeSet<BidirectionalDistanceSorted<PieceDistance>>,
+    piece_count: Arc<AtomicU64>,
 }
 
 impl IndexHashToOffsetDB {
@@ -51,16 +54,67 @@ impl IndexHashToOffsetDB {
     /// You can find discussion of derivation of this number here:
     /// https://github.com/subspace/subspace/pull/449
     const MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP: usize = 8000;
+    const METADATA_COLUMN_FAMILY: &'static str = "metadata";
+    const PIECE_COUNT_KEY: &'static str = "piece_count";
 
     pub(super) fn open_default(path: &Path, public_key: PublicKey) -> Result<Self, PlotError> {
-        let inner = DB::open_default(path).map_err(PlotError::IndexDbOpen)?;
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+        let inner = DB::open_cf(&options, path, &["default", Self::METADATA_COLUMN_FAMILY])
+            .map_err(PlotError::IndexDbOpen)?;
         let mut me = Self {
             inner,
             public_key,
             max_distance_cache: BTreeSet::new(),
+            piece_count: Arc::new(AtomicU64::new(0)),
         };
         me.update_max_distance_cache();
+
+        let mut piece_count = 0;
+        let cf = me
+            .inner
+            .cf_handle(Self::METADATA_COLUMN_FAMILY)
+            .expect("Column name opened in constructor; qed");
+        match me
+            .inner
+            .get_cf(&cf, Self::PIECE_COUNT_KEY)
+            .map_err(Into::into)
+            .map_err(PlotError::PieceCountReadError)?
+        {
+            Some(piece_count_bytes) => {
+                piece_count = u64::from_le_bytes(
+                    piece_count_bytes
+                        .as_slice()
+                        .try_into()
+                        .map_err(Into::into)
+                        .map_err(PlotError::PieceCountReadError)?,
+                );
+            }
+            None => {
+                if me.max_distance_cache.len() < Self::MAX_DISTANCE_CACHE_ONE_SIDE_LOOKUP {
+                    piece_count = me.max_distance_cache.len() as u64;
+                } else {
+                    let mut iter = me.inner.raw_iterator();
+                    while iter.key().is_some() {
+                        piece_count += 1;
+                        iter.next();
+                    }
+                }
+            }
+        }
+
+        me.piece_count.store(piece_count, Ordering::SeqCst);
+        me.inner
+            .put_cf(&cf, Self::PIECE_COUNT_KEY, piece_count.to_le_bytes())
+            .map_err(Into::into)
+            .map_err(PlotError::PieceCountReadError)?;
+
         Ok(me)
+    }
+
+    pub(super) fn piece_count(&self) -> &Arc<AtomicU64> {
+        &self.piece_count
     }
 
     // TODO: optimize fast path using `max_distance_cache`
@@ -150,12 +204,26 @@ impl IndexHashToOffsetDB {
         Ok(())
     }
 
+    // TODO: Batch insert
     pub(super) fn insert(
         &mut self,
         index_hash: &PieceIndexHash,
         offset: PieceOffset,
     ) -> io::Result<()> {
-        self.put(index_hash, offset)
+        self.put(index_hash, offset)?;
+
+        let piece_count = self.piece_count.fetch_add(1, Ordering::SeqCst) + 1;
+        self.inner
+            .put_cf(
+                self.inner
+                    .cf_handle(Self::METADATA_COLUMN_FAMILY)
+                    .expect("Column name opened in constructor; qed"),
+                Self::PIECE_COUNT_KEY,
+                piece_count.to_le_bytes(),
+            )
+            .map_err(io::Error::other)?;
+
+        Ok(())
     }
 
     pub(super) fn replace_furthest(

--- a/crates/subspace-farmer/src/plot/piece_offset_to_index_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_offset_to_index_db.rs
@@ -4,6 +4,7 @@ use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::Path;
 use subspace_core_primitives::PieceIndex;
+use tracing::warn;
 
 pub(super) struct PieceOffsetToIndexDb(File);
 
@@ -17,7 +18,9 @@ impl PieceOffsetToIndexDb {
             .create(true)
             .open(path)?;
 
-        file.preallocate(max_piece_count * PIECE_INDEX_SIZE)?;
+        if let Err(error) = file.preallocate(max_piece_count * PIECE_INDEX_SIZE) {
+            warn!(%error, %max_piece_count, "Failed to pre-allocate plot file");
+        }
         file.advise_random_access()?;
 
         Ok(Self(file))

--- a/crates/subspace-farmer/src/plot/piece_offset_to_index_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_offset_to_index_db.rs
@@ -10,13 +10,14 @@ pub(super) struct PieceOffsetToIndexDb(File);
 const PIECE_INDEX_SIZE: u64 = std::mem::size_of::<PieceIndex>() as u64;
 
 impl PieceOffsetToIndexDb {
-    pub(super) fn open(path: &Path) -> io::Result<Self> {
+    pub(super) fn open(path: &Path, max_piece_count: u64) -> io::Result<Self> {
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .open(path)?;
 
+        file.preallocate(max_piece_count * PIECE_INDEX_SIZE)?;
         file.advise_random_access()?;
 
         Ok(Self(file))

--- a/crates/subspace-farmer/src/plot/piece_offset_to_index_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_offset_to_index_db.rs
@@ -1,28 +1,30 @@
+use crate::file_ext::FileExt;
 use crate::plot::PieceOffset;
 use std::fs::{File, OpenOptions};
 use std::io;
-use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use subspace_core_primitives::PieceIndex;
 
 pub(super) struct PieceOffsetToIndexDb(File);
 
+const PIECE_INDEX_SIZE: u64 = std::mem::size_of::<PieceIndex>() as u64;
+
 impl PieceOffsetToIndexDb {
     pub(super) fn open(path: &Path) -> io::Result<Self> {
-        OpenOptions::new()
+        let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .open(path)
-            .map(Self)
+            .open(path)?;
+
+        file.advise_random_access()?;
+
+        Ok(Self(file))
     }
 
     pub(super) fn get_piece_index(&mut self, offset: PieceOffset) -> io::Result<PieceIndex> {
         let mut buf = [0; 8];
-        self.0.seek(SeekFrom::Start(
-            offset * std::mem::size_of::<PieceIndex>() as u64,
-        ))?;
-        self.0.read_exact(&mut buf)?;
+        self.0.read_exact_at(&mut buf, offset * PIECE_INDEX_SIZE)?;
         Ok(PieceIndex::from_le_bytes(buf))
     }
 
@@ -31,10 +33,8 @@ impl PieceOffsetToIndexDb {
         offset: PieceOffset,
         piece_index: PieceIndex,
     ) -> io::Result<()> {
-        self.0.seek(SeekFrom::Start(
-            offset * std::mem::size_of::<PieceIndex>() as u64,
-        ))?;
-        self.0.write_all(&piece_index.to_le_bytes())
+        self.0
+            .write_all_at(&piece_index.to_le_bytes(), offset * PIECE_INDEX_SIZE)
     }
 
     pub(super) fn put_piece_indexes(
@@ -42,13 +42,11 @@ impl PieceOffsetToIndexDb {
         start_offset: PieceOffset,
         piece_indexes: &[PieceIndex],
     ) -> io::Result<()> {
-        self.0.seek(SeekFrom::Start(
-            start_offset * std::mem::size_of::<PieceIndex>() as u64,
-        ))?;
         let piece_indexes = piece_indexes
             .iter()
             .flat_map(|piece_index| piece_index.to_le_bytes())
             .collect::<Vec<_>>();
-        self.0.write_all(&piece_indexes)
+        self.0
+            .write_all_at(&piece_indexes, start_offset * PIECE_INDEX_SIZE)
     }
 }

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -113,7 +113,7 @@ async fn partial_plot() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
-        max_plot_pieces,
+        max_plot_pieces * PIECE_SIZE as u64,
     )
     .unwrap();
     assert!(plot.is_empty());

--- a/crates/subspace-farmer/src/plot/worker.rs
+++ b/crates/subspace-farmer/src/plot/worker.rs
@@ -96,9 +96,11 @@ impl<T: PlotFile> PlotWorker<T> {
         public_key: PublicKey,
         max_piece_count: u64,
     ) -> Result<Self, PlotError> {
-        let piece_offset_to_index =
-            PieceOffsetToIndexDb::open(&metadata_directory.join("plot-offset-to-index.bin"))
-                .map_err(PlotError::OffsetDbOpen)?;
+        let piece_offset_to_index = PieceOffsetToIndexDb::open(
+            &metadata_directory.join("plot-offset-to-index.bin"),
+            max_piece_count,
+        )
+        .map_err(PlotError::OffsetDbOpen)?;
 
         let piece_index_hash_to_offset_db = IndexHashToOffsetDB::open_default(
             &metadata_directory.join("plot-index-to-offset"),

--- a/crates/subspace-farmer/src/plot/worker.rs
+++ b/crates/subspace-farmer/src/plot/worker.rs
@@ -271,7 +271,7 @@ impl<T: PlotFile> PlotWorker<T> {
                 (current_piece_count..).zip(sequential_piece_indexes)
             {
                 self.piece_index_hash_to_offset_db
-                    .put(&PieceIndexHash::from_index(piece_index), piece_offset)?;
+                    .insert(&PieceIndexHash::from_index(piece_index), piece_offset)?;
             }
 
             self.piece_offset_to_index
@@ -309,16 +309,13 @@ impl<T: PlotFile> PlotWorker<T> {
 
             let piece_offset = self
                 .piece_index_hash_to_offset_db
-                .remove_furthest()?
-                .expect("Must be always present as plot is non-empty; qed");
+                .replace_furthest(&PieceIndexHash::from_index(piece_index))?;
 
             let mut old_piece = Piece::default();
             self.plot.read(piece_offset, &mut old_piece)?;
 
             self.plot.write(piece, piece_offset)?;
 
-            self.piece_index_hash_to_offset_db
-                .put(&PieceIndexHash::from_index(piece_index), piece_offset)?;
             self.piece_offset_to_index
                 .put_piece_index(piece_offset, piece_index)?;
 

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -22,7 +22,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fs, io, mem};
-use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash, PublicKey, PIECE_SIZE};
+use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash, PublicKey};
 use subspace_networking::libp2p::identity::sr25519;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::{Multiaddr, PeerId};
@@ -247,7 +247,7 @@ pub struct PlotFactoryOptions<'a> {
     pub public_key: PublicKey,
     pub plot_directory: &'a Path,
     pub metadata_directory: &'a Path,
-    pub max_piece_count: u64,
+    pub max_plot_size: u64,
 }
 
 pub trait PlotFactory =
@@ -369,7 +369,7 @@ impl SinglePlotFarm {
             public_key,
             plot_directory: &plot_directory,
             metadata_directory: &metadata_directory,
-            max_piece_count: single_plot_farm_info.allocated_plotting_space() / PIECE_SIZE as u64,
+            max_plot_size: single_plot_farm_info.allocated_plotting_space(),
         })?;
 
         info!("Opening object mappings");

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -137,7 +137,7 @@ async fn plotting_piece_eviction() {
         base_directory.as_ref(),
         base_directory.as_ref(),
         public_key,
-        5,
+        5 * PIECE_SIZE as u64,
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();


### PR DESCRIPTION
Tunings described in #656.

Using our bench plotting performance actually went down a bit from ~117M/s to ~112M/s on my machine when everything is stored on HDD, but it should be faster on combination of HDD+SSD.
On the positive side changes in this PR will reduce fragmentation and will ensure there is enough space for plot to be stored and it will avoid unnecessary read-ahead and caching on OS level (evicting other, potentially more useful data from cache).

Fixes #656

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
