### PR TITLE
Integrate the primary block's fork choice into the secondary block import (part-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8033,6 +8033,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-cli",
  "sc-client-api",
+ "sc-consensus",
  "sc-service",
  "sp-api",
  "sp-blockchain",

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -442,6 +442,7 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
                     block_number,
                     mut root_block_sender,
                     block_import_acknowledgement_sender,
+                    ..
                 }) = imported_block_notification_stream.next().await
                 {
                     drop(block_import_acknowledgement_sender);

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -31,6 +31,7 @@ cirrus-test-service = { version = "0.1.0", path = "../../cumulus/test/service" }
 futures = "0.3.21"
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
 sp-keyring = { version = "6.0.0", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
 substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -6,6 +6,7 @@ use cirrus_test_service::runtime::Header;
 use cirrus_test_service::Keyring::{Alice, Bob, Charlie, Dave, Ferdie};
 use codec::Encode;
 use sc_client_api::{HeaderBackend, StorageProof};
+use sc_consensus::ForkChoiceStrategy;
 use sc_service::Role;
 use sp_api::ProvideRuntimeApi;
 use sp_executor::{BundleHeader, ExecutionPhase, ExecutionReceipt, FraudProof, OpaqueBundle};
@@ -119,11 +120,16 @@ async fn execution_proof_creation_and_verification_should_work() {
         // bypass the check of `latest_primary_number = old_best_secondary_number + 1` in `process_bundles`.
         //
         // This invalid primary hash does not affect the test result.
-        (Hash::random(), ferdie.client.info().best_number + 1)
+        (
+            Hash::random(),
+            ferdie.client.info().best_number + 1,
+            ForkChoiceStrategy::LongestChain,
+        )
     } else {
         (
             ferdie.client.info().best_hash,
             ferdie.client.info().best_number,
+            ForkChoiceStrategy::LongestChain,
         )
     };
     alice

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -442,6 +442,7 @@ fn main() -> Result<(), Error> {
                             .then(|imported_block_notification| async move {
                                 (
                                     imported_block_notification.block_number,
+                                    imported_block_notification.fork_choice,
                                     imported_block_notification.block_import_acknowledgement_sender,
                                 )
                             }),

--- a/cumulus/client/cirrus-executor/src/bundle_processor.rs
+++ b/cumulus/client/cirrus-executor/src/bundle_processor.rs
@@ -169,7 +169,11 @@ where
     // TODO: Handle the returned error properly, ref to https://github.com/subspace/subspace/pull/695#discussion_r926721185
     pub(crate) async fn process_bundles(
         self,
-        (primary_hash, primary_number): (PBlock::Hash, NumberFor<PBlock>),
+        (primary_hash, primary_number, fork_choice): (
+            PBlock::Hash,
+            NumberFor<PBlock>,
+            ForkChoiceStrategy,
+        ),
         bundles: Vec<OpaqueBundle<NumberFor<PBlock>, PBlock::Hash, Block::Hash>>,
         shuffling_seed: Randomness,
         maybe_new_runtime: Option<Cow<'static, [u8]>>,
@@ -225,8 +229,8 @@ where
             import_block.body = Some(body);
             import_block.state_action =
                 StateAction::ApplyChanges(StorageChanges::Changes(storage_changes));
-            // TODO: double check the fork choice is correct, see also ParachainBlockImport.
-            import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+            // Follow the primary block's fork choice.
+            import_block.fork_choice = Some(fork_choice);
             import_block
         };
 

--- a/cumulus/client/cirrus-executor/src/lib.rs
+++ b/cumulus/client/cirrus-executor/src/lib.rs
@@ -79,6 +79,7 @@ use codec::{Decode, Encode};
 use futures::channel::mpsc;
 use futures::{FutureExt, Stream};
 use sc_client_api::{AuxStore, BlockBackend};
+use sc_consensus::ForkChoiceStrategy;
 use sc_network::NetworkService;
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::ProvideRuntimeApi;
@@ -208,7 +209,9 @@ where
     where
         SE: SpawnEssentialNamed,
         SC: SelectChain<PBlock>,
-        IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
+        IBNS: Stream<Item = (NumberFor<PBlock>, ForkChoiceStrategy, mpsc::Sender<()>)>
+            + Send
+            + 'static,
         NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
     {
         let active_leaves = active_leaves(primary_chain_client.as_ref(), select_chain).await?;
@@ -466,7 +469,7 @@ where
     #[doc(hidden)]
     pub async fn process_bundles(
         self,
-        primary_info: (PBlock::Hash, NumberFor<PBlock>),
+        primary_info: (PBlock::Hash, NumberFor<PBlock>, ForkChoiceStrategy),
         bundles: Vec<OpaqueBundle<NumberFor<PBlock>, PBlock::Hash, Block::Hash>>,
         shuffling_seed: Randomness,
         maybe_new_runtime: Option<Cow<'static, [u8]>>,
@@ -656,6 +659,9 @@ where
 }
 
 /// Returns the active leaves the overseer should start with.
+///
+/// The longest chain is used as the fork choice for the leaves as the primary block's fork choice
+/// is only available in the imported primary block notifications.
 async fn active_leaves<PBlock, PClient, SC>(
     client: &PClient,
     select_chain: &SC,
@@ -692,6 +698,7 @@ where
                 hash,
                 parent_hash,
                 number,
+                fork_choice: ForkChoiceStrategy::LongestChain,
             })
         })
         .collect::<Vec<_>>();
@@ -703,6 +710,7 @@ where
         hash: best_block.hash(),
         parent_hash: *best_block.parent_hash(),
         number: *best_block.number(),
+        fork_choice: ForkChoiceStrategy::LongestChain,
     });
 
     /// The maximum number of active leaves we forward to the [`Overseer`] on startup.

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -4,6 +4,7 @@ use cirrus_test_service::runtime::{Header, UncheckedExtrinsic};
 use cirrus_test_service::Keyring::{Alice, Bob, Ferdie};
 use codec::{Decode, Encode};
 use sc_client_api::{Backend, BlockBackend, HeaderBackend, StateBackend};
+use sc_consensus::ForkChoiceStrategy;
 use sc_service::Role;
 use sc_transaction_pool_api::TransactionSource;
 use sp_api::ProvideRuntimeApi;
@@ -233,7 +234,11 @@ async fn set_new_code_should_work() {
         .executor
         .clone()
         .process_bundles(
-            (primary_hash, primary_number),
+            (
+                primary_hash,
+                primary_number,
+                ForkChoiceStrategy::LongestChain,
+            ),
             Default::default(),
             BlakeTwo256::hash_of(&[1u8; 64]).into(),
             Some(new_runtime_wasm_blob.clone().into()),

--- a/cumulus/node/src/service.rs
+++ b/cumulus/node/src/service.rs
@@ -9,6 +9,7 @@ use futures::channel::mpsc;
 use futures::Stream;
 use pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi;
 use sc_client_api::{BlockBackend, StateBackendFor};
+use sc_consensus::ForkChoiceStrategy;
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_network::NetworkService;
 use sc_service::{
@@ -227,7 +228,7 @@ where
         + 'static,
     PClient::Api: ExecutorApi<PBlock, Hash>,
     SC: SelectChain<PBlock>,
-    IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
+    IBNS: Stream<Item = (NumberFor<PBlock>, ForkChoiceStrategy, mpsc::Sender<()>)> + Send + 'static,
     NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
     RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, ExecutorDispatch>>
         + Send

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -155,6 +155,7 @@ async fn run_executor(
             .then(|imported_block_notification| async move {
                 (
                     imported_block_notification.block_number,
+                    imported_block_notification.fork_choice,
                     imported_block_notification.block_import_acknowledgement_sender,
                 )
             }),


### PR DESCRIPTION
This PR is primarily for solving the secondary chain fork caused by the natural primary chain fork by literally following the primary block's fork choice.

Part of #835

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
