### PR TITLE
Pallet domain registry (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4484,6 +4484,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-domain-registry"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "pallet-executor-registry",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-domains",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-domains"
 version = "0.1.0"
 dependencies = [

--- a/domains/pallets/domain-registry/Cargo.toml
+++ b/domains/pallets/domain-registry/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "pallet-domain-registry"
+version = "0.1.0"
+authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace/"
+description = "System domain pallet for the domains management"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+frame-system = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+log = { version = "0.4.17", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+serde = { version = "1.0.143", optional = true }
+sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598", default-features = false }
+
+[dev-dependencies]
+pallet-balances = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
+pallet-executor-registry = { path = "../executor-registry" }
+sp-core = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
+sp-io = { git = "https://github.com/subspace/substrate", rev = "1a7c28721fa77ecce9632ad9ce473f2d3cf1a598" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-domains/std",
+	"sp-runtime/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -17,6 +17,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
+mod tests;
+
 use frame_support::traits::{Currency, Get, LockIdentifier, LockableCurrency, WithdrawReasons};
 pub use pallet::*;
 use sp_domains::{BundleEquivocationProof, DomainId, FraudProof, InvalidTransactionProof};

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -1,0 +1,344 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Domain Registry Module
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::traits::{Currency, LockIdentifier};
+pub use pallet::*;
+use sp_domains::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
+
+type BalanceOf<T> =
+    <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+const DOMAIN_LOCK_ID: LockIdentifier = *b"_domains";
+
+#[frame_support::pallet]
+mod pallet {
+    use super::BalanceOf;
+    use frame_support::pallet_prelude::*;
+    use frame_support::traits::LockableCurrency;
+    use frame_system::pallet_prelude::*;
+    use sp_arithmetic::Percent;
+    use sp_domains::{
+        BundleEquivocationProof, DomainId, FraudProof, InvalidTransactionCode,
+        InvalidTransactionProof,
+    };
+    use sp_runtime::traits::Zero;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
+
+        /// Minimum amount of deposit to create a domain.
+        #[pallet::constant]
+        type MinDomainDeposit: Get<BalanceOf<Self>>;
+
+        /// Maximum amount of deposit to create a domain.
+        #[pallet::constant]
+        type MaxDomainDeposit: Get<BalanceOf<Self>>;
+
+        /// Minimal stake to be a domain operator.
+        ///
+        /// This is global, each domain can have its own minimum stake requirement
+        /// but must be no less than this value.
+        #[pallet::constant]
+        type MinDomainOperatorStake: Get<BalanceOf<Self>>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::without_storage_info]
+    pub struct Pallet<T>(_);
+
+    /// Domain configuration.
+    #[derive(Debug, Encode, Decode, TypeInfo, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+    pub struct DomainConfig<Hash, Balance> {
+        /// Hash of the domain wasm runtime blob.
+        pub wasm_runtime_hash: Hash,
+
+        // May be supported later.
+        //pub upgrade_keys: Vec<AccountId>,
+        // TODO: elaborate this field.
+        pub bundle_frequency: u32,
+
+        /// Maximum domain bundle size in bytes.
+        pub max_bundle_size: u32,
+
+        /// Maximum domain bundle weight.
+        pub max_bundle_weight: Weight,
+
+        /// Minimum executor stake value to be an operator on this domain.
+        pub min_operator_stake: Balance,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Creates a new domain with some deposit locked.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn create_domain(
+            origin: OriginFor<T>,
+            deposit: BalanceOf<T>,
+            domain_config: DomainConfig<T::Hash, BalanceOf<T>>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // TODO: impl
+
+            Ok(())
+        }
+
+        // TODO: support destroy_domain in the future.
+
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn update_domain_config(
+            origin: OriginFor<T>,
+            domain_id: DomainId,
+            _domain_config: DomainConfig<T::Hash, BalanceOf<T>>,
+        ) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            // TODO: Check if the origin account is allowed to update the config.
+
+            // TODO: validate domain_config and deposit an event DomainConfigUpdated
+
+            Ok(())
+        }
+
+        /// Register a new domain operator.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn register_domain_operator(
+            origin: OriginFor<T>,
+            domain_id: DomainId,
+            to_stake: Percent,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // TODO: impl
+
+            Ok(())
+        }
+
+        /// Update the domain stake.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn update_domain_stake(
+            origin: OriginFor<T>,
+            domain_id: DomainId,
+            new_stake: Percent,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // TODO: impl
+
+            Ok(())
+        }
+
+        /// Deregister a domain operator.
+        // TODO: proper weight
+        #[pallet::weight(10_000)]
+        pub fn deregister_domain_operator(
+            origin: OriginFor<T>,
+            domain_id: DomainId,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            // TODO: impl
+
+            Ok(())
+        }
+
+        // TODO: proper weight
+        #[pallet::weight((10_000, Pays::No))]
+        pub fn submit_fraud_proof(
+            origin: OriginFor<T>,
+            _fraud_proof: FraudProof,
+        ) -> DispatchResult {
+            ensure_none(origin)?;
+
+            // TODO: slash the executor accordingly.
+
+            Self::deposit_event(Event::FraudProofProcessed);
+
+            Ok(())
+        }
+
+        // TODO: proper weight
+        #[pallet::weight((10_000, Pays::No))]
+        pub fn submit_bundle_equivocation_proof(
+            origin: OriginFor<T>,
+            _bundle_equivocation_proof: BundleEquivocationProof<T::Hash>,
+        ) -> DispatchResult {
+            ensure_none(origin)?;
+
+            // TODO: slash the executor accordingly.
+
+            Self::deposit_event(Event::BundleEquivocationProofProcessed);
+
+            Ok(())
+        }
+
+        // TODO: proper weight
+        #[pallet::weight((10_000, Pays::No))]
+        pub fn submit_invalid_transaction_proof(
+            origin: OriginFor<T>,
+            _invalid_transaction_proof: InvalidTransactionProof,
+        ) -> DispatchResult {
+            ensure_none(origin)?;
+
+            // TODO: slash the executor accordingly.
+
+            Self::deposit_event(Event::InvalidTransactionProofProcessed);
+
+            Ok(())
+        }
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {}
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        FraudProofProcessed,
+
+        BundleEquivocationProofProcessed,
+
+        InvalidTransactionProofProcessed,
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_initialize(_block_number: T::BlockNumber) -> Weight {
+            // TODO: Need a hook in pallet-executor-registry to snapshot the domain
+            // authorities as well as the stake weight on each new epoch.
+
+            // TODO: proper weight
+            Weight::zero()
+        }
+    }
+
+    /// Constructs a `TransactionValidity` with pallet-domain-registry specific defaults.
+    fn unsigned_validity(prefix: &'static str, tag: impl Encode) -> TransactionValidity {
+        ValidTransaction::with_tag_prefix(prefix)
+            .priority(TransactionPriority::MAX)
+            .and_provides(tag)
+            .longevity(TransactionLongevity::MAX)
+            // TODO: may not be necessary if using farmnet as the global executor network.
+            .propagate(true)
+            .build()
+    }
+
+    // TODO: the fraud-proof unsigned extrinsics are same with the ones in pallet-doamins, probably
+    // find an abstraction to unify them.
+    #[pallet::validate_unsigned]
+    impl<T: Config> ValidateUnsigned for Pallet<T> {
+        type Call = Call<T>;
+        fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
+            match call {
+                Call::submit_fraud_proof { .. } => Ok(()),
+                Call::submit_bundle_equivocation_proof { .. } => Ok(()),
+                Call::submit_invalid_transaction_proof { .. } => Ok(()),
+                _ => Err(InvalidTransaction::Call.into()),
+            }
+        }
+
+        fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+            match call {
+                Call::submit_fraud_proof { fraud_proof } => {
+                    if let Err(e) = Self::validate_fraud_proof(fraud_proof) {
+                        log::error!(
+                            target: "runtime::subspace::executor",
+                            "Invalid fraud proof: {:?}, error: {:?}",
+                            fraud_proof, e
+                        );
+                        return InvalidTransactionCode::FraudProof.into();
+                    }
+
+                    // TODO: proper tag value.
+                    unsigned_validity("SubspaceSubmitFraudProof", fraud_proof)
+                }
+                Call::submit_bundle_equivocation_proof {
+                    bundle_equivocation_proof,
+                } => {
+                    if let Err(e) =
+                        Self::validate_bundle_equivocation_proof(bundle_equivocation_proof)
+                    {
+                        log::error!(
+                            target: "runtime::subspace::executor",
+                            "Invalid bundle equivocation proof: {:?}, error: {:?}",
+                            bundle_equivocation_proof, e
+                        );
+                        return InvalidTransactionCode::BundleEquivicationProof.into();
+                    }
+
+                    unsigned_validity(
+                        "SubspaceSubmitBundleEquivocationProof",
+                        bundle_equivocation_proof.hash(),
+                    )
+                }
+                Call::submit_invalid_transaction_proof {
+                    invalid_transaction_proof,
+                } => {
+                    if let Err(e) =
+                        Self::validate_invalid_transaction_proof(invalid_transaction_proof)
+                    {
+                        log::error!(
+                            target: "runtime::subspace::executor",
+                            "Wrong InvalidTransactionProof: {:?}, error: {:?}",
+                            invalid_transaction_proof, e
+                        );
+                        return InvalidTransactionCode::TrasactionProof.into();
+                    }
+
+                    unsigned_validity(
+                        "SubspaceSubmitInvalidTransactionProof",
+                        invalid_transaction_proof,
+                    )
+                }
+
+                _ => InvalidTransaction::Call.into(),
+            }
+        }
+    }
+}
+
+impl<T: Config> Pallet<T> {
+    // TODO: Verify fraud_proof.
+    fn validate_fraud_proof(_fraud_proof: &FraudProof) -> Result<(), Error<T>> {
+        Ok(())
+    }
+
+    // TODO: Verify bundle_equivocation_proof.
+    fn validate_bundle_equivocation_proof(
+        _bundle_equivocation_proof: &BundleEquivocationProof<T::Hash>,
+    ) -> Result<(), Error<T>> {
+        Ok(())
+    }
+
+    // TODO: Verify invalid_transaction_proof.
+    fn validate_invalid_transaction_proof(
+        _invalid_transaction_proof: &InvalidTransactionProof,
+    ) -> Result<(), Error<T>> {
+        Ok(())
+    }
+}

--- a/domains/pallets/domain-registry/src/tests.rs
+++ b/domains/pallets/domain-registry/src/tests.rs
@@ -1,0 +1,343 @@
+use crate::{
+    self as pallet_domain_registry, DomainConfig, DomainCreators, DomainOperators, Domains, Error,
+    NextDomainId,
+};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, GenesisBuild};
+use frame_support::{assert_noop, assert_ok, parameter_types};
+use pallet_balances::AccountData;
+use sp_core::crypto::Pair;
+use sp_core::{H256, U256};
+use sp_domains::{ExecutorPair, StakeWeight};
+use sp_runtime::testing::Header;
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+use sp_runtime::Percent;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+    pub struct Test
+    where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system,
+        Balances: pallet_balances,
+        ExecutorRegistry: pallet_executor_registry,
+        DomainRegistry: pallet_domain_registry,
+    }
+);
+
+type AccountId = u64;
+type BlockNumber = u64;
+type Balance = u128;
+type Hash = H256;
+
+impl frame_system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = BlockNumber;
+    type Hash = Hash;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = ConstU64<2>;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = AccountData<Balance>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ConstU16<42>;
+    type OnSetCode = ();
+    type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+    pub static ExistentialDeposit: Balance = 1;
+}
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = ();
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type Balance = Balance;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const MinExecutorStake: Balance = 10;
+    pub const MaxExecutorStake: Balance = 1000;
+    pub const MinExecutors: u32 = 1;
+    pub const MaxExecutors: u32 = 10;
+    pub const EpochDuration: BlockNumber = 3;
+    pub const MaxWithdrawals: u32 = 1;
+    pub const WithdrawalDuration: BlockNumber = 10;
+}
+
+impl pallet_executor_registry::Config for Test {
+    type Event = Event;
+    type Currency = Balances;
+    type StakeWeight = StakeWeight;
+    type MinExecutorStake = MinExecutorStake;
+    type MaxExecutorStake = MaxExecutorStake;
+    type MinExecutors = MinExecutors;
+    type MaxExecutors = MaxExecutors;
+    type EpochDuration = EpochDuration;
+    type MaxWithdrawals = MaxWithdrawals;
+    type WithdrawalDuration = WithdrawalDuration;
+}
+
+impl crate::ExecutorRegistry<AccountId, Balance> for ExecutorRegistry {
+    fn executor_stake(who: &AccountId) -> Option<Balance> {
+        ExecutorRegistry::executor_stake(who)
+    }
+}
+
+parameter_types! {
+    pub const MinDomainDeposit: Balance = 10;
+    pub const MaxDomainDeposit: Balance = 1000;
+    pub const MinDomainOperatorStake: u32 = 10;
+}
+
+impl pallet_domain_registry::Config for Test {
+    type Event = Event;
+    type Currency = Balances;
+    type ExecutorRegistry = ExecutorRegistry;
+    type MinDomainDeposit = MinDomainDeposit;
+    type MaxDomainDeposit = MaxDomainDeposit;
+    type MinDomainOperatorStake = MinDomainOperatorStake;
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(1, 1000), (2, 2000), (3, 3000), (4, 4000)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    pallet_executor_registry::GenesisConfig::<Test> {
+        executors: vec![
+            (
+                1,
+                100,
+                1 + 10000,
+                ExecutorPair::from_seed(&U256::from(1u32).into()).public(),
+            ),
+            (
+                2,
+                200,
+                2 + 10000,
+                ExecutorPair::from_seed(&U256::from(2u32).into()).public(),
+            ),
+        ],
+        slot_probability: (1u64, 1u64),
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    pallet_domain_registry::GenesisConfig::<Test> {
+        domains: vec![(
+            1,
+            100,
+            DomainConfig {
+                wasm_runtime_hash: Hash::repeat_byte(1),
+                bundle_frequency: 100,
+                max_bundle_size: 1024 * 1024,
+                max_bundle_weight: 100_000_000_000,
+                min_operator_stake: 20,
+            },
+            1,
+            Percent::from_percent(80),
+        )],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    t.into()
+}
+
+#[test]
+fn create_domain_should_work() {
+    new_test_ext().execute_with(|| {
+        let genesis_domain_config = DomainConfig {
+            wasm_runtime_hash: Hash::repeat_byte(1),
+            bundle_frequency: 100,
+            max_bundle_size: 1024 * 1024,
+            max_bundle_weight: 100_000_000_000,
+            min_operator_stake: 20,
+        };
+        assert_eq!(Domains::<Test>::get(0).unwrap(), genesis_domain_config);
+        assert_eq!(NextDomainId::<Test>::get(), 1);
+        assert_eq!(DomainCreators::<Test>::get(0, 1), Some(100));
+
+        let domain_config = DomainConfig {
+            wasm_runtime_hash: Hash::random(),
+            bundle_frequency: 100,
+            max_bundle_size: 1024 * 1024,
+            max_bundle_weight: 100_000_000_000,
+            min_operator_stake: 20,
+        };
+
+        assert_noop!(
+            DomainRegistry::create_domain(Origin::signed(1), 1, domain_config.clone()),
+            Error::<Test>::DepositTooSmall
+        );
+        assert_noop!(
+            DomainRegistry::create_domain(Origin::signed(1), 10_000, domain_config.clone()),
+            Error::<Test>::DepositTooLarge
+        );
+        assert_noop!(
+            DomainRegistry::create_domain(Origin::signed(8), 100, domain_config.clone()),
+            Error::<Test>::InsufficientBalance
+        );
+        assert_noop!(
+            DomainRegistry::create_domain(
+                Origin::signed(1),
+                100,
+                DomainConfig {
+                    min_operator_stake: 1,
+                    ..domain_config
+                }
+            ),
+            Error::<Test>::OperatorStakeThresholdTooLow
+        );
+
+        let (creator, deposit) = (2, 200);
+        let next_domain_id = NextDomainId::<Test>::get();
+        assert_ok!(DomainRegistry::create_domain(
+            Origin::signed(creator),
+            deposit,
+            domain_config.clone(),
+        ));
+        assert_eq!(
+            frame_system::Account::<Test>::get(&creator).data,
+            AccountData {
+                free: 2000,
+                reserved: 0,
+                misc_frozen: deposit,
+                fee_frozen: deposit
+            }
+        );
+
+        assert_eq!(Domains::<Test>::get(next_domain_id).unwrap(), domain_config);
+        assert_eq!(NextDomainId::<Test>::get(), next_domain_id + 1);
+        assert_eq!(
+            DomainCreators::<Test>::get(next_domain_id, creator),
+            Some(deposit)
+        );
+    });
+}
+
+#[test]
+fn register_domain_operator_and_update_domain_stake_should_work() {
+    new_test_ext().execute_with(|| {
+        assert_eq!(
+            DomainOperators::<Test>::get(1, 0).unwrap(),
+            Percent::from_percent(80)
+        );
+
+        assert_noop!(
+            DomainRegistry::update_domain_stake(Origin::signed(1), 0, Percent::from_percent(10),),
+            Error::<Test>::OperatorStakeTooSmall
+        );
+
+        assert_ok!(DomainRegistry::update_domain_stake(
+            Origin::signed(1),
+            0,
+            Percent::from_percent(20),
+        ));
+
+        assert_eq!(
+            DomainOperators::<Test>::get(1, 0).unwrap(),
+            Percent::from_percent(20)
+        );
+
+        assert_ok!(DomainRegistry::create_domain(
+            Origin::signed(2),
+            200,
+            DomainConfig {
+                wasm_runtime_hash: Hash::random(),
+                bundle_frequency: 100,
+                max_bundle_size: 1024 * 1024,
+                max_bundle_weight: 100_000_000_000,
+                min_operator_stake: 20,
+            }
+        ));
+
+        // only 80% is available.
+        assert_noop!(
+            DomainRegistry::register_domain_operator(
+                Origin::signed(1),
+                1,
+                Percent::from_percent(90),
+            ),
+            Error::<Test>::StakeAllocationTooLarge
+        );
+
+        assert_ok!(DomainRegistry::register_domain_operator(
+            Origin::signed(1),
+            1,
+            Percent::from_percent(80),
+        ));
+
+        assert_ok!(DomainRegistry::register_domain_operator(
+            Origin::signed(2),
+            0,
+            Percent::from_percent(50),
+        ));
+
+        assert_eq!(
+            DomainOperators::<Test>::get(2, 0).unwrap(),
+            Percent::from_percent(50)
+        );
+
+        assert_noop!(
+            DomainRegistry::register_domain_operator(
+                Origin::signed(3),
+                1,
+                Percent::from_percent(30),
+            ),
+            Error::<Test>::NotExecutor
+        );
+    });
+}
+
+#[test]
+fn deregister_domain_operator_should_work() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            DomainRegistry::deregister_domain_operator(Origin::signed(3), 0,),
+            Error::<Test>::NotOperator
+        );
+
+        assert_ok!(DomainRegistry::register_domain_operator(
+            Origin::signed(2),
+            0,
+            Percent::from_percent(50),
+        ));
+
+        assert_ok!(DomainRegistry::deregister_domain_operator(
+            Origin::signed(1),
+            0,
+        ));
+
+        assert!(DomainOperators::<Test>::get(1, 0).is_none());
+    });
+}

--- a/domains/pallets/executor-registry/src/lib.rs
+++ b/domains/pallets/executor-registry/src/lib.rs
@@ -749,6 +749,10 @@ mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+    pub fn executor_stake(who: &T::AccountId) -> Option<BalanceOf<T>> {
+        Executors::<T>::get(who).map(|executor| executor.stake)
+    }
+
     fn lock_fund(who: &T::AccountId, value: BalanceOf<T>) {
         T::Currency::set_lock(EXECUTOR_LOCK_ID, who, value, WithdrawReasons::all());
     }


### PR DESCRIPTION
This PR primarily introduces pallet-domain-registry with the basic interfaces implemented:

- `create_domain`
- `register_domain_operator`
- `update_domain_stake`
- `deregister_domain_operator`

`register_domain_operator` and `update_domain_stake` are basically the same at present in terms of the implementation except for the event emitted, having two calls is to make it semantically clearer as I can't find a nice name to express both of them, please comment if you have any idea.

Some TODOs need to be clarified in the design doc with more details. The next part of pallet-domain-registry will be supporting the domain operators' rotation according to the update of executor set on each epoch. Once it's done, we can start the core domain node integration with one genesis core domain registered.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
