### PR TITLE
Publish pieces on DSN in the background

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -380,7 +380,6 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
     client: Arc<Client>,
     telemetry: Option<TelemetryHandle>,
     spawner: &impl sp_core::traits::SpawnEssentialNamed,
-    is_authoring_blocks: bool,
 ) where
     Block: BlockT,
     Backend: BackendT<Block>,
@@ -423,16 +422,12 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
 
             async move {
                 // Farmers may have not received all previous segments, send them now.
-                if is_authoring_blocks {
-                    for archived_segment in older_archived_segments {
-                        send_archived_segment_notification(
-                            &archived_segment_notification_sender,
-                            archived_segment,
-                        )
-                        .await;
-                    }
-                } else {
-                    drop(older_archived_segments);
+                for archived_segment in older_archived_segments {
+                    send_archived_segment_notification(
+                        &archived_segment_notification_sender,
+                        archived_segment,
+                    )
+                    .await;
                 }
 
                 while let Some(ImportedBlockNotification {
@@ -509,13 +504,11 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
                     {
                         let root_block = archived_segment.root_block;
 
-                        if is_authoring_blocks {
-                            send_archived_segment_notification(
-                                &archived_segment_notification_sender,
-                                archived_segment,
-                            )
-                            .await;
-                        }
+                        send_archived_segment_notification(
+                            &archived_segment_notification_sender,
+                            archived_segment,
+                        )
+                        .await;
 
                         let _ = root_block_sender.send(root_block).await;
                     }

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -500,7 +500,6 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
             client.clone(),
             None,
             &task_manager.spawn_essential_handle(),
-            false,
         );
 
         let (archived_pieces_sender, archived_pieces_receiver) = oneshot::channel();

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -205,7 +205,6 @@ fn main() -> Result<(), Error> {
                     client.clone(),
                     None,
                     &task_manager.spawn_essential_handle(),
-                    config.role.is_authority(),
                 );
 
                 Ok((

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -457,6 +457,7 @@ where
                 .archived_segment_notification_stream()
                 .subscribe(),
             node.clone(),
+            task_manager.spawn_handle(),
         );
 
         task_manager.spawn_essential_handle().spawn_essential(

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -520,7 +520,6 @@ where
         client.clone(),
         telemetry.as_ref().map(|telemetry| telemetry.handle()),
         &task_manager.spawn_essential_handle(),
-        config.role.is_authority(),
     );
 
     let (network, system_rpc_tx, tx_handler_controller, network_starter) =

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -21,10 +21,11 @@ mod dsn;
 mod pool;
 pub mod rpc;
 
+use crate::dsn::create_dsn_instance;
 pub use crate::pool::FullPool;
 use derive_more::{Deref, DerefMut, Into};
 use domain_runtime_primitives::Hash as DomainHash;
-use dsn::start_dsn_node;
+use dsn::start_dsn_archiver;
 pub use dsn::DsnConfig;
 use frame_system_rpc_runtime_api::AccountNonceApi;
 use futures::channel::oneshot;
@@ -54,6 +55,7 @@ use sp_blockchain::HeaderMetadata;
 use sp_consensus::Error as ConsensusError;
 use sp_consensus_slots::Slot;
 use sp_consensus_subspace::{FarmerPublicKey, SubspaceApi};
+use sp_core::traits::SpawnEssentialNamed;
 use sp_domains::ExecutorApi;
 use sp_objects::ObjectsApi;
 use sp_offchain::OffchainWorkerApi;
@@ -67,7 +69,7 @@ use subspace_fraud_proof::VerifyFraudProof;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Hash, Index as Nonce};
-use tracing::error;
+use tracing::{error, info, Instrument};
 
 /// Error type for Subspace service.
 #[derive(thiserror::Error, Debug)]
@@ -409,10 +411,11 @@ where
         });
 
     let dsn_bootstrap_nodes = {
-        let node = start_dsn_node(
-            &subspace_link,
+        let span = tracing::info_span!(sc_tracing::logging::PREFIX_LOG_SPAN, name = "DSN");
+        let _enter = span.enter();
+
+        let (node, mut node_runner) = create_dsn_instance::<Block, _>(
             config.dsn_config.clone(),
-            task_manager.spawn_essential_handle(),
             piece_cache.clone(),
             Arc::new({
                 let piece_cache = piece_cache.clone();
@@ -435,6 +438,25 @@ where
             }),
         )
         .await?;
+
+        info!("Subspace networking initialized: Node ID is {}", node.id());
+
+        task_manager.spawn_essential_handle().spawn_essential(
+            "node-runner",
+            Some("subspace-networking"),
+            Box::pin(
+                async move {
+                    node_runner.run().await;
+                }
+                .in_current_span(),
+            ),
+        );
+
+        start_dsn_archiver(
+            &subspace_link,
+            node.clone(),
+            task_manager.spawn_essential_handle(),
+        );
 
         // Fall back to node itself as bootstrap node for DSN so farmer always has someone to
         // connect to


### PR DESCRIPTION
This fixes issue that manifested itself as block producing nodes being unable\* to sync to the tip.

The reason is that block import was waiting for pieces to be published on DSN and this publishing took 10+ seconds per piece!

I had to do some refactoring to clean things up and make it more canonical, after which 4th commit moves piece publishing into the background, which allows node to sync properly.

\* They were, but VERY slowly.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
