### PR TITLE
Verify the core domain fraud proof in the system domain's transaction pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10039,6 +10039,7 @@ name = "subspace-wasm-tools"
 version = "0.1.0"
 dependencies = [
  "sc-executor-common",
+ "sp-domains",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "subspace-runtime-primitives",
  "subspace-test-runtime",
  "subspace-test-service",
+ "subspace-wasm-tools",
  "substrate-test-runtime-client",
  "substrate-test-utils",
  "system-runtime-primitives",
@@ -2316,7 +2317,9 @@ dependencies = [
  "sp-session",
  "sp-transaction-pool",
  "subspace-core-primitives",
+ "subspace-fraud-proof",
  "subspace-runtime-primitives",
+ "subspace-transaction-pool",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "system-runtime-primitives",
@@ -9651,6 +9654,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
+ "subspace-wasm-tools",
  "substrate-test-utils",
  "tempfile",
  "tokio",
@@ -9867,6 +9871,7 @@ dependencies = [
  "subspace-fraud-proof",
  "subspace-networking",
  "subspace-runtime-primitives",
+ "subspace-transaction-pool",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -9984,10 +9989,33 @@ dependencies = [
  "subspace-service",
  "subspace-test-client",
  "subspace-test-runtime",
+ "subspace-transaction-pool",
  "substrate-test-client",
  "substrate-test-utils",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "subspace-transaction-pool"
+version = "0.1.0"
+dependencies = [
+ "domain-runtime-primitives",
+ "futures 0.3.25",
+ "jsonrpsee",
+ "sc-client-api",
+ "sc-service",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-domains",
+ "sp-runtime",
+ "sp-transaction-pool",
+ "subspace-fraud-proof",
+ "substrate-prometheus-endpoint",
+ "tracing",
 ]
 
 [[package]]
@@ -10009,6 +10037,9 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
+dependencies = [
+ "sc-executor-common",
+]
 
 [[package]]
 name = "substrate-bip39"

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -119,6 +119,13 @@ pub enum VerificationError {
     #[cfg(feature = "std")]
     #[cfg_attr(feature = "thiserror", error("Runtime api error: {0}"))]
     RuntimeApi(#[from] sp_api::ApiError),
+    /// Fail to get runtime code.
+    // The `String` here actually repersenting the `sc_executor_common::error::WasmError`
+    // error, but it will be improper to use `WasmError` directly here since it will make
+    // `sp-domain` (a runtime crate) depend on `sc_executor_common` (a client crate).
+    #[cfg(feature = "std")]
+    #[cfg_attr(feature = "thiserror", error("Failed to get runtime code: {0}"))]
+    RuntimeCode(String),
 }
 
 /// Fraud proof for the state computation.

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -22,6 +22,7 @@ sp-domains = { version = "0.1.0", path = "../sp-domains" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+subspace-wasm-tools = { version = "0.1.0", path = "../subspace-wasm-tools" }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -17,7 +17,7 @@ use sp_api::{ProvideRuntimeApi, StorageProof};
 use sp_core::traits::{CodeExecutor, FetchRuntimeCode, RuntimeCode, SpawnNamed};
 use sp_core::H256;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof, VerificationError};
-use sp_domains::ExecutorApi;
+use sp_domains::{DomainId, ExecutorApi};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, HashFor};
 use sp_state_machine::backend::AsTrieBackend;
@@ -25,6 +25,7 @@ use sp_state_machine::{TrieBackend, TrieBackendBuilder, TrieBackendStorage};
 use sp_trie::DBValue;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use subspace_wasm_tools::read_core_domain_runtime_blob;
 
 /// Creates storage proof for verifying an execution without owning the whole state.
 pub struct ExecutionProver<Block, B, Exec> {
@@ -231,6 +232,7 @@ where
     /// Verifies the fraud proof.
     pub fn verify(&self, proof: &FraudProof) -> Result<(), VerificationError> {
         let FraudProof {
+            domain_id,
             parent_hash,
             pre_state_root,
             post_state_root,
@@ -239,13 +241,33 @@ where
             ..
         } = proof;
 
+        let domain_id = *domain_id;
         let at = PBlock::Hash::decode(&mut parent_hash.encode().as_slice())
             .expect("Block Hash must be H256; qed");
-        let wasm_bundle = self
+        let system_wasm_bundle = self
             .client
             .runtime_api()
             .system_domain_wasm_bundle(&BlockId::Hash(at))
             .map_err(VerificationError::RuntimeApi)?;
+
+        let wasm_bundle = match domain_id {
+            DomainId::SYSTEM => system_wasm_bundle,
+            DomainId::CORE_PAYMENTS => read_core_domain_runtime_blob(
+                system_wasm_bundle.as_ref(),
+                domain_id.link_section_name(),
+            )
+            .map_err(|err| {
+                VerificationError::RuntimeCode(format!(
+                    "failed to read core domain {domain_id:?} runtime blob file, error {err:?}"
+                ))
+            })?
+            .into(),
+            _ => {
+                return Err(VerificationError::RuntimeCode(format!(
+                    "No runtime code for {domain_id:?}"
+                )));
+            }
+        };
 
         let code_fetcher = RuntimCodeFetcher {
             wasm_bundle: &wasm_bundle,

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -241,7 +241,6 @@ where
             ..
         } = proof;
 
-        let domain_id = *domain_id;
         let at = PBlock::Hash::decode(&mut parent_hash.encode().as_slice())
             .expect("Block Hash must be H256; qed");
         let system_wasm_bundle = self
@@ -250,18 +249,17 @@ where
             .system_domain_wasm_bundle(&BlockId::Hash(at))
             .map_err(VerificationError::RuntimeApi)?;
 
-        let wasm_bundle = match domain_id {
+        let wasm_bundle = match *domain_id {
             DomainId::SYSTEM => system_wasm_bundle,
-            DomainId::CORE_PAYMENTS => read_core_domain_runtime_blob(
-                system_wasm_bundle.as_ref(),
-                domain_id.link_section_name(),
-            )
-            .map_err(|err| {
-                VerificationError::RuntimeCode(format!(
+            DomainId::CORE_PAYMENTS => {
+                read_core_domain_runtime_blob(system_wasm_bundle.as_ref(), *domain_id)
+                    .map_err(|err| {
+                        VerificationError::RuntimeCode(format!(
                     "failed to read core domain {domain_id:?} runtime blob file, error {err:?}"
                 ))
-            })?
-            .into(),
+                    })?
+                    .into()
+            }
             _ => {
                 return Err(VerificationError::RuntimeCode(format!(
                     "No runtime code for {domain_id:?}"

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -528,6 +528,7 @@ fn main() -> Result<(), Error> {
                     >(
                         secondary_chain_config,
                         primary_chain_node.client.clone(),
+                        primary_chain_node.backend.clone(),
                         primary_chain_node.network.clone(),
                         &primary_chain_node.select_chain,
                         imported_block_notification_stream(),

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -62,6 +62,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
+subspace-transaction-pool = { version = "0.1.0", path = "../subspace-transaction-pool" }
 substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 thiserror = "1.0.32"

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -19,12 +19,10 @@
 
 mod dsn;
 pub mod piece_cache;
-mod pool;
 pub mod rpc;
 
 use crate::dsn::create_dsn_instance;
 use crate::piece_cache::PieceCache;
-pub use crate::pool::FullPool;
 use derive_more::{Deref, DerefMut, Into};
 use domain_runtime_primitives::Hash as DomainHash;
 use dsn::start_dsn_archiver;
@@ -74,6 +72,7 @@ use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::Node;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Hash, Index as Nonce};
+use subspace_transaction_pool::FullPool;
 use tracing::{error, info, Instrument};
 
 /// Error type for Subspace service.
@@ -251,7 +250,7 @@ where
         executor,
         task_manager.spawn_handle(),
     );
-    let transaction_pool = pool::new_full(
+    let transaction_pool = subspace_transaction_pool::new_full(
         config,
         &task_manager,
         client.clone(),

--- a/crates/subspace-transaction-pool/Cargo.toml
+++ b/crates/subspace-transaction-pool/Cargo.toml
@@ -9,18 +9,18 @@ edition = "2021"
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 futures = "0.3.25"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809", default-features = false }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
-sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f", default-features = false }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
-sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 tracing = "0.1.37"
 
 [features]

--- a/crates/subspace-transaction-pool/Cargo.toml
+++ b/crates/subspace-transaction-pool/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "subspace-transaction-pool"
 version = "0.1.0"
+authors = ["Subspace Labs <https://subspace.network>"]
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace"
+description = "Subspace transaction pool"
 
 [dependencies]
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
@@ -22,6 +25,3 @@ sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspac
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
 substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 tracing = "0.1.37"
-
-[features]
-default = []

--- a/crates/subspace-transaction-pool/Cargo.toml
+++ b/crates/subspace-transaction-pool/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "subspace-transaction-pool"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
+futures = "0.3.25"
+jsonrpsee = { version = "0.16.2", features = ["server"] }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809", default-features = false }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sp-domains = { version = "0.1.0", path = "../sp-domains" }
+sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+tracing = "0.1.37"
+
+[features]
+default = []

--- a/crates/subspace-transaction-pool/src/lib.rs
+++ b/crates/subspace-transaction-pool/src/lib.rs
@@ -447,7 +447,7 @@ where
     }
 }
 
-pub(super) fn new_full<Block, Client, Verifier>(
+pub fn new_full<Block, Client, Verifier>(
     config: &Configuration,
     task_manager: &TaskManager,
     client: Arc<Client>,

--- a/crates/subspace-wasm-tools/Cargo.toml
+++ b/crates/subspace-wasm-tools/Cargo.toml
@@ -11,4 +11,4 @@ include = [
 ]
 
 [dependencies]
-sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }
+sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }

--- a/crates/subspace-wasm-tools/Cargo.toml
+++ b/crates/subspace-wasm-tools/Cargo.toml
@@ -9,3 +9,6 @@ include = [
     "/src",
     "/Cargo.toml",
 ]
+
+[dependencies]
+sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "4682b676af9087e8b5c946c383f75d74633d6809" }

--- a/crates/subspace-wasm-tools/Cargo.toml
+++ b/crates/subspace-wasm-tools/Cargo.toml
@@ -12,3 +12,4 @@ include = [
 
 [dependencies]
 sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
+sp-domains = { version = "0.1.0", path = "../sp-domains" }

--- a/crates/subspace-wasm-tools/src/lib.rs
+++ b/crates/subspace-wasm-tools/src/lib.rs
@@ -1,5 +1,6 @@
 use sc_executor_common::error::WasmError;
 use sc_executor_common::runtime_blob::RuntimeBlob;
+use sp_domains::DomainId;
 use std::path::PathBuf;
 use std::{env, fs};
 
@@ -86,15 +87,14 @@ pub fn create_runtime_bundle_inclusion_file(
     });
 }
 
-/// Read the core domain runtime blob file from the system domain runtime blob file.
-///
-/// The `section_contents_name` should be driven from `DomainId::link_section_name`.
+/// Read the core domain runtime blob from the system domain runtime blob.
 pub fn read_core_domain_runtime_blob(
     system_domain_bundle: &[u8],
-    section_contents_name: String,
+    core_domain_id: DomainId,
 ) -> Result<Vec<u8>, WasmError> {
     let system_runtime_blob = RuntimeBlob::new(system_domain_bundle)?;
 
+    let section_contents_name = core_domain_id.link_section_name();
     let embedded_runtime_blob = system_runtime_blob
         .custom_section_contents(&section_contents_name)
         .ok_or_else(|| {

--- a/domains/client/domain-executor/Cargo.toml
+++ b/domains/client/domain-executor/Cargo.toml
@@ -21,7 +21,6 @@ schnorrkel = "0.9.1"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
-sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
@@ -40,6 +39,7 @@ sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 subspace-fraud-proof = { version = "0.1.0", path = "../../../crates/subspace-fraud-proof" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
+subspace-wasm-tools = { version = "0.1.0", path = "../../../crates/subspace-wasm-tools" }
 system-runtime-primitives = { version = "0.1.0", path = "../../primitives/system-runtime" }
 tracing = "0.1.37"
 thiserror = "1.0.32"
@@ -51,6 +51,7 @@ domain-test-service = { version = "0.1.0", path = "../../test/service" }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 pallet-domains = { version = "0.1.0", path = "../../../crates/pallet-domains" }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f", default-features = false }
+sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f", default-features = false }
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 sp-keyring = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -1,8 +1,5 @@
 use crate::fraud_proof::{find_trace_mismatch, FraudProofGenerator};
-use crate::utils::{
-    read_core_domain_runtime_blob, shuffle_extrinsics, to_number_primitive, translate_number_type,
-    DomainBundles,
-};
+use crate::utils::{shuffle_extrinsics, to_number_primitive, translate_number_type, DomainBundles};
 use crate::{ExecutionReceiptFor, TransactionFor};
 use codec::{Decode, Encode};
 use domain_block_builder::{BlockBuilder, BuiltBlock, RecordProof};
@@ -24,6 +21,7 @@ use sp_runtime::Digest;
 use std::borrow::Cow;
 use std::sync::Arc;
 use subspace_core_primitives::Randomness;
+use subspace_wasm_tools::read_core_domain_runtime_blob;
 
 type DomainBlockElements<Block, PBlock> = (
     DomainBundles<Block, PBlock>,
@@ -66,11 +64,12 @@ where
 
         let new_runtime = match domain_id {
             DomainId::SYSTEM => system_domain_runtime,
-            DomainId::CORE_PAYMENTS => {
-                read_core_domain_runtime_blob(system_domain_runtime.as_ref(), domain_id)
-                    .map_err(|err| sp_blockchain::Error::Application(Box::new(err)))?
-                    .into()
-            }
+            DomainId::CORE_PAYMENTS => read_core_domain_runtime_blob(
+                system_domain_runtime.as_ref(),
+                domain_id.link_section_name(),
+            )
+            .map_err(|err| sp_blockchain::Error::Application(Box::new(err)))?
+            .into(),
             _ => {
                 return Err(sp_blockchain::Error::Application(Box::from(format!(
                     "No new runtime code for {domain_id:?}"

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -64,12 +64,11 @@ where
 
         let new_runtime = match domain_id {
             DomainId::SYSTEM => system_domain_runtime,
-            DomainId::CORE_PAYMENTS => read_core_domain_runtime_blob(
-                system_domain_runtime.as_ref(),
-                domain_id.link_section_name(),
-            )
-            .map_err(|err| sp_blockchain::Error::Application(Box::new(err)))?
-            .into(),
+            DomainId::CORE_PAYMENTS => {
+                read_core_domain_runtime_blob(system_domain_runtime.as_ref(), domain_id)
+                    .map_err(|err| sp_blockchain::Error::Application(Box::new(err)))?
+                    .into()
+            }
             _ => {
                 return Err(sp_blockchain::Error::Application(Box::from(format!(
                     "No new runtime code for {domain_id:?}"

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -1,4 +1,3 @@
-use crate::utils::read_core_domain_runtime_blob;
 use codec::{Decode, Encode};
 use domain_runtime_primitives::{DomainCoreApi, Hash};
 use domain_test_service::run_primary_chain_validator_node;
@@ -22,6 +21,7 @@ use sp_runtime::generic::{BlockId, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
 use std::collections::HashSet;
 use subspace_core_primitives::BlockNumber;
+use subspace_wasm_tools::read_core_domain_runtime_blob;
 use tempfile::TempDir;
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
@@ -341,9 +341,11 @@ async fn extract_core_domain_wasm_bundle_in_system_domain_runtime_should_work() 
         .system_domain_wasm_bundle(&BlockId::Hash(ferdie.client.info().best_hash))
         .unwrap();
 
-    let core_payments_runtime_blob =
-        read_core_domain_runtime_blob(system_domain_bundle.as_ref(), DomainId::CORE_PAYMENTS)
-            .unwrap();
+    let core_payments_runtime_blob = read_core_domain_runtime_blob(
+        system_domain_bundle.as_ref(),
+        DomainId::CORE_PAYMENTS.link_section_name(),
+    )
+    .unwrap();
 
     let core_payments_blob = RuntimeBlob::new(&core_payments_runtime_blob).unwrap();
     let core_payments_version = sc_executor::read_embedded_version(&core_payments_blob)

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -341,11 +341,9 @@ async fn extract_core_domain_wasm_bundle_in_system_domain_runtime_should_work() 
         .system_domain_wasm_bundle(&BlockId::Hash(ferdie.client.info().best_hash))
         .unwrap();
 
-    let core_payments_runtime_blob = read_core_domain_runtime_blob(
-        system_domain_bundle.as_ref(),
-        DomainId::CORE_PAYMENTS.link_section_name(),
-    )
-    .unwrap();
+    let core_payments_runtime_blob =
+        read_core_domain_runtime_blob(system_domain_bundle.as_ref(), DomainId::CORE_PAYMENTS)
+            .unwrap();
 
     let core_payments_blob = RuntimeBlob::new(&core_payments_runtime_blob).unwrap();
     let core_payments_version = sc_executor::read_embedded_version(&core_payments_blob)

--- a/domains/client/domain-executor/src/utils.rs
+++ b/domains/client/domain-executor/src/utils.rs
@@ -3,10 +3,8 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use sc_consensus::ForkChoiceStrategy;
-use sc_executor_common::error::WasmError;
-use sc_executor_common::runtime_blob::RuntimeBlob;
 use sp_consensus_slots::Slot;
-use sp_domains::{DomainId, OpaqueBundles, SignedOpaqueBundles};
+use sp_domains::{OpaqueBundles, SignedOpaqueBundles};
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryInto;
@@ -119,22 +117,6 @@ pub(crate) fn shuffle_extrinsics<Extrinsic: Debug>(
     tracing::trace!(?shuffled_extrinsics, "Shuffled extrinsics");
 
     shuffled_extrinsics
-}
-
-pub(crate) fn read_core_domain_runtime_blob(
-    system_domain_bundle: &[u8],
-    core_domain_id: DomainId,
-) -> Result<Vec<u8>, WasmError> {
-    let system_runtime_blob = RuntimeBlob::new(system_domain_bundle)?;
-
-    let section_contents_name = core_domain_id.link_section_name();
-    let embedded_runtime_blob = system_runtime_blob
-        .custom_section_contents(&section_contents_name)
-        .ok_or_else(|| {
-            WasmError::Other(format!("Custom section {section_contents_name} not found"))
-        })?;
-
-    Ok(embedded_runtime_blob.to_vec())
 }
 
 #[cfg(test)]

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -372,6 +372,8 @@ mod pallet {
             Ok(())
         }
 
+        // TODO: Rename this extrinsic since the core bundle is not submit to the transaction pool but crafted and injected
+        // on fly when building the system domain block.
         // TODO: proper weight
         #[pallet::call_index(5)]
         #[pallet::weight((10_000, Pays::No))]

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -629,9 +629,6 @@ impl_runtime_apis! {
                     RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_fraud_proof { fraud_proof }) => {
                         PreValidationObject::FraudProof(fraud_proof)
                     }
-                    RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_core_bundle {
-                        signed_opaque_bundle,
-                    }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
                     _ => PreValidationObject::Null,
                 }
         }

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -14,6 +14,7 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::OpaqueMetadata;
 use sp_domains::bundle_election::BundleElectionParams;
 use sp_domains::fraud_proof::FraudProof;
+use sp_domains::transaction::PreValidationObject;
 use sp_domains::{DomainId, ExecutorPublicKey, SignedOpaqueBundle};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{CrossDomainMessage, MessageId, RelayerMessagesWithStorageKey};
@@ -617,6 +618,22 @@ impl_runtime_apis! {
 
         fn should_relay_inbox_message_response(dst_domain_id: DomainId, msg_id: MessageId) -> bool {
             Messenger::should_relay_inbox_message_response(dst_domain_id, msg_id)
+        }
+    }
+
+    impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
+        fn extract_pre_validation_object(
+            extrinsic: <Block as BlockT>::Extrinsic,
+        ) -> PreValidationObject<Block, domain_runtime_primitives::Hash> {
+                match extrinsic.function {
+                    RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_fraud_proof { fraud_proof }) => {
+                        PreValidationObject::FraudProof(fraud_proof)
+                    }
+                    RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_core_bundle {
+                        signed_opaque_bundle,
+                    }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
+                    _ => PreValidationObject::Null,
+                }
         }
     }
 

--- a/domains/service/Cargo.toml
+++ b/domains/service/Cargo.toml
@@ -58,7 +58,9 @@ sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substra
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 system-runtime-primitives = { version = "0.1.0", path = "../primitives/system-runtime" }
 subspace-core-primitives = { version = "0.1.0", path = "../../crates/subspace-core-primitives" }
+subspace-fraud-proof = { version = "0.1.0", path = "../../crates/subspace-fraud-proof" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives" }
+subspace-transaction-pool = { version = "0.1.0", path = "../../crates/subspace-transaction-pool" }
 substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 
 [build-dependencies]

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -96,10 +96,7 @@ pub type FullPool<RuntimeApi, ExecutorDispatch> = sc_transaction_pool::BasicPool
     Block,
 >;
 
-/// Starts a `ServiceBuilder` for a full service.
-///
-/// Use this macro if you don't actually need the full service, but just the builder in order to
-/// be able to perform chain operations.
+/// Constructs a partial core domain node.
 #[allow(clippy::type_complexity)]
 fn new_partial<RuntimeApi, Executor>(
     config: &ServiceConfiguration,

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -1,4 +1,4 @@
-use crate::{new_partial, DomainConfiguration, FullBackend, FullClient, FullPool};
+use crate::{DomainConfiguration, FullBackend, FullClient};
 use cross_domain_message_gossip::DomainTxPoolSink;
 use domain_client_executor::{CoreExecutor, CoreGossipMessageValidator, EssentialExecutorParams};
 use domain_client_executor_gossip::ExecutorGossipParams;
@@ -13,7 +13,11 @@ use sc_client_api::{BlockBackend, ProofProvider, StateBackendFor};
 use sc_consensus::ForkChoiceStrategy;
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_network::NetworkService;
-use sc_service::{BuildNetworkParams, NetworkStarter, SpawnTasksParams, TFullBackend, TaskManager};
+use sc_service::{
+    BuildNetworkParams, Configuration as ServiceConfiguration, NetworkStarter, PartialComponents,
+    SpawnTasksParams, TFullBackend, TaskManager,
+};
+use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
 use sc_utils::mpsc::tracing_unbounded;
 use sp_api::{ApiExt, BlockT, ConstructRuntimeApi, Metadata, NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
@@ -85,6 +89,102 @@ where
         CoreDomainExecutor<SBlock, PBlock, SClient, PClient, RuntimeApi, ExecutorDispatch>,
     /// Transaction pool sink
     pub tx_pool_sink: DomainTxPoolSink,
+}
+
+pub type FullPool<RuntimeApi, ExecutorDispatch> = sc_transaction_pool::BasicPool<
+    sc_transaction_pool::FullChainApi<FullClient<RuntimeApi, ExecutorDispatch>, Block>,
+    Block,
+>;
+
+/// Starts a `ServiceBuilder` for a full service.
+///
+/// Use this macro if you don't actually need the full service, but just the builder in order to
+/// be able to perform chain operations.
+#[allow(clippy::type_complexity)]
+fn new_partial<RuntimeApi, Executor>(
+    config: &ServiceConfiguration,
+) -> Result<
+    PartialComponents<
+        FullClient<RuntimeApi, Executor>,
+        TFullBackend<Block>,
+        (),
+        sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, Executor>>,
+        sc_transaction_pool::FullPool<Block, FullClient<RuntimeApi, Executor>>,
+        (
+            Option<Telemetry>,
+            Option<TelemetryWorkerHandle>,
+            NativeElseWasmExecutor<Executor>,
+        ),
+    >,
+    sc_service::Error,
+>
+where
+    RuntimeApi:
+        ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi::RuntimeApi: TaggedTransactionQueue<Block>
+        + ApiExt<Block, StateBackend = StateBackendFor<TFullBackend<Block>, Block>>,
+    Executor: NativeExecutionDispatch + 'static,
+{
+    let telemetry = config
+        .telemetry_endpoints
+        .clone()
+        .filter(|x| !x.is_empty())
+        .map(|endpoints| -> Result<_, sc_telemetry::Error> {
+            let worker = TelemetryWorker::new(16)?;
+            let telemetry = worker.handle().new_telemetry(endpoints);
+            Ok((worker, telemetry))
+        })
+        .transpose()?;
+
+    let executor = NativeElseWasmExecutor::new(
+        config.wasm_method,
+        config.default_heap_pages,
+        config.max_runtime_instances,
+        config.runtime_cache_size,
+    );
+
+    let (client, backend, keystore_container, task_manager) = sc_service::new_full_parts(
+        config,
+        telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
+        executor.clone(),
+    )?;
+    let client = Arc::new(client);
+
+    let telemetry_worker_handle = telemetry.as_ref().map(|(worker, _)| worker.handle());
+
+    let telemetry = telemetry.map(|(worker, telemetry)| {
+        task_manager
+            .spawn_handle()
+            .spawn("telemetry", None, worker.run());
+        telemetry
+    });
+
+    let transaction_pool = sc_transaction_pool::BasicPool::new_full(
+        config.transaction_pool.clone(),
+        config.role.is_authority().into(),
+        config.prometheus_registry(),
+        task_manager.spawn_essential_handle(),
+        client.clone(),
+    );
+
+    let import_queue = domain_client_consensus_relay_chain::import_queue(
+        client.clone(),
+        &task_manager.spawn_essential_handle(),
+        config.prometheus_registry(),
+    )?;
+
+    let params = PartialComponents {
+        backend,
+        client,
+        import_queue,
+        keystore_container,
+        task_manager,
+        transaction_pool,
+        select_chain: (),
+        other: (telemetry, telemetry_worker_handle, executor),
+    };
+
+    Ok(params)
 }
 
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -5,7 +5,7 @@ mod rpc;
 mod system_domain;
 
 pub use self::core_domain::{new_full as new_full_core, NewFull as NewFullCore};
-pub use self::system_domain::{new_full, FullPool as TestFullPool, NewFull};
+pub use self::system_domain::{new_full, FullPool, NewFull};
 use domain_runtime_primitives::opaque::Block;
 use domain_runtime_primitives::RelayerId;
 use sc_executor::NativeElseWasmExecutor;

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -5,18 +5,11 @@ mod rpc;
 mod system_domain;
 
 pub use self::core_domain::{new_full as new_full_core, NewFull as NewFullCore};
-pub use self::system_domain::{new_full, NewFull};
+pub use self::system_domain::{new_full, FullPool as TestFullPool, NewFull};
 use domain_runtime_primitives::opaque::Block;
 use domain_runtime_primitives::RelayerId;
-use sc_client_api::StateBackendFor;
-use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
-use sc_service::{
-    Configuration as ServiceConfiguration, PartialComponents, TFullBackend, TFullClient,
-};
-use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
-use sp_api::{ApiExt, ConstructRuntimeApi};
-use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
-use std::sync::Arc;
+use sc_executor::NativeElseWasmExecutor;
+use sc_service::{Configuration as ServiceConfiguration, TFullClient};
 
 /// Domain full client.
 pub type FullClient<RuntimeApi, ExecutorDispatch> =
@@ -24,104 +17,8 @@ pub type FullClient<RuntimeApi, ExecutorDispatch> =
 
 pub type FullBackend = sc_service::TFullBackend<Block>;
 
-pub type FullPool<RuntimeApi, ExecutorDispatch> = sc_transaction_pool::BasicPool<
-    sc_transaction_pool::FullChainApi<FullClient<RuntimeApi, ExecutorDispatch>, Block>,
-    Block,
->;
-
 /// Secondary chain configuration.
 pub struct DomainConfiguration {
     pub service_config: ServiceConfiguration,
     pub maybe_relayer_id: Option<RelayerId>,
-}
-
-/// Starts a `ServiceBuilder` for a full service.
-///
-/// Use this macro if you don't actually need the full service, but just the builder in order to
-/// be able to perform chain operations.
-#[allow(clippy::type_complexity)]
-fn new_partial<RuntimeApi, Executor>(
-    config: &ServiceConfiguration,
-) -> Result<
-    PartialComponents<
-        FullClient<RuntimeApi, Executor>,
-        TFullBackend<Block>,
-        (),
-        sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, Executor>>,
-        sc_transaction_pool::FullPool<Block, FullClient<RuntimeApi, Executor>>,
-        (
-            Option<Telemetry>,
-            Option<TelemetryWorkerHandle>,
-            NativeElseWasmExecutor<Executor>,
-        ),
-    >,
-    sc_service::Error,
->
-where
-    RuntimeApi:
-        ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>> + Send + Sync + 'static,
-    RuntimeApi::RuntimeApi: TaggedTransactionQueue<Block>
-        + ApiExt<Block, StateBackend = StateBackendFor<TFullBackend<Block>, Block>>,
-    Executor: NativeExecutionDispatch + 'static,
-{
-    let telemetry = config
-        .telemetry_endpoints
-        .clone()
-        .filter(|x| !x.is_empty())
-        .map(|endpoints| -> Result<_, sc_telemetry::Error> {
-            let worker = TelemetryWorker::new(16)?;
-            let telemetry = worker.handle().new_telemetry(endpoints);
-            Ok((worker, telemetry))
-        })
-        .transpose()?;
-
-    let executor = NativeElseWasmExecutor::new(
-        config.wasm_method,
-        config.default_heap_pages,
-        config.max_runtime_instances,
-        config.runtime_cache_size,
-    );
-
-    let (client, backend, keystore_container, task_manager) = sc_service::new_full_parts(
-        config,
-        telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
-        executor.clone(),
-    )?;
-    let client = Arc::new(client);
-
-    let telemetry_worker_handle = telemetry.as_ref().map(|(worker, _)| worker.handle());
-
-    let telemetry = telemetry.map(|(worker, telemetry)| {
-        task_manager
-            .spawn_handle()
-            .spawn("telemetry", None, worker.run());
-        telemetry
-    });
-
-    let transaction_pool = sc_transaction_pool::BasicPool::new_full(
-        config.transaction_pool.clone(),
-        config.role.is_authority().into(),
-        config.prometheus_registry(),
-        task_manager.spawn_essential_handle(),
-        client.clone(),
-    );
-
-    let import_queue = domain_client_consensus_relay_chain::import_queue(
-        client.clone(),
-        &task_manager.spawn_essential_handle(),
-        config.prometheus_registry(),
-    )?;
-
-    let params = PartialComponents {
-        backend,
-        client,
-        import_queue,
-        keystore_container,
-        task_manager,
-        transaction_pool,
-        select_chain: (),
-        other: (telemetry, telemetry_worker_handle, executor),
-    };
-
-    Ok(params)
 }

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -96,8 +96,6 @@ where
 pub type FullPool<PBlock, PClient, RuntimeApi, Executor> = subspace_transaction_pool::FullPool<
     Block,
     FullClient<RuntimeApi, Executor>,
-    // The `FraudProofVerifier` need the primary chain client to get the runtime blob file for code domain
-    // runtime thus need `PBlock` and `PClient`.
     FraudProofVerifier<PBlock, PClient, Executor>,
 >;
 
@@ -110,10 +108,7 @@ type FraudProofVerifier<PBlock, PClient, Executor> = subspace_fraud_proof::Proof
     Hash,
 >;
 
-/// Starts a `ServiceBuilder` for a full service.
-///
-/// Use this macro if you don't actually need the full service, but just the builder in order to
-/// be able to perform chain operations.
+/// Constructs a partial system domain node.
 #[allow(clippy::type_complexity)]
 fn new_partial<RuntimeApi, Executor, PBlock, PClient>(
     config: &ServiceConfiguration,

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -1,4 +1,4 @@
-use crate::{new_partial, DomainConfiguration, FullBackend, FullClient, FullPool};
+use crate::{DomainConfiguration, FullBackend, FullClient};
 use cross_domain_message_gossip::DomainTxPoolSink;
 use domain_client_executor::{
     EssentialExecutorParams, SystemExecutor, SystemGossipMessageValidator,
@@ -15,7 +15,11 @@ use sc_client_api::{BlockBackend, StateBackendFor};
 use sc_consensus::ForkChoiceStrategy;
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
 use sc_network::NetworkService;
-use sc_service::{BuildNetworkParams, NetworkStarter, SpawnTasksParams, TFullBackend, TaskManager};
+use sc_service::{
+    BuildNetworkParams, Configuration as ServiceConfiguration, NetworkStarter, PartialComponents,
+    SpawnTaskHandle, SpawnTasksParams, TFullBackend, TaskManager,
+};
+use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
 use sc_utils::mpsc::tracing_unbounded;
 use sp_api::{ApiExt, BlockT, ConstructRuntimeApi, Metadata, NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
@@ -23,6 +27,7 @@ use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::SelectChain;
 use sp_consensus_slots::Slot;
 use sp_core::traits::SpawnEssentialNamed;
+use sp_domains::transaction::PreValidationObjectApi;
 use sp_domains::{DomainId, ExecutorApi};
 use sp_messenger::RelayerApi;
 use sp_offchain::OffchainWorkerApi;
@@ -39,7 +44,7 @@ type SystemDomainExecutor<PBlock, PClient, RuntimeApi, ExecutorDispatch> = Syste
     PBlock,
     FullClient<RuntimeApi, ExecutorDispatch>,
     PClient,
-    FullPool<RuntimeApi, ExecutorDispatch>,
+    FullPool<PBlock, PClient, RuntimeApi, ExecutorDispatch>,
     FullBackend,
     NativeElseWasmExecutor<ExecutorDispatch>,
 >;
@@ -49,6 +54,8 @@ pub struct NewFull<C, CodeExecutor, PBlock, PClient, RuntimeApi, ExecutorDispatc
 where
     PBlock: BlockT,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
+    PClient: ProvideRuntimeApi<PBlock> + Send + Sync + 'static,
+    PClient::Api: ExecutorApi<PBlock, Hash>,
     RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, ExecutorDispatch>>
         + Send
         + Sync
@@ -63,7 +70,8 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + RelayerApi<Block, RelayerId, NumberFor<Block>>,
+        + RelayerApi<Block, RelayerId, NumberFor<Block>>
+        + PreValidationObjectApi<Block, Hash>,
 {
     /// Task manager.
     pub task_manager: TaskManager,
@@ -85,6 +93,122 @@ where
     pub tx_pool_sink: DomainTxPoolSink,
 }
 
+pub type FullPool<PBlock, PClient, RuntimeApi, Executor> = subspace_transaction_pool::FullPool<
+    Block,
+    FullClient<RuntimeApi, Executor>,
+    // The `FraudProofVerifier` need the primary chain client to get the runtime blob file for code domain
+    // runtime thus need `PBlock` and `PClient`.
+    FraudProofVerifier<PBlock, PClient, Executor>,
+>;
+
+type FraudProofVerifier<PBlock, PClient, Executor> = subspace_fraud_proof::ProofVerifier<
+    PBlock,
+    PClient,
+    TFullBackend<PBlock>,
+    NativeElseWasmExecutor<Executor>,
+    SpawnTaskHandle,
+    Hash,
+>;
+
+/// Starts a `ServiceBuilder` for a full service.
+///
+/// Use this macro if you don't actually need the full service, but just the builder in order to
+/// be able to perform chain operations.
+#[allow(clippy::type_complexity)]
+fn new_partial<RuntimeApi, Executor, PBlock, PClient>(
+    config: &ServiceConfiguration,
+    primary_chain_client: Arc<PClient>,
+    primary_backend: Arc<TFullBackend<PBlock>>,
+) -> Result<
+    PartialComponents<
+        FullClient<RuntimeApi, Executor>,
+        FullBackend,
+        (),
+        sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, Executor>>,
+        FullPool<PBlock, PClient, RuntimeApi, Executor>,
+        (
+            Option<Telemetry>,
+            Option<TelemetryWorkerHandle>,
+            NativeElseWasmExecutor<Executor>,
+        ),
+    >,
+    sc_service::Error,
+>
+where
+    PBlock: BlockT,
+    PClient: ProvideRuntimeApi<PBlock> + Send + Sync + 'static,
+    PClient::Api: ExecutorApi<PBlock, Hash>,
+    RuntimeApi:
+        ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi::RuntimeApi: TaggedTransactionQueue<Block>
+        + ApiExt<Block, StateBackend = StateBackendFor<TFullBackend<Block>, Block>>
+        + PreValidationObjectApi<Block, Hash>,
+    Executor: NativeExecutionDispatch + 'static,
+{
+    let telemetry = config
+        .telemetry_endpoints
+        .clone()
+        .filter(|x| !x.is_empty())
+        .map(|endpoints| -> Result<_, sc_telemetry::Error> {
+            let worker = TelemetryWorker::new(16)?;
+            let telemetry = worker.handle().new_telemetry(endpoints);
+            Ok((worker, telemetry))
+        })
+        .transpose()?;
+
+    let executor = NativeElseWasmExecutor::new(
+        config.wasm_method,
+        config.default_heap_pages,
+        config.max_runtime_instances,
+        config.runtime_cache_size,
+    );
+
+    let (client, backend, keystore_container, task_manager) = sc_service::new_full_parts(
+        config,
+        telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
+        executor.clone(),
+    )?;
+    let client = Arc::new(client);
+
+    let telemetry_worker_handle = telemetry.as_ref().map(|(worker, _)| worker.handle());
+
+    let telemetry = telemetry.map(|(worker, telemetry)| {
+        task_manager
+            .spawn_handle()
+            .spawn("telemetry", None, worker.run());
+        telemetry
+    });
+
+    let proof_verifier = subspace_fraud_proof::ProofVerifier::new(
+        primary_chain_client,
+        primary_backend,
+        executor.clone(),
+        task_manager.spawn_handle(),
+    );
+
+    let transaction_pool =
+        subspace_transaction_pool::new_full(config, &task_manager, client.clone(), proof_verifier);
+
+    let import_queue = domain_client_consensus_relay_chain::import_queue(
+        client.clone(),
+        &task_manager.spawn_essential_handle(),
+        config.prometheus_registry(),
+    )?;
+
+    let params = PartialComponents {
+        backend,
+        client,
+        import_queue,
+        keystore_container,
+        task_manager,
+        transaction_pool,
+        select_chain: (),
+        other: (telemetry, telemetry_worker_handle, executor),
+    };
+
+    Ok(params)
+}
+
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
@@ -92,6 +216,7 @@ where
 pub async fn new_full<PBlock, PClient, SC, IBNS, NSNS, RuntimeApi, ExecutorDispatch>(
     mut secondary_chain_config: DomainConfiguration,
     primary_chain_client: Arc<PClient>,
+    primary_backend: Arc<TFullBackend<PBlock>>,
     primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
     select_chain: &SC,
     imported_block_notification_stream: IBNS,
@@ -135,7 +260,8 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + RelayerApi<Block, RelayerId, NumberFor<Block>>,
+        + RelayerApi<Block, RelayerId, NumberFor<Block>>
+        + PreValidationObjectApi<Block, Hash>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
 {
     // TODO: Do we even need block announcement on secondary node?
@@ -147,7 +273,11 @@ where
         .extra_sets
         .push(domain_client_executor_gossip::executor_gossip_peers_set_config());
 
-    let params = new_partial(&secondary_chain_config.service_config)?;
+    let params = new_partial(
+        &secondary_chain_config.service_config,
+        primary_chain_client.clone(),
+        primary_backend,
+    )?;
 
     let (mut telemetry, _telemetry_worker_handle, code_executor) = params.other;
 

--- a/domains/test/runtime/src/runtime.rs
+++ b/domains/test/runtime/src/runtime.rs
@@ -618,9 +618,6 @@ impl_runtime_apis! {
                 RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_fraud_proof { fraud_proof }) => {
                     PreValidationObject::FraudProof(fraud_proof)
                 }
-                RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_core_bundle {
-                    signed_opaque_bundle,
-                }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
                 _ => PreValidationObject::Null,
             }
         }

--- a/domains/test/runtime/src/runtime.rs
+++ b/domains/test/runtime/src/runtime.rs
@@ -15,6 +15,7 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::OpaqueMetadata;
 use sp_domains::bundle_election::BundleElectionParams;
 use sp_domains::fraud_proof::FraudProof;
+use sp_domains::transaction::PreValidationObject;
 use sp_domains::{DomainId, ExecutorPublicKey, SignedOpaqueBundle};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler};
 use sp_messenger::messages::{CrossDomainMessage, MessageId, RelayerMessagesWithStorageKey};
@@ -606,6 +607,22 @@ impl_runtime_apis! {
 
         fn should_relay_inbox_message_response(dst_domain_id: DomainId, msg_id: MessageId) -> bool {
             Messenger::should_relay_inbox_message_response(dst_domain_id, msg_id)
+        }
+    }
+
+    impl sp_domains::transaction::PreValidationObjectApi<Block, domain_runtime_primitives::Hash> for Runtime {
+        fn extract_pre_validation_object(
+            extrinsic: <Block as BlockT>::Extrinsic,
+        ) -> PreValidationObject<Block, domain_runtime_primitives::Hash> {
+            match extrinsic.function {
+                RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_fraud_proof { fraud_proof }) => {
+                    PreValidationObject::FraudProof(fraud_proof)
+                }
+                RuntimeCall::DomainRegistry(pallet_domain_registry::Call::submit_core_bundle {
+                    signed_opaque_bundle,
+                }) => PreValidationObject::Receipts(signed_opaque_bundle.bundle.receipts),
+                _ => PreValidationObject::Null,
+            }
         }
     }
 }

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -54,7 +54,7 @@ use substrate_test_client::{
 };
 
 use cross_domain_message_gossip::GossipWorker;
-use domain_service::{DomainConfiguration, TestFullPool};
+use domain_service::{DomainConfiguration, FullPool};
 pub use domain_test_runtime as runtime;
 use sp_domains::DomainId;
 pub use sp_keyring::Sr25519Keyring as Keyring;
@@ -74,7 +74,7 @@ pub type Executor = domain_client_executor::SystemExecutor<
     PBlock,
     Client,
     subspace_test_client::Client,
-    TestFullPool<PBlock, subspace_test_client::Client, runtime::RuntimeApi, RuntimeExecutor>,
+    FullPool<PBlock, subspace_test_client::Client, runtime::RuntimeApi, RuntimeExecutor>,
     Backend,
     CodeExecutor,
 >;

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -54,7 +54,7 @@ use substrate_test_client::{
 };
 
 use cross_domain_message_gossip::GossipWorker;
-use domain_service::DomainConfiguration;
+use domain_service::{DomainConfiguration, TestFullPool};
 pub use domain_test_runtime as runtime;
 use sp_domains::DomainId;
 pub use sp_keyring::Sr25519Keyring as Keyring;
@@ -74,7 +74,7 @@ pub type Executor = domain_client_executor::SystemExecutor<
     PBlock,
     Client,
     subspace_test_client::Client,
-    sc_transaction_pool::BasicPool<sc_transaction_pool::FullChainApi<Client, Block>, Block>,
+    TestFullPool<PBlock, subspace_test_client::Client, runtime::RuntimeApi, RuntimeExecutor>,
     Backend,
     CodeExecutor,
 >;
@@ -179,6 +179,7 @@ async fn run_executor(
     >(
         secondary_chain_config,
         primary_chain_full_node.client.clone(),
+        primary_chain_full_node.backend.clone(),
         primary_chain_full_node.network.clone(),
         &primary_chain_full_node.select_chain,
         primary_chain_full_node

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -36,6 +36,7 @@ subspace-runtime-primitives = { path = "../../crates/subspace-runtime-primitives
 subspace-service = { path = "../../crates/subspace-service" }
 subspace-test-client = { path = "../subspace-test-client" }
 subspace-test-runtime = { version = "0.1.0", features = ["do-not-enforce-cost-of-storage"], path = "../subspace-test-runtime" }
+subspace-transaction-pool = { path = "../../crates/subspace-transaction-pool" }
 substrate-test-client = { git = "https://github.com/subspace/substrate", rev = "74d61357f76a3cb582dd3febd665552d030e4e7f" }
 tokio = "1.23.0"
 

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -42,13 +42,14 @@ use std::sync::Arc;
 use subspace_networking::libp2p::identity;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::Balance;
-use subspace_service::{DsnConfig, FullPool, NewFull, SubspaceConfiguration, SubspaceNetworking};
+use subspace_service::{DsnConfig, NewFull, SubspaceConfiguration, SubspaceNetworking};
 use subspace_test_client::{
     chain_spec, start_farmer, Backend, Client, FraudProofVerifier, TestExecutorDispatch,
 };
 use subspace_test_runtime::{
     BlockHashCount, Runtime, RuntimeApi, SignedExtra, SignedPayload, UncheckedExtrinsic, VERSION,
 };
+use subspace_transaction_pool::FullPool;
 use substrate_test_client::{
     BlockchainEventsExt, RpcHandlersExt, RpcTransactionError, RpcTransactionOutput,
 };


### PR DESCRIPTION
This PR is part of #1020 

This PR support verifying the core domain fraud-proof in the system domain's transaction pool by:
- Using the original `subspace_service::pool` in the system domain service, this txn pool support verifying the execution receipt and fraud-proof.
- Use the `read_core_domain_runtime_blob` function to extract the core domain runtime code from the system domain runtime blob file, and use that in `ProofVerifier::verify` to verify core domain fraud-proof.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
