### PR TITLE
U256 refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7890,6 +7890,7 @@ dependencies = [
 name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "hex",
  "hmac 0.12.1",
  "num-traits",

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -267,11 +267,14 @@ fn is_within_max_plot(
         return true;
     }
     let max_distance_one_direction = U256::MAX / total_pieces * max_plot_size / 2;
-    U256::from(PieceIndexHash::from_index(piece_index)).distance(&U256::from_be_bytes(
-        AsRef::<[u8]>::as_ref(&public_key)
-            .try_into()
-            .expect("Always correct length; qed"),
-    )) <= max_distance_one_direction
+    subspace_core_primitives::bidirectional_distance(
+        &U256::from(PieceIndexHash::from_index(piece_index)),
+        &U256::from_be_bytes(
+            AsRef::<[u8]>::as_ref(&public_key)
+                .try_into()
+                .expect("Always correct length; qed"),
+        ),
+    ) <= max_distance_one_direction
 }
 
 /// Parameters for checking piece validity

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -267,7 +267,8 @@ fn is_within_max_plot(
         return true;
     }
     let max_distance_one_direction = U256::MAX / total_pieces * max_plot_size / 2;
-    U256::distance(&PieceIndexHash::from_index(piece_index), key.as_ref())
+    U256::from(PieceIndexHash::from_index(piece_index))
+        .distance(&U256::from_big_endian(key.as_ref()))
         <= max_distance_one_direction
 }
 

--- a/crates/sp-consensus-subspace/src/verification.rs
+++ b/crates/sp-consensus-subspace/src/verification.rs
@@ -259,7 +259,7 @@ pub fn is_within_solution_range(target: Tag, tag: Tag, solution_range: u64) -> b
 /// Returns true if piece index is within farmer sector
 fn is_within_max_plot(
     piece_index: PieceIndex,
-    key: &FarmerPublicKey,
+    public_key: &FarmerPublicKey,
     total_pieces: u64,
     max_plot_size: u64,
 ) -> bool {
@@ -267,9 +267,11 @@ fn is_within_max_plot(
         return true;
     }
     let max_distance_one_direction = U256::MAX / total_pieces * max_plot_size / 2;
-    U256::from(PieceIndexHash::from_index(piece_index))
-        .distance(&U256::from_big_endian(key.as_ref()))
-        <= max_distance_one_direction
+    U256::from(PieceIndexHash::from_index(piece_index)).distance(&U256::from_be_bytes(
+        AsRef::<[u8]>::as_ref(&public_key)
+            .try_into()
+            .expect("Always correct length; qed"),
+    )) <= max_distance_one_direction
 }
 
 /// Parameters for checking piece validity

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+derive_more = "0.99.17"
 hex = { version  = "0.4.3", default-features = false }
 hmac = { version  = "0.12.1", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -672,6 +672,36 @@ impl WrappingSub for U256 {
     }
 }
 
+impl From<u8> for U256 {
+    fn from(number: u8) -> Self {
+        Self(number.into())
+    }
+}
+
+impl From<u16> for U256 {
+    fn from(number: u16) -> Self {
+        Self(number.into())
+    }
+}
+
+impl From<u32> for U256 {
+    fn from(number: u32) -> Self {
+        Self(number.into())
+    }
+}
+
+impl From<u64> for U256 {
+    fn from(number: u64) -> Self {
+        Self(number.into())
+    }
+}
+
+impl From<u128> for U256 {
+    fn from(number: u128) -> Self {
+        Self(number.into())
+    }
+}
+
 impl From<PieceIndexHash> for U256 {
     fn from(PieceIndexHash(hash): PieceIndexHash) -> Self {
         Self(private_u256::U256::from_big_endian(&hash))

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -591,11 +591,6 @@ impl U256 {
         Self(private_u256::U256::one())
     }
 
-    /// Calculates bidirectional distance
-    pub fn distance(&self, address: &Self) -> U256 {
-        bidirectional_distance(self, address)
-    }
-
     /// Create from big endian bytes
     pub fn from_be_bytes(bytes: [u8; 32]) -> Self {
         Self(private_u256::U256::from_big_endian(&bytes))

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -567,10 +567,8 @@ mod construct_uint {
 
     impl U256 {
         /// Calculates the distance metric between piece index hash and farmer address.
-        pub fn distance(PieceIndexHash(piece): &PieceIndexHash, address: &[u8]) -> U256 {
-            let piece = Self::from_big_endian(piece);
-            let address = Self::from_big_endian(address);
-            bidirectional_distance(&piece, &address)
+        pub fn distance(&self, address: &Self) -> U256 {
+            bidirectional_distance(self, address)
         }
 
         /// Convert piece distance to big endian bytes
@@ -601,7 +599,7 @@ mod construct_uint {
 
     impl From<PieceIndexHash> for U256 {
         fn from(PieceIndexHash(hash): PieceIndexHash) -> Self {
-            hash.into()
+            Self::from_big_endian(&hash)
         }
     }
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -453,7 +453,19 @@ pub type PieceIndex = u64;
 /// Hash of `PieceIndex`
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Decode, Encode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PieceIndexHash(pub Sha256Hash);
+pub struct PieceIndexHash(Sha256Hash);
+
+impl From<PieceIndexHash> for Sha256Hash {
+    fn from(piece_index_hash: PieceIndexHash) -> Self {
+        piece_index_hash.0
+    }
+}
+
+impl From<Sha256Hash> for PieceIndexHash {
+    fn from(hash: Sha256Hash) -> Self {
+        Self(hash)
+    }
+}
 
 impl AsRef<[u8]> for PieceIndexHash {
     fn as_ref(&self) -> &[u8] {
@@ -566,14 +578,21 @@ mod construct_uint {
     }
 
     impl U256 {
-        /// Calculates the distance metric between piece index hash and farmer address.
+        /// Calculates bidirectional distance
         pub fn distance(&self, address: &Self) -> U256 {
             bidirectional_distance(self, address)
         }
 
-        /// Convert piece distance to big endian bytes
-        pub fn to_bytes(self) -> [u8; 32] {
-            self.into()
+        /// Create from big endian bytes
+        pub fn from_be_bytes(bytes: [u8; 32]) -> Self {
+            U256::from_big_endian(&bytes)
+        }
+
+        /// Convert to big endian bytes
+        pub fn to_be_bytes(self) -> [u8; 32] {
+            let mut arr = [0u8; 32];
+            self.to_big_endian(&mut arr);
+            arr
         }
 
         /// The middle of the piece distance field.

--- a/crates/subspace-farmer/src/dsn.rs
+++ b/crates/subspace-farmer/src/dsn.rs
@@ -143,9 +143,9 @@ where
                 .into_iter()
                 .zip(pieces.as_pieces())
                 .filter(|(index, _)| {
-                    (start..end).contains(&PieceIndexHashNumber::from_big_endian(
-                        &PieceIndexHash::from_index(*index).0,
-                    ))
+                    (start..end).contains(&PieceIndexHashNumber::from(PieceIndexHash::from_index(
+                        *index,
+                    )))
                 })
                 .map(|(index, piece)| {
                     (

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -231,12 +231,7 @@ async fn test_dsn_sync() {
         }
 
         (0..number_of_segments * pieces_per_segment)
-            .map(|index| {
-                (
-                    U256::from_big_endian(&PieceIndexHash::from_index(index).0),
-                    index,
-                )
-            })
+            .map(|index| (U256::from(PieceIndexHash::from_index(index)), index))
             .collect::<BTreeMap<_, _>>()
     };
 
@@ -341,11 +336,8 @@ async fn test_dsn_sync() {
         seeder_max_plot_size,
         range_size,
     );
-    let public_key = U256::from_big_endian(
-        syncer_multi_farming.single_plot_farms()[0]
-            .public_key()
-            .as_ref(),
-    );
+    let public_key =
+        U256::from_be_bytes((*syncer_multi_farming.single_plot_farms()[0].public_key()).into());
 
     tokio::spawn(async move {
         if let Err(error) = syncer_multi_farming.wait().await {
@@ -361,10 +353,7 @@ async fn test_dsn_sync() {
 
     match plot.get_piece_range().unwrap() {
         Some(range) => {
-            let (start, end) = (
-                U256::from_big_endian(&range.start().0),
-                U256::from_big_endian(&range.end().0),
-            );
+            let (start, end) = (U256::from(*range.start()), U256::from(*range.end()));
 
             let shift_to_middle =
                 |n: U256, pub_key| n.wrapping_sub(pub_key).wrapping_add(&U256::MIDDLE);

--- a/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
@@ -166,7 +166,10 @@ impl IndexHashToOffsetDB {
                 subspace_core_primitives::bidirectional_distance(
                     &max_distance_key,
                     &PieceDistance::MIDDLE,
-                ) >= U256::from(index_hash).distance(&self.public_key_as_number)
+                ) >= subspace_core_primitives::bidirectional_distance(
+                    &U256::from(index_hash),
+                    &self.public_key_as_number,
+                )
             })
             .unwrap_or(true)
     }

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -126,7 +126,7 @@ async fn partial_plot() {
     assert!(!plot.is_empty());
 
     let mut piece_indexes = (0..pieces_to_plot).collect::<Vec<_>>();
-    let public_key_as_number = U256::from_big_endian(&public_key);
+    let public_key_as_number = U256::from_be_bytes(public_key.into());
     piece_indexes.sort_by_key(|i| {
         U256::from(PieceIndexHash::from_index(*i)).distance(&public_key_as_number)
     });
@@ -175,7 +175,7 @@ async fn sequential_pieces_iterator() {
     piece_indexes.sort_by_key(|i| PieceIndexHash::from_index(*i));
 
     let got_indexes = plot
-        .get_sequential_pieces(PieceIndexHash([0; 32]), 100)
+        .get_sequential_pieces(PieceIndexHash::from([0; 32]), 100)
         .unwrap()
         .into_iter()
         .map(|(index, _)| index)
@@ -202,42 +202,42 @@ async fn test_read_sequential_pieces() {
     // 6 piece index hashes, sorted as big endian numbers
     let expected_piece_index_hashes: Vec<(PieceIndexHash, u64)> = vec![
         (
-            PieceIndexHash([
+            PieceIndexHash::from([
                 53, 190, 50, 45, 9, 79, 157, 21, 74, 138, 186, 71, 51, 184, 73, 127, 24, 3, 83,
                 189, 122, 231, 176, 161, 95, 144, 181, 134, 181, 73, 242, 139,
             ]),
             3,
         ),
         (
-            PieceIndexHash([
+            PieceIndexHash::from([
                 124, 159, 161, 54, 212, 65, 63, 166, 23, 54, 55, 232, 131, 182, 153, 141, 50, 225,
                 214, 117, 248, 140, 221, 255, 157, 203, 207, 51, 24, 32, 244, 184,
             ]),
             1,
         ),
         (
-            PieceIndexHash([
+            PieceIndexHash::from([
                 175, 85, 112, 245, 161, 129, 11, 122, 247, 140, 175, 75, 199, 10, 102, 15, 13, 245,
                 30, 66, 186, 249, 29, 77, 229, 178, 50, 141, 224, 232, 61, 252,
             ]),
             0,
         ),
         (
-            PieceIndexHash([
+            PieceIndexHash::from([
                 216, 110, 129, 18, 243, 196, 196, 68, 33, 38, 248, 233, 244, 79, 22, 134, 125, 164,
                 135, 242, 144, 82, 191, 145, 184, 16, 69, 125, 179, 66, 9, 164,
             ]),
             2,
         ),
         (
-            PieceIndexHash([
+            PieceIndexHash::from([
                 240, 160, 39, 142, 67, 114, 69, 156, 202, 97, 89, 205, 94, 113, 207, 238, 99, 131,
                 2, 167, 185, 202, 155, 5, 195, 65, 129, 172, 10, 101, 172, 93,
             ]),
             4,
         ),
         (
-            PieceIndexHash([
+            PieceIndexHash::from([
                 241, 62, 230, 237, 84, 234, 42, 174, 159, 196, 154, 159, 174, 181, 218, 110, 141,
                 222, 240, 225, 46, 213, 211, 13, 53, 166, 36, 174, 129, 62, 4, 133,
             ]),
@@ -248,11 +248,8 @@ async fn test_read_sequential_pieces() {
 
     // Public key in the middle of piece index hashes, so we can test all necessary edge-cases
     let public_key_bytes = {
-        let mut bytes = [0u8; 32];
         // Just after second out of four hashes
-        (PieceDistance::from_big_endian(piece_index_hashes[1].0.as_ref()) + 1)
-            .to_big_endian(&mut bytes);
-        bytes
+        (PieceDistance::from(piece_index_hashes[1].0) + 1).to_be_bytes()
     };
     let plot = Plot::open_or_create(
         &0usize.into(),
@@ -267,7 +264,7 @@ async fn test_read_sequential_pieces() {
     // Zero count should return no indexes
     {
         let indexes = plot
-            .read_sequential_piece_indexes(PieceIndexHash([0; 32]), 0)
+            .read_sequential_piece_indexes(PieceIndexHash::from([0; 32]), 0)
             .unwrap();
         let expected_indexes: Vec<PieceIndex> = vec![];
         assert_eq!(indexes, expected_indexes);
@@ -350,7 +347,7 @@ async fn test_read_sequential_pieces() {
     // Wrapping case, read more than there is pieces from zero
     {
         let indexes = plot
-            .read_sequential_piece_indexes(PieceIndexHash([0; 32]), 10)
+            .read_sequential_piece_indexes(PieceIndexHash::from([0; 32]), 10)
             .unwrap();
         // This should read all piece indexes and nothing else
         let expected_indexes = piece_index_hashes

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -1,7 +1,7 @@
 use crate::plot::{PieceDistance, Plot};
 use rand::prelude::*;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Piece, PieceIndex, PieceIndexHash, PIECE_SIZE};
+use subspace_core_primitives::{FlatPieces, Piece, PieceIndex, PieceIndexHash, PIECE_SIZE, U256};
 use tempfile::TempDir;
 
 fn init() {
@@ -126,8 +126,10 @@ async fn partial_plot() {
     assert!(!plot.is_empty());
 
     let mut piece_indexes = (0..pieces_to_plot).collect::<Vec<_>>();
-    piece_indexes
-        .sort_by_key(|i| PieceDistance::distance(&PieceIndexHash::from_index(*i), &public_key));
+    let public_key_as_number = U256::from_big_endian(&public_key);
+    piece_indexes.sort_by_key(|i| {
+        U256::from(PieceIndexHash::from_index(*i)).distance(&public_key_as_number)
+    });
 
     // First pieces should be present and equal
     for &piece_index in &piece_indexes[..max_plot_pieces as usize] {

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -249,7 +249,7 @@ async fn test_read_sequential_pieces() {
     // Public key in the middle of piece index hashes, so we can test all necessary edge-cases
     let public_key_bytes = {
         // Just after second out of four hashes
-        (PieceDistance::from(piece_index_hashes[1].0) + 1).to_be_bytes()
+        (PieceDistance::from(piece_index_hashes[1].0) + PieceDistance::one()).to_be_bytes()
     };
     let plot = Plot::open_or_create(
         &0usize.into(),

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -128,7 +128,10 @@ async fn partial_plot() {
     let mut piece_indexes = (0..pieces_to_plot).collect::<Vec<_>>();
     let public_key_as_number = U256::from_be_bytes(public_key.into());
     piece_indexes.sort_by_key(|i| {
-        U256::from(PieceIndexHash::from_index(*i)).distance(&public_key_as_number)
+        subspace_core_primitives::bidirectional_distance(
+            &U256::from(PieceIndexHash::from_index(*i)),
+            &public_key_as_number,
+        )
     });
 
     // First pieces should be present and equal

--- a/crates/subspace-farmer/src/plot/worker.rs
+++ b/crates/subspace-farmer/src/plot/worker.rs
@@ -295,7 +295,7 @@ impl<T: PlotFile> PlotWorker<T> {
             // Check if piece is out of plot range or if it is in the plot
             if !self
                 .piece_index_hash_to_offset_db
-                .should_store(&PieceIndexHash::from_index(piece_index))
+                .should_store(PieceIndexHash::from_index(piece_index))
             {
                 continue;
             }

--- a/crates/subspace-farmer/src/plot/worker.rs
+++ b/crates/subspace-farmer/src/plot/worker.rs
@@ -175,8 +175,8 @@ impl<T: PlotFile> PlotWorker<T> {
                             count,
                             result_sender,
                         } => {
-                            let _ = result_sender
-                                .send(self.read_piece_indexes(&from_index_hash, count));
+                            let _ =
+                                result_sender.send(self.read_piece_indexes(from_index_hash, count));
                         }
                         Request::GetPieceRange { result_sender } => {
                             let _ = result_sender
@@ -228,7 +228,7 @@ impl<T: PlotFile> PlotWorker<T> {
         let mut buffer = Piece::default();
         let offset = self
             .piece_index_hash_to_offset_db
-            .get(&piece_index_hash)?
+            .get(piece_index_hash)?
             .ok_or_else(|| {
                 io::Error::other(format!("Piece with hash {piece_index_hash:?} not found"))
             })?;
@@ -262,11 +262,11 @@ impl<T: PlotFile> PlotWorker<T> {
             self.plot.write(sequential_pieces, current_piece_count)?;
 
             self.piece_index_hash_to_offset_db.batch_insert(
-                &sequential_piece_indexes
+                sequential_piece_indexes
                     .iter()
                     .copied()
                     .map(PieceIndexHash::from_index)
-                    .collect::<Vec<_>>(),
+                    .collect(),
                 current_piece_count,
             )?;
 
@@ -302,7 +302,7 @@ impl<T: PlotFile> PlotWorker<T> {
 
             let piece_offset = self
                 .piece_index_hash_to_offset_db
-                .replace_furthest(&PieceIndexHash::from_index(piece_index))?;
+                .replace_furthest(PieceIndexHash::from_index(piece_index))?;
 
             let mut old_piece = Piece::default();
             self.plot.read(piece_offset, &mut old_piece)?;
@@ -327,7 +327,7 @@ impl<T: PlotFile> PlotWorker<T> {
 
     fn read_piece_indexes(
         &mut self,
-        from: &PieceIndexHash,
+        from: PieceIndexHash,
         count: u64,
     ) -> io::Result<Vec<PieceIndex>> {
         self.piece_index_hash_to_offset_db

--- a/crates/subspace-networking/examples/get-pieces-complex.rs
+++ b/crates/subspace-networking/examples/get-pieces-complex.rs
@@ -116,12 +116,12 @@ async fn main() {
     let from = {
         let mut buf = peer_id_public_key;
         buf[16] = 0;
-        PieceIndexHash(buf)
+        PieceIndexHash::from(buf)
     };
     let to = {
         let mut buf = peer_id_public_key;
         buf[16] = 50;
-        PieceIndexHash(buf)
+        PieceIndexHash::from(buf)
     };
 
     let stream_future = node.get_pieces_by_range(from, to);

--- a/crates/subspace-networking/examples/get-pieces.rs
+++ b/crates/subspace-networking/examples/get-pieces.rs
@@ -29,7 +29,7 @@ async fn main() {
 
             let response = Some(PiecesByRangeResponse {
                 pieces,
-                next_piece_index_hash: Some(PieceIndexHash([0; 32])),
+                next_piece_index_hash: Some(PieceIndexHash::from([0; 32])),
             });
 
             println!("Sending response... ");
@@ -82,7 +82,7 @@ async fn main() {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let hashed_peer_id = PieceIndexHash(crypto::sha256_hash(&node_1.id().to_bytes()));
+    let hashed_peer_id = PieceIndexHash::from(crypto::sha256_hash(&node_1.id().to_bytes()));
 
     let stream_future = node_2.get_pieces_by_range(hashed_peer_id, hashed_peer_id);
     let mut stream = stream_future.await.unwrap();

--- a/crates/subspace-networking/examples/relayed-get-pieces-complex.rs
+++ b/crates/subspace-networking/examples/relayed-get-pieces-complex.rs
@@ -144,12 +144,12 @@ async fn main() {
     let from = {
         let mut buf = peer_id_public_key;
         buf[16] = 0;
-        PieceIndexHash(buf)
+        PieceIndexHash::from(buf)
     };
     let to = {
         let mut buf = peer_id_public_key;
         buf[16] = 50;
-        PieceIndexHash(buf)
+        PieceIndexHash::from(buf)
     };
 
     let stream_future = node.get_pieces_by_range(from, to);

--- a/crates/subspace-networking/examples/relayed-requests.rs
+++ b/crates/subspace-networking/examples/relayed-requests.rs
@@ -106,8 +106,8 @@ async fn main() {
             .send_pieces_by_range_request(
                 node_2.id(),
                 PiecesByRangeRequest {
-                    from: PieceIndexHash([1u8; 32]),
-                    to: PieceIndexHash([1u8; 32]),
+                    from: PieceIndexHash::from([1u8; 32]),
+                    to: PieceIndexHash::from([1u8; 32]),
                 },
             )
             .await

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -82,8 +82,8 @@ async fn main() {
             .send_pieces_by_range_request(
                 node_1.id(),
                 PiecesByRangeRequest {
-                    from: PieceIndexHash([1u8; 32]),
-                    to: PieceIndexHash([1u8; 32]),
+                    from: PieceIndexHash::from([1u8; 32]),
+                    to: PieceIndexHash::from([1u8; 32]),
                 },
             )
             .await

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -338,13 +338,11 @@ impl Node {
 
         // calculate the middle of the range (big endian)
         let middle = {
-            let from = U256::from_big_endian(&from.0);
-            let to = U256::from_big_endian(&to.0);
+            let from = U256::from(from);
+            let to = U256::from(to);
             // min + (max - min) / 2
             let middle = from.div(2) + to.div(2);
-            let mut buf: [u8; 32] = [0; 32];
-            middle.to_big_endian(&mut buf);
-            buf
+            middle.to_be_bytes()
         };
 
         // obtain closest peers to the middle of the range

--- a/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
+++ b/crates/subspace-networking/src/pieces_by_range_handler/tests.rs
@@ -10,8 +10,8 @@ use subspace_core_primitives::{crypto, FlatPieces, Piece, PieceIndexHash};
 #[tokio::test]
 async fn pieces_by_range_protocol_smoke() {
     let request = PiecesByRangeRequest {
-        from: PieceIndexHash([1u8; 32]),
-        to: PieceIndexHash([1u8; 32]),
+        from: PieceIndexHash::from([1u8; 32]),
+        to: PieceIndexHash::from([1u8; 32]),
     };
 
     let piece_bytes: Vec<u8> = Piece::default().into();
@@ -90,9 +90,9 @@ async fn pieces_by_range_protocol_smoke() {
 
 #[tokio::test]
 async fn get_pieces_by_range_smoke() {
-    let piece_index_from = PieceIndexHash(crypto::sha256_hash(b"from"));
-    let piece_index_continue = PieceIndexHash(crypto::sha256_hash(b"continue"));
-    let piece_index_end = PieceIndexHash(crypto::sha256_hash(b"end"));
+    let piece_index_from = PieceIndexHash::from(crypto::sha256_hash(b"from"));
+    let piece_index_continue = PieceIndexHash::from(crypto::sha256_hash(b"continue"));
+    let piece_index_end = PieceIndexHash::from(crypto::sha256_hash(b"end"));
 
     fn get_pieces_to_plot_mock(seed: u8) -> PiecesToPlot {
         let piece_bytes: Vec<u8> = [seed; 4096].to_vec();


### PR DESCRIPTION
U256 bothered me for a long time.

Implementation by `uint` crate introduces too many methods we don't want to have the way they are there, lacks methods similar to integer types from standard library and alongside related `PieceIndexHash` type exposed internals to the outside world.

This refactoring hides internals of both `U256` and `PieceIndexHash` and for `U256` exposes just the methods necessary in a way that is similar to standard library.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
