### PR TITLE
Fix plotting blocked by commitments creation

### DIFF
--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -249,6 +249,7 @@ pub struct SinglePlotPlotter {
     codec: SubspaceCodec,
     plot: Plot,
     commitments: Commitments,
+    #[allow(dead_code)]
     single_disk_semaphore: SingleDiskSemaphore,
 }
 
@@ -277,8 +278,10 @@ impl SinglePlotPlotter {
 
         let pieces = Arc::new(pieces);
 
-        // Limit concurrent updates on the same disk
-        let _guard = self.single_disk_semaphore.acquire();
+        // TODO: Restore limiting when better approach is figured out, right now commitments
+        //  creation blocks plotting of new pieces, which is not desirable
+        // // Limit concurrent updates on the same disk
+        // let _guard = self.single_disk_semaphore.acquire();
 
         let write_result = self.plot.write_many(pieces, piece_indexes)?;
 


### PR DESCRIPTION
The issue here is that plotting and commitments compete for the same semaphore, causing previously resolved issue where recommitments make it impossible for plotting to work.

I decided to just remove it as it is not 100% clear whether it will be non-issue later or this will not be necessary in the first place.

Alternative solution is to introduce more than one concurrency semaphore or introduce more complex semaphore that can allow plotting even when fully occupied by commitments, but I rejected that as too complex for now.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
