### PR TITLE
Update Gemini 1b boot node identity

### DIFF
--- a/crates/subspace-node/res/chain-spec-raw-gemini-1.json
+++ b/crates/subspace-node/res/chain-spec-raw-gemini-1.json
@@ -7,7 +7,7 @@
   "bootNodes": [
     "/dns/bootstrap-0.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWF9CgB8bDvWCvzPPZrWG3awjhS7gPFu7MzNPkF9F9xWwc",
     "/dns/bootstrap-1.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWLrpSArNaZ3Hvs4mABwYGDY1Rf2bqiNTqUzLm7koxedQQ",
-    "/dns/bootstrap-2.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWNN5uuzPtDNtWoLU28ZDCQP7HTdRjyWbNYo5EA6fZDAMD",
+    "/dns/bootstrap-2.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWH5xhFURgkEoL4dsijUDM7oDHG3wQ5YeXNBWphDHFB7z1",
     "/dns/bootstrap-3.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWM47uyGtvbUFt5tmWdFezNQjwbYZmWE19RpWhXgRzuEqh",
     "/dns/bootstrap-4.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWNMEKxFZm9mbwPXfQ3LQaUgin9JckCq7TJdLS2UnH6E7z",
     "/dns/bootstrap-5.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWFfEtDmpb8BWKXoEAgxkKAMfxU2yGDq8nK87MqnHvXsok",


### PR DESCRIPTION
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)

Spinning up the latest pre-release Docker images `gemini-1b-2022-jul-27` throws the error below.
```
subspace-node    | 2022-08-10 20:12:51 [PrimaryChain] 💔 The bootnode you want to connect provided a different peer ID than the one you expect: `12D3KooWNN5uuzPtDNtWoLU28ZDCQP7HTdRjyWbNYo5EA6fZDAMD` with `12D3KooWH5xhFURgkEoL4dsijUDM7oDHG3wQ5YeXNBWphDHFB7z1`:`Dialer { address: "/dns/bootstrap-2.gemini-1b.subspace.network/tcp/30333/p2p/12D3KooWNN5uuzPtDNtWoLU28ZDCQP7HTdRjyWbNYo5EA6fZDAMD", role_override: Dialer }`.
```
Apologies if the plan is to revert the identity of the node instead.