### PR TITLE
Fast sync support

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -984,6 +984,11 @@ impl<T: Config> Pallet<T> {
     fn do_store_root_blocks(root_blocks: Vec<RootBlock>) -> DispatchResult {
         for root_block in root_blocks {
             RecordsRoot::<T>::insert(root_block.segment_index(), root_block.records_root());
+            // Deposit global randomness data such that light client can validate blocks later.
+            frame_system::Pallet::<T>::deposit_log(DigestItem::records_root(
+                root_block.segment_index(),
+                root_block.records_root(),
+            ));
             Self::deposit_event(Event::RootBlockStored { root_block });
         }
         Ok(())

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -922,6 +922,29 @@ impl<T: Config> Pallet<T> {
         T::EraChangeTrigger::trigger::<T>(block_number);
         // Enact eon change, if necessary.
         T::EonChangeTrigger::trigger::<T>(block_number);
+
+        if let Some(next_global_randomness) = GlobalRandomnesses::<T>::get().next {
+            // Deposit global randomness data such that light client can validate blocks later.
+            frame_system::Pallet::<T>::deposit_log(DigestItem::next_global_randomness(
+                next_global_randomness,
+            ));
+        }
+        if let Some(next_solution_range) = SolutionRanges::<T>::get().next {
+            // Deposit solution range data such that light client can validate blocks later.
+            frame_system::Pallet::<T>::deposit_log(DigestItem::next_solution_range(
+                next_solution_range,
+            ));
+        }
+        {
+            let salts = Salts::<T>::get();
+            if salts.switch_next_block {
+                if let Some(next_salt) = salts.next {
+                    // Deposit next global randomness data such that light client can validate blocks
+                    // later.
+                    frame_system::Pallet::<T>::deposit_log(DigestItem::next_salt(next_salt));
+                }
+            }
+        }
     }
 
     fn do_finalize(_block_number: T::BlockNumber) {

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -37,7 +37,7 @@ use std::sync::Once;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
 use subspace_core_primitives::{
     ArchivedBlockProgress, LastArchivedBlock, LocalChallenge, Piece, Randomness, RootBlock, Salt,
-    Sha256Hash, Solution, Tag, PIECE_SIZE,
+    Sha256Hash, Solution, Tag, PIECE_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
 };
 use subspace_solving::{
     create_tag, create_tag_signature, derive_global_challenge, derive_local_challenge,
@@ -347,11 +347,8 @@ pub fn create_root_block(segment_index: u64) -> RootBlock {
 }
 
 pub fn create_archived_segment() -> ArchivedSegment {
-    let mut archiver = Archiver::new(
-        RecordSize::get() as usize,
-        RecordedHistorySegmentSize::get() as usize,
-    )
-    .unwrap();
+    let mut archiver =
+        Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize).unwrap();
 
     let mut block = vec![0u8; 1024 * 1024];
     rand::thread_rng().fill(block.as_mut_slice());

--- a/crates/sc-consensus-fraud-proof/src/lib.rs
+++ b/crates/sc-consensus-fraud-proof/src/lib.rs
@@ -18,6 +18,7 @@
 
 use codec::{Decode, Encode};
 use sc_consensus::block_import::{BlockCheckParams, BlockImport, BlockImportParams, ImportResult};
+use sc_consensus::StateAction;
 use sp_api::{ApiExt, ProvideRuntimeApi, TransactionFor};
 use sp_consensus::{CacheKeyId, Error as ConsensusError};
 use sp_executor::ExecutorApi;
@@ -88,34 +89,36 @@ where
         let parent_hash = *block.header.parent_hash();
         let parent_block_id = BlockId::Hash(parent_hash);
 
-        let api_version = self
-            .client
-            .runtime_api()
-            .api_version::<dyn ExecutorApi<Block, SecondaryHash>>(&parent_block_id)
-            .ok()
-            .flatten()
-            .ok_or_else(|| {
-                ConsensusError::ClientImport(format!(
-                    "Unable to retrieve api version of ExecutorApi at block {parent_hash}"
-                ))
-            })?;
+        if !matches!(block.state_action, StateAction::Skip) {
+            let api_version = self
+                .client
+                .runtime_api()
+                .api_version::<dyn ExecutorApi<Block, SecondaryHash>>(&parent_block_id)
+                .ok()
+                .flatten()
+                .ok_or_else(|| {
+                    ConsensusError::ClientImport(format!(
+                        "Unable to retrieve api version of ExecutorApi at block {parent_hash}"
+                    ))
+                })?;
 
-        // `extract_fraud_proof` is added since ExecutorApi version 2
-        // TODO: reset the ExecutorApi api version and remove this check when the network is reset.
-        if api_version >= 2 {
-            if let Some(extrinsics) = &block.body {
-                for extrinsic in extrinsics.iter() {
-                    let api_result = self
-                        .client
-                        .runtime_api()
-                        .extract_fraud_proof(&parent_block_id, extrinsic);
+            // `extract_fraud_proof` is added since ExecutorApi version 2
+            // TODO: reset the ExecutorApi api version and remove this check when the network is reset.
+            if api_version >= 2 {
+                if let Some(extrinsics) = &block.body {
+                    for extrinsic in extrinsics.iter() {
+                        let api_result = self
+                            .client
+                            .runtime_api()
+                            .extract_fraud_proof(&parent_block_id, extrinsic);
 
-                    if let Some(fraud_proof) =
-                        api_result.map_err(|e| ConsensusError::ClientImport(e.to_string()))?
-                    {
-                        self.fraud_proof_verifier
-                            .verify_fraud_proof(&fraud_proof)
-                            .map_err(|e| ConsensusError::Other(Box::new(e)))?;
+                        if let Some(fraud_proof) =
+                            api_result.map_err(|e| ConsensusError::ClientImport(e.to_string()))?
+                        {
+                            self.fraud_proof_verifier
+                                .verify_fraud_proof(&fraud_proof)
+                                .map_err(|e| ConsensusError::Other(Box::new(e)))?;
+                        }
                     }
                 }
             }

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -48,7 +48,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{Solution, PIECE_SIZE};
+use subspace_core_primitives::{Solution, PIECE_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE};
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -202,9 +202,8 @@ where
         let farmer_protocol_info: Result<FarmerProtocolInfo, ApiError> = try {
             FarmerProtocolInfo {
                 genesis_hash,
-                record_size: runtime_api.record_size(&best_block_id)?,
-                recorded_history_segment_size: runtime_api
-                    .recorded_history_segment_size(&best_block_id)?,
+                record_size: RECORD_SIZE,
+                recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
                 // TODO: `max_plot_size` in the protocol must change to bytes as well
                 max_plot_size: runtime_api.max_plot_size(&best_block_id)? * PIECE_SIZE as u64,
                 total_pieces: runtime_api.total_pieces(&best_block_id)?,

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -34,7 +34,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
 use subspace_core_primitives::objects::BlockObjectMapping;
-use subspace_core_primitives::{BlockNumber, RootBlock};
+use subspace_core_primitives::{
+    BlockNumber, RootBlock, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
+};
 
 const ARCHIVED_SEGMENT_NOTIFICATION_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -198,14 +200,6 @@ where
     .unwrap_or_else(|_| {
         panic!("Confirmation depth K can't be converted into BlockNumber");
     });
-    let record_size = client
-        .runtime_api()
-        .record_size(&best_block_id)
-        .expect("Failed to get `record_size` from runtime API");
-    let recorded_history_segment_size = client
-        .runtime_api()
-        .recorded_history_segment_size(&best_block_id)
-        .expect("Failed to get `recorded_history_segment_size` from runtime API");
 
     let maybe_last_archived_block = find_last_archived_block(client, best_block_id);
     let have_last_root_block = maybe_last_archived_block.is_some();
@@ -230,8 +224,8 @@ where
         ));
 
         Archiver::with_initial_state(
-            record_size as usize,
-            recorded_history_segment_size as usize,
+            RECORD_SIZE as usize,
+            RECORDED_HISTORY_SEGMENT_SIZE as usize,
             last_root_block,
             &last_archived_block.encode(),
             block_object_mappings,
@@ -240,7 +234,7 @@ where
     } else {
         info!(target: "subspace", "Starting archiving from genesis");
 
-        Archiver::new(record_size as usize, recorded_history_segment_size as usize)
+        Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize)
             .expect("Incorrect parameters for archiver")
     };
 

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -477,6 +477,7 @@ where
     }
 }
 
+// TODO: Replace with querying parent block header when breaking protocol
 /// Extract global randomness for block, given ID of the parent block.
 pub(crate) fn extract_global_randomness_for_block<Block, Client>(
     client: &Client,
@@ -493,6 +494,7 @@ where
         .map(|randomnesses| randomnesses.next.unwrap_or(randomnesses.current))
 }
 
+// TODO: Replace with querying parent block header when breaking protocol
 /// Extract solution ranges for block and votes, given ID of the parent block.
 pub(crate) fn extract_solution_ranges_for_block<Block, Client>(
     client: &Client,
@@ -516,6 +518,7 @@ where
         })
 }
 
+// TODO: Replace with querying parent block header when breaking protocol
 /// Extract salt and next salt for block, given ID of the parent block.
 pub(crate) fn extract_salt_for_block<Block, Client>(
     client: &Client,

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -41,7 +41,9 @@ use sp_runtime::DigestItem;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use subspace_core_primitives::{Randomness, RewardSignature, Salt, Solution};
+use subspace_core_primitives::{
+    Randomness, RewardSignature, Salt, Solution, MERKLE_NUM_LEAVES, RECORD_SIZE,
+};
 use subspace_solving::{derive_global_challenge, derive_target};
 use subspace_verification::{
     check_reward_signature, is_within_solution_range, verify_solution, PieceCheckParams,
@@ -202,14 +204,9 @@ where
                 continue;
             }
 
-            let record_size = runtime_api.record_size(&parent_block_id).ok()?;
-            let recorded_history_segment_size = runtime_api
-                .recorded_history_segment_size(&parent_block_id)
-                .ok()?;
             let max_plot_size = runtime_api.max_plot_size(&parent_block_id).ok()?;
-            let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
-            let segment_index = solution.piece_index / merkle_num_leaves;
-            let position = solution.piece_index % merkle_num_leaves;
+            let segment_index = solution.piece_index / u64::from(MERKLE_NUM_LEAVES);
+            let position = solution.piece_index % u64::from(MERKLE_NUM_LEAVES);
             let mut maybe_records_root = runtime_api
                 .records_root(&parent_block_id, segment_index)
                 .ok()?;
@@ -254,7 +251,7 @@ where
                     piece_check_params: Some(PieceCheckParams {
                         records_root,
                         position,
-                        record_size,
+                        record_size: RECORD_SIZE,
                         max_plot_size,
                         total_pieces,
                     }),

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -43,7 +43,7 @@ use sc_network_test::{
 };
 use sc_service::TaskManager;
 use schnorrkel::Keypair;
-use sp_api::{HeaderT, ProvideRuntimeApi};
+use sp_api::HeaderT;
 use sp_consensus::{
     AlwaysCanAuthor, BlockOrigin, CacheKeyId, DisableProofRecording, Environment,
     NoNetwork as DummyOracle, Proposal, Proposer,
@@ -51,7 +51,7 @@ use sp_consensus::{
 use sp_consensus_slots::{Slot, SlotDuration};
 use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest};
 use sp_consensus_subspace::inherents::InherentDataProvider;
-use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature, SubspaceApi};
+use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature};
 use sp_core::crypto::UncheckedFrom;
 use sp_inherents::{CreateInherentDataProviders, InherentData};
 use sp_runtime::generic::{BlockId, Digest, DigestItem};
@@ -67,7 +67,10 @@ use std::task::Poll;
 use std::time::Duration;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::objects::BlockObjectMapping;
-use subspace_core_primitives::{FlatPieces, LocalChallenge, Piece, Solution, Tag, TagSignature};
+use subspace_core_primitives::{
+    FlatPieces, LocalChallenge, Piece, Solution, Tag, TagSignature, RECORDED_HISTORY_SEGMENT_SIZE,
+    RECORD_SIZE,
+};
 use subspace_solving::{
     create_tag, create_tag_signature, derive_local_challenge, SubspaceCodec, REWARD_SIGNING_CONTEXT,
 };
@@ -429,14 +432,8 @@ fn rejects_empty_block() {
 
 fn get_archived_pieces(client: &TestClient) -> Vec<FlatPieces> {
     let genesis_block_id = BlockId::Number(Zero::zero());
-    let runtime_api = client.runtime_api();
 
-    let record_size = runtime_api.record_size(&genesis_block_id).unwrap();
-    let recorded_history_segment_size = runtime_api
-        .recorded_history_segment_size(&genesis_block_id)
-        .unwrap();
-
-    let mut archiver = Archiver::new(record_size as usize, recorded_history_segment_size as usize)
+    let mut archiver = Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize)
         .expect("Incorrect parameters for archiver");
 
     let genesis_block = client.block(&genesis_block_id).unwrap().unwrap();

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -24,8 +24,9 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Zero;
 use sp_runtime::DigestItem;
+use sp_std::collections::btree_map::{BTreeMap, Entry};
 use sp_std::fmt;
-use subspace_core_primitives::{Randomness, Salt, Solution};
+use subspace_core_primitives::{Randomness, Salt, Sha256Hash, Solution};
 
 /// A Subspace pre-runtime digest. This contains all data required to validate a block and for the
 /// Subspace runtime module.
@@ -90,6 +91,12 @@ pub trait CompatibleDigestItem: Sized {
 
     /// If this item is a Subspace next salt, return it.
     fn as_next_salt(&self) -> Option<Salt>;
+
+    /// Construct a digest item which contains records root.
+    fn records_root(segment_index: u64, records_root: Sha256Hash) -> Self;
+
+    /// If this item is a Subspace records root, return it.
+    fn as_records_root(&self) -> Option<(u64, Sha256Hash)>;
 }
 
 impl CompatibleDigestItem for DigestItem {
@@ -208,6 +215,23 @@ impl CompatibleDigestItem for DigestItem {
             }
         })
     }
+
+    fn records_root(segment_index: u64, records_root: Sha256Hash) -> Self {
+        Self::Consensus(
+            SUBSPACE_ENGINE_ID,
+            ConsensusLog::RecordsRoot((segment_index, records_root)).encode(),
+        )
+    }
+
+    fn as_records_root(&self) -> Option<(u64, Sha256Hash)> {
+        self.consensus_try_to(&SUBSPACE_ENGINE_ID).and_then(|c| {
+            if let ConsensusLog::RecordsRoot(records_root) = c {
+                Some(records_root)
+            } else {
+                None
+            }
+        })
+    }
 }
 
 /// Various kinds of digest types used in errors
@@ -229,6 +253,8 @@ pub enum ErrorDigestType {
     NextSolutionRange,
     /// Next salt
     NextSalt,
+    /// Records root
+    RecordsRoot,
     /// Generic consensus
     Consensus,
 }
@@ -260,6 +286,9 @@ impl fmt::Display for ErrorDigestType {
             ErrorDigestType::NextSalt => {
                 write!(f, "NextSalt")
             }
+            ErrorDigestType::RecordsRoot => {
+                write!(f, "RecordsRoot")
+            }
             ErrorDigestType::Consensus => {
                 write!(f, "Consensus")
             }
@@ -280,12 +309,12 @@ pub enum Error {
         error("Failed to decode Subspace {0} digest: {1}")
     )]
     FailedToDecode(ErrorDigestType, codec::Error),
-    /// Multiple Subspace digests
+    /// Duplicate Subspace digests
     #[cfg_attr(
         feature = "thiserror",
-        error("Multiple Subspace {0} digests, rejecting!")
+        error("Duplicate Subspace {0} digests, rejecting!")
     )]
-    Multiple(ErrorDigestType),
+    Duplicate(ErrorDigestType),
 }
 
 #[cfg(feature = "std")]
@@ -313,6 +342,8 @@ pub struct SubspaceDigestItems<PublicKey, RewardAddress, Signature> {
     pub next_solution_range: Option<u64>,
     /// Next salt
     pub next_salt: Option<Salt>,
+    /// Records roots
+    pub records_roots: BTreeMap<u64, Sha256Hash>,
 }
 
 /// Extract the Subspace global randomness from the given header.
@@ -333,6 +364,7 @@ where
     let mut maybe_next_global_randomness = None;
     let mut maybe_next_solution_range = None;
     let mut maybe_next_salt = None;
+    let mut records_roots = BTreeMap::new();
 
     for log in header.digest().logs() {
         match log {
@@ -348,7 +380,7 @@ where
 
                 match maybe_pre_digest {
                     Some(_) => {
-                        return Err(Error::Multiple(ErrorDigestType::PreDigest));
+                        return Err(Error::Duplicate(ErrorDigestType::PreDigest));
                     }
                     None => {
                         maybe_pre_digest.replace(pre_digest);
@@ -367,7 +399,7 @@ where
                     ConsensusLog::GlobalRandomness(global_randomness) => {
                         match maybe_global_randomness {
                             Some(_) => {
-                                return Err(Error::Multiple(ErrorDigestType::GlobalRandomness));
+                                return Err(Error::Duplicate(ErrorDigestType::GlobalRandomness));
                             }
                             None => {
                                 maybe_global_randomness.replace(global_randomness);
@@ -376,7 +408,7 @@ where
                     }
                     ConsensusLog::SolutionRange(solution_range) => match maybe_solution_range {
                         Some(_) => {
-                            return Err(Error::Multiple(ErrorDigestType::SolutionRange));
+                            return Err(Error::Duplicate(ErrorDigestType::SolutionRange));
                         }
                         None => {
                             maybe_solution_range.replace(solution_range);
@@ -384,7 +416,7 @@ where
                     },
                     ConsensusLog::Salt(salt) => match maybe_salt {
                         Some(_) => {
-                            return Err(Error::Multiple(ErrorDigestType::Salt));
+                            return Err(Error::Duplicate(ErrorDigestType::Salt));
                         }
                         None => {
                             maybe_salt.replace(salt);
@@ -393,7 +425,9 @@ where
                     ConsensusLog::NextGlobalRandomness(global_randomness) => {
                         match maybe_next_global_randomness {
                             Some(_) => {
-                                return Err(Error::Multiple(ErrorDigestType::NextGlobalRandomness));
+                                return Err(Error::Duplicate(
+                                    ErrorDigestType::NextGlobalRandomness,
+                                ));
                             }
                             None => {
                                 maybe_next_global_randomness.replace(global_randomness);
@@ -403,7 +437,7 @@ where
                     ConsensusLog::NextSolutionRange(solution_range) => {
                         match maybe_next_solution_range {
                             Some(_) => {
-                                return Err(Error::Multiple(ErrorDigestType::NextSolutionRange));
+                                return Err(Error::Duplicate(ErrorDigestType::NextSolutionRange));
                             }
                             None => {
                                 maybe_next_solution_range.replace(solution_range);
@@ -412,12 +446,19 @@ where
                     }
                     ConsensusLog::NextSalt(salt) => match maybe_next_salt {
                         Some(_) => {
-                            return Err(Error::Multiple(ErrorDigestType::NextSalt));
+                            return Err(Error::Duplicate(ErrorDigestType::NextSalt));
                         }
                         None => {
                             maybe_next_salt.replace(salt);
                         }
                     },
+                    ConsensusLog::RecordsRoot((segment_index, records_root)) => {
+                        if let Entry::Vacant(entry) = records_roots.entry(segment_index) {
+                            entry.insert(records_root);
+                        } else {
+                            return Err(Error::Duplicate(ErrorDigestType::NextSalt));
+                        }
+                    }
                 }
             }
             DigestItem::Seal(id, data) => {
@@ -430,7 +471,7 @@ where
 
                 match maybe_seal {
                     Some(_) => {
-                        return Err(Error::Multiple(ErrorDigestType::Seal));
+                        return Err(Error::Duplicate(ErrorDigestType::Seal));
                     }
                     None => {
                         maybe_seal.replace(seal);
@@ -457,6 +498,7 @@ where
         next_global_randomness: maybe_next_global_randomness,
         next_solution_range: maybe_next_solution_range,
         next_salt: maybe_next_salt,
+        records_roots,
     })
 }
 
@@ -484,7 +526,7 @@ where
     for log in header.digest().logs() {
         trace!(target: "subspace", "Checking log {:?}, looking for pre runtime digest", log);
         match (log.as_subspace_pre_digest(), pre_digest.is_some()) {
-            (Some(_), true) => return Err(Error::Multiple(ErrorDigestType::PreDigest)),
+            (Some(_), true) => return Err(Error::Duplicate(ErrorDigestType::PreDigest)),
             (None, _) => trace!(target: "subspace", "Ignoring digest not meant for us"),
             (s, false) => pre_digest = s,
         }

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -109,6 +109,9 @@ enum ConsensusLog {
     /// Salt for next block/eon.
     #[codec(index = 6)]
     NextSalt(Salt),
+    /// Records roots.
+    #[codec(index = 7)]
+    RecordsRoot((u64, Sha256Hash)),
 }
 
 /// Farmer vote.

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -293,10 +293,14 @@ sp_api::decl_runtime_apis! {
         /// to the client-dependent transaction confirmation depth `k`).
         fn confirmation_depth_k() -> <<Block as BlockT>::Header as HeaderT>::Number;
 
+        // TODO: Remove, this is a protocol constant
         /// The size of data in one piece (in bytes).
+        #[deprecated = "This is a protocol constant, can be found in subspace-core-primitives"]
         fn record_size() -> u32;
 
+        // TODO: Remove, this is a protocol constant
         /// Recorded history is encoded and plotted in segments of this size (in bytes).
+        #[deprecated = "This is a protocol constant, can be found in subspace-core-primitives"]
         fn recorded_history_segment_size() -> u32;
 
         /// Maximum number of pieces in each plot

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -100,6 +100,15 @@ enum ConsensusLog {
     /// Salt for this block/eon.
     #[codec(index = 3)]
     Salt(Salt),
+    /// Global randomness for next block/interval.
+    #[codec(index = 4)]
+    NextGlobalRandomness(Randomness),
+    /// Solution range for next block/era.
+    #[codec(index = 5)]
+    NextSolutionRange(u64),
+    /// Salt for next block/eon.
+    #[codec(index = 6)]
+    NextSalt(Salt),
 }
 
 /// Farmer vote.

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -142,6 +142,9 @@ pub trait HeaderImporter<Header: HeaderT, Store: Storage<Header>> {
             global_randomness,
             solution_range,
             salt,
+            next_global_randomness: _,
+            next_solution_range: _,
+            next_salt: _,
         } = verify_header_digest_with_parent(&parent_header, &header)?;
 
         // slot must be strictly increasing from the parent header

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -145,6 +145,7 @@ pub trait HeaderImporter<Header: HeaderT, Store: Storage<Header>> {
             next_global_randomness: _,
             next_solution_range: _,
             next_salt: _,
+            records_roots: _,
         } = verify_header_digest_with_parent(&parent_header, &header)?;
 
         // slot must be strictly increasing from the parent header

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -19,6 +19,7 @@
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_docs)]
 #![cfg_attr(feature = "std", warn(missing_debug_implementations))]
+#![feature(int_log)]
 
 #[cfg(test)]
 mod tests;
@@ -79,6 +80,28 @@ pub type SlotNumber = u64;
 
 /// Length of public key in bytes.
 pub const PUBLIC_KEY_LENGTH: usize = 32;
+
+/// 128 data records and 128 parity records (as a result of erasure coding) together form a perfect
+/// Merkle Tree and will result in witness size of `log2(MERKLE_NUM_LEAVES) * SHA256_HASH_SIZE`.
+///
+/// This number is a tradeoff:
+/// * as this number goes up, fewer [`RootBlock`]s are required to be stored for verifying archival
+///   history of the network, which makes sync quicker and more efficient, but also more data in
+///   each [`Piece`] will be occupied with witness, thus wasting space that otherwise could have
+///   been used for storing data (record part of a Piece)
+/// * as this number goes down, witness get smaller leading to better piece utilization, but the
+///   number of root blocks goes up making sync less efficient and less records are needed to be
+///   lost before part of the archived history become unrecoverable, reducing reliability of the
+///   data stored on the network
+pub const MERKLE_NUM_LEAVES: u32 = 256;
+/// Size of witness for a segment record (in bytes).
+pub const WITNESS_SIZE: u32 = SHA256_HASH_SIZE as u32 * MERKLE_NUM_LEAVES.log2();
+/// Size of a segment record given the global piece size (in bytes).
+pub const RECORD_SIZE: u32 = PIECE_SIZE as u32 - WITNESS_SIZE;
+/// Recorded History Segment Size includes half of the records (just data records) that will later
+/// be erasure coded and together with corresponding witnesses will result in `MERKLE_NUM_LEAVES`
+/// pieces of archival history.
+pub const RECORDED_HISTORY_SEGMENT_SIZE: u32 = RECORD_SIZE * MERKLE_NUM_LEAVES / 2;
 
 /// Randomness context
 pub const RANDOMNESS_CONTEXT: &[u8] = b"subspace_randomness";

--- a/crates/subspace-farmer/src/archiving.rs
+++ b/crates/subspace-farmer/src/archiving.rs
@@ -55,7 +55,6 @@ impl Archiving {
             ..
         } = farmer_protocol_info;
 
-        // TODO: This assumes fixed size segments, which might not be the case
         let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
 
         let (archived_segments_sync_sender, archived_segments_sync_receiver) =

--- a/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/dsn_archiving.rs
@@ -33,7 +33,6 @@ pub(super) async fn start_archiving(
     plotter: SinglePlotPlotter,
     single_disk_semaphore: SingleDiskSemaphore,
 ) -> Result<(), StartDsnArchivingError> {
-    // TODO: This assumes fixed size segments, which might not be the case
     let merkle_num_leaves = u64::from(recorded_history_segment_size / record_size * 2);
 
     let (archived_segments_sync_sender, archived_segments_sync_receiver) =

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -29,10 +29,9 @@ use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::Arc;
 use std::task::Poll;
 use subspace_archiving::reconstructor::Reconstructor;
-use subspace_core_primitives::Piece;
+use subspace_core_primitives::{Piece, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE};
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::{multimess, Config};
-use subspace_runtime_primitives::{RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE};
 
 type PieceIndex = u64;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -64,11 +64,14 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use subspace_core_primitives::objects::BlockObjectMapping;
-use subspace_core_primitives::{PublicKey, Randomness, RootBlock, Sha256Hash, PIECE_SIZE};
+use subspace_core_primitives::{
+    PublicKey, Randomness, RootBlock, Sha256Hash, PIECE_SIZE, RECORDED_HISTORY_SEGMENT_SIZE,
+    RECORD_SIZE,
+};
 use subspace_runtime_primitives::{
     opaque, AccountId, Balance, BlockNumber, Hash, Index, Moment, Signature, CONFIRMATION_DEPTH_K,
-    MAX_PLOT_SIZE, MIN_REPLICATION_FACTOR, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE, SHANNON,
-    SSC, STORAGE_FEES_ESCROW_BLOCK_REWARD, STORAGE_FEES_ESCROW_BLOCK_TAX,
+    MAX_PLOT_SIZE, MIN_REPLICATION_FACTOR, SHANNON, SSC, STORAGE_FEES_ESCROW_BLOCK_REWARD,
+    STORAGE_FEES_ESCROW_BLOCK_TAX,
 };
 use subspace_verification::derive_randomness;
 
@@ -721,11 +724,11 @@ impl_runtime_apis! {
         }
 
         fn record_size() -> u32 {
-            <Self as pallet_subspace::Config>::RecordSize::get()
+            RECORD_SIZE
         }
 
         fn recorded_history_segment_size() -> u32 {
-            <Self as pallet_subspace::Config>::RecordedHistorySegmentSize::get()
+            RECORDED_HISTORY_SEGMENT_SIZE
         }
 
         fn slot_duration() -> Duration {

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -55,7 +55,7 @@ use sp_trie::{trie_types::TrieDB, PrefixedMemoryDB, StorageProof};
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use subspace_core_primitives::PIECE_SIZE;
+use subspace_core_primitives::{PIECE_SIZE, RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE};
 use trie_db::{Trie, TrieMut};
 // bench on latest state.
 use sp_consensus_subspace::{FarmerPublicKey, SignedVote};
@@ -848,7 +848,7 @@ cfg_if! {
                 }
 
                 fn record_size() -> u32 {
-                    <Self as pallet_subspace::Config>::RecordSize::get()
+                    RECORD_SIZE
                 }
 
                 fn total_pieces() -> u64 {
@@ -856,7 +856,7 @@ cfg_if! {
                 }
 
                 fn recorded_history_segment_size() -> u32 {
-                    <Self as pallet_subspace::Config>::RecordedHistorySegmentSize::get()
+                    RECORDED_HISTORY_SEGMENT_SIZE
                 }
 
                 fn slot_duration() -> core::time::Duration {
@@ -1104,7 +1104,7 @@ cfg_if! {
                 }
 
                 fn record_size() -> u32 {
-                    <Self as pallet_subspace::Config>::RecordSize::get()
+                    RECORD_SIZE
                 }
 
                 fn max_plot_size() -> u64 {
@@ -1116,7 +1116,7 @@ cfg_if! {
                 }
 
                 fn recorded_history_segment_size() -> u32 {
-                    <Self as pallet_subspace::Config>::RecordedHistorySegmentSize::get()
+                    RECORDED_HISTORY_SEGMENT_SIZE
                 }
 
                 fn slot_duration() -> core::time::Duration {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -68,11 +68,14 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping};
-use subspace_core_primitives::{PublicKey, Randomness, RootBlock, Sha256Hash, PIECE_SIZE};
+use subspace_core_primitives::{
+    PublicKey, Randomness, RootBlock, Sha256Hash, PIECE_SIZE, RECORDED_HISTORY_SEGMENT_SIZE,
+    RECORD_SIZE,
+};
 use subspace_runtime_primitives::{
     opaque, AccountId, Balance, BlockNumber, Hash, Index, Moment, Signature, CONFIRMATION_DEPTH_K,
-    MAX_PLOT_SIZE, MIN_REPLICATION_FACTOR, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
-    STORAGE_FEES_ESCROW_BLOCK_REWARD, STORAGE_FEES_ESCROW_BLOCK_TAX,
+    MAX_PLOT_SIZE, MIN_REPLICATION_FACTOR, STORAGE_FEES_ESCROW_BLOCK_REWARD,
+    STORAGE_FEES_ESCROW_BLOCK_TAX,
 };
 use subspace_verification::derive_randomness;
 
@@ -1009,7 +1012,7 @@ impl_runtime_apis! {
         }
 
         fn record_size() -> u32 {
-            <Self as pallet_subspace::Config>::RecordSize::get()
+            RECORD_SIZE
         }
 
         fn max_plot_size() -> u64 {
@@ -1017,7 +1020,7 @@ impl_runtime_apis! {
         }
 
         fn recorded_history_segment_size() -> u32 {
-            <Self as pallet_subspace::Config>::RecordedHistorySegmentSize::get()
+            RECORDED_HISTORY_SEGMENT_SIZE
         }
 
         fn slot_duration() -> Duration {


### PR DESCRIPTION
This fixes/enables/implements Substrate's fast sync for Subspace node.

The key to fast sync is to be able to verify the block just by looking at the header. Technically block body is available too, but it is not possible to make sense of it because state isn't available.

In order to make it work a few additional digest items were added to headers that are sufficient for node to verify upcoming blocks and a few hacks were applied to make it compatible with Gemini 1b too (though some checks are simply skipped).

NOTE: This is not a light client yet (which was removed from Substrate anyway), it still downloads full blocks, just doesn't bother executing them.

Fixes #682

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
