### PR TITLE
Dsn. Add provider removal for piece announcing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7967,7 +7967,6 @@ dependencies = [
  "dusk-bytes",
  "dusk-plonk",
  "hex",
- "libp2p",
  "num-traits",
  "parity-scale-codec",
  "rand 0.8.5",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -19,7 +19,6 @@ dusk-bls12_381 = { version = "0.11", default-features = false, features = ["allo
 dusk-bytes = "0.1"
 dusk-plonk = { version = "0.12.0", default-features = false, features = ["alloc"], git = "https://github.com/subspace/plonk", rev = "193e68ba3d20f737d730e4b6edc757e4f639e7c3" }
 hex = { version  = "0.4.3", default-features = false }
-libp2p = {version = "0.46.1", optional=true, default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
@@ -38,7 +37,6 @@ std = [
     "dusk-plonk/std",
     "hex/serde",
     "hex/std",
-    "libp2p",
     "num-traits/std",
     "parity-scale-codec/std",
     "rand",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -34,8 +34,6 @@ use alloc::vec::Vec;
 use core::convert::AsRef;
 use core::ops::{Deref, DerefMut};
 use derive_more::{Add, Display, Div, Mul, Sub};
-#[cfg(feature = "std")]
-use libp2p::multihash::{Code, Multihash};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -520,16 +518,6 @@ pub struct PieceIndexHash(Blake2b256Hash);
 impl From<PieceIndexHash> for Blake2b256Hash {
     fn from(piece_index_hash: PieceIndexHash) -> Self {
         piece_index_hash.0
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<PieceIndexHash> for Multihash {
-    fn from(piece_index_hash: PieceIndexHash) -> Self {
-        libp2p::multihash::MultihashDigest::digest(
-            &Code::Identity,
-            &U256::from(piece_index_hash).to_be_bytes(),
-        )
     }
 }
 

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -85,7 +85,7 @@ async fn main() {
         piece_index_hash.to_multihash()
     };
 
-    node.announce(key).await.unwrap();
+    node.start_announcing(key).await.unwrap();
     println!("Node announced key: {:?}", key);
 
     tokio::time::sleep(Duration::from_secs(15)).await;

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -1,0 +1,111 @@
+use futures::channel::oneshot;
+use libp2p::identity::sr25519::Keypair;
+use libp2p::multiaddr::Protocol;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::time::Duration;
+use subspace_core_primitives::PieceIndexHash;
+use subspace_networking::{BootstrappedNetworkingParameters, Config, ToMultihash};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let mut bootstrap_nodes = Vec::new();
+
+    const TOTAL_NODE_COUNT: usize = 90;
+
+    let mut nodes = Vec::with_capacity(TOTAL_NODE_COUNT);
+    for i in 0..TOTAL_NODE_COUNT {
+        let keypair = Keypair::generate();
+        let config = Config {
+            networking_parameters_registry: BootstrappedNetworkingParameters::new(
+                bootstrap_nodes.clone(),
+            )
+            .boxed(),
+            listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
+            allow_non_globals_in_dht: true,
+            ..Config::with_keypair(keypair.clone())
+        };
+
+        let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+
+        println!("Node {} ID is {}", i, node.id());
+
+        let (node_address_sender, node_address_receiver) = oneshot::channel();
+        let _handler = node.on_new_listener(Arc::new({
+            let node_address_sender = Mutex::new(Some(node_address_sender));
+
+            move |address| {
+                if matches!(address.iter().next(), Some(Protocol::Ip4(_))) {
+                    if let Some(node_address_sender) = node_address_sender.lock().take() {
+                        node_address_sender.send(address.clone()).unwrap();
+                    }
+                }
+            }
+        }));
+
+        tokio::spawn(async move {
+            node_runner.run().await;
+        });
+
+        // Wait for node to know its address
+        let node_addr = node_address_receiver.await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(40)).await;
+
+        let address = node_addr.with(Protocol::P2p(node.id().into()));
+
+        bootstrap_nodes.push(address);
+
+        nodes.push(node);
+    }
+
+    let config = Config {
+        listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
+        allow_non_globals_in_dht: true,
+        networking_parameters_registry: BootstrappedNetworkingParameters::new(
+            bootstrap_nodes.clone(),
+        )
+        .boxed(),
+        ..Config::with_generated_keypair()
+    };
+
+    let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+
+    tokio::spawn(async move {
+        node_runner.run().await;
+    });
+
+    node.wait_for_connected_peers().await.unwrap();
+
+    let key = {
+        let piece_index = 1u64;
+        let piece_index_hash = PieceIndexHash::from_index(piece_index);
+        piece_index_hash.to_multihash()
+    };
+
+    node.announce_piece(key).await.unwrap();
+    println!("Node announced key: {:?}", key);
+
+    tokio::time::sleep(Duration::from_secs(15)).await;
+
+    let some_node = nodes.first().unwrap();
+    let providers_result = some_node.get_piece_providers(key).await;
+
+    println!(
+        "Some Node get_piece_providers result: {:?}",
+        providers_result
+    );
+
+    tokio::time::sleep(Duration::from_secs(20)).await;
+
+    let providers_result = some_node.get_piece_providers(key).await;
+
+    println!(
+        "Some Node get_piece_providers result: {:?}",
+        providers_result
+    );
+
+    println!("Exiting..");
+}

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -66,7 +66,7 @@ async fn main() {
         piece_index_hash.to_multihash()
     };
 
-    node_2.announce(key).await.unwrap();
+    node_2.start_announcing(key).await.unwrap();
     println!("Node 2 announced key: {:?}", key);
 
     tokio::time::sleep(Duration::from_secs(2)).await;

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -63,15 +63,21 @@ async fn main() {
     let key = {
         let piece_index = 1u64;
         let piece_index_hash = PieceIndexHash::from_index(piece_index);
-        let multihash: Multihash = piece_index_hash.into();
-
-        multihash
+        piece_index_hash.to_multihash()
     };
 
     node_2.announce_piece(key).await.unwrap();
     println!("Node 2 announced key: {:?}", key);
 
     tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let providers_result = node_1.get_piece_providers(key).await;
+
+    println!("Node 1 get_piece_providers result: {:?}", providers_result);
+
+    node_2.stop_announcing(key).await.unwrap();
+
+    tokio::time::sleep(Duration::from_secs(31)).await;
 
     let providers_result = node_1.get_piece_providers(key).await;
 

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -1,11 +1,10 @@
 use futures::channel::oneshot;
 use libp2p::multiaddr::Protocol;
-use libp2p::multihash::Multihash;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::PieceIndexHash;
-use subspace_networking::{BootstrappedNetworkingParameters, Config};
+use subspace_networking::{BootstrappedNetworkingParameters, Config, ToMultihash};
 
 #[tokio::main]
 async fn main() {
@@ -13,10 +12,6 @@ async fn main() {
 
     let config_1 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        value_getter: Arc::new(|key| {
-            // Return the reversed digest as a value
-            Some(key.digest().iter().copied().rev().collect())
-        }),
         allow_non_globals_in_dht: true,
         ..Config::with_generated_keypair()
     };

--- a/crates/subspace-networking/src/behavior/custom_record_store.rs
+++ b/crates/subspace-networking/src/behavior/custom_record_store.rs
@@ -16,6 +16,7 @@ pub type ValueGetter = Arc<dyn (Fn(&Multihash) -> Option<Vec<u8>>) + Send + Sync
 #[derive(Clone)]
 pub(crate) struct CustomRecordStore {
     value_getter: ValueGetter,
+    // TODO: Optimize providers collection, introduce limits and TTL.
     providers: HashMap<Key, Vec<ProviderRecord>>,
 }
 
@@ -76,10 +77,19 @@ impl<'a> RecordStore<'a> for CustomRecordStore {
     }
 
     fn provided(&'a self) -> Self::ProvidedIter {
-        todo!("'provided' operation is not supported.")
+        self.providers
+            .iter()
+            .flat_map(|(_, v)| v)
+            .map(|x| Cow::Owned(x.clone()))
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
-    fn remove_provider(&'a mut self, _key: &Key, _provider: &PeerId) {
-        // TODO
+    fn remove_provider(&'a mut self, key: &Key, provider: &PeerId) {
+        trace!(?key, ?provider, "Provider record removed.");
+
+        let entry = self.providers.entry(key.clone());
+
+        entry.and_modify(|e| e.retain(|rec| rec.provider != *provider));
     }
 }

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -62,7 +62,7 @@ async fn test_address_timed_removal_from_known_peers_cache() {
     assert_eq!(peers_cache.len(), 0);
 }
 
-#[allow(clippy::mutable_key_type)] // we use it hash set for sorting to compare collections
+#[allow(clippy::mutable_key_type)] // we use hash set for sorting to compare collections
 #[test]
 fn check_custom_store_api() {
     let mut store = CustomRecordStore::new(Arc::new(|_| None));

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -41,9 +41,9 @@ const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 50;
 // The default maximum incoming connection number for the swarm.
 const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 50;
 // Defines an expiration interval for item providers in Kademlia network.
-const KADEMLIA_PROVIDER_TTL_IN_SECS: u64 = 10;
+const KADEMLIA_PROVIDER_TTL_IN_SECS: u64 = 86400; /* 1 day */
 // Defines a republication interval for item providers in Kademlia network.
-const KADEMLIA_PROVIDER_REPUBLICATION_INTERVAL_IN_SECS: u64 = 20;
+const KADEMLIA_PROVIDER_REPUBLICATION_INTERVAL_IN_SECS: u64 = 3600; /* 1 hour */
 
 /// Defines relay configuration for the Node
 #[derive(Clone, Debug)]

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -40,6 +40,10 @@ const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 50;
 // The default maximum incoming connection number for the swarm.
 const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 50;
+// Defines an expiration interval for item providers in Kademlia network.
+const KADEMLIA_PROVIDER_TTL_IN_SECS: u64 = 10;
+// Defines a republication interval for item providers in Kademlia network.
+const KADEMLIA_PROVIDER_REPUBLICATION_INTERVAL_IN_SECS: u64 = 20;
 
 /// Defines relay configuration for the Node
 #[derive(Clone, Debug)]
@@ -122,6 +126,11 @@ impl Config {
         let mut kademlia = KademliaConfig::default();
         kademlia
             .set_protocol_name(KADEMLIA_PROTOCOL)
+            // Providers' settings
+            .set_provider_record_ttl(Some(Duration::from_secs(KADEMLIA_PROVIDER_TTL_IN_SECS)))
+            .set_provider_publication_interval(Some(Duration::from_secs(
+                KADEMLIA_PROVIDER_REPUBLICATION_INTERVAL_IN_SECS,
+            )))
             // Ignore any puts
             .set_record_filtering(KademliaStoreInserts::FilterBoth)
             .set_kbucket_inserts(KademliaBucketInserts::Manual);

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -49,6 +49,7 @@ pub use request_handlers::peer_info::{
 pub use request_handlers::pieces_by_range::{
     PiecesByRangeRequest, PiecesByRangeRequestHandler, PiecesByRangeResponse, PiecesToPlot,
 };
+pub use utils::ToMultihash;
 
 // TODO: Move this out of the networking crate into separate crate.
 pub static PUB_SUB_ARCHIVING_TOPIC: Lazy<Sha256Topic> =

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -425,16 +425,16 @@ impl Node {
         }
     }
 
-    /// Announce iterm by its key. Initiate 'start_providing' Kademlia operation.
-    pub async fn announce(&self, key: Multihash) -> Result<(), AnnounceError> {
+    /// Start announcing item by its key. Initiate 'start_providing' Kademlia operation.
+    pub async fn start_announcing(&self, key: Multihash) -> Result<(), AnnounceError> {
         let (result_sender, result_receiver) = oneshot::channel();
 
-        trace!(?key, "Starting 'announce' request.");
+        trace!(?key, "Starting 'start_announcing' request.");
 
         self.shared
             .command_sender
             .clone()
-            .send(Command::Announce { key, result_sender })
+            .send(Command::StartAnnouncing { key, result_sender })
             .await?;
 
         result_receiver

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -754,7 +754,7 @@ impl NodeRunner {
 
                 let _ = result_sender.send(kademlia_connection_initiated);
             }
-            Command::Announce { key, result_sender } => {
+            Command::StartAnnouncing { key, result_sender } => {
                 let res = self
                     .swarm
                     .behaviour_mut()

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -10,9 +10,11 @@ use futures::{FutureExt, StreamExt};
 use libp2p::core::ConnectedPoint;
 use libp2p::gossipsub::{GossipsubEvent, TopicHash};
 use libp2p::identify::IdentifyEvent;
+use libp2p::kad::store::RecordStore;
 use libp2p::kad::{
     AddProviderError, AddProviderOk, GetClosestPeersError, GetClosestPeersOk, GetProvidersError,
-    GetProvidersOk, GetRecordError, GetRecordOk, KademliaEvent, QueryId, QueryResult, Quorum,
+    GetProvidersOk, GetRecordError, GetRecordOk, InboundRequest, KademliaEvent, QueryId,
+    QueryResult, Quorum,
 };
 use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::{DialError, SwarmEvent};
@@ -421,6 +423,22 @@ impl NodeRunner {
         trace!("Kademlia event: {:?}", event);
 
         match event {
+            KademliaEvent::InboundRequest {
+                request: InboundRequest::AddProvider { record },
+            } => {
+                trace!("Add provider request received: {:?}", record);
+                if let Some(record) = record {
+                    if let Err(err) = self
+                        .swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .store_mut()
+                        .add_provider(record.clone())
+                    {
+                        error!(?err, "Failed to add provider record: {:?}", record);
+                    }
+                }
+            }
             KademliaEvent::OutboundQueryCompleted {
                 id,
                 result: QueryResult::GetClosestPeers(results),
@@ -758,6 +776,14 @@ impl NodeRunner {
                         let _ = result_sender.send(false);
                     }
                 }
+            }
+            Command::StopAnnouncing { key, result_sender } => {
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .stop_providing(&key.into());
+
+                let _ = result_sender.send(true);
             }
             Command::GetPieceProviders { key, result_sender } => {
                 let query_id = self

--- a/crates/subspace-networking/src/request_handlers.rs
+++ b/crates/subspace-networking/src/request_handlers.rs
@@ -1,4 +1,5 @@
 pub mod generic_request_handler;
 pub mod object_mappings;
 pub mod peer_info;
+pub mod piece_by_key;
 pub mod pieces_by_range;

--- a/crates/subspace-networking/src/request_handlers/piece_by_key.rs
+++ b/crates/subspace-networking/src/request_handlers/piece_by_key.rs
@@ -1,0 +1,33 @@
+//! Helper for incoming pieces requests.
+//!
+//! Handle (i.e. answer) incoming pieces requests from a remote peer received via
+//! `RequestResponsesBehaviour` with generic [`GenericRequestHandler`].
+
+use crate::request_handlers::generic_request_handler::{GenericRequest, GenericRequestHandler};
+use parity_scale_codec::{Decode, Encode};
+use subspace_core_primitives::{Piece, PieceIndexHash};
+
+/// Piece-by-hash protocol request.
+#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+pub struct PieceByHashRequest {
+    /// Piece index hash
+    pub piece_index_hash: PieceIndexHash,
+}
+
+impl GenericRequest for PieceByHashRequest {
+    const PROTOCOL_NAME: &'static str = "/subspace/piece-by-hash/0.1.0";
+    const LOG_TARGET: &'static str = "piece-by-hash-request-response-handler";
+    type Response = PieceByHashResponse;
+}
+
+/// Piece-by-hash protocol response.
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct PieceByHashResponse {
+    /// Returned data.
+    pub piece: Option<Piece>,
+}
+
+//TODO: remove attribute on the first usage
+#[allow(dead_code)]
+/// Create a new piece-by-hash request handler.
+pub type PieceByHashRequestHandler = GenericRequestHandler<PieceByHashRequest>;

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -53,7 +53,7 @@ pub(crate) enum Command {
     CheckConnectedPeers {
         result_sender: oneshot::Sender<bool>,
     },
-    Announce {
+    StartAnnouncing {
         key: Multihash,
         result_sender: oneshot::Sender<bool>,
     },

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -57,6 +57,10 @@ pub(crate) enum Command {
         key: Multihash,
         result_sender: oneshot::Sender<bool>,
     },
+    StopAnnouncing {
+        key: Multihash,
+        result_sender: oneshot::Sender<bool>,
+    },
     GetPieceProviders {
         key: Multihash,
         result_sender: oneshot::Sender<Option<Vec<PeerId>>>,

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -2,9 +2,11 @@
 mod tests;
 
 use libp2p::multiaddr::Protocol;
+use libp2p::multihash::{Code, Multihash};
 use libp2p::{Multiaddr, PeerId};
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
+use subspace_core_primitives::{PieceIndexHash, U256};
 use tracing::warn;
 
 /// This test is successful only for global IP addresses and DNS names.
@@ -92,4 +94,17 @@ pub(crate) fn convert_multiaddresses(addresses: Vec<Multiaddr>) -> Vec<PeerAddre
             }
         })
         .collect()
+}
+
+pub trait ToMultihash {
+    fn to_multihash(&self) -> Multihash;
+}
+
+impl ToMultihash for PieceIndexHash {
+    fn to_multihash(&self) -> Multihash {
+        libp2p::multihash::MultihashDigest::digest(
+            &Code::Identity,
+            &U256::from(*self).to_be_bytes(),
+        )
+    }
 }

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -6,7 +6,7 @@ use libp2p::multihash::{Code, Multihash};
 use libp2p::{Multiaddr, PeerId};
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
-use subspace_core_primitives::{PieceIndexHash, U256};
+use subspace_core_primitives::PieceIndexHash;
 use tracing::warn;
 
 /// This test is successful only for global IP addresses and DNS names.
@@ -102,9 +102,6 @@ pub trait ToMultihash {
 
 impl ToMultihash for PieceIndexHash {
     fn to_multihash(&self) -> Multihash {
-        libp2p::multihash::MultihashDigest::digest(
-            &Code::Identity,
-            &U256::from(*self).to_be_bytes(),
-        )
+        libp2p::multihash::MultihashDigest::digest(&Code::Identity, self.as_ref())
     }
 }

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -57,7 +57,7 @@ where
                     .map(|hash| hash.to_multihash());
 
                 let pieces_announcements = keys_iter
-                    .map(|key| node.announce(key).boxed())
+                    .map(|key| node.start_announcing(key).boxed())
                     .collect::<FuturesUnordered<_>>();
 
                 match pieces_announcements

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -4,7 +4,7 @@ use sc_consensus_subspace::{ArchivedSegmentNotification, SubspaceLink};
 use sp_core::traits::SpawnEssentialNamed;
 use sp_runtime::traits::Block as BlockT;
 use subspace_core_primitives::{PieceIndexHash, PIECES_IN_SEGMENT};
-use subspace_networking::CreationError;
+use subspace_networking::{CreationError, ToMultihash};
 use tracing::{error, info, trace};
 
 /// Start an archiver that will listen for archived segments and send it to DSN network using
@@ -54,7 +54,7 @@ where
                 let keys_iter = (first_piece_index..)
                     .take(archived_segment.pieces.count())
                     .map(PieceIndexHash::from_index)
-                    .map(|hash| hash.into());
+                    .map(|hash| hash.to_multihash());
 
                 let pieces_announcements = keys_iter
                     .map(|key| node.announce_piece(key))


### PR DESCRIPTION
This PR continues adding features to archival storage, relates to #846 and #845 

Changes:
- add provider republication and expiration intervals
- add provider removal method for `Node`
- removed libp2p dependency from `subspace-core-primitives`
- add piece-by-hash custom request-response protocol
- add a massive piece announcement example

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
