### PR TITLE
Networking parameters manager upgrade.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.44",
  "winapi 0.3.9",
 ]
@@ -8051,6 +8052,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "chrono",
  "clap 3.2.12",
  "derive_more",
  "event-listener-primitives",

--- a/crates/subspace-farmer/src/dsn/pieces_by_range_tests.rs
+++ b/crates/subspace-farmer/src/dsn/pieces_by_range_tests.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use subspace_core_primitives::{crypto, FlatPieces, Piece, PieceIndexHash};
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::{
-    Config, PiecesByRangeRequest, PiecesByRangeRequestHandler, PiecesByRangeResponse, PiecesToPlot,
+    BootstrappedNetworkingParameters, Config, PiecesByRangeRequest, PiecesByRangeRequestHandler,
+    PiecesByRangeResponse, PiecesToPlot,
 };
 
 #[tokio::test]
@@ -66,7 +67,10 @@ async fn pieces_by_range_protocol_smoke() {
     drop(on_new_listener_handler);
 
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(vec![
+            node_1_addr.with(Protocol::P2p(node_1.id().into()))
+        ])
+        .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         request_response_protocols: vec![PiecesByRangeRequestHandler::create(|_request| None)],
@@ -165,7 +169,10 @@ async fn get_pieces_by_range_smoke() {
     drop(on_new_listener_handler);
 
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(vec![
+            node_1_addr.with(Protocol::P2p(node_1.id().into()))
+        ])
+        .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         request_response_protocols: vec![PiecesByRangeRequestHandler::create(|_request| None)],

--- a/crates/subspace-farmer/src/dsn/pieces_by_range_tests.rs
+++ b/crates/subspace-farmer/src/dsn/pieces_by_range_tests.rs
@@ -82,6 +82,11 @@ async fn pieces_by_range_protocol_smoke() {
         node_runner_2.run().await;
     });
 
+    node_2
+        .wait_for_connected_peers()
+        .await
+        .expect("Unexpected Node failure");
+
     let (mut result_sender, mut result_receiver) = mpsc::unbounded();
     tokio::spawn(async move {
         let resp = node_2
@@ -183,6 +188,11 @@ async fn get_pieces_by_range_smoke() {
     tokio::spawn(async move {
         node_runner_2.run().await;
     });
+
+    node_2
+        .wait_for_connected_peers()
+        .await
+        .expect("Unexpected Node failure");
 
     let mut stream = node_2
         .get_pieces(piece_index_from..piece_index_end)

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -367,11 +367,18 @@ async fn test_dsn_sync() {
     let public_key =
         U256::from_be_bytes((*syncer_multi_farming.single_plot_farms()[0].public_key()).into());
 
+    let syncer_node = syncer_multi_farming.single_plot_farms()[0].node().clone();
+
     tokio::spawn(async move {
         if let Err(error) = syncer_multi_farming.wait().await {
             eprintln!("Syncer exited with error: {error}");
         }
     });
+
+    syncer_node
+        .wait_for_connected_peers()
+        .await
+        .expect("Unexpected Node failure");
 
     dsn_sync.await.unwrap();
 

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -26,8 +26,8 @@ use subspace_networking::libp2p::identity::sr25519;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::multimess::MultihashCode;
 use subspace_networking::{
-    Config, Node, NodeRunner, PiecesByRangeRequest, PiecesByRangeRequestHandler,
-    PiecesByRangeResponse, PiecesToPlot,
+    BootstrappedNetworkingParameters, Config, Node, NodeRunner, PiecesByRangeRequest,
+    PiecesByRangeRequestHandler, PiecesByRangeResponse, PiecesToPlot,
 };
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
@@ -417,7 +417,8 @@ impl SinglePlotFarm {
 
         let codec = SubspaceCodec::new_with_gpu(public_key.as_ref());
         let network_node_config = Config {
-            bootstrap_nodes,
+            networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
+                .boxed(),
             listen_on,
             // TODO: Do we still need it?
             value_getter: Arc::new({

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -18,6 +18,7 @@ include = [
 [dependencies]
 async-trait = "0.1.56"
 bytes = "1.2.0"
+chrono = {version = "0.4.19", features = ["clock", "serde", "std",]}
 derive_more = "0.99.17"
 event-listener-primitives = "2.0.1"
 futures = "0.3.21"

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -5,7 +5,7 @@ use libp2p::identity::sr25519::Keypair;
 use libp2p::Multiaddr;
 use std::sync::Arc;
 use subspace_networking::libp2p::multiaddr::Protocol;
-use subspace_networking::Config;
+use subspace_networking::{BootstrappedNetworkingParameters, Config};
 use tracing::info;
 
 #[derive(Debug, Parser)]
@@ -15,7 +15,7 @@ enum Command {
     Start {
         /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
         #[clap(long)]
-        bootstrap_node: Vec<Multiaddr>,
+        bootstrap_nodes: Vec<Multiaddr>,
         /// Keypair for node identity, can be obtained with `generate-keypair` command
         keypair: String,
         /// Multiaddr to listen on for subspace networking, multiple are supported
@@ -34,12 +34,15 @@ async fn main() -> anyhow::Result<()> {
 
     match command {
         Command::Start {
-            bootstrap_node,
+            bootstrap_nodes,
             keypair,
             listen_on,
         } => {
             let config = Config {
-                bootstrap_nodes: bootstrap_node,
+                networking_parameters_registry: BootstrappedNetworkingParameters::new(
+                    bootstrap_nodes,
+                )
+                .boxed(),
                 listen_on,
                 allow_non_globals_in_dht: true,
                 ..Config::with_keypair(Keypair::decode(hex::decode(keypair)?.as_mut_slice())?)

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -15,7 +15,7 @@ enum Command {
     Start {
         /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
         #[clap(long)]
-        bootstrap_nodes: Vec<Multiaddr>,
+        bootstrap_node: Vec<Multiaddr>,
         /// Keypair for node identity, can be obtained with `generate-keypair` command
         keypair: String,
         /// Multiaddr to listen on for subspace networking, multiple are supported
@@ -34,13 +34,13 @@ async fn main() -> anyhow::Result<()> {
 
     match command {
         Command::Start {
-            bootstrap_nodes,
+            bootstrap_node,
             keypair,
             listen_on,
         } => {
             let config = Config {
                 networking_parameters_registry: BootstrappedNetworkingParameters::new(
-                    bootstrap_nodes,
+                    bootstrap_node,
                 )
                 .boxed(),
                 listen_on,

--- a/crates/subspace-networking/examples/bootstrap-node.rs
+++ b/crates/subspace-networking/examples/bootstrap-node.rs
@@ -14,8 +14,8 @@ enum Command {
     /// Start bootstrap node
     Start {
         /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
-        #[clap(long)]
-        bootstrap_node: Vec<Multiaddr>,
+        #[clap(long, alias = "bootstrap-node")]
+        bootstrap_nodes: Vec<Multiaddr>,
         /// Keypair for node identity, can be obtained with `generate-keypair` command
         keypair: String,
         /// Multiaddr to listen on for subspace networking, multiple are supported
@@ -34,13 +34,13 @@ async fn main() -> anyhow::Result<()> {
 
     match command {
         Command::Start {
-            bootstrap_node,
+            bootstrap_nodes,
             keypair,
             listen_on,
         } => {
             let config = Config {
                 networking_parameters_registry: BootstrappedNetworkingParameters::new(
-                    bootstrap_node,
+                    bootstrap_nodes,
                 )
                 .boxed(),
                 listen_on,

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -1,8 +1,8 @@
-use crate::identity::sr25519::Keypair;
 use futures::channel::oneshot;
+use libp2p::identity::sr25519::Keypair;
 use libp2p::multiaddr::Protocol;
 use libp2p::multihash::{Code, MultihashDigest};
-use libp2p::{identity, PeerId};
+use libp2p::PeerId;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
@@ -100,7 +100,7 @@ async fn main() {
         node_runner.run().await;
     });
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    node.wait_for_connected_peers().await.unwrap();
 
     // Prepare multihash to look for in Kademlia
     let key = Code::Identity.digest(&expected_kaypair.public().encode());
@@ -110,7 +110,9 @@ async fn main() {
     // Uncomment on debugging:
     // println!("Received closest peers: {:?}", peers);
 
-    let peer_id = peers.first().unwrap();
+    let peer_id = peers
+        .first()
+        .expect("get_closest_peers returned empty set. ");
     assert_eq!(*peer_id, expected_node_id);
     println!("Expected Peer ID received.");
 

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -116,7 +116,7 @@ async fn main() {
     assert_eq!(*peer_id, expected_node_id);
     println!("Expected Peer ID received.");
 
-    tokio::time::sleep(Duration::from_secs(12)).await;
+    tokio::time::sleep(Duration::from_secs(120)).await;
 
     println!("Exiting..");
 }

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -1,3 +1,4 @@
+use crate::identity::sr25519::Keypair;
 use futures::channel::oneshot;
 use libp2p::multiaddr::Protocol;
 use libp2p::multihash::{Code, MultihashDigest};
@@ -13,21 +14,29 @@ async fn main() {
 
     let mut bootstrap_nodes = Vec::new();
     let mut expected_node_id = PeerId::random();
+    let mut expected_kaypair = Keypair::generate();
 
     const TOTAL_NODE_COUNT: usize = 100;
     const EXPECTED_NODE_INDEX: usize = 75;
 
     let mut nodes = Vec::with_capacity(TOTAL_NODE_COUNT);
     for i in 0..TOTAL_NODE_COUNT {
+        let keypair = Keypair::generate();
         let config = Config {
             bootstrap_nodes: bootstrap_nodes.clone(),
             listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
             allow_non_globals_in_dht: true,
-            ..Config::with_generated_keypair()
+            ..Config::with_keypair(keypair.clone())
         };
+
         let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
 
         println!("Node {} ID is {}", i, node.id());
+
+        if i == EXPECTED_NODE_INDEX {
+            expected_node_id = node.id();
+            expected_kaypair = keypair;
+        }
 
         let (node_address_sender, node_address_receiver) = oneshot::channel();
         let _handler = node.on_new_listener(Arc::new({
@@ -55,9 +64,6 @@ async fn main() {
 
         bootstrap_nodes.push(address);
 
-        if i == EXPECTED_NODE_INDEX {
-            expected_node_id = node.id();
-        }
         nodes.push(node);
     }
 
@@ -92,16 +98,7 @@ async fn main() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Prepare multihash to look for in Kademlia
-    let encoding = expected_node_id.as_ref().digest();
-    let public_key = identity::PublicKey::from_protobuf_encoding(encoding)
-        .expect("Invalid public key from PeerId.");
-    let peer_id_public_key = if let identity::PublicKey::Sr25519(pk) = public_key {
-        pk.encode()
-    } else {
-        panic!("Expected PublicKey::Sr25519")
-    };
-
-    let key = Code::Identity.digest(&peer_id_public_key);
+    let key = Code::Identity.digest(&expected_kaypair.public().encode());
 
     let peers = node.get_closest_peers(key).await.unwrap();
 
@@ -110,6 +107,7 @@ async fn main() {
 
     let peer_id = peers.first().unwrap();
     assert_eq!(*peer_id, expected_node_id);
+    println!("Expected Peer ID received.");
 
     tokio::time::sleep(Duration::from_secs(12)).await;
 

--- a/crates/subspace-networking/examples/get-peers.rs
+++ b/crates/subspace-networking/examples/get-peers.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{crypto, PieceIndexHash, U256};
-use subspace_networking::Config;
+use subspace_networking::{BootstrappedNetworkingParameters, Config};
 
 #[tokio::main]
 async fn main() {
@@ -46,7 +46,10 @@ async fn main() {
     drop(on_new_listener_handler);
 
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(vec![
+            node_1_addr.with(Protocol::P2p(node_1.id().into()))
+        ])
+        .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::Sha256Hash;
-use subspace_networking::Config;
+use subspace_networking::{BootstrappedNetworkingParameters, Config};
 
 const TOPIC: &str = "Foo";
 
@@ -51,7 +51,10 @@ async fn main() {
     let mut subscription = node_1.subscribe(Sha256Topic::new(TOPIC)).await.unwrap();
 
     let config_2 = Config {
-        bootstrap_nodes: vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))],
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(vec![
+            node_1_addr.with(Protocol::P2p(node_1.id().into()))
+        ])
+        .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/examples/relayed-get-peers-complex.rs
+++ b/crates/subspace-networking/examples/relayed-get-peers-complex.rs
@@ -6,7 +6,7 @@ use libp2p::{identity, PeerId};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_networking::Config;
+use subspace_networking::{BootstrappedNetworkingParameters, Config};
 
 #[tokio::main]
 async fn main() {
@@ -55,7 +55,10 @@ async fn main() {
     for i in 0..TOTAL_NODE_COUNT {
         let keypair = Keypair::generate();
         let config = Config {
-            bootstrap_nodes: bootstrap_nodes.clone(),
+            networking_parameters_registry: BootstrappedNetworkingParameters::new(
+                bootstrap_nodes.clone(),
+            )
+            .boxed(),
             allow_non_globals_in_dht: true,
             ..Config::with_keypair(keypair.clone())
         };
@@ -94,7 +97,10 @@ async fn main() {
     // println!("Bootstrap NODES: {:?}", bootstrap_nodes);
 
     let config = Config {
-        bootstrap_nodes,
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(
+            bootstrap_nodes.clone(),
+        )
+        .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()

--- a/crates/subspace-networking/examples/relayed-get-peers-complex.rs
+++ b/crates/subspace-networking/examples/relayed-get-peers-complex.rs
@@ -1,3 +1,4 @@
+use crate::identity::sr25519::Keypair;
 use futures::channel::oneshot;
 use libp2p::multiaddr::Protocol;
 use libp2p::multihash::{Code, MultihashDigest};
@@ -45,20 +46,28 @@ async fn main() {
 
     let mut bootstrap_nodes = Vec::new();
     let mut expected_node_id = PeerId::random();
+    let mut expected_kaypair = Keypair::generate();
 
     const TOTAL_NODE_COUNT: usize = 100;
     const EXPECTED_NODE_INDEX: usize = 75;
 
     let mut nodes = Vec::with_capacity(TOTAL_NODE_COUNT);
     for i in 0..TOTAL_NODE_COUNT {
+        let keypair = Keypair::generate();
         let config = Config {
             bootstrap_nodes: bootstrap_nodes.clone(),
             allow_non_globals_in_dht: true,
-            ..Config::with_generated_keypair()
+            ..Config::with_keypair(keypair.clone())
         };
+
         let (node, mut node_runner) = relay_node.spawn(config).await.unwrap();
 
         println!("Node {} ID is {}", i, node.id());
+
+        if i == EXPECTED_NODE_INDEX {
+            expected_node_id = node.id();
+            expected_kaypair = keypair;
+        }
 
         tokio::spawn(async move {
             node_runner.run().await;
@@ -103,18 +112,11 @@ async fn main() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Prepare multihash to look for in Kademlia
-    let encoding = expected_node_id.as_ref().digest();
-    let public_key = identity::PublicKey::from_protobuf_encoding(encoding)
-        .expect("Invalid public key from PeerId.");
-    let peer_id_public_key = if let identity::PublicKey::Sr25519(pk) = public_key {
-        pk.encode()
-    } else {
-        panic!("Expected PublicKey::Sr25519")
-    };
-    let key = Code::Identity.digest(&peer_id_public_key);
+    let key = Code::Identity.digest(&expected_kaypair.public().encode());
 
     let peer_id = node.get_closest_peers(key).await.unwrap()[0];
     assert_eq!(peer_id, expected_node_id);
+    println!("Expected Peer ID received.");
 
     tokio::time::sleep(Duration::from_secs(1)).await;
 

--- a/crates/subspace-networking/examples/relayed-get-peers-complex.rs
+++ b/crates/subspace-networking/examples/relayed-get-peers-complex.rs
@@ -120,7 +120,13 @@ async fn main() {
     // Prepare multihash to look for in Kademlia
     let key = Code::Identity.digest(&expected_kaypair.public().encode());
 
-    let peer_id = node.get_closest_peers(key).await.unwrap()[0];
+    let peer_id = *node
+        .get_closest_peers(key)
+        .await
+        .expect("get_closest_peers must return peers")
+        .first()
+        .expect("get_closest_peers returned zero peers");
+
     assert_eq!(peer_id, expected_node_id);
     println!("Expected Peer ID received.");
 

--- a/crates/subspace-networking/examples/relayed-requests.rs
+++ b/crates/subspace-networking/examples/relayed-requests.rs
@@ -82,7 +82,7 @@ async fn main() {
             .with(Protocol::P2pCircuit)
             .with(Protocol::P2p(node_2.id().into()))])
         .boxed(),
-        request_response_protocols: vec![GenericRequestHandler::<ExampleRequest>::client_only()],
+        request_response_protocols: vec![GenericRequestHandler::<ExampleRequest>::create(|_| None)],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
     };

--- a/crates/subspace-networking/examples/relayed-requests.rs
+++ b/crates/subspace-networking/examples/relayed-requests.rs
@@ -4,13 +4,15 @@ use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_networking::{Config, GenericRequest, GenericRequestHandler};
+use subspace_networking::{
+    BootstrappedNetworkingParameters, Config, GenericRequest, GenericRequestHandler,
+};
 
 #[derive(Encode, Decode)]
 struct ExampleRequest;
 
 impl GenericRequest for ExampleRequest {
-    const PROTOCOL_NAME: &'static str = "example";
+    const PROTOCOL_NAME: &'static str = "/example";
     const LOG_TARGET: &'static str = "example_request";
     type Response = ExampleResponse;
 }
@@ -75,10 +77,12 @@ async fn main() {
     // NODE 3 - requester
 
     let config_3 = Config {
-        bootstrap_nodes: vec![node_1_addr
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(vec![node_1_addr
             .with(Protocol::P2p(node_1.id().into()))
             .with(Protocol::P2pCircuit)
-            .with(Protocol::P2p(node_2.id().into()))],
+            .with(Protocol::P2p(node_2.id().into()))])
+        .boxed(),
+        request_response_protocols: vec![GenericRequestHandler::<ExampleRequest>::client_only()],
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
     };
@@ -97,5 +101,8 @@ async fn main() {
         .send_generic_request(node_2.id(), ExampleRequest)
         .await
         .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     println!("Received {:?}", result)
 }

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -69,7 +69,7 @@ async fn main() {
         .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
-        request_response_protocols: vec![GenericRequestHandler::<ExampleRequest>::client_only()],
+        request_response_protocols: vec![GenericRequestHandler::<ExampleRequest>::create(|_| None)],
         ..Config::with_generated_keypair()
     };
 

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -31,8 +31,6 @@ impl RateLimiter for MemoryRateLimiter {
 pub(crate) struct BehaviorConfig {
     /// Identity keypair of a node used for authenticated connections.
     pub(crate) peer_id: PeerId,
-    /// Nodes to connect to on creation.
-    pub(crate) bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
     /// The configuration for the [`Identify`] behaviour.
     pub(crate) identify: IdentifyConfig,
     /// The configuration for the [`Kademlia`] behaviour.
@@ -64,17 +62,11 @@ pub(crate) struct Behavior {
 
 impl Behavior {
     pub(crate) fn new(config: BehaviorConfig) -> Self {
-        let kademlia = {
-            let store = CustomRecordStore::new(config.value_getter);
-            let mut kademlia =
-                Kademlia::<_, IdendityHash>::with_config(config.peer_id, store, config.kademlia);
-
-            for (peer_id, address) in config.bootstrap_nodes {
-                kademlia.add_address(&peer_id, address);
-            }
-
-            kademlia
-        };
+        let kademlia = Kademlia::<_, IdendityHash>::with_config(
+            config.peer_id,
+            CustomRecordStore::new(config.value_getter),
+            config.kademlia,
+        );
 
         let gossipsub = Gossipsub::new(
             // TODO: Do we want message signing?

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -1,5 +1,7 @@
 pub(crate) mod custom_record_store;
 pub(crate) mod persistent_parameters;
+#[cfg(test)]
+mod tests;
 
 use crate::create::ValueGetter;
 use crate::request_responses::{

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -30,8 +30,7 @@ pub trait NetworkingParametersRegistry: Send {
     async fn add_known_peer(&mut self, peer_id: PeerId, addresses: Vec<Multiaddr>);
 
     /// Returns known addresses from networking parameters DB. It removes p2p-protocol suffix.
-    /// Peer number parameter limits peers to retrieve.
-    async fn known_addresses(&self, peer_number: usize) -> Vec<(PeerId, Multiaddr)>;
+    async fn known_addresses(&self) -> Vec<(PeerId, Multiaddr)>;
 
     /// Returns boostrap addresses from networking parameters initialization.
     /// It removes p2p-protocol suffix.
@@ -58,7 +57,7 @@ pub struct NetworkingParametersRegistryStub;
 impl NetworkingParametersRegistry for NetworkingParametersRegistryStub {
     async fn add_known_peer(&mut self, _: PeerId, _: Vec<Multiaddr>) {}
 
-    async fn known_addresses(&self, _: usize) -> Vec<(PeerId, Multiaddr)> {
+    async fn known_addresses(&self) -> Vec<(PeerId, Multiaddr)> {
         Vec::new()
     }
 
@@ -96,7 +95,7 @@ impl BootstrappedNetworkingParameters {
 impl NetworkingParametersRegistry for BootstrappedNetworkingParameters {
     async fn add_known_peer(&mut self, _: PeerId, _: Vec<Multiaddr>) {}
 
-    async fn known_addresses(&self, _: usize) -> Vec<(PeerId, Multiaddr)> {
+    async fn known_addresses(&self) -> Vec<(PeerId, Multiaddr)> {
         Vec::new()
     }
 
@@ -252,10 +251,9 @@ impl NetworkingParametersRegistry for NetworkingParametersManager {
         self.cache_need_saving = true;
     }
 
-    async fn known_addresses(&self, peer_number: usize) -> Vec<(PeerId, Multiaddr)> {
+    async fn known_addresses(&self) -> Vec<(PeerId, Multiaddr)> {
         self.known_peers
             .iter()
-            .take(peer_number)
             .flat_map(|(peer_id, addresses)| {
                 addresses.iter().map(|addr| (*peer_id, addr.0.clone()))
             })

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -35,8 +35,7 @@ async fn test_address_timed_removal_from_known_peers_cache() {
         .expect("Address present")
         .is_none());
 
-    remove_known_peer_addresses_internal(&mut peers_cache, peer_id, addresses.clone(), expiration)
-        .await;
+    remove_known_peer_addresses_internal(&mut peers_cache, peer_id, addresses.clone(), expiration);
 
     // Check after the first run (set the first failure time)
     assert_eq!(peers_cache.len(), 1);
@@ -51,7 +50,7 @@ async fn test_address_timed_removal_from_known_peers_cache() {
         .expect("Address present")
         .is_some());
 
-    remove_known_peer_addresses_internal(&mut peers_cache, peer_id, addresses, expiration).await;
+    remove_known_peer_addresses_internal(&mut peers_cache, peer_id, addresses, expiration);
 
     // Check after the second run (clean cache)
     assert_eq!(peers_cache.len(), 0);

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -1,0 +1,58 @@
+use super::persistent_parameters::remove_known_peer_addresses_internal;
+use chrono::Duration;
+use libp2p::multiaddr::Protocol;
+use libp2p::{Multiaddr, PeerId};
+use lru::LruCache;
+
+#[tokio::test()]
+async fn test_address_timed_removal_from_known_peers_cache() {
+    // Cache initialization
+    let peer_id = PeerId::random();
+    let addr1 = Multiaddr::empty().with(Protocol::Memory(0));
+    let addr2 = Multiaddr::empty().with(Protocol::Memory(1));
+    let addresses = vec![addr1.clone(), addr2.clone()];
+    let expiration = Duration::nanoseconds(1);
+
+    let mut peers_cache = LruCache::new(100);
+    let mut addresses_cache = LruCache::new(100);
+
+    for addr in addresses.clone() {
+        addresses_cache.push(addr, None);
+    }
+
+    peers_cache.push(peer_id, addresses_cache);
+
+    //Precondition-check
+    assert_eq!(peers_cache.len(), 1);
+    let addresses_from_cache = peers_cache.get(&peer_id).expect("PeerId present");
+    assert_eq!(addresses_from_cache.len(), 2);
+    assert!(addresses_from_cache
+        .peek(&addr1)
+        .expect("Address present")
+        .is_none());
+    assert!(addresses_from_cache
+        .peek(&addr2)
+        .expect("Address present")
+        .is_none());
+
+    remove_known_peer_addresses_internal(&mut peers_cache, peer_id, addresses.clone(), expiration)
+        .await;
+
+    // Check after the first run (set the first failure time)
+    assert_eq!(peers_cache.len(), 1);
+    let addresses_from_cache = peers_cache.get(&peer_id).expect("PeerId present");
+    assert_eq!(addresses_from_cache.len(), 2);
+    assert!(addresses_from_cache
+        .peek(&addr1)
+        .expect("Address present")
+        .is_some());
+    assert!(addresses_from_cache
+        .peek(&addr2)
+        .expect("Address present")
+        .is_some());
+
+    remove_known_peer_addresses_internal(&mut peers_cache, peer_id, addresses, expiration).await;
+
+    // Check after the second run (clean cache)
+    assert_eq!(peers_cache.len(), 0);
+}

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -27,7 +27,9 @@ mod request_responses;
 mod shared;
 mod utils;
 
-pub use crate::behavior::persistent_parameters::NetworkingParametersManager;
+pub use crate::behavior::persistent_parameters::{
+    BootstrappedNetworkingParameters, NetworkingParametersManager,
+};
 pub use crate::node::{
     CircuitRelayClientError, GetClosestPeersError, Node, SendRequestError, SubscribeError,
     TopicSubscription,

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -14,7 +14,9 @@ use libp2p::{Multiaddr, PeerId};
 use parity_scale_codec::Decode;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
+use tokio::time::sleep;
 use tracing::{error, trace};
 
 /// Topic subscription, will unsubscribe when last instance is dropped for a particular topic.
@@ -77,6 +79,13 @@ pub enum GetValueError {
 pub enum GetClosestPeersError {
     /// Node runner was dropped, impossible to get closest peers.
     #[error("Node runner was dropped, impossible to get closest peers")]
+    NodeRunnerDropped,
+}
+
+#[derive(Debug, Error)]
+pub enum CheckConnectedPeersError {
+    /// Node runner was dropped, impossible to check connected peers.
+    #[error("Node runner was dropped, impossible to check connected peers")]
     NodeRunnerDropped,
 }
 
@@ -325,6 +334,35 @@ impl Node {
         trace!("Kademlia 'GetClosestPeers' returned {} peers", peers.len());
 
         Ok(peers)
+    }
+
+    // TODO: add timeout
+    /// Waits for peers connection to the swarm and for Kademlia address registration.
+    pub async fn wait_for_connected_peers(&self) -> Result<(), CheckConnectedPeersError> {
+        loop {
+            trace!("Starting 'CheckConnectedPeers' request.");
+
+            let (result_sender, result_receiver) = oneshot::channel();
+
+            self.shared
+                .command_sender
+                .clone()
+                .send(Command::CheckConnectedPeers { result_sender })
+                .await
+                .map_err(|_| CheckConnectedPeersError::NodeRunnerDropped)?;
+
+            let connected_peers_present = result_receiver
+                .await
+                .map_err(|_| CheckConnectedPeersError::NodeRunnerDropped)?;
+
+            trace!("'CheckConnectedPeers' request returned {connected_peers_present}");
+
+            if connected_peers_present {
+                return Ok(());
+            }
+
+            sleep(Duration::from_millis(50)).await;
+        }
     }
 
     /// Node's own addresses where it listens for incoming requests.

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -120,6 +120,8 @@ impl NodeRunner {
                 _ = self.networking_parameters_registry.run().fuse() => {
                     trace!("Network parameters registry runner exited.")
                 },
+                //TODO: consider changing this worker to the reactive approach (using the connection
+                // closing events to maintain established connections set).
                 _ = &mut self.peer_dialing_timeout => {
                     self.handle_peer_dialing().await;
 
@@ -137,7 +139,8 @@ impl NodeRunner {
         if connected_peers.len() < CONNECTED_PEERS_THRESHOLD {
             debug!(
                 %local_peer_id,
-                "Initiate connection to known peers [connected peers={}]", connected_peers.len()
+                connected_peers=connected_peers.len(),
+                "Initiate connection to known peers",
             );
 
             let addresses = self

--- a/crates/subspace-networking/src/request_handlers/generic_request_handler.rs
+++ b/crates/subspace-networking/src/request_handlers/generic_request_handler.rs
@@ -60,6 +60,12 @@ impl<Request: GenericRequest> GenericRequestHandler<Request> {
         })
     }
 
+    /// Creates a protocol handler with empty request handler. It could be used for protocol
+    /// registration in the libp2p stack in client-only usage scenarios.
+    pub fn client_only() -> Box<dyn RequestHandler> {
+        Self::create(|_| None)
+    }
+
     // Invokes external protocol handler.
     fn handle_request(
         &mut self,

--- a/crates/subspace-networking/src/request_handlers/generic_request_handler.rs
+++ b/crates/subspace-networking/src/request_handlers/generic_request_handler.rs
@@ -60,12 +60,6 @@ impl<Request: GenericRequest> GenericRequestHandler<Request> {
         })
     }
 
-    /// Creates a protocol handler with empty request handler. It could be used for protocol
-    /// registration in the libp2p stack in client-only usage scenarios.
-    pub fn client_only() -> Box<dyn RequestHandler> {
-        Self::create(|_| None)
-    }
-
     // Invokes external protocol handler.
     fn handle_request(
         &mut self,

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -15,7 +15,6 @@ use libp2p::kad::record;
 use libp2p::multihash::{Code, MultihashDigest};
 use libp2p::{identity, Multiaddr, PeerId};
 use parking_lot::Mutex;
-use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use subspace_core_primitives::crypto::sha256_hash;
 use subspace_core_primitives::PUBLIC_KEY_LENGTH;
@@ -58,6 +57,9 @@ pub(crate) enum Command {
         request: Vec<u8>,
         result_sender: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
     },
+    CheckConnectedPeers {
+        result_sender: oneshot::Sender<bool>,
+    },
 }
 
 #[derive(Default, Debug)]
@@ -72,7 +74,6 @@ pub(crate) struct Shared {
     pub(crate) id: PeerId,
     /// Addresses on which node is listening for incoming requests.
     pub(crate) listeners: Mutex<Vec<Multiaddr>>,
-    pub(crate) connected_peers_count: AtomicUsize,
     /// Sender end of the channel for sending commands to the swarm.
     pub(crate) command_sender: mpsc::Sender<Command>,
     /// Parent node instance (if any) to keep alive.
@@ -92,7 +93,6 @@ impl Shared {
             handlers: Handlers::default(),
             id,
             listeners: Mutex::default(),
-            connected_peers_count: AtomicUsize::new(0),
             command_sender,
             _parent_node: parent_node,
         }

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -4,7 +4,6 @@ mod tests;
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
 use std::marker::PhantomData;
-
 use std::num::NonZeroUsize;
 
 /// This test is successful only for global IP addresses and DNS names.

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -1,5 +1,11 @@
+#[cfg(test)]
+mod tests;
+
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
+use std::marker::PhantomData;
+
+use std::num::NonZeroUsize;
 
 /// This test is successful only for global IP addresses and DNS names.
 pub(crate) fn is_global_address_or_dns(addr: &Multiaddr) -> bool {
@@ -8,5 +14,52 @@ pub(crate) fn is_global_address_or_dns(addr: &Multiaddr) -> bool {
         Some(Protocol::Ip6(ip)) => ip.is_global(),
         Some(Protocol::Dns(_)) | Some(Protocol::Dns4(_)) | Some(Protocol::Dns6(_)) => true,
         _ => false,
+    }
+}
+
+// Generic collection batching helper.
+#[derive(Clone)]
+pub(crate) struct CollectionBatcher<T: Clone> {
+    last_batch_number: usize,
+    batch_size: NonZeroUsize,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Clone> CollectionBatcher<T> {
+    /// Constructor
+    pub fn new(batch_size: NonZeroUsize) -> Self {
+        Self {
+            batch_size,
+            last_batch_number: 0,
+            _marker: PhantomData,
+        }
+    }
+    /// Extract the next batch from the collection
+    pub fn next_batch(&mut self, collection: Vec<T>) -> Vec<T> {
+        // Collection is empty or less than batch size.
+        if collection.is_empty() || collection.len() < self.batch_size.get() {
+            return collection;
+        }
+
+        let skip_number = {
+            let skip_number = self.last_batch_number * self.batch_size.get();
+
+            // Correction when skip_number exceeds the collection length.
+            if skip_number >= collection.len() {
+                skip_number % collection.len()
+            } else {
+                skip_number
+            }
+        };
+
+        self.last_batch_number += 1;
+
+        collection
+            .iter()
+            .cloned()
+            .cycle()
+            .skip(skip_number)
+            .take(self.batch_size.get())
+            .collect::<Vec<_>>()
     }
 }

--- a/crates/subspace-networking/src/utils/tests.rs
+++ b/crates/subspace-networking/src/utils/tests.rs
@@ -1,0 +1,62 @@
+use super::CollectionBatcher;
+use std::num::NonZeroUsize;
+
+#[test]
+fn test_empty_collection() {
+    let collection = vec![];
+    let mut batcher = CollectionBatcher::<u64>::new(
+        NonZeroUsize::new(3).expect("Manual non-zero initialization failed."),
+    );
+
+    assert_eq!(batcher.next_batch(collection.clone()), Vec::<u64>::new());
+    assert_eq!(batcher.next_batch(collection), Vec::<u64>::new());
+}
+
+#[test]
+fn test_short_collection() {
+    let collection = vec![1, 2];
+    let mut batcher = CollectionBatcher::<u64>::new(
+        NonZeroUsize::new(3).expect("Manual non-zero initialization failed."),
+    );
+
+    assert_eq!(batcher.next_batch(collection.clone()), vec![1, 2]);
+    assert_eq!(batcher.next_batch(collection), vec![1, 2]);
+}
+
+#[test]
+fn test_exact_collection_size() {
+    let collection = vec![1, 2, 3];
+    let mut batcher = CollectionBatcher::<u64>::new(
+        NonZeroUsize::new(3).expect("Manual non-zero initialization failed."),
+    );
+
+    assert_eq!(batcher.next_batch(collection.clone()), vec![1, 2, 3]);
+    assert_eq!(batcher.next_batch(collection), vec![1, 2, 3]);
+}
+
+#[test]
+fn test_batching_with_round_batch_size() {
+    let collection = vec![1, 2, 3, 4, 5, 6];
+    let mut batcher = CollectionBatcher::<u64>::new(
+        NonZeroUsize::new(3).expect("Manual non-zero initialization failed."),
+    );
+
+    assert_eq!(batcher.next_batch(collection.clone()), vec![1, 2, 3]);
+    assert_eq!(batcher.next_batch(collection.clone()), vec![4, 5, 6]);
+    assert_eq!(batcher.next_batch(collection), vec![1, 2, 3]);
+}
+
+#[test]
+fn test_batching() {
+    let collection = vec![1, 2, 3, 4, 5, 6, 7];
+    let mut batcher = CollectionBatcher::<u64>::new(
+        NonZeroUsize::new(4).expect("Manual non-zero initialization failed."),
+    );
+
+    assert_eq!(batcher.next_batch(collection.clone()), vec![1, 2, 3, 4]);
+    assert_eq!(batcher.next_batch(collection.clone()), vec![5, 6, 7, 1]);
+    assert_eq!(batcher.next_batch(collection.clone()), vec![2, 3, 4, 5]);
+    assert_eq!(batcher.next_batch(collection.clone()), vec![6, 7, 1, 2]);
+    assert_eq!(batcher.next_batch(collection.clone()), vec![3, 4, 5, 6]);
+    assert_eq!(batcher.next_batch(collection), vec![7, 1, 2, 3]);
+}

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -31,7 +31,7 @@ use std::task::Poll;
 use subspace_archiving::reconstructor::Reconstructor;
 use subspace_core_primitives::{Piece, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE};
 use subspace_networking::libp2p::Multiaddr;
-use subspace_networking::{multimess, Config};
+use subspace_networking::{multimess, BootstrappedNetworkingParameters, Config};
 
 type PieceIndex = u64;
 
@@ -135,7 +135,8 @@ where
     IQ: ImportQueue<B> + 'static,
 {
     let (node, mut node_runner) = subspace_networking::create(Config {
-        bootstrap_nodes,
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
+            .boxed(),
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
     })


### PR DESCRIPTION
This PR improves networking parameters manager for the `subspace-networking` crate.
Original issue: https://github.com/subspace/subspace/issues/722

#### Changes
- simplified examples  (keypair pregeneration)
- add `BootstrappedNetworkingParameters` stub and removed NetworkingParametersRegistryStub`
- remove bootstrap addresses from Kademlia initialization
- add `remove_known_peer_addresses` method and use it on `OutgoingConnnectionError` swarm event
- add dialing to known peers
- add `established connections` swarm limit
- added time-based expiration for non-responding peers

#### Open questions
- `swarm.dial()` is asynchronous despite its API and doesn't return connection error immediately, I limit all established connections instead of trying addresses for connectivity batch after batch. However, I'm not sure it's a good idea and keep it for now as an example. We could limit initial connections by limiting initial cache size or introduce an additional async-worker to dial known addresses in batches. 

@nazar-pc  Please, comment here.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)