### PR TITLE
Farmer. Add ‘signal’ feature to tokio crate in the Cargo.toml.

### DIFF
--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -50,7 +50,7 @@ subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 substrate-bip39 = "0.4.4"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
-tokio = { version = "1.20.0", features = ["macros", "parking_lot", "rt-multi-thread"] }
+tokio = { version = "1.20.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 ulid = { version = "0.6.0", features = ["serde"] }


### PR DESCRIPTION
Adding the `signal` feature to the `tokio` crate in the subspace-farmer's Cargo.toml fixes the error on the separate package compilation.

```
error[E0432]: unresolved import `tokio::signal`
  --> crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs:20:5
   |
20 | use tokio::signal;
   |     ^^^^^^^^^^^^^ no `signal` in the root

```


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
