### PR TITLE
Use `serde` when `serde` feature is enabled, not `std` in `subspace-core-primitives`

### DIFF
--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -132,9 +132,9 @@ const VRF_PROOF_LENGTH: usize = 64;
 #[derive(
     Debug, Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo,
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PublicKey(
-    #[cfg_attr(feature = "std", serde(with = "hex::serde"))] [u8; PUBLIC_KEY_LENGTH],
+    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; PUBLIC_KEY_LENGTH],
 );
 
 impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
@@ -165,9 +165,9 @@ impl AsRef<[u8]> for PublicKey {
 
 /// A Ristretto Schnorr signature as bytes produced by `schnorrkel` crate.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RewardSignature(
-    #[cfg_attr(feature = "std", serde(with = "serde_arrays"))] [u8; REWARD_SIGNATURE_LENGTH],
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))] [u8; REWARD_SIGNATURE_LENGTH],
 );
 
 impl From<[u8; REWARD_SIGNATURE_LENGTH]> for RewardSignature {
@@ -198,23 +198,23 @@ impl AsRef<[u8]> for RewardSignature {
 
 /// VRF signature output and proof as produced by `schnorrkel` crate.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TagSignature {
     /// VRF output bytes.
     pub output: [u8; VRF_OUTPUT_LENGTH],
     /// VRF proof bytes.
-    #[cfg_attr(feature = "std", serde(with = "serde_arrays"))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
     pub proof: [u8; VRF_PROOF_LENGTH],
 }
 
 /// VRF signature output and proof as produced by `schnorrkel` crate.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LocalChallenge {
     /// VRF output bytes.
     pub output: [u8; VRF_OUTPUT_LENGTH],
     /// VRF proof bytes.
-    #[cfg_attr(feature = "std", serde(with = "serde_arrays"))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
     pub proof: [u8; VRF_PROOF_LENGTH],
 }
 
@@ -224,7 +224,7 @@ pub struct LocalChallenge {
 /// the segment this piece belongs to can be used to verify that a piece belongs to the actual
 /// archival history of the blockchain.
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Piece(Vec<u8>);
 
 impl Default for Piece {
@@ -283,7 +283,7 @@ impl AsMut<[u8]> for Piece {
 
 /// Flat representation of multiple pieces concatenated for higher efficient for processing.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FlatPieces(Vec<u8>);
 
 impl FlatPieces {
@@ -368,8 +368,8 @@ impl AsMut<[u8]> for FlatPieces {
 
 /// Progress of an archived block.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum ArchivedBlockProgress {
     /// The block has been fully archived.
     Complete,
@@ -403,8 +403,8 @@ impl ArchivedBlockProgress {
 
 /// Last archived block
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct LastArchivedBlock {
     /// Block number
     pub number: u32,
@@ -436,12 +436,12 @@ impl LastArchivedBlock {
 /// root blocks that is used for quick and efficient verification that some [`Piece`] corresponds to
 /// the actual archival history of the blockchain.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum RootBlock {
     /// V0 of the root block data structure
     #[codec(index = 0)]
-    #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
         /// Segment index
         segment_index: SegmentIndex,
@@ -531,8 +531,8 @@ impl PieceIndexHash {
 // TODO: Versioned solution enum
 /// Farmer solution for slot challenge.
 #[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Solution<PublicKey, RewardAddress> {
     /// Public key of the farmer that created the solution
     pub public_key: PublicKey,

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -32,8 +32,8 @@ use serde::{Deserialize, Serialize};
 
 /// Object stored inside of the block
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum BlockObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
@@ -72,8 +72,8 @@ impl BlockObject {
 
 /// Mapping of objects stored inside of the block
 #[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BlockObjectMapping {
     /// Objects stored inside of the block
     pub objects: Vec<BlockObject>,
@@ -81,8 +81,8 @@ pub struct BlockObjectMapping {
 
 /// Object stored inside of the block
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum PieceObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
@@ -112,8 +112,8 @@ impl PieceObject {
 
 /// Mapping of objects stored inside of the piece
 #[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PieceObjectMapping {
     /// Objects stored inside of the block
     pub objects: Vec<PieceObject>,
@@ -121,8 +121,8 @@ pub struct PieceObjectMapping {
 
 /// Object stored inside in the history of the blockchain
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum GlobalObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]


### PR DESCRIPTION
We may potentially want to have `serde` without `std`, so better be more specific about it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
