### PR TITLE
Introduce BundleSolution

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -232,7 +232,11 @@ mod pallet {
             Self::deposit_event(Event::BundleStored {
                 domain_id,
                 bundle_hash: signed_opaque_bundle.hash(),
-                bundle_author: signed_opaque_bundle.proof_of_election.executor_public_key,
+                bundle_author: signed_opaque_bundle
+                    .bundle_solution
+                    .proof_of_election()
+                    .executor_public_key
+                    .clone(),
             });
 
             Ok(())
@@ -655,10 +659,12 @@ impl<T: Config> Pallet<T> {
     fn validate_bundle(
         SignedOpaqueBundle {
             bundle,
-            proof_of_election,
+            bundle_solution,
             signature,
         }: &SignedOpaqueBundle<T::BlockNumber, T::Hash, T::DomainHash>,
     ) -> Result<(), BundleError> {
+        let proof_of_election = bundle_solution.proof_of_election();
+
         if !proof_of_election
             .executor_public_key
             .verify(&bundle.hash(), signature)

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -5,8 +5,8 @@ use sp_core::crypto::Pair;
 use sp_core::{H256, U256};
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
 use sp_domains::{
-    Bundle, BundleHeader, DomainId, ExecutionReceipt, ExecutorPair, InvalidTransactionCode,
-    ProofOfElection, SignedOpaqueBundle,
+    Bundle, BundleHeader, BundleSolution, DomainId, ExecutionReceipt, ExecutorPair,
+    InvalidTransactionCode, ProofOfElection, SignedOpaqueBundle,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup, ValidateUnsigned};
@@ -118,9 +118,24 @@ fn create_dummy_bundle(
 
     let signature = pair.sign(bundle.hash().as_ref());
 
+    let proof_of_election = ProofOfElection::dummy(domain_id, pair.public());
+
+    let bundle_solution = if domain_id.is_system() {
+        BundleSolution::System(proof_of_election)
+    } else if domain_id.is_core() {
+        BundleSolution::Core {
+            proof_of_election,
+            core_block_number: Default::default(),
+            core_block_hash: Default::default(),
+            core_state_root: Default::default(),
+        }
+    } else {
+        panic!("Open domain unsupported");
+    };
+
     SignedOpaqueBundle {
         bundle,
-        proof_of_election: ProofOfElection::dummy(domain_id, pair.public()),
+        bundle_solution,
         signature,
     }
 }
@@ -146,9 +161,24 @@ fn create_dummy_bundle_with_receipts(
 
     let signature = pair.sign(bundle.hash().as_ref());
 
+    let proof_of_election = ProofOfElection::dummy(domain_id, pair.public());
+
+    let bundle_solution = if domain_id.is_system() {
+        BundleSolution::System(proof_of_election)
+    } else if domain_id.is_core() {
+        BundleSolution::Core {
+            proof_of_election,
+            core_block_number: Default::default(),
+            core_block_hash: Default::default(),
+            core_state_root: Default::default(),
+        }
+    } else {
+        panic!("Open domain unsupported");
+    };
+
     SignedOpaqueBundle {
         bundle,
-        proof_of_election: ProofOfElection::dummy(domain_id, pair.public()),
+        bundle_solution,
         signature,
     }
 }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -219,12 +219,6 @@ pub struct ProofOfElection<DomainHash> {
     pub block_number: BlockNumber,
     /// Block hash corresponding to the `block_number` above.
     pub block_hash: DomainHash,
-    /// Number of the core domain block at which the proof of election was created.
-    pub core_block_number: Option<BlockNumber>,
-    /// Block hash corresponding to the `core_block_number` above.
-    pub core_block_hash: Option<DomainHash>,
-    /// Core domain state root corresponding to the `core_block_hash` above.
-    pub core_state_root: Option<DomainHash>,
 }
 
 impl<DomainHash: Default> ProofOfElection<DomainHash> {
@@ -240,9 +234,35 @@ impl<DomainHash: Default> ProofOfElection<DomainHash> {
             storage_proof: StorageProof::empty(),
             block_number: Default::default(),
             block_hash: Default::default(),
-            core_block_number: None,
-            core_block_hash: None,
-            core_state_root: None,
+        }
+    }
+}
+
+/// Domain bundle election solution.
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub enum BundleSolution<DomainHash> {
+    /// System domain bundle election.
+    System(ProofOfElection<DomainHash>),
+    /// Core domain bundle election.
+    Core {
+        /// Proof of election.
+        proof_of_election: ProofOfElection<DomainHash>,
+        /// Number of the core domain block at which the proof of election was created.
+        core_block_number: BlockNumber,
+        /// Block hash corresponding to the `core_block_number` above.
+        core_block_hash: DomainHash,
+        /// Core domain state root corresponding to the `core_block_hash` above.
+        core_state_root: DomainHash,
+    },
+}
+
+impl<DomainHash> BundleSolution<DomainHash> {
+    pub fn proof_of_election(&self) -> &ProofOfElection<DomainHash> {
+        match self {
+            Self::System(proof_of_election)
+            | Self::Core {
+                proof_of_election, ..
+            } => proof_of_election,
         }
     }
 }
@@ -296,8 +316,8 @@ impl<Extrinsic: Encode, Number, Hash, DomainHash> Bundle<Extrinsic, Number, Hash
 pub struct SignedBundle<Extrinsic, Number, Hash, DomainHash> {
     /// The bundle header.
     pub bundle: Bundle<Extrinsic, Number, Hash, DomainHash>,
-    /// Proof of bundle election.
-    pub proof_of_election: ProofOfElection<DomainHash>,
+    /// Solution of the bundle election.
+    pub bundle_solution: BundleSolution<DomainHash>,
     /// Signature of the bundle.
     pub signature: ExecutorSignature,
 }
@@ -316,7 +336,7 @@ impl<Extrinsic: Encode, Number: Encode, Hash: Encode, DomainHash: Encode>
 
     /// Returns the domain_id of this bundle.
     pub fn domain_id(&self) -> DomainId {
-        self.proof_of_election.domain_id
+        self.bundle_solution.proof_of_election().domain_id
     }
 }
 
@@ -327,7 +347,7 @@ impl<Extrinsic: Encode, Number, Hash, DomainHash>
     pub fn into_signed_opaque_bundle(self) -> SignedOpaqueBundle<Number, Hash, DomainHash> {
         SignedOpaqueBundle {
             bundle: self.bundle.into_opaque_bundle(),
-            proof_of_election: self.proof_of_election,
+            bundle_solution: self.bundle_solution,
             signature: self.signature,
         }
     }

--- a/domains/client/domain-executor/src/bundle_election_solver.rs
+++ b/domains/client/domain-executor/src/bundle_election_solver.rs
@@ -151,9 +151,6 @@ where
                         storage_proof,
                         block_number: to_number_primitive(best_number),
                         block_hash: best_hash,
-                        core_block_number: None,
-                        core_block_hash: None,
-                        core_state_root: None,
                     };
 
                     return Ok(Some(proof_of_election));

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -200,7 +200,7 @@ where
 
         let SignedBundle {
             bundle,
-            proof_of_election,
+            bundle_solution,
             signature,
         } = signed_bundle;
 
@@ -232,7 +232,7 @@ where
         if bundle_exists {
             Ok(Action::Empty)
         } else {
-            let executor_public_key = &proof_of_election.executor_public_key;
+            let executor_public_key = &bundle_solution.proof_of_election().executor_public_key;
 
             if !executor_public_key.verify(&bundle.hash(), signature) {
                 return Err(Self::Error::BadBundleSignature);

--- a/domains/client/domain-executor/src/system_bundle_producer.rs
+++ b/domains/client/domain-executor/src/system_bundle_producer.rs
@@ -8,7 +8,7 @@ use sc_client_api::{AuxStore, BlockBackend, ProofProvider};
 use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
-use sp_domains::{DomainId, ExecutorApi, SignedOpaqueBundle};
+use sp_domains::{BundleSolution, DomainId, ExecutorApi, SignedOpaqueBundle};
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::Block as BlockT;
@@ -164,7 +164,7 @@ where
             Ok(Some(sign_new_bundle::<Block, PBlock>(
                 bundle,
                 self.keystore,
-                proof_of_election,
+                BundleSolution::System(proof_of_election),
             )?))
         } else {
             Ok(None)

--- a/domains/client/domain-executor/src/system_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/system_gossip_message_validator.rs
@@ -151,7 +151,7 @@ where
 
         let SignedBundle {
             bundle,
-            proof_of_election,
+            bundle_solution,
             signature,
         } = signed_bundle;
 
@@ -182,7 +182,7 @@ where
         if bundle_exists {
             Ok(Action::Empty)
         } else {
-            let executor_public_key = &proof_of_election.executor_public_key;
+            let executor_public_key = &bundle_solution.proof_of_election().executor_public_key;
 
             if !executor_public_key.verify(&bundle.hash(), signature) {
                 return Err(Self::Error::BadBundleSignature);

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -11,7 +11,9 @@ use sp_api::{AsTrieBackend, ProvideRuntimeApi};
 use sp_core::traits::FetchRuntimeCode;
 use sp_core::Pair;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
-use sp_domains::{Bundle, BundleHeader, DomainId, ExecutorPair, ProofOfElection, SignedBundle};
+use sp_domains::{
+    Bundle, BundleHeader, BundleSolution, DomainId, ExecutorPair, ProofOfElection, SignedBundle,
+};
 use sp_runtime::generic::{BlockId, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
 use std::collections::HashSet;
@@ -385,7 +387,10 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
 
         let signed_opaque_bundle = SignedBundle {
             bundle,
-            proof_of_election: ProofOfElection::dummy(DomainId::SYSTEM, pair.public()), // TODO: mock ProofOfElection properly
+            bundle_solution: BundleSolution::System(ProofOfElection::dummy(
+                DomainId::SYSTEM,
+                pair.public(),
+            )), // TODO: mock ProofOfElection properly
             signature,
         }
         .into_signed_opaque_bundle();

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -30,7 +30,8 @@ use sp_domains::bundle_election::{
 };
 use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
 use sp_domains::{
-    DomainId, ExecutionReceipt, ExecutorPublicKey, ProofOfElection, SignedOpaqueBundle, StakeWeight,
+    BundleSolution, DomainId, ExecutionReceipt, ExecutorPublicKey, ProofOfElection,
+    SignedOpaqueBundle, StakeWeight,
 };
 use sp_executor_registry::{ExecutorRegistry, OnNewEpoch};
 use sp_runtime::traits::{BlakeTwo256, Hash, One, Saturating, Zero};
@@ -351,7 +352,7 @@ mod pallet {
         ) -> DispatchResult {
             ensure_none(origin)?;
 
-            let domain_id = signed_opaque_bundle.proof_of_election.domain_id;
+            let domain_id = signed_opaque_bundle.domain_id();
 
             let oldest_receipt_number = OldestReceiptNumber::<T>::get(domain_id);
             let (_, mut best_number) = <ReceiptHead<T>>::get(domain_id);
@@ -527,9 +528,6 @@ mod pallet {
 
         /// Invalid core domain bundle solution.
         BadBundleElectionSolution,
-
-        /// Either `core_block_hash` or `core_state_root` is missing in the proof of election.
-        CoreBlockInfoNotFound,
 
         /// Cannot verify the core domain state root.
         StateRootUnverifiable,
@@ -752,6 +750,15 @@ impl<T: Config> Pallet<T> {
     fn pre_dispatch_submit_core_bundle(
         signed_opaque_bundle: &SignedOpaqueBundle<T::BlockNumber, T::Hash, T::Hash>,
     ) -> Result<(), Error<T>> {
+        let BundleSolution::Core {
+            proof_of_election,
+            core_block_number,
+            core_block_hash,
+            core_state_root
+        } = &signed_opaque_bundle.bundle_solution else {
+            return Err(Error::<T>::NotCoreDomainBundle);
+        };
+
         // The validity of vrf proof itself has been verified on the primary chain, thus only the
         // proof_of_election is necessary to be checked here.
         let ProofOfElection {
@@ -761,23 +768,16 @@ impl<T: Config> Pallet<T> {
             state_root,
             executor_public_key,
             global_challenge,
-            core_block_number,
-            core_block_hash,
-            core_state_root,
             ..
-        } = &signed_opaque_bundle.proof_of_election;
+        } = &proof_of_election;
 
         if !domain_id.is_core() {
             return Err(Error::<T>::NotCoreDomainBundle);
         }
 
-        let core_block_number =
-            T::BlockNumber::from(core_block_number.ok_or(Error::<T>::CoreBlockInfoNotFound)?);
+        let core_block_number = T::BlockNumber::from(*core_block_number);
 
         if !core_block_number.is_zero() {
-            let core_block_hash = core_block_hash.ok_or(Error::<T>::CoreBlockInfoNotFound)?;
-            let core_state_root = core_state_root.ok_or(Error::<T>::CoreBlockInfoNotFound)?;
-
             let maybe_state_root =
                 signed_opaque_bundle
                     .bundle
@@ -786,7 +786,7 @@ impl<T: Config> Pallet<T> {
                     .find_map(|receipt| {
                         receipt.trace.last().and_then(|state_root| {
                             if (receipt.primary_number, receipt.domain_hash)
-                                == (core_block_number, core_block_hash)
+                                == (core_block_number, *core_block_hash)
                             {
                                 Some(*state_root)
                             } else {
@@ -801,7 +801,7 @@ impl<T: Config> Pallet<T> {
                     .ok_or(Error::<T>::StateRootUnverifiable)?,
             };
 
-            if expected_state_root != core_state_root {
+            if expected_state_root != *core_state_root {
                 return Err(Error::<T>::BadStateRoot);
             }
         }


### PR DESCRIPTION
This commit introduces an enum `BundleSolution` to represent a general domain bundle solution which largely consists of a proof of election, with some additional core domain-specific info in the variant Core. No logical changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
