### PR TITLE
Refactor the receipts consecutive check with slice::array_windows

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -16,6 +16,7 @@
 //! Pallet Domains
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(array_windows)]
 
 #[cfg(test)]
 mod tests;
@@ -518,12 +519,9 @@ impl<T: Config> Pallet<T> {
     fn receipts_are_consecutive(
         receipts: &[ExecutionReceipt<T::BlockNumber, T::Hash, T::DomainHash>],
     ) -> bool {
-        if receipts.len() > 1 {
-            (0..receipts.len() - 1)
-                .all(|i| receipts[i].primary_number + One::one() == receipts[i + 1].primary_number)
-        } else {
-            true
-        }
+        receipts
+            .array_windows()
+            .all(|[ref head, ref tail]| head.primary_number + One::one() == tail.primary_number)
     }
 
     fn pre_dispatch_submit_bundle(

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -503,4 +503,5 @@ fn test_receipts_are_consecutive() {
     assert!(!Domains::receipts_are_consecutive(&receipts));
     let receipts = vec![create_dummy_receipt(1, Hash::random())];
     assert!(Domains::receipts_are_consecutive(&receipts));
+    assert!(Domains::receipts_are_consecutive(&[]));
 }

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -195,23 +195,17 @@ where
     Block: BlockT,
     PBlock: BlockT,
 {
-    if receipts.len() > 1 {
-        let maybe_inconsecutive = (0..receipts.len() - 1)
-            .find(|i| receipts[*i].primary_number + One::one() != receipts[i + 1].primary_number);
-
-        if let Some(i) = maybe_inconsecutive {
-            let last_cons = &receipts[i];
-            let got = &receipts[i + 1];
+    for (i, [ref head, ref tail]) in receipts.array_windows().enumerate() {
+        if head.primary_number + One::one() != tail.primary_number {
             return Err(sp_blockchain::Error::Application(Box::from(format!(
                 "Found inconsecutive receipt at index {}, receipts[{i}]: {:?}, receipts[{}]: {:?}",
                 i + 1,
-                (last_cons.primary_number, last_cons.primary_hash),
+                (head.primary_number, head.primary_hash),
                 i + 1,
-                (got.primary_number, got.primary_hash),
+                (tail.primary_number, tail.primary_hash),
             ))));
         }
     }
-
     Ok(())
 }
 

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -253,5 +253,7 @@ mod tests {
 
         let receipts = vec![create_dummy_receipt_for(1)];
         assert!(receipts_sanity_check::<Block, PBlock>(&receipts).is_ok());
+
+        assert!(receipts_sanity_check::<Block, PBlock>(&[]).is_ok());
     }
 }

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -58,6 +58,7 @@
 //! [`BlockBuilder`]: ../domain_block_builder/struct.BlockBuilder.html
 //! [`FraudProof`]: ../sp_domains/struct.FraudProof.html
 
+#![feature(array_windows)]
 #![feature(drain_filter)]
 
 mod aux_schema;


### PR DESCRIPTION
This PR refactor the receipts consecutive check with [slice::array_windows](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.array_windows) as suggested by @nazar-pc in https://github.com/subspace/subspace/pull/1037#discussion_r1055062573

This PR also adds the empty receipts slice test case for the check.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
