### PR TITLE
Farmer graceful shutdown

### DIFF
--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -50,7 +50,7 @@ subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 substrate-bip39 = "0.4.4"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
-tokio = { version = "1.20.0", features = ["macros", "parking_lot", "rt-multi-thread"] }
+tokio = { version = "1.20.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 ulid = { version = "0.6.0", features = ["serde"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -287,7 +287,7 @@ pub(crate) async fn bench(
                     single_plot_farm.plot().clone(),
                 )
             })
-            .map(|(commitments, plot)| move || commitments.create(rand::random(), plot))
+            .map(|(commitments, plot)| move || commitments.create(rand::random(), plot, || false))
             .map(tokio::task::spawn_blocking)
             .collect::<FuturesUnordered<_>>();
         while let Some(result) = tasks.next().await {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -29,8 +29,6 @@ pub(crate) async fn farm_multi_disk(
         return Err(anyhow!("There must be at least one disk farm provided"));
     }
 
-    utils::raise_fd_limit();
-
     let FarmingArgs {
         bootstrap_nodes,
         listen_on,
@@ -209,8 +207,6 @@ pub(crate) async fn farm_legacy(
     base_directory: PathBuf,
     farm_args: FarmingArgs,
 ) -> Result<(), anyhow::Error> {
-    utils::raise_fd_limit();
-
     let FarmingArgs {
         bootstrap_nodes,
         listen_on,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -17,7 +17,7 @@ use subspace_networking::Config;
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use tracing::{info, trace, warn};
 
-use crate::{utils, ArchivingFrom, DiskFarm, FarmingArgs};
+use crate::{ArchivingFrom, DiskFarm, FarmingArgs};
 
 /// Start farming by using multiple replica plot in specified path and connecting to WebSocket
 /// server at specified address.

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -250,6 +250,7 @@ async fn main() -> Result<()> {
             ),
         )
         .init();
+    utils::raise_fd_limit();
 
     let command = Command::parse();
 

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -33,7 +33,7 @@ fn create() {
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
     let piece_indexes = (0..).take(pieces.count()).collect();
     plot.write_many(Arc::new(pieces), piece_indexes).unwrap();
-    commitments.create(salt, plot).unwrap();
+    commitments.create(salt, plot, || false).unwrap();
 
     let (tag, _) = commitments
         .find_by_range(correct_tag, solution_range, salt, TAGS_SEARCH_LIMIT)
@@ -68,7 +68,7 @@ fn find_by_tag() {
     let piece_indexes = (0..).take(pieces.count()).collect();
     plot.write_many(Arc::new(pieces), piece_indexes).unwrap();
 
-    commitments.create(salt, plot).unwrap();
+    commitments.create(salt, plot, || false).unwrap();
 
     {
         let target = [0u8, 0, 0, 0, 0, 0, 0, 1];
@@ -157,7 +157,7 @@ fn remove_commitments() {
     let commitments = Commitments::new(base_directory.path().join("commitments")).unwrap();
     let piece_indexes = (0..).take(pieces.count()).collect();
     plot.write_many(Arc::new(pieces), piece_indexes).unwrap();
-    commitments.create(salt, plot.clone()).unwrap();
+    commitments.create(salt, plot.clone(), || false).unwrap();
 
     let (_, offset) = commitments
         .find_by_range(correct_tag, solution_range, salt, TAGS_SEARCH_LIMIT)

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -137,7 +137,7 @@ async fn no_sync_test() {
     assert!(result.lock().is_empty())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_dsn_sync() {
     init();
 

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -42,7 +42,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
 
     let piece_indexes = (0..).take(pieces.count()).collect();
     plot.write_many(Arc::new(pieces), piece_indexes).unwrap();
-    commitments.create(salt, plot.clone()).unwrap();
+    commitments.create(salt, plot.clone(), || false).unwrap();
 
     let client = MockRpcClient::new();
 

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -155,7 +155,7 @@ async fn plotting_piece_eviction() {
 
     // There are no pieces, but we need to create empty commitments database for this salt, such
     //  that plotter will create commitments for plotted pieces
-    commitments.create(salt, plot.clone()).unwrap();
+    commitments.create(salt, plot.clone(), || false).unwrap();
 
     let client = MockRpcClient::new();
 


### PR DESCRIPTION
Partially solves #601 

This pr adds graceful shutdown to a farmer. The only thing which is unhandled is graceful shutdown of background recommitments. I left it to other pr as it is not clear how to do it.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
