### PR TITLE
Refactor archiving-related APIs to use `u32` instead of `usize`

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1467,7 +1467,8 @@ fn check_vote<T: Config>(
             * 2,
     );
     let segment_index = solution.piece_index / merkle_num_leaves;
-    let position = solution.piece_index % merkle_num_leaves;
+    let position = u32::try_from(solution.piece_index % merkle_num_leaves)
+        .expect("Position within segment always fits into u32; qed");
 
     let records_root = if let Some(records_root) = Pallet::<T>::records_root(segment_index) {
         records_root

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -345,8 +345,7 @@ pub fn create_root_block(segment_index: SegmentIndex) -> RootBlock {
 }
 
 pub fn create_archived_segment() -> ArchivedSegment {
-    let mut archiver =
-        Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize).unwrap();
+    let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE).unwrap();
 
     let mut block = vec![0u8; 1024 * 1024];
     rand::thread_rng().fill(block.as_mut_slice());

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -218,8 +218,8 @@ where
         ));
 
         Archiver::with_initial_state(
-            RECORD_SIZE as usize,
-            RECORDED_HISTORY_SEGMENT_SIZE as usize,
+            RECORD_SIZE,
+            RECORDED_HISTORY_SEGMENT_SIZE,
             last_root_block,
             &last_archived_block.encode(),
             block_object_mappings,
@@ -228,7 +228,7 @@ where
     } else {
         info!(target: "subspace", "Starting archiving from genesis");
 
-        Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize)
+        Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE)
             .expect("Incorrect parameters for archiver")
     };
 

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -212,7 +212,8 @@ where
 
             let max_plot_size = runtime_api.max_plot_size(&parent_block_id).ok()?;
             let segment_index = solution.piece_index / u64::from(MERKLE_NUM_LEAVES);
-            let position = solution.piece_index % u64::from(MERKLE_NUM_LEAVES);
+            let position = u32::try_from(solution.piece_index % u64::from(MERKLE_NUM_LEAVES))
+                .expect("Position within segment always fits into u32; qed");
             let mut maybe_records_root = runtime_api
                 .records_root(&parent_block_id, segment_index)
                 .ok()?;

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -433,7 +433,7 @@ fn rejects_empty_block() {
 fn get_archived_pieces(client: &TestClient) -> Vec<FlatPieces> {
     let genesis_block_id = BlockId::Number(Zero::zero());
 
-    let mut archiver = Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize)
+    let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE)
         .expect("Incorrect parameters for archiver");
 
     let genesis_block = client.block(&genesis_block_id).unwrap().unwrap();

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -389,8 +389,10 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
         let max_plot_size = self.store.chain_constants().max_plot_size;
         let segment_index =
             header_digests.pre_digest.solution.piece_index / u64::from(MERKLE_NUM_LEAVES);
-        let position =
-            header_digests.pre_digest.solution.piece_index % u64::from(MERKLE_NUM_LEAVES);
+        let position = u32::try_from(
+            header_digests.pre_digest.solution.piece_index % u64::from(MERKLE_NUM_LEAVES),
+        )
+        .expect("Position within segment always fits into u32; qed");
         let records_root =
             self.find_records_root_for_segment_index(segment_index, parent_header.header.hash())?;
         let total_pieces = self.total_pieces(parent_header.header.hash())?;

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -68,8 +68,7 @@ fn valid_piece(pub_key: schnorrkel::PublicKey) -> (Piece, u64, SegmentIndex, Rec
     let mut block = vec![0u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
     rng.fill(block.as_mut_slice());
 
-    let mut archiver =
-        Archiver::new(RECORD_SIZE as usize, RECORDED_HISTORY_SEGMENT_SIZE as usize).unwrap();
+    let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE).unwrap();
 
     let archived_segment = archiver
         .add_block(block, Default::default())
@@ -89,8 +88,8 @@ fn valid_piece(pub_key: schnorrkel::PublicKey) -> (Piece, u64, SegmentIndex, Rec
     assert!(subspace_archiving::archiver::is_piece_valid(
         piece,
         archived_segment.root_block.records_root(),
-        position,
-        RECORD_SIZE as usize,
+        position as u32,
+        RECORD_SIZE,
     ));
 
     let codec = SubspaceCodec::new(pub_key.as_ref());

--- a/crates/subspace-archiving/benches/archiving.rs
+++ b/crates/subspace-archiving/benches/archiving.rs
@@ -14,11 +14,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("archiving-2-blocks", |b| {
         b.iter(|| {
-            let mut archiver = Archiver::new(
-                RECORD_SIZE.try_into().unwrap(),
-                RECORDED_HISTORY_SEGMENT_SIZE.try_into().unwrap(),
-            )
-            .unwrap();
+            let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE).unwrap();
             for _ in 0..2 {
                 archiver.add_block(input.clone(), Default::default());
             }

--- a/crates/subspace-archiving/src/merkle_tree.rs
+++ b/crates/subspace-archiving/src/merkle_tree.rs
@@ -68,7 +68,7 @@ type InternalMerkleTree = merkle_light::merkle::MerkleTree<Blake2b256Hash, Blake
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Witness<'a> {
     /// Number of leaves in the Merkle Tree that corresponds to this witness
-    merkle_num_leaves: usize,
+    merkle_num_leaves: u32,
     /// The witness itself
     witness: Cow<'a, [u8]>,
 }
@@ -82,19 +82,14 @@ impl<'a> Witness<'a> {
         }
 
         Ok(Self {
-            merkle_num_leaves: 2_usize.pow((witness.len() / BLAKE2B_256_HASH_SIZE) as u32),
+            merkle_num_leaves: 2_u32.pow((witness.len() / BLAKE2B_256_HASH_SIZE) as u32),
             witness,
         })
     }
 
     /// Check whether witness is valid for a specific leaf hash (none of these parameters are stored
     /// in the witness itself) given its position within a segment
-    pub fn is_valid(
-        &self,
-        root: Blake2b256Hash,
-        position: usize,
-        leaf_hash: Blake2b256Hash,
-    ) -> bool {
+    pub fn is_valid(&self, root: Blake2b256Hash, position: u32, leaf_hash: Blake2b256Hash) -> bool {
         if position >= self.merkle_num_leaves {
             return false;
         }
@@ -118,7 +113,7 @@ impl<'a> Witness<'a> {
         // There is no path inside of witness, but by knowing position and number of leaves we can
         // recover it
         let path = {
-            let mut path = Vec::with_capacity(self.merkle_num_leaves);
+            let mut path = Vec::with_capacity(self.merkle_num_leaves as usize);
             let mut local_position = position;
 
             for _ in 0..self.merkle_num_leaves.ilog2() {

--- a/crates/subspace-archiving/tests/integration/merkle_tree.rs
+++ b/crates/subspace-archiving/tests/integration/merkle_tree.rs
@@ -24,9 +24,13 @@ fn merkle_tree() {
 
         assert_eq!(witness, merkle_tree_hashes.get_witness(position).unwrap());
 
-        assert!(witness.is_valid(root, position, *hashes.get(position).unwrap()));
-        assert!(!witness.is_valid(rand::random(), position, *hashes.get(position).unwrap()));
-        assert!(!witness.is_valid(root, position, rand::random()));
+        assert!(witness.is_valid(root, position as u32, *hashes.get(position).unwrap()));
+        assert!(!witness.is_valid(
+            rand::random(),
+            position as u32,
+            *hashes.get(position).unwrap()
+        ));
+        assert!(!witness.is_valid(root, position as u32, rand::random()));
         assert!(!witness.is_valid(root, rand::random(), *hashes.get(position).unwrap()));
     }
 

--- a/crates/subspace-farmer/src/single_plot_farm.rs
+++ b/crates/subspace-farmer/src/single_plot_farm.rs
@@ -870,13 +870,14 @@ impl<RC: RpcClient> VerifyingPlotter<RC> {
 
         // Perform an actual piece validity check
         for ((piece, piece_index), root) in pieces.as_pieces().zip(piece_indexes).zip(roots) {
-            let position: u64 = piece_index % merkle_num_leaves;
+            let position = u32::try_from(piece_index % merkle_num_leaves)
+                .expect("Position within segment always fits into u32; qed");
 
             if !is_piece_valid(
                 piece,
                 root,
-                position as usize,
-                self.farmer_protocol_info.record_size.get() as usize,
+                position,
+                self.farmer_protocol_info.record_size.get(),
             ) {
                 error!(?piece_index, "Piece validation failed.");
 

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -19,10 +19,10 @@ use subspace_solving::{create_tag, SubspaceCodec};
 use tempfile::TempDir;
 use tracing::error;
 
-const MERKLE_NUM_LEAVES: usize = 8_usize;
-const WITNESS_SIZE: usize = BLAKE2B_256_HASH_SIZE * MERKLE_NUM_LEAVES.ilog2() as usize; // 96
-const RECORD_SIZE: usize = PIECE_SIZE - WITNESS_SIZE; // 4000
-const SEGMENT_SIZE: usize = RECORD_SIZE * MERKLE_NUM_LEAVES / 2; // 16000
+const MERKLE_NUM_LEAVES: u32 = 8;
+const WITNESS_SIZE: u32 = BLAKE2B_256_HASH_SIZE as u32 * MERKLE_NUM_LEAVES.ilog2(); // 96
+const RECORD_SIZE: u32 = PIECE_SIZE as u32 - WITNESS_SIZE; // 4000
+const SEGMENT_SIZE: u32 = RECORD_SIZE * MERKLE_NUM_LEAVES / 2; // 16000
 
 fn init() {
     let _ = tracing_subscriber::fmt::try_init();
@@ -59,8 +59,8 @@ async fn plotting_happy_path() {
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE).unwrap();
     let farmer_protocol_info = FarmerProtocolInfo {
         genesis_hash: [0; 32],
-        record_size: NonZeroU32::new(RECORD_SIZE as u32).unwrap(),
-        recorded_history_segment_size: SEGMENT_SIZE as u32,
+        record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
+        recorded_history_segment_size: SEGMENT_SIZE,
         max_plot_size: u64::MAX,
         total_pieces: 0,
     };
@@ -72,8 +72,8 @@ async fn plotting_happy_path() {
         .await
         .expect("Could not retrieve farmer_protocol_info");
 
-    let encoded_block0 = vec![0u8; SEGMENT_SIZE / 2];
-    let encoded_block1 = vec![1u8; SEGMENT_SIZE / 2];
+    let encoded_block0 = vec![0u8; SEGMENT_SIZE as usize / 2];
+    let encoded_block1 = vec![1u8; SEGMENT_SIZE as usize / 2];
     let encoded_blocks = vec![encoded_block0, encoded_block1];
 
     // This test does not concern with the object mappings at the moment.
@@ -178,12 +178,12 @@ async fn plotting_piece_eviction() {
         .expect("Could not retrieve farmer_protocol_info");
 
     let encoded_block0 = {
-        let mut block = vec![0u8; SEGMENT_SIZE];
+        let mut block = vec![0u8; SEGMENT_SIZE as usize];
         rng.fill(block.as_mut_slice());
         block
     };
     let encoded_block1 = {
-        let mut block = vec![0u8; SEGMENT_SIZE];
+        let mut block = vec![0u8; SEGMENT_SIZE as usize];
         rng.fill(block.as_mut_slice());
         block
     };

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -150,11 +150,8 @@ where
     let best_block_number = client.info().best_number;
     let mut link = WaitLink::new();
     let mut imported_blocks = 0;
-    let mut reconstructor = Reconstructor::new(
-        usize::try_from(RECORD_SIZE).expect("16-bit platform is not supported"),
-        usize::try_from(RECORDED_HISTORY_SEGMENT_SIZE).expect("16-bit platform is not supported"),
-    )
-    .map_err(|error| sc_service::Error::Other(error.to_string()))?;
+    let mut reconstructor = Reconstructor::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE)
+        .map_err(|error| sc_service::Error::Other(error.to_string()))?;
 
     let merkle_num_leaves = u64::from(RECORDED_HISTORY_SEGMENT_SIZE / RECORD_SIZE * 2);
 

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -100,7 +100,7 @@ fn check_piece_tag<FarmerPublicKey, RewardAddress>(
 /// If `records_root` is `None`, piece validity check will be skipped.
 pub fn check_piece<'a, FarmerPublicKey, RewardAddress>(
     records_root: Blake2b256Hash,
-    position: u64,
+    position: u32,
     record_size: u32,
     solution: &'a Solution<FarmerPublicKey, RewardAddress>,
 ) -> Result<(), Error>
@@ -116,12 +116,7 @@ where
         .decode(&mut piece, solution.piece_index)
         .map_err(|_| Error::InvalidPieceEncoding)?;
 
-    if !archiver::is_piece_valid(
-        &piece,
-        records_root,
-        position as usize,
-        record_size as usize,
-    ) {
+    if !archiver::is_piece_valid(&piece, records_root, position, record_size) {
         return Err(Error::InvalidPiece);
     }
 
@@ -164,7 +159,7 @@ pub struct PieceCheckParams {
     /// Records root of segment to which piece belongs
     pub records_root: RecordsRoot,
     /// Position of the piece in the segment
-    pub position: u64,
+    pub position: u32,
     /// Record size, system parameter
     pub record_size: u32,
     /// Maximum plot size in bytes, system parameter

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -193,11 +193,9 @@ where
 {
     let genesis_block_id = BlockId::Number(sp_runtime::traits::Zero::zero());
 
-    let mut archiver = subspace_archiving::archiver::Archiver::new(
-        RECORD_SIZE as usize,
-        RECORDED_HISTORY_SEGMENT_SIZE as usize,
-    )
-    .expect("Incorrect parameters for archiver");
+    let mut archiver =
+        subspace_archiving::archiver::Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE)
+            .expect("Incorrect parameters for archiver");
 
     let genesis_block = client.block(&genesis_block_id).unwrap().unwrap();
     archiver


### PR DESCRIPTION
This is refactoring towards future changes that make `u32` the canonical way of addressing things in archiving instead of relying on variable size `usize` for important things. There are still conversions to/from `usize`, but they are not an issue since we don't support 16-bit platforms anyway and all values are guaranteed to fit in 32-bit address space.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
