### PR TITLE
Executor test fixes

### DIFF
--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -392,7 +392,11 @@ mod pallet {
                             "Invalid signed opaque bundle: {:?}, error: {:?}",
                             signed_opaque_bundle, e
                         );
-                        return InvalidTransactionCode::Bundle.into();
+                        if let BundleError::Receipt(_) = e {
+                            return InvalidTransactionCode::ExecutionReceipt.into();
+                        } else {
+                            return InvalidTransactionCode::Bundle.into();
+                        }
                     }
 
                     let mut builder = ValidTransaction::with_tag_prefix("SubspaceSubmitBundle")

--- a/crates/pallet-executor/src/lib.rs
+++ b/crates/pallet-executor/src/lib.rs
@@ -50,7 +50,6 @@ mod pallet {
     };
     use sp_runtime::SaturatedConversion;
     use sp_std::fmt::Debug;
-    use sp_std::vec::Vec;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/crates/pallet-executor/src/tests.rs
+++ b/crates/pallet-executor/src/tests.rs
@@ -175,6 +175,10 @@ fn submit_execution_receipt_incrementally_should_work() {
     };
 
     new_test_ext().execute_with(|| {
+        let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
+        BlockHash::<Test>::insert(0, genesis_hash);
+        Executor::initialize_genesis_receipt(genesis_hash);
+
         (0..256).for_each(|index| {
             let block_hash = block_hashes[index];
             BlockHash::<Test>::insert((index + 1) as u64, block_hash);

--- a/cumulus/client/cirrus-executor/src/tests.rs
+++ b/cumulus/client/cirrus-executor/src/tests.rs
@@ -65,7 +65,9 @@ async fn test_executor_full_node_catching_up() {
     );
 }
 
-// TODO: Re-enable when it can pass at least in a great chance.
+// TODO: This test fails if running all the tests in this crate
+// with `cargo test -- --ignored`, but passes if running individually, `cargo nextest run` also
+// passes.
 #[substrate_test_utils::test(flavor = "multi_thread")]
 #[ignore]
 async fn fraud_proof_verification_in_tx_pool_should_work() {


### PR DESCRIPTION
In this PR, I fixed the tests for the upgrade in #835 and #809 and run them locally. One thing left is that there is one test `fraud_proof_verification_in_tx_pool_should_work` which can fail if running with all the other tests with `cargo test -- --ignored`, but it passes if running individually, I'd love to revisit when we are about to enable these tests in CI. `cargo nextest run` is green for running all tests.

It's recommended to review commit by commit. The reason behind the changes is detailed in each commit with an explanation in the expanded commit message or the comment.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
