### PR TITLE
Check the receipts in `submit_bundle` earlier in primary chain's transaction pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9850,7 +9850,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.3",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -10654,9 +10654,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
+checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
  "futures 0.3.25",
  "log",

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -29,9 +29,8 @@ pub use pallet::*;
 use sp_core::H256;
 use sp_domains::bundle_election::{verify_system_bundle_solution, verify_vrf_proof};
 use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
-use sp_domains::{
-    DomainId, ExecutionReceipt, InvalidTransactionCode, ProofOfElection, SignedOpaqueBundle,
-};
+use sp_domains::transaction::InvalidTransactionCode;
+use sp_domains::{DomainId, ExecutionReceipt, ProofOfElection, SignedOpaqueBundle};
 use sp_runtime::traits::{BlockNumberProvider, CheckedSub, One, Saturating, Zero};
 use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_runtime::RuntimeAppPublic;
@@ -44,9 +43,8 @@ mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_core::H256;
     use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
-    use sp_domains::{
-        DomainId, ExecutionReceipt, ExecutorPublicKey, InvalidTransactionCode, SignedOpaqueBundle,
-    };
+    use sp_domains::transaction::InvalidTransactionCode;
+    use sp_domains::{DomainId, ExecutionReceipt, ExecutorPublicKey, SignedOpaqueBundle};
     use sp_runtime::traits::{
         CheckEqual, MaybeDisplay, MaybeMallocSizeOf, One, SimpleBitOps, Zero,
     };

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -4,9 +4,10 @@ use frame_support::{assert_noop, assert_ok, parameter_types};
 use sp_core::crypto::Pair;
 use sp_core::{H256, U256};
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
+use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{
-    Bundle, BundleHeader, DomainId, ExecutionReceipt, ExecutorPair, InvalidTransactionCode,
-    ProofOfElection, SignedOpaqueBundle,
+    Bundle, BundleHeader, DomainId, ExecutionReceipt, ExecutorPair, ProofOfElection,
+    SignedOpaqueBundle,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup, ValidateUnsigned};

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod bundle_election;
 pub mod fraud_proof;
+pub mod transaction;
 
 use crate::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
 use parity_scale_codec::{Decode, Encode};
@@ -27,7 +28,6 @@ use schnorrkel::vrf::{VRF_OUTPUT_LENGTH, VRF_PROOF_LENGTH};
 use sp_core::crypto::KeyTypeId;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, NumberFor};
-use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 use sp_runtime::OpaqueExtrinsic;
 use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
@@ -157,28 +157,6 @@ pub struct DomainConfig<Hash, Balance, Weight> {
 
     /// Minimum executor stake value to be an operator on this domain.
     pub min_operator_stake: Balance,
-}
-
-/// Custom invalid validity code for the extrinsics in pallet-executor.
-#[repr(u8)]
-pub enum InvalidTransactionCode {
-    BundleEquivicationProof = 101,
-    TrasactionProof = 102,
-    ExecutionReceipt = 103,
-    Bundle = 104,
-    FraudProof = 105,
-}
-
-impl From<InvalidTransactionCode> for InvalidTransaction {
-    fn from(invalid_code: InvalidTransactionCode) -> Self {
-        InvalidTransaction::Custom(invalid_code as u8)
-    }
-}
-
-impl From<InvalidTransactionCode> for TransactionValidity {
-    fn from(invalid_code: InvalidTransactionCode) -> Self {
-        InvalidTransaction::Custom(invalid_code as u8).into()
-    }
 }
 
 /// Header of transaction bundle.

--- a/crates/sp-domains/src/transaction.rs
+++ b/crates/sp-domains/src/transaction.rs
@@ -1,0 +1,23 @@
+use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
+
+/// Custom invalid validity code for the extrinsics in pallet-domains.
+#[repr(u8)]
+pub enum InvalidTransactionCode {
+    BundleEquivicationProof = 101,
+    TrasactionProof = 102,
+    ExecutionReceipt = 103,
+    Bundle = 104,
+    FraudProof = 105,
+}
+
+impl From<InvalidTransactionCode> for InvalidTransaction {
+    fn from(invalid_code: InvalidTransactionCode) -> Self {
+        InvalidTransaction::Custom(invalid_code as u8)
+    }
+}
+
+impl From<InvalidTransactionCode> for TransactionValidity {
+    fn from(invalid_code: InvalidTransactionCode) -> Self {
+        InvalidTransaction::Custom(invalid_code as u8).into()
+    }
+}

--- a/crates/sp-domains/src/transaction.rs
+++ b/crates/sp-domains/src/transaction.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+pub use self::runtime_decl_for_PreValidationObjectApi::PreValidationObjectApi;
+use crate::fraud_proof::FraudProof;
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 
 /// Custom invalid validity code for the extrinsics in pallet-domains.
@@ -19,5 +24,23 @@ impl From<InvalidTransactionCode> for InvalidTransaction {
 impl From<InvalidTransactionCode> for TransactionValidity {
     fn from(invalid_code: InvalidTransactionCode) -> Self {
         InvalidTransaction::Custom(invalid_code as u8).into()
+    }
+}
+
+/// Object for performing the pre-validation in the transaction pool
+/// before calling into the regular `validate_transaction` runtime api.
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub enum PreValidationObject {
+    Null,
+    FraudProof(FraudProof),
+    // TODO: extract receipts from submit_bundle extrinsic.
+    // Receipts(Vec<ExecutionReceipt>)
+}
+
+sp_api::decl_runtime_apis! {
+    /// API for extracting the pre-validation objects in the primary chain transaction pool wrapper.
+    pub trait PreValidationObjectApi {
+        /// Extract the pre-validation object from the given extrinsic.
+        fn extract_pre_validation_object(extrinsics: Block::Extrinsic) -> PreValidationObject;
     }
 }

--- a/crates/sp-domains/src/transaction.rs
+++ b/crates/sp-domains/src/transaction.rs
@@ -1,5 +1,3 @@
-#[cfg(not(feature = "std"))]
-pub use self::runtime_decl_for_PreValidationObjectApi::PreValidationObjectApi;
 use crate::fraud_proof::FraudProof;
 use crate::ExecutionReceipt;
 use parity_scale_codec::{Decode, Encode};

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -60,7 +60,10 @@ pub fn development_config() -> ExecutionChainSpec<GenesisConfig> {
                     1_000 * SSC,
                     // TODO: proper genesis domain config
                     DomainConfig {
-                        wasm_runtime_hash: Hash::random(),
+                        wasm_runtime_hash: blake2b_256_hash(
+                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                        )
+                        .into(),
                         max_bundle_size: 1024 * 1024,
                         bundle_slot_probability: (1, 1),
                         max_bundle_weight: Weight::MAX,
@@ -114,7 +117,10 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
                     1_000 * SSC,
                     // TODO: proper genesis domain config
                     DomainConfig {
-                        wasm_runtime_hash: Hash::zero(),
+                        wasm_runtime_hash: blake2b_256_hash(
+                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                        )
+                        .into(),
                         max_bundle_size: 1024 * 1024,
                         bundle_slot_probability: (1, 1),
                         max_bundle_weight: Weight::MAX,

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -1,0 +1,136 @@
+use crate::{Block, BlockNumber, Hash, RuntimeCall, UncheckedExtrinsic};
+use sp_consensus_subspace::digests::CompatibleDigestItem;
+use sp_consensus_subspace::FarmerPublicKey;
+use sp_domains::fraud_proof::FraudProof;
+use sp_domains::transaction::PreValidationObject;
+use sp_domains::{DomainId, ExecutionReceipt};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT, Zero};
+use sp_std::vec::Vec;
+use subspace_core_primitives::{PublicKey, Randomness};
+use subspace_verification::derive_randomness;
+
+pub(crate) fn extract_system_bundles(
+    extrinsics: Vec<UncheckedExtrinsic>,
+) -> (
+    sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash>,
+    sp_domains::SignedOpaqueBundles<Block, domain_runtime_primitives::Hash>,
+) {
+    let (system_bundles, core_bundles): (Vec<_>, Vec<_>) = extrinsics
+        .into_iter()
+        .filter_map(|uxt| {
+            if let RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+                signed_opaque_bundle,
+            }) = uxt.function
+            {
+                if signed_opaque_bundle.domain_id().is_system() {
+                    Some((Some(signed_opaque_bundle.bundle), None))
+                } else {
+                    Some((None, Some(signed_opaque_bundle)))
+                }
+            } else {
+                None
+            }
+        })
+        .unzip();
+    (
+        system_bundles.into_iter().flatten().collect(),
+        core_bundles.into_iter().flatten().collect(),
+    )
+}
+
+pub(crate) fn extract_core_bundles(
+    extrinsics: Vec<UncheckedExtrinsic>,
+    domain_id: DomainId,
+) -> sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| match uxt.function {
+            RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+                signed_opaque_bundle,
+            }) if signed_opaque_bundle.domain_id() == domain_id => {
+                Some(signed_opaque_bundle.bundle)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+pub(crate) fn extract_receipts(
+    extrinsics: Vec<UncheckedExtrinsic>,
+    domain_id: DomainId,
+) -> Vec<ExecutionReceipt<BlockNumber, Hash, domain_runtime_primitives::Hash>> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| match uxt.function {
+            RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+                signed_opaque_bundle,
+            }) if signed_opaque_bundle.domain_id() == domain_id => {
+                Some(signed_opaque_bundle.bundle.receipts)
+            }
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}
+
+pub(crate) fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> {
+    extrinsics
+        .into_iter()
+        .filter_map(|uxt| {
+            if let RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) =
+                uxt.function
+            {
+                Some(fraud_proof)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn extract_pre_validation_object(
+    extrinsic: UncheckedExtrinsic,
+) -> PreValidationObject<Block, domain_runtime_primitives::Hash> {
+    match extrinsic.function {
+        RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) => {
+            PreValidationObject::FraudProof(fraud_proof)
+        }
+        RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+            signed_opaque_bundle,
+        }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
+        _ => PreValidationObject::Null,
+    }
+}
+
+pub(crate) fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness {
+    if header.number().is_zero() {
+        Randomness::default()
+    } else {
+        let mut pre_digest: Option<_> = None;
+        for log in header.digest().logs() {
+            match (
+                log.as_subspace_pre_digest::<FarmerPublicKey>(),
+                pre_digest.is_some(),
+            ) {
+                (Some(_), true) => panic!("Multiple Subspace pre-runtime digests in a header"),
+                (None, _) => {}
+                (s, false) => pre_digest = s,
+            }
+        }
+
+        let pre_digest = pre_digest.expect("Header must contain one pre-runtime digest; qed");
+
+        let seed: &[u8] = b"extrinsics-shuffling-seed";
+        let randomness = derive_randomness(
+            &Into::<PublicKey>::into(&pre_digest.solution.public_key),
+            &pre_digest.solution.chunk.to_bytes(),
+            &pre_digest.solution.chunk_signature,
+        )
+        .expect("Tag signature is verified by the client and must always be valid; qed");
+        let mut data = Vec::with_capacity(seed.len() + randomness.len());
+        data.extend_from_slice(seed);
+        data.extend_from_slice(&randomness);
+
+        BlakeTwo256::hash_of(&data).into()
+    }
+}

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -606,11 +606,16 @@ fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> 
         .collect()
 }
 
-fn extract_pre_validation_object(extrinsic: UncheckedExtrinsic) -> PreValidationObject {
+fn extract_pre_validation_object(
+    extrinsic: UncheckedExtrinsic,
+) -> PreValidationObject<Block, domain_runtime_primitives::Hash> {
     match extrinsic.function {
         RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) => {
             PreValidationObject::FraudProof(fraud_proof)
         }
+        RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+            signed_opaque_bundle,
+        }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
         _ => PreValidationObject::Null,
     }
 }
@@ -817,8 +822,8 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_domains::transaction::PreValidationObjectApi<Block> for Runtime {
-        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic) -> sp_domains::transaction::PreValidationObject {
+    impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
+        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic) -> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
             extract_pre_validation_object(extrinsic)
         }
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -19,6 +19,7 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
+mod domains;
 mod feed_processor;
 mod fees;
 mod object_mapping;
@@ -51,8 +52,7 @@ use frame_system::limits::{BlockLength, BlockWeights};
 use frame_system::EnsureNever;
 use pallet_feeds::feed_processor::FeedProcessor;
 pub use pallet_subspace::AllowAuthoringBy;
-use sp_api::{impl_runtime_apis, BlockT, HashT, HeaderT};
-use sp_consensus_subspace::digests::CompatibleDigestItem;
+use sp_api::{impl_runtime_apis, BlockT};
 use sp_consensus_subspace::{
     ChainConstants, EquivocationProof, FarmerPublicKey, GlobalRandomnesses, SignedVote,
     SolutionRanges, Vote,
@@ -60,9 +60,8 @@ use sp_consensus_subspace::{
 use sp_core::crypto::{ByteArray, KeyTypeId};
 use sp_core::OpaqueMetadata;
 use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
-use sp_domains::transaction::PreValidationObject;
 use sp_domains::{DomainId, ExecutionReceipt, SignedOpaqueBundle};
-use sp_runtime::traits::{AccountIdLookup, BlakeTwo256, NumberFor, Zero};
+use sp_runtime::traits::{AccountIdLookup, BlakeTwo256, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, Perbill};
 use sp_std::borrow::Cow;
@@ -72,14 +71,13 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    PublicKey, Randomness, RecordsRoot, RootBlock, SegmentIndex, SolutionRange, PIECE_SIZE,
+    Randomness, RecordsRoot, RootBlock, SegmentIndex, SolutionRange, PIECE_SIZE,
 };
 use subspace_runtime_primitives::{
     opaque, AccountId, Balance, BlockNumber, Hash, Index, Moment, Signature, CONFIRMATION_DEPTH_K,
     MIN_REPLICATION_FACTOR, SHANNON, SSC, STORAGE_FEES_ESCROW_BLOCK_REWARD,
     STORAGE_FEES_ESCROW_BLOCK_TAX,
 };
-use subspace_verification::derive_randomness;
 
 sp_runtime::impl_opaque_keys! {
     pub struct SessionKeys {
@@ -527,132 +525,6 @@ fn extract_root_blocks(ext: &UncheckedExtrinsic) -> Option<Vec<RootBlock>> {
     }
 }
 
-fn extract_system_bundles(
-    extrinsics: Vec<UncheckedExtrinsic>,
-) -> (
-    sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash>,
-    sp_domains::SignedOpaqueBundles<Block, domain_runtime_primitives::Hash>,
-) {
-    let (system_bundles, core_bundles): (Vec<_>, Vec<_>) = extrinsics
-        .into_iter()
-        .filter_map(|uxt| {
-            if let RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
-                signed_opaque_bundle,
-            }) = uxt.function
-            {
-                if signed_opaque_bundle.domain_id().is_system() {
-                    Some((Some(signed_opaque_bundle.bundle), None))
-                } else {
-                    Some((None, Some(signed_opaque_bundle)))
-                }
-            } else {
-                None
-            }
-        })
-        .unzip();
-    (
-        system_bundles.into_iter().flatten().collect(),
-        core_bundles.into_iter().flatten().collect(),
-    )
-}
-
-fn extract_core_bundles(
-    extrinsics: Vec<UncheckedExtrinsic>,
-    domain_id: DomainId,
-) -> sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash> {
-    extrinsics
-        .into_iter()
-        .filter_map(|uxt| match uxt.function {
-            RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
-                signed_opaque_bundle,
-            }) if signed_opaque_bundle.domain_id() == domain_id => {
-                Some(signed_opaque_bundle.bundle)
-            }
-            _ => None,
-        })
-        .collect()
-}
-
-fn extract_receipts(
-    extrinsics: Vec<UncheckedExtrinsic>,
-    domain_id: DomainId,
-) -> Vec<ExecutionReceipt<BlockNumber, Hash, domain_runtime_primitives::Hash>> {
-    extrinsics
-        .into_iter()
-        .filter_map(|uxt| match uxt.function {
-            RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
-                signed_opaque_bundle,
-            }) if signed_opaque_bundle.domain_id() == domain_id => {
-                Some(signed_opaque_bundle.bundle.receipts)
-            }
-            _ => None,
-        })
-        .flatten()
-        .collect()
-}
-
-fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> {
-    extrinsics
-        .into_iter()
-        .filter_map(|uxt| {
-            if let RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) =
-                uxt.function
-            {
-                Some(fraud_proof)
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-fn extract_pre_validation_object(
-    extrinsic: UncheckedExtrinsic,
-) -> PreValidationObject<Block, domain_runtime_primitives::Hash> {
-    match extrinsic.function {
-        RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) => {
-            PreValidationObject::FraudProof(fraud_proof)
-        }
-        RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
-            signed_opaque_bundle,
-        }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
-        _ => PreValidationObject::Null,
-    }
-}
-
-fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness {
-    if header.number().is_zero() {
-        Randomness::default()
-    } else {
-        let mut pre_digest: Option<_> = None;
-        for log in header.digest().logs() {
-            match (
-                log.as_subspace_pre_digest::<FarmerPublicKey>(),
-                pre_digest.is_some(),
-            ) {
-                (Some(_), true) => panic!("Multiple Subspace pre-runtime digests in a header"),
-                (None, _) => {}
-                (s, false) => pre_digest = s,
-            }
-        }
-
-        let pre_digest = pre_digest.expect("Header must contain one pre-runtime digest; qed");
-
-        let seed: &[u8] = b"extrinsics-shuffling-seed";
-        let randomness = derive_randomness(
-            &Into::<PublicKey>::into(&pre_digest.solution.public_key),
-            &pre_digest.solution.chunk.to_bytes(),
-            &pre_digest.solution.chunk_signature,
-        )
-        .expect("Tag signature is verified by the client and must always be valid; qed");
-        let mut data = Vec::with_capacity(seed.len() + randomness.len());
-        data.extend_from_slice(seed);
-        data.extend_from_slice(&randomness);
-
-        BlakeTwo256::hash_of(&data).into()
-    }
-}
-
 struct RewardAddress([u8; 32]);
 
 impl From<FarmerPublicKey> for RewardAddress {
@@ -824,7 +696,7 @@ impl_runtime_apis! {
 
     impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic) -> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
-            extract_pre_validation_object(extrinsic)
+            crate::domains::extract_pre_validation_object(extrinsic)
         }
     }
 
@@ -855,29 +727,29 @@ impl_runtime_apis! {
             sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash>,
             sp_domains::SignedOpaqueBundles<Block, domain_runtime_primitives::Hash>,
         ) {
-            extract_system_bundles(extrinsics)
+            crate::domains::extract_system_bundles(extrinsics)
         }
 
         fn extract_core_bundles(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
             domain_id: DomainId,
         ) -> sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash> {
-            extract_core_bundles(extrinsics, domain_id)
+            crate::domains::extract_core_bundles(extrinsics, domain_id)
         }
 
         fn extract_receipts(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
             domain_id: DomainId,
         ) -> Vec<ExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, domain_runtime_primitives::Hash>> {
-            extract_receipts(extrinsics, domain_id)
+            crate::domains::extract_receipts(extrinsics, domain_id)
         }
 
         fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<FraudProof> {
-            extract_fraud_proofs(extrinsics)
+            crate::domains::extract_fraud_proofs(extrinsics)
         }
 
         fn extrinsics_shuffling_seed(header: <Block as BlockT>::Header) -> Randomness {
-            extrinsics_shuffling_seed::<Block>(header)
+            crate::domains::extrinsics_shuffling_seed::<Block>(header)
         }
 
         fn execution_wasm_bundle() -> Cow<'static, [u8]> {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -181,7 +181,7 @@ where
         + TaggedTransactionQueue<Block>
         + ExecutorApi<Block, DomainHash>
         + ObjectsApi<Block>
-        + PreValidationObjectApi<Block>
+        + PreValidationObjectApi<Block, domain_runtime_primitives::Hash>
         + SubspaceApi<Block, FarmerPublicKey>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
 {
@@ -310,7 +310,7 @@ where
         + 'static,
     Client::Api: TaggedTransactionQueue<Block>
         + ExecutorApi<Block, DomainHash>
-        + PreValidationObjectApi<Block>,
+        + PreValidationObjectApi<Block, domain_runtime_primitives::Hash>,
     Verifier: VerifyFraudProof + Clone + Send + Sync + 'static,
 {
     /// Task manager.
@@ -367,7 +367,7 @@ where
         + TransactionPaymentApi<Block, Balance>
         + ExecutorApi<Block, DomainHash>
         + ObjectsApi<Block>
-        + PreValidationObjectApi<Block>
+        + PreValidationObjectApi<Block, domain_runtime_primitives::Hash>
         + SubspaceApi<Block, FarmerPublicKey>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
 {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -56,6 +56,7 @@ use sp_consensus::Error as ConsensusError;
 use sp_consensus_slots::Slot;
 use sp_consensus_subspace::{FarmerPublicKey, SubspaceApi};
 use sp_core::traits::SpawnEssentialNamed;
+use sp_domains::transaction::PreValidationObjectApi;
 use sp_domains::ExecutorApi;
 use sp_objects::ObjectsApi;
 use sp_offchain::OffchainWorkerApi;
@@ -175,12 +176,13 @@ where
     RuntimeApi::RuntimeApi: ApiExt<Block, StateBackend = StateBackendFor<FullBackend, Block>>
         + Metadata<Block>
         + BlockBuilder<Block>
-        + ExecutorApi<Block, DomainHash>
         + OffchainWorkerApi<Block>
         + SessionKeys<Block>
-        + SubspaceApi<Block, FarmerPublicKey>
+        + TaggedTransactionQueue<Block>
+        + ExecutorApi<Block, DomainHash>
         + ObjectsApi<Block>
-        + TaggedTransactionQueue<Block>,
+        + PreValidationObjectApi<Block>
+        + SubspaceApi<Block, FarmerPublicKey>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
 {
     let telemetry = config
@@ -306,7 +308,9 @@ where
         + HeaderBackend<Block>
         + HeaderMetadata<Block, Error = sp_blockchain::Error>
         + 'static,
-    Client::Api: TaggedTransactionQueue<Block> + ExecutorApi<Block, DomainHash>,
+    Client::Api: TaggedTransactionQueue<Block>
+        + ExecutorApi<Block, DomainHash>
+        + PreValidationObjectApi<Block>,
     Verifier: VerifyFraudProof + Clone + Send + Sync + 'static,
 {
     /// Task manager.
@@ -355,15 +359,16 @@ where
         + 'static,
     RuntimeApi::RuntimeApi: ApiExt<Block, StateBackend = StateBackendFor<FullBackend, Block>>
         + Metadata<Block>
+        + AccountNonceApi<Block, AccountId, Nonce>
         + BlockBuilder<Block>
-        + ExecutorApi<Block, DomainHash>
         + OffchainWorkerApi<Block>
         + SessionKeys<Block>
-        + SubspaceApi<Block, FarmerPublicKey>
-        + ObjectsApi<Block>
         + TaggedTransactionQueue<Block>
-        + AccountNonceApi<Block, AccountId, Nonce>
-        + TransactionPaymentApi<Block, Balance>,
+        + TransactionPaymentApi<Block, Balance>
+        + ExecutorApi<Block, DomainHash>
+        + ObjectsApi<Block>
+        + PreValidationObjectApi<Block>
+        + SubspaceApi<Block, FarmerPublicKey>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
 {
     let PartialComponents {

--- a/crates/subspace-service/src/pool.rs
+++ b/crates/subspace-service/src/pool.rs
@@ -17,6 +17,7 @@ use sc_transaction_pool_api::{
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderMetadata, TreeRoute};
 use sp_core::traits::{SpawnEssentialNamed, SpawnNamed};
+use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::ExecutorApi;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, BlockIdTo, NumberFor, SaturatedConversion};
@@ -166,7 +167,7 @@ where
                                         Err(err) => {
                                             tracing::debug!(target: "txpool", error = ?err, "Invalid fraud proof");
                                             Err(TxPoolError::InvalidTransaction(
-                                                sp_domains::InvalidTransactionCode::FraudProof.into(),
+                                                InvalidTransactionCode::FraudProof.into(),
                                             )
                                             .into())
                                         }

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -11,6 +11,7 @@ use sp_api::{AsTrieBackend, ProvideRuntimeApi};
 use sp_core::traits::FetchRuntimeCode;
 use sp_core::Pair;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
+use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{Bundle, BundleHeader, DomainId, ExecutorPair, ProofOfElection, SignedBundle};
 use sp_runtime::generic::{BlockId, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
@@ -215,10 +216,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
     match submit_invalid_fraud_proof_result.unwrap_err() {
         sc_transaction_pool::error::Error::Pool(
             sc_transaction_pool_api::error::Error::InvalidTransaction(invalid_tx),
-        ) => assert_eq!(
-            invalid_tx,
-            sp_domains::InvalidTransactionCode::FraudProof.into()
-        ),
+        ) => assert_eq!(invalid_tx, InvalidTransactionCode::FraudProof.into()),
         e => panic!("Unexpected error while submitting an invalid fraud proof: {e}"),
     }
 }
@@ -458,10 +456,7 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
     match create_and_send_submit_bundle(5).await.unwrap_err() {
         sc_transaction_pool::error::Error::Pool(
             sc_transaction_pool_api::error::Error::InvalidTransaction(invalid_tx),
-        ) => assert_eq!(
-            invalid_tx,
-            sp_domains::InvalidTransactionCode::ExecutionReceipt.into()
-        ),
+        ) => assert_eq!(invalid_tx, InvalidTransactionCode::ExecutionReceipt.into()),
         e => panic!("Unexpected error while submitting execution receipt: {e}"),
     }
 

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -61,7 +61,8 @@ mod pallet {
     use sp_domain_tracker::CoreDomainTracker;
     use sp_domains::bundle_election::ReadBundleElectionParamsError;
     use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
-    use sp_domains::{DomainId, ExecutionReceipt, InvalidTransactionCode, SignedOpaqueBundle};
+    use sp_domains::transaction::InvalidTransactionCode;
+    use sp_domains::{DomainId, ExecutionReceipt, SignedOpaqueBundle};
     use sp_executor_registry::ExecutorRegistry;
     use sp_runtime::traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, One};
     use sp_runtime::{FixedPointOperand, Percent};

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -51,6 +51,7 @@ use sp_consensus_subspace::{
 use sp_core::crypto::{ByteArray, KeyTypeId};
 use sp_core::{Hasher, OpaqueMetadata};
 use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
+use sp_domains::transaction::PreValidationObject;
 use sp_domains::{DomainId, ExecutionReceipt, SignedOpaqueBundle};
 use sp_runtime::traits::{
     AccountIdLookup, BlakeTwo256, DispatchInfoOf, NumberFor, PostDispatchInfoOf, Zero,
@@ -892,6 +893,15 @@ fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> 
         .collect()
 }
 
+fn extract_pre_validation_object(extrinsic: UncheckedExtrinsic) -> PreValidationObject {
+    match extrinsic.function {
+        RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) => {
+            PreValidationObject::FraudProof(fraud_proof)
+        }
+        _ => PreValidationObject::Null,
+    }
+}
+
 fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness {
     if header.number().is_zero() {
         Randomness::default()
@@ -1081,6 +1091,12 @@ impl_runtime_apis! {
 
         fn chain_constants() -> ChainConstants {
             Subspace::chain_constants()
+        }
+    }
+
+    impl sp_domains::transaction::PreValidationObjectApi<Block> for Runtime {
+        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic) -> sp_domains::transaction::PreValidationObject {
+            extract_pre_validation_object(extrinsic)
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -893,11 +893,16 @@ fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> 
         .collect()
 }
 
-fn extract_pre_validation_object(extrinsic: UncheckedExtrinsic) -> PreValidationObject {
+fn extract_pre_validation_object(
+    extrinsic: UncheckedExtrinsic,
+) -> PreValidationObject<Block, domain_runtime_primitives::Hash> {
     match extrinsic.function {
         RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) => {
             PreValidationObject::FraudProof(fraud_proof)
         }
+        RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+            signed_opaque_bundle,
+        }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
         _ => PreValidationObject::Null,
     }
 }
@@ -1094,8 +1099,8 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_domains::transaction::PreValidationObjectApi<Block> for Runtime {
-        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic) -> sp_domains::transaction::PreValidationObject {
+    impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
+        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic)-> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
             extract_pre_validation_object(extrinsic)
         }
     }


### PR DESCRIPTION
In order to add another pre-validation properly in the transaction pool of primary chain, this PR first did some refactoring to abstract a runtime API `PreValidationObjectApi`, which is used to extract necessary objects from an extrinsic that needs to be checked before calling the regular runtime api `validate_transaction`, and then extend it to also support extracting the receipts for `submit_bundle` extrinsic, it will be dropped immediately if any receipt in this bundle points to a future block since it can't be verified within the runtime anyway.

The last commit is a few fixes I made while working on the domain network debugging.

Close #968

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
