### PR TITLE
networking: Upgrade libp2p version to v0.50.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,11 +208,32 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array 0.14.6",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -229,16 +250,50 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead 0.3.2",
+ "aes 0.6.0",
+ "cipher 0.2.5",
+ "ctr 0.6.0",
+ "ghash 0.3.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead",
- "aes",
+ "aead 0.4.3",
+ "aes 0.7.5",
  "cipher 0.3.0",
- "ctr",
- "ghash",
+ "ctr 0.8.0",
+ "ghash 0.4.4",
  "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -320,6 +375,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "ark-bls12-381"
@@ -454,6 +515,73 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "asn1-rs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
+dependencies = [
+ "asn1-rs-derive 0.1.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+dependencies = [
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "asn1_der"
@@ -617,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
+checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -796,7 +924,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -821,6 +949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
+dependencies = [
+ "block-padding 0.2.1",
+ "cipher 0.2.5",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +966,12 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -989,6 +1133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca1a8fbc20b50ac9673ff014abfb2b5f4085ee1a850d408f14a159c5853ac7"
+dependencies = [
+ "aead 0.3.2",
+ "cipher 0.2.5",
+ "subtle",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,7 +1180,7 @@ name = "chacha20poly1305"
 version = "0.9.0"
 source = "git+https://github.com/RustCrypto/AEADs?rev=06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99#06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99"
 dependencies = [
- "aead",
+ "aead 0.4.3",
  "chacha20",
  "cipher 0.4.3",
  "poly1305",
@@ -1086,6 +1241,15 @@ dependencies = [
  "multihash",
  "serde",
  "unsigned-varint",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1310,6 +1474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1576,21 @@ dependencies = [
  "wasmparser",
  "wasmtime-types",
 ]
+
+[[package]]
+name = "crc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
 
 [[package]]
 name = "crc32fast"
@@ -1561,6 +1746,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array 0.14.6",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
@@ -1577,6 +1772,15 @@ checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -1672,6 +1876,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,7 +1943,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+dependencies = [
+ "asn1-rs 0.5.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1726,6 +1994,37 @@ checksum = "4b6618553c32cd1c1f4fbdb9418cc035f3168422f24406ebb08576f6db5ed6ec"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -1825,6 +2124,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2299,6 +2609,9 @@ dependencies = [
  "ff",
  "generic-array 0.14.6",
  "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2865,13 +3178,13 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01fe9932a224b72b45336d96040aa86386d674a31d0af27d800ea7bc8ca97fe"
+checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
- "rustls",
- "webpki",
+ "rustls 0.20.7",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2979,12 +3292,22 @@ dependencies = [
 
 [[package]]
 name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug 0.3.0",
+ "polyval 0.4.5",
+]
+
+[[package]]
+name = "ghash"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
- "polyval",
+ "polyval 0.5.3",
 ]
 
 [[package]]
@@ -3183,12 +3506,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.1",
  "digest 0.9.0",
 ]
 
@@ -3306,7 +3648,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.7",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -3325,6 +3667,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3362,6 +3710,25 @@ dependencies = [
  "log",
  "rtnetlink",
  "system-configuration",
+ "windows",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7abdbb86e485125dad06c2691e1e393bf3b08c7b743b43aa162a00fd39062e"
+dependencies = [
+ "async-io",
+ "core-foundation",
+ "fnv",
+ "futures 0.3.25",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "rtnetlink",
+ "system-configuration",
+ "tokio",
  "windows",
 ]
 
@@ -3430,6 +3797,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "interceptor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ffaa4d24f546a18eaeee91f7b2c52e080e20e285e43cd7c27a527b4712cfdad"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -3791,24 +4177,56 @@ dependencies = [
  "getrandom 0.2.7",
  "instant",
  "lazy_static",
- "libp2p-core",
- "libp2p-dns",
- "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-metrics",
- "libp2p-mplex",
- "libp2p-noise",
- "libp2p-ping",
- "libp2p-request-response",
- "libp2p-swarm",
- "libp2p-swarm-derive",
- "libp2p-tcp",
+ "libp2p-core 0.37.0",
+ "libp2p-dns 0.37.0",
+ "libp2p-identify 0.40.0",
+ "libp2p-kad 0.41.0",
+ "libp2p-mdns 0.41.0",
+ "libp2p-metrics 0.10.0",
+ "libp2p-mplex 0.37.0",
+ "libp2p-noise 0.40.0",
+ "libp2p-ping 0.40.1",
+ "libp2p-request-response 0.22.1",
+ "libp2p-swarm 0.40.1",
+ "libp2p-swarm-derive 0.30.1",
+ "libp2p-tcp 0.37.0",
  "libp2p-wasm-ext",
- "libp2p-websocket",
- "libp2p-yamux",
- "multiaddr",
+ "libp2p-websocket 0.39.0",
+ "libp2p-yamux 0.41.0",
+ "multiaddr 0.14.0",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.50.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "bytes",
+ "futures 0.3.25",
+ "futures-timer",
+ "getrandom 0.2.7",
+ "instant",
+ "libp2p-core 0.38.0",
+ "libp2p-dns 0.38.0",
+ "libp2p-gossipsub",
+ "libp2p-identify 0.41.0",
+ "libp2p-kad 0.42.0",
+ "libp2p-mdns 0.42.0",
+ "libp2p-metrics 0.11.0",
+ "libp2p-mplex 0.38.0",
+ "libp2p-noise 0.41.0",
+ "libp2p-ping 0.41.0",
+ "libp2p-quic",
+ "libp2p-request-response 0.23.0",
+ "libp2p-swarm 0.41.1",
+ "libp2p-tcp 0.38.0",
+ "libp2p-webrtc",
+ "libp2p-websocket 0.40.0",
+ "libp2p-yamux 0.42.0",
+ "multiaddr 0.16.0",
  "parking_lot 0.12.1",
  "pin-project",
  "smallvec",
@@ -3830,15 +4248,48 @@ dependencies = [
  "instant",
  "lazy_static",
  "log",
- "multiaddr",
+ "multiaddr 0.14.0",
  "multihash",
- "multistream-select",
+ "multistream-select 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.12.1",
  "pin-project",
  "prost",
  "prost-build",
  "rand 0.8.5",
- "rw-stream-sink",
+ "rw-stream-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.10.2",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.38.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.25",
+ "futures-timer",
+ "instant",
+ "log",
+ "multiaddr 0.16.0",
+ "multihash",
+ "multistream-select 0.12.1 (git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35)",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "rw-stream-sink 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35)",
+ "sec1",
  "serde",
  "sha2 0.10.2",
  "smallvec",
@@ -3856,7 +4307,20 @@ checksum = "2322c9fb40d99101def6a01612ee30500c89abbbecb6297b3cd252903a4c1720"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.25",
- "libp2p-core",
+ "libp2p-core 0.37.0",
+ "log",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.38.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "futures 0.3.25",
+ "libp2p-core 0.38.0",
  "log",
  "parking_lot 0.12.1",
  "smallvec",
@@ -3865,9 +4329,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b8d02b9089241196479c6fdae22df4d4444509edb3a8e7ef388218ca9b5e3e"
+version = "0.43.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
 dependencies = [
  "asynchronous-codec",
  "base64",
@@ -3877,17 +4340,19 @@ dependencies = [
  "futures 0.3.25",
  "hex_fmt",
  "instant",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
  "log",
  "prometheus-client",
  "prost",
  "prost-build",
+ "prost-codec 0.3.0",
  "rand 0.8.5",
  "regex",
  "serde",
  "sha2 0.10.2",
  "smallvec",
+ "thiserror",
  "unsigned-varint",
  "wasm-timer",
 ]
@@ -3901,13 +4366,33 @@ dependencies = [
  "asynchronous-codec",
  "futures 0.3.25",
  "futures-timer",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.37.0",
+ "libp2p-swarm 0.40.1",
  "log",
  "lru 0.8.1",
  "prost",
  "prost-build",
- "prost-codec",
+ "prost-codec 0.2.0",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.41.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "asynchronous-codec",
+ "futures 0.3.25",
+ "futures-timer",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
+ "log",
+ "lru 0.8.1",
+ "prost",
+ "prost-build",
+ "prost-codec 0.3.0",
  "smallvec",
  "thiserror",
  "void",
@@ -3927,8 +4412,35 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.37.0",
+ "libp2p-swarm 0.40.1",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "sha2 0.10.2",
+ "smallvec",
+ "thiserror",
+ "uint",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.42.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "arrayvec 0.7.2",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures 0.3.25",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
  "log",
  "prost",
  "prost-build",
@@ -3952,13 +4464,32 @@ dependencies = [
  "data-encoding",
  "dns-parser",
  "futures 0.3.25",
- "if-watch",
- "libp2p-core",
- "libp2p-swarm",
+ "if-watch 2.0.0",
+ "libp2p-core 0.37.0",
+ "libp2p-swarm 0.40.1",
  "log",
  "rand 0.8.5",
  "smallvec",
  "socket2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.42.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "data-encoding",
+ "futures 0.3.25",
+ "if-watch 3.0.0",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "socket2",
+ "tokio",
+ "trust-dns-proto",
  "void",
 ]
 
@@ -3968,12 +4499,25 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee31b08e78b7b8bfd1c4204a9dd8a87b4fcdf6dafc57eb51701c1c264a81cb9"
 dependencies = [
- "libp2p-core",
+ "libp2p-core 0.37.0",
+ "libp2p-identify 0.40.0",
+ "libp2p-kad 0.41.0",
+ "libp2p-ping 0.40.1",
+ "libp2p-swarm 0.40.1",
+ "prometheus-client",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.11.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "libp2p-core 0.38.0",
  "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-ping",
- "libp2p-swarm",
+ "libp2p-identify 0.41.0",
+ "libp2p-kad 0.42.0",
+ "libp2p-ping 0.41.0",
+ "libp2p-swarm 0.41.1",
  "prometheus-client",
 ]
 
@@ -3986,7 +4530,24 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures 0.3.25",
- "libp2p-core",
+ "libp2p-core 0.37.0",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "smallvec",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.38.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures 0.3.25",
+ "libp2p-core 0.38.0",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
@@ -4005,7 +4566,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "futures 0.3.25",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.37.0",
  "log",
  "prost",
  "prost-build",
@@ -4013,7 +4574,29 @@ dependencies = [
  "sha2 0.10.2",
  "snow",
  "static_assertions",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.41.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "bytes",
+ "curve25519-dalek 3.2.0",
+ "futures 0.3.25",
+ "libp2p-core 0.38.0",
+ "log",
+ "once_cell",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "sha2 0.10.2",
+ "snow",
+ "static_assertions",
+ "thiserror",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
@@ -4026,11 +4609,46 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.37.0",
+ "libp2p-swarm 0.40.1",
  "log",
  "rand 0.8.5",
  "void",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.41.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "futures 0.3.25",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
+ "log",
+ "rand 0.8.5",
+ "void",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.7.0-alpha"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "bytes",
+ "futures 0.3.25",
+ "futures-timer",
+ "if-watch 3.0.0",
+ "libp2p-core 0.38.0",
+ "libp2p-tls",
+ "log",
+ "parking_lot 0.12.1",
+ "quinn-proto",
+ "rand 0.8.5",
+ "rustls 0.20.7",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -4043,8 +4661,25 @@ dependencies = [
  "bytes",
  "futures 0.3.25",
  "instant",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.37.0",
+ "libp2p-swarm 0.40.1",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.23.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures 0.3.25",
+ "instant",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm 0.41.1",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -4062,12 +4697,33 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "instant",
- "libp2p-core",
+ "libp2p-core 0.37.0",
  "log",
  "pin-project",
  "rand 0.8.5",
  "smallvec",
  "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.41.1"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "either",
+ "fnv",
+ "futures 0.3.25",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.38.0",
+ "libp2p-swarm-derive 0.31.0",
+ "log",
+ "pin-project",
+ "rand 0.8.5",
+ "smallvec",
+ "thiserror",
+ "tokio",
  "void",
 ]
 
@@ -4083,6 +4739,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-swarm-derive"
+version = "0.31.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "heck",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "libp2p-tcp"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,12 +4757,43 @@ dependencies = [
  "async-io",
  "futures 0.3.25",
  "futures-timer",
- "if-watch",
+ "if-watch 2.0.0",
  "libc",
- "libp2p-core",
+ "libp2p-core 0.37.0",
+ "log",
+ "socket2",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.38.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "futures 0.3.25",
+ "futures-timer",
+ "if-watch 3.0.0",
+ "libc",
+ "libp2p-core 0.38.0",
  "log",
  "socket2",
  "tokio",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.1.0-alpha"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "futures 0.3.25",
+ "futures-rustls",
+ "libp2p-core 0.38.0",
+ "rcgen 0.10.0",
+ "ring",
+ "rustls 0.20.7",
+ "thiserror",
+ "webpki 0.22.0",
+ "x509-parser 0.14.0",
+ "yasna",
 ]
 
 [[package]]
@@ -4107,10 +4804,40 @@ checksum = "a17b5b8e7a73e379e47b1b77f8a82c4721e97eca01abcd18e9cd91a23ca6ce97"
 dependencies = [
  "futures 0.3.25",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.37.0",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libp2p-webrtc"
+version = "0.4.0-alpha"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "futures 0.3.25",
+ "futures-timer",
+ "hex",
+ "if-watch 3.0.0",
+ "libp2p-core 0.38.0",
+ "libp2p-noise 0.41.0",
+ "log",
+ "multihash",
+ "prost",
+ "prost-build",
+ "prost-codec 0.3.0",
+ "rand 0.8.5",
+ "rcgen 0.9.3",
+ "serde",
+ "stun",
+ "thiserror",
+ "tinytemplate",
+ "tokio",
+ "tokio-util",
+ "webrtc",
 ]
 
 [[package]]
@@ -4122,11 +4849,29 @@ dependencies = [
  "either",
  "futures 0.3.25",
  "futures-rustls",
- "libp2p-core",
+ "libp2p-core 0.37.0",
  "log",
  "parking_lot 0.12.1",
  "quicksink",
- "rw-stream-sink",
+ "rw-stream-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soketto",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.40.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "either",
+ "futures 0.3.25",
+ "futures-rustls",
+ "libp2p-core 0.38.0",
+ "log",
+ "parking_lot 0.12.1",
+ "quicksink",
+ "rw-stream-sink 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35)",
  "soketto",
  "url",
  "webpki-roots",
@@ -4139,7 +4884,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30f079097a21ad017fc8139460630286f02488c8c13b26affb46623aa20d8845"
 dependencies = [
  "futures 0.3.25",
- "libp2p-core",
+ "libp2p-core 0.37.0",
+ "log",
+ "parking_lot 0.12.1",
+ "thiserror",
+ "yamux",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.42.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "futures 0.3.25",
+ "libp2p-core 0.38.0",
  "log",
  "parking_lot 0.12.1",
  "thiserror",
@@ -4385,6 +5143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b48670c893079d3c2ed79114e3644b7004df1c361a4e0ad52e2e6940d07c3d"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +5255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,6 +5327,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
+]
+
+[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,9 +5396,22 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multistream-select"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
+checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+dependencies = [
+ "bytes",
+ "futures 0.3.25",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.12.1"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
 dependencies = [
  "bytes",
  "futures 0.3.25",
@@ -4719,6 +5523,7 @@ dependencies = [
  "futures 0.3.25",
  "libc",
  "log",
+ "tokio",
 ]
 
 [[package]]
@@ -4730,6 +5535,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4737,6 +5543,16 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -4839,6 +5655,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
+dependencies = [
+ "asn1-rs 0.3.1",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4bda43fd1b844cbc6e6e54b5444e2b1bc7838bce59ad205902cccbb26d6761"
+dependencies = [
+ "asn1-rs 0.5.1",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4895,6 +5729,28 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.2",
+]
+
+[[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.2",
+]
 
 [[package]]
 name = "pallet-balances"
@@ -5421,6 +6277,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5587,6 +6461,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -5799,6 +6684,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-codec"
+version = "0.3.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "prost",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5845,6 +6742,24 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.1.12",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57098b1a3d2159d13dc3a98c0e3a5f8ab91ac3dd2471e52b1d712ea0c1085555"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.20.7",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5989,6 +6904,31 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "x509-parser 0.13.2",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "yasna",
 ]
 
 [[package]]
@@ -6140,6 +7080,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtcp"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11171e7e37998dcf54a9e9d4a6e2e1932c994424c7d39bc6349fed1424c45c3"
+dependencies = [
+ "bytes",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6152,6 +7103,21 @@ dependencies = [
  "netlink-proto",
  "nix",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "rtp"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a095411ff00eed7b12e4c6a118ba984d113e1079582570d56a5ee723f11f80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -6191,6 +7157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6206,14 +7181,27 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -6248,6 +7236,16 @@ name = "rw-stream-sink"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
+dependencies = [
+ "futures 0.3.25",
+ "pin-project",
+ "static_assertions",
+]
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.3.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=be0b62a78fe9d72811b9eda742137cc8ddc4da35#be0b62a78fe9d72811b9eda742137cc8ddc4da35"
 dependencies = [
  "futures 0.3.25",
  "pin-project",
@@ -6357,7 +7355,7 @@ dependencies = [
  "clap 4.0.26",
  "fdlimit",
  "futures 0.3.25",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "names",
  "parity-scale-codec",
@@ -6447,7 +7445,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "parking_lot 0.12.1",
  "sc-client-api",
@@ -6704,7 +7702,7 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "ip_network",
- "libp2p",
+ "libp2p 0.49.0",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -6741,7 +7739,7 @@ source = "git+https://github.com/subspace/substrate?rev=6d57dbc639bb3d9460dabecc
 dependencies = [
  "cid",
  "futures 0.3.25",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "prost",
  "prost-build",
@@ -6764,7 +7762,7 @@ dependencies = [
  "bytes",
  "futures 0.3.25",
  "futures-timer",
- "libp2p",
+ "libp2p 0.49.0",
  "linked_hash_set",
  "parity-scale-codec",
  "prost-build",
@@ -6788,7 +7786,7 @@ dependencies = [
  "ahash 0.7.6",
  "futures 0.3.25",
  "futures-timer",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "lru 0.8.1",
  "sc-network-common",
@@ -6805,7 +7803,7 @@ source = "git+https://github.com/subspace/substrate?rev=6d57dbc639bb3d9460dabecc
 dependencies = [
  "array-bytes",
  "futures 0.3.25",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "parity-scale-codec",
  "prost",
@@ -6827,7 +7825,7 @@ dependencies = [
  "array-bytes",
  "fork-tree",
  "futures 0.3.25",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "lru 0.8.1",
  "mockall",
@@ -6857,7 +7855,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -6886,7 +7884,7 @@ dependencies = [
  "array-bytes",
  "futures 0.3.25",
  "hex",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "parity-scale-codec",
  "pin-project",
@@ -6909,7 +7907,7 @@ dependencies = [
  "futures-timer",
  "hyper",
  "hyper-rustls",
- "libp2p",
+ "libp2p 0.49.0",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
@@ -6933,7 +7931,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=6d57dbc639bb3d9460dabeccb063cc6556452535#6d57dbc639bb3d9460dabeccb063cc6556452535"
 dependencies = [
  "futures 0.3.25",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "sc-utils",
  "serde_json",
@@ -7168,7 +8166,7 @@ source = "git+https://github.com/subspace/substrate?rev=6d57dbc639bb3d9460dabecc
 dependencies = [
  "chrono",
  "futures 0.3.25",
- "libp2p",
+ "libp2p 0.49.0",
  "log",
  "parking_lot 0.12.1",
  "pin-project",
@@ -7343,12 +8341,34 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sdp"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22a5ef407871893fd72b4562ee15e4742269b173959db4b8df6f538c414e13"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -7698,7 +8718,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek 4.0.0-pre.1",
@@ -8610,6 +9630,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "stun"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
+dependencies = [
+ "base64",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
 name = "subspace-archiving"
 version = "0.1.0"
 dependencies = [
@@ -8766,7 +9805,7 @@ dependencies = [
  "event-listener-primitives",
  "futures 0.3.25",
  "hex",
- "libp2p",
+ "libp2p 0.50.0",
  "lru 0.8.1",
  "nohash-hasher",
  "parity-db",
@@ -9299,6 +10338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9612,9 +10660,9 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.7",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -9804,6 +10852,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
+ "socket2",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -9842,6 +10891,25 @@ name = "tt-call"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e66dcbec4290c69dd03c57e76c2469ea5c7ce109c6dd4351c13055cf71ea055"
+
+[[package]]
+name = "turn"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures 0.3.25",
+ "log",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "stun",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
 
 [[package]]
 name = "twox-hash"
@@ -9972,6 +11040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+dependencies = [
+ "getrandom 0.2.7",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10004,6 +11081,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
 
 [[package]]
 name = "waker-fn"
@@ -10407,6 +11493,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -10421,7 +11517,219 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3bc9049bdb2cea52f5fd4f6f728184225bdb867ed0dc2410eab6df5bdd67bb"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "rcgen 0.9.3",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "rustls 0.19.1",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2 0.10.2",
+ "stun",
+ "thiserror",
+ "time 0.3.17",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef36a4d12baa6e842582fe9ec16a57184ba35e1a09308307b67d43ec8883100"
+dependencies = [
+ "bytes",
+ "derive_builder",
+ "log",
+ "thiserror",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7021987ae0a2ed6c8cd33f68e98e49bb6e74ffe9543310267b48a1bbe3900e5f"
+dependencies = [
+ "aes 0.6.0",
+ "aes-gcm 0.8.0",
+ "async-trait",
+ "bincode",
+ "block-modes",
+ "byteorder",
+ "ccm",
+ "curve25519-dalek 3.2.0",
+ "der-parser 8.1.0",
+ "elliptic-curve",
+ "hkdf",
+ "hmac 0.10.1",
+ "log",
+ "oid-registry 0.6.0",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen 0.9.3",
+ "ring",
+ "rustls 0.19.1",
+ "sec1",
+ "serde",
+ "sha-1 0.9.8",
+ "sha2 0.9.9",
+ "signature",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webpki 0.21.4",
+ "webrtc-util",
+ "x25519-dalek 2.0.0-pre.1",
+ "x509-parser 0.13.2",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494483fbb2f5492620871fdc78b084aed8807377f6e3fe88b2e49f0a9c9c41d7"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2548ae970afc2ae8e0b0dbfdacd9602d426d4f0ff6cda4602a45c0fd7ceaa82a"
+dependencies = [
+ "log",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a3c157a040324e5049bcbd644ffc9079e6738fa2cfab2bcff64e5cc4c00d7"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "derive_builder",
+ "displaydoc",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d47adcd9427eb3ede33d5a7f3424038f63c965491beafcc20bc650a2f6679c0"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6183edc4c1c6c0175f8812eefdce84dfa0aea9c3ece71c2bf6ddd3c964de3da5"
+dependencies = [
+ "aead 0.4.3",
+ "aes 0.7.5",
+ "aes-gcm 0.9.4",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "ctr 0.8.0",
+ "hmac 0.11.0",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha-1 0.9.8",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cc",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -10654,6 +11962,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "base64",
+ "data-encoding",
+ "der-parser 7.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.4.0",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs 0.5.1",
+ "base64",
+ "data-encoding",
+ "der-parser 8.1.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.6.0",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
 name = "yamux"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10665,6 +12021,15 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "static_assertions",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+dependencies = [
+ "time 0.3.17",
 ]
 
 [[package]]

--- a/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
@@ -87,26 +87,29 @@ impl<'a> MultiChannelPieceReceiver<'a> {
     async fn get_piece_from_cache(&self, piece_index: PieceIndex) -> Option<Piece> {
         let key = PieceIndexHash::from_index(piece_index).to_multihash();
 
-        let piece_result = self.dsn_node.get_value(key).await;
+        let get_value_result = self.dsn_node.get_value(key).await;
 
-        match piece_result {
-            Ok(Some(piece)) => {
-                trace!(%piece_index, ?key, "get_value returned a piece");
+        match get_value_result {
+            Ok(mut get_value_stream) => match get_value_stream.next().await {
+                Some(piece) => {
+                    trace!(%piece_index, ?key, "get_value returned a piece");
 
-                match piece.try_into() {
-                    Ok(piece) => {
-                        return Some(piece);
-                    }
-                    Err(error) => {
-                        error!(%piece_index, ?key, ?error, "Error on piece construction");
+                    match piece.try_into() {
+                        Ok(piece) => {
+                            return Some(piece);
+                        }
+                        Err(error) => {
+                            error!(%piece_index, ?key, ?error, "Error on piece construction");
+                        }
                     }
                 }
-            }
-            Ok(None) => {
-                debug!(%piece_index,?key, "get_value returned no piece");
-            }
+                None => {
+                    debug!(%piece_index,?key, "get_value returned no piece");
+                }
+            },
             Err(err) => {
                 error!(%piece_index,?key, ?err, "get_value returned an error");
+                return None;
             }
         }
 
@@ -118,63 +121,70 @@ impl<'a> MultiChannelPieceReceiver<'a> {
         let key =
             PieceIndexHash::from_index(piece_index).to_multihash_by_code(MultihashCode::Sector);
 
-        let piece_result = self.dsn_node.get_value(key).await;
+        let get_value_result = self.dsn_node.get_value(key).await;
 
-        match piece_result {
-            Ok(Some(encoded_gset)) => {
-                trace!(
-                    %piece_index,
-                    ?key,
-                    "get_value returned a piece-by-sector providers"
-                );
-
-                // Workaround for archival sector until we fix https://github.com/libp2p/rust-libp2p/issues/3048
-                let peer_set =
-                    if let Ok(set) = BTreeSet::<Vec<u8>>::decode(&mut encoded_gset.as_slice()) {
-                        set
-                    } else {
-                        warn!(
+        match get_value_result {
+            Ok(mut encoded_gset_stream) => {
+                match encoded_gset_stream.next().await {
+                    Some(encoded_gset) => {
+                        trace!(
                             %piece_index,
                             ?key,
-                            "get_value returned a non-gset value"
+                            "get_value returned a piece-by-sector providers"
                         );
-                        return None;
-                    };
 
-                for peer_id in peer_set.into_iter() {
-                    if let Ok(piece_provider_id) = PeerId::from_bytes(&peer_id) {
-                        let request_result = self
-                            .dsn_node
-                            .send_generic_request(
-                                piece_provider_id,
-                                PieceByHashRequest {
-                                    key: PieceKey::Sector(PieceIndexHash::from_index(piece_index)),
-                                },
-                            )
-                            .await;
+                        // Workaround for archival sector until we fix https://github.com/libp2p/rust-libp2p/issues/3048
+                        let peer_set = if let Ok(set) =
+                            BTreeSet::<Vec<u8>>::decode(&mut encoded_gset.as_slice())
+                        {
+                            set
+                        } else {
+                            warn!(
+                                %piece_index,
+                                ?key,
+                                "get_value returned a non-gset value"
+                            );
+                            return None;
+                        };
 
-                        match request_result {
-                            Ok(request) => {
-                                if let Some(piece) = request.piece {
-                                    return Some(piece);
+                        for peer_id in peer_set.into_iter() {
+                            if let Ok(piece_provider_id) = PeerId::from_bytes(&peer_id) {
+                                let request_result = self
+                                    .dsn_node
+                                    .send_generic_request(
+                                        piece_provider_id,
+                                        PieceByHashRequest {
+                                            key: PieceKey::Sector(PieceIndexHash::from_index(
+                                                piece_index,
+                                            )),
+                                        },
+                                    )
+                                    .await;
+
+                                match request_result {
+                                    Ok(request) => {
+                                        if let Some(piece) = request.piece {
+                                            return Some(piece);
+                                        }
+                                    }
+                                    Err(error) => {
+                                        error!(%piece_index,?peer_id, ?key, ?error, "Error on piece-by-hash request.");
+                                    }
                                 }
-                            }
-                            Err(error) => {
-                                error!(%piece_index,?peer_id, ?key, ?error, "Error on piece-by-hash request.");
+                            } else {
+                                error!(
+                                    %piece_index,
+                                    ?peer_id,
+                                    ?key,
+                                    "Cannot convert piece-by-sector provider PeerId from received bytes"
+                                );
                             }
                         }
-                    } else {
-                        error!(
-                            %piece_index,
-                            ?peer_id,
-                            ?key,
-                            "Cannot convert piece-by-sector provider PeerId from received bytes"
-                        );
+                    }
+                    None => {
+                        info!(%piece_index,?key, "get_value returned no piece-by-sector provider");
                     }
                 }
-            }
-            Ok(None) => {
-                info!(%piece_index,?key, "get_value returned no piece-by-sector provider");
             }
             Err(err) => {
                 error!(%piece_index,?key, ?err, "get_value returned an error (piece-by-sector)");

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -43,20 +43,24 @@ tracing-subscriber = "0.3.16"
 unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_codec"] }
 
 [dependencies.libp2p]
-version = "0.49.0"
+# TODO: change when https://github.com/libp2p/rust-libp2p/pull/3178 is released
+git = "https://github.com/libp2p/rust-libp2p"
+rev = "be0b62a78fe9d72811b9eda742137cc8ddc4da35"
 default-features = false
 features = [
-    "dns-tokio",
+    "dns",
     "gossipsub",
     "identify",
     "kad",
+    "macros",
     "metrics",
     "mplex",
     "noise",
     "ping",
     "request-response",
     "serde",
-    "tcp-tokio",
+    "tcp",
+    "tokio",
     "websocket",
     "yamux",
 ]

--- a/crates/subspace-networking/examples/get-peers.rs
+++ b/crates/subspace-networking/examples/get-peers.rs
@@ -1,4 +1,5 @@
 use futures::channel::oneshot;
+use futures::StreamExt;
 use libp2p::multiaddr::Protocol;
 use libp2p::multihash::Code;
 use parking_lot::Mutex;
@@ -66,7 +67,13 @@ async fn main() {
         &Code::Identity,
         &U256::from(hashed_peer_id).to_be_bytes(),
     );
-    let peer_id = node_2.get_closest_peers(key).await.unwrap()[0];
+    let peer_id = node_2
+        .get_closest_peers(key)
+        .await
+        .unwrap()
+        .next()
+        .await
+        .unwrap();
     assert_eq!(node_1.id(), peer_id);
 
     println!("Exiting..");

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -84,7 +84,7 @@ async fn main() {
     );
     println!("Get value result for:");
     println!("Key: {key:?}");
-    let result = node_2.get_value(key).await;
+    let result = node_2.get_value(key).await.unwrap().next().await;
     println!("Value: {result:?}");
 
     tokio::spawn(async move {

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -13,7 +13,8 @@ use libp2p::gossipsub::{Gossipsub, GossipsubConfig, GossipsubEvent, MessageAuthe
 use libp2p::identify::{Behaviour as Identify, Config as IdentifyConfig, Event as IdentifyEvent};
 use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent};
 use libp2p::ping::{Behaviour as Ping, Event as PingEvent};
-use libp2p::{NetworkBehaviour, PeerId};
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::PeerId;
 
 pub(crate) struct BehaviorConfig<RecordStore = CustomRecordStore> {
     /// Identity keypair of a node used for authenticated connections.

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -25,7 +25,8 @@ use libp2p::mplex::MplexConfig;
 use libp2p::multiaddr::Protocol;
 use libp2p::noise::NoiseConfig;
 use libp2p::swarm::SwarmBuilder;
-use libp2p::tcp::{GenTcpConfig, TokioTcpTransport};
+use libp2p::tcp::tokio::Transport as TokioTcpTransport;
+use libp2p::tcp::Config as GenTcpConfig;
 use libp2p::websocket::WsConfig;
 use libp2p::yamux::{WindowUpdateMode, YamuxConfig};
 use libp2p::{core, identity, noise, Multiaddr, PeerId, Transport, TransportError};
@@ -266,10 +267,7 @@ where
             request_response_protocols,
         });
 
-        let mut swarm = SwarmBuilder::new(transport, behaviour, local_peer_id)
-            .executor(Box::new(|fut| {
-                tokio::spawn(fut);
-            }))
+        let mut swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, local_peer_id)
             .max_negotiating_inbound_streams(SWARM_MAX_NEGOTIATING_INBOUND_STREAMS)
             .build();
 

--- a/crates/subspace-networking/src/request_responses.rs
+++ b/crates/subspace-networking/src/request_responses.rs
@@ -41,18 +41,15 @@ use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use futures::prelude::*;
 use libp2p::core::connection::ConnectionId;
-use libp2p::core::transport::ListenerId;
-use libp2p::core::{ConnectedPoint, Multiaddr, PeerId};
+use libp2p::core::{Multiaddr, PeerId};
 pub use libp2p::request_response::{InboundFailure, OutboundFailure, RequestId};
 use libp2p::request_response::{
     ProtocolSupport, RequestResponse, RequestResponseCodec, RequestResponseConfig,
     RequestResponseEvent, RequestResponseMessage, ResponseChannel,
 };
+use libp2p::swarm::behaviour::{ConnectionClosed, DialFailure, FromSwarm, ListenFailure};
 use libp2p::swarm::handler::multi::MultiHandler;
-use libp2p::swarm::{
-    ConnectionHandler, IntoConnectionHandler, NetworkBehaviour, NetworkBehaviourAction,
-    PollParameters,
-};
+use libp2p::swarm::{ConnectionHandler, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -435,125 +432,117 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
         )
     }
 
+    /// Informs the behaviour about an event from the [`Swarm`](crate::Swarm).
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+        match event {
+            FromSwarm::ConnectionEstablished(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::ConnectionEstablished(inner));
+                }
+            }
+            FromSwarm::ConnectionClosed(inner) => {
+                for (p_name, handler) in inner.handler.into_iter() {
+                    if let Some((protocol, _)) = self.protocols.get_mut(p_name.as_str()) {
+                        protocol.on_swarm_event(FromSwarm::ConnectionClosed(ConnectionClosed {
+                            peer_id: inner.peer_id,
+                            connection_id: inner.connection_id,
+                            endpoint: inner.endpoint,
+                            handler,
+                            remaining_established: inner.remaining_established,
+                        }));
+                    } else {
+                        error!(
+                            target: LOG_TARGET,
+                            "inject_connection_closed: no request-response instance registered \
+                            for protocol {:?}",
+                            p_name,
+                        )
+                    }
+                }
+            }
+            FromSwarm::AddressChange(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::AddressChange(inner));
+                }
+            }
+            FromSwarm::DialFailure(inner) => {
+                for ((protocol, _), (_, handler)) in
+                    self.protocols.values_mut().zip(inner.handler.into_iter())
+                {
+                    protocol.on_swarm_event(FromSwarm::DialFailure(DialFailure {
+                        peer_id: inner.peer_id,
+                        handler,
+                        error: inner.error,
+                    }));
+                }
+            }
+            FromSwarm::ListenFailure(inner) => {
+                for ((protocol, _), (_, handler)) in
+                    self.protocols.values_mut().zip(inner.handler.into_iter())
+                {
+                    protocol.on_swarm_event(FromSwarm::ListenFailure(ListenFailure {
+                        local_addr: inner.local_addr,
+                        send_back_addr: inner.send_back_addr,
+                        handler,
+                    }));
+                }
+            }
+            FromSwarm::NewListener(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::NewListener(inner));
+                }
+            }
+            FromSwarm::NewListenAddr(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::NewListenAddr(inner));
+                }
+            }
+            FromSwarm::ExpiredListenAddr(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::ExpiredListenAddr(inner));
+                }
+            }
+            FromSwarm::ListenerError(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::ListenerError(inner));
+                }
+            }
+            FromSwarm::ListenerClosed(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::ListenerClosed(inner));
+                }
+            }
+            FromSwarm::NewExternalAddr(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::NewExternalAddr(inner));
+                }
+            }
+            FromSwarm::ExpiredExternalAddr(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::ExpiredExternalAddr(inner));
+                }
+            }
+        };
+    }
+
     fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
         Vec::new()
     }
 
-    fn inject_connection_established(
-        &mut self,
-        peer_id: &PeerId,
-        conn: &ConnectionId,
-        endpoint: &ConnectedPoint,
-        failed_addresses: Option<&Vec<Multiaddr>>,
-        other_established: usize,
-    ) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_connection_established(
-                p,
-                peer_id,
-                conn,
-                endpoint,
-                failed_addresses,
-                other_established,
-            )
-        }
-    }
-
-    fn inject_connection_closed(
-        &mut self,
-        peer_id: &PeerId,
-        conn: &ConnectionId,
-        endpoint: &ConnectedPoint,
-        handler: <Self::ConnectionHandler as IntoConnectionHandler>::Handler,
-        remaining_established: usize,
-    ) {
-        for (p_name, event) in handler.into_iter() {
-            if let Some((proto, _)) = self.protocols.get_mut(p_name.as_str()) {
-                proto.inject_connection_closed(
-                    peer_id,
-                    conn,
-                    endpoint,
-                    event,
-                    remaining_established,
-                )
-            } else {
-                error!(
-                    target: LOG_TARGET,
-                    "inject_connection_closed: no request-response instance registered for protocol {:?}",
-                    p_name,
-                )
-            }
-        }
-    }
-
-    fn inject_event(
+    fn on_connection_handler_event(
         &mut self,
         peer_id: PeerId,
         connection: ConnectionId,
         (p_name, event): <Self::ConnectionHandler as ConnectionHandler>::OutEvent,
     ) {
         if let Some((proto, _)) = self.protocols.get_mut(&*p_name) {
-            return proto.inject_event(peer_id, connection, event);
+            return proto.on_connection_handler_event(peer_id, connection, event);
         }
 
         warn!(
             target: LOG_TARGET,
             "inject_node_event: no request-response instance registered for protocol {:?}", p_name
         )
-    }
-
-    fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_new_external_addr(p, addr)
-        }
-    }
-
-    fn inject_expired_external_addr(&mut self, addr: &Multiaddr) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_expired_external_addr(p, addr)
-        }
-    }
-
-    fn inject_expired_listen_addr(&mut self, id: ListenerId, addr: &Multiaddr) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_expired_listen_addr(p, id, addr)
-        }
-    }
-
-    fn inject_dial_failure(
-        &mut self,
-        peer_id: Option<PeerId>,
-        _: Self::ConnectionHandler,
-        error: &libp2p::swarm::DialError,
-    ) {
-        for (p, _) in self.protocols.values_mut() {
-            let handler = p.new_handler();
-            NetworkBehaviour::inject_dial_failure(p, peer_id, handler, error)
-        }
-    }
-
-    fn inject_new_listener(&mut self, id: ListenerId) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_new_listener(p, id)
-        }
-    }
-
-    fn inject_new_listen_addr(&mut self, id: ListenerId, addr: &Multiaddr) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_new_listen_addr(p, id, addr)
-        }
-    }
-
-    fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn std::error::Error + 'static)) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_listener_error(p, id, err)
-        }
-    }
-
-    fn inject_listener_closed(&mut self, id: ListenerId, reason: Result<(), &io::Error>) {
-        for (p, _) in self.protocols.values_mut() {
-            NetworkBehaviour::inject_listener_closed(p, id, reason)
-        }
     }
 
     fn poll(

--- a/crates/subspace-networking/src/request_responses/tests.rs
+++ b/crates/subspace-networking/src/request_responses/tests.rs
@@ -56,7 +56,7 @@ fn build_swarm(
         .collect::<Vec<_>>();
     let behaviour = RequestResponsesBehaviour::new(configs).unwrap();
 
-    let mut swarm = Swarm::new(transport, behaviour, keypair.public().to_peer_id());
+    let mut swarm = Swarm::with_tokio_executor(transport, behaviour, keypair.public().to_peer_id());
     let listen_addr: Multiaddr = format!("/memory/{}", rand::random::<u64>())
         .parse()
         .unwrap();
@@ -65,8 +65,8 @@ fn build_swarm(
     (swarm, listen_addr)
 }
 
-#[test]
-fn basic_request_response_works() {
+#[tokio::test(flavor = "multi_thread")]
+async fn basic_request_response_works() {
     let protocol_name = "/test/req-resp/1";
     let mut pool = LocalPool::new();
 
@@ -166,8 +166,8 @@ fn basic_request_response_works() {
     });
 }
 
-#[test]
-fn max_response_size_exceeded() {
+#[tokio::test(flavor = "multi_thread")]
+async fn max_response_size_exceeded() {
     let protocol_name = "/test/req-resp/1";
     let mut pool = LocalPool::new();
 
@@ -277,8 +277,8 @@ fn max_response_size_exceeded() {
 /// without a [`RequestId`] collision.
 ///
 /// See [`ProtocolRequestId`] for additional information.
-#[test]
-fn request_id_collision() {
+#[tokio::test(flavor = "multi_thread")]
+async fn request_id_collision() {
     let protocol_name_1 = "/test/req-resp-1/1";
     let protocol_name_2 = "/test/req-resp-2/1";
     let mut pool = LocalPool::new();

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -24,12 +24,12 @@ pub(crate) struct CreatedSubscription {
 pub(crate) enum Command {
     GetValue {
         key: Multihash,
-        result_sender: oneshot::Sender<Option<Vec<u8>>>,
+        result_sender: mpsc::UnboundedSender<Vec<u8>>,
     },
     PutValue {
         key: Multihash,
         value: Vec<u8>,
-        result_sender: oneshot::Sender<bool>,
+        result_sender: mpsc::UnboundedSender<()>,
     },
     Subscribe {
         topic: Sha256Topic,
@@ -46,7 +46,7 @@ pub(crate) enum Command {
     },
     GetClosestPeers {
         key: Multihash,
-        result_sender: oneshot::Sender<Vec<PeerId>>,
+        result_sender: mpsc::UnboundedSender<PeerId>,
     },
     GenericRequest {
         peer_id: PeerId,
@@ -59,7 +59,7 @@ pub(crate) enum Command {
     },
     StartAnnouncing {
         key: Multihash,
-        result_sender: oneshot::Sender<bool>,
+        result_sender: mpsc::UnboundedSender<()>,
     },
     StopAnnouncing {
         key: Multihash,
@@ -67,7 +67,7 @@ pub(crate) enum Command {
     },
     GetProviders {
         key: Multihash,
-        result_sender: oneshot::Sender<Option<Vec<PeerId>>>,
+        result_sender: mpsc::UnboundedSender<PeerId>,
     },
 }
 

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -409,8 +409,19 @@ fn main() -> Result<(), Error> {
                             cli.dsn_bootstrap_nodes
                         };
 
+                        // TODO: Libp2p versions for Substrate and Subspace diverged.
+                        // We get type compatibility by encoding and decoding the original keypair.
+                        let encoded_keypair = network_keypair
+                            .to_protobuf_encoding()
+                            .expect("Keypair-to-protobuf encoding should succeed.");
+                        let keypair =
+                            subspace_networking::libp2p::identity::Keypair::from_protobuf_encoding(
+                                &encoded_keypair,
+                            )
+                            .expect("Keypair-from-protobuf decoding should succeed.");
+
                         DsnConfig {
-                            keypair: network_keypair,
+                            keypair,
                             listen_on: cli.dsn_listen_on,
                             bootstrap_nodes: dsn_bootstrap_nodes,
                             reserved_peers: cli.dsn_reserved_peers,

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use clap::Parser;
+use futures::StreamExt;
 use parity_scale_codec::Encode;
 use sc_cli::{CliConfiguration, ImportParams, SharedParams};
 use sc_client_api::{BlockBackend, HeaderBackend};
@@ -191,7 +192,9 @@ where
             let maybe_piece = node
                 .get_value(multihash::create_multihash_by_piece_index(piece_index))
                 .await
-                .map_err(|error| sc_service::Error::Other(error.to_string()))?;
+                .map_err(|error| sc_service::Error::Other(error.to_string()))?
+                .next()
+                .await;
 
             trace!(
                 ?piece_index,

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -132,9 +132,18 @@ pub(crate) async fn start_dsn_archiver<Spawner>(
                         //
                         // trace!(?key, "Announcing result: {:?}", announcing_result);
 
-                        let put_value_result = node.put_value(key, piece.to_vec()).await;
-
-                        trace!(?key, "Put value result: {:?}", put_value_result);
+                        match node.put_value(key, piece.to_vec()).await {
+                            Ok(mut stream) => {
+                                if stream.next().await.is_some() {
+                                    trace!(?key, "Put value succeeded");
+                                } else {
+                                    trace!(?key, "Put value failed");
+                                }
+                            }
+                            Err(error) => {
+                                trace!(?key, "Put value failed: {}", error);
+                            }
+                        }
 
                         //TODO: ensure republication of failed announcements
                     }


### PR DESCRIPTION
Started by @shamil-gadelshin, I finished fixing some things and upgrading deprecated code.

Commit is on `master` branch of `libp2p`, so it'll not go away. Also I think this is not really 0.50.0, this is almost 0.51.0 by the looks of it :man_shrugging: .

This should fix some of the network-related log messages we have seen. This also supposedly opens the door to pull model in DSN.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
