### PR TITLE
Database writing improvements

### DIFF
--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use parity_scale_codec::{Decode, Encode};
-use rocksdb::{WriteBatch, DB};
+use rocksdb::{Options, WriteBatch, DB};
 use std::path::Path;
 use std::sync::Arc;
 use subspace_core_primitives::objects::GlobalObject;
@@ -27,7 +27,10 @@ impl ObjectMappings {
     where
         P: AsRef<Path>,
     {
-        let db = DB::open_default(path).map_err(ObjectMappingError::Db)?;
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        options.set_unordered_write(true);
+        let db = DB::open(&options, path).map_err(ObjectMappingError::Db)?;
 
         Ok(Self { db: Arc::new(db) })
     }


### PR DESCRIPTION
On commitments side this makes sure to write commitments in 16MiB worth of data (key+value pairs) instead of much smaller ones and also pre-sorts keys, which helps a lot. This results in double-digit percentage improvements for commitments creation (both full and during plotting), though total time improves much less when other things are involved.

On object mappings side writes are unordered because we don't care about order.

Most of these changes will be applicable to ParityDb too once we switch to that.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
