### PR TITLE
DSN. Add Sync to NetworkingParametersRegistry trait in the subspace_networking crate.

### DIFF
--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -25,7 +25,7 @@ const DATA_FLUSH_DURATION_SECS: u64 = 5;
 
 /// Defines operations with the networking parameters.
 #[async_trait]
-pub trait NetworkingParametersRegistry: Send {
+pub trait NetworkingParametersRegistry: Send + Sync {
     /// Registers a peer ID and associated addresses
     async fn add_known_peer(&mut self, peer_id: PeerId, addresses: Vec<Multiaddr>);
 


### PR DESCRIPTION
This PR adds `Sync` marker trait to the `NetworkingParametersRegistry` in the subspace_networking crate. This fixes the incompatibility with the subspace desktop.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
