### PR TITLE
Farmer. Add pieces receiver batching.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8720,6 +8720,7 @@ dependencies = [
  "subspace-solving",
  "subspace-verification",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -106,6 +106,7 @@ impl Farmer {
             sector_expiration: 100,
         };
         let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
+        let piece_receiver_batch_size = 20usize;
         block_on(plot_sector(
             &public_key,
             sector_index,
@@ -116,6 +117,7 @@ impl Farmer {
             &sector_codec,
             Cursor::new(sector.as_mut_slice()),
             Cursor::new(sector_metadata.as_mut_slice()),
+            piece_receiver_batch_size,
         ))
         .unwrap();
 

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -18,6 +18,7 @@ bench = false
 [dependencies]
 async-trait = "0.1.58"
 fs2 = "0.4.3"
+futures = "0.3.25"
 libc = "0.2.131"
 parity-scale-codec = "3.2.1"
 rand = "0.8.5"
@@ -28,6 +29,7 @@ subspace-solving = { version = "0.1.0", path = "../subspace-solving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.32"
+tokio = { version = "1.21.2", features = ["sync"] }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -63,6 +63,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     };
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;
+    let piece_receiver_batch_size = 20usize;
 
     let plotted_sector = {
         let mut plotted_sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
@@ -77,6 +78,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &sector_codec,
             plotted_sector.as_mut_slice(),
             io::sink(),
+            piece_receiver_batch_size,
         ))
         .unwrap();
 

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -53,6 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         sector_expiration: 1,
     };
     let piece_receiver = BenchPieceReceiver::new(piece);
+    let piece_receiver_batch_size = 20usize;
 
     let mut group = c.benchmark_group("sector-plotting");
     group.throughput(Throughput::Bytes(PLOT_SECTOR_SIZE));
@@ -68,11 +69,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&sector_codec),
                 black_box(io::sink()),
                 black_box(io::sink()),
+                black_box(piece_receiver_batch_size),
             ))
             .unwrap();
         })
     });
-
+    let piece_receiver_batch_size = 20usize;
     let thread_count = current_num_threads() as u64;
     group.throughput(Throughput::Bytes(PLOT_SECTOR_SIZE * thread_count));
     group.bench_function("no-writes-multi-thread", |b| {
@@ -91,6 +93,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&sector_codec),
                         black_box(io::sink()),
                         black_box(io::sink()),
+                        black_box(piece_receiver_batch_size),
                     ))
                     .unwrap();
                 });

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -66,6 +66,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;
     let reward_address = PublicKey::default();
+    let piece_receiver_batch_size = 20usize;
 
     let (plotted_sector, sector_metadata) = {
         let mut plotted_sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
@@ -81,6 +82,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &sector_codec,
             plotted_sector.as_mut_slice(),
             sector_metadata.as_mut_slice(),
+            piece_receiver_batch_size,
         ))
         .unwrap();
 

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -1,9 +1,12 @@
 use crate::{FarmerProtocolInfo, SectorMetadata};
 use async_trait::async_trait;
+use futures::stream::FuturesOrdered;
+use futures::StreamExt;
 use parity_scale_codec::Encode;
 use std::error::Error;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::{Commitment, Kzg};
 use subspace_core_primitives::sector_codec::{SectorCodec, SectorCodecError};
@@ -11,7 +14,8 @@ use subspace_core_primitives::{
     Piece, PieceIndex, PublicKey, Scalar, SectorId, SectorIndex, PIECE_SIZE, PLOT_SECTOR_SIZE,
 };
 use thiserror::Error;
-use tracing::debug;
+use tokio::sync::Semaphore;
+use tracing::{debug, info};
 
 #[async_trait]
 pub trait PieceReceiver {
@@ -63,6 +67,9 @@ pub enum PlottingError {
     /// I/O error occurred
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
+    /// Incorrect batch size for piece receiver.
+    #[error("Incorrect batch size for piece receiver.")]
+    IncorrectPieceReceivingBatchSize,
 }
 
 /// Plot a single sector, where `sector` and `sector_metadata` must be positioned correctly (seek to
@@ -81,6 +88,7 @@ pub async fn plot_sector<PR, S, SM>(
     sector_codec: &SectorCodec,
     mut sector_output: S,
     mut sector_metadata_output: SM,
+    piece_receiver_batch_size: usize,
 ) -> Result<PlottedSector, PlottingError>
 where
     PR: PieceReceiver,
@@ -109,28 +117,16 @@ where
 
     let mut in_memory_sector_scalars =
         Vec::with_capacity(PLOT_SECTOR_SIZE as usize / Scalar::FULL_BYTES);
-    for piece_index in piece_indexes.iter().copied() {
-        if cancelled.load(Ordering::Acquire) {
-            debug!(
-                %sector_index,
-                "Plotting was cancelled, interrupting plotting"
-            );
-            return Err(PlottingError::Cancelled);
-        }
 
-        let piece = piece_receiver
-            .get_piece(piece_index)
-            .await
-            .map_err(|error| PlottingError::FailedToRetrievePiece { piece_index, error })?
-            .ok_or(PlottingError::PieceNotFound { piece_index })?;
-
-        in_memory_sector_scalars.extend(piece.chunks_exact(Scalar::SAFE_BYTES).map(|bytes| {
-            Scalar::from(
-                <&[u8; Scalar::SAFE_BYTES]>::try_from(bytes)
-                    .expect("Chunked into scalar safe bytes above; qed"),
-            )
-        }));
-    }
+    plot_pieces_in_batches_non_blocking(
+        &mut in_memory_sector_scalars,
+        sector_index,
+        piece_receiver,
+        piece_indexes.clone(),
+        cancelled,
+        piece_receiver_batch_size,
+    )
+    .await?;
 
     sector_codec
         .encode(&mut in_memory_sector_scalars)
@@ -183,4 +179,152 @@ where
         sector_metadata,
         piece_indexes,
     })
+}
+
+// TODO: remove on deciding on the correct algorithm
+#[allow(dead_code)]
+async fn plot_pieces_sequentially<PR: PieceReceiver>(
+    in_memory_sector_scalars: &mut Vec<Scalar>,
+    sector_index: u64,
+    piece_receiver: &PR,
+    piece_indexes: Vec<PieceIndex>,
+    cancelled: &AtomicBool,
+) -> Result<(), PlottingError> {
+    for piece_index in piece_indexes.iter().copied() {
+        check_cancellation(cancelled, sector_index)?;
+
+        let piece = piece_receiver
+            .get_piece(piece_index)
+            .await
+            .map_err(|error| PlottingError::FailedToRetrievePiece { piece_index, error })?
+            .ok_or(PlottingError::PieceNotFound { piece_index })?;
+
+        in_memory_sector_scalars.extend(piece.chunks_exact(Scalar::SAFE_BYTES).map(|bytes| {
+            Scalar::from(
+                <&[u8; Scalar::SAFE_BYTES]>::try_from(bytes)
+                    .expect("Chunked into scalar safe bytes above; qed"),
+            )
+        }));
+    }
+
+    Ok(())
+}
+
+// TODO: remove on deciding on the correct algorithm
+#[allow(dead_code)]
+async fn plot_pieces_in_batches<PR: PieceReceiver>(
+    in_memory_sector_scalars: &mut Vec<Scalar>,
+    sector_index: u64,
+    piece_receiver: &PR,
+    piece_indexes: Vec<PieceIndex>,
+    cancelled: &AtomicBool,
+) -> Result<(), PlottingError> {
+    const PIECE_RECEIVER_BATCH_SIZE: usize = 30;
+    let pieces_receiving_chunks =
+        piece_indexes
+            .chunks(PIECE_RECEIVER_BATCH_SIZE)
+            .map(|piece_index_chunk| {
+                piece_index_chunk
+                    .iter()
+                    .map(|piece_index| Box::pin(piece_receiver.get_piece(*piece_index)))
+                    .collect::<FuturesOrdered<_>>()
+            });
+
+    for mut piece_receiving_chunk in pieces_receiving_chunks {
+        let mut piece_counter = 0usize;
+
+        while let Some(piece_result) = piece_receiving_chunk.next().await {
+            check_cancellation(cancelled, sector_index)?;
+
+            // should match piece indexes because of the ordered future collection
+            let piece_index = piece_indexes[piece_counter];
+
+            let piece = piece_result
+                .map_err(|error| PlottingError::FailedToRetrievePiece { piece_index, error })?
+                .ok_or(PlottingError::PieceNotFound { piece_index })?;
+
+            in_memory_sector_scalars.extend(piece.chunks_exact(Scalar::SAFE_BYTES).map(|bytes| {
+                Scalar::from(
+                    <&[u8; Scalar::SAFE_BYTES]>::try_from(bytes)
+                        .expect("Chunked into scalar safe bytes above; qed"),
+                )
+            }));
+
+            piece_counter += 1;
+        }
+    }
+
+    Ok(())
+}
+
+async fn plot_pieces_in_batches_non_blocking<PR: PieceReceiver>(
+    in_memory_sector_scalars: &mut Vec<Scalar>,
+    sector_index: u64,
+    piece_receiver: &PR,
+    piece_indexes: Vec<PieceIndex>,
+    cancelled: &AtomicBool,
+    piece_receiver_batch_size: usize,
+) -> Result<(), PlottingError> {
+    const MAX_PIECE_RECEIVER_BATCH_SIZE: usize = 60;
+
+    if piece_receiver_batch_size == 0 || piece_receiver_batch_size > MAX_PIECE_RECEIVER_BATCH_SIZE {
+        return Err(PlottingError::IncorrectPieceReceivingBatchSize);
+    }
+
+    let semaphore = Arc::new(Semaphore::new(piece_receiver_batch_size));
+
+    let mut pieces_receiving_futures = piece_indexes
+        .iter()
+        .map(|piece_index| {
+            Box::pin(async {
+                let permit = semaphore
+                    .acquire()
+                    .await
+                    .expect("Should be valid on non-closed semaphore");
+                check_cancellation(cancelled, sector_index)?;
+
+                let piece = piece_receiver.get_piece(*piece_index).await;
+
+                drop(permit);
+                piece
+            })
+        })
+        .collect::<FuturesOrdered<_>>();
+
+    let mut piece_counter = 0usize;
+    while let Some(piece_result) = pieces_receiving_futures.next().await {
+        check_cancellation(cancelled, sector_index)?;
+
+        // should match piece indexes because of the ordered future collection
+        let piece_index = piece_indexes[piece_counter];
+
+        let piece = piece_result
+            .map_err(|error| PlottingError::FailedToRetrievePiece { piece_index, error })?
+            .ok_or(PlottingError::PieceNotFound { piece_index })?;
+
+        in_memory_sector_scalars.extend(piece.chunks_exact(Scalar::SAFE_BYTES).map(|bytes| {
+            Scalar::from(
+                <&[u8; Scalar::SAFE_BYTES]>::try_from(bytes)
+                    .expect("Chunked into scalar safe bytes above; qed"),
+            )
+        }));
+
+        piece_counter += 1;
+    }
+
+    info!(%sector_index, "Plotting was successful.");
+
+    Ok(())
+}
+
+fn check_cancellation(cancelled: &AtomicBool, sector_index: u64) -> Result<(), PlottingError> {
+    if cancelled.load(Ordering::Acquire) {
+        debug!(
+            %sector_index,
+            "Plotting was cancelled, interrupting plotting"
+        );
+        return Err(PlottingError::Cancelled);
+    }
+
+    Ok(())
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -64,6 +64,7 @@ pub(crate) async fn farm_multi_disk(
         disk_concurrency,
         disable_farming,
         mut dsn,
+        piece_receiver_batch_size,
     } = farming_args;
 
     let readers_and_pieces = Arc::new(Mutex::new(None));
@@ -117,6 +118,7 @@ pub(crate) async fn farm_multi_disk(
             rpc_client,
             reward_address,
             dsn_node: node.clone(),
+            piece_receiver_batch_size: farming_args.piece_receiver_batch_size,
         })?;
 
         single_disk_plots.push(single_disk_plot);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -53,6 +53,9 @@ struct FarmingArgs {
     /// DSN parameters
     #[clap(flatten)]
     dsn: DsnArgs,
+    /// Defines size for the pieces batch of the piece receiving process.
+    #[arg(long, default_value_t = 20)]
+    piece_receiver_batch_size: usize,
 }
 
 /// Arguments for DSN

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -271,6 +271,8 @@ pub struct SingleDiskPlotOptions<RC> {
     pub reward_address: PublicKey,
     /// Optional DSN Node.
     pub dsn_node: Node,
+    /// Defines size for the pieces batch of the piece receiving process.
+    pub piece_receiver_batch_size: usize,
 }
 
 /// Errors happening when trying to create/open single disk plot
@@ -464,6 +466,7 @@ impl SingleDiskPlot {
             rpc_client,
             reward_address,
             dsn_node,
+            piece_receiver_batch_size,
         } = options;
 
         // TODO: Account for plot overhead
@@ -703,6 +706,7 @@ impl SingleDiskPlot {
                                 &sector_codec,
                                 sector,
                                 sector_metadata,
+                                piece_receiver_batch_size,
                             )) {
                                 Ok(plotted_sector) => {
                                     debug!(%sector_index, "Sector plotted");

--- a/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
@@ -212,6 +212,7 @@ impl<'a> PieceReceiver for MultiChannelPieceReceiver<'a> {
                     Box::pin(self.get_piece_from_cache(piece_index))
                         as Pin<Box<dyn Future<Output = _> + Send>>,
                 ),
+                //TODO: verify "broken pipe" error cause
                 timeout(
                     GET_PIECE_TIMEOUT,
                     Box::pin(async {

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -252,6 +252,7 @@ where
         sector_expiration: 100,
     };
 
+    let piece_receiver_batch_size = 20usize;
     plot_sector(
         &public_key,
         sector_index,
@@ -262,6 +263,7 @@ where
         sector_codec,
         Cursor::new(sector.as_mut_slice()),
         Cursor::new(sector_metadata.as_mut_slice()),
+        piece_receiver_batch_size,
     )
     .await
     .expect("Plotting one sector in memory must not fail");


### PR DESCRIPTION
This PR adds pieces receiver batch size. It adds an optional farmer CLI argument `--piece-receiver-batch-size` for batch size specification (bounded: 1-50, default=20).

#### Comments
- implementation used `tokio::sync::Semaphore`
- it significantly increases the speed of the piece receiver  
- the first request batches show errors
- the PR contains previous versions of the piece receiver to enable fast rollback
- please, run on testnet before merging it

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
