### PR TITLE
Info command for printing information about different farms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7911,6 +7917,7 @@ dependencies = [
  "async-trait",
  "base58",
  "blake2-rfc",
+ "bytesize",
  "clap 3.1.18",
  "derive_more",
  "dirs",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -18,6 +18,7 @@ async-oneshot = "0.5.0"
 async-trait = "0.1.53"
 base58 = "0.2.0"
 blake2-rfc = "0.2.18"
+bytesize = "1.1.0"
 clap = { version = "3.1.18", features = ["color", "derive"] }
 derive_more = "0.99.17"
 dirs = "4.0.0"

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,7 +1,9 @@
 mod bench;
 mod farm;
+mod info;
 mod wipe;
 
 pub(crate) use bench::bench;
 pub(crate) use farm::{farm_legacy, farm_multi_disk};
+pub(crate) use info::info;
 pub(crate) use wipe::wipe;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/info.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/info.rs
@@ -1,0 +1,120 @@
+use crate::DiskFarm;
+use subspace_farmer::single_disk_farm::{SingleDiskFarm, SingleDiskFarmSummary};
+use subspace_farmer::single_plot_farm::SinglePlotFarmSummary;
+
+pub(crate) fn info(disk_farms: Vec<DiskFarm>) {
+    for (disk_farm_index, disk_farm) in disk_farms.into_iter().enumerate() {
+        if disk_farm_index > 0 {
+            println!();
+        }
+
+        let DiskFarm {
+            plot_directory,
+            metadata_directory,
+            ..
+        } = disk_farm;
+
+        println!("Single disk farm {disk_farm_index}:");
+        match SingleDiskFarm::collect_summary(plot_directory, metadata_directory) {
+            SingleDiskFarmSummary::Found {
+                id,
+                genesis_hash,
+                allocated_plotting_space,
+                plot_directory,
+                metadata_directory,
+                single_plot_farm_summaries,
+            } => {
+                println!("  ID: {id}");
+                println!("  Genesis hash: 0x{}", hex::encode(genesis_hash));
+                println!(
+                    "  Allocated plotting space: {} ({})",
+                    bytesize::to_string(allocated_plotting_space, true),
+                    bytesize::to_string(allocated_plotting_space, false)
+                );
+                println!("  Plot directory (HDD): {}", plot_directory.display());
+                println!(
+                    "  Metadata directory (SSD): {}",
+                    metadata_directory.display()
+                );
+
+                for (plot_farm_index, single_plot_farm_summary) in
+                    single_plot_farm_summaries.into_iter().enumerate()
+                {
+                    println!();
+
+                    match single_plot_farm_summary {
+                        SinglePlotFarmSummary::Found {
+                            id,
+                            public_key,
+                            allocated_plotting_space,
+                            plot_directory,
+                            metadata_directory,
+                        } => {
+                            println!("  Single plot farm {disk_farm_index}.{plot_farm_index}:");
+                            println!("    ID: {id}");
+                            println!("    Public key: 0x{}", hex::encode(public_key));
+                            println!(
+                                "    Allocated plotting space: {} ({})",
+                                bytesize::to_string(allocated_plotting_space, true),
+                                bytesize::to_string(allocated_plotting_space, false)
+                            );
+                            println!("    Plot directory (HDD): {}", plot_directory.display());
+                            println!(
+                                "    Metadata directory (SSD): {}",
+                                metadata_directory.display()
+                            );
+                        }
+                        SinglePlotFarmSummary::NotFound {
+                            plot_directory,
+                            metadata_directory,
+                        } => {
+                            println!("  Single plot farm {}:", plot_farm_index);
+                            println!("    Plot directory (HDD): {}", plot_directory.display());
+                            println!(
+                                "    Metadata directory (SSD): {}",
+                                metadata_directory.display()
+                            );
+                            println!("    No farm found here yet");
+                        }
+                        SinglePlotFarmSummary::Error {
+                            plot_directory,
+                            metadata_directory,
+                            error,
+                        } => {
+                            println!("  Single plot farm {}:", plot_farm_index);
+                            println!("    Plot directory (HDD): {}", plot_directory.display());
+                            println!(
+                                "    Metadata directory (SSD): {}",
+                                metadata_directory.display()
+                            );
+                            println!("    Failed to open farm info: {}", error);
+                        }
+                    }
+                }
+            }
+            SingleDiskFarmSummary::NotFound {
+                plot_directory,
+                metadata_directory,
+            } => {
+                println!("  Plot directory (HDD): {}", plot_directory.display());
+                println!(
+                    "  Metadata directory (SSD): {}",
+                    metadata_directory.display()
+                );
+                println!("  No farm found here yet");
+            }
+            SingleDiskFarmSummary::Error {
+                plot_directory,
+                metadata_directory,
+                error,
+            } => {
+                println!("  Plot directory (HDD): {}", plot_directory.display());
+                println!(
+                    "  Metadata directory (SSD): {}",
+                    metadata_directory.display()
+                );
+                println!("  Failed to open farm info: {}", error);
+            }
+        }
+    }
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -98,6 +98,8 @@ enum Subcommand {
     Wipe,
     /// Start a farmer using previously created plot
     Farm(FarmingArgs),
+    /// Print information about farm and its content
+    Info,
     /// Benchmark disk in order to see a throughput of the disk for plotting
     Bench {
         /// Maximum plot size in human readable format (e.g. 10G, 2T) or just bytes (e.g. 4096).
@@ -303,6 +305,13 @@ async fn main() -> Result<()> {
                     }
                 }
                 commands::farm_multi_disk(command.farm, farming_args).await?;
+            }
+        }
+        Subcommand::Info => {
+            if command.farm.is_empty() {
+                panic!("Printing info for legacy plots is not supported");
+            } else {
+                commands::info(command.farm);
             }
         }
         Subcommand::Bench {

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1,7 +1,7 @@
 use crate::archiving::Archiving;
 use crate::rpc_client::RpcClient;
 use crate::single_plot_farm::{
-    PlotFactory, SinglePlotFarm, SinglePlotFarmId, SinglePlotFarmOptions,
+    PlotFactory, SinglePlotFarm, SinglePlotFarmId, SinglePlotFarmOptions, SinglePlotFarmSummary,
 };
 use crate::utils::get_plot_sizes;
 use crate::ws_rpc_server::PieceGetter;
@@ -105,8 +105,8 @@ impl SingleDiskFarmInfo {
 
     /// Load `SingleDiskFarm` from path, `None` means no info file was found, happens during first
     /// start.
-    pub fn load_from(metadata_directory: &Path) -> io::Result<Option<Self>> {
-        let bytes = match fs::read(metadata_directory.join(Self::FILE_NAME)) {
+    pub fn load_from(path: &Path) -> io::Result<Option<Self>> {
+        let bytes = match fs::read(path.join(Self::FILE_NAME)) {
             Ok(bytes) => bytes,
             Err(error) => {
                 return if error.kind() == io::ErrorKind::NotFound {
@@ -123,9 +123,9 @@ impl SingleDiskFarmInfo {
     }
 
     /// Store `SingleDiskFarm` info to path so it can be loaded again upon restart.
-    pub fn store_to(&self, metadata_directory: &Path) -> io::Result<()> {
+    pub fn store_to(&self, path: &Path) -> io::Result<()> {
         fs::write(
-            metadata_directory.join(Self::FILE_NAME),
+            path.join(Self::FILE_NAME),
             serde_json::to_vec(self).expect("Info serialization never fails; qed"),
         )
     }
@@ -158,6 +158,41 @@ impl SingleDiskFarmInfo {
         } = self;
         single_plot_farms
     }
+}
+
+/// Summary of single disk farm for presentational purposes
+pub enum SingleDiskFarmSummary {
+    /// Farm was found and read successfully
+    Found {
+        // ID of the farm
+        id: SingleDiskFarmId,
+        // Genesis hash of the chain used for farm creation
+        genesis_hash: [u8; 32],
+        // How much space in bytes can farm use for plots (metadata space is not included)
+        allocated_plotting_space: u64,
+        /// Path to directory where plots are stored, typically HDD.
+        plot_directory: PathBuf,
+        /// Path to directory for storing metadata, typically SSD.
+        metadata_directory: PathBuf,
+        // Summaries of single plot farms contained within
+        single_plot_farm_summaries: Vec<SinglePlotFarmSummary>,
+    },
+    /// Farm was not found
+    NotFound {
+        /// Path to directory where plots are stored, typically HDD.
+        plot_directory: PathBuf,
+        /// Path to directory for storing metadata, typically SSD.
+        metadata_directory: PathBuf,
+    },
+    /// Failed to open farm
+    Error {
+        /// Path to directory where plots are stored, typically HDD.
+        plot_directory: PathBuf,
+        /// Path to directory for storing metadata, typically SSD.
+        metadata_directory: PathBuf,
+        /// Error itself
+        error: io::Error,
+    },
 }
 
 /// Options for `SingleDiskFarm` creation
@@ -285,23 +320,23 @@ impl SingleDiskFarm {
                 .zip(plot_sizes)
                 .enumerate()
                 .map(
-                    move |(plot_index, (single_farm_plot_id, allocated_plotting_space))| {
+                    move |(plot_index, (single_plot_farm_id, allocated_plotting_space))| {
                         let _guard = handle.enter();
 
-                        let plot_directory = plot_directory.join(single_farm_plot_id.to_string());
+                        let plot_directory = plot_directory.join(single_plot_farm_id.to_string());
                         let metadata_directory =
-                            metadata_directory.join(single_farm_plot_id.to_string());
+                            metadata_directory.join(single_plot_farm_id.to_string());
                         let farming_client = farming_client.clone();
                         let listen_on = listen_on.clone();
                         let bootstrap_nodes = bootstrap_nodes.clone();
                         let first_listen_on = Arc::clone(&first_listen_on);
                         let single_disk_semaphore = single_disk_semaphore.clone();
 
-                        let span = info_span!("single_plot_farm", %single_farm_plot_id);
+                        let span = info_span!("single_plot_farm", %single_plot_farm_id);
                         let _enter = span.enter();
 
                         SinglePlotFarm::new(SinglePlotFarmOptions {
-                            id: *single_farm_plot_id,
+                            id: *single_plot_farm_id,
                             plot_directory,
                             metadata_directory,
                             plot_index,
@@ -408,6 +443,49 @@ impl SingleDiskFarm {
         }
 
         Ok(())
+    }
+
+    /// Collect summary of single disk farm for presentational purposes
+    pub fn collect_summary(
+        plot_directory: PathBuf,
+        metadata_directory: PathBuf,
+    ) -> SingleDiskFarmSummary {
+        let single_disk_farm_info = match SingleDiskFarmInfo::load_from(&plot_directory) {
+            Ok(Some(single_disk_farm_info)) => single_disk_farm_info,
+            Ok(None) => {
+                return SingleDiskFarmSummary::NotFound {
+                    plot_directory,
+                    metadata_directory,
+                };
+            }
+            Err(error) => {
+                return SingleDiskFarmSummary::Error {
+                    plot_directory,
+                    metadata_directory,
+                    error,
+                };
+            }
+        };
+
+        let single_plot_farm_summaries = single_disk_farm_info
+            .single_plot_farms()
+            .iter()
+            .map(|single_plot_farm_id| {
+                SinglePlotFarm::collect_summary(
+                    plot_directory.join(single_plot_farm_id.to_string()),
+                    metadata_directory.join(single_plot_farm_id.to_string()),
+                )
+            })
+            .collect();
+
+        return SingleDiskFarmSummary::Found {
+            id: *single_disk_farm_info.id(),
+            genesis_hash: *single_disk_farm_info.genesis_hash(),
+            allocated_plotting_space: single_disk_farm_info.allocated_plotting_space(),
+            plot_directory,
+            metadata_directory,
+            single_plot_farm_summaries,
+        };
     }
 
     /// Wipe everything that belongs to this single disk farm


### PR DESCRIPTION
This is an initial version, we can extend it with information about how full plot is, state of recommitments, number of object mappings stored, maybe something else.

In addition to CLI interface there is a library interface as well, but only for new `SingleDiskFarm`, can potentially be used by desktop application and other tools.

Sample output:
```
Single disk farm 0:
  ID: 01G7KKBCXNYY49JJY26BQ57858
  Genesis hash: 0x6a2020a89565b5cd1df1193e8c9e8bbb6d496d0aeb2567b1e19c356394e30897
  Allocated plotting space: 9.3 GiB (10.0 GB)
  Plot directory (HDD): /disks/hdd1
  Metadata directory (SSD): /disks/ssd1

  Single plot farm 0.0:
    ID: 01G7KKBCXN5MTMXB3XVH65Q8XM
    Public key: 0x52b20fdaff35cb0ce061bbd14bb74157fe58b79a3d36d5f472c759e29a776803
    Allocated plotting space: 9.3 GiB (10.0 GB)
    Plot directory (HDD): /disks/hdd1/01G7KKBCXN5MTMXB3XVH65Q8XM
    Metadata directory (SSD): /disks/ssd1/01G7KKBCXN5MTMXB3XVH65Q8XM

Single disk farm 1:
  ID: 01G7KKBCZR3X5Q842D7NSQ20Q3
  Genesis hash: 0x6a2020a89565b5cd1df1193e8c9e8bbb6d496d0aeb2567b1e19c356394e30897
  Allocated plotting space: 9.3 GiB (10.0 GB)
  Plot directory (HDD): /disks/hdd2
  Metadata directory (SSD): /disks/ssd1

  Single plot farm 1.0:
    ID: 01G7KKBCZRKYQQR8AA6D5TD3A8
    Public key: 0x46449e0e04b129e7877cf10b63be742471867a481633337f5c1d73fddc610c3f
    Allocated plotting space: 9.3 GiB (10.0 GB)
    Plot directory (HDD): /disks/hdd2/01G7KKBCZRKYQQR8AA6D5TD3A8
    Metadata directory (SSD): /disks/ssd1/01G7KKBCZRKYQQR8AA6D5TD3A8
```

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
