### PR TITLE
Fix ss58 parsing in farmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8644,6 +8644,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base58",
+ "blake2",
  "bytesize",
  "clap 4.0.26",
  "derive_more",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 base58 = "0.2.0"
+blake2 = "0.10.5"
 bytesize = "1.1.0"
 clap = { version = "4.0.26", features = ["color", "derive"] }
 derive_more = "0.99.17"

--- a/crates/subspace-farmer/src/bin/subspace-farmer/ss58.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/ss58.rs
@@ -18,9 +18,11 @@
 //! `sp-core` into farmer application
 
 use base58::FromBase58;
+use blake2::digest::typenum::U64;
+use blake2::digest::FixedOutput;
+use blake2::{Blake2b, Digest};
 use ss58_registry::Ss58AddressFormat;
-use subspace_core_primitives::crypto::blake2b_256_hash_list;
-use subspace_core_primitives::{Blake2b256Hash, PublicKey, PUBLIC_KEY_LENGTH};
+use subspace_core_primitives::{PublicKey, PUBLIC_KEY_LENGTH};
 use thiserror::Error;
 
 const PREFIX: &[u8] = b"SS58PRE";
@@ -90,6 +92,20 @@ pub(crate) fn parse_ss58_reward_address(s: &str) -> Result<PublicKey, Ss58Parsin
     Ok(PublicKey::from(bytes))
 }
 
-fn ss58hash(data: &[u8]) -> Blake2b256Hash {
-    blake2b_256_hash_list(&[PREFIX, data])
+fn ss58hash(data: &[u8]) -> [u8; 64] {
+    let mut state = Blake2b::<U64>::new();
+    state.update(PREFIX);
+    state.update(data);
+    state.finalize_fixed().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ss58_reward_address;
+
+    #[test]
+    fn basic() {
+        // Alice
+        parse_ss58_reward_address("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY").unwrap();
+    }
 }


### PR DESCRIPTION
The reason was simple: ss58 uses blake2b-512, not blake2b-256 and I wasn't careful enough.

Supersedes #962

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
