### PR TITLE
Ensure receipts are consecutive

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -518,8 +518,12 @@ impl<T: Config> Pallet<T> {
     fn receipts_are_consecutive(
         receipts: &[ExecutionReceipt<T::BlockNumber, T::Hash, T::DomainHash>],
     ) -> bool {
-        (0..receipts.len() - 1)
-            .all(|i| receipts[i].primary_number + One::one() == receipts[i + 1].primary_number)
+        if receipts.len() > 1 {
+            (0..receipts.len() - 1)
+                .all(|i| receipts[i].primary_number + One::one() == receipts[i + 1].primary_number)
+        } else {
+            true
+        }
     }
 
     fn pre_dispatch_submit_bundle(

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -501,4 +501,6 @@ fn test_receipts_are_consecutive() {
         create_dummy_receipt(4, Hash::random()),
     ];
     assert!(!Domains::receipts_are_consecutive(&receipts));
+    let receipts = vec![create_dummy_receipt(1, Hash::random())];
+    assert!(Domains::receipts_are_consecutive(&receipts));
 }

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -486,3 +486,19 @@ fn submit_fraud_proof_should_work() {
         });
     });
 }
+
+#[test]
+fn test_receipts_are_consecutive() {
+    let receipts = vec![
+        create_dummy_receipt(1, Hash::random()),
+        create_dummy_receipt(2, Hash::random()),
+        create_dummy_receipt(3, Hash::random()),
+    ];
+    assert!(Domains::receipts_are_consecutive(&receipts));
+    let receipts = vec![
+        create_dummy_receipt(1, Hash::random()),
+        create_dummy_receipt(2, Hash::random()),
+        create_dummy_receipt(4, Hash::random()),
+    ];
+    assert!(!Domains::receipts_are_consecutive(&receipts));
+}


### PR DESCRIPTION
Previously, pallet-domains only checks whether the receipts in a bundle are sorted which is unable to detect if some receipt is skipped, in another word, we should check if the receipts are consecutive instead of sorted,  [1, 2, 4] is true regarding `is_sorted`, but not consecutive.

~~I'm still looking for the reason of producing consecutive receipts, which makes no sense to me by looking at the related code https://github.com/subspace/subspace/blob/bfda79167f/domains/client/domain-executor/src/domain_bundle_proposer.rs#L174-L180~~. Update: the inconsecutive receipts are essentially caused by #1034. When a primary chain fork occurs, e.g., on the fork block at the same height 13638, the new domain block is 13639, but the receipt for domain block 13639 still [uses the primary number](https://github.com/subspace/subspace/blob/bfda79167f/domains/client/domain-executor/src/domain_block_processor.rs#L218) which is 13638, leading to the inconsecutive receipts because two receipts pointing to the same height 13638.

This glitch does not corrupt gemini-3b as the invalid bundle won't go through the missing receipt checking.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
