### PR TITLE
Fix piece count calculation on upgrade

### DIFF
--- a/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
@@ -96,19 +96,21 @@ impl IndexHashToOffsetDB {
                     piece_count = me.max_distance_cache.len() as u64;
                 } else {
                     let mut iter = me.inner.raw_iterator();
+                    iter.seek_to_first();
                     while iter.key().is_some() {
                         piece_count += 1;
                         iter.next();
                     }
                 }
+
+                me.inner
+                    .put_cf(&cf, Self::PIECE_COUNT_KEY, piece_count.to_le_bytes())
+                    .map_err(Into::into)
+                    .map_err(PlotError::PieceCountReadError)?;
             }
         }
 
         me.piece_count.store(piece_count, Ordering::SeqCst);
-        me.inner
-            .put_cf(&cf, Self::PIECE_COUNT_KEY, piece_count.to_le_bytes())
-            .map_err(Into::into)
-            .map_err(PlotError::PieceCountReadError)?;
 
         Ok(me)
     }


### PR DESCRIPTION
Without seeking to the first key, RocksDB was iterating over random fraction of the keys, counting pieces incorrectly.

As a bonus I decided to now override piece count if it is already there.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
