### PR TITLE
Remove relay nodes from kademlia

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -20,7 +20,7 @@ use subspace_farmer::legacy_multi_plots_farm::{
 use subspace_farmer::rpc_client::bench_rpc_client::{BenchRpcClient, BENCH_FARMER_PROTOCOL_INFO};
 use subspace_farmer::single_plot_farm::PlotFactoryOptions;
 use subspace_farmer::{LegacyObjectMappings, PieceOffset, Plot, PlotFile, RpcClient};
-use subspace_networking::Config;
+use subspace_networking::{Config, RelayMode};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
 use tokio::time::Instant;
@@ -151,7 +151,10 @@ pub(crate) async fn bench(
 
     // Starting the relay server node.
     let (relay_server_node, mut relay_node_runner) =
-        subspace_networking::create(Config::with_generated_keypair()).await?;
+        subspace_networking::create(Config {
+            relay_mode: RelayMode::Server,
+            ..Config::with_generated_keypair()
+        }).await?;
 
     tokio::spawn(async move {
         relay_node_runner.run().await;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/bench.rs
@@ -150,11 +150,11 @@ pub(crate) async fn bench(
     };
 
     // Starting the relay server node.
-    let (relay_server_node, mut relay_node_runner) =
-        subspace_networking::create(Config {
-            relay_mode: RelayMode::Server,
-            ..Config::with_generated_keypair()
-        }).await?;
+    let (relay_server_node, mut relay_node_runner) = subspace_networking::create(Config {
+        relay_mode: RelayMode::Server,
+        ..Config::with_generated_keypair()
+    })
+    .await?;
 
     tokio::spawn(async move {
         relay_node_runner.run().await;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -15,7 +15,7 @@ use subspace_farmer::single_plot_farm::PlotFactoryOptions;
 use subspace_farmer::ws_rpc_server::{RpcServer, RpcServerImpl};
 use subspace_farmer::{LegacyObjectMappings, NodeRpcClient, Plot, RpcClient};
 use subspace_networking::libp2p::multiaddr::Protocol;
-use subspace_networking::Config;
+use subspace_networking::{Config, RelayMode};
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use tokio::signal;
 use tracing::{info, trace, warn};
@@ -111,6 +111,7 @@ pub(crate) async fn farm_multi_disk(
     let (relay_server_node, mut relay_node_runner) = subspace_networking::create(Config {
         listen_on,
         allow_non_globals_in_dht: true,
+        relay_mode: RelayMode::Server,
         ..Config::with_generated_keypair()
     })
     .await?;
@@ -347,6 +348,7 @@ pub(crate) async fn farm_legacy(
     let (relay_server_node, mut relay_node_runner) = subspace_networking::create(Config {
         listen_on,
         allow_non_globals_in_dht: true,
+        relay_mode: RelayMode::Server,
         ..Config::with_generated_keypair()
     })
     .await?;

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -596,7 +596,7 @@ impl SinglePlotFarm {
             farm.tasks.push(Box::pin(async move {
                 trace!("Started waiting for connected peers.");
                 let wait_result = dsn_sync_node.wait_for_connected_peers().await;
-                
+
                 match wait_result{
                     Ok(_) => {
                         trace!("Waiting for connected peers succeeded.");

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -597,7 +597,7 @@ impl SinglePlotFarm {
                 trace!("Started waiting for connected peers.");
                 let wait_result = dsn_sync_node.wait_for_connected_peers().await;
 
-                match wait_result{
+                match wait_result {
                     Ok(_) => {
                         trace!("Waiting for connected peers succeeded.");
                     }

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -591,8 +591,21 @@ impl SinglePlotFarm {
                 sync_range_size,
                 true,
             );
+            let dsn_sync_node = farm.node.clone();
 
             farm.tasks.push(Box::pin(async move {
+                trace!("Started waiting for connected peers.");
+                let wait_result = dsn_sync_node.wait_for_connected_peers().await;
+                
+                match wait_result{
+                    Ok(_) => {
+                        trace!("Waiting for connected peers succeeded.");
+                    }
+                    Err(error) => {
+                        error!(?error, "Waiting for connected peers failed.");
+                    }
+                };
+
                 match dsn_sync_fut.await {
                     Ok(()) => {
                         info!("DSN sync done successfully");

--- a/crates/subspace-networking/examples/relayed-get-peers-complex.rs
+++ b/crates/subspace-networking/examples/relayed-get-peers-complex.rs
@@ -6,7 +6,7 @@ use libp2p::{identity, PeerId};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_networking::{BootstrappedNetworkingParameters, Config};
+use subspace_networking::{BootstrappedNetworkingParameters, Config, RelayMode};
 
 #[tokio::main]
 async fn main() {
@@ -16,6 +16,7 @@ async fn main() {
     let config_1 = Config {
         listen_on: vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
+        relay_mode: RelayMode::Server,
         ..Config::with_generated_keypair()
     };
 
@@ -115,7 +116,7 @@ async fn main() {
         node_runner.run().await;
     });
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    node.wait_for_connected_peers().await.unwrap();
 
     // Prepare multihash to look for in Kademlia
     let key = Code::Identity.digest(&expected_kaypair.public().encode());

--- a/crates/subspace-networking/examples/relayed-requests.rs
+++ b/crates/subspace-networking/examples/relayed-requests.rs
@@ -4,7 +4,9 @@ use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_networking::{BootstrappedNetworkingParameters, Config, GenericRequest, GenericRequestHandler, RelayMode};
+use subspace_networking::{
+    BootstrappedNetworkingParameters, Config, GenericRequest, GenericRequestHandler, RelayMode,
+};
 
 #[derive(Encode, Decode)]
 struct ExampleRequest;

--- a/crates/subspace-networking/examples/relayed-requests.rs
+++ b/crates/subspace-networking/examples/relayed-requests.rs
@@ -4,9 +4,7 @@ use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_networking::{
-    BootstrappedNetworkingParameters, Config, GenericRequest, GenericRequestHandler,
-};
+use subspace_networking::{BootstrappedNetworkingParameters, Config, GenericRequest, GenericRequestHandler, RelayMode};
 
 #[derive(Encode, Decode)]
 struct ExampleRequest;
@@ -28,6 +26,7 @@ async fn main() {
     let config_1 = Config {
         listen_on: vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
         allow_non_globals_in_dht: true,
+        relay_mode: RelayMode::Server,
         ..Config::with_generated_keypair()
     };
 

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::node::{
     TopicSubscription,
 };
 pub use crate::node_runner::NodeRunner;
-pub use create::{create, Config, CreationError};
+pub use create::{create, Config, CreationError, RelayMode};
 pub use libp2p;
 use libp2p::gossipsub::Sha256Topic;
 use once_cell::sync::Lazy;

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -209,8 +209,7 @@ impl Node {
     }
 
     /// Configures circuit relay client using this node as circuit relay server. It expects Node
-    /// running in the relay server mode (which happens automatically when addresses to listen on
-    /// are provided).
+    /// running in the relay server mode.
     pub async fn spawn(&self, mut config: Config) -> Result<(Node, NodeRunner), CreationError> {
         if self.is_relay_server {
             let relay_server_memory_port = self.get_relay_server_memory_port().await?;
@@ -221,6 +220,8 @@ impl Node {
 
             config.relay_mode = RelayMode::Client(relay_server_address);
             config.parent_node.replace(self.clone());
+        } else {
+            return Err(CreationError::RelayServerExpected);
         }
 
         create(config).await

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -29,6 +29,8 @@ use tracing::{debug, error, trace, warn};
 
 // Defines a threshold for starting new connection attempts to known peers.
 const CONNECTED_PEERS_THRESHOLD: usize = 10;
+// Defines a protocol name specific for the relay server
+const RELAY_HOP_PROTOCOL_NAME: &[u8; 31] = b"/libp2p/circuit/relay/0.2.0/hop";
 
 enum QueryResultSender {
     GetValue {
@@ -267,46 +269,68 @@ impl NodeRunner {
 
     async fn handle_identify_event(&mut self, event: IdentifyEvent) {
         if let IdentifyEvent::Received { peer_id, mut info } = event {
+            let local_peer_id = *self.swarm.local_peer_id();
+
             if info.listen_addrs.len() > 30 {
                 debug!(
-                    "Node {} has reported more than 30 addresses; it is identified by {} and {}",
-                    peer_id, info.protocol_version, info.agent_version
+                    %local_peer_id,
+                    %peer_id,
+                    "Node has reported more than 30 addresses; it is identified by {} and {}",
+                    info.protocol_version, info.agent_version
                 );
                 info.listen_addrs.truncate(30);
             }
 
             let kademlia = &mut self.swarm.behaviour_mut().kademlia;
-
-            if info
+            let kademlia_enabled = info
                 .protocols
                 .iter()
-                .any(|protocol| protocol.as_bytes() == kademlia.protocol_name())
-            {
+                .any(|protocol| protocol.as_bytes() == kademlia.protocol_name());
+            let relay_server_enabled = info
+                .protocols
+                .iter()
+                .any(|protocol| protocol.as_bytes() == RELAY_HOP_PROTOCOL_NAME);
+
+            let proper_protocols_supported = !relay_server_enabled && kademlia_enabled;
+            if proper_protocols_supported {
                 for address in info.listen_addrs {
                     if !self.allow_non_globals_in_dht && !utils::is_global_address_or_dns(&address)
                     {
                         trace!(
-                            "Ignoring self-reported non-global address {} from {}.",
-                            address,
-                            peer_id
+                            %local_peer_id,
+                            %peer_id,
+                            %address,
+                            "Ignoring self-reported non-global address.",
                         );
                         continue;
                     }
 
                     trace!(
-                        "Adding self-reported address {} from {} to Kademlia DHT {}.",
-                        address,
-                        peer_id,
+                        %local_peer_id,
+                        %peer_id,
+                        %address,
+                        "Adding self-reported address to Kademlia DHT ({}).",
                         String::from_utf8_lossy(kademlia.protocol_name()),
                     );
                     kademlia.add_address(&peer_id, address);
                 }
             } else {
-                trace!(
-                    "{} doesn't support our Kademlia DHT protocol {}",
-                    peer_id,
-                    String::from_utf8_lossy(kademlia.protocol_name())
-                );
+                if !kademlia_enabled {
+                    trace!(
+                        %local_peer_id,
+                        %peer_id,
+                        "Peer doesn't support our Kademlia DHT protocol ({}). Adding to the DTH skipped.",
+                        String::from_utf8_lossy(kademlia.protocol_name())
+                    )
+                }
+
+                if relay_server_enabled {
+                    trace!(
+                        %local_peer_id,
+                        %peer_id,
+                        "Peer identified as a relay server. Adding to the DHT skipped.",
+                    )
+                }
             }
         }
     }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -30,7 +30,7 @@ use tracing::{debug, error, trace, warn};
 // Defines a threshold for starting new connection attempts to known peers.
 const CONNECTED_PEERS_THRESHOLD: usize = 10;
 // Defines a protocol name specific for the relay server
-const RELAY_HOP_PROTOCOL_NAME: &[u8; 31] = b"/libp2p/circuit/relay/0.2.0/hop";
+const RELAY_HOP_PROTOCOL_NAME: &[u8] = b"/libp2p/circuit/relay/0.2.0/hop";
 
 enum QueryResultSender {
     GetValue {


### PR DESCRIPTION
This PR starts to fix a problem with peers in the DSN that don't support necessary protocols. One of the problems of such behaviour is [broken pieces synchronization](https://github.com/subspace/subspace/issues/745). The PR determines whether the connected peer supports the `hop` protocol (relay server protocol) and filters it from the DHT.

#### Changes
- introduced relay-server peers filtering
- introduced RelayMode to distinguish a configuration without relay server enabled
- added waiting for connected peers on dsn syncing in farmers

#### Comments
- one of the side-effect of this change is a bootstrap address for peers requires to be in the `circuit-aware` format now: 
`
--bootstrap-nodes=/ip4/127.0.0.1/tcp/40333/p2p/12D3L7AV8HYwqg9MuE4gNSnehZDQyu2zpZBJBHQY3uCnMQ6o6KzF/p2p-circuit/p2p/12D3L7AVC1tpAMwt4BgLjZ1HDLevpLAXG9nsk4ZU3BAL7r3qFiHG
`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
