### PR TITLE
Revert changes to sc-consensus-subspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,8 +1863,9 @@ name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "parking_lot 0.12.1",
  "sc-consensus",
- "sc-consensus-subspace",
+ "sc-utils",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
@@ -2021,7 +2022,6 @@ dependencies = [
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-subspace",
  "sc-executor",
  "sc-network",
  "sc-rpc",

--- a/domains/client/consensus-relay-chain/Cargo.toml
+++ b/domains/client/consensus-relay-chain/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.58"
+parking_lot = "0.12.1"
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
-sc-consensus-subspace = { version = "0.1.0", path = "../../../crates/sc-consensus-subspace" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/domains/client/consensus-relay-chain/src/import_queue.rs
+++ b/domains/client/consensus-relay-chain/src/import_queue.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream};
 use sc_consensus::import_queue::{BasicQueue, Verifier as VerifierT};
 use sc_consensus::{
     BlockCheckParams, BlockImport, BlockImportParams, ForkChoiceStrategy, ImportResult,
 };
-use sc_consensus_subspace::notification::{SubspaceNotificationSender, SubspaceNotificationStream};
 use sp_blockchain::Result as ClientResult;
 use sp_consensus::error::Error as ConsensusError;
 use sp_consensus::{BlockOrigin, CacheKeyId};
@@ -142,9 +142,7 @@ where
     I::Transaction: Send,
 {
     let (imported_block_notification_sender, imported_block_notification_receiver) =
-        sc_consensus_subspace::notification::channel(
-            "system_domain_imported_block_notification_stream",
-        );
+        crate::notification::channel("system_domain_imported_block_notification_stream");
     Ok((
         BasicQueue::new(
             Verifier::default(),

--- a/domains/client/consensus-relay-chain/src/lib.rs
+++ b/domains/client/consensus-relay-chain/src/lib.rs
@@ -34,4 +34,6 @@
 //! 5. After the parachain candidate got backed and included, all collators start at 1.
 
 mod import_queue;
+pub mod notification;
+
 pub use import_queue::{import_queue, Verifier};

--- a/domains/client/consensus-relay-chain/src/notification.rs
+++ b/domains/client/consensus-relay-chain/src/notification.rs
@@ -13,7 +13,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
-//! Utility module for handling Subspace client notifications.
+//! Utility module for handling Domain client notifications.
 
 use parking_lot::Mutex;
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
@@ -29,7 +29,7 @@ type SharedNotificationSenders<T> = Arc<Mutex<Vec<TracingUnboundedSender<T>>>>;
 
 /// The sending half of the Subspace notification channel(s).
 #[derive(Clone)]
-pub(crate) struct SubspaceNotificationSender<T: Clone + Send + Sync + fmt::Debug + 'static> {
+pub struct SubspaceNotificationSender<T: Clone + Send + Sync + fmt::Debug + 'static> {
     subscribers: SharedNotificationSenders<T>,
 }
 
@@ -40,7 +40,7 @@ impl<T: Clone + Send + Sync + fmt::Debug + 'static> SubspaceNotificationSender<T
     }
 
     /// Send out a notification to all subscribers.
-    pub(crate) fn notify<F>(&self, get_value: F)
+    pub fn notify<F>(&self, get_value: F)
     where
         F: FnOnce() -> T,
     {
@@ -83,7 +83,7 @@ impl<T: Clone + Send + Sync + fmt::Debug + 'static> SubspaceNotificationStream<T
 }
 
 /// Creates a new pair of receiver and sender of notifications.
-pub(crate) fn channel<T>(
+pub fn channel<T>(
     stream_name: &'static str,
 ) -> (SubspaceNotificationSender<T>, SubspaceNotificationStream<T>)
 where

--- a/domains/service/Cargo.toml
+++ b/domains/service/Cargo.toml
@@ -29,7 +29,6 @@ pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
-sc-consensus-subspace = { version = "0.1.0", path = "../../crates/sc-consensus-subspace" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -1,4 +1,5 @@
 use crate::Configuration;
+use domain_client_consensus_relay_chain::notification::SubspaceNotificationStream;
 use domain_client_executor::CoreExecutor;
 use domain_client_executor_gossip::ExecutorGossipParams;
 use domain_runtime_primitives::{DomainCoreApi, RelayerId};
@@ -8,7 +9,6 @@ use jsonrpsee::tracing;
 use pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi;
 use sc_client_api::{BlockBackend, ProofProvider, StateBackendFor};
 use sc_consensus::ForkChoiceStrategy;
-use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_network::NetworkService;
 use sc_service::{

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -1,4 +1,5 @@
 use crate::Configuration;
+use domain_client_consensus_relay_chain::notification::SubspaceNotificationStream;
 use domain_client_executor::SystemExecutor;
 use domain_client_executor_gossip::ExecutorGossipParams;
 use domain_runtime_primitives::{AccountId, Balance, DomainCoreApi, Hash, RelayerId};
@@ -8,7 +9,6 @@ use jsonrpsee::tracing;
 use pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi;
 use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_consensus::ForkChoiceStrategy;
-use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_network::NetworkService;
 use sc_service::{


### PR DESCRIPTION
This PR is a follow up of the discussion here - https://github.com/subspace/subspace/pull/926#discussion_r1026137365

I wanted to use the notification module from `sc-consensus-subspace`, with this revert domain crates wont relay on this crate. I do not want to use the SubspaceLink as this leaks unneeded info. Since the domain consensus needs notification module, there are two ways to go about it
- Create a notification crate and use it across all the crates. But I do not have a very solid justification why it needs its own crate. 
- Copy notification modules under domain as well so that we can use this module across domains crates.

I went with second option as module itself is not big. Not sure how we have handled this before or if you have any other better alternatives in mind ?

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
