### PR TITLE
DSN. Add GlobalIPsOnlyTransport for swarm.

### DIFF
--- a/crates/subspace-networking/src/create/transport.rs
+++ b/crates/subspace-networking/src/create/transport.rs
@@ -1,0 +1,123 @@
+use crate::CreationError;
+use libp2p::core::multiaddr::{Multiaddr, Protocol};
+use libp2p::core::muxing::StreamMuxerBox;
+use libp2p::core::transport::{Boxed, ListenerId, TransportError, TransportEvent};
+use libp2p::core::Transport;
+use libp2p::dns::TokioDnsConfig;
+use libp2p::noise::NoiseConfig;
+use libp2p::tcp::tokio::Transport as TokioTcpTransport;
+use libp2p::tcp::Config as GenTcpConfig;
+use libp2p::websocket::WsConfig;
+use libp2p::yamux::YamuxConfig;
+use libp2p::{core, identity, noise, PeerId};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tracing::debug;
+
+// Builds the transport stack that LibP2P will communicate over along with a relay client.
+pub(super) fn build_transport(
+    allow_non_global_addresses_in_dht: bool,
+    keypair: &identity::Keypair,
+    timeout: Duration,
+    yamux_config: YamuxConfig,
+) -> Result<Boxed<(PeerId, StreamMuxerBox)>, CreationError> {
+    let transport = {
+        let dns_tcp = TokioDnsConfig::system(TokioTcpTransport::new(
+            GenTcpConfig::default().nodelay(true),
+        ))?;
+        let ws = WsConfig::new(TokioDnsConfig::system(TokioTcpTransport::new(
+            GenTcpConfig::default().nodelay(true),
+        ))?);
+
+        let dns_tcp_or_ws_transport = dns_tcp.or_transport(ws).boxed();
+
+        if allow_non_global_addresses_in_dht {
+            dns_tcp_or_ws_transport
+        } else {
+            GlobalIpOnlyTransport::new(dns_tcp_or_ws_transport).boxed()
+        }
+    };
+
+    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
+        .into_authentic(keypair)
+        .expect("Signing libp2p-noise static DH keypair failed.");
+
+    Ok(transport
+        .upgrade(core::upgrade::Version::V1Lazy)
+        .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
+        .multiplex(yamux_config)
+        .timeout(timeout)
+        .boxed())
+}
+
+// Wrapper around a libp2p `Transport` dropping all dial requests to non-global
+// IP addresses.
+#[derive(Debug, Clone, Default)]
+pub struct GlobalIpOnlyTransport<T> {
+    inner: T,
+}
+
+impl<T> GlobalIpOnlyTransport<T> {
+    pub fn new(transport: T) -> Self {
+        GlobalIpOnlyTransport { inner: transport }
+    }
+}
+
+impl<T: Transport + Unpin> Transport for GlobalIpOnlyTransport<T> {
+    type Output = <T as Transport>::Output;
+    type Error = <T as Transport>::Error;
+    type ListenerUpgrade = <T as Transport>::ListenerUpgrade;
+    type Dial = <T as Transport>::Dial;
+
+    fn listen_on(&mut self, addr: Multiaddr) -> Result<ListenerId, TransportError<Self::Error>> {
+        self.inner.listen_on(addr)
+    }
+
+    fn remove_listener(&mut self, id: ListenerId) -> bool {
+        self.inner.remove_listener(id)
+    }
+
+    fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        match addr.iter().next() {
+            Some(Protocol::Ip4(a)) => {
+                if a.is_global() {
+                    self.inner.dial(addr)
+                } else {
+                    debug!(?a, "Not dialing non global IP address.",);
+                    Err(TransportError::MultiaddrNotSupported(addr))
+                }
+            }
+            Some(Protocol::Ip6(a)) => {
+                if a.is_global() {
+                    self.inner.dial(addr)
+                } else {
+                    debug!(?a, "Not dialing non global IP address.");
+                    Err(TransportError::MultiaddrNotSupported(addr))
+                }
+            }
+            _ => {
+                debug!(?addr, "Not dialing unsupported Multiaddress.");
+                Err(TransportError::MultiaddrNotSupported(addr))
+            }
+        }
+    }
+
+    fn dial_as_listener(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.inner.dial_as_listener(addr)
+    }
+
+    fn address_translation(&self, listen: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+        self.inner.address_translation(listen, observed)
+    }
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<TransportEvent<Self::ListenerUpgrade, Self::Error>> {
+        Pin::new(&mut self.inner).poll(cx)
+    }
+}

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -521,6 +521,18 @@ impl Node {
             .await
     }
 
+    /// Dial multiaddress.
+    /// It could be used to test libp2p transports bypassing protocol checks for bootstrap
+    /// or listen-on addresses.
+    #[doc(hidden)]
+    pub async fn dial(&self, address: Multiaddr) -> Result<(), SendError> {
+        self.shared
+            .command_sender
+            .clone()
+            .send(Command::Dial { address })
+            .await
+    }
+
     /// Node's own addresses where it listens for incoming requests.
     pub fn listeners(&self) -> Vec<Multiaddr> {
         self.shared.listeners.lock().clone()

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1049,6 +1049,9 @@ where
                     .remove_all_known_peer_addresses(peer_id)
                     .await;
             }
+            Command::Dial { address } => {
+                let _ = self.swarm.dial(address);
+            }
         }
     }
 

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -80,6 +80,9 @@ pub(crate) enum Command {
     BanPeer {
         peer_id: PeerId,
     },
+    Dial {
+        address: Multiaddr,
+    },
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
This PR addresses https://github.com/subspace/subspace/issues/1044 and adds optional `GlobalIpOnlyTransport` in the transport stack for libp2p swarm. It also exposes `swarm.dial` method for testing purposes.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
