### PR TITLE
Update example docker compose ports

### DIFF
--- a/docs/farming.md
+++ b/docs/farming.md
@@ -228,8 +228,8 @@ Create `subspace` directory and `docker-compose.yml` in it with following conten
 version: "3.7"
 services:
   node:
-    # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
-    # For running on Aarch64 add `-aarch64` after `DATE`
+# Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+# For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/node:snapshot-DATE
     volumes:
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can
@@ -266,8 +266,8 @@ services:
     depends_on:
       node:
         condition: service_healthy
-    # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
-    # For running on Aarch64 add `-aarch64` after `DATE`
+# Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+# For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/farmer:snapshot-DATE
     volumes:
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -269,18 +269,18 @@ services:
     # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
     # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/farmer:snapshot-DATE
-# Un-comment following 2 lines to unlock farmer's RPC
-#    ports:
+    ports:
+# Un-comment following line to unlock farmer's RPC
 #      - "127.0.0.1:9955:9955"
+# If port 40333 is already occupied by something else, replace all
+# occurrences of `40333` in this file with another value
+      - "0.0.0.0:40333:40333"
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can
 # alternatively specify path to the directory where files will be stored, just make
 # sure everyone is allowed to write there
     volumes:
       - farmer-data:/var/subspace:rw
 #      - /path/to/subspace-farmer:/var/subspace:rw
-# If port 40333 is already occupied by something else, replace all
-# occurrences of `40333` in this file with another value
-      - "0.0.0.0:40333:40333"
     restart: unless-stopped
     command: [
       "--base-path", "/var/subspace",

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -228,8 +228,8 @@ Create `subspace` directory and `docker-compose.yml` in it with following conten
 version: "3.7"
 services:
   node:
-# Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
-# For running on Aarch64 add `-aarch64` after `DATE`
+    # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+    # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/node:snapshot-DATE
     volumes:
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can
@@ -266,8 +266,8 @@ services:
     depends_on:
       node:
         condition: service_healthy
-# Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
-# For running on Aarch64 add `-aarch64` after `DATE`
+    # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
+    # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/farmer:snapshot-DATE
     volumes:
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -270,6 +270,9 @@ services:
     # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/farmer:snapshot-DATE
     volumes:
+# Instead of specifying volume (which will store data in `/var/lib/docker`), you can
+# alternatively specify path to the directory where files will be stored, just make
+# sure everyone is allowed to write there
       - farmer-data:/var/subspace:rw
 #      - /path/to/subspace-farmer:/var/subspace:rw
     ports:
@@ -278,9 +281,6 @@ services:
 # If port 40333 is already occupied by something else, replace all
 # occurrences of `40333` in this file with another value
       - "0.0.0.0:40333:40333"
-# Instead of specifying volume (which will store data in `/var/lib/docker`), you can
-# alternatively specify path to the directory where files will be stored, just make
-# sure everyone is allowed to write there
     restart: unless-stopped
     command: [
       "--base-path", "/var/subspace",

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -269,6 +269,9 @@ services:
     # Replace `snapshot-DATE` with latest release (like `snapshot-2022-apr-29`)
     # For running on Aarch64 add `-aarch64` after `DATE`
     image: ghcr.io/subspace/farmer:snapshot-DATE
+    volumes:
+      - farmer-data:/var/subspace:rw
+#      - /path/to/subspace-farmer:/var/subspace:rw
     ports:
 # Un-comment following line to unlock farmer's RPC
 #      - "127.0.0.1:9955:9955"
@@ -278,9 +281,6 @@ services:
 # Instead of specifying volume (which will store data in `/var/lib/docker`), you can
 # alternatively specify path to the directory where files will be stored, just make
 # sure everyone is allowed to write there
-    volumes:
-      - farmer-data:/var/subspace:rw
-#      - /path/to/subspace-farmer:/var/subspace:rw
     restart: unless-stopped
     command: [
       "--base-path", "/var/subspace",


### PR DESCRIPTION
Fixed a typo in the example `docker-compose.yml` where the `ports` section had not been activated. Some minor comment formatting.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
