### PR TITLE
Limit object mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4727,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a7901b85874402471e131de3332dde0e51f38432c69a3853627c8e25433048"
+checksum = "966eb23bd3a09758b8dac09f82b9d417c00f14e5d46171bf04cffdd9cb2e1eb1"
 dependencies = [
  "blake2-rfc",
  "crc32fast",
@@ -7924,6 +7924,7 @@ dependencies = [
  "libc",
  "lru",
  "num-traits",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "rand 0.8.5",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -603,6 +603,18 @@ impl U256 {
         arr
     }
 
+    /// Create from little endian bytes
+    pub fn from_le_bytes(bytes: [u8; 32]) -> Self {
+        Self(private_u256::U256::from_little_endian(&bytes))
+    }
+
+    /// Convert to little endian bytes
+    pub fn to_le_bytes(self) -> [u8; 32] {
+        let mut arr = [0u8; 32];
+        self.0.to_little_endian(&mut arr);
+        arr
+    }
+
     /// Adds two numbers, checking for overflow. If overflow happens, `None` is returned.
     pub fn checked_add(&self, v: &Self) -> Option<Self> {
         self.0.checked_add(v.0).map(Self)

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -30,6 +30,7 @@ jsonrpsee = { version = "0.14.0", features = ["client", "macros", "server"] }
 libc = "0.2.126"
 lru = "0.7.5"
 num-traits = "0.2.15"
+parity-db = "0.3.14"
 parity-scale-codec = "3.1.2"
 parking_lot = "0.12.0"
 rand = "0.8.5"

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,4 +1,4 @@
-use crate::object_mappings::ObjectMappings;
+use crate::object_mappings::LegacyObjectMappings;
 use crate::rpc_client::RpcClient;
 use crate::utils::AbortingJoinHandle;
 use futures::StreamExt;
@@ -40,7 +40,7 @@ impl Archiving {
     /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
     pub async fn start<Client, OPTP>(
         farmer_protocol_info: FarmerProtocolInfo,
-        object_mappings: Vec<ObjectMappings>,
+        object_mappings: Vec<LegacyObjectMappings>,
         client: Client,
         mut on_pieces_to_plot: OPTP,
     ) -> Result<Archiving, ArchivingError>

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -1,4 +1,4 @@
-use crate::object_mappings::LegacyObjectMappings;
+use crate::object_mappings::{LegacyObjectMappings, ObjectMappings};
 use crate::rpc_client::RpcClient;
 use crate::utils::AbortingJoinHandle;
 use futures::StreamExt;
@@ -40,7 +40,8 @@ impl Archiving {
     /// `on_pieces_to_plot` must return `true` unless archiving is no longer necessary
     pub async fn start<Client, OPTP>(
         farmer_protocol_info: FarmerProtocolInfo,
-        object_mappings: Vec<LegacyObjectMappings>,
+        object_mappings: Vec<ObjectMappings>,
+        legacy_object_mappings: Vec<LegacyObjectMappings>,
         client: Client,
         mut on_pieces_to_plot: OPTP,
     ) -> Result<Archiving, ArchivingError>
@@ -95,6 +96,11 @@ impl Archiving {
                     for object_mappings in &object_mappings {
                         if let Err(error) = object_mappings.store(&object_mapping) {
                             error!(%error, "Failed to store object mappings for pieces");
+                        }
+                    }
+                    for object_mappings in &legacy_object_mappings {
+                        if let Err(error) = object_mappings.store(&object_mapping) {
+                            error!(%error, "Failed to store legacy object mappings for pieces");
                         }
                     }
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -18,7 +18,7 @@ use subspace_farmer::legacy_multi_plots_farm::{
     LegacyMultiPlotsFarm, Options as MultiFarmingOptions,
 };
 use subspace_farmer::single_plot_farm::PlotFactoryOptions;
-use subspace_farmer::{ObjectMappings, PieceOffset, Plot, PlotFile, RpcClient};
+use subspace_farmer::{LegacyObjectMappings, PieceOffset, Plot, PlotFile, RpcClient};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
 use tokio::time::Instant;
@@ -128,7 +128,7 @@ pub(crate) async fn bench(
     let object_mappings = tokio::task::spawn_blocking({
         let path = base_directory.as_ref().join("object-mappings");
 
-        move || ObjectMappings::open_or_create(path)
+        move || LegacyObjectMappings::open_or_create(path)
     })
     .await??;
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -152,6 +152,7 @@ pub(crate) async fn farm_multi_disk(
                 })
                 .collect::<Vec<_>>(),
         ),
+        Arc::new(vec![]),
     );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;
 
@@ -283,6 +284,7 @@ pub(crate) async fn farm_legacy(
         record_size,
         recorded_history_segment_size,
         Arc::new(multi_plots_farm.piece_getter()),
+        Arc::new(vec![]),
         Arc::new(vec![object_mappings]),
     );
     let _stop_handle = ws_server.start(rpc_server.into_rpc())?;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -10,7 +10,7 @@ use subspace_farmer::legacy_multi_plots_farm::{
 use subspace_farmer::single_disk_farm::{SingleDiskFarm, SingleDiskFarmOptions};
 use subspace_farmer::single_plot_farm::PlotFactoryOptions;
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
-use subspace_farmer::{NodeRpcClient, ObjectMappings, Plot, RpcClient};
+use subspace_farmer::{LegacyObjectMappings, NodeRpcClient, Plot, RpcClient};
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use tracing::{info, warn};
 
@@ -226,7 +226,7 @@ pub(crate) async fn farm_legacy(
     let object_mappings = tokio::task::spawn_blocking({
         let path = base_directory.join("object-mappings");
 
-        move || ObjectMappings::open_or_create(path)
+        move || LegacyObjectMappings::open_or_create(path)
     })
     .await??;
 

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -10,8 +10,8 @@ fn init() {
     let _ = tracing_subscriber::fmt::try_init();
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn create() {
+#[test]
+fn create() {
     init();
     let base_directory = TempDir::new().unwrap();
 
@@ -41,8 +41,8 @@ async fn create() {
 
 // TODO: Tests for recommitting in background
 
-#[tokio::test(flavor = "multi_thread")]
-async fn find_by_tag() {
+#[test]
+fn find_by_tag() {
     init();
     let base_directory = TempDir::new().unwrap();
     let salt: Salt = [1u8; 8];
@@ -126,8 +126,8 @@ async fn find_by_tag() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn remove_commitments() {
+#[test]
+fn remove_commitments() {
     init();
     let base_directory = TempDir::new().unwrap();
 

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -2,7 +2,7 @@ use super::{sync, DSNSync, NoSync, PieceIndexHashNumber, SyncOptions};
 use crate::bench_rpc_client::{BenchRpcClient, BENCH_FARMER_PROTOCOL_INFO};
 use crate::legacy_multi_plots_farm::{LegacyMultiPlotsFarm, Options as MultiFarmingOptions};
 use crate::single_plot_farm::PlotFactoryOptions;
-use crate::{ObjectMappings, Plot, RpcClient};
+use crate::{LegacyObjectMappings, Plot, RpcClient};
 use futures::channel::{mpsc, oneshot};
 use futures::SinkExt;
 use num_traits::{WrappingAdd, WrappingSub};
@@ -160,7 +160,7 @@ async fn test_dsn_sync() {
     let object_mappings = tokio::task::spawn_blocking({
         let path = seeder_base_directory.as_ref().join("object-mappings");
 
-        move || ObjectMappings::open_or_create(path)
+        move || LegacyObjectMappings::open_or_create(path)
     })
     .await
     .unwrap()
@@ -287,7 +287,7 @@ async fn test_dsn_sync() {
     let object_mappings = tokio::task::spawn_blocking({
         let path = syncer_base_directory.as_ref().join("object-mappings");
 
-        move || ObjectMappings::open_or_create(path)
+        move || LegacyObjectMappings::open_or_create(path)
     })
     .await
     .unwrap()

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -128,8 +128,8 @@ impl LegacyMultiPlotsFarm {
                 single_plot_farms
                     .iter()
                     .map(|single_plot_farm| single_plot_farm.object_mappings().clone())
-                    .chain([object_mappings])
                     .collect(),
+                vec![object_mappings],
                 archiving_client,
                 {
                     let plotters = single_plot_farms

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -1,5 +1,5 @@
 use crate::archiving::Archiving;
-use crate::object_mappings::ObjectMappings;
+use crate::object_mappings::LegacyObjectMappings;
 use crate::rpc_client::RpcClient;
 use crate::single_disk_farm::SingleDiskSemaphore;
 use crate::single_plot_farm::{PlotFactory, SinglePlotFarm, SinglePlotFarmOptions};
@@ -25,7 +25,7 @@ pub struct Options<C> {
     pub archiving_client: C,
     /// Independent client used for farming, such that it is not blocked by archiving
     pub farming_client: C,
-    pub object_mappings: ObjectMappings,
+    pub object_mappings: LegacyObjectMappings,
     pub reward_address: PublicKey,
     pub bootstrap_nodes: Vec<Multiaddr>,
     pub listen_on: Vec<Multiaddr>,

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -53,6 +53,8 @@ pub use farming::{Farming, FarmingError};
 pub use identity::Identity;
 pub use jsonrpsee;
 pub use node_rpc_client::NodeRpcClient;
-pub use object_mappings::{LegacyObjectMappingError, LegacyObjectMappings};
+pub use object_mappings::{
+    LegacyObjectMappingError, LegacyObjectMappings, ObjectMappingError, ObjectMappings,
+};
 pub use plot::{PieceOffset, Plot, PlotError, PlotFile};
 pub use rpc_client::{Error as RpcClientError, RpcClient};

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -53,6 +53,6 @@ pub use farming::{Farming, FarmingError};
 pub use identity::Identity;
 pub use jsonrpsee;
 pub use node_rpc_client::NodeRpcClient;
-pub use object_mappings::{ObjectMappingError, ObjectMappings};
+pub use object_mappings::{LegacyObjectMappingError, LegacyObjectMappings};
 pub use plot::{PieceOffset, Plot, PlotError, PlotFile};
 pub use rpc_client::{Error as RpcClientError, RpcClient};

--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -1,13 +1,255 @@
 #[cfg(test)]
 mod tests;
 
+use parity_db::{Db, Options};
 use parity_scale_codec::{Decode, Encode};
-use rocksdb::{Options, WriteBatch, DB};
+use parking_lot::Mutex;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::{fmt, iter};
 use subspace_core_primitives::objects::GlobalObject;
-use subspace_core_primitives::Sha256Hash;
+use subspace_core_primitives::{bidirectional_distance, PublicKey, Sha256Hash, U256};
 use thiserror::Error;
+
+/// How full should object mappings database be before we try to prune some values
+const PRUNE_FILL_RATIO: (u64, u64) = (95, 100);
+/// Target fill ratio after pruning
+const RESET_FILL_RATIO: (u64, u64) = (80, 100);
+
+#[repr(u8)]
+enum Columns {
+    Mappings = 0,
+    Metadata = 1,
+}
+
+struct FurthestKey {
+    key: Sha256Hash,
+    /// Size of key + value together
+    size: u16,
+}
+
+struct PruningState {
+    public_key_as_number: U256,
+    furthest_keys: BTreeMap<U256, FurthestKey>,
+    /// Combined size of everything in `furthest_keys`
+    total_size: u64,
+    /// Amount of data we want to remove
+    remove_size: u64,
+}
+
+impl PruningState {
+    fn new(public_key_as_number: U256, remove_size: u64) -> Self {
+        Self {
+            public_key_as_number,
+            furthest_keys: BTreeMap::new(),
+            total_size: 0,
+            remove_size,
+        }
+    }
+
+    fn process(&mut self, furthest_key: FurthestKey) {
+        let distance_from_public_key = bidirectional_distance(
+            &self.public_key_as_number,
+            &U256::from_be_bytes(furthest_key.key),
+        );
+
+        loop {
+            if self.total_size < self.remove_size {
+                self.total_size += u64::from(furthest_key.size);
+                self.furthest_keys
+                    .insert(distance_from_public_key, furthest_key);
+                break;
+            } else {
+                let (closest_distance, closest_furthest_key) = self
+                    .furthest_keys
+                    .first_key_value()
+                    .expect("Total size isn't zero, meaning at least one key is in; qed");
+                let closest_furthest_size = closest_furthest_key.size;
+
+                // Check if the key is further than the closest know distance
+                if &distance_from_public_key > closest_distance {
+                    // Remove existing key and loop to try inserting again
+                    self.furthest_keys.pop_first();
+                    self.total_size -= u64::from(closest_furthest_size);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn keys_to_delete(&self) -> impl Iterator<Item = &FurthestKey> {
+        self.furthest_keys.values()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ObjectMappingError {
+    #[error("DB error: {0}")]
+    Db(#[from] parity_db::Error),
+}
+
+struct Inner {
+    db: Db,
+    public_key_as_number: U256,
+    size: Mutex<u64>,
+    prune_fill_size: u64,
+    reset_fill_size: u64,
+}
+
+/// `ObjectMappings` is a mapping from arbitrary object hash to its location in archived history.
+#[derive(Clone)]
+pub struct ObjectMappings {
+    inner: Arc<Inner>,
+}
+
+impl fmt::Debug for ObjectMappings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObjectMappings").finish()
+    }
+}
+
+impl ObjectMappings {
+    const SIZE_KEY: &'static [u8] = b"size";
+
+    /// Opens or creates a new object mappings database
+    pub fn open_or_create(
+        path: &Path,
+        public_key: PublicKey,
+        max_size: u64,
+    ) -> Result<Self, ObjectMappingError> {
+        let mut options = Options::with_columns(path, 2);
+        {
+            let mappings_column_options = options
+                .columns
+                .get_mut(Columns::Mappings as usize)
+                .expect("Number of columns defined above; qed");
+            mappings_column_options.uniform = true;
+        }
+        // We don't use stats
+        options.stats = false;
+        // Remove salt to avoid mangling of keys
+        options.salt = Some([0u8; 32]);
+        let db = Db::open_or_create(&options)?;
+
+        let size =
+            db.get(Columns::Metadata as u8, Self::SIZE_KEY)?
+                .map(|bytes| {
+                    u64::from_le_bytes(
+                        bytes.as_slice().try_into().expect(
+                            "Values written into size key are always of correct length; qed",
+                        ),
+                    )
+                })
+                .unwrap_or_default();
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                db,
+                public_key_as_number: U256::from_be_bytes(public_key.into()),
+                size: Mutex::new(size),
+                prune_fill_size: max_size.saturating_mul(PRUNE_FILL_RATIO.0) / PRUNE_FILL_RATIO.1,
+                reset_fill_size: max_size.saturating_mul(RESET_FILL_RATIO.0) / RESET_FILL_RATIO.1,
+            }),
+        })
+    }
+
+    /// Retrieve mapping for object
+    pub fn retrieve(
+        &self,
+        object_id: &Sha256Hash,
+    ) -> Result<Option<GlobalObject>, ObjectMappingError> {
+        Ok(self
+            .inner
+            .db
+            .get(Columns::Mappings as u8, object_id)?
+            .and_then(|global_object| GlobalObject::decode(&mut global_object.as_ref()).ok()))
+    }
+
+    /// Store object mappings in database, might run pruning if total size of mappings exceeds
+    /// configured size
+    pub fn store(
+        &self,
+        object_mapping: &[(Sha256Hash, GlobalObject)],
+    ) -> Result<(), ObjectMappingError> {
+        let bytes_to_write = RefCell::new(0u64);
+        let tx = object_mapping.iter().map(|(object_id, global_object)| {
+            let encoded_global_object = global_object.encode();
+            *bytes_to_write.borrow_mut() +=
+                object_id.len() as u64 + encoded_global_object.len() as u64;
+            (
+                Columns::Mappings as u8,
+                object_id.as_ref(),
+                Some(encoded_global_object),
+            )
+        });
+
+        let mut size = self.inner.size.lock();
+
+        let mut new_size = *size;
+
+        let tx = tx.chain(iter::once_with(|| {
+            new_size += *bytes_to_write.borrow();
+
+            (
+                Columns::Metadata as u8,
+                Self::SIZE_KEY,
+                Some(new_size.to_le_bytes().to_vec()),
+            )
+        }));
+        self.inner.db.commit(tx)?;
+
+        *size = new_size;
+
+        if new_size >= self.inner.prune_fill_size {
+            self.prune(new_size - self.inner.reset_fill_size, &mut size)?;
+        }
+
+        Ok(())
+    }
+
+    fn prune(&self, remove_size: u64, size: &mut u64) -> Result<(), parity_db::Error> {
+        let mut pruning_state = PruningState::new(self.inner.public_key_as_number, remove_size);
+        self.inner
+            .db
+            .iter_column_while(Columns::Mappings as u8, |iter_state| {
+                pruning_state.process(FurthestKey {
+                    key: iter_state.key,
+                    size: u16::try_from(iter_state.key.len()).expect("Key always fits in u16; qed")
+                        + u16::try_from(iter_state.value.len())
+                            .expect("Value always fits in u16; qed"),
+                });
+
+                true
+            })?;
+
+        let bytes_to_delete = RefCell::new(0u64);
+        let tx = pruning_state.keys_to_delete().map(|furthest_key| {
+            *bytes_to_delete.borrow_mut() += u64::from(furthest_key.size);
+
+            (Columns::Mappings as u8, furthest_key.key.as_ref(), None)
+        });
+
+        let mut new_size = *size;
+
+        let tx = tx.chain(iter::once_with(|| {
+            new_size -= *bytes_to_delete.borrow();
+
+            (
+                Columns::Metadata as u8,
+                Self::SIZE_KEY,
+                Some(new_size.to_le_bytes().to_vec()),
+            )
+        }));
+        self.inner.db.commit(tx)?;
+
+        *size = new_size;
+
+        Ok(())
+    }
+}
 
 // TODO: Remove once global object mappings are gone
 #[derive(Debug, Error)]
@@ -20,7 +262,7 @@ pub enum LegacyObjectMappingError {
 // TODO: Remove once global object mappings are gone
 #[derive(Debug, Clone)]
 pub struct LegacyObjectMappings {
-    db: Arc<DB>,
+    db: Arc<rocksdb::DB>,
 }
 
 impl LegacyObjectMappings {
@@ -29,10 +271,10 @@ impl LegacyObjectMappings {
     where
         P: AsRef<Path>,
     {
-        let mut options = Options::default();
+        let mut options = rocksdb::Options::default();
         options.create_if_missing(true);
         options.set_unordered_write(true);
-        let db = DB::open(&options, path).map_err(LegacyObjectMappingError::Db)?;
+        let db = rocksdb::DB::open(&options, path).map_err(LegacyObjectMappingError::Db)?;
 
         Ok(Self { db: Arc::new(db) })
     }
@@ -56,7 +298,7 @@ impl LegacyObjectMappings {
     ) -> Result<(), LegacyObjectMappingError> {
         let mut tmp = Vec::new();
 
-        let mut batch = WriteBatch::default();
+        let mut batch = rocksdb::WriteBatch::default();
         for (object_id, global_object) in object_mapping {
             global_object.encode_to(&mut tmp);
             batch.put(object_id, &tmp);

--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -127,6 +127,8 @@ impl ObjectMappings {
                 .get_mut(Columns::Mappings as usize)
                 .expect("Number of columns defined above; qed");
             mappings_column_options.uniform = true;
+            // TODO: Only using BTree because of https://github.com/paritytech/parity-db/issues/81
+            mappings_column_options.btree_index = true;
         }
         // We don't use stats
         options.stats = false;
@@ -212,18 +214,30 @@ impl ObjectMappings {
 
     fn prune(&self, remove_size: u64, size: &mut u64) -> Result<(), parity_db::Error> {
         let mut pruning_state = PruningState::new(self.inner.public_key_as_number, remove_size);
-        self.inner
-            .db
-            .iter_column_while(Columns::Mappings as u8, |iter_state| {
-                pruning_state.process(FurthestKey {
-                    key: iter_state.key,
-                    size: u16::try_from(iter_state.key.len()).expect("Key always fits in u16; qed")
-                        + u16::try_from(iter_state.value.len())
-                            .expect("Value always fits in u16; qed"),
-                });
-
-                true
-            })?;
+        // TODO: Commented code is for non-BTree column, use in the future if switch back from BTree
+        // self.inner
+        //     .db
+        //     .iter_column_while(Columns::Mappings as u8, |iter_state| {
+        //         pruning_state.process(FurthestKey {
+        //             key: iter_state.key,
+        //             size: u16::try_from(iter_state.key.len()).expect("Key always fits in u16; qed")
+        //                 + u16::try_from(iter_state.value.len())
+        //                     .expect("Value always fits in u16; qed"),
+        //         });
+        //
+        //         true
+        //     })?;
+        let mut iter = self.inner.db.iter(Columns::Mappings as u8)?;
+        while let Some((key, value)) = iter.next()? {
+            pruning_state.process(FurthestKey {
+                key: key
+                    .as_slice()
+                    .try_into()
+                    .expect("Key read from database is always of correct size"),
+                size: u16::try_from(key.len()).expect("Key always fits in u16; qed")
+                    + u16::try_from(value.len()).expect("Value always fits in u16; qed"),
+            });
+        }
 
         let bytes_to_delete = RefCell::new(0u64);
         let tx = pruning_state.keys_to_delete().map(|furthest_key| {

--- a/crates/subspace-farmer/src/object_mappings.rs
+++ b/crates/subspace-farmer/src/object_mappings.rs
@@ -203,16 +203,12 @@ impl ObjectMappings {
         });
         let tx = object_mapping
             .iter()
-            .filter(|(object_id, _global_object)| {
-                let (store_from, store_to) = match store {
-                    Some(store) => store,
-                    None => {
-                        return true;
-                    }
-                };
-                let object_id = U256::from_be_bytes(*object_id);
-
-                store_from < object_id && object_id < store_to
+            .filter(|(object_id, _global_object)| match store {
+                Some((store_from, store_to)) => {
+                    let object_id = U256::from_be_bytes(*object_id);
+                    store_from < object_id && object_id < store_to
+                }
+                None => true,
             })
             .map(|(object_id, global_object)| {
                 let encoded_global_object = global_object.encode();

--- a/crates/subspace-farmer/src/object_mappings/tests.rs
+++ b/crates/subspace-farmer/src/object_mappings/tests.rs
@@ -82,7 +82,8 @@ fn basic() {
         let object_mappings = ObjectMappings::open_or_create(
             base_directory.path(),
             public_key,
-            global_mappings[0].encoded_size() as u64 * 3,
+            // Store up to 4 elements, prune down to 3
+            global_mappings[0].encoded_size() as u64 * 5 - 1,
         )
         .unwrap();
         object_mappings.store(&global_mappings).unwrap();
@@ -91,11 +92,7 @@ fn basic() {
             .retrieve(&global_mappings[0].0)
             .unwrap()
             .is_none());
-        assert!(object_mappings
-            .retrieve(&global_mappings[1].0)
-            .unwrap()
-            .is_none());
-        for (hash, global_mapping) in global_mappings.iter().skip(2).take(2) {
+        for (hash, global_mapping) in global_mappings.iter().skip(1).take(3) {
             assert_eq!(
                 object_mappings.retrieve(hash).unwrap().as_ref(),
                 Some(global_mapping)
@@ -105,5 +102,73 @@ fn basic() {
             .retrieve(&global_mappings[4].0)
             .unwrap()
             .is_none());
+
+        // This key is further that keys pruned before and shouldn't be stored once attempted
+        let key_very_far = (
+            public_key_as_number
+                .wrapping_add(&U256::from(21u64))
+                .to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        );
+
+        object_mappings.store(&[key_very_far]).unwrap();
+
+        // Not stored because too far
+        assert!(object_mappings.retrieve(&key_very_far.0).unwrap().is_none());
+
+        // This key is close enough to be stored
+        let key_close_enough = (
+            public_key_as_number
+                .wrapping_add(&U256::from(2u64))
+                .to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        );
+
+        object_mappings.store(&[key_close_enough]).unwrap();
+
+        // Stored because close enough
+        assert_eq!(
+            object_mappings.retrieve(&key_close_enough.0).unwrap(),
+            Some(key_close_enough.1)
+        );
+        // Keys previously stored are still there, so no pruning took effect yet
+        for (hash, global_mapping) in global_mappings.iter().skip(1).take(3) {
+            assert_eq!(
+                object_mappings.retrieve(hash).unwrap().as_ref(),
+                Some(global_mapping)
+            );
+        }
+
+        // Close and re-open database to check reading of parameters on restart
+        drop(object_mappings);
+        let object_mappings = ObjectMappings::open_or_create(
+            base_directory.path(),
+            public_key,
+            // Store up to 4 elements, prune down to 3
+            global_mappings[0].encoded_size() as u64 * 5 - 1,
+        )
+        .unwrap();
+
+        // Make sure old key is still not stored because too far
+        object_mappings.store(&[key_very_far]).unwrap();
+        assert!(object_mappings.retrieve(&key_very_far.0).unwrap().is_none());
+
+        // And no pruning too place because nothing was inserted
+        assert_eq!(
+            object_mappings.retrieve(&key_close_enough.0).unwrap(),
+            Some(key_close_enough.1)
+        );
+        for (hash, global_mapping) in global_mappings.iter().skip(1).take(3) {
+            assert_eq!(
+                object_mappings.retrieve(hash).unwrap().as_ref(),
+                Some(global_mapping)
+            );
+        }
     }
 }

--- a/crates/subspace-farmer/src/object_mappings/tests.rs
+++ b/crates/subspace-farmer/src/object_mappings/tests.rs
@@ -1,1 +1,109 @@
-// TODO: Tests
+use crate::object_mappings::ObjectMappings;
+use num_traits::{WrappingAdd, WrappingSub};
+use parity_scale_codec::Encode;
+use rand::random;
+use subspace_core_primitives::objects::GlobalObject;
+use subspace_core_primitives::{PublicKey, U256};
+use tempfile::TempDir;
+
+fn init() {
+    let _ = tracing_subscriber::fmt::try_init();
+}
+
+#[test]
+fn basic() {
+    init();
+    let public_key = PublicKey::from(random::<[u8; 32]>());
+    let public_key_as_number = U256::from_be_bytes(public_key.into());
+    let global_mappings = vec![
+        (
+            public_key_as_number
+                .wrapping_sub(&U256::from(5u64))
+                .to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        ),
+        (
+            public_key_as_number
+                .wrapping_sub(&U256::from(2u64))
+                .to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        ),
+        (
+            (public_key_as_number).to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        ),
+        (
+            public_key_as_number
+                .wrapping_add(&U256::from(1u64))
+                .to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        ),
+        (
+            public_key_as_number
+                .wrapping_add(&U256::from(20u64))
+                .to_be_bytes(),
+            GlobalObject::V0 {
+                piece_index: 0,
+                offset: 0,
+            },
+        ),
+    ];
+
+    // Test basic retrievability
+    {
+        let base_directory = TempDir::new().unwrap();
+        let object_mappings =
+            ObjectMappings::open_or_create(base_directory.path(), public_key, u64::MAX).unwrap();
+        object_mappings.store(&global_mappings).unwrap();
+
+        for (hash, global_mapping) in &global_mappings {
+            assert_eq!(
+                object_mappings.retrieve(hash).unwrap().as_ref(),
+                Some(global_mapping)
+            );
+        }
+    }
+
+    // Test pruning
+    {
+        let base_directory = TempDir::new().unwrap();
+        let object_mappings = ObjectMappings::open_or_create(
+            base_directory.path(),
+            public_key,
+            global_mappings[0].encoded_size() as u64 * 3,
+        )
+        .unwrap();
+        object_mappings.store(&global_mappings).unwrap();
+
+        assert!(object_mappings
+            .retrieve(&global_mappings[0].0)
+            .unwrap()
+            .is_none());
+        assert!(object_mappings
+            .retrieve(&global_mappings[1].0)
+            .unwrap()
+            .is_none());
+        for (hash, global_mapping) in global_mappings.iter().skip(2).take(2) {
+            assert_eq!(
+                object_mappings.retrieve(hash).unwrap().as_ref(),
+                Some(global_mapping)
+            );
+        }
+        assert!(object_mappings
+            .retrieve(&global_mappings[4].0)
+            .unwrap()
+            .is_none());
+    }
+}

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -20,8 +20,8 @@ fn generate_random_pieces(n: usize) -> FlatPieces {
     pieces
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn read_write() {
+#[test]
+fn read_write() {
     init();
     let base_directory = TempDir::new().unwrap();
 
@@ -60,8 +60,8 @@ async fn read_write() {
     assert!(!plot.is_empty());
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn piece_retrievable() {
+#[test]
+fn piece_retrievable() {
     init();
     let base_directory = TempDir::new().unwrap();
 
@@ -100,8 +100,8 @@ async fn piece_retrievable() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn partial_plot() {
+#[test]
+fn partial_plot() {
     init();
     let base_directory = TempDir::new().unwrap();
 
@@ -153,8 +153,8 @@ async fn partial_plot() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn sequential_pieces_iterator() {
+#[test]
+fn sequential_pieces_iterator() {
     init();
     let base_directory = TempDir::new().unwrap();
 
@@ -187,8 +187,8 @@ async fn sequential_pieces_iterator() {
     assert_eq!(got_indexes, piece_indexes[..got_indexes.len()]);
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_read_sequential_pieces() {
+#[test]
+fn test_read_sequential_pieces() {
     init();
     let base_directory = TempDir::new().unwrap();
 

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -333,6 +333,7 @@ impl SingleDiskFarm {
                     .iter()
                     .map(|single_plot_farm| single_plot_farm.object_mappings().clone())
                     .collect(),
+                vec![],
                 archiving_client,
                 {
                     let plotters = single_plot_farms

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -12,7 +12,7 @@ use crate::single_disk_farm::SingleDiskSemaphore;
 use crate::single_plot_farm::dsn_archiving::start_archiving;
 use crate::utils::AbortingJoinHandle;
 use crate::ws_rpc_server::PieceGetter;
-use crate::{dsn, CommitmentError, ObjectMappings};
+use crate::{dsn, CommitmentError, LegacyObjectMappings};
 use anyhow::anyhow;
 use derive_more::{Display, From};
 use futures::future::try_join;
@@ -283,7 +283,7 @@ pub struct SinglePlotFarm {
     codec: SubspaceCodec,
     plot: Plot,
     commitments: Commitments,
-    object_mappings: ObjectMappings,
+    object_mappings: LegacyObjectMappings,
     farming: Option<Farming>,
     node: Node,
     node_runner: NodeRunner,
@@ -374,7 +374,7 @@ impl SinglePlotFarm {
 
         info!("Opening object mappings");
         let object_mappings =
-            ObjectMappings::open_or_create(metadata_directory.join("object-mappings"))?;
+            LegacyObjectMappings::open_or_create(metadata_directory.join("object-mappings"))?;
 
         info!("Opening commitments");
         let commitments = Commitments::new(metadata_directory.join("commitments"))?;
@@ -600,7 +600,7 @@ impl SinglePlotFarm {
     }
 
     /// Access object mappings instance of the farm
-    pub fn object_mappings(&self) -> &ObjectMappings {
+    pub fn object_mappings(&self) -> &LegacyObjectMappings {
         &self.object_mappings
     }
 

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -543,6 +543,7 @@ impl SinglePlotFarm {
                 farm.object_mappings().clone(),
                 node,
                 farm.plotter(),
+                farm.single_disk_semaphore.clone(),
             );
             let dsn_archiving_handle = tokio::spawn(async move {
                 if let Err(error) = archiving_fut.await {

--- a/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
@@ -1,4 +1,4 @@
-use crate::object_mappings::LegacyObjectMappings;
+use crate::object_mappings::ObjectMappings;
 use crate::single_plot_farm::{SinglePlotFarmId, SinglePlotPlotter};
 use futures::StreamExt;
 use parity_scale_codec::Decode;
@@ -27,7 +27,7 @@ pub(super) async fn start_archiving(
     single_plot_farm_id: SinglePlotFarmId,
     record_size: u32,
     recorded_history_segment_size: u32,
-    object_mappings: LegacyObjectMappings,
+    object_mappings: ObjectMappings,
     node: Node,
     plotter: SinglePlotPlotter,
 ) -> Result<(), StartDsnArchivingError> {

--- a/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
@@ -1,4 +1,4 @@
-use crate::object_mappings::ObjectMappings;
+use crate::object_mappings::LegacyObjectMappings;
 use crate::single_plot_farm::{SinglePlotFarmId, SinglePlotPlotter};
 use futures::StreamExt;
 use parity_scale_codec::Decode;
@@ -27,7 +27,7 @@ pub(super) async fn start_archiving(
     single_plot_farm_id: SinglePlotFarmId,
     record_size: u32,
     recorded_history_segment_size: u32,
-    object_mappings: ObjectMappings,
+    object_mappings: LegacyObjectMappings,
     node: Node,
     plotter: SinglePlotPlotter,
 ) -> Result<(), StartDsnArchivingError> {

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -1,12 +1,12 @@
+use crate::archiving::Archiving;
 use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::mock_rpc_client::MockRpcClient;
-use crate::object_mappings::LegacyObjectMappings;
+use crate::object_mappings::ObjectMappings;
 use crate::plot::Plot;
 use crate::rpc_client::RpcClient;
 use crate::single_disk_farm::SingleDiskSemaphore;
 use crate::single_plot_farm::SinglePlotPlotter;
-use crate::Archiving;
 use rand::prelude::*;
 use rand::Rng;
 use std::num::NonZeroU16;
@@ -46,9 +46,12 @@ async fn plotting_happy_path() {
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
-    let object_mappings =
-        LegacyObjectMappings::open_or_create(base_directory.as_ref().join("object-mappings"))
-            .unwrap();
+    let object_mappings = ObjectMappings::open_or_create(
+        &base_directory.as_ref().join("object-mappings"),
+        public_key,
+        u64::MAX,
+    )
+    .unwrap();
 
     let client = MockRpcClient::new();
 
@@ -92,6 +95,7 @@ async fn plotting_happy_path() {
     let archiving_instance = Archiving::start(
         farmer_protocol_info,
         vec![object_mappings],
+        vec![],
         client.clone(),
         move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
             Ok(()) => true,
@@ -142,9 +146,12 @@ async fn plotting_piece_eviction() {
     )
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
-    let object_mappings =
-        LegacyObjectMappings::open_or_create(base_directory.as_ref().join("object-mappings"))
-            .unwrap();
+    let object_mappings = ObjectMappings::open_or_create(
+        &base_directory.as_ref().join("object-mappings"),
+        public_key,
+        u64::MAX,
+    )
+    .unwrap();
 
     // There are no pieces, but we need to create empty commitments database for this salt, such
     //  that plotter will create commitments for plotted pieces
@@ -200,6 +207,7 @@ async fn plotting_piece_eviction() {
     let archiving_instance = Archiving::start(
         farmer_protocol_info,
         vec![object_mappings],
+        vec![],
         client.clone(),
         move |pieces_to_plot| match single_plot_plotter.plot_pieces(pieces_to_plot) {
             Ok(()) => true,

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -1,7 +1,7 @@
 use crate::commitments::Commitments;
 use crate::identity::Identity;
 use crate::mock_rpc_client::MockRpcClient;
-use crate::object_mappings::ObjectMappings;
+use crate::object_mappings::LegacyObjectMappings;
 use crate::plot::Plot;
 use crate::rpc_client::RpcClient;
 use crate::single_disk_farm::SingleDiskSemaphore;
@@ -47,7 +47,8 @@ async fn plotting_happy_path() {
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
     let object_mappings =
-        ObjectMappings::open_or_create(base_directory.as_ref().join("object-mappings")).unwrap();
+        LegacyObjectMappings::open_or_create(base_directory.as_ref().join("object-mappings"))
+            .unwrap();
 
     let client = MockRpcClient::new();
 
@@ -142,7 +143,8 @@ async fn plotting_piece_eviction() {
     .unwrap();
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
     let object_mappings =
-        ObjectMappings::open_or_create(base_directory.as_ref().join("object-mappings")).unwrap();
+        LegacyObjectMappings::open_or_create(base_directory.as_ref().join("object-mappings"))
+            .unwrap();
 
     // There are no pieces, but we need to create empty commitments database for this salt, such
     //  that plotter will create commitments for plotted pieces

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -1,5 +1,5 @@
-use crate::object_mappings::ObjectMappings;
-use crate::ObjectMappingError;
+use crate::object_mappings::LegacyObjectMappings;
+use crate::LegacyObjectMappingError;
 use async_trait::async_trait;
 use jsonrpsee::core::error::Error;
 use jsonrpsee::proc_macros::rpc;
@@ -152,7 +152,7 @@ pub trait Rpc {
 /// ```rust
 ///  async fn f() -> anyhow::Result<()> {
 /// use jsonrpsee::ws_server::WsServerBuilder;
-/// use subspace_farmer::{Identity, ObjectMappings, Plot};
+/// use subspace_farmer::{Identity, LegacyObjectMappings, Plot};
 /// use subspace_farmer::single_plot_farm::SinglePlotPieceGetter;
 /// use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 /// use subspace_solving::SubspaceCodec;
@@ -171,7 +171,7 @@ pub trait Rpc {
 ///     public_key,
 ///     u64::MAX,
 /// )?;
-/// let object_mappings = ObjectMappings::open_or_create(base_directory.join("object-mappings"))?;
+/// let object_mappings = LegacyObjectMappings::open_or_create(base_directory.join("object-mappings"))?;
 /// let ws_server = WsServerBuilder::default().build(ws_server_listen_addr).await?;
 /// let rpc_server = RpcServerImpl::new(
 ///     3840,
@@ -188,7 +188,7 @@ pub struct RpcServerImpl {
     record_size: u32,
     merkle_num_leaves: u32,
     piece_getter: Arc<dyn PieceGetter + Send + Sync + 'static>,
-    object_mappings: Arc<Vec<ObjectMappings>>,
+    object_mappings: Arc<Vec<LegacyObjectMappings>>,
 }
 
 impl RpcServerImpl {
@@ -196,7 +196,7 @@ impl RpcServerImpl {
         record_size: u32,
         recorded_history_segment_size: u32,
         piece_getter: Arc<dyn PieceGetter + Send + Sync + 'static>,
-        object_mappings: Arc<Vec<ObjectMappings>>,
+        object_mappings: Arc<Vec<LegacyObjectMappings>>,
     ) -> Self {
         Self {
             record_size,
@@ -486,7 +486,7 @@ impl RpcServer for RpcServerImpl {
         let global_object_handle = tokio::task::spawn_blocking({
             let object_mappings = Arc::clone(&self.object_mappings);
 
-            move || -> Result<Option<GlobalObject>, ObjectMappingError> {
+            move || -> Result<Option<GlobalObject>, LegacyObjectMappingError> {
                 for object_mappings in object_mappings.as_ref() {
                     let maybe_global_object = object_mappings.retrieve(&object_id.into())?;
 

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -495,14 +495,14 @@ impl RpcServer for RpcServerImpl {
             let legacy_object_mappings = Arc::clone(&self.legacy_object_mappings);
 
             move || -> Result<Option<GlobalObject>, ObjectMappingError> {
-                for object_mappings in object_mappings.as_ref() {
+                for object_mappings in object_mappings.iter() {
                     let maybe_global_object = object_mappings.retrieve(&object_id.into())?;
 
                     if let Some(global_object) = maybe_global_object {
                         return Ok(Some(global_object));
                     }
                 }
-                for object_mappings in legacy_object_mappings.as_ref() {
+                for object_mappings in legacy_object_mappings.iter() {
                     if let Ok(Some(global_object)) = object_mappings.retrieve(&object_id.into()) {
                         return Ok(Some(global_object));
                     }


### PR DESCRIPTION
This introduces new implementation of object mappings database (using ParityDB) that has a limit to the total size of object mappings stored per plot (hardcoded to 100 MiB for now).

New implementation doesn't try to keep exact number of object mappings, rather it will wait for object mappings to approach the limit and right before they do (to make sure it doesn't exceed the size and also to account for database overhead) it will prune a fraction of objects mappings in a batch (after reading all of them, which is fine due to small database size). This will hopefully reduce write amplification (though I didn't do extensive testing to confirm this at the moment).

Legacy object mappings are used just like before for global object mappings and will go away once we drop `LegacyMultiPlotsFarm`.

We also have some tests for object mappings now, finally :partying_face: 

Fixes #661

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
