### PR TITLE
Add fsync for plot index to offset db

### DIFF
--- a/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
@@ -61,6 +61,7 @@ impl IndexHashToOffsetDB {
         let mut options = Options::default();
         options.create_if_missing(true);
         options.create_missing_column_families(true);
+        options.set_use_fsync(true);
         let inner = DB::open_cf(&options, path, &["default", Self::METADATA_COLUMN_FAMILY])
             .map_err(PlotError::IndexDbOpen)?;
         let mut me = Self {


### PR DESCRIPTION
There was a [bug reported by user](https://forum.subspace.network/t/index-db-open-error-corruption-corrupted-key-redacted/520/4) which led to inconsistent state in rocksdb. I decided to enable fsync and check the performance. Didn't see any impact on SSD and 20G plot.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
