### PR TITLE
Improve archiver tests

### DIFF
--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -443,11 +443,32 @@ fn spill_over_edge_case() {
     // encoding + one more for enum variant, this should result in new segment being created, but
     // the very first segment item will not include newly added block because it would result in
     // subtracting with overflow when trying to slice internal bytes of the segment item
+    let archived_segments = archiver.add_block(
+        vec![0u8; SEGMENT_SIZE as usize],
+        BlockObjectMapping {
+            objects: vec![BlockObject::V0 {
+                hash: Blake2b256Hash::default(),
+                offset: 0,
+            }],
+        },
+    );
+    assert_eq!(archived_segments.len(), 2);
+    // If spill over actually happened, we'll not find object mapping in the first segment
     assert_eq!(
-        archiver
-            .add_block(vec![0u8; 2_usize.pow(17)], BlockObjectMapping::default())
-            .len(),
-        2
+        archived_segments[0]
+            .object_mapping
+            .iter()
+            .filter(|o| !o.objects.is_empty())
+            .count(),
+        0
+    );
+    assert_eq!(
+        archived_segments[1]
+            .object_mapping
+            .iter()
+            .filter(|o| !o.objects.is_empty())
+            .count(),
+        1
     );
 }
 

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -375,11 +375,9 @@ fn invalid_usage() {
     }
 }
 
-// WARNING: Tests for various edge cases below use deliberately computed values and unless
-// calculated carefully on piece size change (decrease from current 32kiB) will be unable to catch
-// edge-cases. Please check commits where this tests are introduced for the edge cases they are
-// testing (filling encoded segment) and ensure they still test those edge cases in case you have to
-// decrease piece size in the future.
+// Please check commits where this tests are introduced for the edge cases they are testing (filling
+// encoded segment) and ensure they still test those edge cases in case you have to decrease piece
+// size in the future.
 
 #[test]
 fn one_byte_smaller_segment() {


### PR DESCRIPTION
I had to do several piece size changes recently and even for me it was hard to work with archiver tests because they are testing very specific rare edge cases and on piece/segment size changes they may start passing for incorrect implementation.

If it is hard for me, it'll be extremely hard for others.

Here I update tests to check edge cases from both sides where it was missing to make sure we check what we think we check. Also hand-picked values are replaced with computed values, so that they check the expected behavior, but do not rely on the specific piece size.

Also some comments were updated to make it even more clear what is happening. It basically describes how things are in memory and goes from there, so by reading the test you can build a mental model of what segment should look like at that moment in time.

Each test is updated in a separate commit for convenience, let me know if this is better and if there is anything else I can do to make it more understandable.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
