### PR TITLE
Pallet executor registry (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
+ "sp-arithmetic",
  "sp-core",
  "sp-executor",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,6 +4543,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-executor-registry"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-executor",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-feeds"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "cumulus/client/cirrus-executor",
     "cumulus/client/consensus/relay-chain",
     "cumulus/client/executor-gossip",
-    "cumulus/pallets/executive",
+    "cumulus/pallets/*",
     "cumulus/node",
     "cumulus/runtime",
     "cumulus/primitives",

--- a/cumulus/pallets/executor-registry/Cargo.toml
+++ b/cumulus/pallets/executor-registry/Cargo.toml
@@ -16,6 +16,7 @@ codec = { package = "parity-scale-codec", version = "3.1.5", default-features = 
 frame-support = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
 frame-system = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+sp-arithmetic = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
 sp-executor = { version = "0.1.0", path = "../../../crates/sp-executor", default-features = false }
 sp-io = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
 sp-runtime = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
@@ -31,6 +32,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"scale-info/std",
+	"sp-arithmetic/std",
 	"sp-executor/std",
 	"sp-io/std",
 	"sp-runtime/std",

--- a/cumulus/pallets/executor-registry/Cargo.toml
+++ b/cumulus/pallets/executor-registry/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "pallet-executor-registry"
+version = "0.1.0"
+authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace/"
+description = "System domain pallet managing the executors and their funds at stake"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+frame-system = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+sp-executor = { version = "0.1.0", path = "../../../crates/sp-executor", default-features = false }
+sp-io = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+
+[dev-dependencies]
+pallet-balances = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
+sp-core = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"scale-info/std",
+	"sp-executor/std",
+	"sp-io/std",
+	"sp-runtime/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/cumulus/pallets/executor-registry/src/lib.rs
+++ b/cumulus/pallets/executor-registry/src/lib.rs
@@ -1,0 +1,239 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Executor Registry Module
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::traits::Currency;
+pub use pallet::*;
+
+type BalanceOf<T> =
+    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+const EXECUTOR_LOCK_ID: LockIdentifier = *b"executor";
+
+#[frame_support::pallet]
+mod pallet {
+    use super::BalanceOf;
+    use frame_support::pallet_prelude::*;
+    use frame_support::traits::LockableCurrency;
+    use frame_system::pallet_prelude::*;
+    use sp_executor::ExecutorId;
+    use sp_runtime::traits::Zero;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
+
+        /// Minimum SSC required to be an executor.
+        type MinExecutorStake: Get<BalanceOf<Self>>;
+
+        /// Maximum SSC that can be staked by a single executor.
+        type MaxExecutorStake: Get<BalanceOf<Self>>;
+
+        /// Minimum number of executors
+        type MinExecutorCount: Get<u32>;
+
+        /// Maximum number of executors.
+        ///
+        /// Increase this number gradually as the network grows.
+        type MaxExecutorCount: Get<u32>;
+
+        /// Maximum number of ongoing unlocking items per executor.
+        type MaxUnlockingCount: Get<u32>;
+
+        /// Number of blocks the withdrawn stake has to remain locked before it can become free.
+        ///
+        /// Typically should be the same with fraud proof challenge period, like one week for arbitrum.
+        ///
+        /// TODO: Use Slot instead of BlockNumber, which is closer to the actual elapsed time.
+        type UnlockingDuration: Get<Self::BlockNumber>;
+
+        /// The amount of time each epoch should last in blocks.
+        ///
+        /// The executor set for the bundle election is scheduled to rotate on each new epoch.
+        type EpochDuration: Get<Self::BlockNumber>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::without_storage_info]
+    pub struct Pallet<T>(_);
+
+    /// Represents the inactive stake of an executor after calling `unlock_stake`.
+    ///
+    /// An executor called `unlock_stake` to withdraw some stakes, which
+    /// have to wait for another lock-up period before making it transferrable again.
+    #[derive(Debug, Encode, Decode, TypeInfo, Clone, PartialEq, Eq)]
+    pub struct Unlocking<Balance, BlockNumber> {
+        /// Amount of the unlocking balance.
+        pub amount: Balance,
+        /// Block number after which the balance can be really unlocked.
+        pub locked_until: BlockNumber,
+    }
+
+    /// Executor configuration.
+    #[derive(DebugNoBound, Encode, Decode, TypeInfo, CloneNoBound, PartialEqNoBound, EqNoBound)]
+    #[scale_info(skip_type_params(T))]
+    pub struct ExecutorConfig<T: Config> {
+        /// Executor's signing key.
+        pub public_key: ExecutorId,
+
+        /// Address for receiving the execution reward.
+        pub reward_address: T::AccountId,
+
+        /// Whether the executor is actively participating in the bundle election.
+        pub is_active: bool,
+
+        /// Amount of balance at stake.
+        ///
+        /// Only the `stake` is used for in the forthcoming bundle election.
+        pub stake: BalanceOf<T>,
+
+        /// Inactive stake still being frozen, which can be freed up once mature.
+        pub unlockings: BoundedVec<Unlocking<BalanceOf<T>, T::BlockNumber>, T::MaxUnlockingCount>,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Register the origin account as an executor.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn register(
+            origin: OriginFor<T>,
+            executor_config: ExecutorConfig<T>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Declare no desire to be an executor and remove the registration.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn deregister(origin: OriginFor<T>) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            // TODO:
+            // Ensure the number of remaining executors can't be lower than T::MinExecutorCount.
+            // Ensure the executor has no funds locked in this pallet(deposits and pending_withdrawals).
+            // Remove the corresponding entry from the Executors.
+            // Deposit an event Deregistered.
+
+            Ok(())
+        }
+
+        /// Increase the executor's stake by locking some more balance.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn stake_extra(origin: OriginFor<T>, extra: BalanceOf<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Decrease the executor stake by unlocking some balance.
+        ///
+        /// The reduced stake will be held locked for a while until it
+        /// can be withdrawn to be transferrable.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn unlock_stake(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Remove the item at given index which is due in the unlocking queue.
+        ///
+        /// The balance being locked will become free on success.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn withdraw_unlocked_stake(
+            origin: OriginFor<T>,
+            unlocking_index: u32,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Stop participating in the bundle election temporarily.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn pause_execution(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Participate in the bundle election again.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn resume_execution(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Set a new executor public key.
+        ///
+        /// It won't take effect until next epoch.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn update_public_key(origin: OriginFor<T>, new: ExecutorId) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+
+        /// Set a new reward address.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn update_reward_address(origin: OriginFor<T>, new: T::AccountId) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            Ok(())
+        }
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {}
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {}
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_initialize(block_number: T::BlockNumber) -> Weight {
+            if (block_number % T::EpochDuration::get()).is_zero() {
+                // TODO: Enact the epoch change.
+            }
+            Weight::zero()
+        }
+
+        fn on_idle(_n: T::BlockNumber, _remaining_weight: Weight) -> Weight {
+            // TODO: Release the mature withdrawal automatically so that users do not have to call
+            // `withdraw_unlocked_deposit` manually.
+            Weight::zero()
+        }
+    }
+}

--- a/cumulus/pallets/executor-registry/src/lib.rs
+++ b/cumulus/pallets/executor-registry/src/lib.rs
@@ -19,6 +19,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
+mod tests;
+
 use frame_support::traits::{Currency, LockIdentifier, LockableCurrency, WithdrawReasons};
 pub use pallet::*;
 

--- a/cumulus/pallets/executor-registry/src/lib.rs
+++ b/cumulus/pallets/executor-registry/src/lib.rs
@@ -469,6 +469,15 @@ mod pallet {
     #[pallet::genesis_build]
     impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
         fn build(&self) {
+            assert!(
+                self.executors.len() >= T::MinExecutors::get() as usize,
+                "Too few genesis executors"
+            );
+            assert!(
+                self.executors.len() <= T::MaxExecutors::get() as usize,
+                "Too many genesis executors"
+            );
+
             for (executor, initial_stake, reward_address, executor_id) in self.executors.clone() {
                 assert!(
                     initial_stake >= T::MinExecutorStake::get()

--- a/cumulus/pallets/executor-registry/src/tests.rs
+++ b/cumulus/pallets/executor-registry/src/tests.rs
@@ -1,0 +1,355 @@
+use crate::{
+    self as pallet_executor_registry, Error, ExecutorConfig, Executors, TotalActiveExecutors,
+    TotalActiveStake, Unlocking,
+};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, GenesisBuild};
+use frame_support::{assert_noop, assert_ok, bounded_vec, parameter_types};
+use pallet_balances::AccountData;
+use sp_core::crypto::Pair;
+use sp_core::{H256, U256};
+use sp_executor::ExecutorPair;
+use sp_runtime::testing::Header;
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+    pub struct Test
+    where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system,
+        Balances: pallet_balances,
+        ExecutorRegistry: pallet_executor_registry,
+    }
+);
+
+type AccountId = u64;
+type BlockNumber = u64;
+type Balance = u128;
+type Hash = H256;
+
+impl frame_system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = BlockNumber;
+    type Hash = Hash;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = ConstU64<2>;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = AccountData<Balance>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ConstU16<42>;
+    type OnSetCode = ();
+    type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+    pub static ExistentialDeposit: Balance = 1;
+}
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = ();
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type Balance = Balance;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const MinExecutorStake: Balance = 10;
+    pub const MaxExecutorStake: Balance = 1000;
+    pub const MinExecutorCount: u32 = 1;
+    pub const MaxExecutorCount: u32 = 10;
+    pub const EpochDuration: BlockNumber = 3;
+    pub const MaxUnlockingCount: u32 = 1;
+    pub const UnlockingDuration: BlockNumber = 10;
+}
+
+impl pallet_executor_registry::Config for Test {
+    type Event = Event;
+    type Currency = Balances;
+    type MinExecutorStake = MinExecutorStake;
+    type MaxExecutorStake = MaxExecutorStake;
+    type MinExecutorCount = MinExecutorCount;
+    type MaxExecutorCount = MaxExecutorCount;
+    type EpochDuration = EpochDuration;
+    type MaxUnlockingCount = MaxUnlockingCount;
+    type UnlockingDuration = UnlockingDuration;
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(1, 1000), (2, 2000), (3, 3000), (4, 4000)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    pallet_executor_registry::GenesisConfig::<Test> {
+        executors: vec![(
+            1,
+            100,
+            1 + 10000,
+            ExecutorPair::from_seed(&U256::from(1u32).into()).public(),
+        )],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    t.into()
+}
+
+#[test]
+fn register_should_work() {
+    new_test_ext().execute_with(|| {
+        assert_eq!(TotalActiveStake::<Test>::get(), 100);
+        assert_eq!(TotalActiveExecutors::<Test>::get(), 1);
+
+        let executor_config = ExecutorConfig {
+            public_key: ExecutorPair::from_seed(&U256::from(2u32).into()).public(),
+            is_active: true,
+            reward_address: 2 + 10_000,
+            stake: 200,
+            unlockings: Default::default(),
+        };
+
+        assert_noop!(
+            ExecutorRegistry::register(
+                Origin::signed(1),
+                ExecutorConfig {
+                    stake: 100_000,
+                    ..executor_config.clone()
+                }
+            ),
+            Error::<Test>::StakeTooLarge
+        );
+        assert_noop!(
+            ExecutorRegistry::register(
+                Origin::signed(1),
+                ExecutorConfig {
+                    stake: 1,
+                    ..executor_config.clone()
+                }
+            ),
+            Error::<Test>::StakeTooSmall
+        );
+        assert_noop!(
+            ExecutorRegistry::register(
+                Origin::signed(8),
+                ExecutorConfig {
+                    stake: 100,
+                    ..executor_config.clone()
+                }
+            ),
+            Error::<Test>::InsufficientBalance
+        );
+        assert_noop!(
+            ExecutorRegistry::register(Origin::signed(1), executor_config.clone()),
+            Error::<Test>::AlreadyExecutor
+        );
+
+        assert_ok!(ExecutorRegistry::register(
+            Origin::signed(2),
+            executor_config.clone()
+        ));
+        assert_eq!(
+            frame_system::Account::<Test>::get(&2).data,
+            AccountData {
+                free: 2000,
+                reserved: 0,
+                misc_frozen: 200,
+                fee_frozen: 200
+            }
+        );
+        assert_eq!(Executors::<Test>::get(&2), Some(executor_config));
+        assert_eq!(TotalActiveStake::<Test>::get(), 100 + 200);
+        assert_eq!(TotalActiveExecutors::<Test>::get(), 2);
+    });
+}
+
+#[test]
+fn stake_extra_should_work() {
+    new_test_ext().execute_with(|| {
+        let executor_config = Executors::<Test>::get(&1).unwrap();
+        assert_eq!(
+            frame_system::Account::<Test>::get(&1).data,
+            AccountData {
+                free: 1000,
+                reserved: 0,
+                misc_frozen: 100,
+                fee_frozen: 100
+            }
+        );
+        let extra = 200;
+        assert_ok!(ExecutorRegistry::stake_extra(Origin::signed(1), extra));
+        assert_eq!(
+            Executors::<Test>::get(&1).unwrap(),
+            ExecutorConfig {
+                stake: executor_config.stake + extra,
+                ..executor_config
+            }
+        );
+        assert_eq!(
+            frame_system::Account::<Test>::get(&1).data,
+            AccountData {
+                free: 1000,
+                reserved: 0,
+                misc_frozen: 100 + extra,
+                fee_frozen: 100 + extra
+            }
+        );
+    });
+}
+
+#[test]
+fn unlock_and_withdraw_stake_should_work() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+
+        assert_eq!(
+            frame_system::Account::<Test>::get(&1).data,
+            AccountData {
+                free: 1000,
+                reserved: 0,
+                misc_frozen: 100,
+                fee_frozen: 100
+            }
+        );
+        assert_noop!(
+            ExecutorRegistry::unlock_stake(Origin::signed(1), 1000),
+            Error::<Test>::InsufficientStake
+        );
+        let executor_config = Executors::<Test>::get(&1).unwrap();
+        let to_unlock = 10;
+
+        assert_ok!(ExecutorRegistry::unlock_stake(Origin::signed(1), to_unlock));
+
+        assert_eq!(
+            frame_system::Account::<Test>::get(&1).data,
+            AccountData {
+                free: 1000,
+                reserved: 0,
+                misc_frozen: 100,
+                fee_frozen: 100
+            }
+        );
+
+        assert_eq!(
+            Executors::<Test>::get(&1).unwrap(),
+            ExecutorConfig {
+                unlockings: bounded_vec![Unlocking {
+                    amount: 10,
+                    locked_until: 11
+                }],
+                stake: executor_config.stake - to_unlock,
+                ..executor_config
+            }
+        );
+
+        System::set_block_number(11);
+        assert_noop!(
+            ExecutorRegistry::withdraw_unlocked_stake(Origin::signed(1), 0),
+            Error::<Test>::PrematureWithdrawal
+        );
+
+        System::set_block_number(12);
+        let executor_config = Executors::<Test>::get(&1).unwrap();
+        assert_ok!(ExecutorRegistry::withdraw_unlocked_stake(
+            Origin::signed(1),
+            0
+        ));
+        assert_eq!(
+            Executors::<Test>::get(&1).unwrap(),
+            ExecutorConfig {
+                unlockings: Default::default(),
+                ..executor_config
+            }
+        );
+        assert_eq!(
+            frame_system::Account::<Test>::get(&1).data,
+            AccountData {
+                free: 1000,
+                reserved: 0,
+                misc_frozen: 90,
+                fee_frozen: 90
+            }
+        );
+    });
+}
+
+#[test]
+fn pause_and_resume_execution_should_work() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            ExecutorRegistry::pause_execution(Origin::signed(1)),
+            Error::<Test>::EmptyActiveExecutors
+        );
+
+        let executor_config = ExecutorConfig {
+            public_key: ExecutorPair::from_seed(&U256::from(2u32).into()).public(),
+            is_active: false,
+            reward_address: 2 + 10_000,
+            stake: 200,
+            unlockings: Default::default(),
+        };
+
+        assert_ok!(ExecutorRegistry::register(
+            Origin::signed(2),
+            executor_config
+        ));
+
+        assert_eq!(TotalActiveStake::<Test>::get(), 100);
+        assert_eq!(TotalActiveExecutors::<Test>::get(), 1);
+
+        assert_ok!(ExecutorRegistry::resume_execution(Origin::signed(2)));
+
+        assert_eq!(TotalActiveStake::<Test>::get(), 100 + 200);
+        assert_eq!(TotalActiveExecutors::<Test>::get(), 2);
+
+        assert_ok!(ExecutorRegistry::pause_execution(Origin::signed(2)));
+
+        assert_eq!(TotalActiveStake::<Test>::get(), 100);
+        assert_eq!(TotalActiveExecutors::<Test>::get(), 1);
+    });
+}
+
+#[test]
+fn update_reward_address_should_work() {
+    new_test_ext().execute_with(|| {
+        let executor_config = Executors::<Test>::get(&1).unwrap();
+        assert_ok!(ExecutorRegistry::update_reward_address(
+            Origin::signed(1),
+            888
+        ));
+        assert_eq!(
+            Executors::<Test>::get(&1).unwrap(),
+            ExecutorConfig {
+                reward_address: 888,
+                ..executor_config
+            }
+        );
+    });
+}

--- a/cumulus/pallets/executor-registry/src/tests.rs
+++ b/cumulus/pallets/executor-registry/src/tests.rs
@@ -327,7 +327,7 @@ fn pause_and_resume_execution_should_work() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             ExecutorRegistry::pause_execution(Origin::signed(1)),
-            Error::<Test>::EmptyActiveExecutors
+            Error::<Test>::TooFewActiveExecutors
         );
 
         let public_key = ExecutorPair::from_seed(&U256::from(2u32).into()).public();


### PR DESCRIPTION
This PR implements the basics of pallet-registry, most of the logic(Calls) are finished except `deregister` and `update_public_key`.

- `deregister` still need some time to think it over.
- `update_public_key` will be supported in follow-up PR with the executor epoch rotation which is the main goal of next PR.

The integration of pallet-executor-registry will also be in the follow-up PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
