### PR TITLE
Add pieces announcement through DSN.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7967,6 +7967,7 @@ dependencies = [
  "dusk-bytes",
  "dusk-plonk",
  "hex",
+ "libp2p",
  "num-traits",
  "parity-scale-codec",
  "rand 0.8.5",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -19,7 +19,7 @@ dusk-bls12_381 = { version = "0.11", default-features = false, features = ["allo
 dusk-bytes = "0.1"
 dusk-plonk = { version = "0.12.0", default-features = false, features = ["alloc"], git = "https://github.com/subspace/plonk", rev = "193e68ba3d20f737d730e4b6edc757e4f639e7c3" }
 hex = { version  = "0.4.3", default-features = false }
-libp2p = {version = "0.46.1", optional=true, default-features = false }
+libp2p = {version = "0.46.1", optional = true, default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -19,6 +19,7 @@ dusk-bls12_381 = { version = "0.11", default-features = false, features = ["allo
 dusk-bytes = "0.1"
 dusk-plonk = { version = "0.12.0", default-features = false, features = ["alloc"], git = "https://github.com/subspace/plonk", rev = "193e68ba3d20f737d730e4b6edc757e4f639e7c3" }
 hex = { version  = "0.4.3", default-features = false }
+libp2p = {version = "0.46.1", optional=true, default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
@@ -37,6 +38,7 @@ std = [
     "dusk-plonk/std",
     "hex/serde",
     "hex/std",
+    "libp2p",
     "num-traits/std",
     "parity-scale-codec/std",
     "rand",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -34,6 +34,8 @@ use alloc::vec::Vec;
 use core::convert::AsRef;
 use core::ops::{Deref, DerefMut};
 use derive_more::{Add, Display, Div, Mul, Sub};
+#[cfg(feature = "std")]
+use libp2p::multihash::{Code, Multihash};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -518,6 +520,16 @@ pub struct PieceIndexHash(Blake2b256Hash);
 impl From<PieceIndexHash> for Blake2b256Hash {
     fn from(piece_index_hash: PieceIndexHash) -> Self {
         piece_index_hash.0
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<PieceIndexHash> for Multihash {
+    fn from(piece_index_hash: PieceIndexHash) -> Self {
+        libp2p::multihash::MultihashDigest::digest(
+            &Code::Identity,
+            &U256::from(piece_index_hash).to_be_bytes(),
+        )
     }
 }
 

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -1,0 +1,86 @@
+use futures::channel::oneshot;
+use libp2p::multiaddr::Protocol;
+use libp2p::multihash::Multihash;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::time::Duration;
+use subspace_core_primitives::PieceIndexHash;
+use subspace_networking::{BootstrappedNetworkingParameters, Config};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let config_1 = Config {
+        listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
+        value_getter: Arc::new(|key| {
+            // Return the reversed digest as a value
+            Some(key.digest().iter().copied().rev().collect())
+        }),
+        allow_non_globals_in_dht: true,
+        ..Config::with_generated_keypair()
+    };
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+
+    println!("Node 1 ID is {}", node_1.id());
+
+    let (node_1_address_sender, node_1_address_receiver) = oneshot::channel();
+    let on_new_listener_handler = node_1.on_new_listener(Arc::new({
+        let node_1_address_sender = Mutex::new(Some(node_1_address_sender));
+
+        move |address| {
+            if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                if let Some(node_1_address_sender) = node_1_address_sender.lock().take() {
+                    node_1_address_sender.send(address.clone()).unwrap();
+                }
+            }
+        }
+    }));
+
+    tokio::spawn(async move {
+        node_runner_1.run().await;
+    });
+
+    // Wait for first node to know its address
+    let node_1_addr = node_1_address_receiver.await.unwrap();
+    drop(on_new_listener_handler);
+
+    let config_2 = Config {
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(vec![
+            node_1_addr.with(Protocol::P2p(node_1.id().into()))
+        ])
+        .boxed(),
+        listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
+        allow_non_globals_in_dht: true,
+        ..Config::with_generated_keypair()
+    };
+
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+
+    println!("Node 2 ID is {}", node_2.id());
+
+    tokio::spawn(async move {
+        node_runner_2.run().await;
+    });
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let key = {
+        let piece_index = 1u64;
+        let piece_index_hash = PieceIndexHash::from_index(piece_index);
+        let multihash: Multihash = piece_index_hash.into();
+
+        multihash
+    };
+
+    node_2.announce_piece(key).await.unwrap();
+    println!("Node 2 announced key: {:?}", key);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let providers_result = node_1.get_piece_providers(key).await;
+
+    println!("Node 1 get_piece_providers result: {:?}", providers_result);
+
+    println!("Exiting..");
+}

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -73,14 +73,14 @@ async fn main() {
         multihash
     };
 
-    node_2.announce_piece(key).await.unwrap();
+    node_2.announce(key).await.unwrap();
     println!("Node 2 announced key: {:?}", key);
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    let providers_result = node_1.get_piece_providers(key).await;
+    let providers_result = node_1.get_providers(key).await;
 
-    println!("Node 1 get_piece_providers result: {:?}", providers_result);
+    println!("Node 1 get_providers result: {:?}", providers_result);
 
     println!("Exiting..");
 }

--- a/crates/subspace-networking/src/behavior/custom_record_store.rs
+++ b/crates/subspace-networking/src/behavior/custom_record_store.rs
@@ -4,8 +4,10 @@ use libp2p::kad::{store, ProviderRecord, Record};
 use libp2p::multihash::Multihash;
 use libp2p::PeerId;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;
+use tracing::trace;
 
 pub type ValueGetter = Arc<dyn (Fn(&Multihash) -> Option<Vec<u8>>) + Send + Sync + 'static>;
 
@@ -14,11 +16,15 @@ pub type ValueGetter = Arc<dyn (Fn(&Multihash) -> Option<Vec<u8>>) + Send + Sync
 #[derive(Clone)]
 pub(crate) struct CustomRecordStore {
     value_getter: ValueGetter,
+    providers: HashMap<Key, Vec<ProviderRecord>>,
 }
 
 impl CustomRecordStore {
     pub(super) fn new(value_getter: ValueGetter) -> Self {
-        Self { value_getter }
+        Self {
+            value_getter,
+            providers: Default::default(),
+        }
     }
 }
 
@@ -52,20 +58,28 @@ impl<'a> RecordStore<'a> for CustomRecordStore {
         Vec::new().into_iter()
     }
 
-    fn add_provider(&'a mut self, _record: ProviderRecord) -> store::Result<()> {
-        // Don't allow to store providers.
-        Err(Error::MaxProvidedKeys)
+    fn add_provider(&'a mut self, record: ProviderRecord) -> store::Result<()> {
+        trace!("New provider record added: {:?}", record);
+
+        let records = self
+            .providers
+            .entry(record.key.clone())
+            .or_insert_with(Default::default);
+
+        records.push(record);
+
+        Ok(())
     }
 
-    fn providers(&'a self, _key: &Key) -> Vec<ProviderRecord> {
-        // No providers here.
-        Vec::new()
+    fn providers(&'a self, key: &Key) -> Vec<ProviderRecord> {
+        self.providers.get(key).unwrap_or(&Vec::default()).clone()
     }
 
     fn provided(&'a self) -> Self::ProvidedIter {
-        // Nothing is provided.
-        Vec::new().into_iter()
+        todo!("'provided' operation is not supported.")
     }
 
-    fn remove_provider(&'a mut self, _key: &Key, _provider: &PeerId) {}
+    fn remove_provider(&'a mut self, _key: &Key, _provider: &PeerId) {
+        // TODO
+    }
 }

--- a/crates/subspace-networking/src/behavior/custom_record_store.rs
+++ b/crates/subspace-networking/src/behavior/custom_record_store.rs
@@ -76,7 +76,8 @@ impl<'a> RecordStore<'a> for CustomRecordStore {
     }
 
     fn provided(&'a self) -> Self::ProvidedIter {
-        todo!("'provided' operation is not supported.")
+        // No iteration support for now.
+        Vec::new().into_iter()
     }
 
     fn remove_provider(&'a mut self, _key: &Key, _provider: &PeerId) {

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -145,38 +145,38 @@ impl From<oneshot::Canceled> for PublishError {
 }
 
 #[derive(Debug, Error)]
-pub enum GetPieceProvidersError {
+pub enum GetProvidersError {
     /// Failed to send command to the node runner
     #[error("Failed to send command to the node runner: {0}")]
     SendCommand(#[from] SendError),
     /// Node runner was dropped
     #[error("Node runner was dropped")]
     NodeRunnerDropped,
-    /// Failed to announce a piece.
-    #[error("Failed to get piece providers.")]
-    GetPieceProviders,
+    /// Failed to get providers.
+    #[error("Failed to get providers.")]
+    GetProviders,
 }
 
-impl From<oneshot::Canceled> for GetPieceProvidersError {
+impl From<oneshot::Canceled> for GetProvidersError {
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
 }
 
 #[derive(Debug, Error)]
-pub enum AnnouncePieceError {
+pub enum AnnounceError {
     /// Failed to send command to the node runner
     #[error("Failed to send command to the node runner: {0}")]
     SendCommand(#[from] SendError),
     /// Node runner was dropped
     #[error("Node runner was dropped")]
     NodeRunnerDropped,
-    /// Failed to announce a piece.
-    #[error("Failed to announce a piece.")]
+    /// Failed to announce an item.
+    #[error("Failed to announce an item.")]
     Announce,
 }
 
-impl From<oneshot::Canceled> for AnnouncePieceError {
+impl From<oneshot::Canceled> for AnnounceError {
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -406,37 +406,34 @@ impl Node {
         }
     }
 
-    /// Announce piece by its key. Initiate 'start_providing' Kademlia operation.
-    pub async fn announce_piece(&self, key: Multihash) -> Result<(), AnnouncePieceError> {
+    /// Announce iterm by its key. Initiate 'start_providing' Kademlia operation.
+    pub async fn announce(&self, key: Multihash) -> Result<(), AnnounceError> {
         let (result_sender, result_receiver) = oneshot::channel();
 
-        trace!(?key, "Starting 'announce_piece' request.");
+        trace!(?key, "Starting 'announce' request.");
 
         self.shared
             .command_sender
             .clone()
-            .send(Command::AnnouncePiece { key, result_sender })
+            .send(Command::Announce { key, result_sender })
             .await?;
 
         result_receiver
             .await?
             .then_some(())
-            .ok_or(AnnouncePieceError::Announce)
+            .ok_or(AnnounceError::Announce)
     }
 
-    /// Get piece providers by its key. Initiate 'providers' Kademlia operation.
-    pub async fn get_piece_providers(
-        &self,
-        key: Multihash,
-    ) -> Result<Vec<PeerId>, GetPieceProvidersError> {
+    /// Get item providers by its key. Initiate 'providers' Kademlia operation.
+    pub async fn get_providers(&self, key: Multihash) -> Result<Vec<PeerId>, GetProvidersError> {
         let (result_sender, result_receiver) = oneshot::channel();
 
-        trace!(?key, "Starting 'get_piece_providers' request.");
+        trace!(?key, "Starting 'get_providers' request.");
 
         self.shared
             .command_sender
             .clone()
-            .send(Command::GetPieceProviders { key, result_sender })
+            .send(Command::GetProviders { key, result_sender })
             .await?;
 
         if let Some(providers) = result_receiver.await? {
@@ -449,7 +446,7 @@ impl Node {
         } else {
             trace!("Kademlia 'GetProviders' returned an error (timeout).");
 
-            Err(GetPieceProvidersError::GetPieceProviders)
+            Err(GetProvidersError::GetProviders)
         }
     }
 

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -736,7 +736,7 @@ impl NodeRunner {
 
                 let _ = result_sender.send(kademlia_connection_initiated);
             }
-            Command::AnnouncePiece { key, result_sender } => {
+            Command::Announce { key, result_sender } => {
                 let res = self
                     .swarm
                     .behaviour_mut()
@@ -759,7 +759,7 @@ impl NodeRunner {
                     }
                 }
             }
-            Command::GetPieceProviders { key, result_sender } => {
+            Command::GetProviders { key, result_sender } => {
                 let query_id = self
                     .swarm
                     .behaviour_mut()

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -53,6 +53,14 @@ pub(crate) enum Command {
     CheckConnectedPeers {
         result_sender: oneshot::Sender<bool>,
     },
+    AnnouncePiece {
+        key: Multihash,
+        result_sender: oneshot::Sender<bool>,
+    },
+    GetPieceProviders {
+        key: Multihash,
+        result_sender: oneshot::Sender<Option<Vec<PeerId>>>,
+    },
 }
 
 #[derive(Default, Debug)]

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -53,11 +53,11 @@ pub(crate) enum Command {
     CheckConnectedPeers {
         result_sender: oneshot::Sender<bool>,
     },
-    AnnouncePiece {
+    Announce {
         key: Multihash,
         result_sender: oneshot::Sender<bool>,
     },
-    GetPieceProviders {
+    GetProviders {
         key: Multihash,
         result_sender: oneshot::Sender<Option<Vec<PeerId>>>,
     },

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -1,9 +1,10 @@
+use futures::future::join_all;
 use futures::StreamExt;
-use parity_scale_codec::Encode;
 use sc_consensus_subspace::{ArchivedSegmentNotification, SubspaceLink};
 use sp_core::traits::SpawnEssentialNamed;
 use sp_runtime::traits::Block as BlockT;
-use subspace_networking::{CreationError, PUB_SUB_ARCHIVING_TOPIC};
+use subspace_core_primitives::{PieceIndexHash, PIECES_IN_SEGMENT};
+use subspace_networking::CreationError;
 use tracing::{error, info, trace};
 
 /// Start an archiver that will listen for archived segments and send it to DSN network using
@@ -46,13 +47,24 @@ where
             }) = archived_segment_notification_stream.next().await
             {
                 trace!(target: "dsn", "ArchivedSegmentNotification received");
-                let data = archived_segment.encode().to_vec();
 
-                match node.publish(PUB_SUB_ARCHIVING_TOPIC.clone(), data).await {
-                    Ok(_) => {
+                let segment_index = archived_segment.root_block.segment_index();
+                let first_piece_index = segment_index * u64::from(PIECES_IN_SEGMENT);
+
+                let keys_iter = (first_piece_index..)
+                    .take(archived_segment.pieces.count())
+                    .map(PieceIndexHash::from_index)
+                    .map(|hash| hash.into());
+
+                let pieces_announcements = keys_iter
+                    .map(|key| node.announce_piece(key))
+                    .collect::<Vec<_>>();
+                let announcement_result = join_all(pieces_announcements).await;
+                match announcement_result.iter().find(|res| res.is_err()) {
+                    None => {
                         trace!(target: "dsn", "Archived segment published.");
                     }
-                    Err(err) => {
+                    Some(err) => {
                         error!(target: "dsn", error = ?err, "Failed to publish archived segment");
                     }
                 }


### PR DESCRIPTION
This PR starts adding the archival storage layer support for the DSN v2. Fixes #846 

### Changes
- add multihash conversion to `PieceIndexHash` primitive
- add `announce_piece` and `get_piece_providers` methods to Node in the networking crate
- change gossipsub archival data publication to Kademlia version
- add provider support to custom_data_store in the networking crate
- added 'announce-piece' example to the networking crate

### Comments
- custom_data_store doesn't support providers' removing yet

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
