### PR TITLE
Boostrap-node CI

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -27,6 +27,7 @@ jobs:
         image:
           - farmer
           - node
+          - bootstrap-node
         platform:
           - arch: linux/amd64
             dockerfile-suffix: ''

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -1,0 +1,54 @@
+FROM ubuntu:20.04
+
+ARG RUSTC_VERSION=nightly-2022-08-12
+ARG PROFILE=production
+ARG RUSTFLAGS
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
+
+WORKDIR /code
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        llvm \
+        clang \
+        cmake \
+        make && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
+
+RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+
+COPY Cargo.lock /code/Cargo.lock
+COPY Cargo.toml /code/Cargo.toml
+COPY rust-toolchain.toml /code/rust-toolchain.toml
+
+COPY crates /code/crates
+COPY cumulus /code/cumulus
+COPY orml /code/orml
+COPY substrate /code/substrate
+COPY test /code/test
+
+# Up until this line all Rust images in this repo should be the same to share the same layers
+
+RUN \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-bootstrap-node \
+        --target $(uname -p)-unknown-linux-gnu && \
+    mv target/*/*/subspace-bootstrap-node subspace-bootstrap-node && \
+    rm -rf target
+
+FROM ubuntu:20.04
+
+COPY --from=0 /code/subspace-bootstrap-node /subspace-bootstrap-node
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/subspace-bootstrap-node"]

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -1,0 +1,70 @@
+FROM ubuntu:20.04
+
+ARG RUSTC_VERSION=nightly-2022-08-12
+ARG PROFILE=production
+ARG RUSTFLAGS
+# Workaround for https://github.com/rust-lang/cargo/issues/10583
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
+
+WORKDIR /code
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        llvm \
+        clang \
+        cmake \
+        make && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
+
+RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+
+COPY Cargo.lock /code/Cargo.lock
+COPY Cargo.toml /code/Cargo.toml
+COPY rust-toolchain.toml /code/rust-toolchain.toml
+
+COPY crates /code/crates
+COPY cumulus /code/cumulus
+COPY orml /code/orml
+COPY substrate /code/substrate
+COPY test /code/test
+
+# Up until this line all Rust images in this repo should be the same to share the same layers
+
+ENV RUSTFLAGS="${RUSTFLAGS} -C linker=aarch64-linux-gnu-gcc"
+
+# Dependencies necessary for successful cross-compilation
+RUN \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        g++-aarch64-linux-gnu \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross
+
+# TODO: Following package is not necessary on Ubuntu 22.04, but RocksDb compilation fails otherwise on Ubuntu 20.04
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-9-multilib
+
+RUN \
+    /root/.cargo/bin/cargo build \
+        -Z build-std \
+        --profile $PROFILE \
+        --bin subspace-bootstrap-node \
+        --target aarch64-unknown-linux-gnu && \
+    mv target/*/*/subspace-bootstrap-node subspace-bootstrap-node && \
+    rm -rf target
+
+FROM arm64v8/ubuntu:20.04
+
+COPY --from=0 /code/subspace-bootstrap-node /subspace-bootstrap-node
+
+RUN mkdir /var/subspace && chown nobody:nogroup /var/subspace
+
+VOLUME /var/subspace
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/subspace-bootstrap-node"]

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -61,10 +61,6 @@ FROM arm64v8/ubuntu:20.04
 
 COPY --from=0 /code/subspace-bootstrap-node /subspace-bootstrap-node
 
-RUN mkdir /var/subspace && chown nobody:nogroup /var/subspace
-
-VOLUME /var/subspace
-
 USER nobody:nogroup
 
 ENTRYPOINT ["/subspace-bootstrap-node"]

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -30,7 +30,7 @@ enum Command {
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
-    info!("Bootstrap Node started",);
+    info!("Subspace Bootstrap Node started",);
 
     let command: Command = Command::parse();
 


### PR DESCRIPTION
This PR introduces changes for github actions to enable new bootstrap-node images creation.

Related issue: https://github.com/subspace/subspace/issues/765

### Changes
- new `Dockerfile-bootstrap-node`
- new `Dockerfile-bootstrap-node.aarch64`
- modified `snapshots-build.yml`

### Comments
The PR contains extra commits from  https://github.com/subspace/subspace/pull/766 and targets its branch until it gets merged.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
