### PR TITLE
Merge receipt into bundle (part 2)

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -90,6 +90,7 @@ mod pallet {
         UnexpectedSigner,
         /// Invalid transaction bundle signature.
         BadSignature,
+        /// An invalid execution receipt found in the bundle.
         Receipt(ExecutionReceiptError),
     }
 
@@ -101,12 +102,8 @@ mod pallet {
 
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug)]
     pub enum ExecutionReceiptError {
-        /// The signer of execution receipt is unexpected.
-        UnexpectedSigner,
         /// The parent execution receipt is unknown.
         MissingParent,
-        /// Invalid execution receipt signature.
-        BadSignature,
         /// The execution receipt is stale.
         Stale,
         /// The execution receipt points to a block unknown to the history.
@@ -115,12 +112,6 @@ mod pallet {
         TooFarInFuture,
         /// Receipts are not in ascending order.
         Unsorted,
-    }
-
-    impl<T> From<ExecutionReceiptError> for Error<T> {
-        fn from(e: ExecutionReceiptError) -> Self {
-            Self::ExecutionReceipt(e)
-        }
     }
 
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug)]
@@ -141,8 +132,6 @@ mod pallet {
     pub enum Error<T> {
         /// Invalid bundle.
         Bundle(BundleError),
-        /// Invalid execution receipt.
-        ExecutionReceipt(ExecutionReceiptError),
         /// Invalid fraud proof.
         FraudProof(FraudProofError),
     }

--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -16,6 +16,7 @@
 //! Pallet Executor
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(is_sorted)]
 
 #[cfg(test)]
 mod tests;
@@ -112,6 +113,8 @@ mod pallet {
         UnknownBlock,
         /// The execution receipt is too far in the future.
         TooFarInFuture,
+        /// Receipts are not in ascending order.
+        Unsorted,
     }
 
     impl<T> From<ExecutionReceiptError> for Error<T> {
@@ -179,7 +182,9 @@ mod pallet {
                 signed_opaque_bundle
             );
 
-            Self::apply_execution_receipt(&signed_opaque_bundle.bundle.receipt);
+            for receipt in &signed_opaque_bundle.bundle.receipts {
+                Self::apply_execution_receipt(receipt);
+            }
 
             Self::deposit_event(Event::TransactionBundleStored {
                 bundle_hash: signed_opaque_bundle.hash(),
@@ -350,7 +355,7 @@ mod pallet {
             match call {
                 Call::submit_transaction_bundle {
                     signed_opaque_bundle,
-                } => Self::pre_dispatch_execution_receipt(&signed_opaque_bundle.bundle.receipt),
+                } => Self::pre_dispatch_execution_receipts(&signed_opaque_bundle.bundle.receipts),
                 Call::submit_fraud_proof { .. } => Ok(()),
                 Call::submit_bundle_equivocation_proof { .. } => Ok(()),
                 Call::submit_invalid_transaction_proof { .. } => Ok(()),
@@ -371,11 +376,17 @@ mod pallet {
                         );
                         return InvalidTransactionCode::Bundle.into();
                     }
-                    let primary_number = signed_opaque_bundle.bundle.receipt.primary_number;
+
+                    let first_primary_number = signed_opaque_bundle
+                        .bundle
+                        .receipts
+                        .get(0)
+                        .expect("Receipts in a bundle must be non-empty; qed")
+                        .primary_number;
 
                     let builder = ValidTransaction::with_tag_prefix("SubspaceSubmitBundle")
                         .priority(TransactionPriority::MAX)
-                        .and_provides(primary_number)
+                        .and_provides(first_primary_number)
                         .longevity(TransactionLongevity::MAX)
                         .propagate(true);
 
@@ -383,10 +394,12 @@ mod pallet {
                     // number above.
                     //
                     // No requires if it's the next expected execution chain number.
-                    if primary_number == ExecutionChainBestNumber::<T>::get() + One::one() {
+                    if first_primary_number == ExecutionChainBestNumber::<T>::get() + One::one() {
                         builder.build()
                     } else {
-                        builder.and_requires(primary_number - One::one()).build()
+                        builder
+                            .and_requires(first_primary_number - One::one())
+                            .build()
                     }
                 }
                 Call::submit_fraud_proof { fraud_proof } => {
@@ -448,64 +461,84 @@ mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
-    fn pre_dispatch_execution_receipt(
-        execution_receipt: &ExecutionReceipt<T::BlockNumber, T::Hash, T::SecondaryHash>,
+    fn pre_dispatch_execution_receipts(
+        execution_receipts: &[ExecutionReceipt<T::BlockNumber, T::Hash, T::SecondaryHash>],
     ) -> Result<(), TransactionValidityError> {
-        let primary_number = execution_receipt.primary_number;
-        let best_number = ExecutionChainBestNumber::<T>::get();
+        let mut best_number = ExecutionChainBestNumber::<T>::get();
 
-        // Ensure the block number of next execution receipt is `best_number + 1`.
-        if primary_number != best_number + One::one() {
-            if primary_number <= best_number {
-                return Err(InvalidTransaction::Stale.into());
-            } else {
-                return Err(InvalidTransaction::Future.into());
+        for execution_receipt in execution_receipts {
+            let primary_number = execution_receipt.primary_number;
+
+            // Ensure the block number of next execution receipt is `best_number + 1`.
+            if primary_number != best_number + One::one() {
+                if primary_number <= best_number {
+                    return Err(InvalidTransaction::Stale.into());
+                } else {
+                    return Err(InvalidTransaction::Future.into());
+                }
             }
-        }
 
-        // TODO: is this check unnecessary as it's actually guaranteed by the above one?
-        // Ensure the parent receipt exists after block #1.
-        if primary_number > One::one() {
-            ensure!(
-                Receipts::<T>::get(primary_number - One::one()).is_some(),
-                TransactionValidityError::Invalid(InvalidTransactionCode::ExecutionReceipt.into())
-            );
+            // TODO: is this check unnecessary as it's actually guaranteed by the above one?
+            // Ensure the parent receipt exists after block #1.
+            if primary_number > One::one() {
+                ensure!(
+                    Receipts::<T>::get(primary_number - One::one()).is_some(),
+                    TransactionValidityError::Invalid(
+                        InvalidTransactionCode::ExecutionReceipt.into()
+                    )
+                );
+            }
+
+            best_number += One::one();
         }
 
         Ok(())
     }
 
-    fn validate_execution_receipt(
-        execution_receipt: &ExecutionReceipt<T::BlockNumber, T::Hash, T::SecondaryHash>,
+    fn validate_execution_receipts(
+        execution_receipts: &[ExecutionReceipt<T::BlockNumber, T::Hash, T::SecondaryHash>],
     ) -> Result<(), ExecutionReceiptError> {
+        if !execution_receipts
+            .iter()
+            .map(|r| r.primary_number)
+            .is_sorted()
+        {
+            return Err(ExecutionReceiptError::Unsorted);
+        }
+
         let current_block_number = frame_system::Pallet::<T>::current_block_number();
 
-        // Due to `initialize_block` is skipped while calling the runtime api, the block
-        // hash mapping for last block is unknown to the transaction pool, but this info
-        // is already available in System.
-        let point_to_parent_block = execution_receipt.primary_number
-            == current_block_number - One::one()
-            && execution_receipt.primary_hash == frame_system::Pallet::<T>::parent_hash();
+        let mut best_number = ExecutionChainBestNumber::<T>::get();
 
-        if !point_to_parent_block
-            && BlockHash::<T>::get(execution_receipt.primary_number)
-                != execution_receipt.primary_hash
-        {
-            return Err(ExecutionReceiptError::UnknownBlock);
-        }
+        for execution_receipt in execution_receipts {
+            // Due to `initialize_block` is skipped while calling the runtime api, the block
+            // hash mapping for last block is unknown to the transaction pool, but this info
+            // is already available in System.
+            let point_to_parent_block = execution_receipt.primary_number
+                == current_block_number - One::one()
+                && execution_receipt.primary_hash == frame_system::Pallet::<T>::parent_hash();
 
-        // Ensure the receipt is neither old nor too new.
-        let primary_number = execution_receipt.primary_number;
+            if !point_to_parent_block
+                && BlockHash::<T>::get(execution_receipt.primary_number)
+                    != execution_receipt.primary_hash
+            {
+                return Err(ExecutionReceiptError::UnknownBlock);
+            }
 
-        let best_number = ExecutionChainBestNumber::<T>::get();
-        if primary_number <= best_number {
-            return Err(ExecutionReceiptError::Stale);
-        }
+            // Ensure the receipt is neither old nor too new.
+            let primary_number = execution_receipt.primary_number;
 
-        if primary_number == current_block_number
-            || primary_number > best_number + T::MaximumReceiptDrift::get()
-        {
-            return Err(ExecutionReceiptError::TooFarInFuture);
+            if primary_number <= best_number {
+                return Err(ExecutionReceiptError::Stale);
+            }
+
+            if primary_number == current_block_number
+                || primary_number > best_number + T::MaximumReceiptDrift::get()
+            {
+                return Err(ExecutionReceiptError::TooFarInFuture);
+            }
+
+            best_number += One::one();
         }
 
         Ok(())
@@ -530,7 +563,7 @@ impl<T: Config> Pallet<T> {
             return Err(BundleError::UnexpectedSigner);
         }
 
-        Self::validate_execution_receipt(&bundle.receipt).map_err(BundleError::Receipt)?;
+        Self::validate_execution_receipts(&bundle.receipts).map_err(BundleError::Receipt)?;
 
         Ok(())
     }

--- a/crates/sp-executor/src/lib.rs
+++ b/crates/sp-executor/src/lib.rs
@@ -104,8 +104,8 @@ impl<Hash: Encode> BundleHeader<Hash> {
 pub struct Bundle<Extrinsic, Number, Hash, SecondaryHash> {
     /// The bundle header.
     pub header: BundleHeader<Hash>,
-    /// Next expected receipt by the primay chain when the bundle was created.
-    pub receipt: ExecutionReceipt<Number, Hash, SecondaryHash>,
+    /// Expected receipts by the primay chain when the bundle was created.
+    pub receipts: Vec<ExecutionReceipt<Number, Hash, SecondaryHash>>,
     /// The accompanying extrinsics.
     pub extrinsics: Vec<Extrinsic>,
 }
@@ -130,7 +130,7 @@ impl<Extrinsic: Encode, Number, Hash, SecondaryHash>
     pub fn into_opaque_bundle(self) -> OpaqueBundle<Number, Hash, SecondaryHash> {
         let Bundle {
             header,
-            receipt,
+            receipts,
             extrinsics,
         } = self;
         let opaque_extrinsics = extrinsics
@@ -142,7 +142,7 @@ impl<Extrinsic: Encode, Number, Hash, SecondaryHash>
             .collect();
         OpaqueBundle {
             header,
-            receipt,
+            receipts,
             extrinsics: opaque_extrinsics,
         }
     }

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -111,7 +111,7 @@ async fn execution_proof_creation_and_verification_should_work() {
             .iter()
             .map(|xt| OpaqueExtrinsic::from_bytes(&xt.encode()).unwrap())
             .collect(),
-        receipt: dummy_receipt,
+        receipts: vec![dummy_receipt],
     }];
 
     let primary_info = if alice.client.info().best_number == ferdie.client.info().best_number {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -560,11 +560,12 @@ fn extract_receipts(
                 signed_opaque_bundle,
             }) = uxt.function
             {
-                Some(signed_opaque_bundle.bundle.receipt)
+                Some(signed_opaque_bundle.bundle.receipts)
             } else {
                 None
             }
         })
+        .flatten()
         .collect()
 }
 

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -1,5 +1,5 @@
 use crate::fraud_proof::{find_trace_mismatch, FraudProofGenerator};
-use crate::{ExecutionReceiptFor, TransactionFor};
+use crate::TransactionFor;
 use cirrus_block_builder::{BlockBuilder, BuiltBlock, RecordProof};
 use cirrus_primitives::{AccountId, SecondaryApi};
 use codec::{Decode, Encode};
@@ -15,12 +15,10 @@ use sp_api::{ApiExt, NumberFor, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockOrigin, SyncOracle};
 use sp_core::traits::{CodeExecutor, SpawnNamed};
-use sp_core::ByteArray;
-use sp_executor::{ExecutionReceipt, ExecutorApi, ExecutorId, OpaqueBundle};
-use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_executor::{ExecutionReceipt, ExecutorApi, OpaqueBundle};
+use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT, One};
-use sp_runtime::RuntimeAppPublic;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
@@ -580,55 +578,6 @@ where
         }
 
         Ok(())
-    }
-
-    fn try_sign_and_send_receipt(
-        &self,
-        primary_hash: PBlock::Hash,
-        execution_receipt: ExecutionReceiptFor<PBlock, Block::Hash>,
-    ) -> Result<(), sp_blockchain::Error> {
-        let executor_id = self
-            .primary_chain_client
-            .runtime_api()
-            .executor_id(&BlockId::Hash(primary_hash))?;
-
-        if self.is_authority
-            && SyncCryptoStore::has_keys(
-                &*self.keystore,
-                &[(ByteArray::to_raw_vec(&executor_id), ExecutorId::ID)],
-            )
-        {
-            let to_sign = execution_receipt.hash();
-            match SyncCryptoStore::sign_with(
-                &*self.keystore,
-                ExecutorId::ID,
-                &executor_id.into(),
-                to_sign.as_ref(),
-            ) {
-                Ok(Some(_signature)) => {
-                    // let best_hash = self.primary_chain_client.info().best_hash;
-
-                    // TODO: Remove this
-                    // Broadcast ER to all farmers via unsigned extrinsic.
-                    // self.primary_chain_client
-                    // .runtime_api()
-                    // .submit_execution_receipt_unsigned(
-                    // &BlockId::Hash(best_hash),
-                    // signed_execution_receipt,
-                    // )?;
-
-                    Ok(())
-                }
-                Ok(None) => Err(sp_blockchain::Error::Application(Box::from(
-                    "This should not happen as the existence of key was just checked",
-                ))),
-                Err(error) => Err(sp_blockchain::Error::Application(Box::from(format!(
-                    "Error occurred when signing the execution receipt: {error}"
-                )))),
-            }
-        } else {
-            Ok(())
-        }
     }
 }
 

--- a/cumulus/client/cirrus-executor/src/bundle_producer.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_producer.rs
@@ -1,5 +1,5 @@
 use crate::worker::ExecutorSlotInfo;
-use crate::BundleSender;
+use crate::{BundleSender, ExecutionReceiptFor};
 use cirrus_primitives::{AccountId, SecondaryApi};
 use codec::{Decode, Encode};
 use futures::{select, FutureExt};
@@ -10,8 +10,8 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
 use sp_core::ByteArray;
 use sp_executor::{
-    Bundle, BundleHeader, ExecutionReceipt, ExecutorApi, ExecutorId, ExecutorSignature,
-    SignedBundle, SignedOpaqueBundle,
+    Bundle, BundleHeader, ExecutorApi, ExecutorId, ExecutorSignature, SignedBundle,
+    SignedOpaqueBundle,
 };
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::generic::BlockId;
@@ -212,8 +212,7 @@ where
         &self,
         primary_hash: PBlock::Hash,
         header_number: NumberFor<Block>,
-    ) -> sp_blockchain::Result<Vec<ExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>>>
-    {
+    ) -> sp_blockchain::Result<Vec<ExecutionReceiptFor<PBlock, Block::Hash>>> {
         let best_execution_chain_number = self
             .primary_chain_client
             .runtime_api()

--- a/cumulus/client/cirrus-executor/src/bundle_producer.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_producer.rs
@@ -15,7 +15,7 @@ use sp_executor::{
 };
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
 use sp_runtime::generic::BlockId;
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT, One};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT};
 use sp_runtime::RuntimeAppPublic;
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -508,13 +508,6 @@ pub enum GossipMessageError {
         got: ExecutorId,
         expected: ExecutorId,
     },
-    #[error("The signature of execution receipt is invalid")]
-    BadExecutionReceiptSignature,
-    #[error("Invalid execution receipt author, got: {got}, expected: {expected}")]
-    InvalidExecutionReceiptAuthor {
-        got: ExecutorId,
-        expected: ExecutorId,
-    },
 }
 
 impl From<sp_blockchain::Error> for GossipMessageError {

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -626,7 +626,10 @@ where
                 });
             }
 
-            self.validate_gossiped_execution_receipt(signed_bundle_hash, &bundle.receipt)?;
+            // TODO: Validate the receipts correctly when the bundle gossip is re-enabled.
+            for receipt in &bundle.receipts {
+                self.validate_gossiped_execution_receipt(signed_bundle_hash, receipt)?;
+            }
 
             for extrinsic in bundle.extrinsics.iter() {
                 let tx_hash = self.transaction_pool.hash_of(extrinsic);

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -849,11 +849,12 @@ fn extract_receipts(
                 signed_opaque_bundle,
             }) = uxt.function
             {
-                Some(signed_opaque_bundle.bundle.receipt)
+                Some(signed_opaque_bundle.bundle.receipts)
             } else {
                 None
             }
         })
+        .flatten()
         .collect()
 }
 


### PR DESCRIPTION
Part 2 of #809, the substantial change in this PR is changing the receipt field in the Bundle structure from `bundle.receipt` to `bundle.receipts` so that the missing receipts can be submitted sooner in a batch. The validation of batched receipts is still based on the single receipt validation, one important thing is that we need to ensure the receipts are ordered properly. ~~It's supposed to write some tests, but I'd love to postpone it a little bit after the planned new features are finished.~~(basic tests in pallet-executor are fixed) Let me know if you have any confusion there.

The receipts validation on the pallet-executor has been done, but the validation of receipts from the gossiped bundle in x-net is left with a TODO since the bundle gossip is disabled for now anyway.                                                        

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
