### PR TITLE
Farmer piece verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9574,6 +9574,7 @@ dependencies = [
  "hex",
  "jemallocator",
  "jsonrpsee",
+ "lru 0.8.1",
  "memmap2",
  "num-traits",
  "parity-db",

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -26,13 +26,13 @@ use core::cmp::Ordering;
 use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
 use reed_solomon_erasure::galois_16::ReedSolomon;
 use subspace_core_primitives::crypto::blake2b_256_254_hash;
-use subspace_core_primitives::crypto::kzg::{Commitment, Kzg, Witness};
+use subspace_core_primitives::crypto::kzg::{Kzg, Witness};
 use subspace_core_primitives::objects::{
     BlockObject, BlockObjectMapping, PieceObject, PieceObjectMapping,
 };
 use subspace_core_primitives::{
     crypto, ArchivedBlockProgress, Blake2b256Hash, BlockNumber, FlatPieces, LastArchivedBlock,
-    RootBlock, BLAKE2B_256_HASH_SIZE, WITNESS_SIZE,
+    RecordsRoot, RootBlock, BLAKE2B_256_HASH_SIZE, WITNESS_SIZE,
 };
 
 const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
@@ -731,7 +731,7 @@ pub fn is_piece_valid(
     kzg: &Kzg,
     num_pieces_in_segment: u32,
     piece: &[u8],
-    commitment: Commitment,
+    commitment: RecordsRoot,
     position: u32,
     record_size: u32,
 ) -> bool {
@@ -762,7 +762,7 @@ pub fn is_piece_record_hash_valid(
     kzg: &Kzg,
     num_pieces_in_segment: u32,
     piece_record_hash: &Blake2b256Hash,
-    commitment: &Commitment,
+    commitment: &RecordsRoot,
     witness: &Witness,
     position: u32,
 ) -> bool {

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -26,6 +26,7 @@ fdlimit = "0.2"
 futures = "0.3.25"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.16.2", features = ["client", "macros", "server"] }
+lru = "0.8.1"
 memmap2 = "0.5.8"
 num-traits = "0.2.15"
 parity-db = "0.4.2"

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use subspace_core_primitives::{PieceIndexHash, SectorIndex, PLOT_SECTOR_SIZE};
 use subspace_farmer::single_disk_plot::piece_reader::PieceReader;
 use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
-use subspace_farmer::{Identity, NodeRpcClient, RpcClient};
+use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
 use subspace_networking::{
     create, peer_id, BootstrappedNetworkingParameters, Config, CustomRecordStore,
@@ -70,7 +70,7 @@ pub(crate) async fn farm_multi_disk(
     let readers_and_pieces = Arc::new(Mutex::new(None));
 
     info!("Connecting to node RPC at {}", node_rpc_url);
-    let rpc_client = NodeRpcClient::new(&node_rpc_url).await?;
+    let node_client = NodeRpcClient::new(&node_rpc_url).await?;
     let concurrent_plotting_semaphore = Arc::new(tokio::sync::Semaphore::new(
         farming_args.max_concurrent_plots.get(),
     ));
@@ -88,7 +88,7 @@ pub(crate) async fn farm_multi_disk(
 
         if dsn.bootstrap_nodes.is_empty() {
             dsn.bootstrap_nodes = {
-                rpc_client
+                node_client
                     .farmer_app_info()
                     .await
                     .map_err(|error| anyhow::anyhow!(error))?
@@ -113,12 +113,12 @@ pub(crate) async fn farm_multi_disk(
         }
 
         info!("Connecting to node RPC at {}", node_rpc_url);
-        let rpc_client = NodeRpcClient::new(&node_rpc_url).await?;
+        let node_client = NodeRpcClient::new(&node_rpc_url).await?;
 
         let single_disk_plot_fut = SingleDiskPlot::new(SingleDiskPlotOptions {
             directory: disk_farm.directory,
             allocated_space: disk_farm.allocated_plotting_space,
-            rpc_client,
+            node_client,
             reward_address,
             dsn_node: node.clone(),
             concurrent_plotting_semaphore: Arc::clone(&concurrent_plotting_semaphore),

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -3,6 +3,7 @@
     drain_filter,
     hash_drain_filter,
     io_error_other,
+    let_chains,
     trait_alias,
     try_blocks,
     type_changing_struct_update

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -30,15 +30,15 @@
 //! 64-bit unsigned integers.
 
 pub(crate) mod identity;
+pub mod node_client;
 pub(crate) mod object_mappings;
 pub mod reward_signing;
-pub mod rpc_client;
 pub mod single_disk_plot;
 mod utils;
 pub mod ws_rpc_server;
 
 pub use identity::Identity;
 pub use jsonrpsee;
+pub use node_client::node_rpc_client::NodeRpcClient;
+pub use node_client::{Error as RpcClientError, NodeClient};
 pub use object_mappings::{ObjectMappingError, ObjectMappings};
-pub use rpc_client::node_rpc_client::NodeRpcClient;
-pub use rpc_client::{Error as RpcClientError, RpcClient};

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -12,9 +12,9 @@ use subspace_rpc_primitives::{
 /// To become error type agnostic
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-/// Abstraction of the Remote Procedure Call Client
+/// Abstraction of the Node Client
 #[async_trait]
-pub trait RpcClient: Clone + Send + Sync + 'static {
+pub trait NodeClient: Clone + Send + Sync + 'static {
     /// Get farmer app info
     async fn farmer_app_info(&self) -> Result<FarmerAppInfo, Error>;
 

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -1,4 +1,4 @@
-use crate::rpc_client::{Error as RpcError, Error, RpcClient};
+use crate::node_client::{Error as RpcError, Error, NodeClient};
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
@@ -24,7 +24,7 @@ pub struct NodeRpcClient {
 }
 
 impl NodeRpcClient {
-    /// Create a new instance of [`RpcClient`].
+    /// Create a new instance of [`NodeClient`].
     pub async fn new(url: &str) -> Result<Self, JsonError> {
         let client = Arc::new(
             WsClientBuilder::default()
@@ -38,7 +38,7 @@ impl NodeRpcClient {
 }
 
 #[async_trait]
-impl RpcClient for NodeRpcClient {
+impl NodeClient for NodeRpcClient {
     async fn farmer_app_info(&self) -> Result<FarmerAppInfo, Error> {
         Ok(self
             .client

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -677,6 +677,13 @@ impl SingleDiskPlot {
                                 (sector_offset as u64 + first_sector_index, sector, metadata)
                             });
 
+                        let piece_receiver = MultiChannelPieceReceiver::new(
+                            &dsn_node,
+                            &node_client,
+                            &kzg,
+                            &shutting_down,
+                        );
+
                         // TODO: Concurrency
                         for (sector_index, sector, sector_metadata) in plot_initial_sector {
                             trace!(%sector_index, "Preparing to plot sector");
@@ -708,10 +715,6 @@ impl SingleDiskPlot {
                                 .farmer_app_info()
                                 .await
                                 .map_err(|error| PlottingError::FailedToGetFarmerInfo { error })?;
-
-                            // TODO: Remove RPC version and keep DSN version only.
-                            let piece_receiver =
-                                MultiChannelPieceReceiver::new(dsn_node.clone(), &shutting_down);
 
                             let plot_sector_fut = plot_sector(
                                 &public_key,

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -511,6 +511,15 @@ impl Node {
         Ok(result_receiver)
     }
 
+    /// Ban peer with specified peer ID.
+    pub async fn ban_peer(&self, peer_id: PeerId) -> Result<(), SendError> {
+        self.shared
+            .command_sender
+            .clone()
+            .send(Command::BanPeer { peer_id })
+            .await
+    }
+
     /// Node's own addresses where it listens for incoming requests.
     pub fn listeners(&self) -> Vec<Multiaddr> {
         self.shared.listeners.lock().clone()

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -10,6 +10,7 @@ use futures::{SinkExt, Stream};
 use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::error::SubscriptionError;
 use libp2p::gossipsub::Sha256Topic;
+use libp2p::kad::PeerRecord;
 use libp2p::{Multiaddr, PeerId};
 use parity_scale_codec::Decode;
 use std::pin::Pin;
@@ -282,7 +283,7 @@ impl Node {
     pub async fn get_value(
         &self,
         key: Multihash,
-    ) -> Result<impl Stream<Item = Vec<u8>>, GetValueError> {
+    ) -> Result<impl Stream<Item = PeerRecord>, GetValueError> {
         let permit = self.kademlia_tasks_semaphore.acquire().await;
         let (result_sender, result_receiver) = mpsc::unbounded();
 

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1042,6 +1042,13 @@ where
                     },
                 );
             }
+            Command::BanPeer { peer_id } => {
+                self.swarm.ban_peer_id(peer_id);
+                self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
+                self.networking_parameters_registry
+                    .remove_all_known_peer_addresses(peer_id)
+                    .await;
+            }
         }
     }
 

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -17,7 +17,7 @@ use libp2p::identify::Event as IdentifyEvent;
 use libp2p::kad::{
     AddProviderError, AddProviderOk, GetClosestPeersError, GetClosestPeersOk, GetProvidersError,
     GetProvidersOk, GetRecordError, GetRecordOk, InboundRequest, Kademlia, KademliaEvent,
-    ProgressStep, PutRecordOk, QueryId, QueryResult, Quorum, Record,
+    PeerRecord, ProgressStep, PutRecordOk, QueryId, QueryResult, Quorum, Record,
 };
 use libp2p::metrics::{Metrics, Recorder};
 use libp2p::swarm::dial_opts::DialOpts;
@@ -43,7 +43,7 @@ const CONCURRENT_TASKS_BOOST_PEERS_THRESHOLD: NonZeroUsize =
 
 enum QueryResultSender {
     Value {
-        sender: mpsc::UnboundedSender<Vec<u8>>,
+        sender: mpsc::UnboundedSender<PeerRecord>,
         // Just holding onto permit while data structure is not dropped
         _permit: ResizableSemaphorePermit,
     },
@@ -615,7 +615,7 @@ where
                             cancelled = Self::unbounded_send_and_cancel_on_error(
                                 &mut self.swarm.behaviour_mut().kademlia,
                                 sender,
-                                rec.record.value,
+                                rec,
                                 "GetRecordOk",
                                 &id,
                             ) || cancelled;

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -9,6 +9,7 @@ use futures::channel::{mpsc, oneshot};
 use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::error::{PublishError, SubscriptionError};
 use libp2p::gossipsub::Sha256Topic;
+use libp2p::kad::PeerRecord;
 use libp2p::{Multiaddr, PeerId};
 use parking_lot::Mutex;
 use std::sync::atomic::AtomicUsize;
@@ -26,7 +27,7 @@ pub(crate) struct CreatedSubscription {
 pub(crate) enum Command {
     GetValue {
         key: Multihash,
-        result_sender: mpsc::UnboundedSender<Vec<u8>>,
+        result_sender: mpsc::UnboundedSender<PeerRecord>,
         permit: ResizableSemaphorePermit,
     },
     PutValue {

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -76,6 +76,9 @@ pub(crate) enum Command {
         result_sender: mpsc::UnboundedSender<PeerId>,
         permit: ResizableSemaphorePermit,
     },
+    BanPeer {
+        peer_id: PeerId,
+    },
 }
 
 #[derive(Default, Debug)]

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -205,7 +205,9 @@ where
             if let Some(piece_vec) = maybe_piece {
                 found_one_piece = true;
 
-                piece.replace(piece_vec.as_slice().try_into()?);
+                // TODO: We do not keep track of peers here and don't verify records, we probably
+                //  should though
+                piece.replace(piece_vec.record.value.as_slice().try_into()?);
             }
         }
 


### PR DESCRIPTION
This implements checking received pieces against blockchain state to ensure pieces that are plotted belong to the history of current blockchain. Also banning of peers that return bad pieces is implemented, so network will partition automatically rather than mixing nodes with various chains.

Fixes #995

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
