### PR TITLE
Allow specifying exact root farmer in genesis config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,7 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnorrkel",
+ "serde",
  "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -20,6 +20,7 @@ log = { version = "0.4.17", default-features = false }
 pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "6b8553511112afd5ae7e8e6877dc2f467850f155" }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
+serde = { version = "1.0.143", optional = true, default-features = false, features = ["derive"] }
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../sp-consensus-subspace" }
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "6b8553511112afd5ae7e8e6877dc2f467850f155" }
 sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "6b8553511112afd5ae7e8e6877dc2f467850f155" }
@@ -48,6 +49,8 @@ std = [
 	"pallet-timestamp/std",
 	"scale-info/std",
 	"schnorrkel/std",
+	"serde",
+	"serde/std",
 	"sp-consensus-subspace/std",
 	"sp-consensus-slots/std",
 	"sp-io/std",

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -290,14 +290,27 @@ mod pallet {
         type WeightInfo: WeightInfo;
     }
 
+    #[derive(Debug, Default, Encode, Decode, TypeInfo)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    pub enum AllowAuthoringBy {
+        /// Anyone can author new blocks at genesis.
+        #[default]
+        Anyone,
+        /// Author of the first block will be able to author blocks going forward unless unlocked
+        /// for everyone.
+        FirstFarmer,
+        /// Specified root farmer is allowed to author blocks unless unlocked for everyone.
+        RootFarmer(FarmerPublicKey),
+    }
+
     #[pallet::genesis_config]
     pub struct GenesisConfig {
         /// Whether rewards should be enabled.
         pub enable_rewards: bool,
         /// Whether storage access should be enabled.
         pub enable_storage_access: bool,
-        /// Allow block authoring by anyone or just root.
-        pub allow_authoring_by_anyone: bool,
+        /// Who can author blocks at genesis.
+        pub allow_authoring_by: AllowAuthoringBy,
     }
 
     #[cfg(feature = "std")]
@@ -306,7 +319,7 @@ mod pallet {
             Self {
                 enable_rewards: true,
                 enable_storage_access: true,
-                allow_authoring_by_anyone: true,
+                allow_authoring_by: AllowAuthoringBy::Anyone,
             }
         }
     }
@@ -318,7 +331,18 @@ mod pallet {
                 EnableRewards::<T>::put::<T::BlockNumber>(One::one());
             }
             IsStorageAccessEnabled::<T>::put(self.enable_storage_access);
-            AllowAuthoringByAnyone::<T>::put(self.allow_authoring_by_anyone);
+            match &self.allow_authoring_by {
+                AllowAuthoringBy::Anyone => {
+                    AllowAuthoringByAnyone::<T>::put(true);
+                }
+                AllowAuthoringBy::FirstFarmer => {
+                    AllowAuthoringByAnyone::<T>::put(false);
+                }
+                AllowAuthoringBy::RootFarmer(root_farmer) => {
+                    AllowAuthoringByAnyone::<T>::put(false);
+                    RootPlotPublicKey::<T>::put(root_farmer.clone());
+                }
+            }
         }
     }
 

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -27,8 +27,8 @@ use sc_telemetry::TelemetryEndpoints;
 use sp_core::crypto::Ss58Codec;
 use sp_executor::ExecutorId;
 use subspace_runtime::{
-    BalancesConfig, ExecutorConfig, GenesisConfig, RuntimeConfigsConfig, SubspaceConfig,
-    SudoConfig, SystemConfig, VestingConfig, MILLISECS_PER_BLOCK, WASM_BINARY,
+    AllowAuthoringBy, BalancesConfig, ExecutorConfig, GenesisConfig, RuntimeConfigsConfig,
+    SubspaceConfig, SudoConfig, SystemConfig, VestingConfig, MILLISECS_PER_BLOCK, WASM_BINARY,
 };
 use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, SSC};
 
@@ -68,7 +68,7 @@ const TOKEN_GRANTS: &[(&str, u128)] = &[
 struct GenesisParams {
     enable_rewards: bool,
     enable_storage_access: bool,
-    allow_authoring_by_anyone: bool,
+    allow_authoring_by: AllowAuthoringBy,
     enable_executor: bool,
 }
 
@@ -141,7 +141,7 @@ pub fn gemini_config_compiled(
                 GenesisParams {
                     enable_rewards: false,
                     enable_storage_access: false,
-                    allow_authoring_by_anyone: false,
+                    allow_authoring_by: AllowAuthoringBy::FirstFarmer,
                     enable_executor: false,
                 },
             )
@@ -236,7 +236,7 @@ pub fn x_net_config_compiled(
                 GenesisParams {
                     enable_rewards: false,
                     enable_storage_access: false,
-                    allow_authoring_by_anyone: false,
+                    allow_authoring_by: AllowAuthoringBy::FirstFarmer,
                     enable_executor: true,
                 },
             )
@@ -292,7 +292,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenesis
                 GenesisParams {
                     enable_rewards: false,
                     enable_storage_access: false,
-                    allow_authoring_by_anyone: true,
+                    allow_authoring_by: AllowAuthoringBy::Anyone,
                     enable_executor: true,
                 },
             )
@@ -350,7 +350,7 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig, ExecutionGenes
                 GenesisParams {
                     enable_rewards: false,
                     enable_storage_access: false,
-                    allow_authoring_by_anyone: true,
+                    allow_authoring_by: AllowAuthoringBy::Anyone,
                     enable_executor: true,
                 },
             )
@@ -384,7 +384,7 @@ fn subspace_genesis_config(
     let GenesisParams {
         enable_rewards,
         enable_storage_access,
-        allow_authoring_by_anyone,
+        allow_authoring_by,
         enable_executor,
     } = genesis_params;
 
@@ -402,7 +402,7 @@ fn subspace_genesis_config(
         subspace: SubspaceConfig {
             enable_rewards,
             enable_storage_access,
-            allow_authoring_by_anyone,
+            allow_authoring_by,
         },
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -44,6 +44,7 @@ use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
 use frame_system::EnsureNever;
 use pallet_feeds::feed_processor::FeedProcessor;
+pub use pallet_subspace::AllowAuthoringBy;
 use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::{

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -6,8 +6,8 @@ use sp_executor::ExecutorId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, Signature};
 use subspace_test_runtime::{
-    BalancesConfig, ExecutorConfig, GenesisConfig, SubspaceConfig, SudoConfig, SystemConfig,
-    VestingConfig, SSC, WASM_BINARY,
+    AllowAuthoringBy, BalancesConfig, ExecutorConfig, GenesisConfig, SubspaceConfig, SudoConfig,
+    SystemConfig, VestingConfig, SSC, WASM_BINARY,
 };
 
 /// The `ChainSpec` parameterized for subspace test runtime.
@@ -93,7 +93,7 @@ fn create_genesis_config(
         subspace: SubspaceConfig {
             enable_rewards: false,
             enable_storage_access: false,
-            allow_authoring_by_anyone: true,
+            allow_authoring_by: AllowAuthoringBy::Anyone,
         },
         vesting: VestingConfig { vesting },
         executor: ExecutorConfig {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -40,6 +40,7 @@ use frame_system::EnsureNever;
 use pallet_balances::NegativeImbalance;
 use pallet_feeds::feed_processor::{FeedMetadata, FeedObjectMapping, FeedProcessor};
 use pallet_grandpa_finality_verifier::chain::Chain;
+pub use pallet_subspace::AllowAuthoringBy;
 use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::{


### PR DESCRIPTION
Before we only had ability to make the farmer that produced the first block a root farmer, with these changes we can specify the exact public key and avoid forks starting at the first block.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
