### PR TITLE
Build container images for current platform

### DIFF
--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -41,7 +41,7 @@ RUN \
         -Z build-std \
         --profile $PROFILE \
         --bin subspace-farmer \
-        --target x86_64-unknown-linux-gnu && \
+        --target $(uname -p)-unknown-linux-gnu && \
     mv target/*/*/subspace-farmer subspace-farmer && \
     rm -rf target
 

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -43,7 +43,7 @@ RUN \
         -Z build-std \
         --profile $PROFILE \
         --bin subspace-node \
-        --target x86_64-unknown-linux-gnu && \
+        --target $(uname -p)-unknown-linux-gnu && \
     mv target/*/*/subspace-node subspace-node && \
     rm -rf target
 


### PR DESCRIPTION
`-Z build-std` requires us to provide `--target` explicitly, but we don't have to hardcode it. At least for x86-64 and aarch64 it matches `uname -p` output, so let's use that for now (I suspect other architectures will work too, but I didn't bother testing).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
