### PR TITLE
DSN. Add `disable_non_global_addresses_in_dht` to the CLI arguments

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -244,6 +244,7 @@ async fn configure_dsn(
         listen_on,
         bootstrap_nodes,
         record_cache_size,
+        disable_non_global_addresses_in_dht,
     }: DsnArgs,
     readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
 ) -> Result<(Node, NodeRunner<ConfiguredRecordStore>), anyhow::Error> {
@@ -266,7 +267,7 @@ async fn configure_dsn(
 
     let config = Config::<ConfiguredRecordStore> {
         listen_on,
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: !disable_non_global_addresses_in_dht,
         networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
             .boxed(),
         request_response_protocols: vec![PieceByHashRequestHandler::create(move |req| {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -244,7 +244,7 @@ async fn configure_dsn(
         listen_on,
         bootstrap_nodes,
         record_cache_size,
-        disable_private_ip,
+        disable_private_ips,
     }: DsnArgs,
     readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
 ) -> Result<(Node, NodeRunner<ConfiguredRecordStore>), anyhow::Error> {
@@ -267,7 +267,7 @@ async fn configure_dsn(
 
     let config = Config::<ConfiguredRecordStore> {
         listen_on,
-        allow_non_global_addresses_in_dht: !disable_private_ip,
+        allow_non_global_addresses_in_dht: !disable_private_ips,
         networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
             .boxed(),
         request_response_protocols: vec![PieceByHashRequestHandler::create(move |req| {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -244,7 +244,7 @@ async fn configure_dsn(
         listen_on,
         bootstrap_nodes,
         record_cache_size,
-        disable_non_global_addresses_in_dht,
+        disable_private_ip,
     }: DsnArgs,
     readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
 ) -> Result<(Node, NodeRunner<ConfiguredRecordStore>), anyhow::Error> {
@@ -267,7 +267,7 @@ async fn configure_dsn(
 
     let config = Config::<ConfiguredRecordStore> {
         listen_on,
-        allow_non_global_addresses_in_dht: !disable_non_global_addresses_in_dht,
+        allow_non_global_addresses_in_dht: !disable_private_ip,
         networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
             .boxed(),
         request_response_protocols: vec![PieceByHashRequestHandler::create(move |req| {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -70,7 +70,7 @@ struct DsnArgs {
     record_cache_size: usize,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
     #[arg(long, default_value_t = false)]
-    disable_private_ip: bool,
+    disable_private_ips: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -70,7 +70,7 @@ struct DsnArgs {
     record_cache_size: usize,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
     #[arg(long, default_value_t = false)]
-    disable_non_global_addresses_in_dht: bool,
+    disable_private_ip: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -68,6 +68,9 @@ struct DsnArgs {
     /// Record cache size in items.
     #[arg(long, default_value_t = 65536)]
     record_cache_size: usize,
+    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
+    #[arg(long, default_value_t = false)]
+    disable_non_global_addresses_in_dht: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -24,7 +24,7 @@ async fn main() {
             )
             .boxed(),
             listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-            allow_non_globals_in_dht: true,
+            allow_non_global_addresses_in_dht: true,
             ..Config::with_keypair(keypair.clone())
         };
 
@@ -63,7 +63,7 @@ async fn main() {
 
     let config = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         networking_parameters_registry: BootstrappedNetworkingParameters::new(
             bootstrap_nodes.clone(),
         )

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -12,7 +12,7 @@ async fn main() {
 
     let config_1 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     };
     let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
@@ -46,7 +46,7 @@ async fn main() {
         ])
         .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     };
 

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -28,7 +28,7 @@ async fn main() {
             )
             .boxed(),
             listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-            allow_non_globals_in_dht: true,
+            allow_non_global_addresses_in_dht: true,
             ..Config::with_keypair(keypair.clone())
         };
 
@@ -81,7 +81,7 @@ async fn main() {
 
     let config = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         networking_parameters_registry: NetworkingParametersManager::new(
             db_path.as_ref(),
             bootstrap_nodes,

--- a/crates/subspace-networking/examples/get-peers.rs
+++ b/crates/subspace-networking/examples/get-peers.rs
@@ -13,7 +13,7 @@ async fn main() {
 
     let config_1 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     };
     let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
@@ -47,7 +47,7 @@ async fn main() {
         ])
         .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     };
 

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -28,7 +28,7 @@ async fn main() {
             })),
             MemoryProviderStorage::default(),
         ),
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     };
     let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
@@ -64,7 +64,7 @@ async fn main() {
         ])
         .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     };
 

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -33,7 +33,7 @@ async fn main() {
 
     let config_1 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         request_response_protocols: vec![GenericRequestHandler::create(|&ExampleRequest| {
             println!("Request handler for request");
             Some(ExampleResponse)
@@ -87,7 +87,7 @@ async fn main() {
         ])
         .boxed(),
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         request_response_protocols: vec![GenericRequestHandler::<ExampleRequest>::create(|_| None)],
         ..Config::with_generated_keypair()
     };

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -37,7 +37,7 @@ enum Command {
         out_peers: Option<u32>,
         /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
         #[arg(long, default_value_t = false)]
-        disable_private_ip: bool,
+        disable_private_ips: bool,
     },
     /// Generate a new keypair
     GenerateKeypair,
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
             reserved_peers,
             in_peers,
             out_peers,
-            disable_private_ip,
+            disable_private_ips,
         } => {
             let config = Config {
                 networking_parameters_registry: BootstrappedNetworkingParameters::new(
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .boxed(),
                 listen_on,
-                allow_non_global_addresses_in_dht: !disable_private_ip,
+                allow_non_global_addresses_in_dht: !disable_private_ips,
                 reserved_peers,
                 max_established_incoming_connections: in_peers
                     .unwrap_or(MAX_ESTABLISHED_INCOMING_CONNECTIONS),

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -35,6 +35,9 @@ enum Command {
         /// Defines max outgoing connections limit for the peer.
         #[arg(long)]
         out_peers: Option<u32>,
+        /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
+        #[arg(long, default_value_t = false)]
+        disable_non_global_addresses_in_dht: bool,
     },
     /// Generate a new keypair
     GenerateKeypair,
@@ -56,6 +59,7 @@ async fn main() -> anyhow::Result<()> {
             reserved_peers,
             in_peers,
             out_peers,
+            disable_non_global_addresses_in_dht,
         } => {
             let config = Config {
                 networking_parameters_registry: BootstrappedNetworkingParameters::new(
@@ -63,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .boxed(),
                 listen_on,
-                allow_non_globals_in_dht: true,
+                allow_non_global_addresses_in_dht: !disable_non_global_addresses_in_dht,
                 reserved_peers,
                 max_established_incoming_connections: in_peers
                     .unwrap_or(MAX_ESTABLISHED_INCOMING_CONNECTIONS),

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -37,7 +37,7 @@ enum Command {
         out_peers: Option<u32>,
         /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
         #[arg(long, default_value_t = false)]
-        disable_non_global_addresses_in_dht: bool,
+        disable_private_ip: bool,
     },
     /// Generate a new keypair
     GenerateKeypair,
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
             reserved_peers,
             in_peers,
             out_peers,
-            disable_non_global_addresses_in_dht,
+            disable_private_ip,
         } => {
             let config = Config {
                 networking_parameters_registry: BootstrappedNetworkingParameters::new(
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .boxed(),
                 listen_on,
-                allow_non_global_addresses_in_dht: !disable_non_global_addresses_in_dht,
+                allow_non_global_addresses_in_dht: !disable_private_ip,
                 reserved_peers,
                 max_established_incoming_connections: in_peers
                     .unwrap_or(MAX_ESTABLISHED_INCOMING_CONNECTIONS),

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use std::{fmt, io};
 use subspace_core_primitives::{crypto, PIECE_SIZE};
 use thiserror::Error;
-use tracing::{debug, error, info};
+use tracing::{error, info, trace};
 
 const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
@@ -315,7 +315,7 @@ where
         Ok((node, node_runner))
     });
 
-    debug!(%allow_non_global_addresses_in_dht, "DSN configured.");
+    trace!(%allow_non_global_addresses_in_dht, "DSN configured.");
 
     create_swarm_fut.await.expect(
         "Blocking tasks never panics, if it does it is an implementation bug and everything \

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use std::{fmt, io};
 use subspace_core_primitives::{crypto, PIECE_SIZE};
 use thiserror::Error;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
@@ -106,7 +106,7 @@ pub struct Config<RecordStore = CustomRecordStore> {
     /// Mplex multiplexing configuration.
     pub mplex_config: MplexConfig,
     /// Should non-global addresses be added to the DHT?
-    pub allow_non_globals_in_dht: bool,
+    pub allow_non_global_addresses_in_dht: bool,
     /// How frequently should random queries be done using Kademlia DHT to populate routing table.
     pub initial_random_query_interval: Duration,
     /// A reference to the `NetworkingParametersRegistry` implementation.
@@ -187,7 +187,7 @@ impl Config {
             kademlia,
             gossipsub,
             record_store: CustomRecordStore::new(NoRecordStorage, MemoryProviderStorage::default()),
-            allow_non_globals_in_dht: false,
+            allow_non_global_addresses_in_dht: false,
             initial_random_query_interval: Duration::from_secs(1),
             networking_parameters_registry: BootstrappedNetworkingParameters::default().boxed(),
             request_response_protocols: Vec::new(),
@@ -242,7 +242,7 @@ where
         record_store,
         yamux_config,
         mplex_config,
-        allow_non_globals_in_dht,
+        allow_non_global_addresses_in_dht,
         initial_random_query_interval,
         networking_parameters_registry,
         request_response_protocols,
@@ -300,7 +300,7 @@ where
 
         let node = Node::new(shared);
         let node_runner = NodeRunner::<RecordStore>::new(NodeRunnerConfig::<RecordStore> {
-            allow_non_globals_in_dht,
+            allow_non_global_addresses_in_dht,
             command_receiver,
             swarm,
             shared_weak,
@@ -314,6 +314,8 @@ where
 
         Ok((node, node_runner))
     });
+
+    debug!(%allow_non_global_addresses_in_dht, "DSN configured.");
 
     create_swarm_fut.await.expect(
         "Blocking tasks never panics, if it does it is an implementation bug and everything \

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -106,7 +106,7 @@ where
 {
     pub(crate) fn new(
         NodeRunnerConfig::<RecordStore> {
-            allow_non_global_addresses_in_dht: allow_non_globals_in_dht,
+            allow_non_global_addresses_in_dht,
             command_receiver,
             swarm,
             shared_weak,
@@ -119,7 +119,7 @@ where
         }: NodeRunnerConfig<RecordStore>,
     ) -> Self {
         Self {
-            allow_non_global_addresses_in_dht: allow_non_globals_in_dht,
+            allow_non_global_addresses_in_dht,
             command_receiver,
             swarm,
             shared_weak,

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -55,7 +55,7 @@ where
     RecordStore: Send + Sync + for<'a> libp2p::kad::store::RecordStore<'a> + 'static,
 {
     /// Should non-global addresses be added to the DHT?
-    allow_non_globals_in_dht: bool,
+    allow_non_global_addresses_in_dht: bool,
     command_receiver: mpsc::Receiver<Command>,
     swarm: Swarm<Behavior<RecordStore>>,
     shared_weak: Weak<Shared>,
@@ -88,7 +88,7 @@ pub(crate) struct NodeRunnerConfig<RecordStore = CustomRecordStore>
 where
     RecordStore: Send + Sync + for<'a> libp2p::kad::store::RecordStore<'a> + 'static,
 {
-    pub allow_non_globals_in_dht: bool,
+    pub allow_non_global_addresses_in_dht: bool,
     pub command_receiver: mpsc::Receiver<Command>,
     pub swarm: Swarm<Behavior<RecordStore>>,
     pub shared_weak: Weak<Shared>,
@@ -106,7 +106,7 @@ where
 {
     pub(crate) fn new(
         NodeRunnerConfig::<RecordStore> {
-            allow_non_globals_in_dht,
+            allow_non_global_addresses_in_dht: allow_non_globals_in_dht,
             command_receiver,
             swarm,
             shared_weak,
@@ -119,7 +119,7 @@ where
         }: NodeRunnerConfig<RecordStore>,
     ) -> Self {
         Self {
-            allow_non_globals_in_dht,
+            allow_non_global_addresses_in_dht: allow_non_globals_in_dht,
             command_receiver,
             swarm,
             shared_weak,
@@ -392,7 +392,8 @@ where
 
             if kademlia_enabled {
                 for address in info.listen_addrs {
-                    if !self.allow_non_globals_in_dht && !utils::is_global_address_or_dns(&address)
+                    if !self.allow_non_global_addresses_in_dht
+                        && !utils::is_global_address_or_dns(&address)
                     {
                         trace!(
                             %local_peer_id,

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -403,7 +403,7 @@ fn main() -> Result<(), Error> {
                             keypair: network_keypair,
                             listen_on: cli.dsn_listen_on,
                             bootstrap_nodes: dsn_bootstrap_nodes,
-                            allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ip,
+                            allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ips,
                         }
                     };
 

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -403,6 +403,8 @@ fn main() -> Result<(), Error> {
                             keypair: network_keypair,
                             listen_on: cli.dsn_listen_on,
                             bootstrap_nodes: dsn_bootstrap_nodes,
+                            allow_non_global_addresses_in_dht: !cli
+                                .dsn_disable_non_global_addresses_in_dht,
                         }
                     };
 

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -403,8 +403,7 @@ fn main() -> Result<(), Error> {
                             keypair: network_keypair,
                             listen_on: cli.dsn_listen_on,
                             bootstrap_nodes: dsn_bootstrap_nodes,
-                            allow_non_global_addresses_in_dht: !cli
-                                .dsn_disable_non_global_addresses_in_dht,
+                            allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ip,
                         }
                     };
 

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -138,7 +138,7 @@ where
     let (node, mut node_runner) = subspace_networking::create(Config {
         networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
             .boxed(),
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: true,
         ..Config::with_generated_keypair()
     })
     .await

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -187,6 +187,11 @@ pub struct Cli {
     #[arg(long)]
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
 
+    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
+    /// in Kademlia DHT for the DSN.
+    #[arg(long, default_value_t = false)]
+    pub dsn_disable_non_global_addresses_in_dht: bool,
+
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
     #[arg(long, default_value = "1GiB")]
     pub piece_cache_size: ByteSize,

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -190,7 +190,7 @@ pub struct Cli {
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
     /// in Kademlia DHT for the DSN.
     #[arg(long, default_value_t = false)]
-    pub dsn_disable_private_ip: bool,
+    pub dsn_disable_private_ips: bool,
 
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
     #[arg(long, default_value = "1GiB")]

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -190,7 +190,7 @@ pub struct Cli {
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
     /// in Kademlia DHT for the DSN.
     #[arg(long, default_value_t = false)]
-    pub dsn_disable_non_global_addresses_in_dht: bool,
+    pub dsn_disable_private_ip: bool,
 
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
     #[arg(long, default_value = "1GiB")]

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -28,6 +28,9 @@ pub struct DsnConfig {
 
     /// Identity keypair of a node used for authenticated connections.
     pub keypair: identity::Keypair,
+
+    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
+    pub allow_non_global_addresses_in_dht: bool,
 }
 
 /// Start an archiver that will listen for archived segments and send it to DSN network using
@@ -57,7 +60,7 @@ where
     > {
         keypair: dsn_config.keypair,
         listen_on: dsn_config.listen_on,
-        allow_non_globals_in_dht: true,
+        allow_non_global_addresses_in_dht: dsn_config.allow_non_global_addresses_in_dht,
         networking_parameters_registry: BootstrappedNetworkingParameters::new(
             dsn_config.bootstrap_nodes,
         )

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -127,6 +127,7 @@ async fn run_executor(
                     .expect("Correct multiaddr; qed")],
                 bootstrap_nodes: vec![],
                 keypair: identity::Keypair::generate_ed25519(),
+                allow_non_global_addresses_in_dht: true,
             },
             piece_cache_size: 1024 * 1024 * 1024,
         };

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -195,6 +195,7 @@ pub async fn run_validator_node(
                     .expect("Correct multiaddr; qed")],
                 bootstrap_nodes: vec![],
                 keypair: identity::Keypair::generate_ed25519(),
+                allow_non_global_addresses_in_dht: true,
             },
             piece_cache_size: 1024 * 1024 * 1024,
         };


### PR DESCRIPTION
This PR adds `disable_non_global_addresses_in_dht` parameters to the DSN-apps. This parameter affects the behaviour of the Kademlia DHT in case of the non-global (local, shared, loopback) IP-addresses.

Affected apps:
- subspace-node - added `dsn_disable_non_global_addresses_in_dht` parameter.
- subspace-farmer - added`disable_non_global_addresses_in_dht` parameter
- subspace-bootstrap-node - added `disable_non_global_addresses_in_dht` parameter

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
