### PR TITLE
Networking. Fix 'large plot issue` and change libp2p Multiplexer. 

### DIFF
--- a/crates/subspace-farmer/src/rpc_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client/node_rpc_client.rs
@@ -13,6 +13,10 @@ use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
+// Defines max_concurrent_requests constant in the node rpc client.
+// It must be set for large plots.
+const WS_PRC_MAX_CONCURRENT_REQUESTS: usize = 1_000_000;
+
 /// `WsClient` wrapper.
 #[derive(Clone, Debug)]
 pub struct NodeRpcClient {
@@ -22,7 +26,12 @@ pub struct NodeRpcClient {
 impl NodeRpcClient {
     /// Create a new instance of [`RpcClient`].
     pub async fn new(url: &str) -> Result<Self, JsonError> {
-        let client = Arc::new(WsClientBuilder::default().build(url).await?);
+        let client = Arc::new(
+            WsClientBuilder::default()
+                .max_concurrent_requests(WS_PRC_MAX_CONCURRENT_REQUESTS)
+                .build(url)
+                .await?,
+        );
         Ok(Self { client })
     }
 }

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -48,6 +48,7 @@ features = [
     "gossipsub",
     "identify",
     "kad",
+    "mplex",
     "noise",
     "ping",
     "relay",

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -15,6 +15,7 @@ use libp2p::gossipsub::{
 };
 use libp2p::identify::IdentifyConfig;
 use libp2p::kad::{KademliaBucketInserts, KademliaConfig, KademliaStoreInserts};
+use libp2p::mplex::MplexConfig;
 use libp2p::multiaddr::Protocol;
 use libp2p::noise::NoiseConfig;
 use libp2p::relay::v2::client::transport::ClientTransport;
@@ -33,6 +34,9 @@ use tracing::info;
 
 const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
+// Defines max_negotiating_inbound_streams constant for the swarm.
+// It must be set for large plots.
+const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 
 /// [`Node`] configuration.
 #[derive(Clone)]
@@ -56,6 +60,8 @@ pub struct Config {
     pub value_getter: ValueGetter,
     /// Yamux multiplexing configuration.
     pub yamux_config: YamuxConfig,
+    /// Mplex multiplexing configuration.
+    pub mplex_config: MplexConfig,
     /// Should non-global addresses be added to the DHT?
     pub allow_non_globals_in_dht: bool,
     /// How frequently should random queries be done using Kademlia DHT to populate routing table.
@@ -99,6 +105,8 @@ impl Config {
         // consumed.
         yamux_config.set_window_update_mode(WindowUpdateMode::on_read());
 
+        let mplex_config = MplexConfig::default();
+
         let gossipsub = GossipsubConfigBuilder::default()
             .protocol_id_prefix(GOSSIPSUB_PROTOCOL_PREFIX)
             // TODO: Do we want message signing?
@@ -124,13 +132,14 @@ impl Config {
             kademlia,
             gossipsub,
             value_getter: Arc::new(|_key| None),
-            yamux_config,
             allow_non_globals_in_dht: false,
             initial_random_query_interval: Duration::from_secs(1),
             relay_server_address: None,
             parent_node: None,
             networking_parameters_registry: BootstrappedNetworkingParameters::default().boxed(),
             request_response_protocols: Vec::new(),
+            yamux_config,
+            mplex_config,
         }
     }
 }
@@ -161,6 +170,7 @@ pub async fn create(config: Config) -> Result<(Node, NodeRunner), CreationError>
         gossipsub,
         value_getter,
         yamux_config,
+        mplex_config,
         allow_non_globals_in_dht,
         initial_random_query_interval,
         relay_server_address,
@@ -172,7 +182,13 @@ pub async fn create(config: Config) -> Result<(Node, NodeRunner), CreationError>
     // Create relay client transport and client.
     let (relay_transport, relay_client) = RelayClient::new_transport_and_behaviour(local_peer_id);
 
-    let transport = build_transport(&keypair, timeout, yamux_config, relay_transport)?;
+    let transport = build_transport(
+        &keypair,
+        timeout,
+        yamux_config,
+        mplex_config,
+        relay_transport,
+    )?;
 
     // libp2p uses blocking API, hence we need to create a blocking task.
     let create_swarm_fut = tokio::task::spawn_blocking(move || {
@@ -193,6 +209,7 @@ pub async fn create(config: Config) -> Result<(Node, NodeRunner), CreationError>
             .executor(Box::new(|fut| {
                 tokio::spawn(fut);
             }))
+            .max_negotiating_inbound_streams(SWARM_MAX_NEGOTIATING_INBOUND_STREAMS)
             .build();
 
         // Setup listen_on addresses
@@ -254,7 +271,8 @@ pub async fn create(config: Config) -> Result<(Node, NodeRunner), CreationError>
 fn build_transport(
     keypair: &identity::Keypair,
     timeout: Duration,
-    yamux_config: YamuxConfig,
+    _yamux_config: YamuxConfig, // TODO: choose yamux or mplex
+    mplex_config: MplexConfig,
     relay_transport: ClientTransport,
 ) -> Result<Boxed<(PeerId, StreamMuxerBox)>, CreationError> {
     let transport = {
@@ -278,7 +296,7 @@ fn build_transport(
     Ok(transport
         .upgrade(core::upgrade::Version::V1Lazy)
         .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(yamux_config)
+        .multiplex(mplex_config)
         .timeout(timeout)
         .boxed())
 }


### PR DESCRIPTION
Libp2p transport layer has a multiplexing feature called `yamux` that caused issues in our system:
- https://github.com/subspace/subspace/issues/746
- https://github.com/subspace/subspace/issues/729

This PR fixes issues for the [large plot](https://github.com/subspace/subspace/issues/729) introducing constants altering networking limits and changes the multiplexer implementation for the system.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
