### PR TITLE
Fix handling of solution range override during adjustment enabling

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1065,6 +1065,9 @@ impl<T: Config> Pallet<T> {
                         solution_range,
                         voting_solution_range,
                     });
+                    frame_system::Pallet::<T>::deposit_log(DigestItem::next_solution_range(
+                        solution_range,
+                    ));
                 }
             });
         }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 3,
+    spec_version: 4,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,


### PR DESCRIPTION
This allows us to resume block production on Gemini 2a after solution range adjustment was enabled with an override.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
