### PR TITLE
Do not error out for every failed extrinsic when executing domain block extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "substrate-test-runtime-client",
+ "tracing",
 ]
 
 [[package]]

--- a/domains/client/block-builder/Cargo.toml
+++ b/domains/client/block-builder/Cargo.toml
@@ -22,6 +22,7 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535" }
+tracing = "0.1.37"
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../substrate/substrate-test-runtime-client" }

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -27,19 +27,16 @@
 #![warn(missing_docs)]
 
 use codec::Encode;
-
+use sc_client_api::backend;
 use sp_api::{
     ApiExt, ApiRef, Core, ProvideRuntimeApi, StorageChanges, StorageProof, TransactionOutcome,
 };
+pub use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{ApplyExtrinsicFailed, Error};
 use sp_core::ExecutionContext;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, Hash, HashFor, Header as HeaderT, NumberFor, One};
 use sp_runtime::Digest;
-
-pub use sp_block_builder::BlockBuilder as BlockBuilderApi;
-
-use sc_client_api::backend;
 
 /// Used as parameter to [`BlockBuilderProvider`] to express if proof recording should be enabled.
 ///
@@ -202,9 +199,8 @@ where
     fn execute_extrinsics(&self) -> Result<(), Error> {
         let block_id = &self.block_id;
 
-        for xt in &self.extrinsics {
-            // TODO: rethink what to do if an error occurs when executing the transaction.
-            self.api.execute_in_transaction(|api| {
+        for (index, xt) in self.extrinsics.iter().enumerate() {
+            let res = self.api.execute_in_transaction(|api| {
                 match api.apply_extrinsic_with_context(
                     block_id,
                     ExecutionContext::BlockConstruction,
@@ -216,7 +212,21 @@ where
                     )),
                     Err(e) => TransactionOutcome::Rollback(Err(Error::from(e))),
                 }
-            })?;
+            });
+
+            match res {
+                Err(Error::ApplyExtrinsicFailed(ApplyExtrinsicFailed::Validity(e)))
+                    if e.exhausted_resources() =>
+                {
+                    tracing::debug!(
+                        "Reached block weight limit, skipping the remaining extrinsics at index {index}, total: {}",
+                        self.extrinsics.len()
+                    );
+                    return Ok(());
+                }
+                Err(e) => tracing::debug!("Apply extrinsic failed: {e}"),
+                Ok(()) => {}
+            }
         }
 
         Ok(())

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -214,18 +214,8 @@ where
                 }
             });
 
-            match res {
-                Err(Error::ApplyExtrinsicFailed(ApplyExtrinsicFailed::Validity(e)))
-                    if e.exhausted_resources() =>
-                {
-                    tracing::debug!(
-                        "Reached block weight limit, skipping the remaining extrinsics at index {index}, total: {}",
-                        self.extrinsics.len()
-                    );
-                    return Ok(());
-                }
-                Err(e) => tracing::debug!("Apply extrinsic failed: {e}"),
-                Ok(()) => {}
+            if let Err(e) = res {
+                tracing::debug!("Apply extrinsic at index {index} failed: {e}");
             }
         }
 

--- a/domains/runtime/core-payments/src/runtime.rs
+++ b/domains/runtime/core-payments/src/runtime.rs
@@ -4,9 +4,7 @@ pub use domain_runtime_primitives::{
 };
 use frame_support::dispatch::DispatchClass;
 use frame_support::traits::{ConstU16, ConstU32, Everything};
-use frame_support::weights::constants::{
-    BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND,
-};
+use frame_support::weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -102,8 +100,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2).set_proof_size(u64::MAX);
+/// TODO: Proper max block weight
+const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::MAX;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -4,9 +4,7 @@ pub use domain_runtime_primitives::{
 };
 use frame_support::dispatch::DispatchClass;
 use frame_support::traits::{ConstU16, ConstU32, Everything};
-use frame_support::weights::constants::{
-    BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND,
-};
+use frame_support::weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -105,8 +103,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.div(2).set_proof_size(u64::MAX);
+/// TODO: Proper max block weight
+const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::MAX;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]


### PR DESCRIPTION
Not all ApplyExtrinsic failure is illegal, we should continue the block execution when running into a legal failure.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
