### PR TITLE
fix rust.yaml

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,11 +12,12 @@ on:
       - '**.md'
       - '.github/CODEOWNERS'
   workflow_dispatch:
-    test-macos:
-      description: 'Whether to run macOS tests'
-      required: true
-      default: false
-      type: boolean
+    inputs:
+      test-macos:
+        description: 'Whether to run macOS tests'
+        required: true
+        default: false
+        type: boolean
 
 env:
   # Not needed in CI, should make things a bit faster


### PR DESCRIPTION
we need `inputs:` before the arguments

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
