### PR TITLE
Prepare gemini 3a chain spec

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -28,16 +28,16 @@ jobs:
 
       - name: Generate testnet chain specifications
         run: |
-          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain gemini-2a-compiled --disable-default-bootnode > chain-spec-gemini-2a.json
-          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain gemini-2a-compiled --disable-default-bootnode --raw > chain-spec-raw-gemini-2a.json
+          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain gemini-3a-compiled --disable-default-bootnode > chain-spec-gemini-3a.json
+          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain gemini-3a-compiled --disable-default-bootnode --raw > chain-spec-raw-gemini-3a.json
 
       - name: Upload chain specifications to artifacts
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
         with:
           name: chain-specifications
           path: |
-            chain-spec-gemini-2a.json
-            chain-spec-raw-gemini-2a.json
+            chain-spec-gemini-3a.json
+            chain-spec-raw-gemini-3a.json
           if-no-files-found: error
 
       - name: Upload chain specifications to assets
@@ -45,4 +45,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["chain-spec-gemini-2a.json", "chain-spec-raw-gemini-2a.json"]'
+          asset_paths: '["chain-spec-gemini-3a.json", "chain-spec-raw-gemini-3a.json"]'

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -14,6 +14,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        protobuf-compiler \
         curl \
         git \
         llvm \

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -14,6 +14,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        protobuf-compiler \
         curl \
         git \
         llvm \

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -14,6 +14,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        protobuf-compiler \
         curl \
         git \
         llvm \

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -14,6 +14,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        protobuf-compiler \
         curl \
         git \
         llvm \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -14,6 +14,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        protobuf-compiler \
         curl \
         git \
         llvm \

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -14,6 +14,7 @@ RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        protobuf-compiler \
         curl \
         git \
         llvm \

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -30,7 +30,6 @@ use subspace_runtime::{
 use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, SSC};
 use system_domain_runtime::GenesisConfig as SystemDomainGenesisConfig;
 
-const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.network/submit/";
 // TODO: replace raw-gemini-2a with raw-gemini-3a
 // const GEMINI_2A_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-gemini-2a.json");
@@ -148,11 +147,8 @@ pub fn gemini_3a_compiled(
         vec![],
         // Telemetry
         Some(
-            TelemetryEndpoints::new(vec![
-                (POLKADOT_TELEMETRY_URL.into(), 1),
-                (SUBSPACE_TELEMETRY_URL.into(), 1),
-            ])
-            .map_err(|error| error.to_string())?,
+            TelemetryEndpoints::new(vec![(SUBSPACE_TELEMETRY_URL.into(), 1)])
+                .map_err(|error| error.to_string())?,
         ),
         // Protocol ID
         Some("subspace-gemini-3a"),
@@ -238,11 +234,8 @@ pub fn x_net_2_config_compiled(
         vec![],
         // Telemetry
         Some(
-            TelemetryEndpoints::new(vec![
-                (POLKADOT_TELEMETRY_URL.into(), 1),
-                (SUBSPACE_TELEMETRY_URL.into(), 1),
-            ])
-            .map_err(|error| error.to_string())?,
+            TelemetryEndpoints::new(vec![(SUBSPACE_TELEMETRY_URL.into(), 1)])
+                .map_err(|error| error.to_string())?,
         ),
         // Protocol ID
         Some("subspace-x-net-2a"),

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -32,7 +32,8 @@ use system_domain_runtime::GenesisConfig as SystemDomainGenesisConfig;
 
 const POLKADOT_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.network/submit/";
-const GEMINI_2A_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-gemini-2a.json");
+// TODO: replace raw-gemini-2a with raw-gemini-3a
+// const GEMINI_2A_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-gemini-2a.json");
 const X_NET_2_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-x-net-2.json");
 
 /// List of accounts which should receive token grants, amounts are specified in SSC.
@@ -70,18 +71,18 @@ struct GenesisParams {
     enable_executor: bool,
 }
 
-pub fn gemini_2a() -> Result<ConsensusChainSpec<GenesisConfig, SystemDomainGenesisConfig>, String> {
-    ConsensusChainSpec::from_json_bytes(GEMINI_2A_CHAIN_SPEC)
+pub fn gemini_3a() -> Result<ConsensusChainSpec<GenesisConfig, SystemDomainGenesisConfig>, String> {
+    unimplemented!("gemini_3a raw chain spec")
 }
 
-pub fn gemini_2a_compiled(
+pub fn gemini_3a_compiled(
 ) -> Result<ConsensusChainSpec<GenesisConfig, SystemDomainGenesisConfig>, String> {
     Ok(ConsensusChainSpec::from_genesis(
         // Name
-        "Subspace Gemini 2a",
+        "Subspace Gemini 3a",
         // ID
-        "subspace_gemini_2a",
-        ChainType::Custom("Subspace Gemini 2a".to_string()),
+        "subspace_gemini_3a",
+        ChainType::Custom("Subspace Gemini 3a".to_string()),
         || {
             let sudo_account =
                 AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
@@ -139,7 +140,7 @@ pub fn gemini_2a_compiled(
                             0x32, 0x6c, 0x3f, 0x7b, 0x4e, 0xd9, 0x41, 0x17,
                         ]),
                     ),
-                    enable_executor: false,
+                    enable_executor: true,
                 },
             )
         },
@@ -154,13 +155,13 @@ pub fn gemini_2a_compiled(
             .map_err(|error| error.to_string())?,
         ),
         // Protocol ID
-        Some("subspace-gemini-2a"),
+        Some("subspace-gemini-3a"),
         None,
         // Properties
         Some(chain_spec_properties()),
         // Extensions
         ChainSpecExtensions {
-            execution_chain_spec: secondary_chain::chain_spec::development_config(),
+            execution_chain_spec: secondary_chain::chain_spec::gemini_3a_config(),
         },
     ))
 }

--- a/crates/subspace-node/src/core_domain/cli.rs
+++ b/crates/subspace-node/src/core_domain/cli.rs
@@ -125,10 +125,11 @@ impl SubstrateCli for CoreDomainCli {
     }
 
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
+        // TODO: add core domain chain spec an extension of system domain chain spec.
         let chain_spec = match self.domain_id {
             DomainId::CORE_PAYMENTS => match id {
-                "x-net-2" => core_payments_chain_spec::x_net_2_config(),
                 "dev" => core_payments_chain_spec::development_config(),
+                "gemini-3a" => core_payments_chain_spec::gemini_3a_config(),
                 "" | "local" => core_payments_chain_spec::local_testnet_config(),
                 path => core_payments_chain_spec::ChainSpec::from_json_file(
                     std::path::PathBuf::from(path),

--- a/crates/subspace-node/src/core_domain/core_payments_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_payments_chain_spec.rs
@@ -32,7 +32,7 @@ pub fn development_config() -> ExecutionChainSpec<GenesisConfig> {
         // Name
         "Development",
         // ID
-        "execution_dev",
+        "core_payments_domain_dev",
         ChainType::Development,
         move || {
             testnet_genesis(vec![
@@ -56,7 +56,7 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
         // Name
         "Local Testnet",
         // ID
-        "execution_local_testnet",
+        "core_payments_domain_local_testnet",
         ChainType::Local,
         move || {
             testnet_genesis(vec![
@@ -88,12 +88,12 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
     )
 }
 
-pub fn x_net_2_config() -> ExecutionChainSpec<GenesisConfig> {
+pub fn gemini_3a_config() -> ExecutionChainSpec<GenesisConfig> {
     ExecutionChainSpec::from_genesis(
         // Name
-        "Subspace X-Net 2 Execution",
+        "Subspace Gemini 3a Core Payments Domain",
         // ID
-        "subspace_x_net_2a_execution",
+        "subspace_gemini_3a_core_payments_domain",
         ChainType::Local,
         move || {
             testnet_genesis(vec![
@@ -107,7 +107,7 @@ pub fn x_net_2_config() -> ExecutionChainSpec<GenesisConfig> {
         // Telemetry
         None,
         // Protocol ID
-        Some("subspace-x-net-2a-execution"),
+        Some("subspace-gemini-3a-core-payments-domain"),
         None,
         // Properties
         Some(chain_spec_properties()),

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -237,8 +237,8 @@ impl SubstrateCli for Cli {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
         let mut chain_spec = match id {
-            "gemini-2a" => chain_spec::gemini_2a()?,
-            "gemini-2a-compiled" => chain_spec::gemini_2a_compiled()?,
+            "gemini-3a" => chain_spec::gemini_3a()?,
+            "gemini-3a-compiled" => chain_spec::gemini_3a_compiled()?,
             "x-net-2" => chain_spec::x_net_2_config()?,
             "x-net-2-compiled" => chain_spec::x_net_2_config_compiled()?,
             "dev" => chain_spec::dev_config()?,

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -139,6 +139,65 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
     )
 }
 
+pub fn gemini_3a_config() -> ExecutionChainSpec<GenesisConfig> {
+    ExecutionChainSpec::from_genesis(
+        // Name
+        "Subspace Gemini 3a System Domain",
+        // ID
+        "subspace_gemini_3a_system_domain",
+        ChainType::Local,
+        move || {
+            testnet_genesis(
+                vec![
+                    // Genesis executor
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
+                        .expect("Wrong executor account address"),
+                ],
+                vec![(
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
+                        .expect("Wrong executor account address"),
+                    1_000 * SSC,
+                    AccountId::from_ss58check("5FsxcczkSUnpqhcSgugPZsSghxrcKx5UEsRKL5WyPTL6SAxB")
+                        .expect("Wrong executor reward address"),
+                    ExecutorPublicKey::from_ss58check(
+                        "5FuuXk1TL8DKQMvg7mcqmP8t9FhxUdzTcYC9aFmebiTLmASx",
+                    )
+                    .expect("Wrong executor public key"),
+                )],
+                vec![(
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
+                        .expect("Wrong executor account address"),
+                    1_000 * SSC,
+                    DomainConfig {
+                        wasm_runtime_hash: blake2b_256_hash(
+                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                        )
+                        .into(),
+                        max_bundle_size: 4 * 1024 * 1024,
+                        bundle_slot_probability: (1, 1),
+                        max_bundle_weight: Weight::MAX,
+                        min_operator_stake: 100 * SSC,
+                    },
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
+                        .expect("Wrong executor account address"),
+                    Percent::one(),
+                )],
+            )
+        },
+        // Bootnodes
+        vec![],
+        // Telemetry
+        None,
+        // Protocol ID
+        Some("subspace-gemini-3a-system-domain"),
+        None,
+        // Properties
+        Some(chain_spec_properties()),
+        // Extensions
+        None,
+    )
+}
+
 pub fn x_net_2_config() -> ExecutionChainSpec<GenesisConfig> {
     ExecutionChainSpec::from_genesis(
         // Name

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -92,7 +92,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 4,
+    spec_version: 0,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,


### PR DESCRIPTION
This PR is the chain spec preparation for gemini 3a. The consensus chain spec is derived from the gemini 2 config, the only difference is the executor is enabled by default. The chain spec build has been tested in my fork, looks fine https://github.com/liuchengxu/subspace/releases/tag/chain-spec-gemini-3a

One thing to note is that `--chain gemini-3a` needs to be used to run the core payments domain, which will be needless once the TODO of adding an extension to system domain chain spec is solved.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
