### PR TITLE
Use jemalloc allocator on the farmer to fix memory usage issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,6 +2915,27 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.1+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2b313609b95939cb0c5a5c6917fb9b7c9394562aa3ef44eb66ffa51736432"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -7877,6 +7904,7 @@ dependencies = [
  "fs2",
  "futures 0.3.21",
  "hex",
+ "jemallocator",
  "jsonrpsee",
  "libc",
  "lru",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -58,6 +58,10 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 zeroize = "1.5.7"
 
+# The only triple tested and confirmed as working in `jemallocator` crate is `x86_64-unknown-linux-gnu`
+[target.'cfg(all(target_arch = "x86_64", target_vendor = "unknown", target_os = "linux", target_env = "gnu"))'.dependencies]
+jemallocator = "0.5.0"
+
 [features]
 default = []
 # Compile with OpenCL support and use it if compatible GPU is available

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -22,6 +22,15 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
+#[cfg(all(
+    target_arch = "x86_64",
+    target_vendor = "unknown",
+    target_os = "linux",
+    target_env = "gnu"
+))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[derive(Debug, Clone, Copy, ArgEnum)]
 enum ArchivingFrom {
     /// Sync from node using RPC endpoint (recommended)


### PR DESCRIPTION
This reduced RAM usage by the farmer on Linux. Other platforms are not guaranteed to work properly from what I understand of readme (even though they compile), so I didn't enable it for anything else yet.

Before/after comparison on Gemini 2a sync example:
System allocator: peak memory usage ~6.7G, ~6.7G settled idle
jemalloc: peak memory usage ~3.5G, ~3.1G settled idle (and continues trickling down over time, 2.9G already)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
