### PR TITLE
fix link to contributing guide when a PR is open

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,2 @@
 ### Code contributor checklist:
-* [ ] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
+* [ ] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
Use Github url  instead of relative url as `../` does not link to correct path as expected. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](../CONTRIBUTING.md)
