### PR TITLE
Create `subspace-farmer-components` crate where plotting, auditing and proving code is moved for wider reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,12 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,20 +465,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.7",
- "instant",
- "pin-project-lite 0.2.9",
- "rand 0.8.5",
- "tokio",
-]
 
 [[package]]
 name = "backtrace"
@@ -8373,30 +8353,23 @@ dependencies = [
 
 [[package]]
 name = "subspace-farmer"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "arc-swap",
- "async-oneshot",
  "async-trait",
- "backoff",
  "base58",
  "bitvec",
  "blake2-rfc",
  "bytesize",
  "clap 4.0.22",
- "criterion",
  "derive_more",
  "dirs",
  "event-listener-primitives",
  "fdlimit",
- "fs2",
  "futures 0.3.21",
  "hex",
  "jemallocator",
  "jsonrpsee",
- "libc",
- "lru 0.7.8",
  "memmap2",
  "num-traits",
  "parity-db",
@@ -8405,7 +8378,6 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "schnorrkel",
- "scopeguard",
  "serde",
  "serde_json",
  "ss58-registry",
@@ -8413,10 +8385,10 @@ dependencies = [
  "std-semaphore",
  "subspace-archiving",
  "subspace-core-primitives",
+ "subspace-farmer-components",
  "subspace-networking",
  "subspace-rpc-primitives",
  "subspace-solving",
- "subspace-verification",
  "substrate-bip39",
  "tempfile",
  "thiserror",
@@ -8425,6 +8397,32 @@ dependencies = [
  "tracing-subscriber 0.3.15",
  "ulid",
  "zeroize",
+]
+
+[[package]]
+name = "subspace-farmer-components"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bitvec",
+ "blake2-rfc",
+ "criterion",
+ "fs2",
+ "futures 0.3.21",
+ "libc",
+ "memmap2",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "rayon",
+ "schnorrkel",
+ "static_assertions",
+ "subspace-archiving",
+ "subspace-core-primitives",
+ "subspace-rpc-primitives",
+ "subspace-solving",
+ "subspace-verification",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "subspace-farmer-components"
+description = "Farmer for the Subspace Network Blockchain"
+license = "MIT OR Apache-2.0"
+version = "0.1.0"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+    "/README.md",
+]
+
+[lib]
+# Necessary for CLI options to work on benches
+bench = false
+
+[dependencies]
+async-trait = "0.1.57"
+bitvec = "1.0.1"
+blake2-rfc = "0.2.18"
+fs2 = "0.4.3"
+libc = "0.2.131"
+parity-scale-codec = "3.1.5"
+rand = "0.8.5"
+schnorrkel = "0.9.1"
+static_assertions = "1.1.0"
+subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
+subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
+subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
+thiserror = "1.0.32"
+tracing = "0.1.36"
+
+[dev-dependencies]
+criterion = "0.4.0"
+futures = "0.3.21"
+memmap2 = "0.5.7"
+rayon = "1.5.3"
+subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
+
+[[bench]]
+name = "plotting"
+harness = false
+
+[[bench]]
+name = "auditing"
+harness = false
+
+[[bench]]
+name = "proving"
+harness = false

--- a/crates/subspace-farmer-components/README.md
+++ b/crates/subspace-farmer-components/README.md
@@ -1,0 +1,5 @@
+# Subspace Farmer Components
+
+Components of the reference implementation of Subspace Farmer for Subspace Network Blockchain.
+
+These components are used to implement farmer itself, but can also be used independently if necessary.

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -14,9 +14,9 @@ use subspace_core_primitives::{
     Blake2b256Hash, Piece, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE,
     RECORD_SIZE,
 };
-use subspace_farmer::file_ext::FileExt;
-use subspace_farmer::single_disk_plot::farming::audit_sector;
-use subspace_farmer::single_disk_plot::plotting::plot_sector;
+use subspace_farmer_components::farming::audit_sector;
+use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::plotting::plot_sector;
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use utils::BenchPieceReceiver;
 

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -13,7 +13,7 @@ use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{
     Piece, PublicKey, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE, RECORD_SIZE,
 };
-use subspace_farmer::single_disk_plot::plotting::plot_sector;
+use subspace_farmer_components::plotting::plot_sector;
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use utils::BenchPieceReceiver;
 

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -15,10 +15,10 @@ use subspace_core_primitives::{
     Blake2b256Hash, Piece, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE,
     RECORD_SIZE,
 };
-use subspace_farmer::file_ext::FileExt;
-use subspace_farmer::single_disk_plot::farming::audit_sector;
-use subspace_farmer::single_disk_plot::plotting::plot_sector;
-use subspace_farmer::single_disk_plot::SectorMetadata;
+use subspace_farmer_components::farming::audit_sector;
+use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::plotting::plot_sector;
+use subspace_farmer_components::SectorMetadata;
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use utils::BenchPieceReceiver;
 

--- a/crates/subspace-farmer-components/benches/utils/mod.rs
+++ b/crates/subspace-farmer-components/benches/utils/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use std::error::Error;
 use subspace_core_primitives::{Piece, PieceIndex};
-use subspace_farmer::single_disk_plot::piece_receiver::PieceReceiver;
+use subspace_farmer_components::plotting::PieceReceiver;
 
 pub struct BenchPieceReceiver {
     piece: Piece,

--- a/crates/subspace-farmer-components/src/farming.rs
+++ b/crates/subspace-farmer-components/src/farming.rs
@@ -1,4 +1,4 @@
-use crate::single_disk_plot::{FarmingError, SectorMetadata};
+use crate::SectorMetadata;
 use bitvec::prelude::*;
 use parity_scale_codec::{Decode, IoReader};
 use schnorrkel::Keypair;
@@ -13,7 +13,22 @@ use subspace_core_primitives::{
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::{create_chunk_signature, derive_chunk_otp};
 use subspace_verification::is_within_solution_range;
+use thiserror::Error;
 use tracing::error;
+
+/// Errors that happen during farming
+#[derive(Debug, Error)]
+pub enum FarmingError {
+    /// Failed to decode sector metadata
+    #[error("Failed to decode sector metadata: {error}")]
+    FailedToDecodeMetadata {
+        /// Lower-level error
+        error: parity_scale_codec::Error,
+    },
+    /// I/O error occurred
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+}
 
 /// Sector that can be used to create a solution that is within desired solution range
 #[derive(Debug, Clone)]

--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -1,6 +1,10 @@
+//! File extension trait
+
 use std::fs::File;
 use std::io::Result;
 
+/// Extension convenience trait that allows pre-allocating files, suggesting random access pattern
+/// and doing cross-platform exact reads/writes
 pub trait FileExt {
     /// Make sure file has specified number of bytes allocated for it
     fn preallocate(&self, len: u64) -> Result<()>;

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -1,0 +1,38 @@
+//! Components of the reference implementation of Subspace Farmer for Subspace Network Blockchain.
+//!
+//! These components are used to implement farmer itself, but can also be used independently if necessary.
+
+pub mod farming;
+pub mod file_ext;
+pub mod plotting;
+
+use parity_scale_codec::{Decode, Encode};
+use static_assertions::const_assert;
+use std::num::NonZeroU64;
+use subspace_core_primitives::SegmentIndex;
+
+// Refuse to compile on non-64-bit platforms, offsets may fail on those when converting from u64 to
+// usize depending on chain parameters
+const_assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u64>());
+
+/// Metadata of the plotted sector
+#[doc(hidden)]
+#[derive(Debug, Encode, Decode, Clone)]
+pub struct SectorMetadata {
+    /// Total number of pieces in archived history of the blockchain as of sector creation
+    pub total_pieces: NonZeroU64,
+    /// Sector expiration, defined as sector of the archived history of the blockchain
+    pub expires_at: SegmentIndex,
+}
+
+impl SectorMetadata {
+    /// Size of encoded sector metadata
+    pub fn encoded_size() -> usize {
+        let default = SectorMetadata {
+            total_pieces: NonZeroU64::new(1).expect("1 is not 0; qed"),
+            expires_at: 0,
+        };
+
+        default.encoded_size()
+    }
+}

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -1,17 +1,26 @@
-use crate::single_disk_plot::piece_receiver::PieceReceiver;
-use crate::single_disk_plot::{PlottingError, SectorMetadata};
+use crate::SectorMetadata;
+use async_trait::async_trait;
 use bitvec::order::Lsb0;
 use bitvec::prelude::*;
 use parity_scale_codec::Encode;
+use std::error::Error;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use subspace_core_primitives::{
-    PieceIndex, PublicKey, SectorId, SectorIndex, PIECE_SIZE, PLOT_SECTOR_SIZE,
+    Piece, PieceIndex, PublicKey, SectorId, SectorIndex, PIECE_SIZE, PLOT_SECTOR_SIZE,
 };
 use subspace_rpc_primitives::FarmerProtocolInfo;
 use subspace_solving::derive_chunk_otp;
 use thiserror::Error;
 use tracing::debug;
+
+#[async_trait]
+pub trait PieceReceiver {
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
+}
 
 /// Information about sector that was plotted
 #[derive(Debug, Clone)]
@@ -28,13 +37,27 @@ pub struct PlottedSector {
 
 /// Plotting status
 #[derive(Debug, Error)]
-pub enum PlotSectorError {
+pub enum PlottingError {
     /// Plotting was cancelled
     #[error("Plotting was cancelled")]
     Cancelled,
-    /// Plotting failed
-    #[error("Plotting failed: {0}")]
-    Plotting(#[from] PlottingError),
+    /// Piece not found, can't create sector, this should never happen
+    #[error("Piece {piece_index} not found, can't create sector, this should never happen")]
+    PieceNotFound {
+        /// Piece index
+        piece_index: PieceIndex,
+    },
+    /// Failed to retrieve piece
+    #[error("Failed to retrieve piece {piece_index}: {error}")]
+    FailedToRetrievePiece {
+        /// Piece index
+        piece_index: PieceIndex,
+        /// Lower-level error
+        error: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+    /// I/O error occurred
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
 }
 
 /// Plot a single sector, where `sector` and `sector_metadata` must be positioned correctly (seek to
@@ -50,7 +73,7 @@ pub async fn plot_sector<PR, S, SM>(
     farmer_protocol_info: &FarmerProtocolInfo,
     mut sector_output: S,
     mut sector_metadata_output: SM,
-) -> Result<PlottedSector, PlotSectorError>
+) -> Result<PlottedSector, PlottingError>
 where
     PR: PieceReceiver,
     S: io::Write,
@@ -82,7 +105,7 @@ where
                 %sector_index,
                 "Plotting was cancelled, interrupting plotting"
             );
-            return Err(PlotSectorError::Cancelled);
+            return Err(PlottingError::Cancelled);
         }
 
         let mut piece = piece_receiver
@@ -115,7 +138,7 @@ where
                     });
             });
 
-        sector_output.write_all(&piece).map_err(PlottingError::Io)?;
+        sector_output.write_all(&piece)?;
     }
 
     let sector_metadata = SectorMetadata {
@@ -123,9 +146,7 @@ where
         expires_at,
     };
 
-    sector_metadata_output
-        .write_all(&sector_metadata.encode())
-        .map_err(PlottingError::Io)?;
+    sector_metadata_output.write_all(&sector_metadata.encode())?;
 
     Ok(PlottedSector {
         sector_id,

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "subspace-farmer"
 description = "Farmer for the Subspace Network Blockchain"
 license = "MIT OR Apache-2.0"
-version = "0.3.0"
+version = "0.1.0"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"
 include = [
@@ -11,16 +11,9 @@ include = [
     "/README.md",
 ]
 
-[lib]
-# Necessary for CLI options to work on benches
-bench = false
-
 [dependencies]
 anyhow = "1.0.61"
-arc-swap = "1.5.1"
-async-oneshot = "0.5.0"
 async-trait = "0.1.57"
-backoff = { version = "0.4.0", features = ["tokio"] }
 base58 = "0.2.0"
 bitvec = "1.0.1"
 blake2-rfc = "0.2.18"
@@ -30,12 +23,9 @@ derive_more = "0.99.17"
 dirs = "4.0.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2"
-fs2 = "0.4.3"
 futures = "0.3.21"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.15.1", features = ["client", "macros", "server"] }
-libc = "0.2.131"
-lru = "0.7.8"
 memmap2 = "0.5.7"
 num-traits = "0.2.15"
 parity-db = "0.3.17"
@@ -43,18 +33,17 @@ parity-scale-codec = "3.1.5"
 parking_lot = "0.12.1"
 rand = "0.8.5"
 schnorrkel = "0.9.1"
-scopeguard = "1.1.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 static_assertions = "1.1.0"
 std-semaphore = "0.1.0"
 ss58-registry = "1.25.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
+subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
-subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 substrate-bip39 = "0.4.4"
 tempfile = "3.3.0"
 thiserror = "1.0.32"
@@ -69,17 +58,4 @@ zeroize = "1.5.7"
 jemallocator = "0.5.0"
 
 [dev-dependencies]
-criterion = "0.4.0"
 rayon = "1.5.3"
-
-[[bench]]
-name = "plotting"
-harness = false
-
-[[bench]]
-name = "auditing"
-harness = false
-
-[[bench]]
-name = "proving"
-harness = false

--- a/crates/subspace-farmer/README.md
+++ b/crates/subspace-farmer/README.md
@@ -1,4 +1,4 @@
-# Subspace Node
+# Subspace Farmer
 
 Reference implementation of Subspace Farmer for Subspace Network Blockchain.
 

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -30,8 +30,6 @@
 //! are `target ± ½ * solution range` (while also handing overflow/underflow) when interpreted as
 //! 64-bit unsigned integers.
 
-#[doc(hidden)]
-pub mod file_ext;
 pub(crate) mod identity;
 pub(crate) mod object_mappings;
 pub mod reward_signing;

--- a/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
+use subspace_farmer_components::plotting::PieceReceiver;
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::multihash::MultihashCode;
 use subspace_networking::{Node, PieceByHashRequest, PieceKey, ToMultihash};
@@ -14,14 +15,6 @@ use tracing::{debug, error, info, trace, warn};
 
 /// Defines a duration between get_piece calls.
 const GET_PIECE_WAITING_DURATION_IN_SECS: u64 = 1;
-
-#[async_trait]
-pub trait PieceReceiver {
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
-}
 
 // Temporary struct serving pieces from different providers using configuration arguments.
 pub(crate) struct MultiChannelPieceReceiver<'a, RC: RpcClient> {


### PR DESCRIPTION
While working on v2.2 consensus I was about to write (again) custom plotting and farming implementations for testing purposes AGAIN. At the same time we have pretty good abstractions in the farmer already.

This PR extracts some of those abstractions such that we can do in-memory farming for testing purposes and avoid major code duplication going forward.

There is no logic changes here, just minor refactoring to error handling code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
