### PR TITLE
Fix block production by dropping block import acknowledgement sender

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -442,9 +442,10 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
                 while let Some(ImportedBlockNotification {
                     block_number,
                     mut root_block_sender,
-                    ..
+                    block_import_acknowledgement_sender,
                 }) = imported_block_notification_stream.next().await
                 {
+                    drop(block_import_acknowledgement_sender);
                     let block_number_to_archive =
                         match block_number.checked_sub(&confirmation_depth_k.into()) {
                             Some(block_number_to_archive) => block_number_to_archive,


### PR DESCRIPTION
#737 introduced a regression that prevented block production from happening.

Yes, this is one of those things that I hate about Rust. Both `..` and `block_import_acknowledgement_sender: _` don't drop values immediately, but rather at the end of the loop, but block import will not proceed to archiving until acknowledgement is received first, deadlocking in the end.

Super confusing, but explicit drop fixes it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
