### PR TITLE
Fix era transition for fast sync checks by not wrapping a bunch of logic with check for the first block

### DIFF
--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -408,6 +408,7 @@ impl From<Error> for String {
 }
 
 /// Digest items extracted from a header into convenient form
+#[derive(Debug)]
 pub struct SubspaceDigestItems<PublicKey, RewardAddress, Signature> {
     /// Pre-runtime digest
     pub pre_digest: PreDigest<PublicKey, RewardAddress>,


### PR DESCRIPTION
I didn't notice when it happened, but a bunch of code was unnecessarily wrapped in `if block_number.is_one()`, breaking verification.

I recommend reviewing with whilespaces ignored, the diff is tiny.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
