### PR TITLE
Fix block production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5970,11 +5970,10 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -5982,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -8644,6 +8643,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "rayon",
  "scale-info",
  "serde",
  "serde_arrays",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -31,6 +31,7 @@ parity-scale-codec = { version = "3.2.1", default-features = false, features = [
 rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false, features = ["alloc"] }
+rayon = { version = "1.6.0", optional = true }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.147", optional = true, features = ["derive"] }
 serde_arrays = "0.1.0"
@@ -41,7 +42,13 @@ uint = { version = "0.9.4", default-features = false }
 criterion = "0.4.0"
 
 [features]
-default = ["std"]
+default = [
+    "parallel-decoding",
+    "std",
+]
+# Parallel decoding will use all CPUs available, but will allocate a memory of a size of a sector instead of square root
+# of that
+parallel-decoding = ["rayon"]
 std = [
     "ark-bls12-381/std",
     "ark-ff/std",

--- a/crates/subspace-core-primitives/src/sector_codec.rs
+++ b/crates/subspace-core-primitives/src/sector_codec.rs
@@ -8,6 +8,8 @@ use alloc::vec::Vec;
 use ark_bls12_381::Fr;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use num_integer::Roots;
+#[cfg(feature = "parallel-decoding")]
+use rayon::prelude::*;
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
@@ -125,30 +127,66 @@ impl SectorCodec {
             return Err(SectorCodecError::FailedToInstantiateDomain);
         };
 
-        let mut row = Vec::with_capacity(self.sector_side_size_in_scalars);
+        #[cfg(not(feature = "parallel-decoding"))]
+        {
+            let mut row = Vec::with_capacity(self.sector_side_size_in_scalars);
 
-        for row_index in 0..self.sector_side_size_in_scalars {
-            row.extend(
+            for row_index in 0..self.sector_side_size_in_scalars {
+                row.extend(
+                    sector
+                        .iter()
+                        .skip(row_index)
+                        .step_by(self.sector_side_size_in_scalars)
+                        .map(|scalar| scalar.0),
+                );
+
+                domain.coset_ifft_in_place(&mut row);
+                domain.fft_in_place(&mut row);
+
+                sector
+                    .iter_mut()
+                    .skip(row_index)
+                    .step_by(self.sector_side_size_in_scalars)
+                    .zip(row.iter())
+                    .for_each(|(output, input)| *output = Scalar(*input));
+
+                // Clear for next iteration of the loop
+                row.clear();
+            }
+        }
+        #[cfg(feature = "parallel-decoding")]
+        {
+            // Transform sector grid from columns to rows
+            let mut rows = vec![
+                vec![Fr::default(); self.sector_side_size_in_scalars];
+                self.sector_side_size_in_scalars
+            ];
+            for (row_index, row) in rows.iter_mut().enumerate() {
                 sector
                     .iter()
                     .skip(row_index)
                     .step_by(self.sector_side_size_in_scalars)
-                    .map(|scalar| scalar.0),
-            );
+                    .zip(row)
+                    .for_each(|(input, output)| *output = input.0);
+            }
 
-            domain.coset_ifft_in_place(&mut row);
-            domain.fft_in_place(&mut row);
+            // Decode rows in parallel
+            rows.par_iter_mut().for_each(|row| {
+                domain.coset_ifft_in_place(row);
+                domain.fft_in_place(row);
+            });
 
-            sector
-                .iter_mut()
-                .skip(row_index)
-                .step_by(self.sector_side_size_in_scalars)
-                .zip(row.iter())
-                .for_each(|(output, input)| *output = Scalar(*input));
-
-            // Clear for next iteration of the loop
-            row.clear();
+            // Store result back into inout sector
+            for (row_index, row) in rows.into_iter().enumerate() {
+                sector
+                    .iter_mut()
+                    .skip(row_index)
+                    .step_by(self.sector_side_size_in_scalars)
+                    .zip(row)
+                    .for_each(|(output, input)| *output = Scalar(input));
+            }
         }
+
         Ok(())
     }
 }

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -34,7 +34,7 @@ tracing = "0.1.37"
 criterion = "0.4.0"
 futures = "0.3.25"
 memmap2 = "0.5.8"
-rayon = "1.5.3"
+rayon = "1.6.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 
 [[bench]]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -58,4 +58,4 @@ zeroize = "1.5.7"
 jemallocator = "0.5.0"
 
 [dev-dependencies]
-rayon = "1.5.3"
+rayon = "1.6.0"

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -915,6 +915,13 @@ impl SingleDiskPlot {
                                 if solutions.len() >= SOLUTIONS_LIMIT {
                                     break;
                                 }
+                                // TODO: It is known that decoding is slow now and we'll only be
+                                //  able to decode a single sector within time slot reliably, in the
+                                //  future we may want allow more than one sector to be valid within
+                                //  the same disk plot.
+                                if !solutions.is_empty() {
+                                    break;
+                                }
                             }
 
                             let response = SolutionResponse {

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -46,7 +46,7 @@ use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
 use tokio::runtime::Handle;
 use tokio::sync::broadcast;
-use tracing::{debug, error, info, info_span, trace, Instrument, Span};
+use tracing::{debug, error, info, info_span, trace, warn, Instrument, Span};
 use ulid::Ulid;
 
 // Refuse to compile on non-64-bit platforms, offsets may fail on those when converting from u64 to
@@ -715,23 +715,29 @@ impl SingleDiskPlot {
                                 Err(error) => Err(PlottingError::LowLevel(error))?,
                             };
 
-                            let mut metadata_header = metadata_header.lock();
-                            metadata_header.sector_count += 1;
-                            metadata_header_mmap
-                                .copy_from_slice(metadata_header.encode().as_slice());
+                            {
+                                let mut metadata_header = metadata_header.lock();
+                                metadata_header.sector_count += 1;
+                                metadata_header_mmap
+                                    .copy_from_slice(metadata_header.encode().as_slice());
+                            }
 
                             handlers.sector_plotted.call_simple(&plotted_sector);
 
                             // TODO: Migrate this over to using `on_sector_plotted` instead
                             // Publish pieces-by-sector if we use DSN
-                            let publishing_result = handle.block_on(
-                                piece_publisher.publish_pieces(plotted_sector.piece_indexes),
-                            );
+                            tokio::spawn({
+                                let piece_publisher = piece_publisher.clone();
 
-                            // cancelled
-                            if publishing_result.is_err() {
-                                return;
-                            }
+                                async move {
+                                    if let Err(error) = piece_publisher
+                                        .publish_pieces(plotted_sector.piece_indexes)
+                                        .await
+                                    {
+                                        warn!(%sector_index, %error, "Failed to publish pieces to DSN");
+                                    }
+                                }
+                            });
                         }
                     };
 

--- a/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, trace};
 const PUBLISH_PIECE_BY_SECTOR_WAITING_DURATION_IN_SECS: u64 = 1;
 
 // Piece-by-sector DSN publishing helper.
+#[derive(Clone)]
 pub(crate) struct PieceSectorPublisher {
     dsn_node: Node,
     cancelled: Arc<AtomicBool>,


### PR DESCRIPTION
There were several issues related to block production, one of which was decoding performance and another locking of farming due to EXTREMELY slow DSN piece publishing that I moved into background task.

Sector decoding specifically improved ~50x for single-threaded option (thanks, @dariolina!) and ~100x for parallelized version on my machine (optional feature enabled by default in `subspace-core-primitives`).

With this I'm able to successfully produce blocks, votes and plot all at the same time.

Going through commits should make sense.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
