### PR TITLE
Remove the parent receipt check for submit_bundle extrinsic from the tx pool

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -44,8 +44,8 @@ mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_core::H256;
     use sp_domains::{
-        BundleEquivocationProof, ExecutionReceipt, FraudProof, InvalidTransactionCode,
-        InvalidTransactionProof, SignedOpaqueBundle,
+        BundleEquivocationProof, ExecutionReceipt, ExecutorPublicKey, FraudProof,
+        InvalidTransactionCode, InvalidTransactionProof, SignedOpaqueBundle,
     };
     use sp_runtime::traits::{
         BlockNumberProvider, CheckEqual, MaybeDisplay, MaybeMallocSizeOf, One, SimpleBitOps, Zero,
@@ -172,8 +172,11 @@ mod pallet {
             primary_number: T::BlockNumber,
             primary_hash: T::Hash,
         },
-        /// A transaction bundle was included.
-        TransactionBundleStored { bundle_hash: H256 },
+        /// A domain bundle was included.
+        BundleStored {
+            bundle_hash: H256,
+            bundle_author: ExecutorPublicKey,
+        },
         /// A fraud proof was processed.
         FraudProofProcessed,
         /// A bundle equivocation proof was processed.
@@ -202,8 +205,9 @@ mod pallet {
                 Self::apply_execution_receipt(receipt);
             }
 
-            Self::deposit_event(Event::TransactionBundleStored {
+            Self::deposit_event(Event::BundleStored {
                 bundle_hash: signed_opaque_bundle.hash(),
+                bundle_author: signed_opaque_bundle.proof_of_election.executor_public_key,
             });
 
             Ok(())

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,15 +1,15 @@
-use crate::{self as pallet_domains, BlockHash, ReceiptVotes, Receipts};
+use crate::{self as pallet_domains, BlockHash, OldestReceiptNumber, ReceiptVotes, Receipts};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Hooks};
 use frame_support::{assert_noop, assert_ok, parameter_types};
 use sp_core::crypto::Pair;
 use sp_core::{H256, U256};
 use sp_domains::{
     Bundle, BundleHeader, ExecutionPhase, ExecutionReceipt, ExecutorPair, FraudProof,
-    ProofOfElection, SignedOpaqueBundle,
+    InvalidTransactionCode, ProofOfElection, SignedOpaqueBundle,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup, ValidateUnsigned};
-use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidityError};
+use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_trie::StorageProof;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -202,7 +202,7 @@ fn submit_execution_receipt_incrementally_should_work() {
             pallet_domains::Pallet::<Test>::pre_dispatch(&pallet_domains::Call::submit_bundle {
                 signed_opaque_bundle: dummy_bundles[258].clone()
             }),
-            TransactionValidityError::Invalid(InvalidTransaction::Future)
+            TransactionValidityError::Invalid(InvalidTransactionCode::ExecutionReceipt.into())
         );
 
         assert_ok!(Domains::submit_bundle(
@@ -329,14 +329,17 @@ fn submit_bundle_with_many_reeipts_should_work() {
         assert!(BlockHash::<Test>::contains_key(0));
         assert_ok!(Domains::submit_bundle(Origin::none(), bundle2));
         assert!(!BlockHash::<Test>::contains_key(0));
+        assert_eq!(OldestReceiptNumber::<Test>::get(), 1);
 
         assert!(BlockHash::<Test>::contains_key(1));
         assert_ok!(Domains::submit_bundle(Origin::none(), bundle3));
         assert!(!BlockHash::<Test>::contains_key(1));
+        assert_eq!(OldestReceiptNumber::<Test>::get(), 2);
 
         assert!(BlockHash::<Test>::contains_key(2));
         assert_ok!(Domains::submit_bundle(Origin::none(), bundle4));
         assert!(!BlockHash::<Test>::contains_key(2));
+        assert_eq!(OldestReceiptNumber::<Test>::get(), 3);
         assert_eq!(Domains::finalized_receipt_number(), 2);
         assert_eq!(Domains::best_execution_chain_number(), 258);
     });


### PR DESCRIPTION
Based on the agreement, the parent receipt checking that is not strictly necessary is removed from the tx pool, which is effectively done by removing the `requires` tag of the submit_bundle extrinsic.

The logic of processing the receipts inside `submit_bundle` is also changed, now there is a clear separation between processing the new best and non-new-best receipt, the main difference is the new best receipt will update the receipt head and optionally prune the stale receipts, the non-new-best receipt will increase the receipt votes and may be tracked if it's a fork receipt.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
