### PR TITLE
Fix `submit_bundle` in pallet-domains that core domain receipts are tracked incorrectly

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -5,8 +5,8 @@ use sp_core::crypto::Pair;
 use sp_core::{H256, U256};
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
 use sp_domains::{
-    Bundle, BundleHeader, ExecutionReceipt, ExecutorPair, InvalidTransactionCode, ProofOfElection,
-    SignedOpaqueBundle,
+    Bundle, BundleHeader, DomainId, ExecutionReceipt, ExecutorPair, InvalidTransactionCode,
+    ProofOfElection, SignedOpaqueBundle,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup, ValidateUnsigned};
@@ -98,6 +98,7 @@ fn create_dummy_receipt(
 }
 
 fn create_dummy_bundle(
+    domain_id: DomainId,
     primary_number: BlockNumber,
     primary_hash: Hash,
 ) -> SignedOpaqueBundle<BlockNumber, Hash, H256> {
@@ -119,12 +120,13 @@ fn create_dummy_bundle(
 
     SignedOpaqueBundle {
         bundle,
-        proof_of_election: ProofOfElection::with_public_key(pair.public()),
+        proof_of_election: ProofOfElection::dummy(domain_id, pair.public()),
         signature,
     }
 }
 
 fn create_dummy_bundle_with_receipts(
+    domain_id: DomainId,
     primary_hash: Hash,
     receipts: Vec<ExecutionReceipt<BlockNumber, Hash, H256>>,
 ) -> SignedOpaqueBundle<BlockNumber, Hash, H256> {
@@ -146,7 +148,7 @@ fn create_dummy_bundle_with_receipts(
 
     SignedOpaqueBundle {
         bundle,
-        proof_of_election: ProofOfElection::with_public_key(pair.public()),
+        proof_of_election: ProofOfElection::dummy(domain_id, pair.public()),
         signature,
     }
 }
@@ -156,7 +158,10 @@ fn submit_execution_receipt_incrementally_should_work() {
     let (dummy_bundles, block_hashes): (Vec<_>, Vec<_>) = (1u64..=256u64 + 3u64)
         .map(|n| {
             let primary_hash = Hash::random();
-            (create_dummy_bundle(n, primary_hash), primary_hash)
+            (
+                create_dummy_bundle(DomainId::SYSTEM, n, primary_hash),
+                primary_hash,
+            )
         })
         .unzip();
 
@@ -225,7 +230,10 @@ fn submit_execution_receipt_with_huge_gap_should_work() {
     let (dummy_bundles, block_hashes): (Vec<_>, Vec<_>) = (1u64..=256u64 + 2)
         .map(|n| {
             let primary_hash = Hash::random();
-            (create_dummy_bundle(n, primary_hash), primary_hash)
+            (
+                create_dummy_bundle(DomainId::SYSTEM, n, primary_hash),
+                primary_hash,
+            )
         })
         .unzip();
 
@@ -292,19 +300,19 @@ fn submit_bundle_with_many_reeipts_should_work() {
         .unzip();
 
     let primary_hash_255 = *block_hashes.last().unwrap();
-    let bundle1 = create_dummy_bundle_with_receipts(primary_hash_255, receipts);
+    let bundle1 = create_dummy_bundle_with_receipts(DomainId::SYSTEM, primary_hash_255, receipts);
 
     let primary_hash_256 = Hash::random();
     block_hashes.push(primary_hash_256);
-    let bundle2 = create_dummy_bundle(256, primary_hash_256);
+    let bundle2 = create_dummy_bundle(DomainId::SYSTEM, 256, primary_hash_256);
 
     let primary_hash_257 = Hash::random();
     block_hashes.push(primary_hash_257);
-    let bundle3 = create_dummy_bundle(257, primary_hash_257);
+    let bundle3 = create_dummy_bundle(DomainId::SYSTEM, 257, primary_hash_257);
 
     let primary_hash_258 = Hash::random();
     block_hashes.push(primary_hash_258);
-    let bundle4 = create_dummy_bundle(258, primary_hash_258);
+    let bundle4 = create_dummy_bundle(DomainId::SYSTEM, 258, primary_hash_258);
 
     let run_to_block = |n: BlockNumber, block_hashes: Vec<Hash>| {
         System::set_block_number(1);
@@ -355,7 +363,10 @@ fn submit_fraud_proof_should_work() {
     let (dummy_bundles, block_hashes): (Vec<_>, Vec<_>) = (1u64..=256u64)
         .map(|n| {
             let primary_hash = Hash::random();
-            (create_dummy_bundle(n, primary_hash), primary_hash)
+            (
+                create_dummy_bundle(DomainId::SYSTEM, n, primary_hash),
+                primary_hash,
+            )
         })
         .unzip();
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -229,9 +229,9 @@ pub struct ProofOfElection<DomainHash> {
 
 impl<DomainHash: Default> ProofOfElection<DomainHash> {
     #[cfg(feature = "std")]
-    pub fn with_public_key(executor_public_key: ExecutorPublicKey) -> Self {
+    pub fn dummy(domain_id: DomainId, executor_public_key: ExecutorPublicKey) -> Self {
         Self {
-            domain_id: DomainId::default(),
+            domain_id,
             vrf_output: [0u8; VRF_OUTPUT_LENGTH],
             vrf_proof: [0u8; VRF_PROOF_LENGTH],
             executor_public_key,

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -11,7 +11,7 @@ use sp_api::{AsTrieBackend, ProvideRuntimeApi};
 use sp_core::traits::FetchRuntimeCode;
 use sp_core::Pair;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
-use sp_domains::{Bundle, BundleHeader, ExecutorPair, ProofOfElection, SignedBundle};
+use sp_domains::{Bundle, BundleHeader, DomainId, ExecutorPair, ProofOfElection, SignedBundle};
 use sp_runtime::generic::{BlockId, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
 use std::collections::HashSet;
@@ -385,7 +385,7 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
 
         let signed_opaque_bundle = SignedBundle {
             bundle,
-            proof_of_election: ProofOfElection::with_public_key(pair.public()), // TODO: mock ProofOfElection properly
+            proof_of_election: ProofOfElection::dummy(DomainId::SYSTEM, pair.public()), // TODO: mock ProofOfElection properly
             signature,
         }
         .into_signed_opaque_bundle();


### PR DESCRIPTION
This PR fix a bug in pallet-domains that `submit_bundle` should only process the system domain receipts on the primary chain but incorrectly also tracked the core domain receipts, which is fixed by first checking the domain_id and only continue the receipt processing when it's a system domain. There are also a few minor refactorings to the related events in this PR.

Thanks to @NingLin-P for catching this!

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
