### PR TITLE
Add object mapping roots into `RootBlock`

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -990,7 +990,7 @@ impl<T: Config> Pallet<T> {
             RecordsRoot::<T>::insert(root_block.segment_index(), root_block.records_root());
             ObjectMappingRoots::<T>::insert(
                 root_block.segment_index(),
-                root_block.object_mapping_root(),
+                root_block.object_mappings_root(),
             );
             // Deposit global randomness data such that light client can validate blocks later.
             frame_system::Pallet::<T>::deposit_log(DigestItem::records_root(

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -338,6 +338,7 @@ pub fn create_root_block(segment_index: u64) -> RootBlock {
     RootBlock::V0 {
         segment_index,
         records_root: Sha256Hash::default(),
+        object_mappings_root: Sha256Hash::default(),
         prev_root_block_hash: Sha256Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -310,6 +310,7 @@ fn invalid_usage() {
             RootBlock::V0 {
                 segment_index: 0,
                 records_root: Sha256Hash::default(),
+                object_mappings_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -337,6 +338,7 @@ fn invalid_usage() {
             RootBlock::V0 {
                 segment_index: 0,
                 records_root: Sha256Hash::default(),
+                object_mappings_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -432,6 +434,7 @@ fn object_on_the_edge_of_segment() {
                     - RootBlock::V0 {
                         segment_index: 0,
                         records_root: Default::default(),
+                        object_mappings_root: Default::default(),
                         prev_root_block_hash: Default::default(),
                         last_archived_block: LastArchivedBlock {
                             number: 0,

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -199,13 +199,13 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(13233));
+        assert_eq!(last_archived_block.partial_archived(), Some(13201));
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(29143));
+        assert_eq!(last_archived_block.partial_archived(), Some(29079));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -264,7 +264,7 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 3);
-        assert_eq!(last_archived_block.partial_archived(), None);
+        assert_eq!(last_archived_block.partial_archived(), Some(12956));
 
         for (position, piece) in archived_segment.pieces.as_pieces().enumerate() {
             assert!(archiver::is_piece_valid(
@@ -473,6 +473,6 @@ fn object_on_the_edge_of_segment() {
     // This will only need to be adjusted when implementation changes
     assert_eq!(
         archived_segment[1].object_mapping[0].objects[0].offset(),
-        88
+        120
     );
 }

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -117,7 +117,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(3896)
+                archived_progress: ArchivedBlockProgress::Partial(3864)
             }
         );
 
@@ -136,7 +136,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(3896)
+                archived_progress: ArchivedBlockProgress::Partial(3864)
             }
         );
     }
@@ -156,7 +156,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(19806)
+                archived_progress: ArchivedBlockProgress::Partial(19742)
             }
         );
     }
@@ -177,7 +177,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(19806)
+                archived_progress: ArchivedBlockProgress::Partial(19742)
             }
         );
     }
@@ -197,7 +197,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(35716)
+                archived_progress: ArchivedBlockProgress::Partial(35620)
             }
         );
     }
@@ -218,7 +218,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(35716)
+                archived_progress: ArchivedBlockProgress::Partial(35620)
             }
         );
     }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -459,6 +459,16 @@ impl RootBlock {
         }
     }
 
+    /// Merkle root of the object mappings in a segments.
+    pub fn object_mappings_root(&self) -> Sha256Hash {
+        match self {
+            Self::V0 {
+                object_mappings_root,
+                ..
+            } => *object_mappings_root,
+        }
+    }
+
     /// Hash of the root block of the previous segment
     pub fn prev_root_block_hash(&self) -> Sha256Hash {
         match self {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -430,6 +430,8 @@ pub enum RootBlock {
         segment_index: u64,
         /// Merkle root of the records in a segment.
         records_root: Sha256Hash,
+        /// Merkle root of object mappings root
+        object_mappings_root: Sha256Hash,
         /// Hash of the root block of the previous segment
         prev_root_block_hash: Sha256Hash,
         /// Last archived block

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -210,6 +210,7 @@ pub(crate) async fn bench(
             let root_block = RootBlock::V0 {
                 segment_index,
                 records_root: Sha256Hash::default(),
+                object_mappings_root: Sha256Hash::default(),
                 prev_root_block_hash: Sha256Hash::default(),
                 last_archived_block,
             };

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -261,6 +261,7 @@ async fn test_dsn_sync() {
                 let root_block = RootBlock::V0 {
                     segment_index,
                     records_root: Sha256Hash::default(),
+                    object_mappings_root: Sha256Hash::default(),
                     prev_root_block_hash: Sha256Hash::default(),
                     last_archived_block,
                 };


### PR DESCRIPTION
Fixes #705

This pr adds object mappings roots into block header via adding its header to `RootBlock`. Not sure how we should verify the validity of block header.

### Code contributor checklist:
* [x] I have reviewed my own changes one more time to spot typos, unintended changes, following project conventions, etc.
* [x] I have prepared clean readable history of commits before submitting this PR to make reviewer's life easier
* [x] I have tested my changes and/or added corresponding test cases (if relevant)
* [x] I understand that any changes to this PR going forward will notify multiple developers and will try to minimize them
* [x] I have added sufficient description of changes to make review process easier
* [x] This PR is ready for review by developers
