### PR TITLE
DSN farmer plot integration

### DIFF
--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -526,7 +526,7 @@ pub type PieceIndex = u64;
 pub type SectorIndex = u64;
 
 /// Hash of `PieceIndex`
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Decode, Encode)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PieceIndexHash(Blake2b256Hash);
 

--- a/crates/subspace-farmer/benches/auditing.rs
+++ b/crates/subspace-farmer/benches/auditing.rs
@@ -71,7 +71,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         block_on(plot_sector(
             &public_key,
             sector_index,
-            &mut BenchPieceReceiver::new(piece),
+            &BenchPieceReceiver::new(piece),
             &cancelled,
             &farmer_protocol_info,
             plotted_sector.as_mut_slice(),

--- a/crates/subspace-farmer/benches/plotting.rs
+++ b/crates/subspace-farmer/benches/plotting.rs
@@ -51,6 +51,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         space_l: NonZeroU16::new(20).unwrap(),
         sector_expiration: 1,
     };
+    let piece_receiver = BenchPieceReceiver::new(piece);
 
     let mut group = c.benchmark_group("sector-plotting");
     group.throughput(Throughput::Bytes(plot_sector_size(
@@ -61,7 +62,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             block_on(plot_sector(
                 black_box(&public_key),
                 black_box(sector_index),
-                black_box(&mut BenchPieceReceiver::new(piece.clone())),
+                black_box(&piece_receiver),
                 black_box(&cancelled),
                 black_box(&farmer_protocol_info),
                 black_box(io::sink()),
@@ -84,7 +85,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     block_on(plot_sector(
                         black_box(&public_key),
                         black_box(sector_index),
-                        black_box(&mut BenchPieceReceiver::new(piece.clone())),
+                        black_box(&piece_receiver),
                         black_box(&cancelled),
                         black_box(&farmer_protocol_info),
                         black_box(io::sink()),

--- a/crates/subspace-farmer/benches/proving.rs
+++ b/crates/subspace-farmer/benches/proving.rs
@@ -76,7 +76,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         block_on(plot_sector(
             &public_key,
             sector_index,
-            &mut BenchPieceReceiver::new(piece),
+            &BenchPieceReceiver::new(piece),
             &cancelled,
             &farmer_protocol_info,
             plotted_sector.as_mut_slice(),

--- a/crates/subspace-farmer/benches/utils/mod.rs
+++ b/crates/subspace-farmer/benches/utils/mod.rs
@@ -10,7 +10,7 @@ pub struct BenchPieceReceiver {
 #[async_trait]
 impl PieceReceiver for BenchPieceReceiver {
     async fn get_piece(
-        &mut self,
+        &self,
         _piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
         Ok(Some(self.piece.clone()))

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -245,9 +245,12 @@ async fn configure_dsn(
                     (reader, piece_details)
                 };
 
-                handle.block_on(
-                    reader.read_piece(piece_details.sector_index, piece_details.piece_offset),
-                )
+                let handle = handle.clone();
+                tokio::task::block_in_place(move || {
+                    handle.block_on(
+                        reader.read_piece(piece_details.sector_index, piece_details.piece_offset),
+                    )
+                })
             } else {
                 debug!(key=?req.key, "Incorrect piece request - unsupported key type.");
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -65,7 +65,7 @@ pub(crate) async fn farm_multi_disk(
 
     let mut single_disk_plots_stream = single_disk_plots
         .into_iter()
-        .map(|single_disk_plot| single_disk_plot.wait())
+        .map(|single_disk_plot| single_disk_plot.run())
         .collect::<FuturesUnordered<_>>();
 
     futures::select!(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -91,6 +91,8 @@ pub(crate) async fn farm_multi_disk(
         .map(|single_disk_plot| single_disk_plot.piece_reader())
         .collect::<Vec<_>>();
 
+    debug!("Collecting already plotted pieces");
+
     // Collect already plotted pieces
     let plotted_pieces: HashMap<PieceIndexHash, PieceDetails> = single_disk_plots
         .iter()
@@ -130,6 +132,8 @@ pub(crate) async fn farm_multi_disk(
         })
         // We implicitly ignore duplicates here, reading just from one of the plots
         .collect();
+
+    debug!("Finished collecting already plotted pieces");
 
     readers_and_pieces.lock().replace(ReadersAndPieces {
         readers: piece_readers,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -3,13 +3,32 @@ use crate::{DiskFarm, FarmingArgs, Multiaddr};
 use anyhow::{anyhow, Result};
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use subspace_core_primitives::{PieceIndexHash, SectorIndex};
+use subspace_farmer::single_disk_plot::piece_reader::PieceReader;
 use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
 use subspace_farmer::NodeRpcClient;
 use subspace_networking::{
     create, BootstrappedNetworkingParameters, Config, Node, NodeRunner, PieceByHashRequestHandler,
     PieceByHashResponse, PieceKey,
 };
-use tracing::{debug, info};
+use tokio::runtime::Handle;
+use tracing::{debug, error, info};
+
+#[derive(Debug, Copy, Clone)]
+struct PieceDetails {
+    plot_offset: usize,
+    sector_index: SectorIndex,
+    piece_offset: u64,
+}
+
+#[derive(Debug)]
+struct ReadersAndPieces {
+    readers: Vec<PieceReader>,
+    pieces: HashMap<PieceIndexHash, PieceDetails>,
+}
 
 /// Start farming by using multiple replica plot in specified path and connecting to WebSocket
 /// server at specified address.
@@ -36,7 +55,10 @@ pub(crate) async fn farm_multi_disk(
         enable_dsn,
     } = farming_args;
 
-    let (node, node_runner) = configure_dsn(enable_dsn, listen_on, bootstrap_nodes).await?;
+    let readers_and_pieces = Arc::new(Mutex::new(None));
+
+    let (node, node_runner) =
+        configure_dsn(enable_dsn, listen_on, bootstrap_nodes, &readers_and_pieces).await?;
     let mut single_disk_plots = Vec::with_capacity(disk_farms.len());
 
     // TODO: Check plot and metadata sizes to ensure there is enough space for farmer to not
@@ -63,10 +85,99 @@ pub(crate) async fn farm_multi_disk(
         single_disk_plots.push(single_disk_plot);
     }
 
+    // Store piece readers so we can reference them later
+    let piece_readers = single_disk_plots
+        .iter()
+        .map(|single_disk_plot| single_disk_plot.piece_reader())
+        .collect::<Vec<_>>();
+
+    // Collect already plotted pieces
+    let plotted_pieces: HashMap<PieceIndexHash, PieceDetails> = single_disk_plots
+        .iter()
+        .enumerate()
+        .flat_map(|(plot_offset, single_disk_plot)| {
+            single_disk_plot
+                .plotted_sectors()
+                .enumerate()
+                .filter_map(move |(sector_offset, plotted_sector_result)| {
+                    match plotted_sector_result {
+                        Ok(plotted_sector) => Some(plotted_sector),
+                        Err(error) => {
+                            error!(
+                                %error,
+                                %plot_offset,
+                                %sector_offset,
+                                "Failed reading plotted sector on startup, skipping"
+                            );
+                            None
+                        }
+                    }
+                })
+                .flat_map(move |plotted_sector| {
+                    plotted_sector.piece_indexes.into_iter().enumerate().map(
+                        move |(piece_offset, piece_index)| {
+                            (
+                                PieceIndexHash::from_index(piece_index),
+                                PieceDetails {
+                                    plot_offset,
+                                    sector_index: plotted_sector.sector_index,
+                                    piece_offset: piece_offset as u64,
+                                },
+                            )
+                        },
+                    )
+                })
+        })
+        // We implicitly ignore duplicates here, reading just from one of the plots
+        .collect();
+
+    readers_and_pieces.lock().replace(ReadersAndPieces {
+        readers: piece_readers,
+        pieces: plotted_pieces,
+    });
+
     let mut single_disk_plots_stream = single_disk_plots
         .into_iter()
-        .map(|single_disk_plot| single_disk_plot.run())
+        .enumerate()
+        .map(|(plot_offset, single_disk_plot)| {
+            let readers_and_pieces = Arc::clone(&readers_and_pieces);
+
+            // Collect newly plotted pieces
+            // TODO: Once we have replotting, this will have to be updated
+            single_disk_plot
+                .on_sector_plotted(Arc::new(move |plotted_sector| {
+                    readers_and_pieces
+                        .lock()
+                        .as_mut()
+                        .expect("Initial value was populated above; qed")
+                        .pieces
+                        .extend(
+                            plotted_sector
+                                .piece_indexes
+                                .iter()
+                                .copied()
+                                .enumerate()
+                                .map(|(piece_offset, piece_index)| {
+                                    (
+                                        PieceIndexHash::from_index(piece_index),
+                                        PieceDetails {
+                                            plot_offset,
+                                            sector_index: plotted_sector.sector_index,
+                                            piece_offset: piece_offset as u64,
+                                        },
+                                    )
+                                }),
+                        );
+                }))
+                .detach();
+
+            single_disk_plot.run()
+        })
         .collect::<FuturesUnordered<_>>();
+
+    // Drop original instance such that the only remaining instances are in `SingleDiskPlot`
+    // event handlers
+    drop(readers_and_pieces);
 
     futures::select!(
         // Signal future
@@ -103,21 +214,40 @@ async fn configure_dsn(
     enable_dsn: bool,
     listen_on: Vec<Multiaddr>,
     bootstrap_nodes: Vec<Multiaddr>,
+    readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
 ) -> Result<(Option<Node>, Option<NodeRunner>), anyhow::Error> {
     if !enable_dsn {
         info!("No DSN configured.");
         return Ok((None, None));
     }
 
+    let weak_readers_and_pieces = Arc::downgrade(readers_and_pieces);
+
+    let handle = Handle::current();
     let config = Config {
         listen_on,
         allow_non_globals_in_dht: true,
         networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
             .boxed(),
         request_response_protocols: vec![PieceByHashRequestHandler::create(move |req| {
-            let result = if let PieceKey::Sector(_piece_index_hash) = req.key {
-                // TODO: Implement actual handler
-                None
+            let result = if let PieceKey::Sector(piece_index_hash) = req.key {
+                let (mut reader, piece_details) = {
+                    let readers_and_pieces = weak_readers_and_pieces.upgrade()?;
+                    let readers_and_pieces = readers_and_pieces.lock();
+                    let readers_and_pieces = readers_and_pieces.as_ref()?;
+                    let piece_details =
+                        readers_and_pieces.pieces.get(&piece_index_hash).copied()?;
+                    let reader = readers_and_pieces
+                        .readers
+                        .get(piece_details.plot_offset)
+                        .cloned()
+                        .expect("Offsets strictly correspond to existing plots; qed");
+                    (reader, piece_details)
+                };
+
+                handle.block_on(
+                    reader.read_piece(piece_details.sector_index, piece_details.piece_offset),
+                )
             } else {
                 debug!(key=?req.key, "Incorrect piece request - unsupported key type.");
 

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -771,7 +771,7 @@ impl SingleDiskPlot {
         };
         #[cfg(unix)]
         {
-            global_plot_mmap.advise(memmap2::Advice::Random).unwrap();
+            global_plot_mmap.advise(memmap2::Advice::Random)?;
         }
         let global_sector_metadata_mmap = unsafe {
             MmapOptions::new()
@@ -821,7 +821,9 @@ impl SingleDiskPlot {
                             };
                             #[cfg(unix)]
                             {
-                                plot_mmap.advise(memmap2::Advice::Random).unwrap();
+                                plot_mmap
+                                    .advise(memmap2::Advice::Random)
+                                    .map_err(FarmingError::Io)?;
                             }
                             let metadata_mmap = unsafe {
                                 MmapOptions::new()
@@ -832,7 +834,9 @@ impl SingleDiskPlot {
                             };
                             #[cfg(unix)]
                             {
-                                metadata_mmap.advise(memmap2::Advice::Random).unwrap();
+                                metadata_mmap
+                                    .advise(memmap2::Advice::Random)
+                                    .map_err(FarmingError::Io)?;
                             }
                             let shutting_down = Arc::clone(&shutting_down);
 

--- a/crates/subspace-farmer/src/single_disk_plot/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/farming.rs
@@ -7,7 +7,8 @@ use std::io::SeekFrom;
 use subspace_core_primitives::crypto::blake2b_256_254_hash;
 use subspace_core_primitives::crypto::kzg::Witness;
 use subspace_core_primitives::{
-    Blake2b256Hash, Chunk, Piece, PublicKey, SectorId, Solution, SolutionRange, PIECE_SIZE,
+    Blake2b256Hash, Chunk, Piece, PublicKey, SectorId, SectorIndex, Solution, SolutionRange,
+    PIECE_SIZE,
 };
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::{create_chunk_signature, derive_chunk_otp};
@@ -20,7 +21,7 @@ pub struct EligibleSector {
     /// Sector ID
     pub sector_id: SectorId,
     /// Sector index
-    pub sector_index: u64,
+    pub sector_index: SectorIndex,
     /// Derived local challenge
     pub local_challenge: SolutionRange,
     /// Audit index corresponding to the challenge used

--- a/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
@@ -1,0 +1,99 @@
+use bitvec::prelude::*;
+use futures::channel::{mpsc, oneshot};
+use futures::SinkExt;
+use std::num::{NonZeroU16, NonZeroU32};
+use subspace_core_primitives::{Piece, PublicKey, SectorId, SectorIndex, PIECE_SIZE};
+use subspace_solving::derive_chunk_otp;
+
+#[derive(Debug)]
+pub(super) struct ReadPieceRequest {
+    pub(super) sector_index: SectorIndex,
+    pub(super) piece_offset: u64,
+    pub(super) response_sender: oneshot::Sender<Option<Piece>>,
+}
+
+/// Wrapper data structure that can be used to read pieces from single disk plot
+#[derive(Debug, Clone)]
+pub struct PieceReader {
+    read_piece_sender: mpsc::Sender<ReadPieceRequest>,
+}
+
+impl PieceReader {
+    pub(super) fn new() -> (Self, mpsc::Receiver<ReadPieceRequest>) {
+        let (read_piece_sender, read_piece_receiver) = mpsc::channel::<ReadPieceRequest>(10);
+
+        (Self { read_piece_sender }, read_piece_receiver)
+    }
+
+    pub(super) fn close_all_readers(&mut self) {
+        self.read_piece_sender.close_channel();
+    }
+
+    /// Read piece from sector by offset, `None` means input parameters are incorrect or piece
+    /// reader was shut down
+    pub async fn read_piece(
+        &mut self,
+        sector_index: SectorIndex,
+        piece_offset: u64,
+    ) -> Option<Piece> {
+        let (response_sender, response_receiver) = oneshot::channel();
+        self.read_piece_sender
+            .send(ReadPieceRequest {
+                sector_index,
+                piece_offset,
+                response_sender,
+            })
+            .await
+            .ok()?;
+        response_receiver.await.ok()?
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn read_piece(
+    sector_index: SectorIndex,
+    piece_offset: u64,
+    sector_count: u64,
+    public_key: &PublicKey,
+    first_sector_index: SectorIndex,
+    plot_sector_size: u64,
+    record_size: NonZeroU32,
+    space_l: NonZeroU16,
+    global_plot: &[u8],
+) -> Option<Piece> {
+    let sector_offset = sector_index - first_sector_index;
+    // Sector must be plotted
+    if sector_offset <= sector_count {
+        None?;
+    }
+    // Piece must be within sector
+    if piece_offset >= plot_sector_size / PIECE_SIZE as u64 {
+        None?;
+    }
+    let sector_bytes = &global_plot[(sector_offset * plot_sector_size) as usize..];
+    let piece_bytes = &sector_bytes[piece_offset as usize * PIECE_SIZE..][..PIECE_SIZE];
+    let mut piece = Piece::try_from(piece_bytes).ok()?;
+
+    let sector_id = SectorId::new(public_key, sector_index);
+
+    // Decode piece
+    let (record, witness_bytes) = piece.split_at_mut(record_size.get() as usize);
+    // TODO: Extract encoding into separate function reusable in farmer and
+    //  otherwise
+    record
+        .view_bits_mut::<Lsb0>()
+        .chunks_mut(space_l.get() as usize)
+        .enumerate()
+        .for_each(|(chunk_index, bits)| {
+            // Derive one-time pad
+            let mut otp = derive_chunk_otp(&sector_id, witness_bytes, chunk_index as u32);
+            // XOR chunk bit by bit with one-time pad
+            bits.iter_mut()
+                .zip(otp.view_bits_mut::<Lsb0>().iter())
+                .for_each(|(mut a, b)| {
+                    *a ^= *b;
+                });
+        });
+
+    Some(piece)
+}

--- a/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
@@ -61,14 +61,17 @@ pub(super) fn read_piece(
     space_l: NonZeroU16,
     global_plot: &[u8],
 ) -> Option<Piece> {
+    if sector_index < first_sector_index {
+        return None;
+    }
     let sector_offset = sector_index - first_sector_index;
     // Sector must be plotted
     if sector_offset <= sector_count {
-        None?;
+        return None;
     }
     // Piece must be within sector
     if piece_offset >= plot_sector_size / PIECE_SIZE as u64 {
-        None?;
+        return None;
     }
     let sector_bytes = &global_plot[(sector_offset * plot_sector_size) as usize..];
     let piece_bytes = &sector_bytes[piece_offset as usize * PIECE_SIZE..][..PIECE_SIZE];

--- a/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
@@ -4,6 +4,7 @@ use futures::SinkExt;
 use std::num::{NonZeroU16, NonZeroU32};
 use subspace_core_primitives::{Piece, PublicKey, SectorId, SectorIndex, PIECE_SIZE};
 use subspace_solving::derive_chunk_otp;
+use tracing::warn;
 
 #[derive(Debug)]
 pub(super) struct ReadPieceRequest {
@@ -62,15 +63,36 @@ pub(super) fn read_piece(
     global_plot: &[u8],
 ) -> Option<Piece> {
     if sector_index < first_sector_index {
+        warn!(
+            %sector_index,
+            %piece_offset,
+            %sector_count,
+            %first_sector_index,
+            "Incorrect first sector index"
+        );
         return None;
     }
     let sector_offset = sector_index - first_sector_index;
     // Sector must be plotted
-    if sector_offset <= sector_count {
+    if sector_offset >= sector_count {
+        warn!(
+            %sector_index,
+            %piece_offset,
+            %sector_count,
+            %first_sector_index,
+            "Incorrect sector offset"
+        );
         return None;
     }
     // Piece must be within sector
     if piece_offset >= plot_sector_size / PIECE_SIZE as u64 {
+        warn!(
+            %sector_index,
+            %piece_offset,
+            %sector_count,
+            %first_sector_index,
+            "Incorrect piece offset"
+        );
         return None;
     }
     let sector_bytes = &global_plot[(sector_offset * plot_sector_size) as usize..];

--- a/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
@@ -100,7 +100,7 @@ impl<'a, RC: RpcClient> MultiChannelPieceReceiver<'a, RC> {
                     }
                 }
                 Ok(None) => {
-                    info!(%piece_index,?key, "get_value returned no piece");
+                    debug!(%piece_index,?key, "get_value returned no piece");
                 }
                 Err(err) => {
                     error!(%piece_index,?key, ?err, "get_value returned an error");

--- a/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
@@ -1,6 +1,5 @@
 use crate::RpcClient;
 use async_trait::async_trait;
-use std::collections::HashSet;
 use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -17,7 +16,7 @@ const GET_PIECE_WAITING_DURATION_IN_SECS: u64 = 1;
 #[async_trait]
 pub trait PieceReceiver {
     async fn get_piece(
-        &mut self,
+        &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
 }
@@ -27,7 +26,6 @@ pub(crate) struct MultiChannelPieceReceiver<'a, RC: RpcClient> {
     rpc_client: RC,
     dsn_node: Option<Node>,
     cancelled: &'a AtomicBool,
-    registered_piece_indexes: HashSet<PieceIndex>,
 }
 
 impl<'a, RC: RpcClient> MultiChannelPieceReceiver<'a, RC> {
@@ -36,12 +34,7 @@ impl<'a, RC: RpcClient> MultiChannelPieceReceiver<'a, RC> {
             rpc_client,
             dsn_node,
             cancelled,
-            registered_piece_indexes: HashSet::new(),
         }
-    }
-
-    pub(crate) fn registered_piece_indexes(&self) -> Vec<PieceIndex> {
-        self.registered_piece_indexes.iter().cloned().collect()
     }
 
     fn check_cancellation(&self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
@@ -52,10 +45,6 @@ impl<'a, RC: RpcClient> MultiChannelPieceReceiver<'a, RC> {
         }
 
         Ok(())
-    }
-
-    fn register_piece_index(&mut self, piece_index: PieceIndex) {
-        self.registered_piece_indexes.insert(piece_index);
     }
 
     // restore after fixing https://github.com/libp2p/rust-libp2p/issues/3048
@@ -184,15 +173,13 @@ impl<'a, RC: RpcClient> MultiChannelPieceReceiver<'a, RC> {
 #[async_trait]
 impl<'a, RC: RpcClient> PieceReceiver for MultiChannelPieceReceiver<'a, RC> {
     async fn get_piece(
-        &mut self,
+        &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>
     where
         RC: RpcClient,
     {
         trace!(%piece_index, "Piece request. DSN={:?}", self.dsn_node.is_some());
-
-        self.register_piece_index(piece_index);
 
         if self.dsn_node.is_some() {
             // until we get a valid piece

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -44,7 +44,7 @@ pub enum PlotSectorError {
 pub async fn plot_sector<PR, S, SM>(
     public_key: &PublicKey,
     sector_index: u64,
-    piece_receiver: &mut PR,
+    piece_receiver: &PR,
     cancelled: &AtomicBool,
     farmer_protocol_info: &FarmerProtocolInfo,
     mut sector_output: S,

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -5,11 +5,25 @@ use bitvec::prelude::*;
 use parity_scale_codec::Encode;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
-use subspace_core_primitives::{plot_sector_size, PieceIndex, PublicKey, SectorId, PIECE_SIZE};
+use subspace_core_primitives::{
+    plot_sector_size, PieceIndex, PublicKey, SectorId, SectorIndex, PIECE_SIZE,
+};
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::derive_chunk_otp;
 use thiserror::Error;
 use tracing::debug;
+
+/// Information about sector that was plotted
+pub struct PlottedSector {
+    /// Sector ID
+    pub sector_id: SectorId,
+    /// Sector index
+    pub sector_index: SectorIndex,
+    /// Sector metadata
+    pub sector_metadata: SectorMetadata,
+    /// Indexes of pieces that were plotted
+    pub piece_indexes: Vec<PieceIndex>,
+}
 
 /// Plotting status
 #[derive(Debug, Error)]
@@ -33,9 +47,9 @@ pub async fn plot_sector<PR, S, SM>(
     piece_receiver: &mut PR,
     cancelled: &AtomicBool,
     farmer_protocol_info: &FarmerProtocolInfo,
-    mut sector: S,
-    mut sector_metadata: SM,
-) -> Result<(), PlotSectorError>
+    mut sector_output: S,
+    mut sector_metadata_output: SM,
+) -> Result<PlottedSector, PlotSectorError>
 where
     PR: PieceReceiver,
     S: io::Write,
@@ -52,7 +66,17 @@ where
         * 2;
     let expires_at = current_segment_index + farmer_protocol_info.sector_expiration;
 
-    for piece_offset in (0u64..).take(plot_sector_size as usize / PIECE_SIZE) {
+    let piece_indexes: Vec<PieceIndex> = (0u64..)
+        .take(plot_sector_size as usize / PIECE_SIZE)
+        .map(|piece_offset| {
+            sector_id.derive_piece_index(
+                piece_offset as PieceIndex,
+                farmer_protocol_info.total_pieces,
+            )
+        })
+        .collect();
+
+    for piece_index in piece_indexes.iter().copied() {
         if cancelled.load(Ordering::Acquire) {
             debug!(
                 %sector_index,
@@ -60,10 +84,6 @@ where
             );
             return Err(PlotSectorError::Cancelled);
         }
-        let piece_index = sector_id.derive_piece_index(
-            piece_offset as PieceIndex,
-            farmer_protocol_info.total_pieces,
-        );
 
         let mut piece = piece_receiver
             .get_piece(piece_index)
@@ -95,18 +115,22 @@ where
                     });
             });
 
-        sector.write_all(&piece).map_err(PlottingError::Io)?;
+        sector_output.write_all(&piece).map_err(PlottingError::Io)?;
     }
 
-    sector_metadata
-        .write_all(
-            &SectorMetadata {
-                total_pieces: farmer_protocol_info.total_pieces,
-                expires_at,
-            }
-            .encode(),
-        )
+    let sector_metadata = SectorMetadata {
+        total_pieces: farmer_protocol_info.total_pieces,
+        expires_at,
+    };
+
+    sector_metadata_output
+        .write_all(&sector_metadata.encode())
         .map_err(PlottingError::Io)?;
 
-    Ok(())
+    Ok(PlottedSector {
+        sector_id,
+        sector_index,
+        sector_metadata,
+        piece_indexes,
+    })
 }


### PR DESCRIPTION
This implements retrieval of pieces from farmer's plot for DSN purposes.

First few commits introduce new APIs and change behavior slightly that allows to both read pieces that were plotted during previous runs (and make sure nothing is plotted in the meantime) and subscribe to notifications about newly plotted pieces.

The last commit just wires those new APIs into DSN on the level of farming command.

There is still room for optimizations here, such as reading pieces from one plot for the needs of the other plot or allow parallel reads from the same plot, but as an MVP this should do the job.

@shamil-gadelshin I didn't really test this with DSN, but supposedly this works. Please let me know how it goes for you.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
