### PR TITLE
Remove incorrect assertion on primary block number in bundle processor

### DIFF
--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -16,7 +16,7 @@ use sp_core::traits::CodeExecutor;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::{DomainId, ExecutionReceipt, ExecutorApi, OpaqueBundles};
 use sp_runtime::generic::BlockId;
-use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT, One};
+use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT};
 use sp_runtime::Digest;
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -175,12 +175,6 @@ where
         digests: Digest,
     ) -> Result<DomainBlockResult<Block, PBlock>, sp_blockchain::Error> {
         let primary_number = to_number_primitive(primary_number);
-
-        assert_eq!(
-            Into::<NumberFor<Block>>::into(primary_number),
-            parent_number + One::one(),
-            "New secondary best number must be equal to the primary number"
-        );
 
         let (header_hash, header_number, state_root) = self
             .build_and_import_block(


### PR DESCRIPTION
After some observation and thinking on executor panic during gemini-3a, I realize this assertion essentially expects the best number of domain chain increases strictly by 1, which is incorrect because the domain chain is entirely driven by the primary chain and the primary chain fork is legally possible.

This commit removes it as the domain already follows the fork choice of primary chain, that being said, the domain chain forks when the primary chain fork occurs.



Close #890

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
