### PR TITLE
DSN.Add piece cache parameters configuration.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6956,7 +6956,6 @@ dependencies = [
 name = "sc-piece-cache"
 version = "0.1.0"
 dependencies = [
- "bytesize",
  "parity-scale-codec",
  "sc-client-api",
  "subspace-core-primitives",
@@ -8923,7 +8922,6 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
- "bytesize",
  "derive_more",
  "domain-runtime-primitives",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6956,10 +6956,12 @@ dependencies = [
 name = "sc-piece-cache"
 version = "0.1.0"
 dependencies = [
+ "bytesize",
  "parity-scale-codec",
  "sc-client-api",
  "subspace-core-primitives",
  "subspace-networking",
+ "tracing",
 ]
 
 [[package]]
@@ -8800,6 +8802,7 @@ dependencies = [
 name = "subspace-node"
 version = "0.1.0"
 dependencies = [
+ "bytesize",
  "clap 4.0.26",
  "core-payments-domain-runtime",
  "dirs",
@@ -8920,6 +8923,7 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
+ "bytesize",
  "derive_more",
  "domain-runtime-primitives",
  "frame-support",

--- a/crates/sc-piece-cache/Cargo.toml
+++ b/crates/sc-piece-cache/Cargo.toml
@@ -12,7 +12,6 @@ include = [
 ]
 
 [dependencies]
-bytesize = "1.1.0"
 parity-scale-codec = { version = "3.2.1" }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }

--- a/crates/sc-piece-cache/Cargo.toml
+++ b/crates/sc-piece-cache/Cargo.toml
@@ -12,7 +12,9 @@ include = [
 ]
 
 [dependencies]
+bytesize = "1.1.0"
 parity-scale-codec = { version = "3.2.1" }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
+tracing = "0.1.37"

--- a/crates/sc-piece-cache/src/lib.rs
+++ b/crates/sc-piece-cache/src/lib.rs
@@ -6,16 +6,20 @@
 #[cfg(test)]
 mod tests;
 
+use bytesize::ByteSize;
 use parity_scale_codec::Encode;
 use sc_client_api::backend::AuxStore;
 use std::error::Error;
 use std::fmt::Debug;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Piece, PieceIndex, PieceIndexHash, PIECES_IN_SEGMENT};
+use subspace_core_primitives::{
+    FlatPieces, Piece, PieceIndex, PieceIndexHash, PIECES_IN_SEGMENT, PIECE_SIZE,
+};
 use subspace_networking::ToMultihash;
+use tracing::info;
 
-/// Defines maximum segments number stored in the cache (as pieces).
-pub const MAX_SEGMENTS_NUMBER_IN_CACHE: u64 = 32; // ~ 1 GB
+// Defines a minimum piece cache size.
+pub(crate) const ONE_GB: u64 = 1024 * 1024 * 1024;
 
 // Defines how often we clear pieces from cache.
 pub(crate) const TOLERANCE_SEGMENTS_NUMBER: u64 = 2;
@@ -42,12 +46,14 @@ pub trait PieceCache: Clone {
 #[derive(Debug)]
 pub struct AuxPieceCache<AS> {
     aux_store: Arc<AS>,
+    max_segments_number_in_cache: Option<u64>,
 }
 
 impl<AS> Clone for AuxPieceCache<AS> {
     fn clone(&self) -> Self {
         Self {
             aux_store: Arc::clone(&self.aux_store),
+            max_segments_number_in_cache: self.max_segments_number_in_cache,
         }
     }
 }
@@ -58,9 +64,31 @@ where
 {
     const KEY_PREFIX: &[u8] = b"piece_cache";
 
-    /// Create new instance
-    pub fn new(aux_store: Arc<AS>) -> Self {
-        Self { aux_store }
+    /// Create a new instance. Optional cache_size parameter could redefine the default cache size.
+    pub fn new(aux_store: Arc<AS>, cache_size: Option<ByteSize>) -> Self {
+        let max_segments_number_in_cache = cache_size.map(|size| {
+            let segment_number = Self::segments_number_in_cache(size.as_u64());
+            let min_segment_number = Self::min_segments_number_in_cache();
+
+            if segment_number >= min_segment_number {
+                segment_number
+            } else {
+                min_segment_number
+            }
+        });
+
+        let cache = Self {
+            aux_store,
+            max_segments_number_in_cache,
+        };
+
+        info!(
+            cache_size = cache_size.map(|s| s.as_u64()).unwrap_or(ONE_GB),
+            segment_number = cache.max_segments_number_in_cache(),
+            "Piece cache initialized."
+        );
+
+        cache
     }
 
     fn key(piece_index: PieceIndex) -> Vec<u8> {
@@ -75,6 +103,22 @@ where
         PieceIndexHash::from_index(piece_index)
             .to_multihash()
             .to_bytes()
+    }
+
+    #[inline]
+    fn segments_number_in_cache(size: u64) -> u64 {
+        size / (PIECES_IN_SEGMENT as u64 * PIECE_SIZE as u64)
+    }
+
+    #[inline]
+    fn min_segments_number_in_cache() -> u64 {
+        Self::segments_number_in_cache(ONE_GB)
+    }
+
+    /// Returns configured maximum configured segments number in the cache.
+    pub fn max_segments_number_in_cache(&self) -> u64 {
+        self.max_segments_number_in_cache
+            .unwrap_or_else(Self::min_segments_number_in_cache)
     }
 }
 
@@ -105,7 +149,7 @@ where
         let segment_index = first_piece_index / PIECES_IN_SEGMENT as u64;
 
         let starting_piece_index = segment_index
-            .checked_sub(MAX_SEGMENTS_NUMBER_IN_CACHE + TOLERANCE_SEGMENTS_NUMBER - 1)
+            .checked_sub(self.max_segments_number_in_cache() + TOLERANCE_SEGMENTS_NUMBER - 1)
             .map(|starting_segment_index| starting_segment_index * PIECES_IN_SEGMENT as u64);
 
         let pieces_to_delete_number =

--- a/crates/sc-piece-cache/src/tests.rs
+++ b/crates/sc-piece-cache/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{AuxPieceCache, PieceCache, TOLERANCE_SEGMENTS_NUMBER};
+use crate::{AuxPieceCache, PieceCache, ONE_GB, TOLERANCE_SEGMENTS_NUMBER};
 use sc_client_api::AuxStore;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -43,7 +43,7 @@ impl AuxStore for TestAuxStore {
 
 #[test]
 fn adding_retrieval_operations_work() {
-    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()), None);
+    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()), ONE_GB);
 
     store
         .add_pieces(0, &FlatPieces::new(PIECES_IN_SEGMENT as usize))
@@ -68,7 +68,7 @@ fn adding_retrieval_operations_work() {
 
 #[test]
 fn test_segment_deletion() {
-    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()), None);
+    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()), ONE_GB);
 
     for i in 0..store.max_segments_number_in_cache() {
         store

--- a/crates/sc-piece-cache/src/tests.rs
+++ b/crates/sc-piece-cache/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{AuxPieceCache, PieceCache, MAX_SEGMENTS_NUMBER_IN_CACHE, TOLERANCE_SEGMENTS_NUMBER};
+use crate::{AuxPieceCache, PieceCache, TOLERANCE_SEGMENTS_NUMBER};
 use sc_client_api::AuxStore;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -43,7 +43,7 @@ impl AuxStore for TestAuxStore {
 
 #[test]
 fn adding_retrieval_operations_work() {
-    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()));
+    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()), None);
 
     store
         .add_pieces(0, &FlatPieces::new(PIECES_IN_SEGMENT as usize))
@@ -68,9 +68,9 @@ fn adding_retrieval_operations_work() {
 
 #[test]
 fn test_segment_deletion() {
-    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()));
+    let store = AuxPieceCache::new(Arc::new(TestAuxStore::default()), None);
 
-    for i in 0..MAX_SEGMENTS_NUMBER_IN_CACHE {
+    for i in 0..store.max_segments_number_in_cache() {
         store
             .add_pieces(
                 i * PIECES_IN_SEGMENT as u64,
@@ -95,7 +95,7 @@ fn test_segment_deletion() {
     // Tolerance works
     store
         .add_pieces(
-            MAX_SEGMENTS_NUMBER_IN_CACHE * PIECES_IN_SEGMENT as u64,
+            store.max_segments_number_in_cache() * PIECES_IN_SEGMENT as u64,
             &FlatPieces::new(PIECES_IN_SEGMENT as usize),
         )
         .unwrap();
@@ -108,7 +108,7 @@ fn test_segment_deletion() {
     // Deletion
     store
         .add_pieces(
-            (1 + MAX_SEGMENTS_NUMBER_IN_CACHE) * PIECES_IN_SEGMENT as u64,
+            (1 + store.max_segments_number_in_cache()) * PIECES_IN_SEGMENT as u64,
             &FlatPieces::new(PIECES_IN_SEGMENT as usize),
         )
         .unwrap();
@@ -130,14 +130,16 @@ fn test_segment_deletion() {
         .is_some());
     assert!(store
         .get_piece(
-            (TOLERANCE_SEGMENTS_NUMBER + MAX_SEGMENTS_NUMBER_IN_CACHE) * PIECES_IN_SEGMENT as u64
+            (TOLERANCE_SEGMENTS_NUMBER + store.max_segments_number_in_cache())
+                * PIECES_IN_SEGMENT as u64
                 - 1
         )
         .unwrap()
         .is_some());
     assert!(store
         .get_piece(
-            (TOLERANCE_SEGMENTS_NUMBER + MAX_SEGMENTS_NUMBER_IN_CACHE) * PIECES_IN_SEGMENT as u64
+            (TOLERANCE_SEGMENTS_NUMBER + store.max_segments_number_in_cache())
+                * PIECES_IN_SEGMENT as u64
         )
         .unwrap()
         .is_none());

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+bytesize = "1.1.0"
 clap = { version = "4.0.26", features = ["derive"] }
 core-payments-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/core-payments" }
 dirs = "4.0.0"

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -411,6 +411,7 @@ fn main() -> Result<(), Error> {
                         // Secondary node needs slots notifications for bundle production.
                         force_new_slot_notifications: !cli.secondary_chain_args.is_empty(),
                         dsn_config,
+                        piece_cache_size: cli.piece_cache_size,
                     };
 
                     subspace_service::new_full::<RuntimeApi, ExecutorDispatch>(

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -411,7 +411,7 @@ fn main() -> Result<(), Error> {
                         // Secondary node needs slots notifications for bundle production.
                         force_new_slot_notifications: !cli.secondary_chain_args.is_empty(),
                         dsn_config,
-                        piece_cache_size: cli.piece_cache_size,
+                        piece_cache_size: cli.piece_cache_size.as_u64(),
                     };
 
                     subspace_service::new_full::<RuntimeApi, ExecutorDispatch>(

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -188,8 +188,8 @@ pub struct Cli {
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
 
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
-    #[arg(long)]
-    pub piece_cache_size: Option<ByteSize>,
+    #[arg(long, default_value = "1Gib")]
+    pub piece_cache_size: ByteSize,
 
     /// Secondary chain arguments
     ///

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -24,6 +24,7 @@ mod secondary_chain;
 
 pub use crate::import_blocks_from_dsn::ImportBlocksFromDsnCmd;
 pub use crate::secondary_chain::cli::SecondaryChainCli;
+use bytesize::ByteSize;
 use clap::Parser;
 use sc_cli::{RunCmd, SubstrateCli};
 use sc_executor::{NativeExecutionDispatch, RuntimeVersion};
@@ -185,6 +186,10 @@ pub struct Cli {
     /// Bootstrap nodes for DSN.
     #[arg(long)]
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
+
+    /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
+    #[arg(long)]
+    pub piece_cache_size: Option<ByteSize>,
 
     /// Secondary chain arguments
     ///

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -188,7 +188,7 @@ pub struct Cli {
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
 
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
-    #[arg(long, default_value = "1Gib")]
+    #[arg(long, default_value = "1GiB")]
     pub piece_cache_size: ByteSize,
 
     /// Secondary chain arguments

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,7 +16,6 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-bytesize = "1.1.0"
 derive_more = "0.99.17"
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+bytesize = "1.1.0"
 derive_more = "0.99.17"
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/crates/subspace-service/src/dsn/piece_record_store.rs
+++ b/crates/subspace-service/src/dsn/piece_record_store.rs
@@ -1,5 +1,5 @@
 use sc_client_api::AuxStore;
-use sc_piece_cache::{AuxPieceCache, PieceCache, MAX_SEGMENTS_NUMBER_IN_CACHE};
+use sc_piece_cache::{AuxPieceCache, PieceCache};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -72,8 +72,9 @@ impl<'a, AS: AuxStore> RecordStorage<'a> for AuxRecordStorage<AS> {
     fn records(&'a self) -> Self::RecordsIter {
         let segment_index = (self.last_segment_index_getter)();
 
-        let starting_piece_index: PieceIndex =
-            segment_index.saturating_sub(MAX_SEGMENTS_NUMBER_IN_CACHE) * PIECES_IN_SEGMENT as u64;
+        let starting_piece_index: PieceIndex = segment_index
+            .saturating_sub(self.piece_cache.max_segments_number_in_cache())
+            * PIECES_IN_SEGMENT as u64;
 
         AuxStoreRecordIterator::new(starting_piece_index, self.piece_cache.clone())
     }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -22,6 +22,7 @@ mod pool;
 pub mod rpc;
 
 pub use crate::pool::FullPool;
+use bytesize::ByteSize;
 use derive_more::{Deref, DerefMut, Into};
 use domain_runtime_primitives::Hash as DomainHash;
 use dsn::start_dsn_node;
@@ -134,6 +135,8 @@ pub struct SubspaceConfiguration {
     pub force_new_slot_notifications: bool,
     /// Subspace networking configuration (for DSN).
     pub dsn_config: DsnConfig,
+    /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
+    pub piece_cache_size: Option<ByteSize>,
 }
 
 /// Creates `PartialComponents` for Subspace client.
@@ -158,7 +161,6 @@ pub fn new_partial<RuntimeApi, ExecutorDispatch>(
                 Transaction = TransactionFor<FullClient<RuntimeApi, ExecutorDispatch>, Block>,
             >,
             SubspaceLink<Block>,
-            AuxPieceCache<FullClient<RuntimeApi, ExecutorDispatch>>,
             Option<Telemetry>,
         ),
     >,
@@ -265,39 +267,6 @@ where
         },
     )?;
 
-    let piece_cache = AuxPieceCache::new(client.clone());
-
-    // Start before archiver below, so we don't have potential race condition and miss pieces
-    task_manager
-        .spawn_handle()
-        .spawn_blocking("subspace-piece-cache", None, {
-            let piece_cache = piece_cache.clone();
-            let mut archived_segment_notification_stream = subspace_link
-                .archived_segment_notification_stream()
-                .subscribe();
-
-            async move {
-                while let Some(archived_segment_notification) =
-                    archived_segment_notification_stream.next().await
-                {
-                    let segment_index = archived_segment_notification
-                        .archived_segment
-                        .root_block
-                        .segment_index();
-                    if let Err(error) = piece_cache.add_pieces(
-                        segment_index * u64::from(PIECES_IN_SEGMENT),
-                        &archived_segment_notification.archived_segment.pieces,
-                    ) {
-                        error!(
-                            %segment_index,
-                            %error,
-                            "Failed to store pieces for segment in cache"
-                        );
-                    }
-                }
-            }
-        });
-
     let slot_duration = subspace_link.slot_duration();
     let import_queue = sc_consensus_subspace::import_queue(
         block_import.clone(),
@@ -323,7 +292,7 @@ where
         keystore_container,
         select_chain,
         transaction_pool,
-        other: (block_import, subspace_link, piece_cache, telemetry),
+        other: (block_import, subspace_link, telemetry),
     })
 }
 
@@ -404,8 +373,41 @@ where
         keystore_container,
         select_chain,
         transaction_pool,
-        other: (block_import, subspace_link, piece_cache, mut telemetry),
+        other: (block_import, subspace_link, mut telemetry),
     } = new_partial::<RuntimeApi, ExecutorDispatch>(&config)?;
+
+    let piece_cache = AuxPieceCache::new(client.clone(), config.piece_cache_size);
+
+    // Start before archiver below, so we don't have potential race condition and miss pieces
+    task_manager
+        .spawn_handle()
+        .spawn_blocking("subspace-piece-cache", None, {
+            let piece_cache = piece_cache.clone();
+            let mut archived_segment_notification_stream = subspace_link
+                .archived_segment_notification_stream()
+                .subscribe();
+
+            async move {
+                while let Some(archived_segment_notification) =
+                    archived_segment_notification_stream.next().await
+                {
+                    let segment_index = archived_segment_notification
+                        .archived_segment
+                        .root_block
+                        .segment_index();
+                    if let Err(error) = piece_cache.add_pieces(
+                        segment_index * u64::from(PIECES_IN_SEGMENT),
+                        &archived_segment_notification.archived_segment.pieces,
+                    ) {
+                        error!(
+                            %segment_index,
+                            %error,
+                            "Failed to store pieces for segment in cache"
+                        );
+                    }
+                }
+            }
+        });
 
     let dsn_bootstrap_nodes = {
         let node = start_dsn_node(

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -22,7 +22,6 @@ mod pool;
 pub mod rpc;
 
 pub use crate::pool::FullPool;
-use bytesize::ByteSize;
 use derive_more::{Deref, DerefMut, Into};
 use domain_runtime_primitives::Hash as DomainHash;
 use dsn::start_dsn_node;
@@ -135,8 +134,8 @@ pub struct SubspaceConfiguration {
     pub force_new_slot_notifications: bool,
     /// Subspace networking configuration (for DSN).
     pub dsn_config: DsnConfig,
-    /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
-    pub piece_cache_size: Option<ByteSize>,
+    /// Piece cache size in bytes.
+    pub piece_cache_size: u64,
 }
 
 /// Creates `PartialComponents` for Subspace client.

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -128,6 +128,7 @@ async fn run_executor(
                 bootstrap_nodes: vec![],
                 keypair: identity::Keypair::generate_ed25519(),
             },
+            piece_cache_size: None,
         };
 
         subspace_service::new_full::<

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -128,7 +128,7 @@ async fn run_executor(
                 bootstrap_nodes: vec![],
                 keypair: identity::Keypair::generate_ed25519(),
             },
-            piece_cache_size: None,
+            piece_cache_size: 1024 * 1024 * 1024,
         };
 
         subspace_service::new_full::<

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -196,6 +196,7 @@ pub async fn run_validator_node(
                 bootstrap_nodes: vec![],
                 keypair: identity::Keypair::generate_ed25519(),
             },
+            piece_cache_size: None,
         };
 
         subspace_service::new_full::<subspace_test_runtime::RuntimeApi, TestExecutorDispatch>(

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn run_validator_node(
                 bootstrap_nodes: vec![],
                 keypair: identity::Keypair::generate_ed25519(),
             },
-            piece_cache_size: None,
+            piece_cache_size: 1024 * 1024 * 1024,
         };
 
         subspace_service::new_full::<subspace_test_runtime::RuntimeApi, TestExecutorDispatch>(


### PR DESCRIPTION
This PR adds a configurable piece cache size parameter for subspace-node in the `bytesize` format. This size is converted to the max segment number in the piece cache. Actual cache size will be logged.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
