### PR TITLE
Update API with GATs and change `RecordStorage` API

### DIFF
--- a/crates/subspace-networking/src/behavior/custom_record_store.rs
+++ b/crates/subspace-networking/src/behavior/custom_record_store.rs
@@ -145,8 +145,7 @@ impl ProviderStorage for MemoryProviderStorage {
         entry.and_modify(|e| e.retain(|rec| rec.provider != *provider));
     }
 }
-// TODO: Consider adding a generic lifetime when we upgrade the compiler to 1.65 (GAT feature)
-// fn records(&'_ self) -> Self::RecordsIter<'_>;
+
 pub trait RecordStorage {
     /// Gets a record from the store, given its key.
     fn get(&'_ self, k: &Key) -> Option<Cow<'_, Record>>;

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -117,11 +117,8 @@ where
     }
 }
 
-impl<'a, AS> RecordStorage<'a> for PieceCache<AS>
-where
-    AS: AuxStore + 'a,
-{
-    fn get(&'a self, key: &Key) -> Option<Cow<'_, Record>> {
+impl<AS: AuxStore> RecordStorage for PieceCache<AS> {
+    fn get(&'_ self, key: &Key) -> Option<Cow<'_, Record>> {
         let get_result = self.get_piece_by_index_multihash(key.as_ref());
 
         match get_result {


### PR DESCRIPTION
This pr adds a cosmetic change needed for GATs and changes `RecordStorage::get` to return `Cow` bounded by `self` lifetime. It is needed by sdk (in [this pr](https://github.com/subspace/subspace-sdk/pull/93)).

The problem was in `subspace_sdk::networking::MaybeRecordStorage` which is a wrapper around `Arc<Mutex<Storage>>`. I couldn't return propper `Cow` for the `RecordStorage::get` (yes, even the `Cow::Owned` didn't work).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
