### PR TITLE
Only run clippy for macOS and skip tests

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,6 +12,11 @@ on:
       - '**.md'
       - '.github/CODEOWNERS'
   workflow_dispatch:
+    test-macos:
+      description: 'Whether to run macOS tests'
+      required: true
+      default: false
+      type: boolean
 
 env:
   # Not needed in CI, should make things a bit faster
@@ -121,6 +126,7 @@ jobs:
           - windows-2022
 
     runs-on: ${{ matrix.os }}
+    if: runner.os != 'macOS' || inputs.test-macos == true || github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This is supposed to skip macOS tests except on `main` and when triggered in a workflow with macOS tests enabled specifically.

Should save us time if we switch to beefier workers for Linux and Windows, because we'll not have to wait for macOS quite as long.

This came out of discussion with Jeremy and observation that we have very little platform-specific code, so as long as it compiles and passes tests on other platforms, it should work.

Syntax in `if` condition should work, but as with all things DevOps it is a lottery and you never know ntil you try.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
