### PR TITLE
Fix span entering in async context

### DIFF
--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -816,13 +816,12 @@ impl<RC: RpcClient> VerifyingPlotter<RC> {
 
 #[async_trait]
 impl<RC: RpcClient> OnSync for VerifyingPlotter<RC> {
+    #[tracing::instrument(parent = &self.span, skip_all)]
     async fn on_pieces(
         &self,
         pieces: FlatPieces,
         piece_indexes: Vec<PieceIndex>,
     ) -> anyhow::Result<()> {
-        let _guard = self.span.enter();
-
         if self.pieces_verification_enabled {
             self.verify_pieces_at_blockchain(&piece_indexes, &pieces)
                 .await?;


### PR DESCRIPTION
There are some issues with manually entered spans in asynchronous code, due to their natures. More on this [here](https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code).

This results in improper spans displayed in logs. The solution is described [here](https://docs.rs/tracing/latest/tracing/attr.instrument.html#examples-2) in the section describing generated span's parent.

This though creates a new span which inherits fields from the parent span, which adds some noise to logs a bit.

Discovered this issue accidentally while adding logs to `on_pieces` function.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
