### PR TITLE
Light client: Extract next digest items from Parent header

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -924,13 +924,13 @@ impl<T: Config> Pallet<T> {
         T::EonChangeTrigger::trigger::<T>(block_number);
 
         if let Some(next_global_randomness) = GlobalRandomnesses::<T>::get().next {
-            // Deposit global randomness data such that light client can validate blocks later.
+            // Deposit next global randomness data such that light client can validate blocks later.
             frame_system::Pallet::<T>::deposit_log(DigestItem::next_global_randomness(
                 next_global_randomness,
             ));
         }
         if let Some(next_solution_range) = SolutionRanges::<T>::get().next {
-            // Deposit solution range data such that light client can validate blocks later.
+            // Deposit next solution range data such that light client can validate blocks later.
             frame_system::Pallet::<T>::deposit_log(DigestItem::next_solution_range(
                 next_solution_range,
             ));
@@ -939,8 +939,7 @@ impl<T: Config> Pallet<T> {
             let salts = Salts::<T>::get();
             if salts.switch_next_block {
                 if let Some(next_salt) = salts.next {
-                    // Deposit next global randomness data such that light client can validate blocks
-                    // later.
+                    // Deposit next salt data such that light client can validate blocks later.
                     frame_system::Pallet::<T>::deposit_log(DigestItem::next_salt(next_salt));
                 }
             }

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -304,18 +304,23 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
         SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature>,
         ImportError<Header>,
     > {
+        // extract digest items from the header
         let pre_digest_items = extract_subspace_digest_items(header)?;
-        if pre_digest_items.global_randomness != parent_header.derived_global_randomness {
+        // extract next digest items from the parent header
+        let next_digest_items = parent_header.extract_next_digest_items()?;
+
+        // check the digest items against the next digest items from parent header
+        if pre_digest_items.global_randomness != next_digest_items.next_global_randomness {
             return Err(ImportError::InvalidDigest(
                 ErrorDigestType::GlobalRandomness,
             ));
         }
 
-        if pre_digest_items.solution_range != parent_header.derived_solution_range {
+        if pre_digest_items.solution_range != next_digest_items.next_solution_range {
             return Err(ImportError::InvalidDigest(ErrorDigestType::SolutionRange));
         }
 
-        if pre_digest_items.salt != parent_header.derived_salt {
+        if pre_digest_items.salt != next_digest_items.next_salt {
             return Err(ImportError::InvalidDigest(ErrorDigestType::Salt));
         }
 

--- a/crates/sp-lightclient/src/mock.rs
+++ b/crates/sp-lightclient/src/mock.rs
@@ -1,4 +1,6 @@
 use crate::{BlockWeight, ChainConstants, HashOf, HeaderExt, NumberOf, SolutionRange, Storage};
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_arithmetic::traits::Zero;
 use sp_runtime::traits::{BlakeTwo256, Header as HeaderT};
 use std::collections::HashMap;
@@ -12,6 +14,11 @@ struct StorageData {
     number_to_hashes: HashMap<NumberOf<Header>, Vec<HashOf<Header>>>,
     best_header: (NumberOf<Header>, HashOf<Header>),
     finalized_head: Option<(NumberOf<Header>, HashOf<Header>)>,
+}
+
+#[derive(Default, Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub(crate) struct TestOverrides {
+    pub(crate) solution_range: Option<SolutionRange>,
 }
 
 #[derive(Debug)]
@@ -119,7 +126,7 @@ impl MockStorage {
         solution_range: SolutionRange,
     ) {
         let mut header = self.0.headers.remove(&hash).unwrap();
-        header.derived_solution_range = solution_range;
+        header.test_overrides.solution_range = Some(solution_range);
         self.0.headers.insert(hash, header);
     }
 

--- a/crates/sp-lightclient/src/mock.rs
+++ b/crates/sp-lightclient/src/mock.rs
@@ -130,6 +130,11 @@ impl MockStorage {
         self.0.headers.insert(hash, header);
     }
 
+    // hack to adjust constants when importing Block #1
+    pub(crate) fn override_constants(&mut self, constants: ChainConstants<Header>) {
+        self.0.constants = constants;
+    }
+
     // hack to adjust the cumulative weight
     pub(crate) fn override_cumulative_weight(&mut self, hash: HashOf<Header>, weight: BlockWeight) {
         let mut header = self.0.headers.remove(&hash).unwrap();

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::mock::{Header, MockStorage};
 use crate::{
-    ChainConstants, HashOf, HeaderExt, HeaderImporter, ImportError, NumberOf, SolutionRange,
-    Storage,
+    ChainConstants, HashOf, HeaderExt, HeaderImporter, ImportError, NextDigestItems, NumberOf,
+    SolutionRange, Storage,
 };
 use frame_support::{assert_err, assert_ok};
 use schnorrkel::Keypair;
@@ -25,7 +25,15 @@ fn default_randomness_and_salt() -> (Randomness, Salt) {
 }
 
 fn default_test_constants() -> ChainConstants<Header> {
-    ChainConstants { k_depth: 7 }
+    let (randomness, salt) = default_randomness_and_salt();
+    ChainConstants {
+        k_depth: 7,
+        genesis_digest_items: NextDigestItems {
+            next_global_randomness: randomness,
+            next_solution_range: Default::default(),
+            next_salt: salt,
+        },
+    }
 }
 
 fn derive_solution_range(target: Tag, tag: Tag) -> SolutionRange {
@@ -307,6 +315,12 @@ fn create_fork_chain_from(
         importer.store.override_cumulative_weight(parent_hash, 0);
         parent_hash = header.hash();
         next_slot += 1;
+        if number == 1 {
+            // adjust Chain constants for Block #1
+            let mut constants = importer.store.chain_constants();
+            constants.genesis_digest_items.next_solution_range = solution_range;
+            importer.store.override_constants(constants)
+        }
         assert_ok!(importer.import_header(header));
         // best header should not change
         assert_eq!(importer.store.best_header().header, best_header_ext.header);

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -115,18 +115,15 @@ fn import_blocks_until(
     let mut parent_hash = Default::default();
     let mut slot = start_slot;
     for block_number in 0..=number {
-        let (header, solution_range) =
+        let (header, _solution_range) =
             valid_header_with_default_randomness_and_salt(parent_hash, block_number, slot, keypair);
         parent_hash = header.hash();
         slot += 1;
 
-        let (randomness, salt) = default_randomness_and_salt();
         let header_ext = HeaderExt {
             header,
-            derived_global_randomness: randomness,
-            derived_solution_range: solution_range,
-            derived_salt: salt,
             total_weight: 0,
+            test_overrides: Default::default(),
         };
         store.store_header(header_ext, true);
     }


### PR DESCRIPTION
This PR extracts the next_(global_randomness, solution_range, salt) from digests introduced in #714 and use them to verify the immediate next descendant header.

Follow commit by commit for easier review.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
