### PR TITLE
Check if core domain receipt points to a valid primary block in pallet-domain-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
+ "sp-domain-digests",
  "sp-domain-tracker",
  "sp-domains",
  "sp-executor-registry",

--- a/domains/client/domain-executor/src/system_bundle_processor.rs
+++ b/domains/client/domain-executor/src/system_bundle_processor.rs
@@ -106,12 +106,18 @@ where
             .client
             .header(BlockId::Hash(parent_hash))?
             .map(|header| {
-                let item = AsPredigest::system_domain_state_root_update(StateRootUpdate {
-                    number: parent_number,
-                    state_root: *header.state_root(),
-                });
+                let system_domain_state_root =
+                    AsPredigest::system_domain_state_root_update(StateRootUpdate {
+                        number: parent_number,
+                        state_root: *header.state_root(),
+                    });
 
-                Digest { logs: vec![item] }
+                let primary_block_info: sp_runtime::DigestItem =
+                    AsPredigest::primary_block_info((primary_number, primary_hash));
+
+                Digest {
+                    logs: vec![system_domain_state_root, primary_block_info],
+                }
             })
             .unwrap_or_default();
 

--- a/domains/client/domain-executor/src/system_bundle_processor.rs
+++ b/domains/client/domain-executor/src/system_bundle_processor.rs
@@ -14,7 +14,7 @@ use sp_domains::ExecutorApi;
 use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT};
-use sp_runtime::Digest;
+use sp_runtime::{Digest, DigestItem};
 use std::borrow::Cow;
 use std::sync::Arc;
 use subspace_core_primitives::Randomness;
@@ -107,13 +107,13 @@ where
             .header(BlockId::Hash(parent_hash))?
             .map(|header| {
                 let system_domain_state_root =
-                    AsPredigest::system_domain_state_root_update(StateRootUpdate {
+                    DigestItem::system_domain_state_root_update(StateRootUpdate {
                         number: parent_number,
                         state_root: *header.state_root(),
                     });
 
-                let primary_block_info: sp_runtime::DigestItem =
-                    AsPredigest::primary_block_info((primary_number, primary_hash));
+                let primary_block_info =
+                    DigestItem::primary_block_info((primary_number, primary_hash));
 
                 Digest {
                     logs: vec![system_domain_state_root, primary_block_info],

--- a/domains/pallets/domain-registry/Cargo.toml
+++ b/domains/pallets/domain-registry/Cargo.toml
@@ -20,6 +20,7 @@ scale-info = { version = "2.3.1", default-features = false, features = ["derive"
 serde = { version = "1.0.147", optional = true }
 sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", default-features = false }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains", default-features = false }
+sp-domain-digests = { version = "0.1.0", path = "../../primitives/digests", default-features = false }
 sp-domain-tracker = { version = "0.1.0", path = "../../primitives/domain-tracker", default-features = false }
 sp-executor-registry = { version = "0.1.0", path = "../../primitives/executor-registry", default-features = false }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "6d57dbc639bb3d9460dabeccb063cc6556452535", default-features = false }
@@ -43,6 +44,7 @@ std = [
 	"serde/std",
 	"sp-core/std",
 	"sp-domains/std",
+	"sp-domain-digests/std",
 	"sp-domain-tracker/std",
 	"sp-executor-registry/std",
 	"sp-runtime/std",

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -235,6 +235,9 @@ mod pallet {
     /// The oldest block hash will be pruned once the oldest receipt is pruned. However, if a
     /// core domain stalls, i.e., no receipts are included in the system domain for a long time,
     /// the corresponding entry will grow indefinitely.
+    ///
+    /// TODO: there is a pitfall that any stalled domain can lead to an ubounded runtime storage
+    /// growth.
     #[pallet::storage]
     pub(super) type BlockHash<T: Config> = StorageDoubleMap<
         _,

--- a/domains/primitives/digests/src/lib.rs
+++ b/domains/primitives/digests/src/lib.rs
@@ -6,6 +6,8 @@ use sp_runtime::{ConsensusEngineId, DigestItem};
 
 const DOMAIN_ENGINE_ID: ConsensusEngineId = *b"DMN_";
 
+const DOMAIN_REGISTRY_ENGINE_ID: ConsensusEngineId = *b"RGTR";
+
 /// Trait to provide simpler abstractions to create predigests for runtime.
 pub trait AsPredigest {
     /// Returns state root update digest
@@ -17,6 +19,12 @@ pub trait AsPredigest {
     fn system_domain_state_root_update<Number: Encode, StateRoot: Encode>(
         update: StateRootUpdate<Number, StateRoot>,
     ) -> Self;
+
+    /// Returna a pair of (primary_block_number, primary_block_hash).
+    fn as_primary_block_info<Number: Decode, Hash: Decode>(&self) -> Option<(Number, Hash)>;
+
+    /// Creates a new digest of primary block info for system domain.
+    fn primary_block_info<Number: Encode, Hash: Encode>(info: (Number, Hash)) -> Self;
 }
 
 impl AsPredigest for DigestItem {
@@ -30,5 +38,14 @@ impl AsPredigest for DigestItem {
         update: StateRootUpdate<Number, StateRoot>,
     ) -> Self {
         DigestItem::PreRuntime(DOMAIN_ENGINE_ID, update.encode())
+    }
+
+    /// Returna a pair of (primary_block_number, primary_block_hash).
+    fn as_primary_block_info<Number: Decode, Hash: Decode>(&self) -> Option<(Number, Hash)> {
+        self.pre_runtime_try_to(&DOMAIN_REGISTRY_ENGINE_ID)
+    }
+
+    fn primary_block_info<Number: Encode, Hash: Encode>(info: (Number, Hash)) -> Self {
+        DigestItem::PreRuntime(DOMAIN_REGISTRY_ENGINE_ID, info.encode())
     }
 }


### PR DESCRIPTION
There is a problem before: when a core domain stalls while the system domain proceeds as normal, once it's deep enough, the `BlockHash` in pallet-domains will be pruned along with the expired receipt pruning, in that sense, when the core domain resumes later, pallet-domains can not verify if the domain receipt points to a valid primary block. The solution is to maintain a `BlockHash` for each non-system domain in pallet-domain-registry, the pair of (primary_block_number, primary_block_hash) is fed into the system domain in a header digest.

What this PR does is to make pallet-domains(primary chain) only check if the system domain receipt points to a valid primary block, the same check on core domain receipt is handled in pallet-domain-registry(system domain).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
