### PR TITLE
networking: Reverse muxer back to yamux.

### DIFF
--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -320,8 +320,8 @@ fn build_transport(
         .upgrade(core::upgrade::Version::V1Lazy)
         .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(core::upgrade::SelectUpgrade::new(
-            mplex_config,
             yamux_config,
+            mplex_config,
         ))
         .timeout(timeout)
         .boxed())


### PR DESCRIPTION
Mplex muxer produces unstable results for relayed configurations. Changing its parameters improves the situation but not for all relayed examples. It was introduced as an attempt to fix [this issue](https://github.com/subspace/subspace/issues/729).

This PR contains a quick fix for the problem - it returns back yamux as preferred multiplexer until we figure out possible reasons for the behaviour or remove mplex altogether.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
