### PR TITLE
Node. Add piece publishing batcher.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9186,6 +9186,7 @@ dependencies = [
  "subspace-farmer-components",
  "subspace-solving",
  "subspace-verification",
+ "tokio",
 ]
 
 [[package]]
@@ -10055,6 +10056,7 @@ dependencies = [
  "subspace-service",
  "subspace-solving",
  "subspace-test-runtime",
+ "tokio",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9965,6 +9965,7 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
+ "backoff",
  "derive_more",
  "domain-runtime-primitives",
  "frame-support",
@@ -10009,6 +10010,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
+ "subspace-archiving",
  "subspace-core-primitives",
  "subspace-fraud-proof",
  "subspace-networking",
@@ -10016,6 +10018,7 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/sp-lightclient/Cargo.toml
+++ b/crates/sp-lightclient/Cargo.toml
@@ -35,6 +35,7 @@ futures = "0.3.25"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving"}
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }
+tokio = { version = "1.21.2", features = ["sync"] }
 
 [features]
 default = ["std"]

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -106,6 +106,7 @@ impl Farmer {
             sector_expiration: 100,
         };
         let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
+        let piece_receiver_batch_size = 20usize;
 
         block_on(plot_sector(
             &public_key,
@@ -117,7 +118,7 @@ impl Farmer {
             &sector_codec,
             Cursor::new(sector.as_mut_slice()),
             Cursor::new(sector_metadata.as_mut_slice()),
-            &tokio::sync::Semaphore::new(usize::MAX),
+            &tokio::sync::Semaphore::new(piece_receiver_batch_size),
         ))
         .unwrap();
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -106,7 +106,7 @@ impl Farmer {
             sector_expiration: 100,
         };
         let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-        let piece_receiver_batch_size = 20usize;
+
         block_on(plot_sector(
             &public_key,
             sector_index,
@@ -117,7 +117,7 @@ impl Farmer {
             &sector_codec,
             Cursor::new(sector.as_mut_slice()),
             Cursor::new(sector_metadata.as_mut_slice()),
-            piece_receiver_batch_size,
+            &tokio::sync::Semaphore::new(usize::MAX),
         ))
         .unwrap();
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -19,6 +19,7 @@ use subspace_farmer_components::farming::audit_sector;
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::plot_sector;
 use subspace_farmer_components::FarmerProtocolInfo;
+use tokio::sync::Semaphore;
 use utils::BenchPieceReceiver;
 
 mod utils;
@@ -63,7 +64,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     };
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;
-    let piece_receiver_batch_size = 20usize;
+    let piece_receiver_semaphore = Semaphore::new(usize::MAX);
 
     let plotted_sector = {
         let mut plotted_sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
@@ -78,7 +79,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &sector_codec,
             plotted_sector.as_mut_slice(),
             io::sink(),
-            piece_receiver_batch_size,
+            &piece_receiver_semaphore,
         ))
         .unwrap();
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -64,7 +64,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     };
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;
-    let piece_receiver_semaphore = Semaphore::new(usize::MAX);
+    let piece_receiver_batch_size = 20usize;
+    let piece_receiver_semaphore = Semaphore::new(piece_receiver_batch_size);
 
     let plotted_sector = {
         let mut plotted_sector = vec![0u8; PLOT_SECTOR_SIZE as usize];

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -16,6 +16,7 @@ use subspace_core_primitives::{
 };
 use subspace_farmer_components::plotting::plot_sector;
 use subspace_farmer_components::FarmerProtocolInfo;
+use tokio::sync::Semaphore;
 use utils::BenchPieceReceiver;
 
 mod utils;
@@ -53,7 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         sector_expiration: 1,
     };
     let piece_receiver = BenchPieceReceiver::new(piece);
-    let piece_receiver_batch_size = 20usize;
+    let piece_receiver_semaphore = Semaphore::new(usize::MAX);
 
     let mut group = c.benchmark_group("sector-plotting");
     group.throughput(Throughput::Bytes(PLOT_SECTOR_SIZE));
@@ -69,12 +70,12 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&sector_codec),
                 black_box(io::sink()),
                 black_box(io::sink()),
-                black_box(piece_receiver_batch_size),
+                black_box(&piece_receiver_semaphore),
             ))
             .unwrap();
         })
     });
-    let piece_receiver_batch_size = 20usize;
+
     let thread_count = current_num_threads() as u64;
     group.throughput(Throughput::Bytes(PLOT_SECTOR_SIZE * thread_count));
     group.bench_function("no-writes-multi-thread", |b| {
@@ -93,7 +94,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&sector_codec),
                         black_box(io::sink()),
                         black_box(io::sink()),
-                        black_box(piece_receiver_batch_size),
+                        black_box(&piece_receiver_semaphore),
                     ))
                     .unwrap();
                 });

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -54,7 +54,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         sector_expiration: 1,
     };
     let piece_receiver = BenchPieceReceiver::new(piece);
-    let piece_receiver_semaphore = Semaphore::new(usize::MAX);
+    let piece_receiver_batch_size = 20usize;
+    let piece_receiver_semaphore = Semaphore::new(piece_receiver_batch_size);
 
     let mut group = c.benchmark_group("sector-plotting");
     group.throughput(Throughput::Bytes(PLOT_SECTOR_SIZE));

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -20,6 +20,7 @@ use subspace_farmer_components::farming::audit_sector;
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::plot_sector;
 use subspace_farmer_components::{FarmerProtocolInfo, SectorMetadata};
+use tokio::sync::Semaphore;
 use utils::BenchPieceReceiver;
 
 mod utils;
@@ -66,7 +67,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;
     let reward_address = PublicKey::default();
-    let piece_receiver_batch_size = 20usize;
+    let piece_receiver_semaphore = Semaphore::new(usize::MAX);
 
     let (plotted_sector, sector_metadata) = {
         let mut plotted_sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
@@ -82,7 +83,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &sector_codec,
             plotted_sector.as_mut_slice(),
             sector_metadata.as_mut_slice(),
-            piece_receiver_batch_size,
+            &piece_receiver_semaphore,
         ))
         .unwrap();
 

--- a/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
@@ -5,8 +5,6 @@ use futures::StreamExt;
 use parity_scale_codec::Encode;
 use std::collections::BTreeSet;
 use std::error::Error;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -101,12 +99,8 @@ impl PieceSectorPublisher {
             self.check_cancellation()
                 .map_err(backoff::Error::Permanent)?;
 
-            let publish_timeout_result: Result<Result<(), _>, Elapsed> = timeout(
-                PUT_PIECE_TIMEOUT,
-                Box::pin(self.publish_single_piece(piece_index))
-                    as Pin<Box<dyn Future<Output = _> + Send>>,
-            )
-            .await;
+            let publish_timeout_result: Result<Result<(), _>, Elapsed> =
+                timeout(PUT_PIECE_TIMEOUT, self.publish_single_piece(piece_index)).await;
 
             if let Ok(publish_result) = publish_timeout_result {
                 if publish_result.is_ok() {

--- a/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_receiver.rs
@@ -23,7 +23,7 @@ const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
 /// Defines max duration between get_piece calls.
 const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(5);
 /// Delay for getting piece from cache before resorting to archival storage
-const GET_PIECE_ARCHIVAL_STORAGE_DELAY: Duration = Duration::from_secs(1);
+const GET_PIECE_ARCHIVAL_STORAGE_DELAY: Duration = Duration::from_secs(2);
 /// Max time allocated for getting piece from DSN before attempt is considered to fail
 const GET_PIECE_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/crates/subspace-networking/src/behavior/custom_record_store.rs
+++ b/crates/subspace-networking/src/behavior/custom_record_store.rs
@@ -297,7 +297,7 @@ impl<'a> RecordStorage<'a> for NoRecordStorage {
     }
 
     fn put(&mut self, record: Record) -> store::Result<()> {
-        debug!("Detected an attempt to add a new record: {:?}", record);
+        debug!(key = ?record.key, "Detected an attempt to add a new record.", );
 
         Ok(())
     }

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -61,7 +61,7 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-p
 subspace-service = { version = "0.1.0", path = "../subspace-service" }
 system-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/system" }
 thiserror = "1.0.32"
-tokio = "1.17.0"
+tokio = "1.21.2"
 
 [build-dependencies]
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -36,6 +36,9 @@ use subspace_runtime::{Block, RuntimeApi};
 use subspace_service::{DsnConfig, SubspaceConfiguration, SubspaceNetworking};
 use system_domain_runtime::GenesisConfig as ExecutionGenesisConfig;
 
+// Defines a maximum constraint for the piece publisher batch.
+const MAX_PIECE_PUBLISHER_BATCH_SIZE: usize = 30;
+
 /// System domain executor instance.
 pub struct SystemDomainExecutorDispatch;
 
@@ -412,6 +415,16 @@ fn main() -> Result<(), Error> {
                             cli.dsn_bootstrap_nodes
                         };
 
+                        if cli.dsn_piece_publisher_batch_size == 0
+                            || cli.dsn_piece_publisher_batch_size > MAX_PIECE_PUBLISHER_BATCH_SIZE
+                        {
+                            return Err(sc_service::Error::Other(format!(
+                                "Incorrect piece publisher batch size: {}. Should be 1-{}",
+                                cli.dsn_piece_publisher_batch_size, MAX_PIECE_PUBLISHER_BATCH_SIZE
+                            ))
+                            .into());
+                        }
+
                         // TODO: Libp2p versions for Substrate and Subspace diverged.
                         // We get type compatibility by encoding and decoding the original keypair.
                         let encoded_keypair = network_keypair
@@ -429,6 +442,7 @@ fn main() -> Result<(), Error> {
                             bootstrap_nodes: dsn_bootstrap_nodes,
                             reserved_peers: cli.dsn_reserved_peers,
                             allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ips,
+                            piece_publisher_batch_size: cli.dsn_piece_publisher_batch_size,
                         }
                     };
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -196,6 +196,10 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub dsn_disable_private_ips: bool,
 
+    /// Defines piece publishing batch size
+    #[arg(long, default_value_t = 15)]
+    pub dsn_piece_publisher_batch_size: usize,
+
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
     #[arg(long, default_value = "1GiB")]
     pub piece_cache_size: ByteSize,

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 derive_more = "0.99.17"
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
@@ -57,6 +58,7 @@ sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate",
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
@@ -64,6 +66,7 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-p
 substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 thiserror = "1.0.32"
+tokio = { version = "1.21.2", features = ["sync"] }
 tracing = "0.1.37"
 
 sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -137,6 +137,8 @@ pub enum SubspaceNetworking {
         node: Node,
         /// Bootstrap nodes used (that can be also sent to the farmer over RPC)
         bootstrap_nodes: Vec<Multiaddr>,
+        /// Defines piece publishing batch size
+        piece_publisher_batch_size: usize,
     },
     /// Networking must be instantiated internally
     Create {
@@ -424,72 +426,78 @@ where
         other: (block_import, subspace_link, mut telemetry),
     } = partial_components;
 
-    let (node, bootstrap_nodes) = match config.subspace_networking.clone() {
-        SubspaceNetworking::Reuse {
-            node,
-            bootstrap_nodes,
-        } => (node, bootstrap_nodes),
-        SubspaceNetworking::Create {
-            config,
-            piece_cache_size,
-        } => {
-            let piece_cache = PieceCache::new(client.clone(), piece_cache_size);
+    let (node, bootstrap_nodes, piece_publisher_batch_size) =
+        match config.subspace_networking.clone() {
+            SubspaceNetworking::Reuse {
+                node,
+                bootstrap_nodes,
+                piece_publisher_batch_size,
+            } => (node, bootstrap_nodes, piece_publisher_batch_size),
+            SubspaceNetworking::Create {
+                config,
+                piece_cache_size,
+            } => {
+                let piece_cache = PieceCache::new(client.clone(), piece_cache_size);
 
-            // Start before archiver below, so we don't have potential race condition and miss pieces
-            task_manager
-                .spawn_handle()
-                .spawn_blocking("subspace-piece-cache", None, {
-                    let piece_cache = piece_cache.clone();
-                    let mut archived_segment_notification_stream = subspace_link
-                        .archived_segment_notification_stream()
-                        .subscribe();
+                // Start before archiver below, so we don't have potential race condition and miss pieces
+                task_manager
+                    .spawn_handle()
+                    .spawn_blocking("subspace-piece-cache", None, {
+                        let piece_cache = piece_cache.clone();
+                        let mut archived_segment_notification_stream = subspace_link
+                            .archived_segment_notification_stream()
+                            .subscribe();
 
-                    async move {
-                        while let Some(archived_segment_notification) =
-                            archived_segment_notification_stream.next().await
-                        {
-                            let segment_index = archived_segment_notification
-                                .archived_segment
-                                .root_block
-                                .segment_index();
-                            if let Err(error) = piece_cache.add_pieces(
-                                segment_index * u64::from(PIECES_IN_SEGMENT),
-                                &archived_segment_notification.archived_segment.pieces,
-                            ) {
-                                error!(
-                                    %segment_index,
-                                    %error,
-                                    "Failed to store pieces for segment in cache"
-                                );
+                        async move {
+                            while let Some(archived_segment_notification) =
+                                archived_segment_notification_stream.next().await
+                            {
+                                let segment_index = archived_segment_notification
+                                    .archived_segment
+                                    .root_block
+                                    .segment_index();
+                                if let Err(error) = piece_cache.add_pieces(
+                                    segment_index * u64::from(PIECES_IN_SEGMENT),
+                                    &archived_segment_notification.archived_segment.pieces,
+                                ) {
+                                    error!(
+                                        %segment_index,
+                                        %error,
+                                        "Failed to store pieces for segment in cache"
+                                    );
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
-            let (node, mut node_runner) =
-                create_dsn_instance::<Block, _>(config.clone(), piece_cache.clone())
-                    .instrument(tracing::info_span!(
-                        sc_tracing::logging::PREFIX_LOG_SPAN,
-                        name = "DSN"
-                    ))
-                    .await?;
+                let (node, mut node_runner) =
+                    create_dsn_instance::<Block, _>(config.clone(), piece_cache.clone())
+                        .instrument(tracing::info_span!(
+                            sc_tracing::logging::PREFIX_LOG_SPAN,
+                            name = "DSN"
+                        ))
+                        .await?;
 
-            info!("Subspace networking initialized: Node ID is {}", node.id());
+                info!("Subspace networking initialized: Node ID is {}", node.id());
 
-            task_manager.spawn_essential_handle().spawn_essential(
-                "node-runner",
-                Some("subspace-networking"),
-                Box::pin(
-                    async move {
-                        node_runner.run().await;
-                    }
-                    .in_current_span(),
-                ),
-            );
+                task_manager.spawn_essential_handle().spawn_essential(
+                    "node-runner",
+                    Some("subspace-networking"),
+                    Box::pin(
+                        async move {
+                            node_runner.run().await;
+                        }
+                        .in_current_span(),
+                    ),
+                );
 
-            (node, config.bootstrap_nodes)
-        }
-    };
+                (
+                    node,
+                    config.bootstrap_nodes,
+                    config.piece_publisher_batch_size,
+                )
+            }
+        };
 
     let dsn_archiving_fut = start_dsn_archiver(
         subspace_link
@@ -497,6 +505,7 @@ where
             .subscribe(),
         node.clone(),
         task_manager.spawn_handle(),
+        piece_publisher_batch_size,
     );
 
     task_manager.spawn_essential_handle().spawn_essential(

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -134,6 +134,7 @@ async fn run_executor(
                     reserved_peers: vec![],
                     keypair: identity::Keypair::generate_ed25519(),
                     allow_non_global_addresses_in_dht: true,
+                    piece_publisher_batch_size: 10,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },

--- a/test/subspace-test-client/Cargo.toml
+++ b/test/subspace-test-client/Cargo.toml
@@ -34,4 +34,5 @@ subspace-farmer-components = { path = "../../crates/subspace-farmer-components" 
 subspace-service = { path = "../../crates/subspace-service" }
 subspace-solving = { path = "../../crates/subspace-solving" }
 subspace-test-runtime = { version = "0.1.0", features = ["do-not-enforce-cost-of-storage"], path = "../subspace-test-runtime" }
+tokio = { version = "1.21.2", features = ["sync"] }
 zeroize = "1.5.7"

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -251,6 +251,7 @@ where
         // TODO: This constant should come from the chain itself
         sector_expiration: 100,
     };
+    let piece_receiver_batch_size = 20usize;
 
     plot_sector(
         &public_key,
@@ -262,7 +263,7 @@ where
         sector_codec,
         Cursor::new(sector.as_mut_slice()),
         Cursor::new(sector_metadata.as_mut_slice()),
-        &tokio::sync::Semaphore::new(usize::MAX),
+        &tokio::sync::Semaphore::new(piece_receiver_batch_size),
     )
     .await
     .expect("Plotting one sector in memory must not fail");

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -252,7 +252,6 @@ where
         sector_expiration: 100,
     };
 
-    let piece_receiver_batch_size = 20usize;
     plot_sector(
         &public_key,
         sector_index,
@@ -263,7 +262,7 @@ where
         sector_codec,
         Cursor::new(sector.as_mut_slice()),
         Cursor::new(sector_metadata.as_mut_slice()),
-        piece_receiver_batch_size,
+        &tokio::sync::Semaphore::new(usize::MAX),
     )
     .await
     .expect("Plotting one sector in memory must not fail");

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -198,6 +198,7 @@ pub async fn run_validator_node(
                     reserved_peers: vec![],
                     keypair: identity::Keypair::generate_ed25519(),
                     allow_non_global_addresses_in_dht: true,
+                    piece_publisher_batch_size: 10,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },


### PR DESCRIPTION
This PR adds a piece publishing batcher with a backoff policy for the node app. It introduces a bounded batch size CLI argument `--dsn-piece-publisher-batch-size`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)