### PR TITLE
Improve piece getting mechanism on farmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.7",
+ "instant",
+ "pin-project-lite 0.2.9",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8643,6 +8657,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "base58",
  "blake2",
  "bytesize",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -14,6 +14,7 @@ include = [
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.58"
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base58 = "0.2.0"
 blake2 = "0.10.5"
 bytesize = "1.1.0"

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -663,8 +663,8 @@ impl SingleDiskPlot {
                                 // Some sectors may already be plotted, skip them
                                 metadata_header.lock().sector_count as usize,
                             )
-                            .map(|(sector_index, (sector, metadata))| {
-                                (sector_index as u64 + first_sector_index, sector, metadata)
+                            .map(|(sector_offset, (sector, metadata))| {
+                                (sector_offset as u64 + first_sector_index, sector, metadata)
                             });
 
                         // TODO: Concurrency
@@ -676,6 +676,8 @@ impl SingleDiskPlot {
                                 );
                                 return;
                             }
+
+                            debug!(%sector_index, "Plotting sector");
 
                             let farmer_app_info = handle
                                 .block_on(rpc_client.farmer_app_info())


### PR DESCRIPTION
We basically have two way to get pieces and were trying them sequentially. While it works, there is a faster approach to try both getting from cache and from archival storage. Also there wasn't any timeout on those operations, which meant things were moving VERY slowly.

On top of all that I decided to use idiomatic `backoff` crate rather than `loop`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
