### PR TITLE
EC consensus (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8144,8 +8144,9 @@ dependencies = [
 name = "sp-lightclient"
 version = "0.1.0"
 dependencies = [
- "bitvec",
+ "async-trait",
  "frame-support",
+ "futures 0.3.25",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
@@ -8157,6 +8158,7 @@ dependencies = [
  "sp-std",
  "subspace-archiving",
  "subspace-core-primitives",
+ "subspace-farmer-components",
  "subspace-solving",
  "subspace-verification",
 ]
@@ -8635,7 +8637,6 @@ dependencies = [
  "ark-bls12-381",
  "ark-ff",
  "ark-poly",
- "bitvec",
  "blake2-rfc",
  "criterion",
  "derive_more",
@@ -8663,7 +8664,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base58",
- "bitvec",
  "blake2-rfc",
  "bytesize",
  "clap 4.0.26",
@@ -8709,7 +8709,6 @@ name = "subspace-farmer-components"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bitvec",
  "blake2-rfc",
  "criterion",
  "fs2",
@@ -8983,7 +8982,7 @@ dependencies = [
 name = "subspace-test-client"
 version = "0.1.0"
 dependencies = [
- "bitvec",
+ "async-trait",
  "futures 0.3.25",
  "sc-chain-spec",
  "sc-client-api",
@@ -8997,6 +8996,7 @@ dependencies = [
  "sp-runtime",
  "subspace-archiving",
  "subspace-core-primitives",
+ "subspace-farmer-components",
  "subspace-runtime-primitives",
  "subspace-service",
  "subspace-solving",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,14 @@ members = [
 #
 # This list is ordered alphabetically.
 [profile.dev.package]
+ark-bls12-381 = { opt-level = 3 }
+ark-ec = { opt-level = 3 }
+ark-ff = { opt-level = 3 }
+ark-ff-asm = { opt-level = 3 }
+ark-poly = { opt-level = 3 }
+ark-serialize = { opt-level = 3 }
+ark-std = { opt-level = 3 }
 blake2 = { opt-level = 3 }
-blake2-rfc = { opt-level = 3 }
 blake2b_simd = { opt-level = 3 }
 chacha20poly1305 = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
@@ -35,7 +41,7 @@ crypto-mac = { opt-level = 3 }
 curve25519-dalek = { opt-level = 3 }
 dusk-bls12_381 = { opt-level = 3 }
 dusk-plonk = { opt-level = 3 }
-ed25519-dalek = { opt-level = 3 }
+ed25519-zebra = { opt-level = 3 }
 flate2 = { opt-level = 3 }
 futures-channel = { opt-level = 3 }
 hashbrown = { opt-level = 3 }
@@ -43,6 +49,7 @@ hash-db = { opt-level = 3 }
 hmac = { opt-level = 3 }
 httparse = { opt-level = 3 }
 integer-sqrt = { opt-level = 3 }
+k256 = { opt-level = 3 }
 keccak = { opt-level = 3 }
 libm = { opt-level = 3 }
 libsecp256k1 = { opt-level = 3 }
@@ -57,6 +64,7 @@ primitive-types = { opt-level = 3 }
 reed-solomon-erasure = { opt-level = 3 }
 ring = { opt-level = 3 }
 rustls = { opt-level = 3 }
+secp256k1 = { opt-level = 3 }
 sha2 = { opt-level = 3 }
 sha3 = { opt-level = 3 }
 smallvec = { opt-level = 3 }

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -22,7 +22,7 @@ use crate::mock::{
     RuntimeEvent, RuntimeOrigin, Subspace, System, Test, INITIAL_SOLUTION_RANGE, SLOT_PROBABILITY,
 };
 use crate::{
-    pallet, AllowAuthoringByAnyone, BlockList, Call, CheckVoteError, Config,
+    pallet, AllowAuthoringByAnyone, BlockList, Call, CheckVoteError, ChunkOffset, Config,
     CurrentBlockAuthorInfo, CurrentBlockVoters, CurrentSlot, Error, ParentBlockAuthorInfo,
     ParentBlockVoters, RecordsRoot, SubspaceEquivocationOffence, WeightInfo,
 };
@@ -1164,6 +1164,7 @@ fn vote_equivocation_current_block_plus_vote() {
         CurrentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             0,
+            ChunkOffset(0),
             slot,
             reward_address,
         ));
@@ -1215,6 +1216,7 @@ fn vote_equivocation_parent_block_plus_vote() {
         ParentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             sector_index,
+            ChunkOffset(0),
             slot,
         ));
 
@@ -1287,6 +1289,7 @@ fn vote_equivocation_current_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(voter_keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    ChunkOffset(0),
                     slot,
                 ),
                 (reward_address, signed_vote.signature.clone()),
@@ -1306,6 +1309,7 @@ fn vote_equivocation_current_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(voter_keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    ChunkOffset(0),
                     slot,
                 ),
                 (reward_address, FarmerSignature::unchecked_from([0; 64])),
@@ -1364,6 +1368,7 @@ fn vote_equivocation_parent_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    ChunkOffset(0),
                     slot,
                 ),
                 (reward_address, signed_vote.signature.clone()),
@@ -1383,6 +1388,7 @@ fn vote_equivocation_parent_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    ChunkOffset(0),
                     slot,
                 ),
                 (reward_address, FarmerSignature::unchecked_from([0; 64])),
@@ -1410,6 +1416,7 @@ fn enabling_block_rewards_works() {
         CurrentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(Keypair::generate().public.to_bytes()),
             0,
+            ChunkOffset(0),
             Subspace::current_slot(),
             1,
         ));
@@ -1419,6 +1426,7 @@ fn enabling_block_rewards_works() {
                 (
                     FarmerPublicKey::unchecked_from(Keypair::generate().public.to_bytes()),
                     0,
+                    ChunkOffset(0),
                     Subspace::current_slot(),
                 ),
                 (2, FarmerSignature::unchecked_from([0; 64])),

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -43,7 +43,7 @@ use sp_core::H256;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::Block as BlockT;
 use std::marker::PhantomData;
-use std::num::{NonZeroU16, NonZeroU32};
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
@@ -203,8 +203,6 @@ where
                 recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
                 total_pieces: runtime_api.total_pieces(&best_block_id)?,
                 // TODO: Fetch this from the runtime
-                space_l: NonZeroU16::new(20).expect("Not zero; qed"),
-                // TODO: Fetch this from the runtime
                 sector_expiration: 100,
             }
         };
@@ -279,6 +277,7 @@ where
                                     piece_offset: solution.piece_offset,
                                     piece_record_hash: solution.piece_record_hash,
                                     piece_witness: solution.piece_witness,
+                                    chunk_offset: solution.chunk_offset,
                                     chunk: solution.chunk,
                                     chunk_signature: solution.chunk_signature,
                                 };

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -87,7 +87,9 @@ use subspace_core_primitives::{
     PIECES_IN_SEGMENT, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
 };
 use subspace_solving::{derive_global_challenge, REWARD_SIGNING_CONTEXT};
-use subspace_verification::{Error as VerificationPrimitiveError, VerifySolutionParams};
+use subspace_verification::{
+    derive_audit_chunk, Error as VerificationPrimitiveError, VerifySolutionParams,
+};
 
 /// Information about new slot that just arrived
 #[derive(Debug, Copy, Clone)]
@@ -1081,13 +1083,13 @@ where
 
             let local_challenge = sector_id.derive_local_challenge(&global_challenge);
 
-            let expanded_chunk = pre_digest.solution.chunk.expand(local_challenge);
+            let audit_chunk = derive_audit_chunk(&pre_digest.solution.chunk.to_bytes());
 
             BlockWeight::from(
                 SolutionRange::MAX
                     - subspace_core_primitives::bidirectional_distance(
                         &local_challenge,
-                        &expanded_chunk,
+                        &audit_chunk,
                     ),
             )
         };

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -685,6 +685,7 @@ pub fn dummy_claim_slot(
                 piece_offset: 0,
                 piece_record_hash: Default::default(),
                 piece_witness: Default::default(),
+                chunk_offset: 0,
                 chunk: Default::default(),
                 chunk_signature: ChunkSignature {
                     output: [0; 32],

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -590,7 +590,7 @@ pub fn derive_next_global_randomness<Header: HeaderT>(
 
     derive_randomness(
         &PublicKey::from(&pre_digest.solution.public_key),
-        &pre_digest.solution.chunk,
+        &pre_digest.solution.chunk.to_bytes(),
         &pre_digest.solution.chunk_signature,
     )
     .map(Some)

--- a/crates/sp-consensus-subspace/src/tests.rs
+++ b/crates/sp-consensus-subspace/src/tests.rs
@@ -27,6 +27,7 @@ fn test_is_equivocation_proof_valid() {
         piece_offset: 0,
         piece_record_hash: Default::default(),
         piece_witness: Default::default(),
+        chunk_offset: 0,
         chunk: Default::default(),
         chunk_signature: ChunkSignature {
             output: Default::default(),

--- a/crates/sp-lightclient/Cargo.toml
+++ b/crates/sp-lightclient/Cargo.toml
@@ -29,10 +29,12 @@ subspace-solving = { version = "0.1.0", path = "../subspace-solving", default-fe
 subspace-verification = { version = "0.1.0", path = "../subspace-verification", default-features = false }
 
 [dev-dependencies]
-bitvec = "1.0.1"
+async-trait = "0.1.58"
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+futures = "0.3.25"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving"}
+subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }
 
 [features]
 default = ["std"]

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -3,8 +3,10 @@ use crate::{
     ChainConstants, DigestError, HashOf, HeaderExt, HeaderImporter, ImportError, NextDigestItems,
     NumberOf, Storage, StorageBound,
 };
-use bitvec::prelude::*;
+use async_trait::async_trait;
+use codec::{Decode, Encode};
 use frame_support::{assert_err, assert_ok};
+use futures::executor::block_on;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use schnorrkel::Keypair;
@@ -19,18 +21,23 @@ use sp_runtime::app_crypto::UncheckedFrom;
 use sp_runtime::testing::H256;
 use sp_runtime::traits::Header as HeaderT;
 use sp_runtime::{Digest, DigestItem};
-use std::num::{NonZeroU16, NonZeroU64};
+use std::error::Error;
+use std::io::Cursor;
+use std::num::{NonZeroU32, NonZeroU64};
+use std::sync::atomic::AtomicBool;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
-use subspace_core_primitives::crypto::kzg::{Kzg, Witness};
-use subspace_core_primitives::crypto::{blake2b_256_254_hash, kzg};
+use subspace_core_primitives::crypto::kzg;
+use subspace_core_primitives::crypto::kzg::Kzg;
+use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
-    Chunk, Piece, PublicKey, Randomness, RecordsRoot, SectorId, SegmentIndex, Solution,
-    SolutionRange, PIECE_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
+    Piece, PieceIndex, PublicKey, Randomness, RecordsRoot, RootBlock, SectorId, SegmentIndex,
+    Solution, SolutionRange, PLOT_SECTOR_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
 };
-use subspace_solving::{
-    create_chunk_signature, derive_chunk_otp, derive_global_challenge, REWARD_SIGNING_CONTEXT,
-};
-use subspace_verification::derive_randomness;
+use subspace_farmer_components::farming::audit_sector;
+use subspace_farmer_components::plotting::{plot_sector, PieceReceiver};
+use subspace_farmer_components::{FarmerProtocolInfo, SectorMetadata};
+use subspace_solving::{derive_global_challenge, REWARD_SIGNING_CONTEXT};
+use subspace_verification::{derive_audit_chunk, derive_randomness};
 
 fn default_randomness() -> Randomness {
     [1u8; 32]
@@ -49,15 +56,14 @@ fn default_test_constants() -> ChainConstants<Header> {
         era_duration: 20,
         slot_probability: (1, 6),
         storage_bound: Default::default(),
-        space_l: NonZeroU16::new(20).unwrap(),
     }
 }
 
 fn derive_solution_range(
     local_challenge: &SolutionRange,
-    expanded_chunk: &SolutionRange,
+    audit_chunk: &SolutionRange,
 ) -> SolutionRange {
-    subspace_core_primitives::bidirectional_distance(local_challenge, expanded_chunk) * 2
+    subspace_core_primitives::bidirectional_distance(local_challenge, audit_chunk) * 2
 }
 
 fn archived_segment(kzg: Kzg) -> ArchivedSegment {
@@ -75,14 +81,80 @@ fn archived_segment(kzg: Kzg) -> ArchivedSegment {
         .unwrap()
 }
 
+struct Farmer {
+    root_block: RootBlock,
+    farmer_protocol_info: FarmerProtocolInfo,
+    sector: Vec<u8>,
+    sector_metadata: Vec<u8>,
+}
+
+impl Farmer {
+    fn new(keypair: &Keypair) -> Self {
+        let kzg = Kzg::new(kzg::test_public_parameters());
+        let archived_segment = archived_segment(kzg.clone());
+        let root_block = archived_segment.root_block;
+        let total_pieces = NonZeroU64::new(archived_segment.pieces.count() as u64).unwrap();
+        let mut sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
+        let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
+        let sector_index = 0;
+        let piece_receiver = TestPieceReceiver { archived_segment };
+        let public_key = PublicKey::from(keypair.public.to_bytes());
+        let farmer_protocol_info = FarmerProtocolInfo {
+            genesis_hash: Default::default(),
+            record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
+            recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
+            total_pieces,
+            sector_expiration: 100,
+        };
+        let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
+        block_on(plot_sector(
+            &public_key,
+            sector_index,
+            &piece_receiver,
+            &AtomicBool::new(false),
+            &farmer_protocol_info,
+            &kzg,
+            &sector_codec,
+            Cursor::new(sector.as_mut_slice()),
+            Cursor::new(sector_metadata.as_mut_slice()),
+        ))
+        .unwrap();
+
+        Self {
+            root_block,
+            farmer_protocol_info,
+            sector,
+            sector_metadata,
+        }
+    }
+}
+
 struct ValidHeaderParams<'a> {
     parent_hash: HashOf<Header>,
     number: NumberOf<Header>,
     slot: u64,
     keypair: &'a Keypair,
     randomness: Randomness,
-    kzg: &'a Kzg,
-    space_l: NonZeroU16,
+    farmer: &'a Farmer,
+}
+
+struct TestPieceReceiver {
+    archived_segment: ArchivedSegment,
+}
+
+#[async_trait]
+impl PieceReceiver for TestPieceReceiver {
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+        Ok(self
+            .archived_segment
+            .pieces
+            .as_pieces()
+            .nth(piece_index as usize)
+            .map(|piece_bytes| Piece::try_from(piece_bytes).unwrap()))
+    }
 }
 
 fn valid_header(
@@ -94,111 +166,65 @@ fn valid_header(
         slot,
         keypair,
         randomness,
-        kzg,
-        space_l,
+        farmer,
     } = params;
-    let chunks_in_sector = u64::from(RECORD_SIZE) * u64::from(u8::BITS) / u64::from(space_l.get());
+
+    let segment_index = farmer.root_block.segment_index();
+    let records_root = farmer.root_block.records_root();
+    let sector_index = 0;
+    let public_key = PublicKey::from(keypair.public.to_bytes());
+    let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
+
     let global_challenge = derive_global_challenge(&randomness, slot);
-    let archived_segment = archived_segment(kzg.clone());
-    let segment_index = archived_segment.root_block.segment_index();
-    let records_root = archived_segment.root_block.records_root();
-    let total_pieces = NonZeroU64::new(archived_segment.pieces.count() as u64).unwrap();
-
-    // There may be no solution in the first sector, iterate until we get a solution
-    for sector_index in 0.. {
-        let sector_id = SectorId::new(&PublicKey::from(keypair.public.to_bytes()), sector_index);
-        let local_challenge = sector_id.derive_local_challenge(&global_challenge);
-        let audit_index: u64 = local_challenge % chunks_in_sector;
-        let audit_piece_offset = (audit_index / u64::from(u8::BITS)) / PIECE_SIZE as u64;
-        // Offset of the piece in sector (in bytes)
-        let audit_piece_bytes_offset = audit_piece_offset * PIECE_SIZE as u64;
-        // Audit index (chunk) within corresponding piece
-        let audit_index_within_piece = audit_index - audit_piece_bytes_offset * u64::from(u8::BITS);
-        let piece_index = sector_id.derive_piece_index(audit_piece_offset, total_pieces);
-        let mut piece = Piece::try_from(
-            archived_segment
-                .pieces
-                .as_pieces()
-                .nth(piece_index as usize)
-                .unwrap(),
+    let eligible_sector = audit_sector(
+        &public_key,
+        sector_index,
+        &global_challenge,
+        SolutionRange::MAX,
+        Cursor::new(&farmer.sector),
+    )
+    .unwrap()
+    .expect("With max solution range there must be a sector eligible; qed");
+    let local_challenge = eligible_sector.local_challenge;
+    let solution = eligible_sector
+        .try_into_solutions(
+            keypair,
+            public_key,
+            &farmer.farmer_protocol_info,
+            &sector_codec,
+            farmer.sector.as_slice(),
+            farmer.sector_metadata.as_slice(),
         )
-        .unwrap();
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("With max solution range there must be a solution; qed");
+    // Lazy conversion to a different type of public key and reward address
+    let solution =
+        Solution::<FarmerPublicKey, FarmerPublicKey>::decode(&mut solution.encode().as_slice())
+            .unwrap();
+    let audit_chunk = derive_audit_chunk(&solution.chunk.to_bytes());
+    let solution_range = derive_solution_range(&local_challenge, &audit_chunk);
 
-        // Encode piece
-        let (record, witness_bytes) = piece.split_at_mut(RECORD_SIZE as usize);
-        let piece_witness = Witness::try_from_bytes((&*witness_bytes).try_into().unwrap()).unwrap();
-        let piece_record_hash = blake2b_256_254_hash(record);
-        // TODO: Extract encoding into separate function reusable in
-        //  farmer and otherwise
-        record
-            .view_bits_mut::<Lsb0>()
-            .chunks_mut(space_l.get() as usize)
-            .enumerate()
-            .for_each(|(chunk_index, bits)| {
-                // Derive one-time pad
-                let mut otp = derive_chunk_otp(&sector_id, witness_bytes, chunk_index as u32);
-                // XOR chunk bit by bit with one-time pad
-                bits.iter_mut()
-                    .zip(otp.view_bits_mut::<Lsb0>().iter())
-                    .for_each(|(mut a, b)| {
-                        *a ^= *b;
-                    });
-            });
+    let pre_digest = PreDigest {
+        slot: slot.into(),
+        solution,
+    };
+    let digests = vec![
+        DigestItem::global_randomness(randomness),
+        DigestItem::solution_range(solution_range),
+        DigestItem::subspace_pre_digest(&pre_digest),
+    ];
 
-        // TODO: We are skipping witness part of the piece or else it is not
-        //  decodable
-        let maybe_chunk = piece[..RECORD_SIZE as usize]
-            .view_bits()
-            .chunks_exact(space_l.get() as usize)
-            .nth(audit_index_within_piece as usize);
+    let header = Header {
+        parent_hash,
+        number,
+        state_root: Default::default(),
+        extrinsics_root: Default::default(),
+        digest: Digest { logs: digests },
+    };
 
-        let chunk = match maybe_chunk {
-            Some(chunk) => Chunk::from(chunk),
-            None => {
-                // TODO: Record size is not multiple of `space_l`, last bits
-                //  were not encoded and should not be used for solving
-                continue;
-            }
-        };
-
-        // TODO: This just have 20 bits of entropy as input, should we add
-        //  something else?
-        let expanded_chunk = chunk.expand(local_challenge);
-
-        let solution_range = derive_solution_range(&local_challenge, &expanded_chunk);
-        let chunk_signature = create_chunk_signature(keypair, &chunk);
-        let pre_digest = PreDigest {
-            slot: slot.into(),
-            solution: Solution {
-                public_key: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
-                reward_address: FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
-                sector_index,
-                total_pieces,
-                piece_offset: audit_piece_offset,
-                piece_record_hash,
-                piece_witness,
-                chunk,
-                chunk_signature,
-            },
-        };
-        let digests = vec![
-            DigestItem::global_randomness(randomness),
-            DigestItem::solution_range(solution_range),
-            DigestItem::subspace_pre_digest(&pre_digest),
-        ];
-
-        let header = Header {
-            parent_hash,
-            number,
-            state_root: Default::default(),
-            extrinsics_root: Default::default(),
-            digest: Digest { logs: digests },
-        };
-
-        return (header, solution_range, segment_index, records_root);
-    }
-
-    unreachable!()
+    (header, solution_range, segment_index, records_root)
 }
 
 fn seal_header(keypair: &Keypair, header: &mut Header) {
@@ -303,7 +329,7 @@ fn add_headers_to_chain(
     keypair: &Keypair,
     headers_to_add: NumberOf<Header>,
     maybe_fork_chain: Option<ForkAt>,
-    kzg: &Kzg,
+    farmer: &Farmer,
 ) -> HashOf<Header> {
     let best_header_ext = importer.store.best_header();
     let constants = importer.store.chain_constants();
@@ -353,8 +379,7 @@ fn add_headers_to_chain(
                 slot: slot.into(),
                 keypair,
                 randomness,
-                kzg,
-                space_l: constants.space_l,
+                farmer,
             });
         let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
             extract_subspace_digest_items(&header).unwrap();
@@ -457,21 +482,19 @@ fn ensure_finalized_heads_have_no_forks(store: &MockStorage, finalized_number: N
 
 #[test]
 fn test_header_import_missing_parent() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let constants = default_test_constants();
-    let space_l = constants.space_l;
     let (mut store, _genesis_hash) = initialize_store(constants, true, None);
     let randomness = default_randomness();
-    let keypair = Keypair::generate();
     let (header, _, segment_index, records_root) = valid_header(ValidHeaderParams {
         parent_hash: Default::default(),
         number: 1,
         slot: 1,
         keypair: &keypair,
         randomness,
-        kzg: &kzg,
-        space_l,
+        farmer: &farmer,
     });
     store.store_records_root(segment_index, records_root);
     let mut importer = HeaderImporter::new(store);
@@ -483,18 +506,18 @@ fn test_header_import_missing_parent() {
 
 #[test]
 fn test_header_import_non_canonical() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let constants = default_test_constants();
     let (store, _genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
-    let hash_of_2 = add_headers_to_chain(&mut importer, &keypair, 2, None, &kzg);
+    let hash_of_2 = add_headers_to_chain(&mut importer, &keypair, 2, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_2);
 
     // import canonical block 3
-    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 1, None, &kzg);
+    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 1, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_3);
     let best_header = importer.store.header(hash_of_3).unwrap();
@@ -509,7 +532,7 @@ fn test_header_import_non_canonical() {
             parent_hash: hash_of_2,
             is_best: Some(false),
         }),
-        &kzg,
+        &farmer,
     );
 
     let best_header_ext = importer.store.best_header();
@@ -520,18 +543,18 @@ fn test_header_import_non_canonical() {
 
 #[test]
 fn test_header_import_canonical() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let constants = default_test_constants();
     let (store, _genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
-    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 5, None, &kzg);
+    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 5, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_5);
 
     // import some more canonical blocks
-    let hash_of_25 = add_headers_to_chain(&mut importer, &keypair, 20, None, &kzg);
+    let hash_of_25 = add_headers_to_chain(&mut importer, &keypair, 20, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_25);
     assert_eq!(importer.store.headers_at_number(25).len(), 1);
@@ -539,18 +562,18 @@ fn test_header_import_canonical() {
 
 #[test]
 fn test_header_import_non_canonical_with_equal_block_weight() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let constants = default_test_constants();
     let (store, _genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
-    let hash_of_2 = add_headers_to_chain(&mut importer, &keypair, 2, None, &kzg);
+    let hash_of_2 = add_headers_to_chain(&mut importer, &keypair, 2, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_2);
 
     // import canonical block 3
-    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 1, None, &kzg);
+    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 1, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_3);
     let best_header = importer.store.header(hash_of_3).unwrap();
@@ -565,7 +588,7 @@ fn test_header_import_non_canonical_with_equal_block_weight() {
             parent_hash: hash_of_2,
             is_best: None,
         }),
-        &kzg,
+        &farmer,
     );
 
     let best_header_ext = importer.store.best_header();
@@ -576,19 +599,19 @@ fn test_header_import_non_canonical_with_equal_block_weight() {
 
 #[test]
 fn test_chain_reorg_to_longer_chain() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.k_depth = 4;
     let (store, genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_4);
     assert_eq!(
@@ -605,7 +628,7 @@ fn test_chain_reorg_to_longer_chain() {
             parent_hash: genesis_hash,
             is_best: Some(false),
         }),
-        &kzg,
+        &farmer,
     );
     assert_eq!(best_header.header.hash(), hash_of_4);
     // block 0 is still finalized
@@ -616,7 +639,7 @@ fn test_chain_reorg_to_longer_chain() {
     ensure_finalized_heads_have_no_forks(&importer.store, 0);
 
     // add new best header at 5
-    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 1, None, &kzg);
+    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 1, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_5);
 
@@ -633,7 +656,7 @@ fn test_chain_reorg_to_longer_chain() {
             parent_hash: hash_of_4,
             is_best: Some(false),
         }),
-        &kzg,
+        &farmer,
     );
 
     // best header should still be the same
@@ -655,7 +678,7 @@ fn test_chain_reorg_to_longer_chain() {
             parent_hash: fork_hash_of_8,
             is_best: Some(true),
         }),
-        &kzg,
+        &farmer,
     );
     assert_eq!(importer.store.best_header().header.hash(), hash_of_9);
 
@@ -665,19 +688,19 @@ fn test_chain_reorg_to_longer_chain() {
 
 #[test]
 fn test_reorg_to_heavier_smaller_chain() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.k_depth = 4;
     let (store, genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 5, None, &kzg);
+    let hash_of_5 = add_headers_to_chain(&mut importer, &keypair, 5, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_5);
     assert_eq!(importer.store.finalized_header().header.number, 1);
@@ -705,8 +728,7 @@ fn test_reorg_to_heavier_smaller_chain() {
             slot: next_slot(constants.slot_probability, digests_at_2.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_2.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     seal_header(&keypair, &mut header);
     let digests: SubspaceDigestItems<FarmerPublicKey, FarmerPublicKey, FarmerSignature> =
@@ -736,19 +758,19 @@ fn test_reorg_to_heavier_smaller_chain() {
 
 #[test]
 fn test_next_global_randomness_digest() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.global_randomness_interval = 5;
     let (store, genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
 
     // try to import header with out next global randomness
@@ -766,8 +788,7 @@ fn test_next_global_randomness_digest() {
             slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_4.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     seal_header(&keypair, &mut header);
     importer
@@ -793,7 +814,7 @@ fn test_next_global_randomness_digest() {
     let pre_digest = extract_pre_digest(&header).unwrap();
     let randomness = derive_randomness(
         &PublicKey::from(&pre_digest.solution.public_key),
-        &pre_digest.solution.chunk,
+        &pre_digest.solution.chunk.to_bytes(),
         &pre_digest.solution.chunk_signature,
     )
     .unwrap();
@@ -807,19 +828,19 @@ fn test_next_global_randomness_digest() {
 
 #[test]
 fn test_next_solution_range_digest_with_adjustment_enabled() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.era_duration = 5;
     let (store, genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
 
     // try to import header with out next global randomness
@@ -837,8 +858,7 @@ fn test_next_solution_range_digest_with_adjustment_enabled() {
             slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_4.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     seal_header(&keypair, &mut header);
     importer
@@ -879,19 +899,19 @@ fn test_next_solution_range_digest_with_adjustment_enabled() {
 
 #[test]
 fn test_next_solution_range_digest_with_adjustment_disabled() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.era_duration = 5;
     let (store, genesis_hash) = initialize_store(constants, false, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
 
     // try to import header with out next global randomness
@@ -909,8 +929,7 @@ fn test_next_solution_range_digest_with_adjustment_disabled() {
             slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_4.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     importer
         .store
@@ -936,19 +955,19 @@ fn test_next_solution_range_digest_with_adjustment_disabled() {
 
 #[test]
 fn test_enable_solution_range_adjustment_without_override() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.era_duration = 5;
     let (store, genesis_hash) = initialize_store(constants, false, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
     // solution range adjustment is disabled
     assert!(!importer.store.best_header().should_adjust_solution_range);
@@ -968,8 +987,7 @@ fn test_enable_solution_range_adjustment_without_override() {
             slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_4.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     importer
         .store
@@ -1004,19 +1022,19 @@ fn test_enable_solution_range_adjustment_without_override() {
 
 #[test]
 fn test_enable_solution_range_adjustment_with_override_between_update_intervals() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.era_duration = 5;
     let (store, genesis_hash) = initialize_store(constants, false, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 3, None, &kzg);
+    let hash_of_3 = add_headers_to_chain(&mut importer, &keypair, 3, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_3);
     // solution range adjustment is disabled
     assert!(!importer.store.best_header().should_adjust_solution_range);
@@ -1036,8 +1054,7 @@ fn test_enable_solution_range_adjustment_with_override_between_update_intervals(
             slot: next_slot(constants.slot_probability, digests_at_3.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_3.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     importer
         .store
@@ -1072,19 +1089,19 @@ fn test_enable_solution_range_adjustment_with_override_between_update_intervals(
 
 #[test]
 fn test_enable_solution_range_adjustment_with_override_at_interval_change() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.era_duration = 5;
     let (store, genesis_hash) = initialize_store(constants, false, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
     // solution range adjustment is disabled
     assert!(!importer.store.best_header().should_adjust_solution_range);
@@ -1104,8 +1121,7 @@ fn test_enable_solution_range_adjustment_with_override_at_interval_change() {
             slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_4.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     importer
         .store
@@ -1134,19 +1150,19 @@ fn test_enable_solution_range_adjustment_with_override_at_interval_change() {
 
 #[test]
 fn test_disallow_enable_solution_range_digest_when_solution_range_adjustment_is_already_enabled() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     constants.era_duration = 5;
     let (store, genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     assert_eq!(
         importer.store.finalized_header().header.hash(),
         genesis_hash
     );
 
-    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &kzg);
+    let hash_of_4 = add_headers_to_chain(&mut importer, &keypair, 4, None, &farmer);
     assert_eq!(importer.store.best_header().header.hash(), hash_of_4);
 
     // try to import header with enable solution range adjustment digest
@@ -1164,8 +1180,7 @@ fn test_disallow_enable_solution_range_digest_when_solution_range_adjustment_is_
             slot: next_slot(constants.slot_probability, digests_at_4.pre_digest.slot).into(),
             keypair: &keypair,
             randomness: digests_at_4.global_randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     importer
         .store
@@ -1190,16 +1205,18 @@ fn test_disallow_enable_solution_range_digest_when_solution_range_adjustment_is_
     );
 }
 
-fn ensure_store_is_storage_bounded(headers_to_keep_beyond_k_depth: NumberOf<Header>, kzg: &Kzg) {
+fn ensure_store_is_storage_bounded(headers_to_keep_beyond_k_depth: NumberOf<Header>) {
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
+
     let mut constants = default_test_constants();
     constants.k_depth = 7;
     constants.storage_bound =
         StorageBound::NumberOfHeaderToKeepBeyondKDepth(headers_to_keep_beyond_k_depth);
     let (store, _genesis_hash) = initialize_store(constants, true, None);
-    let keypair = Keypair::generate();
     let mut importer = HeaderImporter::new(store);
     // import some more canonical blocks
-    let hash_of_50 = add_headers_to_chain(&mut importer, &keypair, 50, None, kzg);
+    let hash_of_50 = add_headers_to_chain(&mut importer, &keypair, 50, None, &farmer);
     let best_header = importer.store.best_header();
     assert_eq!(best_header.header.hash(), hash_of_50);
 
@@ -1218,28 +1235,23 @@ fn ensure_store_is_storage_bounded(headers_to_keep_beyond_k_depth: NumberOf<Head
 
 #[test]
 fn test_storage_bound_with_headers_beyond_k_depth_is_zero() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
-
-    ensure_store_is_storage_bounded(0, &kzg)
+    ensure_store_is_storage_bounded(0)
 }
 
 #[test]
 fn test_storage_bound_with_headers_beyond_k_depth_is_one() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
-
-    ensure_store_is_storage_bounded(1, &kzg)
+    ensure_store_is_storage_bounded(1)
 }
 
 #[test]
 fn test_storage_bound_with_headers_beyond_k_depth_is_more_than_one() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
-
-    ensure_store_is_storage_bounded(5, &kzg)
+    ensure_store_is_storage_bounded(5)
 }
 
 #[test]
 fn test_block_author_different_farmer() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     let keypair_allowed = Keypair::generate();
@@ -1257,8 +1269,7 @@ fn test_block_author_different_farmer() {
             slot: 1,
             keypair: &keypair_disallowed,
             randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     seal_header(&keypair_disallowed, &mut header);
     constants.genesis_digest_items.next_solution_range = solution_range;
@@ -1278,10 +1289,10 @@ fn test_block_author_different_farmer() {
 
 #[test]
 fn test_block_author_first_farmer() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
-    let keypair = Keypair::generate();
     let pub_key = FarmerPublicKey::unchecked_from(keypair.public.to_bytes());
     let (store, genesis_hash) = initialize_store(constants.clone(), true, None);
     let mut importer = HeaderImporter::new(store);
@@ -1295,8 +1306,7 @@ fn test_block_author_first_farmer() {
             slot: 1,
             keypair: &keypair,
             randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     header
         .digest
@@ -1320,10 +1330,10 @@ fn test_block_author_first_farmer() {
 
 #[test]
 fn test_block_author_allow_any_farmer() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
-    let keypair = Keypair::generate();
     let pub_key = FarmerPublicKey::unchecked_from(keypair.public.to_bytes());
     let (store, genesis_hash) = initialize_store(constants.clone(), true, Some(pub_key));
     let mut importer = HeaderImporter::new(store);
@@ -1337,8 +1347,7 @@ fn test_block_author_allow_any_farmer() {
             slot: 1,
             keypair: &keypair,
             randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     header
         .digest
@@ -1360,7 +1369,8 @@ fn test_block_author_allow_any_farmer() {
 
 #[test]
 fn test_disallow_root_plot_public_key_override() {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let keypair = Keypair::generate();
+    let farmer = Farmer::new(&keypair);
 
     let mut constants = default_test_constants();
     let keypair_allowed = Keypair::generate();
@@ -1377,8 +1387,7 @@ fn test_disallow_root_plot_public_key_override() {
             slot: 1,
             keypair: &keypair_allowed,
             randomness,
-            kzg: &kzg,
-            space_l: constants.space_l,
+            farmer: &farmer,
         });
     let keypair_disallowed = Keypair::generate();
     let pub_key = FarmerPublicKey::unchecked_from(keypair_disallowed.public.to_bytes());

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -19,7 +19,6 @@ bench = false
 ark-bls12-381 = "0.3.0"
 ark-ff = "0.3.0"
 ark-poly = "0.3.0"
-bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic"] }
 # Not using `blake2` crate due to https://github.com/RustCrypto/hashes/issues/360
 blake2-rfc = { version = "0.2.18", default-features = false }
 derive_more = "0.99.17"
@@ -48,7 +47,6 @@ std = [
     "ark-bls12-381/std",
     "ark-ff/std",
     "ark-poly/std",
-    "bitvec/std",
     "blake2-rfc/std",
     "dusk-bls12_381/std",
     "dusk-plonk/std",

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -229,7 +229,6 @@ impl Scalar {
     }
 
     /// Converts scalar to bytes that will be written to `bytes`.
-    #[allow(clippy::result_unit_err)]
     pub fn write_to_bytes(&self, bytes: &mut [u8; Self::FULL_BYTES]) {
         self.0
             .into_repr()

--- a/crates/subspace-core-primitives/src/sector_codec.rs
+++ b/crates/subspace-core-primitives/src/sector_codec.rs
@@ -46,11 +46,11 @@ pub struct SectorCodec {
 impl SectorCodec {
     /// Create new instance for sector size (in bytes)
     pub fn new(sector_size: usize) -> Result<Self, SectorCodecError> {
-        if sector_size % Scalar::SAFE_BYTES != 0 {
+        if sector_size % Scalar::FULL_BYTES != 0 {
             return Err(SectorCodecError::WrongSectorSize);
         }
 
-        let sector_size_in_scalars = sector_size / Scalar::SAFE_BYTES;
+        let sector_size_in_scalars = sector_size / Scalar::FULL_BYTES;
 
         if sector_size_in_scalars == 0 || !sector_size_in_scalars.is_power_of_two() {
             return Err(SectorCodecError::WrongSectorSize);
@@ -75,8 +75,8 @@ impl SectorCodec {
     pub fn encode(&self, sector: &mut [Scalar]) -> Result<(), SectorCodecError> {
         if sector.len() != self.sector_size_in_scalars {
             return Err(SectorCodecError::WrongInputSectorSize {
-                expected: self.sector_size_in_scalars * Scalar::SAFE_BYTES,
-                actual: sector.len() * Scalar::SAFE_BYTES,
+                expected: self.sector_size_in_scalars * Scalar::FULL_BYTES,
+                actual: sector.len() * Scalar::FULL_BYTES,
             });
         }
 
@@ -118,8 +118,8 @@ impl SectorCodec {
     pub fn decode(&self, sector: &mut [Scalar]) -> Result<(), SectorCodecError> {
         if sector.len() != self.sector_size_in_scalars {
             return Err(SectorCodecError::WrongInputSectorSize {
-                expected: self.sector_size_in_scalars * Scalar::SAFE_BYTES,
-                actual: sector.len() * Scalar::SAFE_BYTES,
+                expected: self.sector_size_in_scalars * Scalar::FULL_BYTES,
+                actual: sector.len() * Scalar::FULL_BYTES,
             });
         }
 

--- a/crates/subspace-core-primitives/src/sector_codec/tests.rs
+++ b/crates/subspace-core-primitives/src/sector_codec/tests.rs
@@ -4,13 +4,13 @@ use crate::Scalar;
 #[test]
 fn basic() {
     let rows_columns_count = 128_usize;
-    let sector_size = rows_columns_count.pow(2) * Scalar::SAFE_BYTES;
+    let sector_size = rows_columns_count.pow(2) * Scalar::FULL_BYTES;
 
     let sector = {
-        let mut sector = Vec::with_capacity(sector_size / Scalar::SAFE_BYTES);
+        let mut sector = Vec::with_capacity(sector_size / Scalar::FULL_BYTES);
 
         for _ in 0..sector.capacity() {
-            sector.push(Scalar::try_from(rand::random::<[u8; 31]>().as_slice()).unwrap());
+            sector.push(Scalar::try_from(&rand::random::<[u8; Scalar::SAFE_BYTES]>()).unwrap());
         }
 
         sector
@@ -29,18 +29,16 @@ fn basic() {
     assert_eq!(sector, decoded);
 }
 
-// TODO: Unlock this test once https://github.com/arkworks-rs/algebra/issues/516 is resolved
 #[test]
-#[ignore]
 fn two_way_transformation_works() {
     let rows_columns_count = 4_usize;
-    let sector_size = rows_columns_count.pow(2) * Scalar::SAFE_BYTES;
+    let sector_size = rows_columns_count.pow(2) * Scalar::FULL_BYTES;
 
     let mut scalars = {
-        let mut sector = Vec::with_capacity(sector_size / Scalar::SAFE_BYTES);
+        let mut sector = Vec::with_capacity(sector_size / Scalar::FULL_BYTES);
 
         for _ in 0..sector.capacity() {
-            sector.push(Scalar::try_from(rand::random::<[u8; 31]>().as_slice()).unwrap());
+            sector.push(Scalar::try_from(&rand::random::<[u8; Scalar::SAFE_BYTES]>()).unwrap());
         }
 
         sector

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -17,7 +17,6 @@ bench = false
 
 [dependencies]
 async-trait = "0.1.58"
-bitvec = "1.0.1"
 blake2-rfc = "0.2.18"
 fs2 = "0.4.3"
 hex = { version = "0.4.3", features = ["serde"] }

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -4,12 +4,13 @@ use rand::{thread_rng, Rng};
 use rayon::current_num_threads;
 use rayon::prelude::*;
 use std::io;
-use std::num::{NonZeroU16, NonZeroU32, NonZeroU64};
+use std::num::{NonZeroU32, NonZeroU64};
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
+use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
     Piece, PublicKey, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE, RECORD_SIZE,
 };
@@ -28,7 +29,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut input = vec![0u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
     thread_rng().fill(input.as_mut_slice());
     let kzg = Kzg::new(kzg::test_public_parameters());
-    let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg).unwrap();
+    let mut archiver =
+        Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
+    let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
     let piece = Piece::try_from(
         archiver
             .add_block(input, Default::default())
@@ -48,7 +51,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
         recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
         total_pieces: NonZeroU64::new(1).unwrap(),
-        space_l: NonZeroU16::new(20).unwrap(),
         sector_expiration: 1,
     };
     let piece_receiver = BenchPieceReceiver::new(piece);
@@ -63,6 +65,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&piece_receiver),
                 black_box(&cancelled),
                 black_box(&farmer_protocol_info),
+                black_box(&kzg),
+                black_box(&sector_codec),
                 black_box(io::sink()),
                 black_box(io::sink()),
             ))
@@ -84,6 +88,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&piece_receiver),
                         black_box(&cancelled),
                         black_box(&farmer_protocol_info),
+                        black_box(&kzg),
+                        black_box(&sector_codec),
                         black_box(io::sink()),
                         black_box(io::sink()),
                     ))

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -4,13 +4,14 @@ use memmap2::Mmap;
 use schnorrkel::Keypair;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::num::{NonZeroU16, NonZeroU32, NonZeroU64};
+use std::num::{NonZeroU32, NonZeroU64};
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 use std::{env, fs, io};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
+use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
     Blake2b256Hash, Piece, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE,
     RECORD_SIZE,
@@ -39,7 +40,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let sector_index = 0;
     let input = vec![1u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
     let kzg = Kzg::new(kzg::test_public_parameters());
-    let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg).unwrap();
+    let mut archiver =
+        Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
+    let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
     let piece = Piece::try_from(
         archiver
             .add_block(input, Default::default())
@@ -59,7 +62,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
         recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
         total_pieces: NonZeroU64::new(1).unwrap(),
-        space_l: NonZeroU16::new(20).unwrap(),
         sector_expiration: 1,
     };
     let global_challenge = Blake2b256Hash::default();
@@ -76,6 +78,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &BenchPieceReceiver::new(piece),
             &cancelled,
             &farmer_protocol_info,
+            &kzg,
+            &sector_codec,
             plotted_sector.as_mut_slice(),
             sector_metadata.as_mut_slice(),
         ))
@@ -87,10 +91,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let eligible_sector = audit_sector(
         &public_key,
         sector_index,
-        &farmer_protocol_info,
         &global_challenge,
         solution_range,
-        io::Cursor::new(plotted_sector),
+        io::Cursor::new(plotted_sector.as_slice()),
     )
     .unwrap()
     .unwrap();
@@ -101,10 +104,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             eligible_sector
                 .clone()
-                .try_into_solution(
+                .try_into_solutions(
                     black_box(&keypair),
                     black_box(reward_address),
                     black_box(&farmer_protocol_info),
+                    black_box(&sector_codec),
+                    black_box(plotted_sector.as_slice()),
                     black_box(sector_metadata.as_slice()),
                 )
                 .unwrap();
@@ -146,10 +151,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 for metadata in sector_metadata_mmap.chunks_exact(SectorMetadata::encoded_size()) {
                     eligible_sector
                         .clone()
-                        .try_into_solution(
+                        .try_into_solutions(
                             black_box(&keypair),
                             black_box(reward_address),
                             black_box(&farmer_protocol_info),
+                            black_box(&sector_codec),
+                            black_box(plotted_sector.as_slice()),
                             black_box(metadata),
                         )
                         .unwrap();

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -15,7 +15,6 @@ include = [
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 base58 = "0.2.0"
-bitvec = "1.0.1"
 blake2-rfc = "0.2.18"
 bytesize = "1.1.0"
 clap = { version = "4.0.26", features = ["color", "derive"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -202,14 +202,16 @@ pub(crate) async fn farm_multi_disk(
         }).fuse() => {},
 
         // Plotting future
-        _ = Box::pin(async move {
+        result = Box::pin(async move {
             while let Some(result) = single_disk_plots_stream.next().await {
                 result?;
 
                 info!("Farm exited successfully");
             }
             anyhow::Ok(())
-        }).fuse() => {},
+        }).fuse() => {
+            result?;
+        },
 
         // Node runner future
         _ = Box::pin(async move {

--- a/crates/subspace-farmer/src/identity.rs
+++ b/crates/subspace-farmer/src/identity.rs
@@ -5,7 +5,7 @@ use schnorrkel::{ExpansionMode, Keypair, PublicKey, SecretKey, Signature};
 use std::fs;
 use std::ops::Deref;
 use std::path::Path;
-use subspace_core_primitives::{Chunk, ChunkSignature};
+use subspace_core_primitives::{ChunkSignature, Scalar};
 use subspace_solving::{create_chunk_signature, REWARD_SIGNING_CONTEXT};
 use substrate_bip39::mini_secret_from_entropy;
 use tracing::debug;
@@ -130,8 +130,8 @@ impl Identity {
         &self.entropy
     }
 
-    pub fn create_chunk_signature(&self, chunk: &Chunk) -> ChunkSignature {
-        create_chunk_signature(&self.keypair, chunk)
+    pub fn create_chunk_signature(&self, chunk_bytes: &[u8; Scalar::FULL_BYTES]) -> ChunkSignature {
+        create_chunk_signature(&self.keypair, chunk_bytes)
     }
 
     /// Sign reward hash.

--- a/crates/subspace-farmer/src/rpc_client/bench_rpc_client.rs
+++ b/crates/subspace-farmer/src/rpc_client/bench_rpc_client.rs
@@ -3,7 +3,7 @@ use crate::utils::AbortingJoinHandle;
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::{stream, SinkExt, Stream, StreamExt};
-use std::num::{NonZeroU16, NonZeroU32, NonZeroU64};
+use std::num::{NonZeroU32, NonZeroU64};
 use std::pin::Pin;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
@@ -36,7 +36,6 @@ pub const BENCH_FARMER_PROTOCOL_INFO: FarmerProtocolInfo = FarmerProtocolInfo {
     recorded_history_segment_size: 491520, // RECORD_SIZE * PIECES_IN_SEGMENT / 2
     // Doesn't matter, as we don't start sync
     total_pieces: NonZeroU64::new(1).unwrap(),
-    space_l: NonZeroU16::new(20).unwrap(),
     sector_expiration: 100,
 };
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -144,8 +144,8 @@ const ERA_DURATION_IN_BLOCKS: BlockNumber = 2016;
 
 const EQUIVOCATION_REPORT_LONGEVITY: BlockNumber = 256;
 
-// We assume initial plot size starts with the a single sector, hence we have one attempt per time
-// slot.
+// We assume initial plot size starts with the a single sector, where we effectively audit each
+// chunk of every piece.
 const INITIAL_SOLUTION_RANGE: SolutionRange =
     SolutionRange::MAX / SLOT_PROBABILITY.1 * SLOT_PROBABILITY.0;
 
@@ -628,7 +628,7 @@ fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness
         let seed: &[u8] = b"extrinsics-shuffling-seed";
         let randomness = derive_randomness(
             &Into::<PublicKey>::into(&pre_digest.solution.public_key),
-            &pre_digest.solution.chunk,
+            &pre_digest.solution.chunk.to_bytes(),
             &pre_digest.solution.chunk_signature,
         )
         .expect("Tag signature is verified by the client and must always be valid; qed");

--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -101,11 +101,7 @@ where
     } = deps;
 
     let chain_name = chain_spec.name().to_string();
-    let genesis_hash = client
-        .block_hash(0)
-        .ok()
-        .flatten()
-        .expect("Genesis block exists; qed");
+    let genesis_hash = client.info().genesis_hash;
     let properties = chain_spec.properties();
     module.merge(ChainSpec::new(chain_name, genesis_hash, properties).into_rpc())?;
 

--- a/crates/subspace-solving/src/lib.rs
+++ b/crates/subspace-solving/src/lib.rs
@@ -24,7 +24,7 @@ use merlin::Transcript;
 use schnorrkel::vrf::{VRFInOut, VRFOutput, VRFProof};
 use schnorrkel::{Keypair, PublicKey, SignatureResult};
 use subspace_core_primitives::crypto::blake2b_256_hash_list;
-use subspace_core_primitives::{Blake2b256Hash, Chunk, ChunkSignature, Randomness, SectorId};
+use subspace_core_primitives::{Blake2b256Hash, ChunkSignature, Randomness, Scalar};
 
 const CHUNK_SIGNATURE_LABEL: &[u8] = b"subspace_chunk_signature";
 
@@ -38,15 +38,18 @@ pub fn derive_global_challenge(global_randomness: &Randomness, slot: u64) -> Bla
 }
 
 /// Transcript used for creation and verification of VRF signatures for chunks.
-pub fn create_chunk_signature_transcript(chunk: &Chunk) -> Transcript {
+pub fn create_chunk_signature_transcript(chunk_bytes: &[u8; Scalar::FULL_BYTES]) -> Transcript {
     let mut transcript = Transcript::new(CHUNK_SIGNATURE_LABEL);
-    transcript.append_message(b"chunk", chunk.as_ref());
+    transcript.append_message(b"chunk", chunk_bytes);
     transcript
 }
 
 /// Create tag signature using farmer's keypair.
-pub fn create_chunk_signature(keypair: &Keypair, chunk: &Chunk) -> ChunkSignature {
-    let (in_out, proof, _) = keypair.vrf_sign(create_chunk_signature_transcript(chunk));
+pub fn create_chunk_signature(
+    keypair: &Keypair,
+    chunk_bytes: &[u8; Scalar::FULL_BYTES],
+) -> ChunkSignature {
+    let (in_out, proof, _) = keypair.vrf_sign(create_chunk_signature_transcript(chunk_bytes));
 
     ChunkSignature {
         output: in_out.output.to_bytes(),
@@ -56,34 +59,15 @@ pub fn create_chunk_signature(keypair: &Keypair, chunk: &Chunk) -> ChunkSignatur
 
 /// Verify that chunk signature was created correctly.
 pub fn verify_chunk_signature(
-    chunk: &Chunk,
+    chunk_bytes: &[u8; Scalar::FULL_BYTES],
     chunk_signature: &ChunkSignature,
     public_key: &PublicKey,
 ) -> SignatureResult<VRFInOut> {
     public_key
         .vrf_verify(
-            create_chunk_signature_transcript(chunk),
+            create_chunk_signature_transcript(chunk_bytes),
             &VRFOutput(chunk_signature.output),
             &VRFProof::from_bytes(&chunk_signature.proof)?,
         )
         .map(|(in_out, _)| in_out)
-}
-
-// TODO: This is temporary and correct V2 spec will use Chia PoS primitive instead
-/// Derive one-time pad for piece chunk encoding/decoding. One-time pad is big enough for any
-/// reasonable size of `space_l`, but doesn't have to be used fully.
-pub fn derive_chunk_otp(
-    sector_id: &SectorId,
-    piece_witness_bytes: &[u8],
-    chunk_index: u32,
-) -> [u8; 8] {
-    let hash = blake2b_256_hash_list(&[
-        sector_id.as_ref(),
-        piece_witness_bytes,
-        &chunk_index.to_le_bytes(),
-    ]);
-
-    [
-        hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7],
-    ]
 }

--- a/domains/service/src/rpc.rs
+++ b/domains/service/src/rpc.rs
@@ -58,11 +58,7 @@ where
     } = deps;
 
     let chain_name = chain_spec.name().to_string();
-    let genesis_hash = client
-        .block_hash(0)
-        .ok()
-        .flatten()
-        .expect("Genesis block exists; qed");
+    let genesis_hash = client.info().genesis_hash;
     let properties = chain_spec.properties();
     module.merge(ChainSpec::new(chain_name, genesis_hash, properties).into_rpc())?;
 

--- a/test/subspace-test-client/Cargo.toml
+++ b/test/subspace-test-client/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-bitvec = "1.0.1"
+async-trait = "0.1.58"
 futures = "0.3.25"
 schnorrkel = "0.9.1"
 sc-chain-spec = { git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
@@ -30,6 +30,7 @@ sp-runtime = { git = "https://github.com/subspace/substrate", rev = "6d57dbc639b
 subspace-archiving = { path = "../../crates/subspace-archiving" }
 subspace-core-primitives = { path = "../../crates/subspace-core-primitives" }
 subspace-runtime-primitives = { path = "../../crates/subspace-runtime-primitives" }
+subspace-farmer-components = { path = "../../crates/subspace-farmer-components" }
 subspace-service = { path = "../../crates/subspace-service" }
 subspace-solving = { path = "../../crates/subspace-solving" }
 subspace-test-runtime = { version = "0.1.0", features = ["do-not-enforce-cost-of-storage"], path = "../subspace-test-runtime" }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -915,7 +915,7 @@ fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness
         let seed: &[u8] = b"extrinsics-shuffling-seed";
         let randomness = derive_randomness(
             &Into::<PublicKey>::into(&pre_digest.solution.public_key),
-            &pre_digest.solution.chunk,
+            &pre_digest.solution.chunk.to_bytes(),
             &pre_digest.solution.chunk_signature,
         )
         .expect("Tag signature is verified by the client and must always be valid; qed");


### PR DESCRIPTION
This is a big one again, but I tried to structure it somewhat so it is reviewable and previous PRs took some of the weight.

Basically this implements a version of https://www.notion.so/subspacelabs/Consensus-v2-MS-II-Phase-I-v2-2-08af61d7c0154cbf99b0fc3830aaad6b

This is still a prototype, but it is something we can evolve.

Encoding/decoding is formally there to maintain performance properties of what it should be, but done on cloned data because actual encoding/decoding is not working due to https://github.com/arkworks-rs/algebra/issues/516 (see ignored test from the first commit as a simple reproduction). We are out of ideas for now and may try to reimplement the same logic without arkworks libraries instead.

Implementation did get slower comparing to [v2.1](https://github.com/subspace/subspace/pull/872):
```
audit/memory            time:   [151.28 µs 151.45 µs 151.66 µs]
                        thrpt:  [6.5938 Kelem/s 6.6029 Kelem/s 6.6102 Kelem/s]
audit/disk              time:   [1.5315 ms 1.5324 ms 1.5334 ms]
                        thrpt:  [6.5215 Kelem/s 6.5258 Kelem/s 6.5296 Kelem/s]
sector-plotting/no-writes-single-thread
                        time:   [7.7452 s 7.7569 s 7.7692 s]
                        thrpt:  [3.9901 MiB/s 3.9964 MiB/s 4.0025 MiB/s]
sector-plotting/no-writes-multi-thread
                        time:   [101.85 s 102.11 s 102.40 s]
                        thrpt:  [7.2656 MiB/s 7.2864 MiB/s 7.3048 MiB/s]
proving/memory          time:   [493.72 ms 495.23 ms 497.11 ms]
                        thrpt:  [2.0116  elem/s 2.0192  elem/s 2.0254  elem/s]
proving/disk            time:   [4.8919 s 4.9396 s 5.0031 s]
                        thrpt:  [1.9987  elem/s 2.0245  elem/s 2.0442  elem/s]
```

Earlier refactoring in https://github.com/subspace/subspace/pull/921 allowed to **relatively** easily integrate consensus changes to testing abstractions, though I think we may still want to abstract it further for testing purposes (likely extend farmer that I wrote for `sp-lightclient`).

Due to the way consensus works now and the fact that encoding is not working, it might generate A LOT of votes. I tried to fix benchmarking features and almost succeeded before hitting https://substrate.stackexchange.com/questions/5927/assimilate-storage-not-implemented-for-chainspec, but at least it compiles now, previously it didn't (see https://forum.subspace.network/t/errors-while-building-with-features-runtime-benchmarks/1066). I ended up simply restricting the weight of the vote extrinsic to not include too many of them into the same block.

Reviewing by commits should make the most sense as usual and feel free to ask any questions you might have so far.

Fixes #894

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
