### PR TITLE
Larger piece size

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -134,7 +134,7 @@ impl pallet_offences_subspace::Config for Test {
 pub const SLOT_PROBABILITY: (u64, u64) = (3, 10);
 
 pub const INITIAL_SOLUTION_RANGE: SolutionRange =
-    u64::MAX / (1024 * 1024 * 1024 / 4096) * SLOT_PROBABILITY.0 / SLOT_PROBABILITY.1;
+    u64::MAX / (1024 * 1024 * 1024 / PIECE_SIZE as u64) * SLOT_PROBABILITY.0 / SLOT_PROBABILITY.1;
 
 parameter_types! {
     pub const GlobalRandomnessUpdateInterval: u64 = 10;

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -350,7 +350,7 @@ pub fn create_archived_segment() -> ArchivedSegment {
     let kzg = Kzg::new(kzg::test_public_parameters());
     let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg).unwrap();
 
-    let mut block = vec![0u8; 1024 * 1024];
+    let mut block = vec![0u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
     rand::thread_rng().fill(block.as_mut_slice());
     archiver
         .add_block(block, Default::default())

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -32,7 +32,7 @@ use subspace_core_primitives::objects::{
 };
 use subspace_core_primitives::{
     crypto, ArchivedBlockProgress, Blake2b256Hash, BlockNumber, FlatPieces, LastArchivedBlock,
-    RootBlock, BLAKE2B_256_HASH_SIZE, PIECE_SIZE, WITNESS_SIZE,
+    RootBlock, BLAKE2B_256_HASH_SIZE, WITNESS_SIZE,
 };
 
 const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
@@ -147,12 +147,6 @@ pub enum ArchiverInstantiationError {
         error("Segment size is not a multiple of record size")
     )]
     SegmentSizesNotMultipleOfRecordSize,
-    /// Wrong record and segment size, it will not be possible to produce pieces
-    #[cfg_attr(
-        feature = "thiserror",
-        error("Wrong record and segment size, it will not be possible to produce pieces")
-    )]
-    WrongRecordAndSegmentCombination,
     /// Invalid last archived block, its size is the same as encoded block
     #[cfg_attr(
         feature = "thiserror",
@@ -242,10 +236,6 @@ impl Archiver {
         }
         if segment_size % record_size != 0 {
             return Err(ArchiverInstantiationError::SegmentSizesNotMultipleOfRecordSize);
-        }
-
-        if record_size + WITNESS_SIZE != PIECE_SIZE as u32 {
-            return Err(ArchiverInstantiationError::WrongRecordAndSegmentCombination);
         }
 
         let data_shards = segment_size / record_size;
@@ -745,7 +735,7 @@ pub fn is_piece_valid(
     position: u32,
     record_size: u32,
 ) -> bool {
-    if piece.len() != PIECE_SIZE {
+    if piece.len() != (record_size + WITNESS_SIZE) as usize {
         return false;
     }
 

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -8,7 +8,6 @@ use parity_scale_codec::Decode;
 use reed_solomon_erasure::galois_16::ReedSolomon;
 use subspace_core_primitives::{
     ArchivedBlockProgress, BlockNumber, LastArchivedBlock, Piece, RootBlock, SegmentIndex,
-    PIECE_SIZE, WITNESS_SIZE,
 };
 
 /// Reconstructor-related instantiation error.
@@ -27,12 +26,6 @@ pub enum ReconstructorInstantiationError {
         error("Segment size is not a multiple of record size")
     )]
     SegmentSizesNotMultipleOfRecordSize,
-    /// Wrong record and segment size, it will not be possible to produce pieces
-    #[cfg_attr(
-        feature = "thiserror",
-        error("Wrong record and segment size, it will not be possible to produce pieces")
-    )]
-    WrongRecordAndSegmentCombination,
 }
 
 /// Reconstructor-related instantiation error
@@ -95,10 +88,6 @@ impl Reconstructor {
         }
         if segment_size % record_size != 0 {
             return Err(ReconstructorInstantiationError::SegmentSizesNotMultipleOfRecordSize);
-        }
-
-        if record_size + WITNESS_SIZE != PIECE_SIZE as u32 {
-            return Err(ReconstructorInstantiationError::WrongRecordAndSegmentCombination);
         }
 
         let data_shards = segment_size / record_size;

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -313,11 +313,6 @@ fn invalid_usage() {
         Err(ArchiverInstantiationError::SegmentSizesNotMultipleOfRecordSize),
     );
 
-    assert_matches!(
-        Archiver::new(17, 34, kzg.clone()),
-        Err(ArchiverInstantiationError::WrongRecordAndSegmentCombination),
-    );
-
     {
         let result = Archiver::with_initial_state(
             RECORD_SIZE,

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -48,7 +48,7 @@ fn archiver() {
             .as_mut()
             .write_all(&Compact(100_u64).encode())
             .unwrap();
-        block[7000..]
+        block[SEGMENT_SIZE as usize / 3..]
             .as_mut()
             .write_all(&Compact(128_u64).encode())
             .unwrap();
@@ -60,7 +60,7 @@ fn archiver() {
                 },
                 BlockObject::V0 {
                     hash: Blake2b256Hash::default(),
-                    offset: 7000u32,
+                    offset: SEGMENT_SIZE / 3,
                 },
             ],
         };
@@ -74,15 +74,15 @@ fn archiver() {
 
     let (block_1, block_1_object_mapping) = {
         let mut block = rand::random::<[u8; SEGMENT_SIZE as usize / 3 * 2]>().to_vec();
-        block[100..]
+        block[SEGMENT_SIZE as usize / 6..]
             .as_mut()
             .write_all(&Compact(100_u64).encode())
             .unwrap();
-        block[1000..]
+        block[SEGMENT_SIZE as usize / 5..]
             .as_mut()
             .write_all(&Compact(2048_u64).encode())
             .unwrap();
-        block[10000..]
+        block[SEGMENT_SIZE as usize / 3 * 2 - 200..]
             .as_mut()
             .write_all(&Compact(100_u64).encode())
             .unwrap();
@@ -90,15 +90,15 @@ fn archiver() {
             objects: vec![
                 BlockObject::V0 {
                     hash: Blake2b256Hash::default(),
-                    offset: 100u32,
+                    offset: SEGMENT_SIZE / 6,
                 },
                 BlockObject::V0 {
                     hash: Blake2b256Hash::default(),
-                    offset: 1000u32,
+                    offset: SEGMENT_SIZE / 5,
                 },
                 BlockObject::V0 {
                     hash: Blake2b256Hash::default(),
-                    offset: 10000u32,
+                    offset: SEGMENT_SIZE / 3 * 2 - 200,
                 },
             ],
         };
@@ -121,7 +121,7 @@ fn archiver() {
     {
         let last_archived_block = first_archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 1);
-        assert_eq!(last_archived_block.partial_archived(), Some(8088));
+        assert_eq!(last_archived_block.partial_archived(), Some(65428));
     }
 
     // 4 objects fit into the first segment
@@ -208,13 +208,13 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(13377));
+        assert_eq!(last_archived_block.partial_archived(), Some(108945));
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(29463));
+        assert_eq!(last_archived_block.partial_archived(), Some(239719));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -248,7 +248,7 @@ fn archiver() {
     }
 
     // Add a block such that it fits in the next segment exactly
-    let block_3 = rand::random::<[u8; SEGMENT_SIZE as usize - 3030]>().to_vec();
+    let block_3 = rand::random::<[u8; SEGMENT_SIZE as usize - 22154]>().to_vec();
     let archived_segments = archiver.add_block(block_3.clone(), BlockObjectMapping::default());
     assert_eq!(archived_segments.len(), 1);
 
@@ -375,24 +375,39 @@ fn invalid_usage() {
     }
 }
 
+// WARNING: Tests for various edge cases below use deliberately computed values and unless
+// calculated carefully on piece size change (decrease from current 32kiB) will be unable to catch
+// edge-cases. Please check commits where this tests are introduced for the edge cases they are
+// testing (filling encoded segment) and ensure they still test those edge cases in case you have to
+// decrease piece size in the future.
+
 #[test]
 fn one_byte_smaller_segment() {
     let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
-    let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg).unwrap();
 
     // Carefully compute the block size such that there is just 2 bytes left to fill the segment,
     // but this should already produce archived segment since just enum variant and smallest compact
     // vector length encoding will take 2 bytes to encode, thus it will be impossible to slice
     // internal bytes of the segment item anyway
     assert_eq!(
-        archiver
+        Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg.clone())
+            .unwrap()
             .add_block(
-                vec![0u8; SEGMENT_SIZE as usize - 7],
+                vec![0u8; SEGMENT_SIZE as usize - 9],
                 BlockObjectMapping::default()
             )
             .len(),
         1
     );
+    // Cutting just one byte more is not sufficient to produce a segment, this is a protection
+    // against code regressions
+    assert!(Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg)
+        .unwrap()
+        .add_block(
+            vec![0u8; SEGMENT_SIZE as usize - 10],
+            BlockObjectMapping::default()
+        )
+        .is_empty());
 }
 
 #[test]
@@ -403,7 +418,7 @@ fn spill_over_edge_case() {
     // Carefully compute the block size such that there is just 3 byte left to fill the segment
     assert!(archiver
         .add_block(
-            vec![0u8; SEGMENT_SIZE as usize - 8],
+            vec![0u8; SEGMENT_SIZE as usize - 10],
             BlockObjectMapping::default()
         )
         .is_empty());
@@ -414,7 +429,7 @@ fn spill_over_edge_case() {
     // subtracting with overflow when trying to slice internal bytes of the segment item
     assert_eq!(
         archiver
-            .add_block(vec![0u8; 2_usize.pow(14)], BlockObjectMapping::default())
+            .add_block(vec![0u8; 2_usize.pow(17)], BlockObjectMapping::default())
             .len(),
         2
     );
@@ -494,6 +509,6 @@ fn object_on_the_edge_of_segment() {
     // This will only need to be adjusted when implementation changes
     assert_eq!(
         archived_segment[1].object_mapping[0].objects[0].offset(),
-        104
+        108
     );
 }

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -319,11 +319,6 @@ fn invalid_usage() {
         Err(ReconstructorInstantiationError::SegmentSizesNotMultipleOfRecordSize),
     );
 
-    assert_matches!(
-        Reconstructor::new(17, 34),
-        Err(ReconstructorInstantiationError::WrongRecordAndSegmentCombination),
-    );
-
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg).unwrap();
     // Block that overflows into the next segments
     let block_0 = rand::random::<[u8; SEGMENT_SIZE as usize * 4]>().to_vec();

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -80,7 +80,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 1,
-                archived_progress: ArchivedBlockProgress::Partial(8088)
+                archived_progress: ArchivedBlockProgress::Partial(65428)
             }
         );
 
@@ -99,7 +99,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 1,
-                archived_progress: ArchivedBlockProgress::Partial(8088)
+                archived_progress: ArchivedBlockProgress::Partial(65428)
             }
         );
     }
@@ -119,7 +119,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(3928)
+                archived_progress: ArchivedBlockProgress::Partial(32592)
             }
         );
 
@@ -138,7 +138,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(3928)
+                archived_progress: ArchivedBlockProgress::Partial(32592)
             }
         );
     }
@@ -158,7 +158,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(20014)
+                archived_progress: ArchivedBlockProgress::Partial(163366)
             }
         );
     }
@@ -179,7 +179,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(20014)
+                archived_progress: ArchivedBlockProgress::Partial(163366)
             }
         );
     }
@@ -199,7 +199,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(36100)
+                archived_progress: ArchivedBlockProgress::Partial(294140)
             }
         );
     }
@@ -220,7 +220,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(36100)
+                archived_progress: ArchivedBlockProgress::Partial(294140)
             }
         );
     }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -43,10 +43,10 @@ use serde::{Deserialize, Serialize};
 /// Size of BLAKE2b-256 hash output (in bytes).
 pub const BLAKE2B_256_HASH_SIZE: usize = 32;
 
-/// Byte size of a piece in Subspace Network, 4KiB.
+/// Byte size of a piece in Subspace Network, 32KiB.
 ///
 /// This can not changed after the network is launched.
-pub const PIECE_SIZE: usize = 4096;
+pub const PIECE_SIZE: usize = 32 * 1024;
 /// Size of witness for a segment record (in bytes).
 pub const WITNESS_SIZE: u32 = 48;
 /// Size of a segment record given the global piece size (in bytes).
@@ -249,7 +249,7 @@ impl TryFrom<&[u8]> for Piece {
     type Error = &'static str;
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         if slice.len() != PIECE_SIZE {
-            Err("Wrong piece size, expected: 4096")
+            Err("Wrong piece size, expected: 32768")
         } else {
             Ok(Self(slice.to_vec()))
         }

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -90,7 +90,7 @@ pub enum PieceObject {
         /// Object hash
         hash: Blake2b256Hash,
         /// Offset of the object
-        offset: u16,
+        offset: u32,
     },
 }
 
@@ -103,7 +103,7 @@ impl PieceObject {
     }
 
     /// Offset of the object
-    pub fn offset(&self) -> u16 {
+    pub fn offset(&self) -> u32 {
         match self {
             Self::V0 { offset, .. } => *offset,
         }
@@ -130,7 +130,7 @@ pub enum GlobalObject {
         /// Piece index where object is contained (at least its beginning, might not fit fully)
         piece_index: u64,
         /// Offset of the object
-        offset: u16,
+        offset: u32,
     },
 }
 
@@ -143,7 +143,7 @@ impl GlobalObject {
     }
 
     /// Offset of the object
-    pub fn offset(&self) -> u16 {
+    pub fn offset(&self) -> u32 {
         match self {
             Self::V0 { offset, .. } => *offset,
         }

--- a/crates/subspace-farmer/benches/plot-write.rs
+++ b/crates/subspace-farmer/benches/plot-write.rs
@@ -7,8 +7,8 @@ use tempfile::TempDir;
 
 #[tokio::main]
 async fn main() {
-    let batch_size = 4096; // 16M
-    let piece_count = 2u64.pow(20); // 4G
+    let batch_size = 16 * 1024 * 1024 / PIECE_SIZE as u64; // 16M
+    let piece_count = 4 * 1024 * 1024 * 1024 / PIECE_SIZE as u64; // 4G
     let base_directory = TempDir::new_in(std::env::current_dir().unwrap()).unwrap();
 
     let mut pieces = vec![0u8; batch_size as usize * PIECE_SIZE];

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -21,7 +21,7 @@ fn create() {
 
     let pieces: FlatPieces = vec![9u8; PIECE_SIZE].try_into().unwrap();
     let salt: Salt = [1u8; 8];
-    let correct_tag: Tag = [236, 70, 144, 186, 210, 167, 219, 49];
+    let correct_tag: Tag = [239, 33, 205, 166, 75, 168, 171, 137];
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
     let plot = Plot::open_or_create(

--- a/crates/subspace-farmer/src/commitments/tests.rs
+++ b/crates/subspace-farmer/src/commitments/tests.rs
@@ -19,7 +19,7 @@ fn create() {
     init();
     let base_directory = TempDir::new().unwrap();
 
-    let pieces: FlatPieces = vec![9u8; 4096].try_into().unwrap();
+    let pieces: FlatPieces = vec![9u8; PIECE_SIZE].try_into().unwrap();
     let salt: Salt = [1u8; 8];
     let correct_tag: Tag = [236, 70, 144, 186, 210, 167, 219, 49];
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
@@ -147,7 +147,7 @@ fn remove_commitments() {
     init();
     let base_directory = TempDir::new().unwrap();
 
-    let pieces: FlatPieces = vec![9u8; 4096].try_into().unwrap();
+    let pieces: FlatPieces = vec![9u8; PIECE_SIZE].try_into().unwrap();
     let salt: Salt = [1u8; 8];
     let correct_tag: Tag = [23, 245, 162, 52, 107, 135, 192, 210];
     let solution_range = u64::from_be_bytes([0xff_u8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);

--- a/crates/subspace-farmer/src/dsn/tests.rs
+++ b/crates/subspace-farmer/src/dsn/tests.rs
@@ -538,7 +538,7 @@ async fn get_pieces_by_range_smoke() {
     let piece_index_end = PieceIndexHash::from(crypto::blake2b_256_hash(b"end"));
 
     fn get_pieces_to_plot_mock(seed: u8) -> PiecesToPlot {
-        let piece_bytes: Vec<u8> = [seed; 4096].to_vec();
+        let piece_bytes: Vec<u8> = [seed; PIECE_SIZE].to_vec();
         let flat_pieces = FlatPieces::try_from(piece_bytes).unwrap();
 
         PiecesToPlot {

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -10,7 +10,9 @@ use futures::{SinkExt, StreamExt};
 use std::num::NonZeroU16;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Salt, SolutionRange, Tag, BLAKE2B_256_HASH_SIZE};
+use subspace_core_primitives::{
+    FlatPieces, Salt, SolutionRange, Tag, BLAKE2B_256_HASH_SIZE, PIECE_SIZE,
+};
 use subspace_rpc_primitives::SlotInfo;
 use tempfile::TempDir;
 use tokio::time::{sleep, Duration};
@@ -27,7 +29,7 @@ async fn farming_simulator(slots: Vec<SlotInfo>, tags: Vec<Tag>) {
     let identity =
         Identity::open_or_create(&base_directory).expect("Could not open/create identity!");
 
-    let pieces: FlatPieces = vec![9u8; 4096].try_into().unwrap();
+    let pieces: FlatPieces = vec![9u8; PIECE_SIZE].try_into().unwrap();
     let salt: Salt = slots[0].salt; // the first slots salt should be used for the initial commitments
 
     let public_key = identity.public_key().to_bytes().into();

--- a/crates/subspace-farmer/src/farming/tests.rs
+++ b/crates/subspace-farmer/src/farming/tests.rs
@@ -126,7 +126,7 @@ async fn farming_happy_path() {
     };
     let slots = vec![slot_info];
 
-    let correct_tag: Tag = [236, 70, 144, 186, 210, 167, 219, 49];
+    let correct_tag: Tag = [239, 33, 205, 166, 75, 168, 171, 137];
     let tags = vec![correct_tag];
 
     farming_simulator(slots, tags).await;
@@ -160,9 +160,9 @@ async fn farming_salt_change() {
     };
     let slots = vec![first_slot, second_slot, third_slot];
 
-    let first_tag: Tag = [236, 70, 144, 186, 210, 167, 219, 49];
-    let second_tag: Tag = [236, 70, 144, 186, 210, 167, 219, 49];
-    let third_tag: Tag = [45, 146, 164, 29, 29, 179, 126, 171];
+    let first_tag: Tag = [239, 33, 205, 166, 75, 168, 171, 137];
+    let second_tag: Tag = [239, 33, 205, 166, 75, 168, 171, 137];
+    let third_tag: Tag = [7, 86, 27, 30, 212, 133, 146, 144];
     let tags = vec![first_tag, second_tag, third_tag];
 
     farming_simulator(slots, tags).await;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -20,7 +20,7 @@
 //!   and value is an offset of corresponding encoded piece in the plot (we can do this because all
 //!   pieces have the same size).
 //!
-//! In short, for every 4096 bytes we also store a record with 8-bytes tag and 8-bytes index (+some
+//! In short, for every piece we also store a record with 8-bytes tag and 8-bytes index (+some
 //! overhead of RocksDB itself).
 //!
 //! During farming we receive a global challenge and need to find a solution based on *target* and

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -85,7 +85,7 @@ pub struct SubspaceCodec {
 }
 
 impl SubspaceCodec {
-    /// New instance with 256-bit prime and 4096-byte genesis piece size
+    /// New instance with 256-bit prime
     pub fn new(farmer_public_key: &[u8]) -> Self {
         Self {
             farmer_public_key_hash: crypto::blake2b_256_hash(farmer_public_key),
@@ -98,8 +98,7 @@ impl SubspaceCodec {
         }
     }
 
-    /// New instance with 256-bit prime and 4096-byte genesis piece size, try to use GPU if
-    /// available
+    /// New instance with 256-bit prime, try to use GPU if available
     pub fn new_with_gpu(farmer_public_key: &[u8]) -> Self {
         #[cfg(feature = "opencl")]
         let opencl_encoder = Arc::new(Mutex::new(

--- a/crates/subspace-solving/src/codec.rs
+++ b/crates/subspace-solving/src/codec.rs
@@ -73,6 +73,7 @@ fn mix_public_key_hash_with_piece_index(public_key_hash: &mut [u8], piece_index:
         });
 }
 
+// TODO: This is a dummy encoder now, but will likely go away in the future or will be replaced
 /// Subspace codec is used to encode pieces of archived history before writing them to disk and also
 /// to decode them after reading from disk.
 #[derive(Debug, Clone)]
@@ -128,7 +129,9 @@ impl SubspaceCodec {
         piece: &mut [u8],
         piece_index: PieceIndex,
     ) -> Result<(), cpu::EncodeError> {
-        cpu::encode(piece, &self.create_expanded_iv(piece_index), ENCODE_ROUNDS)
+        // TODO
+        let _ = cpu::encode(piece, &self.create_expanded_iv(piece_index), ENCODE_ROUNDS);
+        Ok(())
     }
 
     /// Number of elements processed efficiently during one iteration of batched encoding.
@@ -220,7 +223,9 @@ impl SubspaceCodec {
         piece: &mut [u8],
         piece_index: PieceIndex,
     ) -> Result<(), cpu::DecodeError> {
-        cpu::decode(piece, &self.create_expanded_iv(piece_index), ENCODE_ROUNDS)
+        // TODO
+        let _ = cpu::decode(piece, &self.create_expanded_iv(piece_index), ENCODE_ROUNDS);
+        Ok(())
     }
 
     fn create_expanded_iv(&self, piece_index: PieceIndex) -> Blake2b256Hash {
@@ -240,7 +245,11 @@ impl SubspaceCodec {
         pieces
             .par_chunks_exact_mut(PIECE_SIZE)
             .zip_eq(piece_indexes)
-            .try_for_each(|(piece, &piece_index)| self.encode(piece, piece_index))
+            .try_for_each(|(piece, &piece_index)| {
+                // TODO
+                let _ = self.encode(piece, piece_index);
+                Ok(())
+            })
     }
 
     #[cfg(not(feature = "std"))]
@@ -252,7 +261,11 @@ impl SubspaceCodec {
         pieces
             .chunks_exact_mut(PIECE_SIZE)
             .zip(piece_indexes)
-            .try_for_each(|(piece, &piece_index)| self.encode(piece, piece_index))
+            .try_for_each(|(piece, &piece_index)| {
+                // TODO
+                let _ = self.encode(piece, piece_index);
+                Ok(())
+            })
     }
 
     #[cfg(feature = "opencl")]
@@ -273,6 +286,8 @@ impl SubspaceCodec {
                 mix_public_key_hash_with_piece_index(expanded_iv, piece_index);
             });
 
-        opencl_encoder.encode(pieces, &expanded_ivs, ENCODE_ROUNDS)
+        // TODO
+        let _ = opencl_encoder.encode(pieces, &expanded_ivs, ENCODE_ROUNDS);
+        Ok(())
     }
 }

--- a/crates/subspace-solving/tests/integration/codec.rs
+++ b/crates/subspace-solving/tests/integration/codec.rs
@@ -1,48 +1,49 @@
-use std::iter;
-use subspace_core_primitives::{FlatPieces, PIECE_SIZE};
-use subspace_solving::SubspaceCodec;
-
-#[test]
-fn single_piece() {
-    let public_key = rand::random::<[u8; 32]>();
-    let original_piece = rand::random::<[u8; PIECE_SIZE]>();
-    let piece_index = rand::random();
-
-    let subspace_codec = SubspaceCodec::new_with_gpu(&public_key);
-    let mut piece = original_piece;
-
-    subspace_codec.encode(&mut piece, piece_index).unwrap();
-    assert_ne!(original_piece, piece);
-
-    subspace_codec.decode(&mut piece, piece_index).unwrap();
-    assert_eq!(original_piece, piece);
-}
-
-#[test]
-fn batch() {
-    let public_key = rand::random::<[u8; 32]>();
-    let subspace_codec = SubspaceCodec::new_with_gpu(&public_key);
-    // Use 2.5 batches worth of pieces
-    let piece_count = subspace_codec.batch_size() * 2 + subspace_codec.batch_size() / 2;
-
-    let mut pieces = FlatPieces::new(piece_count);
-    for piece in pieces.as_pieces_mut() {
-        piece.copy_from_slice(&rand::random::<[u8; PIECE_SIZE]>());
-    }
-    let original_pieces = pieces.clone();
-    let piece_indexes: Vec<u64> = iter::repeat_with(rand::random).take(piece_count).collect();
-
-    subspace_codec
-        .batch_encode(&mut pieces, &piece_indexes)
-        .unwrap();
-
-    for ((original_piece, piece), piece_index) in original_pieces
-        .as_pieces()
-        .zip(pieces.as_pieces_mut())
-        .zip(piece_indexes)
-    {
-        assert_ne!(original_piece, piece);
-        subspace_codec.decode(piece, piece_index).unwrap();
-        assert_eq!(original_piece, piece);
-    }
-}
+// TODO: Unlock once codec is fixed
+// use std::iter;
+// use subspace_core_primitives::{FlatPieces, PIECE_SIZE};
+// use subspace_solving::SubspaceCodec;
+//
+// #[test]
+// fn single_piece() {
+//     let public_key = rand::random::<[u8; 32]>();
+//     let original_piece = rand::random::<[u8; PIECE_SIZE]>();
+//     let piece_index = rand::random();
+//
+//     let subspace_codec = SubspaceCodec::new_with_gpu(&public_key);
+//     let mut piece = original_piece;
+//
+//     subspace_codec.encode(&mut piece, piece_index).unwrap();
+//     assert_ne!(original_piece, piece);
+//
+//     subspace_codec.decode(&mut piece, piece_index).unwrap();
+//     assert_eq!(original_piece, piece);
+// }
+//
+// #[test]
+// fn batch() {
+//     let public_key = rand::random::<[u8; 32]>();
+//     let subspace_codec = SubspaceCodec::new_with_gpu(&public_key);
+//     // Use 2.5 batches worth of pieces
+//     let piece_count = subspace_codec.batch_size() * 2 + subspace_codec.batch_size() / 2;
+//
+//     let mut pieces = FlatPieces::new(piece_count);
+//     for piece in pieces.as_pieces_mut() {
+//         piece.copy_from_slice(&rand::random::<[u8; PIECE_SIZE]>());
+//     }
+//     let original_pieces = pieces.clone();
+//     let piece_indexes: Vec<u64> = iter::repeat_with(rand::random).take(piece_count).collect();
+//
+//     subspace_codec
+//         .batch_encode(&mut pieces, &piece_indexes)
+//         .unwrap();
+//
+//     for ((original_piece, piece), piece_index) in original_pieces
+//         .as_pieces()
+//         .zip(pieces.as_pieces_mut())
+//         .zip(piece_indexes)
+//     {
+//         assert_ne!(original_piece, piece);
+//         subspace_codec.decode(piece, piece_index).unwrap();
+//         assert_eq!(original_piece, piece);
+//     }
+// }


### PR DESCRIPTION
Here I increase piece size from 4kiB to 32kiB.

There were certain assumptions in various places in the code that I had to tweak to make it work, also during archiving process byte vectors with SCALE codec had to start using 4-byte length prefix that required updating tests again (having such opportunity I also improved them a bit).

Further piece size increases should be less painful (we are very unlikely to decrease it, which is good) and fixed size commitment scheme means that witness doesn't change either.

@rg3l3dr I tried to make piece size generic in the archiving, but it just spreads all over the codebase, so for benchmarking purposes we'll have to modify a constant and ignore failing tests while doing so (benchmark should still work just fine).

`sloth256-189` is designed to work with 4kiB pieces, so for now it is turned into no-op codec with tests ignored. Will either be removed completely soon or refactored into different codec, we'll see.

Resolves https://github.com/subspace/subspace/issues/817

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
