### PR TITLE
Storage bound for light client

### DIFF
--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -872,7 +872,11 @@ pub fn verify_next_digests<Header: HeaderT>(
     if let Some(updated_root_plot_public_key) = &header_digests.root_plot_public_key_update {
         match updated_root_plot_public_key {
             Some(updated_root_plot_public_key) => {
-                if number.is_one() && root_plot_public_key.is_none() {
+                if number.is_one()
+                    && root_plot_public_key.is_none()
+                    && &header_digests.pre_digest.solution.public_key
+                        == updated_root_plot_public_key
+                {
                     root_plot_public_key.replace(updated_root_plot_public_key.clone());
                 } else {
                     return Err(Error::NextDigestVerificationError(

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -51,7 +51,7 @@ mod tests;
 mod mock;
 
 /// Chain constants.
-#[derive(Debug, Clone)]
+#[derive(Debug, Encode, Decode, Clone, TypeInfo)]
 pub struct ChainConstants<Header: HeaderT> {
     /// K Depth at which we finalize the heads.
     pub k_depth: NumberOf<Header>,
@@ -81,6 +81,19 @@ pub struct ChainConstants<Header: HeaderT> {
 
     /// Interval after the eon change when next eon salt is revealed
     pub next_salt_reveal_interval: u64,
+
+    /// Storage bound for the light client store.
+    pub storage_bound: StorageBound<NumberOf<Header>>,
+}
+
+/// Defines the storage bound for the light client store.
+#[derive(Default, Debug, Encode, Decode, TypeInfo, Clone)]
+pub enum StorageBound<Number> {
+    /// Keeps all the headers in the storage.
+    #[default]
+    Unbounded,
+    /// Keeps only # number of headers beyond K depth.
+    NumberOfHeaderToKeepBeyondKDepth(Number),
 }
 
 /// Data that is useful to derive the next salt.
@@ -119,7 +132,7 @@ pub struct HeaderExt<Header> {
 }
 
 /// Type to hold next digest items present in parent header that are used to verify the immediate descendant.
-#[derive(Debug, Clone, Default)]
+#[derive(Default, Debug, Encode, Decode, Clone, TypeInfo)]
 pub struct NextDigestItems {
     next_global_randomness: Randomness,
     next_solution_range: SolutionRange,

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -482,9 +482,10 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
 
         self.store.store_header(header_ext, is_best_header);
 
-        // finalize and prune forks if the chain has progressed
+        // finalize, prune forks, and ensure storage is bounded if the chain has progressed
         if is_best_header {
             self.finalize_header_at_k_depth()?;
+            self.ensure_storage_bound();
         }
 
         Ok(())
@@ -970,6 +971,48 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
 
                 Ok(())
             }
+        }
+    }
+
+    /// Ensure light client storage is bounded by the defined storage bound constant.
+    /// If unbounded, we keep all the finalized headers in the store.
+    /// If bounded, we fetch the finalized head and then prune all the headers
+    /// beyond K depth as per bounded value.
+    /// If finalized head is at x and storage is bounded to keep y headers beyond, then
+    /// prune all headers at and below (x - y - 1)
+    fn ensure_storage_bound(&mut self) {
+        let storage_bound = self.store.chain_constants().storage_bound;
+        let number_of_headers_to_keep_beyond_k_depth = match storage_bound {
+            // unbounded storage, so return
+            StorageBound::Unbounded => return,
+            // bounded storage, keep only # number of headers beyond K depth
+            StorageBound::NumberOfHeaderToKeepBeyondKDepth(number_of_headers_to_keep) => {
+                number_of_headers_to_keep
+            }
+        };
+
+        let finalized_head_number = *self.store.finalized_header().header.number();
+        // (finalized_number - bound_value - 1)
+        let mut maybe_prune_headers_from_number = finalized_head_number
+            .checked_sub(&number_of_headers_to_keep_beyond_k_depth)
+            .and_then(|number| number.checked_sub(&One::one()));
+
+        let mut headers_to_prune = maybe_prune_headers_from_number
+            .map(|number| self.store.headers_at_number(number))
+            .unwrap_or_default();
+
+        while !headers_to_prune.is_empty() {
+            // loop and prune even though there should be only 1 head beyond finalized head
+            for header in headers_to_prune {
+                self.store.prune_header(header.header.hash())
+            }
+
+            maybe_prune_headers_from_number =
+                maybe_prune_headers_from_number.and_then(|number| number.checked_sub(&One::one()));
+
+            headers_to_prune = maybe_prune_headers_from_number
+                .map(|number| self.store.headers_at_number(number))
+                .unwrap_or_default();
         }
     }
 }

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -51,6 +51,7 @@ fn default_test_constants() -> ChainConstants<Header> {
         slot_probability: (1, 6),
         eon_duration: 20,
         next_salt_reveal_interval: 6,
+        storage_bound: Default::default(),
     }
 }
 


### PR DESCRIPTION
This PR brings following changes
- Storage bound for light client
	- This bound ensures # number of headers are kept beyond K depth
- Add tests for root plot public key

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
