### PR TITLE
Messenger genesis config and start relayers in dev mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9882,6 +9882,7 @@ dependencies = [
  "substrate-build-script-utils",
  "system-domain-runtime",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -61,6 +61,7 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-p
 subspace-service = { version = "0.1.0", path = "../subspace-service" }
 system-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/system" }
 thiserror = "1.0.32"
+tokio = "1.17.0"
 
 [build-dependencies]
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -250,7 +250,7 @@ fn main() -> Result<(), Error> {
                     maybe_secondary_chain_spec.ok_or_else(|| {
                         "Primary chain spec must contain secondary chain spec".to_string()
                     })?,
-                    cli.secondary_chain_args.iter(),
+                    cli.secondary_chain_args.into_iter(),
                 );
 
                 let secondary_chain_config = SubstrateCli::create_configuration(
@@ -482,9 +482,7 @@ fn main() -> Result<(), Error> {
                         maybe_secondary_chain_spec.ok_or_else(|| {
                             "Primary chain spec must contain secondary chain spec".to_string()
                         })?,
-                        [SecondaryChainCli::executable_name()]
-                            .iter()
-                            .chain(cli.secondary_chain_args.iter()),
+                        cli.secondary_chain_args.into_iter(),
                     );
 
                     // Increase default number of peers

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -501,8 +501,19 @@ fn main() -> Result<(), Error> {
                         ))
                     })?;
 
+                    // if is dev, use the known key ring to start relayer
+                    let maybe_relayer_id = if secondary_chain_cli.shared_params().is_dev() {
+                        secondary_chain_cli
+                            .run
+                            .run_system
+                            .get_keyring()
+                            .map(|kr| kr.to_account_id())
+                    } else {
+                        secondary_chain_cli.run.relayer_id
+                    };
+
                     let secondary_chain_config =
-                        Configuration::new(service_config, secondary_chain_cli.run.relayer_id);
+                        Configuration::new(service_config, maybe_relayer_id);
 
                     let imported_block_notification_stream = || {
                         primary_chain_node
@@ -583,10 +594,18 @@ fn main() -> Result<(), Error> {
                             ))
                         })?;
 
-                        let core_domain_config = Configuration::new(
-                            core_domain_service_config,
-                            core_domain_cli.relayer_id,
-                        );
+                        // if is dev, use the known key ring to start relayer
+                        let maybe_relayer_id = if core_domain_cli.shared_params().is_dev() {
+                            core_domain_cli
+                                .run
+                                .get_keyring()
+                                .map(|kr| kr.to_account_id())
+                        } else {
+                            core_domain_cli.relayer_id
+                        };
+
+                        let core_domain_config =
+                            Configuration::new(core_domain_service_config, maybe_relayer_id);
 
                         let core_domain_node = match core_domain_cli.domain_id {
                             DomainId::CORE_PAYMENTS => {

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -482,7 +482,9 @@ fn main() -> Result<(), Error> {
                         maybe_secondary_chain_spec.ok_or_else(|| {
                             "Primary chain spec must contain secondary chain spec".to_string()
                         })?,
-                        cli.secondary_chain_args.iter(),
+                        [SecondaryChainCli::executable_name()]
+                            .iter()
+                            .chain(cli.secondary_chain_args.iter()),
                     );
 
                     // Increase default number of peers

--- a/crates/subspace-node/src/core_domain/cli.rs
+++ b/crates/subspace-node/src/core_domain/cli.rs
@@ -103,7 +103,7 @@ impl CoreDomainCli {
         tokio_handle: tokio::runtime::Handle,
     ) -> sc_cli::Result<DomainConfiguration> {
         // if is dev, use the known key ring to start relayer
-        let maybe_relayer_id = if self.shared_params().is_dev() {
+        let maybe_relayer_id = if self.shared_params().is_dev() && self.relayer_id.is_none() {
             self.run.get_keyring().map(|kr| kr.to_account_id())
         } else {
             self.relayer_id.clone()

--- a/crates/subspace-node/src/core_domain/cli.rs
+++ b/crates/subspace-node/src/core_domain/cli.rs
@@ -72,13 +72,17 @@ impl CoreDomainCli {
     /// Constructs a new instance of [`CoreDomainCli`].
     ///
     /// If no explicit base path for the secondary chain, the default value will be `primary_base_path/executor`.
-    pub fn new<'a>(
+    pub fn new(
         system_domain_base_path: Option<PathBuf>,
-        core_payments_domain_args: impl Iterator<Item = &'a String>,
+        core_payments_domain_args: impl Iterator<Item = String>,
     ) -> Self {
         let mut cli = Self {
             base_path: system_domain_base_path,
-            ..Self::parse_from(core_payments_domain_args)
+            ..Self::parse_from(
+                [Self::executable_name()]
+                    .into_iter()
+                    .chain(core_payments_domain_args),
+            )
         };
 
         cli.base_path

--- a/crates/subspace-node/src/core_domain/core_payments_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_payments_chain_spec.rs
@@ -18,8 +18,10 @@
 
 use crate::chain_spec_utils::{chain_spec_properties, get_account_id_from_seed};
 use core_payments_domain_runtime::{
-    AccountId, BalancesConfig, GenesisConfig, SudoConfig, SystemConfig, WASM_BINARY,
+    AccountId, BalancesConfig, GenesisConfig, MessengerConfig, SudoConfig, SystemConfig,
+    WASM_BINARY,
 };
+use domain_runtime_primitives::RelayerId;
 use sc_service::ChainType;
 use sc_subspace_chain_specs::ExecutionChainSpec;
 use sp_core::crypto::Ss58Codec;
@@ -43,6 +45,10 @@ pub fn development_config() -> ExecutionChainSpec<GenesisConfig> {
                     get_account_id_from_seed("Bob//stash"),
                 ],
                 Some(get_account_id_from_seed("Alice")),
+                vec![(
+                    get_account_id_from_seed("Alice"),
+                    get_account_id_from_seed("Alice"),
+                )],
             )
         },
         vec![],
@@ -78,6 +84,16 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
                     get_account_id_from_seed("Ferdie//stash"),
                 ],
                 Some(get_account_id_from_seed("Alice")),
+                vec![
+                    (
+                        get_account_id_from_seed("Alice"),
+                        get_account_id_from_seed("Alice"),
+                    ),
+                    (
+                        get_account_id_from_seed("Bob"),
+                        get_account_id_from_seed("Bob"),
+                    ),
+                ],
             )
         },
         // Bootnodes
@@ -109,6 +125,7 @@ pub fn gemini_3a_config() -> ExecutionChainSpec<GenesisConfig> {
                         .expect("Wrong executor account address"),
                 ],
                 None,
+                Default::default(),
             )
         },
         // Bootnodes
@@ -128,6 +145,7 @@ pub fn gemini_3a_config() -> ExecutionChainSpec<GenesisConfig> {
 fn testnet_genesis(
     endowed_accounts: Vec<AccountId>,
     maybe_sudo_account: Option<AccountId>,
+    relayers: Vec<(AccountId, RelayerId)>,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -146,5 +164,6 @@ fn testnet_genesis(
                 .map(|k| (k, 1_000_000 * SSC))
                 .collect(),
         },
+        messenger: MessengerConfig { relayers },
     }
 }

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -19,6 +19,7 @@
 use crate::chain_spec_utils::{
     chain_spec_properties, get_account_id_from_seed, get_public_key_from_seed,
 };
+use domain_runtime_primitives::RelayerId;
 use frame_support::weights::Weight;
 use sc_service::ChainType;
 use sc_subspace_chain_specs::ExecutionChainSpec;
@@ -29,7 +30,7 @@ use subspace_core_primitives::crypto::blake2b_256_hash;
 use subspace_runtime_primitives::SSC;
 use system_domain_runtime::{
     AccountId, Balance, BalancesConfig, DomainRegistryConfig, ExecutorRegistryConfig,
-    GenesisConfig, Hash, SudoConfig, SystemConfig, WASM_BINARY,
+    GenesisConfig, Hash, MessengerConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 
 type DomainConfig = sp_domains::DomainConfig<Hash, Balance, Weight>;
@@ -73,6 +74,10 @@ pub fn development_config() -> ExecutionChainSpec<GenesisConfig> {
                     Percent::one(),
                 )],
                 Some(get_account_id_from_seed("Alice")),
+                vec![(
+                    get_account_id_from_seed("Alice"),
+                    get_account_id_from_seed("Alice"),
+                )],
             )
         },
         vec![],
@@ -131,6 +136,16 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
                     Percent::one(),
                 )],
                 Some(get_account_id_from_seed("Alice")),
+                vec![
+                    (
+                        get_account_id_from_seed("Alice"),
+                        get_account_id_from_seed("Alice"),
+                    ),
+                    (
+                        get_account_id_from_seed("Bob"),
+                        get_account_id_from_seed("Bob"),
+                    ),
+                ],
             )
         },
         // Bootnodes
@@ -191,6 +206,7 @@ pub fn gemini_3a_config() -> ExecutionChainSpec<GenesisConfig> {
                     Percent::one(),
                 )],
                 None,
+                Default::default(),
             )
         },
         // Bootnodes
@@ -250,6 +266,7 @@ pub fn x_net_2_config() -> ExecutionChainSpec<GenesisConfig> {
                     Percent::one(),
                 )],
                 None,
+                Default::default(),
             )
         },
         // Bootnodes
@@ -271,6 +288,7 @@ fn testnet_genesis(
     executors: Vec<(AccountId, Balance, AccountId, ExecutorPublicKey)>,
     domains: Vec<(AccountId, Balance, DomainConfig, AccountId, Percent)>,
     maybe_sudo_account: Option<AccountId>,
+    relayers: Vec<(AccountId, RelayerId)>,
 ) -> GenesisConfig {
     GenesisConfig {
         system: SystemConfig {
@@ -295,5 +313,6 @@ fn testnet_genesis(
             slot_probability: (1, 1),
         },
         domain_registry: DomainRegistryConfig { domains },
+        messenger: MessengerConfig { relayers },
     }
 }

--- a/crates/subspace-node/src/secondary_chain/cli.rs
+++ b/crates/subspace-node/src/secondary_chain/cli.rs
@@ -73,19 +73,21 @@ impl SecondaryChainCli {
     /// Constructs a new instance of [`SecondaryChainCli`].
     ///
     /// If no explicit base path for the secondary chain, the default value will be `primary_base_path/executor`.
-    pub fn new<'a>(
+    pub fn new(
         mut base_path: Option<PathBuf>,
         chain_spec: ExecutionChainSpec<SystemDomainGenesisConfig>,
-        secondary_chain_args: impl Iterator<Item = &'a String>,
+        secondary_chain_args: impl Iterator<Item = String>,
     ) -> (Self, Option<CoreDomainCli>) {
-        let domain_cli = DomainCli::parse_from(secondary_chain_args);
+        let domain_cli = DomainCli::parse_from(
+            [Self::executable_name()]
+                .into_iter()
+                .chain(secondary_chain_args),
+        );
 
         let maybe_core_domain_cli = if !domain_cli.core_domain_args.is_empty() {
             let core_domain_cli = CoreDomainCli::new(
                 base_path.clone(),
-                [CoreDomainCli::executable_name()]
-                    .iter()
-                    .chain(domain_cli.core_domain_args.iter()),
+                domain_cli.core_domain_args.clone().into_iter(),
             );
             Some(core_domain_cli)
         } else {

--- a/crates/subspace-node/src/secondary_chain/cli.rs
+++ b/crates/subspace-node/src/secondary_chain/cli.rs
@@ -81,8 +81,12 @@ impl SecondaryChainCli {
         let domain_cli = DomainCli::parse_from(secondary_chain_args);
 
         let maybe_core_domain_cli = if !domain_cli.core_domain_args.is_empty() {
-            let core_domain_cli =
-                CoreDomainCli::new(base_path.clone(), domain_cli.core_domain_args.iter());
+            let core_domain_cli = CoreDomainCli::new(
+                base_path.clone(),
+                [CoreDomainCli::executable_name()]
+                    .iter()
+                    .chain(domain_cli.core_domain_args.iter()),
+            );
             Some(core_domain_cli)
         } else {
             None

--- a/crates/subspace-node/src/secondary_chain/cli.rs
+++ b/crates/subspace-node/src/secondary_chain/cli.rs
@@ -111,7 +111,7 @@ impl SecondaryChainCli {
         tokio_handle: tokio::runtime::Handle,
     ) -> sc_cli::Result<DomainConfiguration> {
         // if is dev, use the known key ring to start relayer
-        let maybe_relayer_id = if self.shared_params().is_dev() {
+        let maybe_relayer_id = if self.shared_params().is_dev() && self.run.relayer_id.is_none() {
             self.run
                 .run_system
                 .get_keyring()

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -1,4 +1,4 @@
-use crate::{new_partial, Configuration, FullBackend, FullClient, FullPool};
+use crate::{new_partial, DomainConfiguration, FullBackend, FullClient, FullPool};
 use cross_domain_message_gossip::DomainTxPoolSink;
 use domain_client_executor::{CoreExecutor, CoreGossipMessageValidator, EssentialExecutorParams};
 use domain_client_executor_gossip::ExecutorGossipParams;
@@ -103,7 +103,7 @@ pub async fn new_full<
     ExecutorDispatch,
 >(
     domain_id: DomainId,
-    mut secondary_chain_config: Configuration,
+    mut secondary_chain_config: DomainConfiguration,
     system_domain_client: Arc<SClient>,
     secondary_network: Arc<NetworkService<SBlock, SBlock::Hash>>,
     primary_chain_client: Arc<PClient>,

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -30,18 +30,9 @@ pub type FullPool<RuntimeApi, ExecutorDispatch> = sc_transaction_pool::BasicPool
 >;
 
 /// Secondary chain configuration.
-pub struct Configuration {
-    service_config: ServiceConfiguration,
-    maybe_relayer_id: Option<RelayerId>,
-}
-
-impl Configuration {
-    pub fn new(service_config: ServiceConfiguration, maybe_relayer_id: Option<RelayerId>) -> Self {
-        Configuration {
-            service_config,
-            maybe_relayer_id,
-        }
-    }
+pub struct DomainConfiguration {
+    pub service_config: ServiceConfiguration,
+    pub maybe_relayer_id: Option<RelayerId>,
 }
 
 /// Starts a `ServiceBuilder` for a full service.

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -1,4 +1,4 @@
-use crate::{new_partial, Configuration, FullBackend, FullClient, FullPool};
+use crate::{new_partial, DomainConfiguration, FullBackend, FullClient, FullPool};
 use cross_domain_message_gossip::DomainTxPoolSink;
 use domain_client_executor::{
     EssentialExecutorParams, SystemExecutor, SystemGossipMessageValidator,
@@ -90,7 +90,7 @@ where
 /// This is the actual implementation that is abstract over the executor and the runtime api.
 #[allow(clippy::too_many_arguments)]
 pub async fn new_full<PBlock, PClient, SC, IBNS, NSNS, RuntimeApi, ExecutorDispatch>(
-    mut secondary_chain_config: Configuration,
+    mut secondary_chain_config: DomainConfiguration,
     primary_chain_client: Arc<PClient>,
     primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
     select_chain: &SC,

--- a/domains/test/service/src/chain_spec.rs
+++ b/domains/test/service/src/chain_spec.rs
@@ -113,5 +113,6 @@ fn testnet_genesis(
             slot_probability: (1, 1),
         },
         domain_registry: domain_test_runtime::DomainRegistryConfig { domains },
+        messenger: Default::default(),
     }
 }

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -53,7 +53,7 @@ use substrate_test_client::{
 };
 
 use cross_domain_message_gossip::GossipWorker;
-use domain_service::Configuration;
+use domain_service::DomainConfiguration;
 pub use domain_test_runtime as runtime;
 use sp_domains::DomainId;
 pub use sp_keyring::Sr25519Keyring as Keyring;
@@ -161,7 +161,10 @@ async fn run_executor(
 
     let (gossip_msg_sink, gossip_msg_stream) =
         sc_utils::mpsc::tracing_unbounded("Cross domain gossip messages");
-    let secondary_chain_config = Configuration::new(secondary_chain_config, None);
+    let secondary_chain_config = DomainConfiguration {
+        service_config: secondary_chain_config,
+        maybe_relayer_id: None,
+    };
     let block_import_throttling_buffer_size = 10;
     let secondary_chain_node = domain_service::new_full::<
         _,


### PR DESCRIPTION
This PR brings following changes
- Adds Genesis config for Messenger to add any relayers to the pool.
- Ensure cli for secondary and core uses known keyrings when running in dev mode.
- Seems like for secondary chain as well as core domain, cli args should always be seperated with two `--`  instead of one else first argument is ignored as its assumed to be executable name. So added executable_name manually when parsing the args so that first argument is not ignored. With this change domain arguments separation can be done with only one `--`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
