### PR TITLE
Add peer-info protocol for networking and farmers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8000,6 +8000,7 @@ dependencies = [
  "rayon",
  "rocksdb",
  "schnorrkel",
+ "scopeguard",
  "serde",
  "serde_json",
  "ss58-registry",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -37,6 +37,7 @@ parking_lot = "0.12.1"
 rand = "0.8.5"
 rayon = "1.5.3"
 schnorrkel = "0.9.1"
+scopeguard = "1.1.0"
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = "1.0.82"
 std-semaphore = "0.1.0"

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -20,6 +20,7 @@ use futures::future::try_join_all;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use num_traits::Zero;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -34,8 +35,9 @@ use subspace_networking::libp2p::identity::sr25519;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::multimess::MultihashCode;
 use subspace_networking::{
-    BootstrappedNetworkingParameters, Config, Node, PiecesByRangeRequest,
-    PiecesByRangeRequestHandler, PiecesByRangeResponse, PiecesToPlot,
+    BootstrappedNetworkingParameters, Config, Node, PeerInfo, PeerInfoRequestHandler,
+    PeerInfoResponse, PeerSyncStatus, PiecesByRangeRequest, PiecesByRangeRequestHandler,
+    PiecesByRangeResponse, PiecesToPlot,
 };
 use subspace_rpc_primitives::{FarmerProtocolInfo, MAX_SEGMENT_INDEXES_PER_REQUEST};
 use subspace_solving::{BatchEncodeError, SubspaceCodec};
@@ -68,6 +70,9 @@ impl SinglePlotFarmId {
         Self::Ulid(Ulid::new())
     }
 }
+
+/// An alias defining a peer status providing callback.
+pub type PeerSyncStatusProvider = Box<dyn Fn() -> PeerSyncStatus + Send>;
 
 /// Important information about the contents of the `SinglePlotFarm`
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -425,6 +430,8 @@ impl SinglePlotFarm {
         let commitments = Commitments::new(metadata_directory.join("commitments"))?;
 
         let codec = SubspaceCodec::new_with_gpu(public_key.as_ref());
+        let peer_sync_status_provider: Arc<Mutex<PeerSyncStatusProvider>> =
+            Arc::new(Mutex::new(Box::new(|| PeerSyncStatus::Ready)));
         let network_node_config = Config {
             networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
                 .boxed(),
@@ -455,47 +462,61 @@ impl SinglePlotFarm {
                         .map(|piece| piece.to_vec())
                 }
             }),
-            request_response_protocols: vec![PiecesByRangeRequestHandler::create({
-                let plot = plot.clone();
-                let codec = codec.clone();
+            request_response_protocols: vec![
+                PiecesByRangeRequestHandler::create({
+                    let plot = plot.clone();
+                    let codec = codec.clone();
 
-                // TODO: also ask for how many pieces to read
-                move |&PiecesByRangeRequest { start, end }| {
-                    let mut pieces_and_indexes = plot
-                        .get_sequential_pieces(start, SYNC_PIECES_AT_ONCE)
-                        .ok()?;
+                    // TODO: also ask for how many pieces to read
+                    move |&PiecesByRangeRequest { start, end }| {
+                        let mut pieces_and_indexes = plot
+                            .get_sequential_pieces(start, SYNC_PIECES_AT_ONCE)
+                            .ok()?;
 
-                    let next_piece_index_hash = if let Some(idx) = pieces_and_indexes
-                        .iter()
-                        .position(|(piece_index, _)| PieceIndexHash::from_index(*piece_index) > end)
-                    {
-                        pieces_and_indexes.truncate(idx);
-                        None
-                    } else if pieces_and_indexes.len() == 1 {
-                        None
-                    } else {
-                        pieces_and_indexes
-                            .pop()
-                            .map(|(index, _)| PieceIndexHash::from_index(index))
-                    };
+                        let next_piece_index_hash = if let Some(idx) =
+                            pieces_and_indexes.iter().position(|(piece_index, _)| {
+                                PieceIndexHash::from_index(*piece_index) > end
+                            }) {
+                            pieces_and_indexes.truncate(idx);
+                            None
+                        } else if pieces_and_indexes.len() == 1 {
+                            None
+                        } else {
+                            pieces_and_indexes
+                                .pop()
+                                .map(|(index, _)| PieceIndexHash::from_index(index))
+                        };
 
-                    let (piece_indexes, pieces) = pieces_and_indexes
-                        .into_iter()
-                        .flat_map(|(index, mut piece)| {
-                            codec.decode(&mut piece, index).ok()?;
-                            Some((index, piece))
+                        let (piece_indexes, pieces) = pieces_and_indexes
+                            .into_iter()
+                            .flat_map(|(index, mut piece)| {
+                                codec.decode(&mut piece, index).ok()?;
+                                Some((index, piece))
+                            })
+                            .unzip();
+
+                        Some(PiecesByRangeResponse {
+                            pieces: PiecesToPlot {
+                                piece_indexes,
+                                pieces,
+                            },
+                            next_piece_index_hash,
                         })
-                        .unzip();
+                    }
+                }),
+                PeerInfoRequestHandler::create({
+                    let peer_sync_status_provider = peer_sync_status_provider.clone();
+                    move |_req| {
+                        let peer_sync_status_provider = peer_sync_status_provider.lock();
 
-                    Some(PiecesByRangeResponse {
-                        pieces: PiecesToPlot {
-                            piece_indexes,
-                            pieces,
-                        },
-                        next_piece_index_hash,
-                    })
-                }
-            })],
+                        Some(PeerInfoResponse {
+                            peer_info: PeerInfo {
+                                status: peer_sync_status_provider(),
+                            },
+                        })
+                    }
+                }),
+            ],
             allow_non_globals_in_dht: true,
             ..Config::with_keypair(sr25519::Keypair::from(
                 sr25519::SecretKey::from_bytes(identity.secret_key().to_bytes())
@@ -510,6 +531,20 @@ impl SinglePlotFarm {
                 subspace_networking::create(network_node_config).await
             }
         })?;
+
+        // Replace the default peer sync status provider based on actual Node status.
+        {
+            let sync_status_node = node.clone();
+            let mut peer_sync_status_provider = peer_sync_status_provider.lock();
+
+            *peer_sync_status_provider = Box::new(move || {
+                sync_status_node
+                    .sync_status_handler()
+                    .status()
+                    .then_some(PeerSyncStatus::Syncing)
+                    .unwrap_or(PeerSyncStatus::Ready)
+            });
+        }
 
         info!("Network peer ID {}", node.id());
 
@@ -608,7 +643,7 @@ impl SinglePlotFarm {
 
                 match dsn_sync_fut.await {
                     Ok(()) => {
-                        info!("DSN sync done successfully");
+                        info!("DSN sync finished.");
                     }
                     Err(error) => {
                         error!(?error, "DSN sync failed");

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -431,7 +431,7 @@ impl SinglePlotFarm {
 
         let codec = SubspaceCodec::new_with_gpu(public_key.as_ref());
         let peer_sync_status_provider: Arc<Mutex<PeerSyncStatusProvider>> =
-            Arc::new(Mutex::new(Box::new(|| PeerSyncStatus::Ready)));
+            Arc::new(Mutex::new(Box::new(|| PeerSyncStatus::Unknown)));
         let network_node_config = Config {
             networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
                 .boxed(),

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -538,11 +538,11 @@ impl SinglePlotFarm {
             let mut peer_sync_status_provider = peer_sync_status_provider.lock();
 
             *peer_sync_status_provider = Box::new(move || {
-                sync_status_node
-                    .sync_status_handler()
-                    .status()
-                    .then_some(PeerSyncStatus::Syncing)
-                    .unwrap_or(PeerSyncStatus::Ready)
+                if sync_status_node.sync_status_handler().status() {
+                    PeerSyncStatus::Syncing
+                } else {
+                    PeerSyncStatus::Ready
+                }
             });
         }
 

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -320,8 +320,8 @@ fn build_transport(
         .upgrade(core::upgrade::Version::V1Lazy)
         .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(core::upgrade::SelectUpgrade::new(
-            mplex_config,
             yamux_config,
+            mplex_config,
         ))
         .timeout(timeout)
         .boxed())

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -43,6 +43,9 @@ pub use request_handlers::generic_request_handler::{GenericRequest, GenericReque
 pub use request_handlers::object_mappings::{
     ObjectMappingsRequest, ObjectMappingsRequestHandler, ObjectMappingsResponse,
 };
+pub use request_handlers::peer_info::{
+    PeerInfo, PeerInfoRequest, PeerInfoRequestHandler, PeerInfoResponse, PeerSyncStatus,
+};
 pub use request_handlers::pieces_by_range::{
     PiecesByRangeRequest, PiecesByRangeRequestHandler, PiecesByRangeResponse, PiecesToPlot,
 };

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -15,6 +15,7 @@ use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
 use parity_scale_codec::Decode;
 use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -192,6 +193,39 @@ pub struct Node {
     shared: Arc<Shared>,
     is_relay_server: bool,
     relay_server_memory_port: Arc<Mutex<Option<u64>>>,
+    /// Indicates whether the peer data synchronization is in progress
+    sync_status: Arc<NodeSynchronizationStatusHandler>,
+}
+
+/// Provides operations for managing thread-safe node synchronization status.
+#[derive(Debug, Clone)]
+pub struct NodeSynchronizationStatusHandler {
+    syncing: Arc<AtomicBool>,
+}
+
+impl NodeSynchronizationStatusHandler {
+    /// Constructor. Set initial sync status to false.
+    pub(crate) fn new() -> Self {
+        Self {
+            syncing: Arc::new(AtomicBool::new(false)),
+        }
+    }
+    /// Sets sync status.
+    pub fn toggle_on(&self) {
+        trace!("Toggle syncing on.");
+        self.syncing.store(true, Ordering::Relaxed);
+    }
+
+    /// Unsets sync status.
+    pub fn toggle_off(&self) {
+        trace!("Toggle syncing off.");
+        self.syncing.store(false, Ordering::Relaxed);
+    }
+
+    /// Returns the current node synchronization status.
+    pub fn status(&self) -> bool {
+        self.syncing.load(Ordering::Relaxed)
+    }
 }
 
 impl Node {
@@ -200,7 +234,13 @@ impl Node {
             shared,
             is_relay_server,
             relay_server_memory_port: Arc::new(Mutex::new(None)),
+            sync_status: Arc::new(NodeSynchronizationStatusHandler::new()),
         }
+    }
+
+    /// Node's synchronization status handler.
+    pub fn sync_status_handler(&self) -> NodeSynchronizationStatusHandler {
+        (*self.sync_status).clone()
     }
 
     /// Node's own local ID.

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -194,7 +194,7 @@ pub struct Node {
     is_relay_server: bool,
     relay_server_memory_port: Arc<Mutex<Option<u64>>>,
     /// Indicates whether the peer data synchronization is in progress
-    sync_status: Arc<NodeSynchronizationStatusHandler>,
+    sync_status: NodeSynchronizationStatusHandler,
 }
 
 /// Provides operations for managing thread-safe node synchronization status.
@@ -234,13 +234,13 @@ impl Node {
             shared,
             is_relay_server,
             relay_server_memory_port: Arc::new(Mutex::new(None)),
-            sync_status: Arc::new(NodeSynchronizationStatusHandler::new()),
+            sync_status: NodeSynchronizationStatusHandler::new(),
         }
     }
 
     /// Node's synchronization status handler.
     pub fn sync_status_handler(&self) -> NodeSynchronizationStatusHandler {
-        (*self.sync_status).clone()
+        self.sync_status.clone()
     }
 
     /// Node's own local ID.

--- a/crates/subspace-networking/src/request_handlers.rs
+++ b/crates/subspace-networking/src/request_handlers.rs
@@ -1,3 +1,4 @@
 pub mod generic_request_handler;
 pub mod object_mappings;
+pub mod peer_info;
 pub mod pieces_by_range;

--- a/crates/subspace-networking/src/request_handlers/peer_info.rs
+++ b/crates/subspace-networking/src/request_handlers/peer_info.rs
@@ -1,0 +1,40 @@
+use crate::{GenericRequest, GenericRequestHandler};
+use parity_scale_codec::{Decode, Encode};
+
+/// Peer-info protocol request.
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+pub struct PeerInfoRequest;
+
+/// Defines peer synchronization status.
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub enum PeerSyncStatus {
+    /// Synchronization is not supported for this peer.
+    NotSupported,
+    /// Peer is ready to provide data for the synchronization.
+    Ready,
+    /// Peer is synchronizing itself.
+    Syncing,
+}
+
+/// Defines peer current state.
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct PeerInfo {
+    /// Synchronization status.
+    pub status: PeerSyncStatus,
+}
+
+impl GenericRequest for PeerInfoRequest {
+    const PROTOCOL_NAME: &'static str = "/subspace/sync/peer-info/0.1.0";
+    const LOG_TARGET: &'static str = "peer-info-request-response-handler";
+    type Response = PeerInfoResponse;
+}
+
+/// Peer-info protocol response.
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct PeerInfoResponse {
+    /// Returned data.
+    pub peer_info: PeerInfo,
+}
+
+/// Create a new peer-info request handler.
+pub type PeerInfoRequestHandler = GenericRequestHandler<PeerInfoRequest>;

--- a/crates/subspace-networking/src/request_handlers/peer_info.rs
+++ b/crates/subspace-networking/src/request_handlers/peer_info.rs
@@ -8,11 +8,13 @@ pub struct PeerInfoRequest;
 /// Defines peer synchronization status.
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 pub enum PeerSyncStatus {
+    /// Special status for starting peer. Receiving it in the running mode means an error.
+    Unknown,
     /// Synchronization is not supported for this peer.
     NotSupported,
     /// Peer is ready to provide data for synchronization.
     Ready,
-    /// Peer is synchronizing itself.
+    /// Peer is synchronizing.
     Syncing,
 }
 

--- a/crates/subspace-networking/src/request_handlers/peer_info.rs
+++ b/crates/subspace-networking/src/request_handlers/peer_info.rs
@@ -10,7 +10,7 @@ pub struct PeerInfoRequest;
 pub enum PeerSyncStatus {
     /// Synchronization is not supported for this peer.
     NotSupported,
-    /// Peer is ready to provide data for the synchronization.
+    /// Peer is ready to provide data for synchronization.
     Ready,
     /// Peer is synchronizing itself.
     Syncing,


### PR DESCRIPTION
This PR introduces the peer-info protocol for networking. It also adds a basic protocol implementation for farmers.

Related issue: https://github.com/subspace/subspace/issues/745

### Changes

- peer-info protocol handler for networking
- protocol implementation that signifies the synchronization-in-progress status for farmers

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
