### PR TITLE
simplify workflow

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -125,6 +125,11 @@ jobs:
           - ubuntu-22.04
           - macos-12
           - windows-2022
+        run-macos: 
+          - ${{ inputs.test-macos == true || github.ref == 'refs/heads/main' }}
+        exclude: # excludes macos-12 from the matrices if `run-macos` is false
+          - run-macos: false
+            os: macos-12
 
     runs-on: ${{ matrix.os }}
 
@@ -154,4 +159,3 @@ jobs:
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
         with:
           command: test
-        if: runner.os != 'macOS' || inputs.test-macos == true || github.ref == 'refs/heads/main'

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -125,13 +125,14 @@ jobs:
           - ubuntu-22.04
           - macos-12
           - windows-2022
-        run-macos: 
+        run-macos:
           - ${{ inputs.test-macos == true || github.ref == 'refs/heads/main' }}
         exclude: # excludes macos-12 from the matrices if `run-macos` is false
           - run-macos: false
             os: macos-12
 
     runs-on: ${{ matrix.os }}
+    name: cargo-test (${{ matrix.os }})
 
     steps:
       - name: Checkout


### PR DESCRIPTION
With this change, we don't have to put conditions for each step. The specified `os` will be excluded from the matrices, and no runner will be assigned to that `os` for that job.

I just tried to refactor the current workflow. However, if wanted, the following can be done:
- remove also windows from the jobs (ofc, still be run on main and manual dispatch)
- remove macos or windows from other jobs as well (like clippy or fmt)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
