### PR TITLE
add sudo key to chain spec for core and system domain

### DIFF
--- a/crates/subspace-node/src/core_domain/core_payments_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_payments_chain_spec.rs
@@ -118,13 +118,16 @@ pub fn gemini_3b_config() -> ExecutionChainSpec<GenesisConfig> {
         "subspace_gemini_3b_core_payments_domain",
         ChainType::Local,
         move || {
+            let sudo_account =
+                AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
+                    .expect("Invalid Sudo account");
             testnet_genesis(
                 vec![
                     // Genesis executor
                     AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
                         .expect("Wrong executor account address"),
                 ],
-                None,
+                Some(sudo_account),
                 Default::default(),
             )
         },

--- a/crates/subspace-node/src/secondary_chain/chain_spec.rs
+++ b/crates/subspace-node/src/secondary_chain/chain_spec.rs
@@ -170,6 +170,9 @@ pub fn gemini_3b_config() -> ExecutionChainSpec<GenesisConfig> {
         "subspace_gemini_3b_system_domain",
         ChainType::Local,
         move || {
+            let sudo_account =
+                AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
+                    .expect("Invalid Sudo account.");
             testnet_genesis(
                 vec![
                     // Genesis executor
@@ -205,7 +208,7 @@ pub fn gemini_3b_config() -> ExecutionChainSpec<GenesisConfig> {
                         .expect("Wrong executor account address"),
                     Percent::one(),
                 )],
-                None,
+                Some(sudo_account),
                 Default::default(),
             )
         },


### PR DESCRIPTION
This adds the existing sudo key on primary to system and core domain. 
For current Gemini-3b, we have to do a runtime migration to set the sudo but unsure yet if we are going to do that. 
For future chains, where we simply rename the chainspec, sudo key will be included.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
