### PR TITLE
Use domain id to identify the correct fraud proof that needs to be handled

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -247,20 +247,22 @@ mod pallet {
 
             log::trace!(target: "runtime::domains", "Processing fraud proof: {fraud_proof:?}");
 
-            // Revert the execution chain.
-            let (_, mut to_remove) = ReceiptHead::<T>::get();
+            if fraud_proof.domain_id.is_system() {
+                // Revert the execution chain.
+                let (_, mut to_remove) = ReceiptHead::<T>::get();
 
-            let new_best_number: T::BlockNumber = fraud_proof.parent_number.into();
-            let new_best_hash = BlockHash::<T>::get(new_best_number);
+                let new_best_number: T::BlockNumber = fraud_proof.parent_number.into();
+                let new_best_hash = BlockHash::<T>::get(new_best_number);
 
-            ReceiptHead::<T>::put((new_best_hash, new_best_number));
+                ReceiptHead::<T>::put((new_best_hash, new_best_number));
 
-            while to_remove > new_best_number {
-                let block_hash = BlockHash::<T>::get(to_remove);
-                for (receipt_hash, _) in <ReceiptVotes<T>>::drain_prefix(block_hash) {
-                    Receipts::<T>::remove(receipt_hash);
+                while to_remove > new_best_number {
+                    let block_hash = BlockHash::<T>::get(to_remove);
+                    for (receipt_hash, _) in <ReceiptVotes<T>>::drain_prefix(block_hash) {
+                        Receipts::<T>::remove(receipt_hash);
+                    }
+                    to_remove -= One::one();
                 }
-                to_remove -= One::one();
             }
 
             // TODO: slash the executor accordingly.

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -427,8 +427,8 @@ fn submit_fraud_proof_should_work() {
         })
         .unzip();
 
-    let dummy_proof = FraudProof {
-        domain_id: DomainId::SYSTEM,
+    let dummy_proof = |domain_id| FraudProof {
+        domain_id,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: 99,
         parent_hash: block_hashes[98],
@@ -455,9 +455,18 @@ fn submit_fraud_proof_should_work() {
             assert_eq!(votes.next(), None);
         });
 
+        // non-system domain fraud proof should be ignored
         assert_ok!(Domains::submit_fraud_proof(
             RuntimeOrigin::none(),
-            dummy_proof
+            dummy_proof(DomainId::new(100))
+        ));
+        assert_eq!(Domains::head_receipt_number(), 256);
+        let receipt_hash = dummy_bundles[255].clone().bundle.receipts[0].hash();
+        assert!(Receipts::<Test>::get(receipt_hash).is_some());
+
+        assert_ok!(Domains::submit_fraud_proof(
+            RuntimeOrigin::none(),
+            dummy_proof(DomainId::SYSTEM)
         ));
         assert_eq!(Domains::head_receipt_number(), 99);
         let receipt_hash = dummy_bundles[98].clone().bundle.receipts[0].hash();

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -428,6 +428,7 @@ fn submit_fraud_proof_should_work() {
         .unzip();
 
     let dummy_proof = FraudProof {
+        domain_id: DomainId::SYSTEM,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: 99,
         parent_hash: block_hashes[98],

--- a/crates/sc-consensus-fraud-proof/src/lib.rs
+++ b/crates/sc-consensus-fraud-proof/src/lib.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use sc_consensus::block_import::{BlockCheckParams, BlockImport, BlockImportParams, ImportResult};
 use sp_api::{ProvideRuntimeApi, TransactionFor};
 use sp_consensus::{CacheKeyId, Error as ConsensusError};
-use sp_domains::ExecutorApi;
+use sp_domains::{DomainId, ExecutorApi};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use std::collections::HashMap;
@@ -93,7 +93,7 @@ where
                 let fraud_proofs = self
                     .client
                     .runtime_api()
-                    .extract_fraud_proofs(&parent_block_id, extrinsics.clone())
+                    .extract_fraud_proofs(&parent_block_id, extrinsics.clone(), DomainId::SYSTEM)
                     .map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
 
                 for fraud_proof in fraud_proofs {

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -1,4 +1,4 @@
-use crate::BundleHeader;
+use crate::{BundleHeader, DomainId};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
@@ -124,6 +124,8 @@ pub enum VerificationError {
 /// Fraud proof for the state computation.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct FraudProof {
+    /// The id of the domain this fraud proof targetted
+    pub domain_id: DomainId,
     /// Hash of the signed bundle in which an invalid state transition occurred.
     pub bad_signed_bundle_hash: H256,
     /// Parent number.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -398,7 +398,7 @@ sp_api::decl_runtime_apis! {
         ) -> Vec<ExecutionReceipt<NumberFor<Block>, Block::Hash, DomainHash>>;
 
         /// Extract the fraud proofs from the given extrinsics.
-        fn extract_fraud_proofs(extrinsics: Vec<Block::Extrinsic>) -> Vec<FraudProof>;
+        fn extract_fraud_proofs(extrinsics: Vec<Block::Extrinsic>, domain_id: DomainId,) -> Vec<FraudProof>;
 
         /// Generates a randomness seed for extrinsics shuffling.
         fn extrinsics_shuffling_seed(header: Block::Header) -> Randomness;

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -10,11 +10,14 @@ use sc_consensus::ForkChoiceStrategy;
 use sc_service::{BasePath, Role};
 use sp_api::ProvideRuntimeApi;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
-use sp_domains::{BundleHeader, ExecutionReceipt, OpaqueBundle};
+use sp_domains::{BundleHeader, DomainId, ExecutionReceipt, OpaqueBundle};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
 use sp_runtime::OpaqueExtrinsic;
 use tempfile::TempDir;
+
+// Use the system domain id for testing
+const TEST_DOMAIN_ID: DomainId = DomainId::SYSTEM;
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
 #[ignore]
@@ -250,6 +253,7 @@ async fn execution_proof_creation_and_verification_should_work() {
     let parent_number_alice = ferdie.client.info().best_number;
 
     let fraud_proof = FraudProof {
+        domain_id: TEST_DOMAIN_ID,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
@@ -307,6 +311,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         );
 
         let fraud_proof = FraudProof {
+            domain_id: TEST_DOMAIN_ID,
             bad_signed_bundle_hash: Hash::random(),
             parent_number: parent_number_alice,
             parent_hash: parent_hash_alice,
@@ -353,6 +358,7 @@ async fn execution_proof_creation_and_verification_should_work() {
     assert_eq!(post_execution_root, *header.state_root());
 
     let fraud_proof = FraudProof {
+        domain_id: TEST_DOMAIN_ID,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
@@ -531,6 +537,7 @@ async fn invalid_execution_proof_should_not_work() {
     let parent_number_alice = ferdie.client.info().best_number;
 
     let fraud_proof = FraudProof {
+        domain_id: TEST_DOMAIN_ID,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
@@ -542,6 +549,7 @@ async fn invalid_execution_proof_should_not_work() {
     assert!(proof_verifier.verify(&fraud_proof).is_err());
 
     let fraud_proof = FraudProof {
+        domain_id: TEST_DOMAIN_ID,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,
@@ -553,6 +561,7 @@ async fn invalid_execution_proof_should_not_work() {
     assert!(proof_verifier.verify(&fraud_proof).is_err());
 
     let fraud_proof = FraudProof {
+        domain_id: TEST_DOMAIN_ID,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: parent_number_alice,
         parent_hash: parent_hash_alice,

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -73,17 +73,19 @@ pub(crate) fn extract_receipts(
         .collect()
 }
 
-pub(crate) fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> {
+pub(crate) fn extract_fraud_proofs(
+    extrinsics: Vec<UncheckedExtrinsic>,
+    domain_id: DomainId,
+) -> Vec<FraudProof> {
     extrinsics
         .into_iter()
-        .filter_map(|uxt| {
-            if let RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) =
-                uxt.function
+        .filter_map(|uxt| match uxt.function {
+            RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof })
+                if fraud_proof.domain_id == domain_id =>
             {
                 Some(fraud_proof)
-            } else {
-                None
             }
+            _ => None,
         })
         .collect()
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -744,8 +744,8 @@ impl_runtime_apis! {
             crate::domains::extract_receipts(extrinsics, domain_id)
         }
 
-        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<FraudProof> {
-            crate::domains::extract_fraud_proofs(extrinsics)
+        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>, domain_id: DomainId,) -> Vec<FraudProof> {
+            crate::domains::extract_fraud_proofs(extrinsics, domain_id)
         }
 
         fn extrinsics_shuffling_seed(header: <Block as BlockT>::Header) -> Randomness {

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -9,7 +9,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CodeExecutor, SpawnNamed};
 use sp_core::H256;
 use sp_domains::fraud_proof::{BundleEquivocationProof, InvalidTransactionProof};
-use sp_domains::{Bundle, ExecutorApi, SignedBundle};
+use sp_domains::{Bundle, DomainId, ExecutorApi, SignedBundle};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, HashFor, NumberFor};
 use sp_runtime::RuntimeAppPublic;
@@ -127,6 +127,7 @@ where
         &self,
         signed_bundle_hash: H256,
         execution_receipt: &ExecutionReceiptFor<PBlock, Block::Hash>,
+        domain_id: DomainId,
     ) -> Result<(), GossipMessageError> {
         let head_receipt_number = self
             .primary_chain_client
@@ -138,6 +139,7 @@ where
             signed_bundle_hash,
             execution_receipt,
             head_receipt_number,
+            domain_id,
         )? {
             self.primary_chain_client
                 .runtime_api()
@@ -241,8 +243,9 @@ where
             // TODO: validate the bundle election.
 
             // TODO: Validate the receipts correctly when the bundle gossip is re-enabled.
+            let domain_id = bundle_solution.proof_of_election().domain_id;
             for receipt in &bundle.receipts {
-                self.validate_gossiped_execution_receipt(signed_bundle_hash, receipt)?;
+                self.validate_gossiped_execution_receipt(signed_bundle_hash, receipt, domain_id)?;
             }
 
             for extrinsic in bundle.extrinsics.iter() {

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -420,7 +420,7 @@ where
         let fraud_proofs = self
             .primary_chain_client
             .runtime_api()
-            .extract_fraud_proofs(&BlockId::Hash(primary_hash), extrinsics)?;
+            .extract_fraud_proofs(&BlockId::Hash(primary_hash), extrinsics, self.domain_id)?;
 
         let bad_receipts_to_delete = fraud_proofs
             .into_iter()

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -489,7 +489,12 @@ where
 
             let fraud_proof = self
                 .fraud_proof_generator
-                .generate_proof(trace_mismatch_index, &local_receipt, bad_signed_bundle_hash)
+                .generate_proof(
+                    self.domain_id,
+                    trace_mismatch_index,
+                    &local_receipt,
+                    bad_signed_bundle_hash,
+                )
                 .map_err(|err| {
                     sp_blockchain::Error::Application(Box::from(format!(
                         "Failed to generate fraud proof: {err}"

--- a/domains/client/domain-executor/src/fraud_proof.rs
+++ b/domains/client/domain-executor/src/fraud_proof.rs
@@ -8,7 +8,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CodeExecutor, SpawnNamed};
 use sp_core::H256;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
-use sp_domains::ExecutionReceipt;
+use sp_domains::{DomainId, ExecutionReceipt};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT, NumberFor};
 use sp_trie::StorageProof;
@@ -81,6 +81,7 @@ where
 
     pub(crate) fn generate_proof(
         &self,
+        domain_id: DomainId,
         local_trace_index: u32,
         local_receipt: &ExecutionReceipt<NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
         bad_signed_bundle_hash: H256,
@@ -136,6 +137,7 @@ where
             )?;
 
             FraudProof {
+                domain_id,
                 bad_signed_bundle_hash,
                 parent_number,
                 parent_hash: as_h256(&parent_header.hash())?,
@@ -171,6 +173,7 @@ where
             )?;
 
             FraudProof {
+                domain_id,
                 bad_signed_bundle_hash,
                 parent_number,
                 parent_hash: as_h256(&parent_header.hash())?,
@@ -193,6 +196,7 @@ where
 
             // TODO: proof should be a CompactProof.
             FraudProof {
+                domain_id,
                 bad_signed_bundle_hash,
                 parent_number,
                 parent_hash: as_h256(&parent_header.hash())?,

--- a/domains/client/domain-executor/src/gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/gossip_message_validator.rs
@@ -8,7 +8,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CodeExecutor, SpawnNamed};
 use sp_core::H256;
 use sp_domains::fraud_proof::FraudProof;
-use sp_domains::{ExecutorApi, ExecutorPublicKey};
+use sp_domains::{DomainId, ExecutorApi, ExecutorPublicKey};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT};
 use std::sync::Arc;
@@ -155,6 +155,7 @@ where
         signed_bundle_hash: H256,
         execution_receipt: &ExecutionReceiptFor<PBlock, Block::Hash>,
         head_receipt_number: BlockNumber,
+        domain_id: DomainId,
     ) -> Result<Option<FraudProof>, GossipMessageError> {
         let primary_number = to_number_primitive(execution_receipt.primary_number);
 
@@ -198,6 +199,7 @@ where
 
         if let Some(trace_mismatch_index) = find_trace_mismatch(&local_receipt, execution_receipt) {
             let fraud_proof = self.fraud_proof_generator.generate_proof(
+                domain_id,
                 trace_mismatch_index,
                 &local_receipt,
                 signed_bundle_hash,

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -164,6 +164,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
     let parent_number_ferdie = *header_ferdie.number();
 
     let valid_fraud_proof = FraudProof {
+        domain_id: DomainId::SYSTEM,
         bad_signed_bundle_hash: Hash::random(),
         parent_number: parent_number_ferdie,
         parent_hash: parent_hash_ferdie,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -878,17 +878,19 @@ fn extract_receipts(
         .collect()
 }
 
-fn extract_fraud_proofs(extrinsics: Vec<UncheckedExtrinsic>) -> Vec<FraudProof> {
+fn extract_fraud_proofs(
+    extrinsics: Vec<UncheckedExtrinsic>,
+    domain_id: DomainId,
+) -> Vec<FraudProof> {
     extrinsics
         .into_iter()
-        .filter_map(|uxt| {
-            if let RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof }) =
-                uxt.function
+        .filter_map(|uxt| match uxt.function {
+            RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof })
+                if fraud_proof.domain_id == domain_id =>
             {
                 Some(fraud_proof)
-            } else {
-                None
             }
+            _ => None,
         })
         .collect()
 }
@@ -1149,8 +1151,8 @@ impl_runtime_apis! {
             extract_receipts(extrinsics, domain_id)
         }
 
-        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>) -> Vec<FraudProof> {
-            extract_fraud_proofs(extrinsics)
+        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>, domain_id: DomainId) -> Vec<FraudProof> {
+            extract_fraud_proofs(extrinsics, domain_id)
         }
 
         fn extrinsics_shuffling_seed(header: <Block as BlockT>::Header) -> Randomness {


### PR DESCRIPTION
fix #990 

The first commit adding a `domain_id` field to `FraudProof` is a preparation for the fix. And the second commit uses the `domain_id` field in `FraudProof` to identify the correct fraud-proof that needs to be handled for the cases mentioned in #990 


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
