### PR TITLE
Fix thread creation where Tokio runtime is not available

### DIFF
--- a/crates/subspace-farmer/src/commitments/databases.rs
+++ b/crates/subspace-farmer/src/commitments/databases.rs
@@ -146,7 +146,7 @@ impl CommitmentDatabases {
                 Ok(())
             })?;
 
-            tokio::task::spawn_blocking(move || {
+            std::thread::spawn(move || {
                 // Take a lock to make sure database was released by whatever user there was and we
                 // have an exclusive access to it, then drop it
                 old_db_entry.db.lock().take();


### PR DESCRIPTION
Unfortunately I somehow missed it during refactoring, we need to make a new snapshot now.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
