### PR TITLE
Display the primary number when execution receipt not found

### DIFF
--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -246,7 +246,9 @@ async fn pallet_executor_unsigned_extrinsics_should_work() {
 			alice.client.hash(primary_number).unwrap().unwrap(),
 		)
 		.expect("Failed to load execution receipt from the local aux_db")
-		.expect("The requested execution receipt must exist");
+		.unwrap_or_else(|| {
+			panic!("The requested execution receipt for block {primary_number} does not exist")
+		});
 
 		let pair = ExecutorPair::from_string("//Alice", None).unwrap();
 		let signature = pair.sign(execution_receipt.hash().as_ref());


### PR DESCRIPTION
To help debug #545, I want to know which primary block the receipt was
missing and if there is a pattern there.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
