### PR TITLE
Change node cache size constant.

### DIFF
--- a/crates/sc-piece-cache/src/lib.rs
+++ b/crates/sc-piece-cache/src/lib.rs
@@ -15,7 +15,7 @@ use subspace_core_primitives::{FlatPieces, Piece, PieceIndex, PieceIndexHash, PI
 use subspace_networking::ToMultihash;
 
 /// Defines maximum segments number stored in the cache (as pieces).
-pub const MAX_SEGMENTS_NUMBER_IN_CACHE: u64 = 10;
+pub const MAX_SEGMENTS_NUMBER_IN_CACHE: u64 = 32; // ~ 1 GB
 
 // Defines how often we clear pieces from cache.
 pub(crate) const TOLERANCE_SEGMENTS_NUMBER: u64 = 2;


### PR DESCRIPTION
This PR increases the segment number in the piece cache from 10 to 32. The change increases the cache size up to 1Gb with the current segment size (32MB). This is a quick fix  - proper cache setting via CLI arguments will follow.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
