### PR TITLE
Change the default record cache size for farmers.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -66,7 +66,7 @@ struct DsnArgs {
     #[arg(long, default_value = "/ip4/0.0.0.0/tcp/30533")]
     listen_on: Vec<Multiaddr>,
     /// Record cache size in items.
-    #[arg(long, default_value_t = 32768)]
+    #[arg(long, default_value_t = 65536)]
     record_cache_size: usize,
 }
 


### PR DESCRIPTION
Increase the default value from 32768 to 65536 for the `--record_cache_size` for the subspace-farmer. It will make the cache size closer to 1GB. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
