### PR TITLE
Digest items refactoring

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -37,9 +37,7 @@ pub use pallet::*;
 use scale_info::TypeInfo;
 use schnorrkel::SignatureError;
 use sp_consensus_slots::Slot;
-use sp_consensus_subspace::digests::{
-    CompatibleDigestItem, GlobalRandomnessDescriptor, SaltDescriptor, SolutionRangeDescriptor,
-};
+use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::offence::{OffenceDetails, OffenceError, OnOffenceHandler};
 use sp_consensus_subspace::{
     EquivocationProof, FarmerPublicKey, FarmerSignature, SignedVote, Vote,
@@ -887,21 +885,15 @@ impl<T: Config> Pallet<T> {
         PorRandomness::<T>::put(por_randomness);
 
         // Deposit global randomness data such that light client can validate blocks later.
-        frame_system::Pallet::<T>::deposit_log(DigestItem::global_randomness_descriptor(
-            GlobalRandomnessDescriptor {
-                global_randomness: GlobalRandomnesses::<T>::get().current,
-            },
+        frame_system::Pallet::<T>::deposit_log(DigestItem::global_randomness(
+            GlobalRandomnesses::<T>::get().current,
         ));
         // Deposit solution range data such that light client can validate blocks later.
-        frame_system::Pallet::<T>::deposit_log(DigestItem::solution_range_descriptor(
-            SolutionRangeDescriptor {
-                solution_range: SolutionRanges::<T>::get().current,
-            },
+        frame_system::Pallet::<T>::deposit_log(DigestItem::solution_range(
+            SolutionRanges::<T>::get().current,
         ));
         // Deposit salt data such that light client can validate blocks later.
-        frame_system::Pallet::<T>::deposit_log(DigestItem::salt_descriptor(SaltDescriptor {
-            salt: Salts::<T>::get().current,
-        }));
+        frame_system::Pallet::<T>::deposit_log(DigestItem::salt(Salts::<T>::get().current));
 
         let next_salt_reveal = Self::current_eon_start()
             .checked_add(T::EonNextSaltReveal::get())

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -154,21 +154,12 @@ where
 /// Errors encountered by the Subspace authorship task.
 #[derive(Debug, thiserror::Error)]
 pub enum Error<Header: HeaderT> {
-    /// Multiple Subspace pre-runtime digests
-    #[error("Multiple Subspace pre-runtime digests, rejecting!")]
-    MultiplePreRuntimeDigests,
+    /// Error during digest item extraction
+    #[error("Digest item error: {0}")]
+    DigestItemError(#[from] DigestError),
     /// No Subspace pre-runtime digest found
     #[error("No Subspace pre-runtime digest found")]
     NoPreRuntimeDigest,
-    /// Multiple Subspace global randomness digests
-    #[error("Multiple Subspace global randomness digests, rejecting!")]
-    MultipleGlobalRandomnessDigests,
-    /// Multiple Subspace solution range digests
-    #[error("Multiple Subspace solution range digests, rejecting!")]
-    MultipleSolutionRangeDigests,
-    /// Multiple Subspace salt digests
-    #[error("Multiple Subspace salt digests, rejecting!")]
-    MultipleSaltDigests,
     /// Header rejected: too far in the future
     #[error("Header {0:?} rejected: too far in the future")]
     TooFarInFuture(Header::Hash),
@@ -285,21 +276,6 @@ where
                 }
                 VerificationPrimitiveError::OutsideMaxPlot => Error::OutsideOfMaxPlot(slot),
             },
-        }
-    }
-}
-
-impl<Header> From<DigestError> for Error<Header>
-where
-    Header: HeaderT,
-{
-    fn from(error: DigestError) -> Self {
-        match error {
-            DigestError::MultipleGlobalRandomnessDigests => Error::MultipleGlobalRandomnessDigests,
-            DigestError::MultipleSolutionRangeDigests => Error::MultipleSolutionRangeDigests,
-            DigestError::MultipleSaltDigests => Error::MultipleSaltDigests,
-            DigestError::MultiplePreRuntimeDigests => Error::MultiplePreRuntimeDigests,
-            DigestError::NoPreRuntimeDigest => Error::NoPreRuntimeDigest,
         }
     }
 }

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    extract_pre_digest, NewSlotInfo, NewSlotNotification, RewardSigningNotification, SubspaceLink,
-};
+use crate::{NewSlotInfo, NewSlotNotification, RewardSigningNotification, SubspaceLink};
 use futures::{StreamExt, TryFutureExt};
 use log::{debug, error, info, warn};
 use sc_consensus::block_import::{BlockImport, BlockImportParams, StateAction};
@@ -33,7 +31,7 @@ use sp_api::{ApiError, NumberFor, ProvideRuntimeApi, TransactionFor};
 use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata};
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SyncOracle};
 use sp_consensus_slots::Slot;
-use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest};
+use sp_consensus_subspace::digests::{extract_pre_digest, CompatibleDigestItem, PreDigest};
 use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature, SignedVote, SubspaceApi, Vote};
 use sp_core::crypto::ByteArray;
 use sp_core::H256;

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    find_pre_digest, NewSlotInfo, NewSlotNotification, RewardSigningNotification, SubspaceLink,
+    extract_pre_digest, NewSlotInfo, NewSlotNotification, RewardSigningNotification, SubspaceLink,
 };
 use futures::{StreamExt, TryFutureExt};
 use log::{debug, error, info, warn};
@@ -333,7 +333,7 @@ where
 
     fn should_backoff(&self, slot: Slot, chain_head: &Block::Header) -> bool {
         if let Some(ref strategy) = self.backoff_authoring_blocks {
-            if let Ok(chain_head_slot) = find_pre_digest(chain_head).map(|digest| digest.slot) {
+            if let Ok(chain_head_slot) = extract_pre_digest(chain_head).map(|digest| digest.slot) {
                 return strategy.should_backoff(
                     *chain_head.number(),
                     chain_head_slot,
@@ -367,7 +367,9 @@ where
     }
 
     fn proposing_remaining_duration(&self, slot_info: &SlotInfo<Block>) -> std::time::Duration {
-        let parent_slot = find_pre_digest(&slot_info.chain_head).ok().map(|d| d.slot);
+        let parent_slot = extract_pre_digest(&slot_info.chain_head)
+            .ok()
+            .map(|d| d.slot);
 
         sc_consensus_slots::proposing_remaining_duration(
             parent_slot,

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -341,63 +341,6 @@ where
     })
 }
 
-/// Extract the Subspace global randomness from the given header.
-pub fn extract_global_randomness<Header>(header: &Header) -> Result<Option<Randomness>, Error>
-where
-    Header: HeaderT,
-{
-    let mut maybe_global_randomness = None;
-    for log in header.digest().logs() {
-        trace!(target: "subspace", "Checking log {:?}, looking for global randomness digest.", log);
-        match (
-            log.as_global_randomness(),
-            maybe_global_randomness.is_some(),
-        ) {
-            (Some(_), true) => return Err(Error::Multiple(ErrorDigestType::GlobalRandomness)),
-            (Some(global_randomness), false) => maybe_global_randomness = Some(global_randomness),
-            _ => trace!(target: "subspace", "Ignoring digest not meant for us"),
-        }
-    }
-
-    Ok(maybe_global_randomness)
-}
-
-/// Extract the Subspace solution range from the given header.
-pub fn extract_solution_range<Header>(header: &Header) -> Result<Option<u64>, Error>
-where
-    Header: HeaderT,
-{
-    let mut maybe_solution_range = None;
-    for log in header.digest().logs() {
-        trace!(target: "subspace", "Checking log {:?}, looking for solution range digest.", log);
-        match (log.as_solution_range(), maybe_solution_range.is_some()) {
-            (Some(_), true) => return Err(Error::Multiple(ErrorDigestType::SolutionRange)),
-            (Some(solution_range), false) => maybe_solution_range = Some(solution_range),
-            _ => trace!(target: "subspace", "Ignoring digest not meant for us"),
-        }
-    }
-
-    Ok(maybe_solution_range)
-}
-
-/// Extract the Subspace salt from the given header.
-pub fn extract_salt<Header>(header: &Header) -> Result<Option<Salt>, Error>
-where
-    Header: HeaderT,
-{
-    let mut maybe_salt = None;
-    for log in header.digest().logs() {
-        trace!(target: "subspace", "Checking log {:?}, looking for salt digest.", log);
-        match (log.as_salt(), maybe_salt.is_some()) {
-            (Some(_), true) => return Err(Error::Multiple(ErrorDigestType::Salt)),
-            (Some(salt), false) => maybe_salt = Some(salt),
-            _ => trace!(target: "subspace", "Ignoring digest not meant for us"),
-        }
-    }
-
-    Ok(maybe_salt)
-}
-
 /// Extract the Subspace pre digest from the given header. Pre-runtime digests are mandatory, the
 /// function will return `Err` if none is found.
 pub fn extract_pre_digest<Header>(

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -25,10 +25,7 @@ pub mod offence;
 #[cfg(test)]
 mod tests;
 
-use crate::digests::{
-    CompatibleDigestItem, GlobalRandomnessDescriptor, PreDigest, SaltDescriptor,
-    SolutionRangeDescriptor,
-};
+use crate::digests::{CompatibleDigestItem, PreDigest};
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::time::Duration;
 use scale_info::TypeInfo;
@@ -94,13 +91,13 @@ pub type EquivocationProof<Header> = sp_consensus_slots::EquivocationProof<Heade
 enum ConsensusLog {
     /// Global randomness for this block/interval.
     #[codec(index = 1)]
-    GlobalRandomness(GlobalRandomnessDescriptor),
+    GlobalRandomness(Randomness),
     /// Solution range for this block/era.
     #[codec(index = 2)]
-    SolutionRange(SolutionRangeDescriptor),
+    SolutionRange(u64),
     /// Salt for this block/eon.
     #[codec(index = 3)]
-    Salt(SaltDescriptor),
+    Salt(Salt),
 }
 
 /// Farmer vote.

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -19,6 +19,8 @@
 #![forbid(unsafe_code, missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate core;
+
 pub mod digests;
 pub mod inherents;
 pub mod offence;


### PR DESCRIPTION
While working on #682 I needed to add even more digest items and it was clear that copy-pasting functions isn't productive if we need most if not all digest items in most places, which is why I decided to first do some refactoring on top of #693 to create a convenient `SubspaceDigestItems` data structure and do some other cleanups so I can add more digest items easily.

I think this will also be convenient for light client implementation (#682 will actually behave somewhat like light client).

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
