### PR TITLE
Lightclient updates

### DIFF
--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -654,7 +654,8 @@ where
 
 type NumberOf<T> = <T as HeaderT>::Number;
 
-fn derive_next_global_randomness<Header: HeaderT>(
+/// Returns the next global randomness if interval is met.
+pub fn derive_next_global_randomness<Header: HeaderT>(
     number: NumberOf<Header>,
     global_randomness_interval: NumberOf<Header>,
     pre_digest: &PreDigest<FarmerPublicKey, FarmerPublicKey>,
@@ -672,7 +673,8 @@ fn derive_next_global_randomness<Header: HeaderT>(
     .map_err(|_err| Error::NextDigestDerivationError(ErrorDigestType::GlobalRandomness))
 }
 
-fn derive_next_salt<Header: HeaderT>(
+/// Returns the next salt if eon changes.
+pub fn derive_next_salt<Header: HeaderT>(
     eon_duration: u64,
     current_eon_index: EonIndex,
     genesis_slot: Slot,
@@ -700,18 +702,28 @@ fn derive_next_salt<Header: HeaderT>(
     Ok(None)
 }
 
-struct DeriveNextSolutionRangeParams<Header: HeaderT> {
-    number: NumberOf<Header>,
-    era_duration: NumberOf<Header>,
-    slot_probability: (u64, u64),
-    current_slot: Slot,
-    current_solution_range: SolutionRange,
-    era_start_slot: Slot,
-    should_adjust_solution_range: bool,
-    maybe_next_solution_range_override: Option<SolutionRange>,
+/// Params used to derive the next solution range.
+pub struct DeriveNextSolutionRangeParams<Header: HeaderT> {
+    /// Current number of the block.
+    pub number: NumberOf<Header>,
+    /// Era duration of the chain.
+    pub era_duration: NumberOf<Header>,
+    /// Slot probability at which a block is produced.
+    pub slot_probability: (u64, u64),
+    /// Current slot of the block.
+    pub current_slot: Slot,
+    /// Current solution range of the block.
+    pub current_solution_range: SolutionRange,
+    /// Slot at which era has begun.
+    pub era_start_slot: Slot,
+    /// Flag to check if the next solution range should be adjusted.
+    pub should_adjust_solution_range: bool,
+    /// Solution range override that should be used instead of deriving from current.
+    pub maybe_next_solution_range_override: Option<SolutionRange>,
 }
 
-fn derive_next_solution_range<Header: HeaderT>(
+/// Derives next solution range if era duration interval has met.
+pub fn derive_next_solution_range<Header: HeaderT>(
     params: DeriveNextSolutionRangeParams<Header>,
 ) -> Result<Option<SolutionRange>, Error> {
     let DeriveNextSolutionRangeParams {

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -111,6 +111,8 @@ pub struct HeaderExt<Header> {
     pub maybe_next_solution_range_override: Option<SolutionRange>,
     /// Restrict block authoring to this public key.
     pub maybe_root_plot_public_key: Option<FarmerPublicKey>,
+    /// Genesis slot of the chain.
+    pub genesis_slot: Slot,
 
     #[cfg(test)]
     test_overrides: mock::TestOverrides,
@@ -318,7 +320,11 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
 
         // verify next digest items
         let constants = self.store.chain_constants();
-        let genesis_slot = self.find_genesis_slot(&header)?;
+        let genesis_slot = if header.number().is_one() {
+            header_digests.pre_digest.slot
+        } else {
+            parent_header.genesis_slot
+        };
         // re-check if the salt was revealed and eon also changes with this header, then derive randomness
         let parent_salt_derivation_info = SaltDerivationInfo {
             eon_index: parent_header.salt_derivation_info.eon_index,
@@ -416,7 +422,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
         };
 
         let salt_derivation_info =
-            self.next_salt_derivation_info(&header, &parent_salt_derivation_info)?;
+            self.next_salt_derivation_info(&header, genesis_slot, &parent_salt_derivation_info)?;
 
         // check if era has changed
         let era_start_slot = if Self::has_era_changed(&header, constants.era_duration) {
@@ -453,6 +459,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
             maybe_current_solution_range_override,
             maybe_next_solution_range_override,
             maybe_root_plot_public_key,
+            genesis_slot,
 
             #[cfg(test)]
             test_overrides: Default::default(),
@@ -472,11 +479,11 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
     fn next_salt_derivation_info(
         &self,
         header: &Header,
+        genesis_slot: Slot,
         parent_salt_derivation_info: &SaltDerivationInfo,
     ) -> Result<SaltDerivationInfo, ImportError<Header>> {
         let constants = self.store.chain_constants();
         let eon_duration = constants.eon_duration;
-        let genesis_slot = self.find_genesis_slot(header)?;
         let pre_digest = extract_pre_digest(header)?;
 
         // check if the eon is about to be changed
@@ -550,23 +557,6 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
         };
 
         Ok(maybe_randomness)
-    }
-
-    /// Returns the genesis slot of the chain with header being the best tip.
-    /// Since the Genesis block doesn't have any digests, we return the Slot of #1.
-    fn find_genesis_slot(&self, header: &Header) -> Result<Slot, ImportError<Header>> {
-        // short circuit if the header is #1
-        if header.number().is_one() {
-            let digests = extract_pre_digest(header)?;
-            return Ok(digests.slot);
-        }
-
-        let header_at_one = self
-            .find_ancestor_of_header_at_number(*header.parent_hash(), One::one())
-            .ok_or_else(|| ImportError::MissingAncestorHeader(*header.parent_hash(), One::one()))?;
-
-        let digests = extract_pre_digest(&header_at_one.header)?;
-        Ok(digests.slot)
     }
 
     fn has_era_changed(header: &Header, era_duration: NumberOf<Header>) -> bool {

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -330,7 +330,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
             eon_index: parent_header.salt_derivation_info.eon_index,
             maybe_randomness: parent_header.salt_derivation_info.maybe_randomness.or(
                 Self::randomness_for_next_salt(
-                    self.store.chain_constants(),
+                    &constants,
                     parent_header.salt_derivation_info.eon_index,
                     genesis_slot,
                     &header_digests.pre_digest,
@@ -502,7 +502,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
                 eon_index: next_eon_index,
                 // check if the salt will be revealed with new eon index
                 maybe_randomness: Self::randomness_for_next_salt(
-                    constants,
+                    &constants,
                     next_eon_index,
                     genesis_slot,
                     &pre_digest,
@@ -515,7 +515,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
                 // if the salt is not revealed yet, check if salt will be revealed at this header for the current eon index
                 maybe_randomness: parent_salt_derivation_info.maybe_randomness.or(
                     Self::randomness_for_next_salt(
-                        constants,
+                        &constants,
                         parent_salt_derivation_info.eon_index,
                         genesis_slot,
                         &pre_digest,
@@ -527,7 +527,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
 
     /// Returns randomness used to derive the next salt if the next salt is revealed after importing header.
     fn randomness_for_next_salt(
-        constants: ChainConstants<Header>,
+        constants: &ChainConstants<Header>,
         eon_index: EonIndex,
         genesis_slot: Slot,
         pre_digest: &PreDigest<FarmerPublicKey, FarmerPublicKey>,

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -9,26 +9,25 @@ use rand::{Rng, SeedableRng};
 use schnorrkel::Keypair;
 use sp_consensus_slots::Slot;
 use sp_consensus_subspace::digests::{
-    extract_pre_digest, extract_subspace_digest_items, CompatibleDigestItem, ErrorDigestType,
-    PreDigest, SubspaceDigestItems,
+    derive_next_global_randomness, derive_next_salt, derive_next_solution_range,
+    extract_pre_digest, extract_subspace_digest_items, CompatibleDigestItem,
+    DeriveNextSolutionRangeParams, ErrorDigestType, PreDigest, SubspaceDigestItems,
 };
 use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature};
 use sp_runtime::app_crypto::UncheckedFrom;
+use sp_runtime::testing::H256;
+use sp_runtime::traits::Header as HeaderT;
 use sp_runtime::{Digest, DigestItem};
-use std::cmp::Ordering;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::{
-    EonIndex, Piece, Randomness, RecordsRoot, Salt, SegmentIndex, Solution, SolutionRange, Tag,
+    Piece, PublicKey, Randomness, RecordsRoot, Salt, SegmentIndex, Solution, SolutionRange, Tag,
     RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
 };
 use subspace_solving::{
     create_tag, create_tag_signature, derive_global_challenge, derive_local_challenge,
     derive_target, SubspaceCodec, REWARD_SIGNING_CONTEXT,
 };
-use subspace_verification::{
-    derive_next_eon_index, derive_next_salt_from_randomness, derive_next_solution_range,
-    derive_randomness,
-};
+use subspace_verification::derive_randomness;
 
 fn default_randomness_and_salt() -> (Randomness, Salt) {
     let randomness = [1u8; 32];
@@ -105,73 +104,6 @@ fn valid_piece(pub_key: schnorrkel::PublicKey) -> (Piece, u64, SegmentIndex, Rec
     )
 }
 
-fn valid_header_with_default_randomness_and_salt(
-    parent_hash: HashOf<Header>,
-    number: NumberOf<Header>,
-    slot: u64,
-    keypair: &Keypair,
-) -> (Header, SolutionRange, SegmentIndex, RecordsRoot) {
-    let (randomness, salt) = default_randomness_and_salt();
-    valid_header(ValidHeaderParams {
-        parent_hash,
-        number,
-        slot,
-        keypair,
-        randomness,
-        salt,
-        should_add_next_randomness: false,
-        maybe_next_solution_range: None,
-        maybe_next_salt: None,
-        maybe_derive_salt_from_predigest: None,
-    })
-}
-
-fn valid_header_with_next_digests(
-    parent_hash: HashOf<Header>,
-    number: NumberOf<Header>,
-    slot: u64,
-    keypair: &Keypair,
-    should_add_next_randomness: bool,
-    maybe_next_solution_range: Option<(Slot, (u64, u64), NumberOf<Header>)>,
-    maybe_next_salt: Option<Salt>,
-) -> (Header, SolutionRange, SegmentIndex, RecordsRoot) {
-    let (randomness, salt) = default_randomness_and_salt();
-    valid_header(ValidHeaderParams {
-        parent_hash,
-        number,
-        slot,
-        keypair,
-        randomness,
-        salt,
-        should_add_next_randomness,
-        maybe_next_solution_range,
-        maybe_next_salt,
-        maybe_derive_salt_from_predigest: None,
-    })
-}
-
-fn valid_header_with_next_salt_revealed_at_this_header(
-    parent_hash: HashOf<Header>,
-    number: NumberOf<Header>,
-    slot: u64,
-    keypair: &Keypair,
-    maybe_derive_salt_from_predigest: Option<EonIndex>,
-) -> (Header, SolutionRange, SegmentIndex, RecordsRoot) {
-    let (randomness, salt) = default_randomness_and_salt();
-    valid_header(ValidHeaderParams {
-        parent_hash,
-        number,
-        slot,
-        keypair,
-        randomness,
-        salt,
-        should_add_next_randomness: false,
-        maybe_next_solution_range: None,
-        maybe_next_salt: None,
-        maybe_derive_salt_from_predigest,
-    })
-}
-
 struct ValidHeaderParams<'a> {
     parent_hash: HashOf<Header>,
     number: NumberOf<Header>,
@@ -179,10 +111,6 @@ struct ValidHeaderParams<'a> {
     keypair: &'a Keypair,
     randomness: Randomness,
     salt: Salt,
-    should_add_next_randomness: bool,
-    maybe_next_solution_range: Option<(Slot, (u64, u64), NumberOf<Header>)>,
-    maybe_next_salt: Option<Salt>,
-    maybe_derive_salt_from_predigest: Option<EonIndex>,
 }
 
 fn valid_header(
@@ -195,10 +123,6 @@ fn valid_header(
         keypair,
         randomness,
         salt,
-        should_add_next_randomness,
-        maybe_next_solution_range,
-        maybe_next_salt,
-        maybe_derive_salt_from_predigest: derive_next_salt_from_predigest,
     } = params;
     let (encoding, piece_index, segment_index, records_root) = valid_piece(keypair.public);
     let tag: Tag = create_tag(encoding.as_ref(), salt);
@@ -211,7 +135,6 @@ fn valid_header(
     )
     .unwrap();
     let solution_range = derive_solution_range(target, tag);
-    let ctx = schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT);
     let tag_signature = create_tag_signature(keypair, tag);
     let pre_digest = PreDigest {
         slot: slot.into(),
@@ -225,56 +148,14 @@ fn valid_header(
             tag,
         },
     };
-    let mut digests = vec![
+    let digests = vec![
         DigestItem::global_randomness(randomness),
         DigestItem::solution_range(solution_range),
         DigestItem::salt(salt),
         DigestItem::subspace_pre_digest(&pre_digest),
     ];
 
-    if should_add_next_randomness {
-        let next_global_randomness = derive_randomness(
-            &subspace_core_primitives::PublicKey::from(&FarmerPublicKey::unchecked_from(
-                keypair.public.to_bytes(),
-            )),
-            tag,
-            &tag_signature,
-        )
-        .unwrap();
-        digests.push(DigestItem::next_global_randomness(next_global_randomness));
-    }
-
-    if let Some((start_slot, probability, era_duration)) = maybe_next_solution_range {
-        let expected_next_solution_range = derive_next_solution_range(
-            u64::from(start_slot),
-            slot,
-            probability,
-            solution_range,
-            era_duration,
-        );
-
-        digests.push(DigestItem::next_solution_range(
-            expected_next_solution_range,
-        ))
-    }
-
-    if let Some(next_salt) = maybe_next_salt {
-        digests.push(DigestItem::next_salt(next_salt))
-    } else if let Some(eon_index) = derive_next_salt_from_predigest {
-        let randomness = derive_randomness(
-            &subspace_core_primitives::PublicKey::from(&FarmerPublicKey::unchecked_from(
-                keypair.public.to_bytes(),
-            )),
-            pre_digest.solution.tag,
-            &pre_digest.solution.tag_signature,
-        )
-        .unwrap();
-
-        let next_salt = derive_next_salt_from_randomness(eon_index, &randomness);
-        digests.push(DigestItem::next_salt(next_salt))
-    }
-
-    let mut header = Header {
+    let header = Header {
         parent_hash,
         number,
         state_root: Default::default(),
@@ -282,6 +163,11 @@ fn valid_header(
         digest: Digest { logs: digests },
     };
 
+    (header, solution_range, segment_index, records_root)
+}
+
+fn seal_header(keypair: &Keypair, header: &mut Header) {
+    let ctx = schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT);
     let pre_hash = header.hash();
     let signature =
         FarmerSignature::unchecked_from(keypair.sign(ctx.bytes(pre_hash.as_bytes())).to_bytes());
@@ -289,153 +175,249 @@ fn valid_header(
         .digest
         .logs
         .push(DigestItem::subspace_seal(signature));
-
-    (header, solution_range, segment_index, records_root)
 }
 
-fn import_blocks_until(
-    store: &mut MockStorage,
-    number: NumberOf<Header>,
-    start_slot: u64,
-    keypair: &Keypair,
-) -> (HashOf<Header>, u64) {
-    let mut parent_hash = Default::default();
-    let mut slot = start_slot;
-    let mut next_eon_index = 0;
-    let genesis_slot = start_slot;
-    let mut era_start_slot = start_slot;
-    for block_number in 0..=number {
-        let (header, _solution_range, segment_index, records_root) =
-            valid_header_with_default_randomness_and_salt(parent_hash, block_number, slot, keypair);
-        parent_hash = header.hash();
-        slot += 1;
+fn remove_seal(header: &mut Header) {
+    let digests = header.digest_mut();
+    digests.pop();
+}
 
-        if HeaderImporter::<_, MockStorage>::has_era_changed(
-            &header,
-            store.chain_constants().era_duration,
-        ) {
-            era_start_slot = slot;
-        }
-        let header_ext = HeaderExt {
+fn next_slot(slot_probability: (u64, u64), current_slot: Slot) -> Slot {
+    let mut rng = StdRng::seed_from_u64(current_slot.into());
+    current_slot + rng.gen_range(slot_probability.0..=slot_probability.1)
+}
+
+fn initialize_store(constants: ChainConstants<Header>) -> (MockStorage, HashOf<Header>) {
+    let mut store = MockStorage::new(constants);
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut state_root = vec![0u8; 32];
+    rng.fill(state_root.as_mut_slice());
+    let genesis_header = Header {
+        parent_hash: Default::default(),
+        number: 0,
+        state_root: H256::from_slice(&state_root),
+        extrinsics_root: Default::default(),
+        digest: Default::default(),
+    };
+
+    let genesis_hash = genesis_header.hash();
+    let header = HeaderExt {
+        header: genesis_header,
+        total_weight: 0,
+        salt_derivation_info: Default::default(),
+        era_start_slot: Default::default(),
+        should_adjust_solution_range: true,
+        maybe_current_solution_range_override: None,
+        maybe_next_solution_range_override: None,
+        maybe_root_plot_public_key: None,
+        genesis_slot: Default::default(),
+        test_overrides: Default::default(),
+    };
+
+    store.store_header(header, true);
+    (store, genesis_hash)
+}
+
+fn add_next_digests(store: &MockStorage, number: NumberOf<Header>, header: &mut Header) {
+    let constants = store.chain_constants();
+    let parent_header = store.header(*header.parent_hash()).unwrap();
+    let digests =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
             header,
-            total_weight: 0,
-            salt_derivation_info: SaltDerivationInfo {
-                eon_index: next_eon_index,
-                maybe_randomness: None,
-            },
-            era_start_slot: era_start_slot.into(),
-            should_adjust_solution_range: true,
-            maybe_current_solution_range_override: None,
-            maybe_next_solution_range_override: None,
-            maybe_root_plot_public_key: None,
-            test_overrides: Default::default(),
-        };
-        store.store_header(header_ext, true);
-        store.store_records_root(segment_index, records_root);
-        next_eon_index = derive_next_eon_index(
-            next_eon_index,
-            store.chain_constants().eon_duration,
-            genesis_slot,
-            slot,
         )
-        .unwrap_or(next_eon_index)
+        .unwrap();
+
+    let digest_logs = header.digest_mut();
+    if let Some(next_randomness) = derive_next_global_randomness::<Header>(
+        number,
+        constants.global_randomness_interval,
+        &digests.pre_digest,
+    )
+    .unwrap()
+    {
+        digest_logs.push(DigestItem::next_global_randomness(next_randomness));
     }
 
-    (parent_hash, slot)
-}
+    if let Some(next_solution_range) =
+        derive_next_solution_range::<Header>(DeriveNextSolutionRangeParams {
+            number,
+            era_duration: constants.era_duration,
+            slot_probability: constants.slot_probability,
+            current_slot: digests.pre_digest.slot,
+            current_solution_range: digests.solution_range,
+            era_start_slot: parent_header.era_start_slot,
+            should_adjust_solution_range: true,
+            maybe_next_solution_range_override: None,
+        })
+        .unwrap()
+    {
+        digest_logs.push(DigestItem::next_solution_range(next_solution_range));
+    }
 
-#[test]
-fn test_header_import_missing_parent() {
-    let constants = default_test_constants();
-    let mut store = MockStorage::new(constants);
-    let keypair = Keypair::generate();
-    let (_parent_hash, next_slot) = import_blocks_until(&mut store, 0, 0, &keypair);
-    let (header, _, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(Default::default(), 1, next_slot, &keypair);
-    store.store_records_root(segment_index, records_root);
-    let mut importer = HeaderImporter::new(store);
-    assert_err!(
-        importer.import_header(header.clone()),
-        ImportError::MissingParent(header.hash())
-    );
-}
-
-fn header_import_reorg_at_same_height(new_header_weight: Ordering) {
-    let constants = default_test_constants();
-    let mut store = MockStorage::new(constants);
-    let keypair = Keypair::generate();
-    let (parent_hash, next_slot) = import_blocks_until(&mut store, 2, 1, &keypair);
-    let best_header = store.best_header();
-    assert_eq!(best_header.header.hash(), parent_hash);
-    let mut importer = HeaderImporter::new(store);
-
-    // import block 3
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(parent_hash, 3, next_slot, &keypair);
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-    assert_ok!(importer.import_header(header.clone()));
-    let best_header_ext = importer.store.best_header();
-    assert_eq!(best_header_ext.header, header);
-    let mut best_header = header;
-
-    // try an import another fork at 3
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(parent_hash, 3, next_slot + 1, &keypair);
-    let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
-        extract_subspace_digest_items(&header).unwrap();
-    let new_weight = HeaderImporter::<Header, MockStorage>::calculate_block_weight(
-        &digests.global_randomness,
-        &digests.pre_digest,
-    );
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-    match new_header_weight {
-        Ordering::Less => {
-            importer
-                .store
-                .override_cumulative_weight(best_header_ext.header.hash(), new_weight + 1);
-        }
-        Ordering::Equal => {
-            importer
-                .store
-                .override_cumulative_weight(best_header_ext.header.hash(), new_weight);
-        }
-        Ordering::Greater => {
-            importer
-                .store
-                .override_cumulative_weight(best_header_ext.header.hash(), new_weight - 1);
-            best_header = header.clone();
-        }
+    // re-check if the salt was revealed and eon also changes with this header, then derive randomness
+    let parent_salt_derivation_info = SaltDerivationInfo {
+        eon_index: parent_header.salt_derivation_info.eon_index,
+        maybe_randomness: parent_header
+            .salt_derivation_info
+            .maybe_randomness
+            .or_else(|| {
+                HeaderImporter::<Header, MockStorage>::randomness_for_next_salt(
+                    store.chain_constants(),
+                    parent_header.salt_derivation_info.eon_index,
+                    parent_header.genesis_slot,
+                    &digests.pre_digest,
+                )
+                .unwrap()
+            }),
     };
-    assert_ok!(importer.import_header(header));
+
+    if let Some(next_salt) = derive_next_salt::<Header>(
+        constants.eon_duration,
+        parent_salt_derivation_info.eon_index,
+        parent_header.genesis_slot,
+        digests.pre_digest.slot,
+        parent_salt_derivation_info.maybe_randomness,
+    )
+    .unwrap()
+    {
+        digest_logs.push(DigestItem::next_salt(next_salt));
+    }
+}
+
+struct ForkAt {
+    parent_hash: HashOf<Header>,
+    // if None, fork chain cumulative weight is equal to canonical chain weight
+    is_best: Option<bool>,
+}
+
+fn add_headers_to_chain(
+    importer: &mut HeaderImporter<Header, MockStorage>,
+    keypair: &Keypair,
+    headers_to_add: NumberOf<Header>,
+    maybe_fork_chain: Option<ForkAt>,
+) -> HashOf<Header> {
     let best_header_ext = importer.store.best_header();
-    assert_eq!(best_header_ext.header, best_header);
-    // we still track the forks
-    assert_eq!(importer.store.headers_at_number(3).len(), 2);
-}
+    let constants = importer.store.chain_constants();
+    let (parent_hash, number, slot) = if let Some(ForkAt { parent_hash, .. }) = maybe_fork_chain {
+        let header = importer.store.header(parent_hash).unwrap();
+        let digests = extract_pre_digest(&header.header).unwrap();
 
-#[test]
-fn test_header_import_non_canonical() {
-    header_import_reorg_at_same_height(Ordering::Less)
-}
+        (parent_hash, *header.header.number(), digests.slot)
+    } else {
+        let digests = extract_pre_digest(&best_header_ext.header).unwrap();
+        (
+            best_header_ext.header.hash(),
+            *best_header_ext.header.number(),
+            digests.slot,
+        )
+    };
 
-#[test]
-fn test_header_import_canonical() {
-    header_import_reorg_at_same_height(Ordering::Greater)
-}
+    let until_number = number + headers_to_add;
+    let mut parent_hash = parent_hash;
+    let mut number = number + 1;
+    let mut slot = next_slot(constants.slot_probability, slot);
+    let mut best_header_hash = best_header_ext.header.hash();
+    while number <= until_number {
+        let (randomness, salt, override_next_solution) = if number == 1 {
+            let (randomness, salt) = default_randomness_and_salt();
+            (randomness, salt, false)
+        } else {
+            let header = importer.store.header(parent_hash).unwrap();
+            let digests = extract_subspace_digest_items::<
+                _,
+                FarmerPublicKey,
+                FarmerPublicKey,
+                FarmerSignature,
+            >(&header.header)
+            .unwrap();
 
-#[test]
-fn test_header_import_non_canonical_with_equal_block_weight() {
-    header_import_reorg_at_same_height(Ordering::Equal)
+            let randomness = digests
+                .next_global_randomness
+                .unwrap_or(digests.global_randomness);
+            let salt = digests.next_salt.unwrap_or(digests.salt);
+            (randomness, salt, digests.next_global_randomness.is_some())
+        };
+
+        let (mut header, solution_range, segment_index, records_root) =
+            valid_header(ValidHeaderParams {
+                parent_hash,
+                number,
+                slot: slot.into(),
+                keypair,
+                randomness,
+                salt,
+            });
+        let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
+            extract_subspace_digest_items(&header).unwrap();
+        let new_weight = HeaderImporter::<Header, MockStorage>::calculate_block_weight(
+            &digests.global_randomness,
+            &digests.pre_digest,
+        );
+        importer.store.override_cumulative_weight(parent_hash, 0);
+        if number == 1 {
+            // adjust Chain constants for Block #1
+            let mut constants = importer.store.chain_constants();
+            constants.genesis_digest_items.next_solution_range = solution_range;
+            importer.store.override_constants(constants)
+        } else if override_next_solution {
+            importer
+                .store
+                .override_next_solution_range(parent_hash, solution_range);
+        } else {
+            importer
+                .store
+                .override_solution_range(parent_hash, solution_range);
+        }
+        importer
+            .store
+            .store_records_root(segment_index, records_root);
+        if let Some(ForkAt {
+            is_best: maybe_best,
+            ..
+        }) = maybe_fork_chain
+        {
+            if let Some(is_best) = maybe_best {
+                if is_best {
+                    importer
+                        .store
+                        .override_cumulative_weight(best_header_hash, new_weight - 1)
+                } else {
+                    importer
+                        .store
+                        .override_cumulative_weight(best_header_hash, new_weight + 1)
+                }
+            } else {
+                importer
+                    .store
+                    .override_cumulative_weight(best_header_hash, new_weight)
+            }
+        }
+
+        add_next_digests(&importer.store, number, &mut header);
+        seal_header(keypair, &mut header);
+        parent_hash = header.hash();
+        slot = next_slot(constants.slot_probability, slot);
+        number += 1;
+
+        assert_ok!(importer.import_header(header.clone()));
+        if let Some(ForkAt {
+            is_best: maybe_best,
+            ..
+        }) = maybe_fork_chain
+        {
+            if let Some(is_best) = maybe_best {
+                if is_best {
+                    best_header_hash = header.hash()
+                }
+            }
+        } else {
+            best_header_hash = header.hash()
+        }
+
+        assert_eq!(importer.store.best_header().header.hash(), best_header_hash);
+    }
+
+    parent_hash
 }
 
 fn ensure_finalized_heads_have_no_forks(store: &MockStorage, finalized_number: NumberOf<Header>) {
@@ -463,341 +445,169 @@ fn ensure_finalized_heads_have_no_forks(store: &MockStorage, finalized_number: N
 }
 
 #[test]
-fn test_header_import_success() {
-    let mut constants = default_test_constants();
-    constants.global_randomness_interval = 11;
-    constants.era_duration = 11;
-    constants.eon_duration = 10;
-    constants.next_salt_reveal_interval = 3;
-    let mut store = MockStorage::new(constants);
+fn test_header_import_missing_parent() {
+    let constants = default_test_constants();
+    let (mut store, _genesis_hash) = initialize_store(constants);
+    let (randomness, salt) = default_randomness_and_salt();
     let keypair = Keypair::generate();
-    let (parent_hash, next_slot) = import_blocks_until(&mut store, 2, 1, &keypair);
-    let best_header = store.best_header();
-    assert_eq!(best_header.header.hash(), parent_hash);
-    let mut importer = HeaderImporter::new(store);
-
-    // verify and import next headers
-    let mut slot = next_slot;
-    let mut parent_hash = parent_hash;
-    for number in 3..=10 {
-        let (header, solution_range, segment_index, records_root) =
-            valid_header_with_default_randomness_and_salt(parent_hash, number, slot, &keypair);
-        importer
-            .store
-            .override_solution_range(parent_hash, solution_range);
-        importer
-            .store
-            .store_records_root(segment_index, records_root);
-
-        let res = importer.import_header(header.clone());
-        assert_ok!(res);
-        // best header should be correct
-        let best_header = importer.store.best_header();
-        assert_eq!(best_header.header, header);
-        slot += 1;
-        parent_hash = header.hash();
-    }
-
-    // finalized head must be best 10 - 7 = 3
-    let finalized_header = importer.store.finalized_header();
-    assert_eq!(finalized_header.header.number, 3);
-
-    // header count at the finalized head must be 1
-    ensure_finalized_heads_have_no_forks(&importer.store, 3);
-
-    // verify global randomness
-    // global randomness at block number 11 should be updated as the interval is 11.
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(parent_hash, 11, slot, &keypair);
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-
-    // this should fail since the next digest for randomness is missing
-    let res = importer.import_header(header);
-    assert_err!(
-        res,
-        ImportError::DigestError(DigestError::NextDigestVerificationError(
-            ErrorDigestType::NextGlobalRandomness
-        ))
-    );
-
-    // inject expected randomness digest but should still fail due to missing next solution range
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_next_digests(parent_hash, 11, slot, &keypair, true, None, None);
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-
-    // this should fail since the next digest for solution range is missing
-    let res = importer.import_header(header);
-    assert_err!(
-        res,
-        ImportError::DigestError(DigestError::NextDigestVerificationError(
-            ErrorDigestType::NextSolutionRange
-        ))
-    );
-
-    // inject next solution range
-    let ancestor_header = importer
-        .store
-        .headers_at_number(1)
-        .first()
-        .cloned()
-        .unwrap();
-    let ancestor_digests =
-        extract_subspace_digest_items::<Header, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
-            &ancestor_header.header,
-        )
-        .unwrap();
-
-    let constants = importer.store.chain_constants();
-    let (header, solution_range, segment_index, records_root) = valid_header_with_next_digests(
-        parent_hash,
-        11,
-        slot,
-        &keypair,
-        true,
-        Some((
-            ancestor_digests.pre_digest.slot,
-            constants.slot_probability,
-            constants.era_duration,
-        )),
-        None,
-    );
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-
-    let res = importer.import_header(header);
-    assert_err!(
-        res,
-        ImportError::DigestError(DigestError::NextDigestVerificationError(
-            ErrorDigestType::NextSalt
-        ))
-    );
-
-    // inject next salt
-    let header_at_3 = importer
-        .store
-        .headers_at_number(3)
-        .first()
-        .cloned()
-        .unwrap();
-    let header_at_4 = importer
-        .store
-        .headers_at_number(4)
-        .first()
-        .cloned()
-        .unwrap();
-
-    // verify salt reveal at block #4
-    // salt reveal number should be empty at header #3
-    assert_eq!(header_at_3.salt_derivation_info.eon_index, 0);
-    assert_eq!(header_at_3.salt_derivation_info.maybe_randomness, None);
-    // eon index should still be 0 and the next salt should be revealed at #4
-    assert_eq!(header_at_4.salt_derivation_info.eon_index, 0);
-    let digests_at_4 = extract_pre_digest(&header_at_4.header).unwrap();
-    let randomness = derive_randomness(
-        &subspace_core_primitives::PublicKey::from(&FarmerPublicKey::unchecked_from(
-            keypair.public.to_bytes(),
-        )),
-        digests_at_4.solution.tag,
-        &digests_at_4.solution.tag_signature,
-    )
-    .unwrap();
-    assert_eq!(
-        header_at_4.salt_derivation_info.maybe_randomness,
-        Some(randomness)
-    );
-
-    let next_salt = derive_next_salt_from_randomness(0, &randomness);
-
-    // edge case when slot between #10 and #11 is long enough that, salt is revealed immediately in the first of block of next eon.
-    // so set the next slot far enough
-    slot = 15;
-    let (header, solution_range, segment_index, records_root) = valid_header_with_next_digests(
-        parent_hash,
-        11,
-        slot,
-        &keypair,
-        true,
-        Some((
-            ancestor_digests.pre_digest.slot,
-            constants.slot_probability,
-            constants.era_duration,
-        )),
-        Some(next_salt),
-    );
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-
-    let res = importer.import_header(header);
-    assert_ok!(res);
-
-    // verify eon index changes at block #11
-    let header_at_11 = importer
-        .store
-        .headers_at_number(11)
-        .first()
-        .cloned()
-        .unwrap();
-
-    // eon index should be 1
-    // since the slot is far enough, the salt should be revealed in this header as well
-    let digests_at_11 =
-        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
-            &header_at_11.header,
-        )
-        .unwrap();
-    let randomness = derive_randomness(
-        &subspace_core_primitives::PublicKey::from(&FarmerPublicKey::unchecked_from(
-            keypair.public.to_bytes(),
-        )),
-        digests_at_11.pre_digest.solution.tag,
-        &digests_at_11.pre_digest.solution.tag_signature,
-    )
-    .unwrap();
-    assert_eq!(header_at_11.salt_derivation_info.eon_index, 1);
-    assert_eq!(
-        header_at_11.salt_derivation_info.maybe_randomness,
-        Some(randomness)
-    );
-
-    parent_hash = header_at_11.header.hash();
-    slot += 1;
-    let (header, solution_range, segment_index, records_root) = valid_header(ValidHeaderParams {
-        parent_hash,
-        number: 12,
-        slot,
+    let (header, _, segment_index, records_root) = valid_header(ValidHeaderParams {
+        parent_hash: Default::default(),
+        number: 1,
+        slot: 1,
         keypair: &keypair,
-        randomness: digests_at_11.next_global_randomness.unwrap(),
-        salt: digests_at_11.next_salt.unwrap(),
-        should_add_next_randomness: false,
-        maybe_next_solution_range: None,
-        maybe_next_salt: None,
-        maybe_derive_salt_from_predigest: None,
+        randomness,
+        salt,
     });
-    importer
-        .store
-        .override_next_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-
-    let res = importer.import_header(header.clone());
-    assert_ok!(res);
-    // best header should be correct
-    let best_header = importer.store.best_header();
-    assert_eq!(best_header.header, header);
-    // randomness should be carried over till next eon change
-    assert_eq!(best_header.salt_derivation_info.eon_index, 1);
-    assert_eq!(
-        best_header.salt_derivation_info.maybe_randomness,
-        Some(randomness)
+    store.store_records_root(segment_index, records_root);
+    let mut importer = HeaderImporter::new(store);
+    assert_err!(
+        importer.import_header(header.clone()),
+        ImportError::MissingParent(header.hash())
     );
-}
-
-fn create_fork_chain_from(
-    importer: &mut HeaderImporter<Header, MockStorage>,
-    parent_hash: HashOf<Header>,
-    from: NumberOf<Header>,
-    until: NumberOf<Header>,
-    slot: u64,
-    keypair: &Keypair,
-) -> (HashOf<Header>, u64) {
-    let best_header_ext = importer.store.best_header();
-    let mut parent_hash = parent_hash;
-    let mut next_slot = slot + 1;
-    for number in from..=until {
-        let (header, solution_range, segment_index, records_root) =
-            valid_header_with_default_randomness_and_salt(parent_hash, number, next_slot, keypair);
-        let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
-            extract_subspace_digest_items(&header).unwrap();
-        let new_weight = HeaderImporter::<Header, MockStorage>::calculate_block_weight(
-            &digests.global_randomness,
-            &digests.pre_digest,
-        );
-        importer
-            .store
-            .override_solution_range(parent_hash, solution_range);
-        importer
-            .store
-            .store_records_root(segment_index, records_root);
-        importer
-            .store
-            .override_cumulative_weight(best_header_ext.header.hash(), new_weight + 1);
-        // override parent weight to 0
-        importer.store.override_cumulative_weight(parent_hash, 0);
-        parent_hash = header.hash();
-        next_slot += 1;
-        if number == 1 {
-            // adjust Chain constants for Block #1
-            let mut constants = importer.store.chain_constants();
-            constants.genesis_digest_items.next_solution_range = solution_range;
-            importer.store.override_constants(constants)
-        }
-        assert_ok!(importer.import_header(header));
-        // best header should not change
-        assert_eq!(importer.store.best_header().header, best_header_ext.header);
-    }
-
-    (parent_hash, next_slot)
 }
 
 #[test]
-fn test_finalized_chain_reorg_to_longer_chain() {
+fn test_header_import_non_canonical() {
+    let constants = default_test_constants();
+    let (store, _genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    let hash_of_2 = add_headers_to_chain(&mut importer, &keypair, 2, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_2);
+
+    // import canonical block 3
+    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 1, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_3);
+    let best_header = importer.store.header(hash_of_3).unwrap();
+    assert_eq!(importer.store.headers_at_number(3).len(), 1);
+
+    // import non canonical block 3
+    add_headers_to_chain(
+        &mut importer,
+        &keypair,
+        1,
+        Some(ForkAt {
+            parent_hash: hash_of_2,
+            is_best: Some(false),
+        }),
+    );
+
+    let best_header_ext = importer.store.best_header();
+    assert_eq!(best_header_ext.header, best_header.header);
+    // we still track the forks
+    assert_eq!(importer.store.headers_at_number(3).len(), 2);
+}
+
+#[test]
+fn test_header_import_canonical() {
+    let constants = default_test_constants();
+    let (store, _genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 5, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_5);
+
+    // import some more canonical blocks
+    let hash_of_25 = add_headers_to_chain(&mut importer, &keypair, 20, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_25);
+    assert_eq!(importer.store.headers_at_number(25).len(), 1);
+}
+
+#[test]
+fn test_header_import_non_canonical_with_equal_block_weight() {
+    let constants = default_test_constants();
+    let (store, _genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    let hash_of_2 = add_headers_to_chain(&mut importer, &keypair, 2, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_2);
+
+    // import canonical block 3
+    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 1, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_3);
+    let best_header = importer.store.header(hash_of_3).unwrap();
+    assert_eq!(importer.store.headers_at_number(3).len(), 1);
+
+    // import non canonical block 3
+    add_headers_to_chain(
+        &mut importer,
+        &keypair,
+        1,
+        Some(ForkAt {
+            parent_hash: hash_of_2,
+            is_best: None,
+        }),
+    );
+
+    let best_header_ext = importer.store.best_header();
+    assert_eq!(best_header_ext.header, best_header.header);
+    // we still track the forks
+    assert_eq!(importer.store.headers_at_number(3).len(), 2);
+}
+
+#[test]
+fn test_chain_reorg_to_longer_chain() {
     let mut constants = default_test_constants();
     constants.k_depth = 4;
-    let mut store = MockStorage::new(constants);
+    let (store, genesis_hash) = initialize_store(constants);
     let keypair = Keypair::generate();
-    let (parent_hash, next_slot) = import_blocks_until(&mut store, 4, 1, &keypair);
-    let best_header = store.best_header();
-    assert_eq!(best_header.header.hash(), parent_hash);
     let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
 
-    // create a fork chain from number 1
-    let genesis_hash = importer.store.headers_at_number(0)[0].header.hash();
-    create_fork_chain_from(&mut importer, genesis_hash, 1, 5, next_slot + 1, &keypair);
-    assert_eq!(best_header.header.hash(), parent_hash);
-    // block 0 should be finalized
-    assert_eq!(importer.store.finalized_header().header.number, 0);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_4);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
+
+    // create a fork chain of 4 headers from number 1
+    add_headers_to_chain(
+        &mut importer,
+        &keypair,
+        4,
+        Some(ForkAt {
+            parent_hash: genesis_hash,
+            is_best: Some(false),
+        }),
+    );
+    assert_eq!(best_header.header.hash(), hash_of_4);
+    // block 0 is still finalized
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
     ensure_finalized_heads_have_no_forks(&importer.store, 0);
 
     // add new best header at 5
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(parent_hash, 5, next_slot, &keypair);
-    importer
-        .store
-        .override_solution_range(parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-    let res = importer.import_header(header.clone());
-    assert_ok!(res);
+    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 1, None);
     let best_header = importer.store.best_header();
-    assert_eq!(best_header.header, header);
+    assert_eq!(best_header.header.hash(), hash_of_5);
 
     // block 1 should be finalized
     assert_eq!(importer.store.finalized_header().header.number, 1);
     ensure_finalized_heads_have_no_forks(&importer.store, 1);
 
-    // create a fork chain from number 5
-    let (fork_parent_hash, fork_next_slot) =
-        create_fork_chain_from(&mut importer, parent_hash, 5, 8, next_slot, &keypair);
+    // create a fork chain from number 5 with block until 8
+    let fork_hash_of_8 = add_headers_to_chain(
+        &mut importer,
+        &keypair,
+        4,
+        Some(ForkAt {
+            parent_hash: hash_of_4,
+            is_best: Some(false),
+        }),
+    );
 
     // best header should still be the same
     assert_eq!(best_header.header, importer.store.best_header().header);
@@ -810,35 +620,16 @@ fn test_finalized_chain_reorg_to_longer_chain() {
     ensure_finalized_heads_have_no_forks(&importer.store, 1);
 
     // import a new head to the fork chain and make it the best.
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(
-            fork_parent_hash,
-            9,
-            fork_next_slot,
-            &keypair,
-        );
-    let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
-        extract_subspace_digest_items(&header).unwrap();
-    let new_weight = HeaderImporter::<Header, MockStorage>::calculate_block_weight(
-        &digests.global_randomness,
-        &digests.pre_digest,
+    let hash_of_9 = add_headers_to_chain(
+        &mut importer,
+        &keypair,
+        1,
+        Some(ForkAt {
+            parent_hash: fork_hash_of_8,
+            is_best: Some(true),
+        }),
     );
-    importer
-        .store
-        .override_solution_range(fork_parent_hash, solution_range);
-    importer
-        .store
-        .store_records_root(segment_index, records_root);
-    importer
-        .store
-        .override_cumulative_weight(importer.store.best_header().header.hash(), new_weight - 1);
-    // override parent weight to 0
-    importer
-        .store
-        .override_cumulative_weight(fork_parent_hash, 0);
-    let res = importer.import_header(header.clone());
-    assert_ok!(res);
-    assert_eq!(importer.store.best_header().header, header);
+    assert_eq!(importer.store.best_header().header.hash(), hash_of_9);
 
     // now the finalized header must be 5
     ensure_finalized_heads_have_no_forks(&importer.store, 5)
@@ -848,45 +639,45 @@ fn test_finalized_chain_reorg_to_longer_chain() {
 fn test_reorg_to_heavier_smaller_chain() {
     let mut constants = default_test_constants();
     constants.k_depth = 4;
-    let mut store = MockStorage::new(constants);
+    let (store, genesis_hash) = initialize_store(constants);
     let keypair = Keypair::generate();
-    let (parent_hash, next_slot) = import_blocks_until(&mut store, 2, 1, &keypair);
-    let best_header = store.best_header();
-    assert_eq!(best_header.header.hash(), parent_hash);
     let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
 
-    // verify and import next headers
-    let mut slot = next_slot;
-    let mut parent_hash = parent_hash;
-    let fork_parent_hash = parent_hash;
-    for number in 3..=5 {
-        let (header, solution_range, segment_index, records_root) =
-            valid_header_with_default_randomness_and_salt(parent_hash, number, slot, &keypair);
-        importer
-            .store
-            .override_solution_range(parent_hash, solution_range);
-        importer
-            .store
-            .store_records_root(segment_index, records_root);
-        let res = importer.import_header(header.clone());
-        assert_ok!(res);
-        // best header should be correct
-        let best_header = importer.store.best_header();
-        assert_eq!(best_header.header, header);
-        slot += 1;
-        parent_hash = header.hash();
-    }
-
-    // finalized head must be best(5) - 4 = 1
-    let number = importer.store.finalized_header().header.number;
-    assert_eq!(number, 1);
+    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 5, None);
+    let best_header = importer.store.best_header();
+    assert_eq!(best_header.header.hash(), hash_of_5);
+    assert_eq!(importer.store.finalized_header().header.number, 1);
 
     // header count at the finalized head must be 1
     ensure_finalized_heads_have_no_forks(&importer.store, 1);
 
     // now import a fork header 3 that becomes canonical
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_default_randomness_and_salt(fork_parent_hash, 3, next_slot + 1, &keypair);
+    let constants = importer.store.chain_constants();
+    let header_at_2 = importer
+        .store
+        .headers_at_number(2)
+        .first()
+        .cloned()
+        .unwrap();
+    let digests_at_2 =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
+            &header_at_2.header,
+        )
+        .unwrap();
+    let (mut header, solution_range, segment_index, records_root) =
+        valid_header(ValidHeaderParams {
+            parent_hash: header_at_2.header.hash(),
+            number: 3,
+            slot: next_slot(constants.slot_probability, digests_at_2.pre_digest.slot).into(),
+            keypair: &keypair,
+            randomness: digests_at_2.global_randomness,
+            salt: digests_at_2.salt,
+        });
+    seal_header(&keypair, &mut header);
     let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
         extract_subspace_digest_items(&header).unwrap();
     let new_weight = HeaderImporter::<Header, MockStorage>::calculate_block_weight(
@@ -895,7 +686,7 @@ fn test_reorg_to_heavier_smaller_chain() {
     );
     importer
         .store
-        .override_solution_range(fork_parent_hash, solution_range);
+        .override_solution_range(header_at_2.header.hash(), solution_range);
     importer
         .store
         .store_records_root(segment_index, records_root);
@@ -905,53 +696,344 @@ fn test_reorg_to_heavier_smaller_chain() {
     // override parent weight to 0
     importer
         .store
-        .override_cumulative_weight(fork_parent_hash, 0);
+        .override_cumulative_weight(header_at_2.header.hash(), 0);
     let res = importer.import_header(header);
     assert_err!(res, ImportError::SwitchedToForkBelowArchivingDepth)
 }
 
 #[test]
-fn test_salt_reveal_and_eon_change_in_same_block() {
+fn test_next_global_randomness_digest() {
+    let mut constants = default_test_constants();
+    constants.global_randomness_interval = 5;
+    let (store, genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
+
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None);
+    assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
+
+    // try to import header with out next global randomness
+    let constants = importer.store.chain_constants();
+    let header_at_4 = importer.store.header(hash_of_4).unwrap();
+    let digests_at_4 =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
+            &header_at_4.header,
+        )
+        .unwrap();
+    let (mut header, solution_range, segment_index, records_root) =
+        valid_header(ValidHeaderParams {
+            parent_hash: header_at_4.header.hash(),
+            number: 5,
+            slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
+            keypair: &keypair,
+            randomness: digests_at_4.global_randomness,
+            salt: digests_at_4.salt,
+        });
+    seal_header(&keypair, &mut header);
+    importer
+        .store
+        .override_solution_range(header_at_4.header.hash(), solution_range);
+    importer
+        .store
+        .store_records_root(segment_index, records_root);
+    importer
+        .store
+        .override_cumulative_weight(header_at_4.header.hash(), 0);
+    let res = importer.import_header(header.clone());
+    assert_err!(
+        res,
+        ImportError::DigestError(DigestError::NextDigestVerificationError(
+            ErrorDigestType::NextGlobalRandomness
+        ))
+    );
+    assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
+
+    // add next global randomness
+    remove_seal(&mut header);
+    let pre_digest = extract_pre_digest(&header).unwrap();
+    let randomness = derive_randomness(
+        &PublicKey::from(&pre_digest.solution.public_key),
+        pre_digest.solution.tag,
+        &pre_digest.solution.tag_signature,
+    )
+    .unwrap();
+    let digests = header.digest_mut();
+    digests.push(DigestItem::next_global_randomness(randomness));
+    seal_header(&keypair, &mut header);
+    let res = importer.import_header(header.clone());
+    assert_ok!(res);
+    assert_eq!(importer.store.best_header().header.hash(), header.hash());
+}
+
+#[test]
+fn test_next_solution_range_digest() {
+    let mut constants = default_test_constants();
+    constants.era_duration = 5;
+    let (store, genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
+
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None);
+    assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
+
+    // try to import header with out next global randomness
+    let constants = importer.store.chain_constants();
+    let header_at_4 = importer.store.header(hash_of_4).unwrap();
+    let digests_at_4 =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
+            &header_at_4.header,
+        )
+        .unwrap();
+    let (mut header, solution_range, segment_index, records_root) =
+        valid_header(ValidHeaderParams {
+            parent_hash: header_at_4.header.hash(),
+            number: 5,
+            slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
+            keypair: &keypair,
+            randomness: digests_at_4.global_randomness,
+            salt: digests_at_4.salt,
+        });
+    seal_header(&keypair, &mut header);
+    importer
+        .store
+        .override_solution_range(header_at_4.header.hash(), solution_range);
+    importer
+        .store
+        .store_records_root(segment_index, records_root);
+    importer
+        .store
+        .override_cumulative_weight(header_at_4.header.hash(), 0);
+    let pre_digest = extract_pre_digest(&header).unwrap();
+    let res = importer.import_header(header.clone());
+    assert_err!(
+        res,
+        ImportError::DigestError(DigestError::NextDigestVerificationError(
+            ErrorDigestType::NextSolutionRange
+        ))
+    );
+    assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
+
+    // add next solution range
+    remove_seal(&mut header);
+    let next_solution_range = subspace_verification::derive_next_solution_range(
+        u64::from(header_at_4.era_start_slot),
+        u64::from(pre_digest.slot),
+        constants.slot_probability,
+        solution_range,
+        constants.era_duration,
+    );
+    let digests = header.digest_mut();
+    digests.push(DigestItem::next_solution_range(next_solution_range));
+    seal_header(&keypair, &mut header);
+    let res = importer.import_header(header.clone());
+    assert_ok!(res);
+    assert_eq!(importer.store.best_header().header.hash(), header.hash());
+}
+
+#[test]
+fn test_next_salt_digest() {
     let mut constants = default_test_constants();
     constants.eon_duration = 10;
     constants.next_salt_reveal_interval = 3;
-    let mut store = MockStorage::new(constants);
+    // slot probability to 1 block a second so that we can predict eon change
+    constants.slot_probability = (1, 1);
+    let (store, genesis_hash) = initialize_store(constants);
     let keypair = Keypair::generate();
-    let (parent_hash, next_slot) = import_blocks_until(&mut store, 1, 0, &keypair);
-    let best_header = store.best_header();
-    assert_eq!(best_header.header.hash(), parent_hash);
     let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
 
-    // verify and import next headers
-    let mut slot = next_slot;
-    let mut parent_hash = parent_hash;
-    for number in 2..=3 {
-        let (header, solution_range, segment_index, records_root) =
-            valid_header_with_default_randomness_and_salt(parent_hash, number, slot, &keypair);
-        importer
-            .store
-            .override_solution_range(parent_hash, solution_range);
-        importer
-            .store
-            .store_records_root(segment_index, records_root);
+    let hash_of_10 = add_headers_to_chain(&mut importer, &keypair, 10, None);
+    let header_at_10 = importer.store.best_header();
+    assert_eq!(header_at_10.header.hash(), hash_of_10);
+    assert_eq!(header_at_10.salt_derivation_info.eon_index, 0);
 
-        let res = importer.import_header(header.clone());
-        assert_ok!(res);
-        // best header should be correct
-        let best_header = importer.store.best_header();
-        assert_eq!(best_header.header, header);
-        slot += 1;
-        parent_hash = header.hash();
-    }
-
+    // salt must been revealed at header_4 so randomness should be empty until 3
     let header_at_3 = importer
         .store
         .headers_at_number(3)
         .first()
         .cloned()
         .unwrap();
+    assert_eq!(header_at_3.salt_derivation_info.eon_index, 0);
+    assert_eq!(header_at_3.salt_derivation_info.maybe_randomness, None);
 
-    // salt reveal number should be empty at header #3
+    // randomness is stored starting from header 4
+    let header_at_4 = importer
+        .store
+        .headers_at_number(4)
+        .first()
+        .cloned()
+        .unwrap();
+    assert_eq!(header_at_4.salt_derivation_info.eon_index, 0);
+    let digests_at_4 = extract_pre_digest(&header_at_4.header).unwrap();
+    let randomness_at_4 = derive_randomness(
+        &PublicKey::from(&digests_at_4.solution.public_key),
+        digests_at_4.solution.tag,
+        &digests_at_4.solution.tag_signature,
+    )
+    .unwrap();
+    assert_eq!(
+        header_at_4.salt_derivation_info.maybe_randomness,
+        Some(randomness_at_4)
+    );
+
+    // try to import header at 11 without next salt
+    let digests_at_10 =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
+            &header_at_10.header,
+        )
+        .unwrap();
+    let (mut header, solution_range, segment_index, records_root) =
+        valid_header(ValidHeaderParams {
+            parent_hash: header_at_10.header.hash(),
+            number: 11,
+            slot: digests_at_10.pre_digest.slot.saturating_add(1u64).into(),
+            keypair: &keypair,
+            randomness: digests_at_10.global_randomness,
+            salt: digests_at_10.salt,
+        });
+    seal_header(&keypair, &mut header);
+    importer
+        .store
+        .override_solution_range(header_at_10.header.hash(), solution_range);
+    importer
+        .store
+        .store_records_root(segment_index, records_root);
+    importer
+        .store
+        .override_cumulative_weight(header_at_10.header.hash(), 0);
+    let res = importer.import_header(header.clone());
+    assert_err!(
+        res,
+        ImportError::DigestError(DigestError::NextDigestVerificationError(
+            ErrorDigestType::NextSalt
+        ))
+    );
+
+    // add next salt and eon index will change
+    remove_seal(&mut header);
+    let next_salt = subspace_verification::derive_next_salt_from_randomness(0, &randomness_at_4);
+    let digests = header.digest_mut();
+    digests.push(DigestItem::next_salt(next_salt));
+    seal_header(&keypair, &mut header);
+    let res = importer.import_header(header.clone());
+    assert_ok!(res);
+    let header_at_11 = importer.store.best_header();
+    assert_eq!(header_at_11.header.hash(), header.hash());
+    assert_eq!(header_at_11.salt_derivation_info.eon_index, 1);
+    assert_eq!(header_at_11.salt_derivation_info.maybe_randomness, None);
+}
+
+#[test]
+fn test_next_salt_reveal_in_same_block_as_eon_change() {
+    let mut constants = default_test_constants();
+    constants.eon_duration = 10;
+    constants.next_salt_reveal_interval = 3;
+    // slot probability to 1 block a second so that we can predict eon change
+    constants.slot_probability = (1, 1);
+    let (store, genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
+
+    let hash_of_10 = add_headers_to_chain(&mut importer, &keypair, 10, None);
+    let header_at_10 = importer.store.best_header();
+    assert_eq!(header_at_10.header.hash(), hash_of_10);
+    assert_eq!(header_at_10.salt_derivation_info.eon_index, 0);
+
+    // header 11 slot is long enough that it missed the salt reveal
+    // hence, next salt for next eon is revealed at block 11 itself
+    let digests_at_10 =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
+            &header_at_10.header,
+        )
+        .unwrap();
+    let (mut header, solution_range, segment_index, records_root) =
+        valid_header(ValidHeaderParams {
+            parent_hash: header_at_10.header.hash(),
+            number: 11,
+            slot: digests_at_10.pre_digest.slot.saturating_add(5u64).into(),
+            keypair: &keypair,
+            randomness: digests_at_10.global_randomness,
+            salt: digests_at_10.salt,
+        });
+    importer
+        .store
+        .override_solution_range(header_at_10.header.hash(), solution_range);
+    importer
+        .store
+        .store_records_root(segment_index, records_root);
+    importer
+        .store
+        .override_cumulative_weight(header_at_10.header.hash(), 0);
+    let header_at_4 = importer
+        .store
+        .headers_at_number(4)
+        .first()
+        .cloned()
+        .unwrap();
+    assert_eq!(header_at_4.salt_derivation_info.eon_index, 0);
+    let digests_at_4 = extract_pre_digest(&header_at_4.header).unwrap();
+    let randomness_at_4 = derive_randomness(
+        &PublicKey::from(&digests_at_4.solution.public_key),
+        digests_at_4.solution.tag,
+        &digests_at_4.solution.tag_signature,
+    )
+    .unwrap();
+    let next_salt = subspace_verification::derive_next_salt_from_randomness(0, &randomness_at_4);
+    let digests = header.digest_mut();
+    digests.push(DigestItem::next_salt(next_salt));
+    seal_header(&keypair, &mut header);
+    let res = importer.import_header(header.clone());
+    assert_ok!(res);
+    let header_at_11 = importer.store.best_header();
+    assert_eq!(header_at_11.header.hash(), header.hash());
+    assert_eq!(header_at_11.salt_derivation_info.eon_index, 1);
+    let digests_at_11 = extract_pre_digest(&header_at_11.header).unwrap();
+    let randomness_at_11 = derive_randomness(
+        &PublicKey::from(&digests_at_11.solution.public_key),
+        digests_at_11.solution.tag,
+        &digests_at_11.solution.tag_signature,
+    )
+    .unwrap();
+    assert_eq!(
+        header_at_11.salt_derivation_info.maybe_randomness,
+        Some(randomness_at_11)
+    );
+}
+
+#[test]
+fn test_current_salt_reveal_and_eon_change_in_same_block() {
+    let mut constants = default_test_constants();
+    constants.eon_duration = 10;
+    constants.next_salt_reveal_interval = 3;
+    // slot probability to 1 block a second so that we can predict eon change
+    constants.slot_probability = (1, 1);
+    let (store, genesis_hash) = initialize_store(constants);
+    let keypair = Keypair::generate();
+    let mut importer = HeaderImporter::new(store);
+    assert_eq!(
+        importer.store.finalized_header().header.hash(),
+        genesis_hash
+    );
+
+    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 3, None);
+    let header_at_3 = importer.store.best_header();
+    assert_eq!(header_at_3.header.hash(), hash_of_3);
     assert_eq!(header_at_3.salt_derivation_info.eon_index, 0);
     assert_eq!(header_at_3.salt_derivation_info.maybe_randomness, None);
 
@@ -959,54 +1041,47 @@ fn test_salt_reveal_and_eon_change_in_same_block() {
     // Salt is revealed
     // eon will be changed
     // next salt is also revealed
-    slot = 15;
-    let (header, solution_range, segment_index, records_root) =
-        valid_header_with_next_salt_revealed_at_this_header(
-            parent_hash,
-            4,
-            slot,
-            &keypair,
-            Some(0),
-        );
+    let digests_at_3 =
+        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
+            &header_at_3.header,
+        )
+        .unwrap();
+    let (mut header, solution_range, segment_index, records_root) =
+        valid_header(ValidHeaderParams {
+            parent_hash: header_at_3.header.hash(),
+            number: 4,
+            slot: digests_at_3.pre_digest.slot.saturating_add(8u64).into(),
+            keypair: &keypair,
+            randomness: digests_at_3.global_randomness,
+            salt: digests_at_3.salt,
+        });
     importer
         .store
-        .override_solution_range(parent_hash, solution_range);
+        .override_solution_range(header_at_3.header.hash(), solution_range);
     importer
         .store
         .store_records_root(segment_index, records_root);
-
-    let res = importer.import_header(header);
-    assert_ok!(res);
-
-    // verify eon index changeed and also next salt is revealed
-    let header_at_4 = importer
+    importer
         .store
-        .headers_at_number(4)
-        .first()
-        .cloned()
-        .unwrap();
-
-    let digests_at_4 =
-        extract_subspace_digest_items::<_, FarmerPublicKey, FarmerPublicKey, FarmerSignature>(
-            &header_at_4.header,
-        )
-        .unwrap();
-
-    let randomness = derive_randomness(
-        &subspace_core_primitives::PublicKey::from(&FarmerPublicKey::unchecked_from(
-            keypair.public.to_bytes(),
-        )),
-        digests_at_4.pre_digest.solution.tag,
-        &digests_at_4.pre_digest.solution.tag_signature,
+        .override_cumulative_weight(header_at_3.header.hash(), 0);
+    let digests_at_4 = extract_pre_digest(&header).unwrap();
+    let randomness_at_4 = derive_randomness(
+        &PublicKey::from(&digests_at_4.solution.public_key),
+        digests_at_4.solution.tag,
+        &digests_at_4.solution.tag_signature,
     )
     .unwrap();
+    let next_salt = subspace_verification::derive_next_salt_from_randomness(0, &randomness_at_4);
+    let digests = header.digest_mut();
+    digests.push(DigestItem::next_salt(next_salt));
+    seal_header(&keypair, &mut header);
+    let res = importer.import_header(header.clone());
+    assert_ok!(res);
 
-    // eon index has changed
+    let header_at_4 = importer.store.best_header();
+    assert_eq!(header_at_4.header.hash(), header.hash());
     assert_eq!(header_at_4.salt_derivation_info.eon_index, 1);
-    assert_eq!(
-        header_at_4.salt_derivation_info.maybe_randomness,
-        Some(randomness)
-    );
+    assert_eq!(header_at_4.salt_derivation_info.maybe_randomness, None);
 }
 
 // TODO: Tests for locked solution range and override

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -265,7 +265,7 @@ fn add_next_digests(store: &MockStorage, number: NumberOf<Header>, header: &mut 
             .maybe_randomness
             .or_else(|| {
                 HeaderImporter::<Header, MockStorage>::randomness_for_next_salt(
-                    store.chain_constants(),
+                    &store.chain_constants(),
                     parent_header.salt_derivation_info.eon_index,
                     parent_header.genesis_slot,
                     &digests.pre_digest,


### PR DESCRIPTION
This PR brings following changes as individual commits
- Track genesis slot in header instead of fetching it from block 1 when required.
	- This is useful when we make light client storage bound and not rely on potentially pruned headers 
- Rework on tests to realistic header slots based on slot probability and header generation
- Add test cases for enable solution range digests

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
