### PR TITLE
Extra check for single disk plot shutdown

### DIFF
--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -764,6 +764,11 @@ impl SingleDiskPlot {
 
                         while let Some(slot_info) = handle.block_on(slot_info_notifications.next())
                         {
+                            if shutting_down.load(Ordering::Acquire) {
+                                debug!("Instance is shutting down, interrupting farming");
+                                return;
+                            }
+
                             debug!(?slot_info, "New slot");
 
                             let sector_count = metadata_header.lock().sector_count;


### PR DESCRIPTION
I discovered a deadlock on drop of single disk plot. So this pr fixes that with addition of shutdown check on each slot.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)