### PR TITLE
Consensus v2 prototyping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8013,6 +8013,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base58",
+ "bitvec",
  "blake2-rfc",
  "bytesize",
  "clap 3.2.16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -8027,6 +8027,7 @@ dependencies = [
  "jsonrpsee",
  "libc",
  "lru",
+ "memmap2",
  "num-traits",
  "parity-db",
  "parity-scale-codec",
@@ -8038,6 +8039,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ss58-registry",
+ "static_assertions",
  "std-semaphore",
  "subspace-archiving",
  "subspace-core-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8292,6 +8292,7 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "merlin 2.0.1",
  "num-traits",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,6 +7985,7 @@ dependencies = [
 name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "blake2-rfc",
  "derive_more",
  "dusk-bls12_381",
@@ -8292,7 +8293,6 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
- "bitvec",
  "merlin 2.0.1",
  "num-traits",
  "num_cpus",

--- a/crates/pallet-feeds/src/tests.rs
+++ b/crates/pallet-feeds/src/tests.rs
@@ -267,7 +267,7 @@ fn create_custom_content_feed(
             // key should match the feed name spaced key
             assert_eq!(
                 mappings[i].key,
-                crypto::blake2b_256_hash_pair(&FEED_ID.encode(), key.as_slice())
+                crypto::blake2b_256_hash_list(&[&FEED_ID.encode(), key.as_slice()])
             );
         });
 

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -46,7 +46,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU16, NonZeroU32};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -222,6 +222,10 @@ where
                 total_pieces: runtime_api
                     .total_pieces(&best_block_id)?
                     .max(PIECES_IN_SEGMENT as u64),
+                // TODO: Fetch this from the runtime
+                space_l: NonZeroU16::new(20).expect("Not zero; qed"),
+                // TODO: Fetch this from the runtime
+                sector_expiration: 100,
             }
         };
 

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = "0.99.17"
 dusk-bls12_381 = { version = "0.11", default-features = false, features = ["alloc", "groups", "pairings", "endo"] }
 dusk-bytes = "0.1"
 dusk-plonk = { version = "0.12.0", default-features = false, features = ["alloc"], git = "https://github.com/subspace/plonk", rev = "193e68ba3d20f737d730e4b6edc757e4f639e7c3" }
-hex = { version  = "0.4.3", default-features = false }
+hex = { version  = "0.4.3", default-features = false, features = ["alloc"] }
 libp2p = {version = "0.46.1", optional = true, default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic"] }
 # Not using `blake2` crate due to https://github.com/RustCrypto/hashes/issues/360
 blake2-rfc = { version = "0.2.18", default-features = false }
 derive_more = "0.99.17"
@@ -33,6 +34,7 @@ uint = { version = "0.9", default-features = false }
 [features]
 default = ["std"]
 std = [
+    "bitvec/std",
     "blake2-rfc/std",
     "dusk-bls12_381/std",
     "dusk-plonk/std",

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -45,11 +45,12 @@ pub fn blake2b_256_hash_with_key(data: &[u8], key: &[u8]) -> Blake2b256Hash {
         .expect("Initialized with correct length; qed")
 }
 
-/// BLAKE2b-256 hashing of a pair of values.
-pub fn blake2b_256_hash_pair(a: &[u8], b: &[u8]) -> Blake2b256Hash {
+/// BLAKE2b-256 hashing of a list of values.
+pub fn blake2b_256_hash_list(data: &[&[u8]]) -> Blake2b256Hash {
     let mut state = Blake2b::new(BLAKE2B_256_HASH_SIZE);
-    state.update(a);
-    state.update(b);
+    for d in data {
+        state.update(d);
+    }
     state
         .finalize()
         .as_bytes()

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -32,6 +32,7 @@ use crate::crypto::kzg::Commitment;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::AsRef;
+use core::fmt;
 use core::ops::{Deref, DerefMut};
 use derive_more::{Add, Display, Div, Mul, Rem, Sub};
 #[cfg(feature = "std")]
@@ -138,6 +139,12 @@ const VRF_PROOF_LENGTH: usize = 64;
 pub struct PublicKey(
     #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; PUBLIC_KEY_LENGTH],
 );
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
 
 impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
     fn from(bytes: [u8; PUBLIC_KEY_LENGTH]) -> Self {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -28,6 +28,7 @@ pub mod objects;
 
 extern crate alloc;
 
+use crate::crypto::blake2b_256_hash_with_key;
 use crate::crypto::kzg::Commitment;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -857,6 +858,15 @@ impl SectorId {
         piece_index
             .try_into()
             .expect("Remainder of division by PieceIndex is guaranteed to fit into PieceIndex; qed")
+    }
+
+    /// Derive local challenge for this sector from provided global challenge
+    pub fn derive_local_challenge(&self, global_challenge: &Blake2b256Hash) -> SolutionRange {
+        let hash = blake2b_256_hash_with_key(global_challenge, &self.0);
+
+        SolutionRange::from_be_bytes([
+            hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7],
+        ])
     }
 }
 

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -18,6 +18,7 @@ async-oneshot = "0.5.0"
 async-trait = "0.1.57"
 backoff = { version = "0.4.0", features = ["tokio"] }
 base58 = "0.2.0"
+bitvec = "1.0.1"
 blake2-rfc = "0.2.18"
 bytesize = "1.1.0"
 clap = { version = "3.2.16", features = ["color", "derive"] }

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -31,6 +31,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.15.1", features = ["client", "macros", "server"] }
 libc = "0.2.131"
 lru = "0.7.8"
+memmap2 = "0.5.7"
 num-traits = "0.2.15"
 parity-db = "0.3.17"
 parity-scale-codec = "3.1.5"
@@ -41,6 +42,7 @@ schnorrkel = "0.9.1"
 scopeguard = "1.1.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
+static_assertions = "1.1.0"
 std-semaphore = "0.1.0"
 ss58-registry = "1.25.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -40,6 +40,7 @@ pub(crate) mod object_mappings;
 pub(crate) mod plot;
 pub mod rpc_client;
 pub mod single_disk_farm;
+pub mod single_disk_plot;
 pub mod single_plot_farm;
 mod utils;
 pub mod ws_rpc_server;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -8,6 +8,7 @@
     trait_alias,
     try_blocks
 )]
+#![feature(int_roundings)]
 
 //! # `subspace-farmer` library implementation overview
 //!

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -38,6 +38,7 @@ mod file_ext;
 pub(crate) mod identity;
 pub(crate) mod object_mappings;
 pub(crate) mod plot;
+pub mod reward_signing;
 pub mod rpc_client;
 pub mod single_disk_farm;
 pub mod single_disk_plot;

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -8,7 +8,6 @@
     trait_alias,
     try_blocks
 )]
-#![feature(int_roundings)]
 
 //! # `subspace-farmer` library implementation overview
 //!

--- a/crates/subspace-farmer/src/reward_signing.rs
+++ b/crates/subspace-farmer/src/reward_signing.rs
@@ -1,0 +1,52 @@
+use crate::identity::Identity;
+use crate::rpc_client::RpcClient;
+use futures::StreamExt;
+use std::future::Future;
+use subspace_rpc_primitives::{RewardSignatureResponse, RewardSigningInfo};
+use tracing::{info, warn};
+
+pub async fn reward_signing<RC>(
+    rpc_client: RC,
+    identity: Identity,
+) -> Result<impl Future<Output = ()>, Box<dyn std::error::Error + Send + Sync>>
+where
+    RC: RpcClient,
+{
+    info!("Subscribing to reward signing notifications");
+
+    let mut reward_signing_info_notifications = rpc_client.subscribe_reward_signing().await?;
+
+    let reward_signing_fut = async move {
+        while let Some(RewardSigningInfo { hash, public_key }) =
+            reward_signing_info_notifications.next().await
+        {
+            // Multiple plots might have solved, only sign with correct one
+            if identity.public_key().to_bytes() != public_key {
+                continue;
+            }
+
+            let signature = identity.sign_reward_hash(&hash);
+
+            match rpc_client
+                .submit_reward_signature(RewardSignatureResponse {
+                    hash,
+                    signature: Some(signature.to_bytes().into()),
+                })
+                .await
+            {
+                Ok(_) => {
+                    info!("Successfully signed reward hash 0x{}", hex::encode(hash));
+                }
+                Err(error) => {
+                    warn!(
+                        %error,
+                        "Failed to send signature for reward hash 0x{}",
+                        hex::encode(hash),
+                    );
+                }
+            }
+        }
+    };
+
+    Ok(reward_signing_fut)
+}

--- a/crates/subspace-farmer/src/rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::Stream;
 use std::pin::Pin;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{RecordsRoot, SegmentIndex};
+use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -56,4 +56,6 @@ pub trait RpcClient: Clone + Send + Sync + 'static {
         &self,
         segment_indexes: Vec<SegmentIndex>,
     ) -> Result<Vec<Option<RecordsRoot>>, Error>;
+
+    async fn get_piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, Error>;
 }

--- a/crates/subspace-farmer/src/rpc_client/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client/bench_rpc_client.rs
@@ -3,7 +3,7 @@ use crate::utils::AbortingJoinHandle;
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::{stream, SinkExt, Stream, StreamExt};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU16, NonZeroU32};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
@@ -37,6 +37,8 @@ pub const BENCH_FARMER_PROTOCOL_INFO: FarmerProtocolInfo = FarmerProtocolInfo {
     max_plot_size: 100 * 1024 * 1024 * 1024, // 100G
     // Doesn't matter, as we don't start sync
     total_pieces: 0,
+    space_l: NonZeroU16::new(20).unwrap(),
+    sector_expiration: 100,
 };
 
 impl BenchRpcClient {

--- a/crates/subspace-farmer/src/rpc_client/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client/bench_rpc_client.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroU32;
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{RecordsRoot, SegmentIndex};
+use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -143,5 +143,9 @@ impl RpcClient for BenchRpcClient {
 
     async fn records_roots(&self, _: Vec<SegmentIndex>) -> Result<Vec<Option<RecordsRoot>>, Error> {
         Ok(Default::default())
+    }
+
+    async fn get_piece(&self, _piece_index: PieceIndex) -> Result<Option<Piece>, Error> {
+        unimplemented!()
     }
 }

--- a/crates/subspace-farmer/src/rpc_client/mock_rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client/mock_rpc_client.rs
@@ -5,7 +5,7 @@ use futures::{SinkExt, Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{RecordsRoot, SegmentIndex};
+use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -242,5 +242,9 @@ impl RpcClient for MockRpcClient {
         _: Vec<SegmentIndex>,
     ) -> Result<Vec<Option<RecordsRoot>>, MockError> {
         Ok(Default::default())
+    }
+
+    async fn get_piece(&self, _piece_index: PieceIndex) -> Result<Option<Piece>, MockError> {
+        unimplemented!()
     }
 }

--- a/crates/subspace-farmer/src/rpc_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client/node_rpc_client.rs
@@ -8,7 +8,7 @@ use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{RecordsRoot, SegmentIndex};
+use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerProtocolInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -144,6 +144,13 @@ impl RpcClient for NodeRpcClient {
         Ok(self
             .client
             .request("subspace_recordsRoots", rpc_params![&segment_indexes])
+            .await?)
+    }
+
+    async fn get_piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, RpcError> {
+        Ok(self
+            .client
+            .request("subspace_getPiece", rpc_params![&piece_index])
             .await?)
     }
 }

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -274,7 +274,7 @@ pub enum SingleDiskPlotError {
     /// Wrong chain (genesis hash)
     #[error(
         "Genesis hash of plot {id} {wrong_chain} is different from {correct_chain} when plot was \
-        created, is is not possible to use plot on a different chain"
+        created, it is not possible to use plot on a different chain"
     )]
     WrongChain {
         /// Plot ID
@@ -324,8 +324,8 @@ pub enum PlottingError {
         /// Piece index
         piece_index: PieceIndex,
     },
-    /// Failed to retriever piece
-    #[error("Failed to retriever piece {piece_index}: {error}")]
+    /// Failed to retrieve piece
+    #[error("Failed to retrieve piece {piece_index}: {error}")]
     FailedToRetrievePiece {
         /// Piece index
         piece_index: PieceIndex,

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -223,12 +223,16 @@ impl PlotMetadataHeader {
 
 #[derive(Debug, Encode, Decode)]
 struct SectorMetadata {
+    created_at: SegmentIndex,
     expires_at: SegmentIndex,
 }
 
 impl SectorMetadata {
     fn encoded_size() -> usize {
-        let default = SectorMetadata { expires_at: 0 };
+        let default = SectorMetadata {
+            created_at: 0,
+            expires_at: 0,
+        };
 
         default.encoded_size()
     }
@@ -683,8 +687,13 @@ impl SingleDiskPlot {
 
                             // TODO: Invert table in future
 
-                            sector_metadata
-                                .copy_from_slice(&SectorMetadata { expires_at }.encode());
+                            sector_metadata.copy_from_slice(
+                                &SectorMetadata {
+                                    created_at: current_segment_index,
+                                    expires_at,
+                                }
+                                .encode(),
+                            );
                             let mut metadata_header = metadata_header.lock();
                             metadata_header.sector_count += 1;
                             metadata_header_mmap

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -832,7 +832,7 @@ impl SingleDiskPlot {
 
                                 // TODO: This just have 20 bits of entropy as input, should we add
                                 //  something else?
-                                let expanded_chunk = chunk.expand();
+                                let expanded_chunk = chunk.expand(local_challenge);
 
                                 if is_within_solution_range2(
                                     local_challenge,

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -758,6 +758,9 @@ impl SingleDiskPlot {
                             .map_err(|error| FarmingError::FailedToGetFarmerProtocolInfo {
                                 error,
                             })?;
+                        let chunks_in_sector = u64::from(farmer_protocol_info.record_size.get())
+                            * u64::from(u8::BITS)
+                            / u64::from(space_l.get());
 
                         while let Some(slot_info) = handle.block_on(slot_info_notifications.next())
                         {
@@ -799,8 +802,7 @@ impl SingleDiskPlot {
 
                                 let local_challenge =
                                     sector_id.derive_local_challenge(&slot_info.global_challenge);
-                                let audit_index: u64 =
-                                    local_challenge % (plot_sector_size * u64::from(u8::BITS));
+                                let audit_index: u64 = local_challenge % chunks_in_sector;
                                 // Offset of the piece in sector (in bytes)
                                 let audit_piece_offset = (audit_index / u64::from(u8::BITS))
                                     / PIECE_SIZE as u64

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -1,0 +1,349 @@
+use crate::identity::Identity;
+use crate::rpc_client::RpcClient;
+use crate::single_disk_farm::SingleDiskSemaphore;
+use anyhow::anyhow;
+use derive_more::{Display, From};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::num::NonZeroU16;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::SystemTime;
+use std::{fs, io};
+use subspace_core_primitives::PublicKey;
+use subspace_networking::Node;
+use subspace_rpc_primitives::FarmerProtocolInfo;
+use subspace_solving::SubspaceCodec;
+use tracing::{error, Instrument, Span};
+use ulid::Ulid;
+
+/// An identifier for single disk plot, can be used for in logs, thread names, etc.
+#[derive(
+    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Display, From,
+)]
+#[serde(untagged)]
+pub enum SingleDiskPlotId {
+    /// Plot ID
+    Ulid(Ulid),
+}
+
+#[allow(clippy::new_without_default)]
+impl SingleDiskPlotId {
+    /// Creates new ID
+    pub fn new() -> Self {
+        Self::Ulid(Ulid::new())
+    }
+}
+
+/// Important information about the contents of the `SingleDiskPlot`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SingleDiskPlotInfo {
+    /// V0 of the info
+    #[serde(rename_all = "camelCase")]
+    V0 {
+        /// ID of the plot
+        id: SingleDiskPlotId,
+        /// Genesis hash of the chain used for plot creation
+        #[serde(with = "hex::serde")]
+        genesis_hash: [u8; 32],
+        /// Public key of identity used for plot creation
+        public_key: PublicKey,
+        /// First sector index in this plot
+        ///
+        /// Multiple plots can reuse the same identity, but they have to use different ranges for
+        /// sector indexes or else they'll essentially plot the same data and will not result in
+        /// increased probability of winning the reward.
+        first_sector_index: u64,
+        /// How much space in bytes is allocated for plot in this plot (metadata space is not
+        /// included)
+        allocated_plotting_space: u64,
+    },
+}
+
+impl SingleDiskPlotInfo {
+    const FILE_NAME: &'static str = "single_disk_plot.json";
+
+    pub fn new(
+        id: SingleDiskPlotId,
+        genesis_hash: [u8; 32],
+        public_key: PublicKey,
+        first_sector_index: u64,
+        allocated_plotting_space: u64,
+    ) -> Self {
+        Self::V0 {
+            id,
+            genesis_hash,
+            public_key,
+            first_sector_index,
+            allocated_plotting_space,
+        }
+    }
+
+    /// Load `SingleDiskPlot` from path is supposed to be stored, `None` means no info file was
+    /// found, happens during first start.
+    pub fn load_from(path: &Path) -> io::Result<Option<Self>> {
+        let bytes = match fs::read(path.join(Self::FILE_NAME)) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return if error.kind() == io::ErrorKind::NotFound {
+                    Ok(None)
+                } else {
+                    Err(error)
+                };
+            }
+        };
+
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    /// Store `SingleDiskPlot` info to path so it can be loaded again upon restart.
+    pub fn store_to(&self, directory: &Path) -> io::Result<()> {
+        fs::write(
+            directory.join(Self::FILE_NAME),
+            serde_json::to_vec(self).expect("Info serialization never fails; qed"),
+        )
+    }
+
+    // ID of the plot
+    pub fn id(&self) -> &SingleDiskPlotId {
+        let Self::V0 { id, .. } = self;
+        id
+    }
+
+    // Genesis hash of the chain used for plot creation
+    pub fn genesis_hash(&self) -> &[u8; 32] {
+        let Self::V0 { genesis_hash, .. } = self;
+        genesis_hash
+    }
+
+    // Public key of identity used for plot creation
+    pub fn public_key(&self) -> &PublicKey {
+        let Self::V0 { public_key, .. } = self;
+        public_key
+    }
+
+    /// First sector index in this plot
+    ///
+    /// Multiple plots can reuse the same identity, but they have to use different ranges for
+    /// sector indexes or else they'll essentially plot the same data and will not result in
+    /// increased probability of winning the reward.
+    pub fn first_sector_index(&self) -> u64 {
+        let Self::V0 {
+            first_sector_index, ..
+        } = self;
+        *first_sector_index
+    }
+
+    /// How much space in bytes is allocated for plot in this plot (metadata space is not included)
+    pub fn allocated_plotting_space(&self) -> u64 {
+        let Self::V0 {
+            allocated_plotting_space,
+            ..
+        } = self;
+        *allocated_plotting_space
+    }
+}
+
+/// Summary of single disk plot for presentational purposes
+pub enum SingleDiskPlotSummary {
+    /// Plot was found and read successfully
+    Found {
+        // ID of the plot
+        id: SingleDiskPlotId,
+        // Genesis hash of the chain used for plot creation
+        genesis_hash: [u8; 32],
+        // Public key of identity used for plot creation
+        public_key: PublicKey,
+        /// First sector index in this plot
+        first_sector_index: u64,
+        // How much space in bytes can plot use for plot (metadata space is not included)
+        allocated_plotting_space: u64,
+        /// Path to directory where plot is stored.
+        directory: PathBuf,
+    },
+    /// Plot was not found
+    NotFound {
+        /// Path to directory where plot is stored.
+        directory: PathBuf,
+    },
+    /// Failed to open plot
+    Error {
+        /// Path to directory where plot is stored.
+        directory: PathBuf,
+        /// Error itself
+        error: io::Error,
+    },
+}
+
+/// Options used to open single dis plot
+pub struct SingleDiskPlotOptions<RC> {
+    /// Path to directory where plot are stored.
+    pub directory: PathBuf,
+    /// How much space in bytes can farm use for plot
+    pub allocated_plotting_space: u64,
+    /// Identity associated with plot
+    pub identity: Identity,
+    /// Networking instance for external communication with DSN
+    pub node: Node,
+    /// RPC client connected to Subspace node
+    pub rpc_client: RC,
+    /// Address where farming rewards should go
+    pub reward_address: PublicKey,
+    /// Information about protocol necessary for farmer
+    pub farmer_protocol_info: FarmerProtocolInfo,
+}
+
+/// Single disk plot abstraction is a container for everything necessary to plot/farm with a single
+/// disk plot.
+#[must_use = "Plot does not function properly unless run() method is called"]
+pub struct SingleDiskPlot {
+    id: SingleDiskPlotId,
+    span: Span,
+    tasks: FuturesUnordered<Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>>,
+}
+
+impl SingleDiskPlot {
+    /// Create new single disk plot instance
+    pub fn new<RC>(options: SingleDiskPlotOptions<RC>) -> anyhow::Result<Self>
+    where
+        RC: RpcClient,
+    {
+        let SingleDiskPlotOptions {
+            directory,
+            allocated_plotting_space,
+            identity,
+            // TODO: Use this or remove
+            node: _,
+            farmer_protocol_info,
+            // TODO: Use this or remove
+            rpc_client: _,
+            // TODO: Use this or remove
+            reward_address: _,
+        } = options;
+
+        fs::create_dir_all(&directory)?;
+
+        // TODO: Parametrize concurrency, much higher default due to SSD focus
+        // TODO: Use this or remove
+        let _single_disk_semaphore =
+            SingleDiskSemaphore::new(NonZeroU16::new(10).expect("Not a zero; qed"));
+
+        let public_key = identity.public_key().to_bytes().into();
+
+        let single_disk_plot_info = match SingleDiskPlotInfo::load_from(&directory)? {
+            Some(single_disk_plot_info) => {
+                if allocated_plotting_space != single_disk_plot_info.allocated_plotting_space() {
+                    error!(
+                        id = %single_disk_plot_info.id(),
+                        "Usable plotting space {} is different from {} when farm was created, \
+                        resizing isn't supported yet",
+                        allocated_plotting_space,
+                        single_disk_plot_info.allocated_plotting_space(),
+                    );
+
+                    return Err(anyhow!("Can't resize farm after creation"));
+                }
+
+                if &farmer_protocol_info.genesis_hash != single_disk_plot_info.genesis_hash() {
+                    error!(
+                        id = %single_disk_plot_info.id(),
+                        "Genesis hash {} is different from {} when farm was created, is is not \
+                        possible to use farm on a different chain",
+                        hex::encode(farmer_protocol_info.genesis_hash),
+                        hex::encode(single_disk_plot_info.genesis_hash()),
+                    );
+
+                    return Err(anyhow!("Wrong chain (genesis hash)"));
+                }
+
+                if &public_key != single_disk_plot_info.public_key() {
+                    error!(
+                        id = %single_disk_plot_info.id(),
+                        "Public key {} is different from {} when farm was created, something \
+                        went wrong, likely due to manual edits",
+                        hex::encode(&public_key),
+                        hex::encode(single_disk_plot_info.public_key()),
+                    );
+
+                    return Err(anyhow!("Public key in identity doesn't match metadata"));
+                }
+
+                single_disk_plot_info
+            }
+            None => {
+                // TODO: Global generator that makes sure to avoid returning the same sector index for multiple disks
+                let first_sector_index = SystemTime::UNIX_EPOCH
+                    .elapsed()
+                    .expect("Unix epoch is always in the past; qed")
+                    .as_secs()
+                    .wrapping_mul(u64::from(u32::MAX));
+
+                let single_disk_plot_info = SingleDiskPlotInfo::new(
+                    SingleDiskPlotId::new(),
+                    farmer_protocol_info.genesis_hash,
+                    public_key,
+                    first_sector_index,
+                    allocated_plotting_space,
+                );
+
+                single_disk_plot_info.store_to(&directory)?;
+
+                single_disk_plot_info
+            }
+        };
+
+        // TODO: Use this or remove
+        let _codec = SubspaceCodec::new_with_gpu(public_key.as_ref());
+
+        let tasks =
+            FuturesUnordered::<Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>>::new();
+
+        let farm = Self {
+            id: *single_disk_plot_info.id(),
+            span: Span::current(),
+            tasks,
+        };
+
+        Ok(farm)
+    }
+
+    /// Collect summary of single disk plot for presentational purposes
+    pub fn collect_summary(directory: PathBuf) -> SingleDiskPlotSummary {
+        let single_disk_plot_info = match SingleDiskPlotInfo::load_from(&directory) {
+            Ok(Some(single_disk_plot_info)) => single_disk_plot_info,
+            Ok(None) => {
+                return SingleDiskPlotSummary::NotFound { directory };
+            }
+            Err(error) => {
+                return SingleDiskPlotSummary::Error { directory, error };
+            }
+        };
+
+        return SingleDiskPlotSummary::Found {
+            id: *single_disk_plot_info.id(),
+            genesis_hash: *single_disk_plot_info.genesis_hash(),
+            public_key: *single_disk_plot_info.public_key(),
+            first_sector_index: single_disk_plot_info.first_sector_index(),
+            allocated_plotting_space: single_disk_plot_info.allocated_plotting_space(),
+            directory,
+        };
+    }
+
+    /// ID of this farm
+    pub fn id(&self) -> &SingleDiskPlotId {
+        &self.id
+    }
+
+    pub async fn run(&mut self) -> anyhow::Result<()> {
+        while let Some(result) = self.tasks.next().instrument(self.span.clone()).await {
+            result?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -178,16 +178,8 @@ impl SingleDiskPlotInfo {
 pub enum SingleDiskPlotSummary {
     /// Plot was found and read successfully
     Found {
-        // ID of the plot
-        id: SingleDiskPlotId,
-        // Genesis hash of the chain used for plot creation
-        genesis_hash: [u8; 32],
-        // Public key of identity used for plot creation
-        public_key: PublicKey,
-        /// First sector index in this plot
-        first_sector_index: u64,
-        // How much space in bytes can plot use for plot (metadata space is not included)
-        allocated_space: u64,
+        /// Plot info
+        info: SingleDiskPlotInfo,
         /// Path to directory where plot is stored.
         directory: PathBuf,
     },
@@ -672,8 +664,8 @@ impl SingleDiskPlot {
                                         &piece[farmer_protocol_info.record_size.get() as usize..],
                                     )
                                     .expect(
-                                        "Witness must have correct size unless unless \
-                                        implementation is broken in a big way; qed",
+                                        "Witness must have correct size unless implementation \
+                                        is broken in a big way; qed",
                                     ),
                                 ) {
                                     Ok(piece_witness) => piece_witness,
@@ -688,7 +680,7 @@ impl SingleDiskPlot {
                                 };
                                 // TODO: We are skipping witness part of the piece or else it is not
                                 //  decodable
-                                // TODO: Last bits may not be encoded is record size is not multiple
+                                // TODO: Last bits may not be encoded if record size is not multiple
                                 //  of `space_l`
                                 // Encode piece
                                 piece[..farmer_protocol_info.record_size.get() as usize]
@@ -850,8 +842,8 @@ impl SingleDiskPlot {
 
                                     let piece_witness = match Witness::try_from_bytes(
                                         &<[u8; 48]>::try_from(&piece[record_size..]).expect(
-                                            "Witness must have correct size unless unless \
-                                            implementation is broken in a big way; qed",
+                                            "Witness must have correct size unless implementation \
+                                            is broken in a big way; qed",
                                         ),
                                     ) {
                                         Ok(piece_witness) => piece_witness,
@@ -948,14 +940,10 @@ impl SingleDiskPlot {
             }
         };
 
-        return SingleDiskPlotSummary::Found {
-            id: *single_disk_plot_info.id(),
-            genesis_hash: *single_disk_plot_info.genesis_hash(),
-            public_key: *single_disk_plot_info.public_key(),
-            first_sector_index: single_disk_plot_info.first_sector_index(),
-            allocated_space: single_disk_plot_info.allocated_space(),
+        SingleDiskPlotSummary::Found {
+            info: single_disk_plot_info,
             directory,
-        };
+        }
     }
 
     /// ID of this farm

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -416,7 +416,6 @@ impl SingleDiskPlot {
 
         // TODO: Account for plot overhead
         let target_sector_count = allocated_space / plot_sector_size;
-        let plot_file_size = target_sector_count * plot_sector_size;
 
         let mut metadata_file = OpenOptions::new()
             .read(true)
@@ -479,7 +478,8 @@ impl SingleDiskPlot {
             .create(true)
             .open(directory.join(Self::PLOT_FILE))?;
 
-        plot_file.preallocate(plot_file_size)?;
+        plot_file.preallocate(plot_sector_size * target_sector_count)?;
+        plot_file.advise_random_access()?;
 
         let mut plot_mmap = unsafe { MmapMut::map_mut(&plot_file)? };
 

--- a/crates/subspace-farmer/src/single_plot_farm/tests.rs
+++ b/crates/subspace-farmer/src/single_plot_farm/tests.rs
@@ -64,6 +64,8 @@ async fn plotting_happy_path() {
         recorded_history_segment_size: SEGMENT_SIZE,
         max_plot_size: u64::MAX,
         total_pieces: 0,
+        space_l: NonZeroU16::new(20).unwrap(),
+        sector_expiration: 100,
     };
 
     client.send_farmer_protocol_info(farmer_protocol_info).await;
@@ -170,6 +172,8 @@ async fn plotting_piece_eviction() {
         recorded_history_segment_size: SEGMENT_SIZE as u32,
         max_plot_size: u64::MAX,
         total_pieces: 0,
+        space_l: NonZeroU16::new(20).unwrap(),
+        sector_expiration: 100,
     };
 
     client.send_farmer_protocol_info(farmer_protocol_info).await;

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -16,9 +16,10 @@
 //! Primitives for Subspace RPC.
 
 use serde::{Deserialize, Serialize};
-use std::num::NonZeroU32;
+use std::num::{NonZeroU16, NonZeroU32};
 use subspace_core_primitives::{
-    Blake2b256Hash, PublicKey, RewardSignature, Salt, SlotNumber, Solution, SolutionRange,
+    Blake2b256Hash, PublicKey, RewardSignature, Salt, SegmentIndex, SlotNumber, Solution,
+    SolutionRange,
 };
 
 /// Defines a limit for segment indexes array. It affects storage access on the runtime side.
@@ -39,6 +40,10 @@ pub struct FarmerProtocolInfo {
     pub max_plot_size: u64,
     /// Total number of pieces stored on the network
     pub total_pieces: u64,
+    /// Space parameter for proof-of-replication in bits
+    pub space_l: NonZeroU16,
+    /// Number of segments after which sector expires
+    pub sector_expiration: SegmentIndex,
 }
 
 /// Information about new slot that just arrived

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -183,7 +183,7 @@ fn get_successful_calls(block: Block) -> Vec<Hash> {
 }
 
 fn key(feed_id: u64, data: &[u8]) -> Blake2b256Hash {
-    crypto::blake2b_256_hash_pair(&feed_id.encode(), data)
+    crypto::blake2b_256_hash_list(&[&feed_id.encode(), data])
 }
 
 #[test]

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,7 +12,6 @@ include = [
 ]
 
 [dependencies]
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic"] }
 merlin = { version = "2.0.1", default-features = false }
 num_cpus = { version = "1.13.0", optional = true }
 num-traits = { version = "0.2.15", default-features = false }

--- a/crates/subspace-solving/Cargo.toml
+++ b/crates/subspace-solving/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic"] }
 merlin = { version = "2.0.1", default-features = false }
 num_cpus = { version = "1.13.0", optional = true }
 num-traits = { version = "0.2.15", default-features = false }

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -53,7 +53,7 @@ pub fn create_tag(piece: &[u8], salt: Salt) -> Tag {
 // TODO: Separate type for global challenge
 /// Derive global slot challenge from global randomness.
 pub fn derive_global_challenge(global_randomness: &Randomness, slot: u64) -> Blake2b256Hash {
-    crypto::blake2b_256_hash_pair(global_randomness, &slot.to_le_bytes())
+    crypto::blake2b_256_hash_list(&[global_randomness, &slot.to_le_bytes()])
 }
 
 fn create_local_challenge_transcript(global_challenge: &Blake2b256Hash) -> Transcript {

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -26,8 +26,9 @@ pub use codec::{BatchEncodeError, SubspaceCodec};
 use merlin::Transcript;
 use schnorrkel::vrf::{VRFInOut, VRFOutput, VRFProof};
 use schnorrkel::{Keypair, PublicKey, SignatureResult};
+use subspace_core_primitives::crypto::{blake2b_256_hash_list, blake2b_256_hash_with_key};
 use subspace_core_primitives::{
-    crypto, Blake2b256Hash, LocalChallenge, Piece, Randomness, Salt, Tag, TagSignature, TAG_SIZE,
+    Blake2b256Hash, LocalChallenge, Piece, Randomness, Salt, SectorId, Tag, TagSignature, TAG_SIZE,
 };
 
 const LOCAL_CHALLENGE_LABEL: &[u8] = b"subspace_local_challenge";
@@ -45,7 +46,7 @@ pub fn is_tag_valid(piece: &Piece, salt: Salt, tag: Tag) -> bool {
 
 /// Create a commitment tag of a piece for a particular salt.
 pub fn create_tag(piece: &[u8], salt: Salt) -> Tag {
-    crypto::blake2b_256_hash_with_key(piece, &salt)[..TAG_SIZE]
+    blake2b_256_hash_with_key(piece, &salt)[..TAG_SIZE]
         .try_into()
         .expect("Slice is always of correct size; qed")
 }
@@ -53,7 +54,7 @@ pub fn create_tag(piece: &[u8], salt: Salt) -> Tag {
 // TODO: Separate type for global challenge
 /// Derive global slot challenge from global randomness.
 pub fn derive_global_challenge(global_randomness: &Randomness, slot: u64) -> Blake2b256Hash {
-    crypto::blake2b_256_hash_list(&[global_randomness, &slot.to_le_bytes()])
+    blake2b_256_hash_list(&[global_randomness, &slot.to_le_bytes()])
 }
 
 fn create_local_challenge_transcript(global_challenge: &Blake2b256Hash) -> Transcript {
@@ -153,4 +154,23 @@ pub fn verify_tag_signature(
             &VRFProof::from_bytes(&tag_signature.proof)?,
         )
         .map(|(in_out, _)| in_out)
+}
+
+// TODO: This is temporary and correct V2 spec will use Chia PoS primitive instead
+/// Derive one-time pad for piece chunk encoding/decoding. One-time pad is big enough for any
+/// reasonable size of `space_l`, but doesn't have to be used fully.
+pub fn derive_piece_chunk_otp(
+    sector_id: &SectorId,
+    piece_commitment: &Blake2b256Hash,
+    chunk_index: u32,
+) -> [u8; 8] {
+    let hash = blake2b_256_hash_list(&[
+        sector_id.as_ref(),
+        piece_commitment.as_ref(),
+        &chunk_index.to_le_bytes(),
+    ]);
+
+    [
+        hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7],
+    ]
 }

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -27,6 +27,7 @@ pub use codec::{BatchEncodeError, SubspaceCodec};
 use merlin::Transcript;
 use schnorrkel::vrf::{VRFInOut, VRFOutput, VRFProof};
 use schnorrkel::{Keypair, PublicKey, SignatureResult};
+use subspace_core_primitives::crypto::kzg::Witness;
 use subspace_core_primitives::crypto::{
     blake2b_256_hash, blake2b_256_hash_list, blake2b_256_hash_with_key,
 };
@@ -165,12 +166,12 @@ pub fn verify_tag_signature(
 /// reasonable size of `space_l`, but doesn't have to be used fully.
 pub fn derive_piece_chunk_otp(
     sector_id: &SectorId,
-    piece_commitment: &Blake2b256Hash,
+    piece_witness: &Witness,
     chunk_index: u32,
 ) -> [u8; 8] {
     let hash = blake2b_256_hash_list(&[
         sector_id.as_ref(),
-        piece_commitment.as_ref(),
+        &piece_witness.to_bytes(),
         &chunk_index.to_le_bytes(),
     ]);
 

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -22,18 +22,14 @@
 
 mod codec;
 
-use bitvec::prelude::*;
 pub use codec::{BatchEncodeError, SubspaceCodec};
 use merlin::Transcript;
 use schnorrkel::vrf::{VRFInOut, VRFOutput, VRFProof};
 use schnorrkel::{Keypair, PublicKey, SignatureResult};
 use subspace_core_primitives::crypto::kzg::Witness;
-use subspace_core_primitives::crypto::{
-    blake2b_256_hash, blake2b_256_hash_list, blake2b_256_hash_with_key,
-};
+use subspace_core_primitives::crypto::{blake2b_256_hash_list, blake2b_256_hash_with_key};
 use subspace_core_primitives::{
-    Blake2b256Hash, LocalChallenge, Piece, Randomness, Salt, SectorId, SolutionRange, Tag,
-    TagSignature, TAG_SIZE,
+    Blake2b256Hash, LocalChallenge, Piece, Randomness, Salt, SectorId, Tag, TagSignature, TAG_SIZE,
 };
 
 const LOCAL_CHALLENGE_LABEL: &[u8] = b"subspace_local_challenge";
@@ -164,7 +160,7 @@ pub fn verify_tag_signature(
 // TODO: This is temporary and correct V2 spec will use Chia PoS primitive instead
 /// Derive one-time pad for piece chunk encoding/decoding. One-time pad is big enough for any
 /// reasonable size of `space_l`, but doesn't have to be used fully.
-pub fn derive_piece_chunk_otp(
+pub fn derive_chunk_otp(
     sector_id: &SectorId,
     piece_witness: &Witness,
     chunk_index: u32,
@@ -178,23 +174,4 @@ pub fn derive_piece_chunk_otp(
     [
         hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7],
     ]
-}
-
-/// Expand chunk to be the same size as solution range for further comparison
-pub fn expand_chunk(chunk: &BitSlice<u8, Lsb0>) -> SolutionRange {
-    let mut bytes = 0u64.to_le_bytes();
-
-    bytes
-        .view_bits_mut::<Lsb0>()
-        .iter_mut()
-        .zip(chunk)
-        .for_each(|(mut expanded, source)| {
-            *expanded = *source;
-        });
-
-    let hash = blake2b_256_hash(&bytes);
-
-    SolutionRange::from_le_bytes([
-        hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7],
-    ])
 }

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -132,12 +132,23 @@ where
     Ok(())
 }
 
+// TODO: Delete this when dropping v1 consensus code
 /// Returns true if `solution.tag` is within the solution range.
 pub fn is_within_solution_range(target: Tag, tag: Tag, solution_range: SolutionRange) -> bool {
     let target = SolutionRange::from_be_bytes(target);
     let tag = SolutionRange::from_be_bytes(tag);
 
     subspace_core_primitives::bidirectional_distance(&target, &tag) <= solution_range / 2
+}
+
+/// Returns true if `solution.tag` is within the solution range.
+pub fn is_within_solution_range2(
+    local_challenge: SolutionRange,
+    expanded_chunk: SolutionRange,
+    solution_range: SolutionRange,
+) -> bool {
+    subspace_core_primitives::bidirectional_distance(&local_challenge, &expanded_chunk)
+        <= solution_range / 2
 }
 
 /// Returns true if piece index is within farmer sector


### PR DESCRIPTION
This PR starts with some preparation (2 commits) and then step by step prototyping `SingleDiskPlot` abstraction (derived from both `SingleDiskFarm` and `SinglePlotFarm` implementations) that will be used for V2 consensus implementation.

I tried to clean it up somewhat in the history, it compiles with 0 warnings and touches the rest of the codebase minimally. It is not used anywhere yet though.

There are still a few things that need to be done to make it functional (I have a dirty version that produces blocks locally, but needs more love before it is reviewable). The changes there will be quite massive and even more so if I make it compile without warnings, but I'd like to get your eyes on something sooner rather than later.

This is the simplified version of V2 consensus that does the following:
* derives sectors for the provided plot size
* for each sector it derives and pulls corresponding pieces form the node (will be replaced with querying DSN in the future)
* then every piece is sliced into chunks (except witness part so we can decode it later) of specified bit size and encoded with one-time pad derived from sector ID, witness of the piece and chunk index
* metadata about each sector is also stored in a separate flat binary file and contains information about the height (in pieces) at sector creation and expiration info
* during audit we derive local challenge for every sector separately
* as the result we get audit index, pointing to chunk in sector we need to audit
* chunk is expanded to the size of solution range and checked against local challenge (which is of the same size) to see if it is within solution range
* actual solution creation and verification is missing because it requires a lot of changes all around the codebase

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
