### PR TITLE
Only use substrate-wasm-builder when std feature is enabled

### DIFF
--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -61,8 +61,8 @@ subspace-verification = { version = "0.1.0", default-features = false, path = ".
 system-domain-runtime = { version = "0.1.0", default-features = false, path = "../../domains/runtime/system" }
 
 [build-dependencies]
-subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../subspace-wasm-tools" }
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+subspace-wasm-tools = { version = "0.1.0", path = "../subspace-wasm-tools" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3.3"
@@ -113,6 +113,7 @@ std = [
 	"subspace-runtime-primitives/std",
 	"subspace-verification/std",
 	"system-domain-runtime/std",
+	"substrate-wasm-builder",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/crates/subspace-runtime/build.rs
+++ b/crates/subspace-runtime/build.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
         "system-domain-runtime",
@@ -23,9 +21,12 @@ fn main() {
         "execution_wasm_bundle.rs",
     );
 
-    WasmBuilder::new()
-        .with_current_project()
-        .export_heap_base()
-        .import_memory()
-        .build();
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .export_heap_base()
+            .import_memory()
+            .build();
+    }
 }

--- a/domains/runtime/core-payments/Cargo.toml
+++ b/domains/runtime/core-payments/Cargo.toml
@@ -47,8 +47,8 @@ sp-version = { version = "5.0.0", default-features = false, git = "https://githu
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 
 [build-dependencies]
-subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../../crates/subspace-wasm-tools" }
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+subspace-wasm-tools = { version = "0.1.0", path = "../../../crates/subspace-wasm-tools" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", optional = true }
 
 [features]
 default = [
@@ -85,6 +85,7 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"subspace-runtime-primitives/std",
+	"substrate-wasm-builder",
 ]
 # Internal implementation detail, enabled during building of wasm blob.
 wasm-builder = []

--- a/domains/runtime/core-payments/build.rs
+++ b/domains/runtime/core-payments/build.rs
@@ -1,12 +1,13 @@
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-    WasmBuilder::new()
-        .with_current_project()
-        .enable_feature("wasm-builder")
-        .export_heap_base()
-        .import_memory()
-        .build();
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .enable_feature("wasm-builder")
+            .export_heap_base()
+            .import_memory()
+            .build();
+    }
 
     subspace_wasm_tools::export_wasm_bundle_path();
 }

--- a/domains/runtime/core-payments/src/lib.rs
+++ b/domains/runtime/core-payments/src/lib.rs
@@ -12,6 +12,6 @@ mod runtime;
 #[cfg(any(feature = "wasm-builder", feature = "std"))]
 pub use runtime::*;
 
-// Make the WASM binary available, except in wasm builder environment.
-#[cfg(not(feature = "wasm-builder"))]
+// Make the WASM binary available.
+#[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));

--- a/domains/runtime/system/Cargo.toml
+++ b/domains/runtime/system/Cargo.toml
@@ -49,8 +49,8 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subsp
 system-runtime-primitives = { version = "0.1.0", path = "../../primitives/system-runtime", default-features = false }
 
 [build-dependencies]
-subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../../crates/subspace-wasm-tools" }
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+subspace-wasm-tools = { version = "0.1.0", path = "../../../crates/subspace-wasm-tools" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", optional = true }
 
 [features]
 default = [
@@ -91,6 +91,7 @@ std = [
 	"sp-version/std",
 	"subspace-runtime-primitives/std",
 	"system-runtime-primitives/std",
+	"substrate-wasm-builder",
 ]
 # Internal implementation detail, enabled during building of wasm blob.
 wasm-builder = []

--- a/domains/runtime/system/build.rs
+++ b/domains/runtime/system/build.rs
@@ -1,5 +1,3 @@
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
         "core-payments-domain-runtime",
@@ -7,12 +5,15 @@ fn main() {
         "core_payments_wasm_bundle.rs",
     );
 
-    WasmBuilder::new()
-        .with_current_project()
-        .enable_feature("wasm-builder")
-        .export_heap_base()
-        .import_memory()
-        .build();
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .enable_feature("wasm-builder")
+            .export_heap_base()
+            .import_memory()
+            .build();
+    }
 
     subspace_wasm_tools::export_wasm_bundle_path();
 }

--- a/domains/runtime/system/src/lib.rs
+++ b/domains/runtime/system/src/lib.rs
@@ -12,8 +12,8 @@ mod runtime;
 #[cfg(any(feature = "wasm-builder", feature = "std"))]
 pub use runtime::*;
 
-// Make the WASM binary available, except in wasm builder environment.
-#[cfg(not(feature = "wasm-builder"))]
+// Make the WASM binary available.
+#[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/domains/test/runtime/Cargo.toml
+++ b/domains/test/runtime/Cargo.toml
@@ -13,8 +13,8 @@ links = "domain-test-runtime"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../../crates/subspace-wasm-tools" }
-substrate-wasm-builder = { git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+subspace-wasm-tools = { version = "0.1.0", path = "../../../crates/subspace-wasm-tools" }
+substrate-wasm-builder = { git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive"]}
@@ -88,6 +88,7 @@ std = [
 	"sp-version/std",
 	"system-runtime-primitives/std",
 	"subspace-runtime-primitives/std",
+	"substrate-wasm-builder",
 ]
 # Internal implementation detail, enabled during building of wasm blob.
 wasm-builder = []

--- a/domains/test/runtime/build.rs
+++ b/domains/test/runtime/build.rs
@@ -1,12 +1,13 @@
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-    WasmBuilder::new()
-        .with_current_project()
-        .enable_feature("wasm-builder")
-        .export_heap_base()
-        .import_memory()
-        .build();
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .enable_feature("wasm-builder")
+            .export_heap_base()
+            .import_memory()
+            .build();
+    }
 
     subspace_wasm_tools::export_wasm_bundle_path();
 }

--- a/domains/test/runtime/src/lib.rs
+++ b/domains/test/runtime/src/lib.rs
@@ -12,6 +12,6 @@ mod runtime;
 #[cfg(any(feature = "wasm-builder", feature = "std"))]
 pub use runtime::*;
 
-// Make the WASM binary available, except in wasm builder environment.
-#[cfg(not(feature = "wasm-builder"))]
+// Make the WASM binary available.
+#[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));

--- a/substrate/substrate-test-runtime/Cargo.toml
+++ b/substrate/substrate-test-runtime/Cargo.toml
@@ -56,7 +56,7 @@ substrate-test-runtime-client = { version = "2.0.0", path = "../substrate-test-r
 futures = "0.3.25"
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", optional = true }
 
 [features]
 default = [
@@ -94,6 +94,7 @@ std = [
 	"sp-trie/std",
 	"sp-transaction-pool/std",
 	"subspace-core-primitives/std",
+	"substrate-wasm-builder",
 ]
 # Special feature to disable logging
 disable-logging = [ "sp-api/disable-logging" ]

--- a/substrate/substrate-test-runtime/build.rs
+++ b/substrate/substrate-test-runtime/build.rs
@@ -15,24 +15,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		// Note that we set the stack-size to 1MB explicitly even though it is set
-		// to this value by default. This is because some of our tests (`restoration_of_globals`)
-		// depend on the stack-size.
-		.append_to_rust_flags("-Clink-arg=-zstack-size=1048576")
-		.import_memory()
-		.build();
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .export_heap_base()
+            // Note that we set the stack-size to 1MB explicitly even though it is set
+            // to this value by default. This is because some of our tests (`restoration_of_globals`)
+            // depend on the stack-size.
+            .append_to_rust_flags("-Clink-arg=-zstack-size=1048576")
+            .import_memory()
+            .build();
+    }
 
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.set_file_name("wasm_binary_logging_disabled.rs")
-		.enable_feature("disable-logging")
-		.build();
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .export_heap_base()
+            .import_memory()
+            .set_file_name("wasm_binary_logging_disabled.rs")
+            .enable_feature("disable-logging")
+            .build();
+    }
 }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -60,8 +60,8 @@ frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 
 [build-dependencies]
-subspace-wasm-tools = { version = "0.1.0", default-features = false, path = "../../crates/subspace-wasm-tools" }
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+subspace-wasm-tools = { version = "0.1.0", path = "../../crates/subspace-wasm-tools" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", optional = true }
 
 [features]
 default = ["std"]
@@ -104,6 +104,7 @@ std = [
 	"sp-version/std",
 	"subspace-core-primitives/std",
 	"subspace-runtime-primitives/std",
-	"subspace-verification/std"
+	"subspace-verification/std",
+	"substrate-wasm-builder",
 ]
 do-not-enforce-cost-of-storage = []

--- a/test/subspace-test-runtime/build.rs
+++ b/test/subspace-test-runtime/build.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
         "domain-test-runtime",
@@ -23,9 +21,12 @@ fn main() {
         "execution_wasm_bundle.rs",
     );
 
-    WasmBuilder::new()
-        .with_current_project()
-        .export_heap_base()
-        .import_memory()
-        .build()
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .export_heap_base()
+            .import_memory()
+            .build();
+    }
 }


### PR DESCRIPTION
Turns out we can skip `substrate-wasm-builder` and (more importantly) its heavy dependencies unless we're building with `std` feature (in which case we'll have inner WASM runtime and will need this dependency).

This is an equivalent change to https://github.com/paritytech/substrate/pull/12790 and will provide similar (if not bigger) improvements to https://github.com/paritytech/substrate/pull/12786

@liuchengxu please check that everything still runs properly after this.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
