### PR TITLE
Add backpressure to the unsigned extrinsic submission in executor

### DIFF
--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -183,6 +183,7 @@ where
         }
     }
 
+    // TODO: Handle the returned error properly, ref to https://github.com/subspace/subspace/pull/695#discussion_r926721185
     pub(crate) async fn process_bundles(
         self,
         (primary_hash, primary_number): (PBlock::Hash, NumberFor<PBlock>),

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -72,6 +72,7 @@ mod worker;
 use crate::bundle_processor::BundleProcessor;
 use crate::bundle_producer::BundleProducer;
 use crate::fraud_proof::{find_trace_mismatch, FraudProofError, FraudProofGenerator};
+use crate::unsigned_submitter::UnsignedSubmitter;
 use crate::worker::BlockInfo;
 use cirrus_client_executor_gossip::{Action, GossipMessageHandler};
 use cirrus_primitives::{AccountId, SecondaryApi};
@@ -223,6 +224,11 @@ where
             code_executor,
         );
 
+        let unsigned_submitter = UnsignedSubmitter::new::<Block, PBlock, PClient>(
+            primary_chain_client.clone(),
+            spawner.clone(),
+        );
+
         let bundle_processor = BundleProcessor::new(
             primary_chain_client.clone(),
             primary_network,
@@ -233,6 +239,7 @@ where
             keystore,
             spawner.clone(),
             fraud_proof_generator.clone(),
+            unsigned_submitter,
         );
 
         spawn_essential.spawn_essential_blocking(

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -66,6 +66,7 @@ mod fraud_proof;
 mod merkle_tree;
 #[cfg(test)]
 mod tests;
+mod unsigned_submitter;
 mod worker;
 
 use crate::bundle_processor::BundleProcessor;

--- a/cumulus/client/cirrus-executor/src/unsigned_submitter.rs
+++ b/cumulus/client/cirrus-executor/src/unsigned_submitter.rs
@@ -1,0 +1,111 @@
+use crate::LOG_TARGET;
+use futures::FutureExt;
+use sc_client_api::HeaderBackend;
+use sp_api::ProvideRuntimeApi;
+use sp_core::traits::SpawnNamed;
+use sp_executor::{BundleEquivocationProof, ExecutorApi, FraudProof, InvalidTransactionProof};
+use sp_runtime::generic::BlockId;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::Sender;
+
+const UNSIGNED_MESSAGE_BUFFER_SIZE: usize = 128;
+
+#[derive(Debug, Clone)]
+pub(crate) enum UnsignedMessage {
+    Fraud(FraudProof),
+    BundleEquivocation(BundleEquivocationProof),
+    InvalidTransaction(InvalidTransactionProof),
+}
+
+/// Submits various executor-specific unsigned extrinsic to the primary node.
+#[derive(Clone)]
+pub(crate) struct UnsignedSubmitter {
+    sender: Sender<UnsignedMessage>,
+}
+
+impl UnsignedSubmitter {
+    pub(crate) fn new<Block, PBlock, PClient>(
+        primary_chain_client: Arc<PClient>,
+        spawner: Box<dyn SpawnNamed + Send + Sync>,
+    ) -> Self
+    where
+        Block: BlockT,
+        PBlock: BlockT,
+        PClient: HeaderBackend<PBlock> + ProvideRuntimeApi<PBlock> + 'static,
+        PClient::Api: ExecutorApi<PBlock, Block::Hash>,
+    {
+        let (sender, mut receiver) = mpsc::channel(UNSIGNED_MESSAGE_BUFFER_SIZE);
+
+        spawner.spawn_blocking("cirrus-submit-unsigned-extrinsic", None, {
+            async move {
+                let runtime_api = primary_chain_client.runtime_api();
+
+                while let Some(msg) = receiver.recv().await {
+                    let at = BlockId::Hash(primary_chain_client.info().best_hash);
+                    match msg {
+                        UnsignedMessage::Fraud(fraud_proof) => {
+                            if let Err(error) =
+                                runtime_api.submit_fraud_proof_unsigned(&at, fraud_proof)
+                            {
+                                tracing::error!(
+                                    target: LOG_TARGET,
+                                    ?error,
+                                    "Failed to submit fraud proof"
+                                );
+                            }
+                        }
+                        UnsignedMessage::BundleEquivocation(bundle_equivocation_proof) => {
+                            if let Err(error) = runtime_api
+                                .submit_bundle_equivocation_proof_unsigned(
+                                    &at,
+                                    bundle_equivocation_proof,
+                                )
+                            {
+                                tracing::error!(
+                                    target: LOG_TARGET,
+                                    ?error,
+                                    "Failed to submit bundle equivocation proof"
+                                );
+                            }
+                        }
+                        UnsignedMessage::InvalidTransaction(invalid_transaction_proof) => {
+                            if let Err(error) = runtime_api
+                                .submit_invalid_transaction_proof_unsigned(
+                                    &at,
+                                    invalid_transaction_proof,
+                                )
+                            {
+                                tracing::error!(
+                                    target: LOG_TARGET,
+                                    ?error,
+                                    "Failed to submit invalid transaction proof"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            .boxed()
+        });
+
+        Self { sender }
+    }
+
+    pub(crate) fn try_submit(&self, msg: UnsignedMessage) -> Result<(), UnsignedMessage> {
+        self.sender
+            .try_send(msg)
+            .map_err(|try_send_error| match try_send_error {
+                TrySendError::Full(msg) => msg,
+                TrySendError::Closed(msg) => {
+                    tracing::error!(
+                        target: LOG_TARGET,
+                        "Channel closed unexpectedly, this should not happen"
+                    );
+                    msg
+                }
+            })
+    }
+}


### PR DESCRIPTION
This PR aims to support submitting the unsigned extrinsic with some backpressure. Given that these unsigned extrinsics are kind of crucial, it's better not to drop any of them, we choose to slow down the message producers, which are the bundle processor and the gossiped executor message handler. Whenever the message producers are invoked, they'll first check if there is a pending message and try to resend it if there is one, if the resend is successful, continue as normal, otherwise, skip the further processing.

The buffer size is hardcoded to 128 for now, can be tweaked once we have a better idea.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
