### PR TITLE
Fix core domain state root verification

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -219,7 +219,9 @@ pub struct ProofOfElection<DomainHash> {
     pub block_number: BlockNumber,
     /// Block hash corresponding to the `block_number` above.
     pub block_hash: DomainHash,
-    /// Block hash of the core domain block at which the proof of election was created.
+    /// Number of the core domain block at which the proof of election was created.
+    pub core_block_number: Option<BlockNumber>,
+    /// Block hash corresponding to the `core_block_number` above.
     pub core_block_hash: Option<DomainHash>,
     /// Core domain state root corresponding to the `core_block_hash` above.
     pub core_state_root: Option<DomainHash>,
@@ -238,6 +240,7 @@ impl<DomainHash: Default> ProofOfElection<DomainHash> {
             storage_proof: StorageProof::empty(),
             block_number: Default::default(),
             block_hash: Default::default(),
+            core_block_number: None,
             core_block_hash: None,
             core_state_root: None,
         }

--- a/domains/client/domain-executor/src/bundle_election_solver.rs
+++ b/domains/client/domain-executor/src/bundle_election_solver.rs
@@ -154,6 +154,7 @@ where
                         storage_proof,
                         block_number: best_number,
                         block_hash: best_hash,
+                        core_block_number: None,
                         core_block_hash: None,
                         core_state_root: None,
                     };

--- a/domains/client/domain-executor/src/core_bundle_producer.rs
+++ b/domains/client/domain-executor/src/core_bundle_producer.rs
@@ -143,7 +143,13 @@ where
                 to_sign.as_ref(),
             ) {
                 Ok(Some(signature)) => {
-                    let best_hash = self.client.info().best_hash;
+                    let core_block_number: BlockNumber = self
+                        .client
+                        .info()
+                        .best_number
+                        .try_into()
+                        .unwrap_or_else(|_| panic!("Domain block number must fit into u32; qed"));
+                    let core_block_hash = self.client.info().best_hash;
 
                     let as_core_block_hash = |system_block_hash: SBlock::Hash| {
                         Block::Hash::decode(&mut system_block_hash.encode().as_slice()).unwrap()
@@ -163,11 +169,12 @@ where
                             block_hash: as_core_block_hash(proof_of_election.block_hash),
                             // TODO: override the core block info, see if there is a nicer way
                             // later.
-                            core_block_hash: Some(best_hash),
+                            core_block_number: Some(core_block_number),
+                            core_block_hash: Some(core_block_hash),
                             core_state_root: Some(
                                 *self
                                     .client
-                                    .header(BlockId::Hash(best_hash))?
+                                    .header(BlockId::Hash(core_block_hash))?
                                     .expect("Best block header must exist; qed")
                                     .state_root(),
                             ),


### PR DESCRIPTION
This commit fixes the bug that the system block number was misused as the core block number. I was likely drunk while initially writing this. I ran a few hundreds of blocks locally before but wasn't able to catch it earlier probably due to the coincidence that the system block number happens to match the core domain block number. After the recent consensus change, it became to be more obvious causing the error `StateRootUnveriable` with slower farming.

Having a look at the system domain state root verification in pallet-domains can also help understand the changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
