### PR TITLE
Disable fraud-proof until it's handled properly

### DIFF
--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -309,6 +309,8 @@ where
         Ok((header_hash, header_number, state_root))
     }
 
+    // TODO: remove once fraud-proof is enabled again.
+    #[allow(unreachable_code, unused_variables)]
     pub(crate) fn on_domain_block_processed(
         &self,
         primary_hash: PBlock::Hash,
@@ -330,6 +332,10 @@ where
         )?;
 
         // TODO: The applied txs can be fully removed from the transaction pool
+
+        // TODO: Skip fraud-proof processing until
+        // https://github.com/subspace/subspace/issues/1020 is resolved.
+        return Ok(None);
 
         self.check_receipts_in_primary_block(primary_hash)?;
 


### PR DESCRIPTION
In terms of the domains, now only the work on the happy path is testable, we haven't taken care of the unhappy path. This commit disables the fraud-proof processing for now, we'll enable it after https://github.com/subspace/subspace/issues/1020 is closed.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
