### PR TITLE
Simpler way to include one runtime WASM bundle into another

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "subspace-runtime-primitives",
+ "subspace-wasm-tools",
  "substrate-wasm-builder",
 ]
 
@@ -991,6 +992,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "subspace-runtime-primitives",
+ "subspace-wasm-tools",
  "substrate-wasm-builder",
 ]
 

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -66,7 +66,6 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "h
 frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86", optional = true }
 
 [build-dependencies]
-cirrus-runtime = { version = "0.1.0", path = "../../cumulus/runtime" }
 subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../subspace-wasm-tools" }
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 

--- a/cumulus/runtime/Cargo.toml
+++ b/cumulus/runtime/Cargo.toml
@@ -7,6 +7,7 @@ license = "Unlicense"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/cumulus/"
 edition = "2021"
+links = "cirrus-runtime"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -49,6 +50,7 @@ sp-executor = { path = "../../crates/sp-executor", default-features = false }
 subspace-runtime-primitives = { path = "../../crates/subspace-runtime-primitives", default-features = false }
 
 [build-dependencies]
+subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../crates/subspace-wasm-tools" }
 substrate-wasm-builder = { git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 
 [features]

--- a/cumulus/runtime/build.rs
+++ b/cumulus/runtime/build.rs
@@ -6,5 +6,7 @@ fn main() {
         .enable_feature("wasm-builder")
         .export_heap_base()
         .import_memory()
-        .build()
+        .build();
+
+    subspace_wasm_tools::export_wasm_bundle_path();
 }

--- a/cumulus/test/runtime/Cargo.toml
+++ b/cumulus/test/runtime/Cargo.toml
@@ -7,11 +7,13 @@ license = "Unlicense"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/cumulus/"
 edition = "2021"
+links = "cirrus-test-runtime"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
+subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../../crates/subspace-wasm-tools" }
 substrate-wasm-builder = { git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 
 [dependencies]

--- a/cumulus/test/runtime/build.rs
+++ b/cumulus/test/runtime/build.rs
@@ -6,5 +6,7 @@ fn main() {
         .enable_feature("wasm-builder")
         .export_heap_base()
         .import_memory()
-        .build()
+        .build();
+
+    subspace_wasm_tools::export_wasm_bundle_path();
 }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -61,7 +61,6 @@ frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 
 [build-dependencies]
-cirrus-test-runtime = { version = "0.1.0", path = "../../cumulus/test/runtime" }
 subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../crates/subspace-wasm-tools" }
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 


### PR DESCRIPTION
@ozgunozerk this should fix CI issue in desktop app. I don't know what the reason is there, but this leveraging an approach described in Cargo's documentation, so should work regardless.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
