### PR TITLE
Build node and farmer separately to use less RAM in CI

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -149,7 +149,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-arm64-cross
         if: matrix.build.target == 'aarch64-unknown-linux-gnu'
 
-      - name: Build (farmer on Ubuntu or Windows with OpenCL)
+      - name: Build farmer on Ubuntu or Windows with OpenCL
         uses: actions-rs/cargo@v1
         with:
           command: build
@@ -166,11 +166,17 @@ jobs:
           move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe ${{ env.PRODUCTION_TARGET }}/subspace-farmer-opencl.exe
         if: runner.os == 'Windows'
 
-      - name: Build (farmer and node without OpenCL)
+      - name: Build farmer without OpenCL
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-node --bin subspace-farmer
+          args: -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
+
+      - name: Build node
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-node
 
       - name: Sign Application (macOS)
         run: |


### PR DESCRIPTION
In test run the process was killed, I guessed it is because our codebase gets heavier over time, so compiling took more RAM. Separating farmer and node into separate steps helped CI to pass successfully.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
