### PR TITLE
Rename `execution_wasm_bundle()` to `system_domain_wasm_bundle()` and other trivial cleanups

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -405,13 +405,13 @@ sp_api::decl_runtime_apis! {
         ) -> Vec<ExecutionReceipt<NumberFor<Block>, Block::Hash, DomainHash>>;
 
         /// Extract the fraud proofs from the given extrinsics.
-        fn extract_fraud_proofs(extrinsics: Vec<Block::Extrinsic>, domain_id: DomainId,) -> Vec<FraudProof>;
+        fn extract_fraud_proofs(extrinsics: Vec<Block::Extrinsic>, domain_id: DomainId) -> Vec<FraudProof>;
 
         /// Generates a randomness seed for extrinsics shuffling.
         fn extrinsics_shuffling_seed(header: Block::Header) -> Randomness;
 
-        /// WASM bundle for execution runtime.
-        fn execution_wasm_bundle() -> Cow<'static, [u8]>;
+        /// WASM bundle for system domain runtime.
+        fn system_domain_wasm_bundle() -> Cow<'static, [u8]>;
 
         /// Returns the best execution chain number.
         fn head_receipt_number() -> NumberFor<Block>;

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -244,7 +244,7 @@ where
         let wasm_bundle = self
             .client
             .runtime_api()
-            .execution_wasm_bundle(&BlockId::Hash(at))
+            .system_domain_wasm_bundle(&BlockId::Hash(at))
             .map_err(VerificationError::RuntimeApi)?;
 
         let code_fetcher = RuntimCodeFetcher {

--- a/crates/subspace-runtime/build.rs
+++ b/crates/subspace-runtime/build.rs
@@ -17,9 +17,9 @@
 fn main() {
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
         "system-domain-runtime",
-        "EXECUTION_WASM_BUNDLE",
+        "SYSTEM_DOMAIN_WASM_BUNDLE",
         None,
-        "execution_wasm_bundle.rs",
+        "system_domain_wasm_bundle.rs",
     );
 
     #[cfg(feature = "std")]

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -26,8 +26,8 @@ mod object_mapping;
 mod signed_extensions;
 mod weights;
 
-// Make execution WASM runtime available.
-include!(concat!(env!("OUT_DIR"), "/execution_wasm_bundle.rs"));
+// Make system domain WASM runtime available.
+include!(concat!(env!("OUT_DIR"), "/system_domain_wasm_bundle.rs"));
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -695,13 +695,17 @@ impl_runtime_apis! {
     }
 
     impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
-        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic) -> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
+        fn extract_pre_validation_object(
+            extrinsic: <Block as BlockT>::Extrinsic,
+        ) -> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
             crate::domains::extract_pre_validation_object(extrinsic)
         }
     }
 
     impl sp_domains::ExecutorApi<Block, domain_runtime_primitives::Hash> for Runtime {
-        fn submit_bundle_unsigned(opaque_bundle: SignedOpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, domain_runtime_primitives::Hash>) {
+        fn submit_bundle_unsigned(
+            opaque_bundle: SignedOpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, domain_runtime_primitives::Hash>,
+        ) {
             Domains::submit_bundle_unsigned(opaque_bundle)
         }
 
@@ -744,7 +748,7 @@ impl_runtime_apis! {
             crate::domains::extract_receipts(extrinsics, domain_id)
         }
 
-        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>, domain_id: DomainId,) -> Vec<FraudProof> {
+        fn extract_fraud_proofs(extrinsics: Vec<<Block as BlockT>::Extrinsic>, domain_id: DomainId) -> Vec<FraudProof> {
             crate::domains::extract_fraud_proofs(extrinsics, domain_id)
         }
 
@@ -752,8 +756,8 @@ impl_runtime_apis! {
             crate::domains::extrinsics_shuffling_seed::<Block>(header)
         }
 
-        fn execution_wasm_bundle() -> Cow<'static, [u8]> {
-            EXECUTION_WASM_BUNDLE.into()
+        fn system_domain_wasm_bundle() -> Cow<'static, [u8]> {
+            SYSTEM_DOMAIN_WASM_BUNDLE.into()
         }
 
         fn head_receipt_number() -> NumberFor<Block> {

--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -298,7 +298,7 @@ where
     {
         let system_domain_runtime = primary_chain_client
             .runtime_api()
-            .execution_wasm_bundle(&block_id)?;
+            .system_domain_wasm_bundle(&block_id)?;
 
         let new_runtime = match domain_id {
             DomainId::SYSTEM => system_domain_runtime,

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -343,7 +343,7 @@ async fn extract_core_domain_wasm_bundle_in_system_domain_runtime_should_work() 
     let system_domain_bundle = ferdie
         .client
         .runtime_api()
-        .execution_wasm_bundle(&BlockId::Hash(ferdie.client.info().best_hash))
+        .system_domain_wasm_bundle(&BlockId::Hash(ferdie.client.info().best_hash))
         .unwrap();
 
     let core_payments_runtime_blob =
@@ -351,7 +351,6 @@ async fn extract_core_domain_wasm_bundle_in_system_domain_runtime_should_work() 
             .unwrap();
 
     let core_payments_blob = RuntimeBlob::new(&core_payments_runtime_blob).unwrap();
-
     let core_payments_version = sc_executor::read_embedded_version(&core_payments_blob)
         .unwrap()
         .unwrap();

--- a/domains/test/runtime/src/runtime.rs
+++ b/domains/test/runtime/src/runtime.rs
@@ -107,12 +107,12 @@ impl_opaque_keys! {
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace-executor"),
     impl_name: create_runtime_str!("subspace-executor"),
-    authoring_version: 1,
-    spec_version: 1,
+    authoring_version: 0,
+    spec_version: 0,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 1,
-    state_version: 1,
+    transaction_version: 0,
+    state_version: 0,
 };
 
 /// The existential deposit. Same with the one on primary chain.
@@ -517,12 +517,28 @@ impl_runtime_apis! {
                 .collect()
         }
 
-        fn bundle_elections_params(_domain_id: DomainId) -> BundleElectionParams {
-            // TODO: support all kinds of domains.
-            BundleElectionParams {
-                authorities: ExecutorRegistry::authorities().into(),
-                total_stake_weight: ExecutorRegistry::total_stake_weight(),
-                slot_probability: ExecutorRegistry::slot_probability(),
+        fn bundle_elections_params(domain_id: DomainId) -> BundleElectionParams {
+            if domain_id.is_system() {
+                BundleElectionParams {
+                    authorities: ExecutorRegistry::authorities().into(),
+                    total_stake_weight: ExecutorRegistry::total_stake_weight(),
+                    slot_probability: ExecutorRegistry::slot_probability(),
+                }
+            } else {
+                match (
+                    DomainRegistry::domain_authorities(domain_id),
+                    DomainRegistry::domain_total_stake_weight(domain_id),
+                    DomainRegistry::domain_slot_probability(domain_id),
+                ) {
+                    (authorities, Some(total_stake_weight), Some(slot_probability)) => {
+                        BundleElectionParams {
+                            authorities,
+                            total_stake_weight,
+                            slot_probability,
+                        }
+                    }
+                    _ => BundleElectionParams::empty(),
+                }
             }
         }
 

--- a/test/subspace-test-runtime/build.rs
+++ b/test/subspace-test-runtime/build.rs
@@ -17,9 +17,9 @@
 fn main() {
     subspace_wasm_tools::create_runtime_bundle_inclusion_file(
         "domain-test-runtime",
-        "EXECUTION_WASM_BUNDLE",
+        "TEST_DOMAIN_WASM_BUNDLE",
         None,
-        "execution_wasm_bundle.rs",
+        "test_domain_wasm_bundle.rs",
     );
 
     #[cfg(feature = "std")]

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -19,8 +19,8 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
-// Make execution WASM runtime available.
-include!(concat!(env!("OUT_DIR"), "/execution_wasm_bundle.rs"));
+// Make `domain-test-runtime` WASM runtime available.
+include!(concat!(env!("OUT_DIR"), "/test_domain_wasm_bundle.rs"));
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -1111,13 +1111,17 @@ impl_runtime_apis! {
     }
 
     impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
-        fn extract_pre_validation_object(extrinsic: <Block as BlockT>::Extrinsic)-> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
+        fn extract_pre_validation_object(
+            extrinsic: <Block as BlockT>::Extrinsic,
+        )-> sp_domains::transaction::PreValidationObject<Block, domain_runtime_primitives::Hash> {
             extract_pre_validation_object(extrinsic)
         }
     }
 
     impl sp_domains::ExecutorApi<Block, domain_runtime_primitives::Hash> for Runtime {
-        fn submit_bundle_unsigned(opaque_bundle: SignedOpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, domain_runtime_primitives::Hash>) {
+        fn submit_bundle_unsigned(
+            opaque_bundle: SignedOpaqueBundle<NumberFor<Block>, <Block as BlockT>::Hash, domain_runtime_primitives::Hash>,
+        ) {
             Domains::submit_bundle_unsigned(opaque_bundle)
         }
 
@@ -1168,8 +1172,8 @@ impl_runtime_apis! {
             extrinsics_shuffling_seed::<Block>(header)
         }
 
-        fn execution_wasm_bundle() -> Cow<'static, [u8]> {
-            EXECUTION_WASM_BUNDLE.into()
+        fn system_domain_wasm_bundle() -> Cow<'static, [u8]> {
+            TEST_DOMAIN_WASM_BUNDLE.into()
         }
 
         fn head_receipt_number() -> NumberFor<Block> {


### PR DESCRIPTION
A tiny PR to primarily rename runtime API` execution_wasm_bundle()` to be more specific `system_domain_wasm_bundle()` and fix some leftovers in the test env, with no logical changes to the production code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
