### PR TITLE
Circuit relay improvements

### DIFF
--- a/crates/subspace-networking/examples/get-pieces.rs
+++ b/crates/subspace-networking/examples/get-pieces.rs
@@ -1,6 +1,7 @@
-use futures::channel::mpsc;
+use futures::channel::oneshot;
 use futures::StreamExt;
 use libp2p::multiaddr::Protocol;
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{crypto, FlatPieces, Piece, PieceIndexHash};
@@ -43,25 +44,29 @@ async fn main() {
 
     println!("Node 1 ID is {}", node_1.id());
 
-    let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
-    node_1
-        .on_new_listener(Arc::new(move |address| {
-            node_1_addresses_sender
-                .unbounded_send(address.clone())
-                .unwrap();
-        }))
-        .detach();
+    let (node_1_address_sender, node_1_address_receiver) = oneshot::channel();
+    let on_new_listener_handler = node_1.on_new_listener(Arc::new({
+        let node_1_address_sender = Mutex::new(Some(node_1_address_sender));
+
+        move |address| {
+            if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                if let Some(node_1_address_sender) = node_1_address_sender.lock().take() {
+                    node_1_address_sender.send(address.clone()).unwrap();
+                }
+            }
+        }
+    }));
 
     tokio::spawn(async move {
         node_runner_1.run().await;
     });
 
+    // Wait for first node to know its address
+    let node_1_addr = node_1_address_receiver.await.unwrap();
+    drop(on_new_listener_handler);
+
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addresses_receiver
-            .next()
-            .await
-            .unwrap()
-            .with(Protocol::P2p(node_1.id().into()))],
+        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -1,8 +1,9 @@
 use env_logger::Env;
-use futures::channel::mpsc;
+use futures::channel::oneshot;
 use futures::StreamExt;
 use libp2p::gossipsub::Sha256Topic;
 use libp2p::multiaddr::Protocol;
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::Sha256Hash;
@@ -27,27 +28,31 @@ async fn main() {
 
     println!("Node 1 ID is {}", node_1.id());
 
-    let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
-    node_1
-        .on_new_listener(Arc::new(move |address| {
-            node_1_addresses_sender
-                .unbounded_send(address.clone())
-                .unwrap();
-        }))
-        .detach();
+    let (node_1_address_sender, node_1_address_receiver) = oneshot::channel();
+    let on_new_listener_handler = node_1.on_new_listener(Arc::new({
+        let node_1_address_sender = Mutex::new(Some(node_1_address_sender));
+
+        move |address| {
+            if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                if let Some(node_1_address_sender) = node_1_address_sender.lock().take() {
+                    node_1_address_sender.send(address.clone()).unwrap();
+                }
+            }
+        }
+    }));
 
     tokio::spawn(async move {
         node_runner_1.run().await;
     });
 
+    // Wait for first node to know its address
+    let node_1_addr = node_1_address_receiver.await.unwrap();
+    drop(on_new_listener_handler);
+
     let mut subscription = node_1.subscribe(Sha256Topic::new(TOPIC)).await.unwrap();
 
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addresses_receiver
-            .next()
-            .await
-            .unwrap()
-            .with(Protocol::P2p(node_1.id().into()))],
+        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/examples/relayed-get-pieces-complex.rs
+++ b/crates/subspace-networking/examples/relayed-get-pieces-complex.rs
@@ -1,25 +1,22 @@
+use futures::channel::oneshot;
 use futures::StreamExt;
 use libp2p::multiaddr::Protocol;
-use libp2p::{identity, Multiaddr, PeerId};
+use libp2p::{identity, PeerId};
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{FlatPieces, Piece, PieceIndexHash};
-use subspace_networking::{
-    Config, PiecesByRangeResponse, PiecesToPlot, RelayConfiguration, RelayLimitSettings,
-};
+use subspace_networking::{Config, PiecesByRangeResponse, PiecesToPlot, RelayConfiguration};
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let relay_server_address = Multiaddr::empty().with(Protocol::Memory(1_000_000_000));
-
     // Relay node
-    let relay_node_addr: Multiaddr = "/ip4/127.0.0.1/tcp/50000".parse().unwrap();
     let config_1 = Config {
-        listen_on: vec![relay_node_addr.clone()],
+        listen_on: vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
-        relay_config: RelayConfiguration::Server(relay_server_address.clone(), relay_config()),
+        relay_config: RelayConfiguration::Server,
         ..Config::with_generated_keypair()
     };
 
@@ -27,9 +24,29 @@ async fn main() {
 
     println!("Relay Node ID is {}", relay_node.id());
 
+    let (relay_node_addresses_sender, relay_node_addresses_receiver) = oneshot::channel();
+    relay_node
+        .on_new_listener(Arc::new({
+            let relay_node_addresses_sender = Mutex::new(Some(relay_node_addresses_sender));
+
+            move |address| {
+                if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                    if let Some(relay_node_addresses_sender) =
+                        relay_node_addresses_sender.lock().take()
+                    {
+                        relay_node_addresses_sender.send(address.clone()).unwrap();
+                    }
+                }
+            }
+        }))
+        .detach();
+
     tokio::spawn(async move {
         relay_node_runner.run().await;
     });
+
+    // Wait for relay to know its address
+    let relay_node_addr = relay_node_addresses_receiver.await.unwrap();
 
     let mut bootstrap_nodes = Vec::new();
     let mut expected_node_id = PeerId::random();
@@ -68,6 +85,7 @@ async fn main() {
             }),
             relay_config: relay_node
                 .configure_relay_client()
+                .await
                 .expect("Server should be configured."),
             ..Config::with_generated_keypair()
         };
@@ -149,16 +167,4 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
     println!("Exiting..");
-}
-
-fn relay_config() -> RelayLimitSettings {
-    RelayLimitSettings {
-        max_reservations: 128000,
-        max_reservations_per_peer: 128000,
-        reservation_duration: Duration::from_secs(60 * 60),
-        max_circuits: 128000,
-        max_circuits_per_peer: 128000,
-        max_circuit_duration: Duration::from_secs(2 * 60),
-        max_circuit_bytes: 1 << 27,
-    }
 }

--- a/crates/subspace-networking/examples/relayed-requests.rs
+++ b/crates/subspace-networking/examples/relayed-requests.rs
@@ -1,6 +1,7 @@
 use env_logger::Env;
+use futures::channel::oneshot;
 use libp2p::multiaddr::Protocol;
-use libp2p::Multiaddr;
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{FlatPieces, Piece, PieceIndexHash};
@@ -13,12 +14,10 @@ async fn main() {
     env_logger::init_from_env(Env::new().default_filter_or("info"));
 
     // NODE 1 - Relay
-    let node_1_addr: Multiaddr = "/ip4/127.0.0.1/tcp/50000".parse().unwrap();
-    let custom_relay_address: Multiaddr = "/memory/10".parse().unwrap();
     let config_1 = Config {
-        listen_on: vec![node_1_addr.clone()],
+        listen_on: vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
-        relay_config: RelayConfiguration::Server(custom_relay_address.clone(), Default::default()),
+        relay_config: RelayConfiguration::Server,
         ..Config::with_generated_keypair()
     };
 
@@ -26,9 +25,27 @@ async fn main() {
 
     println!("Node 1 (relay) ID is {}", node_1.id());
 
+    let (node_1_addresses_sender, node_1_addresses_receiver) = oneshot::channel();
+    node_1
+        .on_new_listener(Arc::new({
+            let node_1_addresses_sender = Mutex::new(Some(node_1_addresses_sender));
+
+            move |address| {
+                if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                    if let Some(node_1_addresses_sender) = node_1_addresses_sender.lock().take() {
+                        node_1_addresses_sender.send(address.clone()).unwrap();
+                    }
+                }
+            }
+        }))
+        .detach();
+
     tokio::spawn(async move {
         node_runner_1.run().await;
     });
+
+    // Wait for relay to know its address
+    let node_1_addr = node_1_addresses_receiver.await.unwrap();
 
     // NODE 2 - Server
 
@@ -51,6 +68,7 @@ async fn main() {
         }),
         relay_config: node_1
             .configure_relay_client()
+            .await
             .expect("Relay Server should be configured."),
         ..Config::with_generated_keypair()
     };
@@ -66,7 +84,6 @@ async fn main() {
 
     let config_3 = Config {
         bootstrap_nodes: vec![node_1_addr
-            .clone()
             .with(Protocol::P2p(node_1.id().into()))
             .with(Protocol::P2pCircuit)
             .with(Protocol::P2p(node_2.id().into()))],

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -1,7 +1,7 @@
 use env_logger::Env;
-use futures::channel::mpsc;
-use futures::StreamExt;
+use futures::channel::oneshot;
 use libp2p::multiaddr::Protocol;
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{FlatPieces, Piece, PieceIndexHash};
@@ -39,25 +39,29 @@ async fn main() {
 
     println!("Node 1 ID is {}", node_1.id());
 
-    let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
-    node_1
-        .on_new_listener(Arc::new(move |address| {
-            node_1_addresses_sender
-                .unbounded_send(address.clone())
-                .unwrap();
-        }))
-        .detach();
+    let (node_1_address_sender, node_1_address_receiver) = oneshot::channel();
+    let on_new_listener_handler = node_1.on_new_listener(Arc::new({
+        let node_1_address_sender = Mutex::new(Some(node_1_address_sender));
+
+        move |address| {
+            if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                if let Some(node_1_address_sender) = node_1_address_sender.lock().take() {
+                    node_1_address_sender.send(address.clone()).unwrap();
+                }
+            }
+        }
+    }));
 
     tokio::spawn(async move {
         node_runner_1.run().await;
     });
 
+    // Wait for first node to know its address
+    let node_1_addr = node_1_address_receiver.await.unwrap();
+    drop(on_new_listener_handler);
+
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addresses_receiver
-            .next()
-            .await
-            .unwrap()
-            .with(Protocol::P2p(node_1.id().into()))],
+        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -105,15 +105,11 @@ pub enum RelayConfiguration {
     /// It will enable creating a relay circuit.
     /// This option will toggle the relay-client behaviour.
     ClientInitiator,
-
-    /// No relay configuration.
-    /// This option will have both relay (server) and relay client behaviour disabled.
-    NoRelay,
 }
 
 impl Default for RelayConfiguration {
     fn default() -> Self {
-        Self::NoRelay
+        Self::ClientInitiator
     }
 }
 

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -29,7 +29,7 @@ mod utils;
 
 pub use crate::node::{GetPiecesByRangeError, Node, SubscribeError, TopicSubscription};
 pub use crate::node_runner::NodeRunner;
-pub use create::{create, Config, CreationError, RelayConfiguration, RelayLimitSettings};
+pub use create::{create, Config, CreationError, RelayConfiguration};
 pub use libp2p;
 use libp2p::gossipsub::Sha256Topic;
 use once_cell::sync::Lazy;

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -149,8 +149,6 @@ impl NodeRunner {
                     }
                 } else {
                     // TODO: Add support for public address for add_external_address, AutoNAT
-                    self.swarm
-                        .add_external_address(address.clone(), AddressScore::Infinite);
                 }
                 self.shared.handlers.new_listener.call_simple(&address);
             }

--- a/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
+++ b/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
@@ -1,7 +1,8 @@
 use crate::{Config, PiecesByRangeRequest, PiecesByRangeResponse, PiecesToPlot};
-use futures::channel::mpsc;
+use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
 use libp2p::multiaddr::Protocol;
+use parking_lot::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use subspace_core_primitives::{crypto, FlatPieces, Piece, PieceIndexHash};
@@ -40,25 +41,29 @@ async fn pieces_by_range_protocol_smoke() {
     };
     let (node_1, mut node_runner_1) = crate::create(config_1).await.unwrap();
 
-    let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
-    node_1
-        .on_new_listener(Arc::new(move |address| {
-            node_1_addresses_sender
-                .unbounded_send(address.clone())
-                .unwrap();
-        }))
-        .detach();
+    let (node_1_address_sender, node_1_address_receiver) = oneshot::channel();
+    let on_new_listener_handler = node_1.on_new_listener(Arc::new({
+        let node_1_address_sender = Mutex::new(Some(node_1_address_sender));
+
+        move |address| {
+            if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                if let Some(node_1_address_sender) = node_1_address_sender.lock().take() {
+                    node_1_address_sender.send(address.clone()).unwrap();
+                }
+            }
+        }
+    }));
 
     tokio::spawn(async move {
         node_runner_1.run().await;
     });
 
+    // Wait for first node to know its address
+    let node_1_addr = node_1_address_receiver.await.unwrap();
+    drop(on_new_listener_handler);
+
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addresses_receiver
-            .next()
-            .await
-            .unwrap()
-            .with(Protocol::P2p(node_1.id().into()))],
+        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
@@ -134,25 +139,29 @@ async fn get_pieces_by_range_smoke() {
     };
     let (node_1, mut node_runner_1) = crate::create(config_1).await.unwrap();
 
-    let (node_1_addresses_sender, mut node_1_addresses_receiver) = mpsc::unbounded();
-    node_1
-        .on_new_listener(Arc::new(move |address| {
-            node_1_addresses_sender
-                .unbounded_send(address.clone())
-                .unwrap();
-        }))
-        .detach();
+    let (node_1_address_sender, node_1_address_receiver) = oneshot::channel();
+    let on_new_listener_handler = node_1.on_new_listener(Arc::new({
+        let node_1_address_sender = Mutex::new(Some(node_1_address_sender));
+
+        move |address| {
+            if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                if let Some(node_1_address_sender) = node_1_address_sender.lock().take() {
+                    node_1_address_sender.send(address.clone()).unwrap();
+                }
+            }
+        }
+    }));
 
     tokio::spawn(async move {
         node_runner_1.run().await;
     });
 
+    // Wait for first node to know its address
+    let node_1_addr = node_1_address_receiver.await.unwrap();
+    drop(on_new_listener_handler);
+
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addresses_receiver
-            .next()
-            .await
-            .unwrap()
-            .with(Protocol::P2p(node_1.id().into()))],
+        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()


### PR DESCRIPTION
Some changes to `subspace-networking` API mentioned in #668, though I still think we need to have `node.spawn()`.

This removes support for behavior without relay server, there is basically no reason for it to exist now.

It hides memory address from public API almost completely (will be hidden completely once we have `node.spawn()`) and replaces it with automatic discovery of the memory transport address.

I also changed explicit TCP ports just like explicit memory port to a random one, after which decided to unify other places where we have similar code (it was leaking memory in some cases, though mostly in examples and tests).

I will send a PR in a few hours with `node.spawn()` and with restricting relay circuit to only local peers. It will remove `listen_on` from generic configuration and will replace it with a separate argument because it will become unique to circuit relay server.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
