### PR TITLE
Optimize pieces by range handle

### DIFF
--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -344,18 +344,19 @@ impl Plot {
         })?
     }
 
-    /// Returns sequential piece indexes for piece retrieval
-    pub(crate) fn read_sequential_piece_indexes(
+    // TODO: Return (Vec<PieceIndex>, FlatPieces) instead
+    /// Returns pieces and their indexes starting from supplied piece index hash (`from`)
+    pub(crate) fn get_sequential_pieces(
         &self,
         from_index_hash: PieceIndexHash,
         count: u64,
-    ) -> io::Result<Vec<PieceIndex>> {
+    ) -> io::Result<Vec<(PieceIndex, Piece)>> {
         let (result_sender, result_receiver) = mpsc::channel();
 
         self.inner
             .requests_sender
             .send(RequestWithPriority {
-                request: Request::ReadPieceIndexes {
+                request: Request::ReadSequentialPieces {
                     from_index_hash,
                     count,
                     result_sender,
@@ -373,22 +374,6 @@ impl Plot {
                 "Read piece indexes result sender was dropped: {error}",
             ))
         })?
-    }
-
-    // TODO: Return (Vec<PieceIndex>, FlatPieces) instead
-    /// Returns pieces and their indexes starting from supplied piece index hash (`from`)
-    pub(crate) fn get_sequential_pieces(
-        &self,
-        from: PieceIndexHash,
-        count: u64,
-    ) -> io::Result<Vec<(PieceIndex, Piece)>> {
-        self.read_sequential_piece_indexes(from, count)?
-            .into_iter()
-            .map(|index| {
-                self.read_piece(PieceIndexHash::from_index(index))
-                    .map(|piece| (index, piece))
-            })
-            .collect()
     }
 
     pub fn on_progress_change(

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -382,16 +382,19 @@ impl Plot {
         for count in std::iter::repeat(Self::PIECES_PER_REQUEST)
             .take((count / Self::PIECES_PER_REQUEST) as usize)
         {
-            let mut new_pieces = receive_pieces(from_index_hash, count)?;
+            let new_pieces = receive_pieces(from_index_hash, count)?;
             if count > new_pieces.len() as u64 {
                 pieces.extend(new_pieces);
                 return Ok(pieces);
             }
 
             from_index_hash = new_pieces
-                .pop()
-                .map(|(idx, _)| PieceIndexHash::from_index(idx))
+                .last()
+                .map(|(idx, _)| PieceIndexHash::from_index(*idx))
                 .expect("Vector is not empty");
+            from_index_hash = U256::from(from_index_hash)
+                .saturating_add(&U256::one())
+                .into();
             pieces.extend(new_pieces)
         }
 

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -113,6 +113,8 @@ impl fmt::Debug for Plot {
 }
 
 impl Plot {
+    const PIECES_PER_REQUEST: u64 = 1000;
+
     /// Creates a new plot for persisting encoded pieces to disk
     pub fn open_or_create(
         single_plot_farm_id: &SinglePlotFarmId,
@@ -343,8 +345,6 @@ impl Plot {
             ))
         })?
     }
-
-    const PIECES_PER_REQUEST: u64 = 1000;
 
     // TODO: Return (Vec<PieceIndex>, FlatPieces) instead
     /// Returns pieces and their indexes starting from supplied piece index hash (`from`)

--- a/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
+++ b/crates/subspace-farmer/src/plot/piece_index_hash_to_offset_db.rs
@@ -301,6 +301,11 @@ impl IndexHashToOffsetDB {
                             .expect("Key read from database must always have correct length; qed"),
                     ));
 
+                    if matches!(piece_index_hashes_and_offsets.last(), Some((last_index_hash, _)) if *last_index_hash > index_hash)
+                    {
+                        break;
+                    }
+
                     piece_index_hashes_and_offsets.push((index_hash, offset));
 
                     iter.next();

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -1,6 +1,5 @@
 use crate::plot::{PieceDistance, Plot};
 use rand::prelude::*;
-use std::collections::BTreeSet;
 use std::sync::Arc;
 use subspace_core_primitives::{FlatPieces, Piece, PieceIndexHash, PIECE_SIZE, U256};
 use tempfile::TempDir;
@@ -184,12 +183,8 @@ fn sequential_pieces_iterator() {
         .into_iter()
         .map(|(index, _)| index)
         .take(100)
-        .collect::<BTreeSet<_>>();
-    let expected_piece_indexes = piece_indexes[..got_indexes.len()]
-        .iter()
-        .copied()
-        .collect::<BTreeSet<_>>();
-    assert_eq!(got_indexes, expected_piece_indexes);
+        .collect::<Vec<_>>();
+    assert_eq!(got_indexes, piece_indexes[..got_indexes.len()]);
 }
 
 #[test]
@@ -284,13 +279,13 @@ fn test_read_sequential_pieces() {
             .unwrap()
             .into_iter()
             .map(|(idx, _)| idx)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(1)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
@@ -301,13 +296,13 @@ fn test_read_sequential_pieces() {
             .unwrap()
             .into_iter()
             .map(|(idx, _)| idx)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(3)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
@@ -318,14 +313,14 @@ fn test_read_sequential_pieces() {
             .unwrap()
             .into_iter()
             .map(|(idx, _)| idx)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         // This will wrap around number line, but will not reach the last pieces index hash
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(3)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
@@ -336,14 +331,14 @@ fn test_read_sequential_pieces() {
             .unwrap()
             .into_iter()
             .map(|(idx, _)| idx)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         // This will wrap around number line and capture `max`, but will not go any further
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(4)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
@@ -354,7 +349,7 @@ fn test_read_sequential_pieces() {
             .unwrap()
             .into_iter()
             .map(|(idx, _)| idx)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         // This will wrap around number line, capture `max` and crosses `min`, but will not
         // capture it because it crosses public key itself
         let expected_indexes = piece_index_hashes
@@ -362,7 +357,7 @@ fn test_read_sequential_pieces() {
             .skip(4)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
@@ -373,12 +368,12 @@ fn test_read_sequential_pieces() {
             .unwrap()
             .into_iter()
             .map(|(idx, _)| idx)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         // This should read all piece indexes and nothing else
         let expected_indexes = piece_index_hashes
             .iter()
             .map(|(_, index)| *index)
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 }

--- a/crates/subspace-farmer/src/plot/tests.rs
+++ b/crates/subspace-farmer/src/plot/tests.rs
@@ -1,7 +1,8 @@
 use crate::plot::{PieceDistance, Plot};
 use rand::prelude::*;
+use std::collections::BTreeSet;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Piece, PieceIndex, PieceIndexHash, PIECE_SIZE, U256};
+use subspace_core_primitives::{FlatPieces, Piece, PieceIndexHash, PIECE_SIZE, U256};
 use tempfile::TempDir;
 
 fn init() {
@@ -183,8 +184,12 @@ fn sequential_pieces_iterator() {
         .into_iter()
         .map(|(index, _)| index)
         .take(100)
-        .collect::<Vec<_>>();
-    assert_eq!(got_indexes, piece_indexes[..got_indexes.len()]);
+        .collect::<BTreeSet<_>>();
+    let expected_piece_indexes = piece_indexes[..got_indexes.len()]
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    assert_eq!(got_indexes, expected_piece_indexes);
 }
 
 #[test]
@@ -267,75 +272,89 @@ fn test_read_sequential_pieces() {
     // Zero count should return no indexes
     {
         let indexes = plot
-            .read_sequential_piece_indexes(PieceIndexHash::from([0; 32]), 0)
+            .get_sequential_pieces(PieceIndexHash::from([0; 32]), 0)
             .unwrap();
-        let expected_indexes: Vec<PieceIndex> = vec![];
-        assert_eq!(indexes, expected_indexes);
+        assert_eq!(indexes, vec![]);
     }
 
     // Non-wrapping simple case start at the left side of number line
     {
         let indexes = plot
-            .read_sequential_piece_indexes(piece_index_hashes[1].0, 2)
-            .unwrap();
+            .get_sequential_pieces(piece_index_hashes[1].0, 2)
+            .unwrap()
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect::<BTreeSet<_>>();
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(1)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
     // Non-wrapping simple case start at the right side of number line
     {
         let indexes = plot
-            .read_sequential_piece_indexes(piece_index_hashes[3].0, 2)
-            .unwrap();
+            .get_sequential_pieces(piece_index_hashes[3].0, 2)
+            .unwrap()
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect::<BTreeSet<_>>();
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(3)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
     // Wrapping before reaching `max`
     {
         let indexes = plot
-            .read_sequential_piece_indexes(piece_index_hashes[3].0, 2)
-            .unwrap();
+            .get_sequential_pieces(piece_index_hashes[3].0, 2)
+            .unwrap()
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect::<BTreeSet<_>>();
         // This will wrap around number line, but will not reach the last pieces index hash
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(3)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
     // Wrapping that crosses `max`, but doesn't reach `min`
     {
         let indexes = plot
-            .read_sequential_piece_indexes(piece_index_hashes[4].0, 2)
-            .unwrap();
+            .get_sequential_pieces(piece_index_hashes[4].0, 2)
+            .unwrap()
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect::<BTreeSet<_>>();
         // This will wrap around number line and capture `max`, but will not go any further
         let expected_indexes = piece_index_hashes
             .iter()
             .skip(4)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
     // Wrapping that crosses `max`, and crosses `min`
     {
         let indexes = plot
-            .read_sequential_piece_indexes(piece_index_hashes[4].0, 3)
-            .unwrap();
+            .get_sequential_pieces(piece_index_hashes[4].0, 2)
+            .unwrap()
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect::<BTreeSet<_>>();
         // This will wrap around number line, capture `max` and crosses `min`, but will not
         // capture it because it crosses public key itself
         let expected_indexes = piece_index_hashes
@@ -343,20 +362,23 @@ fn test_read_sequential_pieces() {
             .skip(4)
             .take(2)
             .map(|(_, index)| *index)
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 
     // Wrapping case, read more than there is pieces from zero
     {
         let indexes = plot
-            .read_sequential_piece_indexes(PieceIndexHash::from([0; 32]), 10)
-            .unwrap();
+            .get_sequential_pieces(PieceIndexHash::from([0; 32]), 10)
+            .unwrap()
+            .into_iter()
+            .map(|(idx, _)| idx)
+            .collect::<BTreeSet<_>>();
         // This should read all piece indexes and nothing else
         let expected_indexes = piece_index_hashes
             .iter()
             .map(|(_, index)| *index)
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
         assert_eq!(indexes, expected_indexes);
     }
 }

--- a/crates/subspace-farmer/src/plot/worker.rs
+++ b/crates/subspace-farmer/src/plot/worker.rs
@@ -174,9 +174,8 @@ impl<T: PlotFile> PlotWorker<T> {
                         } => {
                             let result = self
                                 .read_piece_offsets_and_indexes(from_index_hash, count)
-                                .and_then(|mut indexes_and_offsets| {
-                                    indexes_and_offsets.sort_by_key(|(off, _)| *off);
-                                    indexes_and_offsets
+                                .and_then(|offsets_and_indexes| {
+                                    offsets_and_indexes
                                         .into_iter()
                                         .map(|(off, idx)| {
                                             let mut buf = Piece::default();
@@ -340,8 +339,11 @@ impl<T: PlotFile> PlotWorker<T> {
         from: PieceIndexHash,
         count: u64,
     ) -> io::Result<Vec<(PieceOffset, PieceIndex)>> {
-        self.piece_index_hash_to_offset_db
-            .get_sequential(from, count as usize)
+        let mut piece_index_hashes_and_offsets = self
+            .piece_index_hash_to_offset_db
+            .get_sequential(from, count as usize);
+        piece_index_hashes_and_offsets.sort_by_key(|(_, off)| *off);
+        piece_index_hashes_and_offsets
             .into_iter()
             .map(|(_, offset)| {
                 self.piece_offset_to_index

--- a/crates/subspace-farmer/src/plot/worker.rs
+++ b/crates/subspace-farmer/src/plot/worker.rs
@@ -342,7 +342,7 @@ impl<T: PlotFile> PlotWorker<T> {
         let mut piece_index_hashes_and_offsets = self
             .piece_index_hash_to_offset_db
             .get_sequential(from, count as usize);
-        piece_index_hashes_and_offsets.sort_by_key(|(_, off)| *off);
+        piece_index_hashes_and_offsets.sort_unstable_by_key(|(_, off)| *off);
         piece_index_hashes_and_offsets
             .into_iter()
             .map(|(_, offset)| {


### PR DESCRIPTION
This pr optimizes getting pieces from peer by using only one request to plot worker (per request from other peer) for getting ascending pieces.

One contract was broken though - now returned pieces are not sorted by piece index hash.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
