### PR TITLE
Dsn sync fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.7",
+ "instant",
+ "pin-project-lite 0.2.9",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7986,6 +8000,7 @@ dependencies = [
  "arc-swap",
  "async-oneshot",
  "async-trait",
+ "backoff",
  "base58",
  "blake2-rfc",
  "bytesize",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.61"
 arc-swap = "1.5.1"
 async-oneshot = "0.5.0"
 async-trait = "0.1.57"
+backoff = { version = "0.4.0", features = ["tokio"] }
 base58 = "0.2.0"
 blake2-rfc = "0.2.18"
 bytesize = "1.1.0"

--- a/crates/subspace-farmer/src/dsn.rs
+++ b/crates/subspace-farmer/src/dsn.rs
@@ -174,12 +174,11 @@ impl DSNSync for subspace_networking::Node {
                         // select first peer for the piece-by-range protocol
                         for id in peers {
                             match node.send_generic_request(id, PeerInfoRequest).await {
-                                Ok(PeerInfoResponse {
-                                    peer_info: PeerInfo { status },
-                                }) if status == PeerSyncStatus::Ready => return Ok(id),
-                                Ok(PeerInfoResponse {
-                                    peer_info: PeerInfo { status },
-                                }) => trace!(%id, ?status, "Peer is not ready for synchronization"),
+                                Ok(PeerInfoResponse { peer_info: PeerInfo { status }}) => if status == PeerSyncStatus::Ready {
+                                    return Ok(id)
+                                } else {
+                                    trace!(%id, ?status, "Peer is not ready for synchronization")
+                                },
                                 Err(err) => {
                                     debug!(%id, %err, "Peer info request returned an error")
                                 }

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -460,7 +460,7 @@ async fn test_dsn_sync() {
 
 #[tokio::test]
 async fn pieces_by_range_protocol_smoke() {
-    let request = PiecesByRangeRequest {
+    let expected_request = PiecesByRangeRequest {
         start: PieceIndexHash::from([1u8; 32]),
         end: PieceIndexHash::from([1u8; 32]),
     };
@@ -477,7 +477,6 @@ async fn pieces_by_range_protocol_smoke() {
         next_piece_index_hash: None,
     };
 
-    let expected_request = request.clone();
     let expected_response = response.clone();
 
     let config_1 = Config {
@@ -537,7 +536,7 @@ async fn pieces_by_range_protocol_smoke() {
     let (mut result_sender, mut result_receiver) = mpsc::unbounded();
     tokio::spawn(async move {
         let resp = node_2
-            .send_generic_request(node_1.id(), request)
+            .send_generic_request(node_1.id(), expected_request)
             .await
             .unwrap();
 

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -113,6 +113,7 @@ impl fmt::Debug for Plot {
 }
 
 impl Plot {
+    /// A bit more than 4M. Should correspond to requested range size from DSN.
     const PIECES_PER_REQUEST: u64 = 1100;
 
     /// Creates a new plot for persisting encoded pieces to disk

--- a/crates/subspace-farmer/src/plot.rs
+++ b/crates/subspace-farmer/src/plot.rs
@@ -113,7 +113,7 @@ impl fmt::Debug for Plot {
 }
 
 impl Plot {
-    const PIECES_PER_REQUEST: u64 = 1000;
+    const PIECES_PER_REQUEST: u64 = 1100;
 
     /// Creates a new plot for persisting encoded pieces to disk
     pub fn open_or_create(

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -46,7 +46,7 @@ use tokio::runtime::Handle;
 use tracing::{error, info, trace, warn, Instrument, Span};
 use ulid::Ulid;
 
-const SYNC_PIECES_AT_ONCE: u64 = 5000;
+const SYNC_PIECES_AT_ONCE: u64 = 1100;
 /// 100 MiB worth of object mappings per plot
 const MAX_OBJECT_MAPPINGS_SIZE: u64 = 100 * 1024 * 1024;
 

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -46,6 +46,7 @@ use tokio::runtime::Handle;
 use tracing::{error, info, trace, warn, Instrument, Span};
 use ulid::Ulid;
 
+/// A bit more than 4M. Should correspond to requested range size from DSN.
 const SYNC_PIECES_AT_ONCE: u64 = 1100;
 /// 100 MiB worth of object mappings per plot
 const MAX_OBJECT_MAPPINGS_SIZE: u64 = 100 * 1024 * 1024;

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -291,9 +291,7 @@ impl NodeRunner {
                 .iter()
                 .any(|protocol| protocol.as_bytes() == RELAY_HOP_PROTOCOL_NAME);
 
-            // TODO: figure out how to filter peers by supported protocols
-            // let proper_protocols_supported = !relay_server_enabled && kademlia_enabled;
-            let proper_protocols_supported = kademlia_enabled;
+            let proper_protocols_supported = !relay_server_enabled && kademlia_enabled;
             if proper_protocols_supported {
                 for address in info.listen_addrs {
                     if !self.allow_non_globals_in_dht && !utils::is_global_address_or_dns(&address)

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -291,7 +291,9 @@ impl NodeRunner {
                 .iter()
                 .any(|protocol| protocol.as_bytes() == RELAY_HOP_PROTOCOL_NAME);
 
-            let proper_protocols_supported = !relay_server_enabled && kademlia_enabled;
+            // TODO: figure out how to filter peers by supported protocols
+            // let proper_protocols_supported = !relay_server_enabled && kademlia_enabled;
+            let proper_protocols_supported = kademlia_enabled;
             if proper_protocols_supported {
                 for address in info.listen_addrs {
                     if !self.allow_non_globals_in_dht && !utils::is_global_address_or_dns(&address)

--- a/crates/subspace-networking/src/request_handlers/pieces_by_range.rs
+++ b/crates/subspace-networking/src/request_handlers/pieces_by_range.rs
@@ -14,7 +14,7 @@ pub struct PiecesToPlot {
 }
 
 /// Pieces-by-range protocol request. Assumes requests with paging.
-#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Encode, Decode)]
 pub struct PiecesByRangeRequest {
     /// Start of the requested range
     pub start: PieceIndexHash,


### PR DESCRIPTION
This pr fixes dsn sync in a bit hacky way. We had a [problem](https://github.com/subspace/subspace/issue/745) with filtering out nodes which doesn't support getting pieces by range (like relay node).
- disable filtering relay node (as we can't discover other peers because of that)
- ~test each peer if it supports getting pieces (just by sending dummy request)~
- retry getting peers (peers sometimes disconnect and reconnect in less than 50ms)

Also it changes plot constants for piece retrieval in order to correspond to dsn sync range size.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
