### PR TITLE
Graceful shutdown for recommitments

### DIFF
--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -50,7 +50,7 @@ subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 substrate-bip39 = "0.4.4"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
-tokio = { version = "1.20.0", features = ["macros", "parking_lot", "rt-multi-thread"] }
+tokio = { version = "1.20.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 ulid = { version = "0.6.0", features = ["serde"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -29,8 +29,6 @@ pub(crate) async fn farm_multi_disk(
         return Err(anyhow!("There must be at least one disk farm provided"));
     }
 
-    utils::raise_fd_limit();
-
     let FarmingArgs {
         bootstrap_nodes,
         listen_on,
@@ -209,8 +207,6 @@ pub(crate) async fn farm_legacy(
     base_directory: PathBuf,
     farm_args: FarmingArgs,
 ) -> Result<(), anyhow::Error> {
-    utils::raise_fd_limit();
-
     let FarmingArgs {
         bootstrap_nodes,
         listen_on,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -250,6 +250,7 @@ async fn main() -> Result<()> {
             ),
         )
         .init();
+    utils::raise_fd_limit();
 
     let command = Command::parse();
 

--- a/crates/subspace-farmer/src/farming.rs
+++ b/crates/subspace-farmer/src/farming.rs
@@ -10,6 +10,7 @@ use crate::rpc_client::RpcClient;
 use crate::single_disk_farm::SingleDiskSemaphore;
 use crate::single_plot_farm::SinglePlotFarmId;
 use crate::utils::AbortingJoinHandle;
+use crate::CommitmentError;
 use futures::future::{Fuse, FusedFuture};
 use futures::{FutureExt, StreamExt};
 use std::sync::mpsc;
@@ -308,6 +309,9 @@ fn update_commitments(
 
                     if let Err(error) = commitments.create(salt, plot) {
                         error!(%error, "Failed to create commitment");
+                        if matches!(error, CommitmentError::Stop) {
+                            return;
+                        }
                     } else {
                         info!(
                             took_seconds = started.elapsed().as_secs_f32(),

--- a/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
+++ b/crates/subspace-farmer/src/legacy_multi_plots_farm.rs
@@ -197,4 +197,23 @@ impl LegacyMultiPlotsFarm {
 
         Ok(())
     }
+
+    /// Returns a future which can be polled in order to stop the legacy multi plots farming
+    pub fn on_exit(&mut self) -> impl std::future::Future<Output = ()> + Send + 'static {
+        let archiving_stop = self.archiving.as_mut().map(Archiving::on_exit);
+        let single_plot_farms_on_exit = self
+            .single_plot_farms
+            .iter()
+            .map(SinglePlotFarm::on_exit)
+            .collect::<Vec<_>>();
+
+        async move {
+            if let Some(archiving_stop) = archiving_stop {
+                archiving_stop.await;
+            }
+            for single_plot_farm_on_exit in single_plot_farms_on_exit {
+                single_plot_farm_on_exit.await;
+            }
+        }
+    }
 }

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -80,6 +80,12 @@ struct Inner {
 
 impl Drop for Inner {
     fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+impl Inner {
+    pub fn stop(&self) {
         let (result_sender, result_receiver) = mpsc::channel();
 
         if self
@@ -119,6 +125,11 @@ impl fmt::Debug for Plot {
 }
 
 impl Plot {
+    /// Stop the corresponding plot worker
+    pub fn stop(&self) {
+        self.inner.stop()
+    }
+
     /// Creates a new plot for persisting encoded pieces to disk
     pub fn open_or_create(
         single_plot_farm_id: &SinglePlotFarmId,

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -583,6 +583,16 @@ impl SinglePlotFarm {
         Ok(farm)
     }
 
+    /// Returns a future which can be polled in order to stop the single plot farm
+    pub fn on_exit(&self) -> impl std::future::Future<Output = ()> + Send + 'static {
+        let node = self.node.clone();
+        let plot = self.plot.clone();
+        async move {
+            node.stop();
+            plot.stop();
+        }
+    }
+
     /// Collect summary of single plot farm for presentational purposes
     pub fn collect_summary(
         plot_directory: PathBuf,

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -587,9 +587,11 @@ impl SinglePlotFarm {
     pub fn on_exit(&self) -> impl std::future::Future<Output = ()> + Send + 'static {
         let node = self.node.clone();
         let plot = self.plot.clone();
+        let commitments = self.commitments.clone();
         async move {
             node.stop();
             plot.stop();
+            commitments.stop().await;
         }
     }
 

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -75,6 +75,8 @@ pub(crate) struct Shared {
     pub(crate) connected_peers_count: AtomicUsize,
     /// Sender end of the channel for sending commands to the swarm.
     pub(crate) command_sender: mpsc::Sender<Command>,
+    /// Sender which would stop the corresponding node runner.
+    pub(crate) stop_sender: Mutex<Option<oneshot::Sender<()>>>,
     /// Parent node instance (if any) to keep alive.
     ///
     /// This is needed to ensure relay server doesn't stop, cutting this node from ability to
@@ -87,6 +89,7 @@ impl Shared {
         id: PeerId,
         parent_node: Option<Node>,
         command_sender: mpsc::Sender<Command>,
+        stop_sender: oneshot::Sender<()>,
     ) -> Self {
         Self {
             handlers: Handlers::default(),
@@ -94,6 +97,7 @@ impl Shared {
             listeners: Mutex::default(),
             connected_peers_count: AtomicUsize::new(0),
             command_sender,
+            stop_sender: Mutex::new(Some(stop_sender)),
             _parent_node: parent_node,
         }
     }


### PR DESCRIPTION
Closes #601 

Should be reviewed after #716.

This pr tries to gracefully shutdown recommitment background task. It can be interrupted in between commit batches.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers