### PR TITLE
Decrease batch size of writing the commitments

### DIFF
--- a/crates/subspace-farmer/src/commitments.rs
+++ b/crates/subspace-farmer/src/commitments.rs
@@ -22,8 +22,8 @@ use tracing::trace;
 /// Number of pieces to read at once during commitments creation (16MiB)
 const PLOT_READ_BATCH_SIZE: u64 = (16 * 1024 * 1024 / PIECE_SIZE) as u64;
 const PIECE_OFFSET_SIZE: usize = mem::size_of::<PieceOffset>();
-/// Number of commitments to store in memory before writing as a batch to disk (16MiB)
-const TAGS_WRITE_BATCH_SIZE: usize = 16 * 1024 * 1024 / (TAG_SIZE + PIECE_OFFSET_SIZE);
+/// Number of commitments to store in memory before writing as a batch to disk (4MiB)
+const TAGS_WRITE_BATCH_SIZE: usize = 4 * 1024 * 1024 / (TAG_SIZE + PIECE_OFFSET_SIZE);
 
 #[derive(Debug, Error)]
 pub enum CommitmentError {


### PR DESCRIPTION
This pr should fix memory issues with parity-db.

I haven't tested syncing the chain, but with example from [this](https://github.com/paritytech/parity-db/issues/93) issue I've got following results.

For 8 threads and commitments databases for system allocator, peak memory usage dropped from 12G to 7G. As for the jemalloc it went down from 7.8G to 4.3G.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
