### PR TITLE
Enable transfer for dev network

### DIFF
--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -27,11 +27,15 @@ mod pallet {
     #[pallet::generate_store(pub trait Store)]
     pub struct Pallet<T>(_);
 
-    /// Sets this value to `true` to enable the signed extension `DisablePallets` which
-    /// disallowes the Call from pallet-executor.
+    /// Whether to disable the executor calls.
     #[pallet::storage]
     #[pallet::getter(fn enable_executor)]
     pub type EnableExecutor<T> = StorageValue<_, bool, ValueQuery>;
+
+    /// Whether to disable the normal balances transfer calls.
+    #[pallet::storage]
+    #[pallet::getter(fn enable_transfer)]
+    pub type EnableTransfer<T> = StorageValue<_, bool, ValueQuery>;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {}
@@ -40,14 +44,19 @@ mod pallet {
     #[derive(Default)]
     pub struct GenesisConfig {
         pub enable_executor: bool,
+        pub enable_transfer: bool,
     }
 
     #[pallet::genesis_build]
     impl<T: Config> GenesisBuild<T> for GenesisConfig {
         fn build(&self) {
-            let Self { enable_executor } = self;
+            let Self {
+                enable_executor,
+                enable_transfer,
+            } = self;
 
             <EnableExecutor<T>>::put(enable_executor);
+            <EnableTransfer<T>>::put(enable_transfer);
         }
     }
 }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -67,6 +67,7 @@ struct GenesisParams {
     enable_storage_access: bool,
     allow_authoring_by: AllowAuthoringBy,
     enable_executor: bool,
+    enable_transfer: bool,
 }
 
 pub fn gemini_3b() -> Result<ConsensusChainSpec<GenesisConfig, SystemDomainGenesisConfig>, String> {
@@ -137,6 +138,7 @@ pub fn gemini_3b_compiled(
                         )),
                     ),
                     enable_executor: true,
+                    enable_transfer: false,
                 },
             )
         },
@@ -224,6 +226,7 @@ pub fn x_net_2_config_compiled(
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::FirstFarmer,
                     enable_executor: true,
+                    enable_transfer: false,
                 },
             )
         },
@@ -274,6 +277,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig, SystemDomainGene
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     enable_executor: true,
+                    enable_transfer: true,
                 },
             )
         },
@@ -329,6 +333,7 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig, SystemDomainGe
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     enable_executor: true,
+                    enable_transfer: true,
                 },
             )
         },
@@ -362,6 +367,7 @@ fn subspace_genesis_config(
         enable_storage_access,
         allow_authoring_by,
         enable_executor,
+        enable_transfer,
     } = genesis_params;
 
     GenesisConfig {
@@ -381,6 +387,9 @@ fn subspace_genesis_config(
             allow_authoring_by,
         },
         vesting: VestingConfig { vesting },
-        runtime_configs: RuntimeConfigsConfig { enable_executor },
+        runtime_configs: RuntimeConfigsConfig {
+            enable_executor,
+            enable_transfer,
+        },
     }
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -174,7 +174,7 @@ impl frame_system::Config for Runtime {
     /// The basic call filter to use in dispatchable.
     ///
     /// `Everything` is used here as we use the signed extension
-    /// [`DisablePallets`] as the actual call filter.
+    /// `DisablePallets` as the actual call filter.
     type BaseCallFilter = Everything;
     /// Block & extrinsics weights: base values and limits.
     type BlockWeights = SubspaceBlockWeights;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -44,7 +44,7 @@ use crate::object_mapping::extract_block_object_mapping;
 use crate::signed_extensions::{CheckStorageAccess, DisablePallets};
 use core::num::NonZeroU64;
 use core::time::Duration;
-use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Contains, Get};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Everything, Get};
 use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types};
@@ -170,25 +170,12 @@ pub type SS58Prefix = ConstU16<2254>;
 
 // Configure FRAME pallets to include in runtime.
 
-pub struct CallFilter;
-
-impl Contains<RuntimeCall> for CallFilter {
-    fn contains(c: &RuntimeCall) -> bool {
-        // Disable executor and all balance transfers
-        !matches!(
-            c,
-            RuntimeCall::Balances(
-                pallet_balances::Call::transfer { .. }
-                    | pallet_balances::Call::transfer_keep_alive { .. }
-                    | pallet_balances::Call::transfer_all { .. }
-            )
-        )
-    }
-}
-
 impl frame_system::Config for Runtime {
     /// The basic call filter to use in dispatchable.
-    type BaseCallFilter = CallFilter;
+    ///
+    /// `Everything` is used here as we use the signed extension
+    /// [`DisablePallets`] as the actual call filter.
+    type BaseCallFilter = Everything;
     /// Block & extrinsics weights: base values and limits.
     type BlockWeights = SubspaceBlockWeights;
     /// The maximum length of a block (in bytes).

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -76,7 +76,8 @@ impl SignedExtension for DisablePallets {
                     | pallet_balances::Call::transfer_keep_alive { .. }
                     | pallet_balances::Call::transfer_all { .. }
             )
-        ) {
+        ) && !RuntimeConfigs::enable_transfer()
+        {
             InvalidTransaction::Call.into()
         } else {
             Ok(ValidTransaction::default())

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -61,13 +61,36 @@ impl SignedExtension for DisablePallets {
         Ok(())
     }
 
-    fn pre_dispatch(
-        self,
+    fn validate(
+        &self,
         _who: &Self::AccountId,
-        _call: &Self::Call,
+        call: &Self::Call,
         _info: &DispatchInfoOf<Self::Call>,
         _len: usize,
+    ) -> TransactionValidity {
+        // Disable normal balance transfers.
+        if matches!(
+            call,
+            RuntimeCall::Balances(
+                pallet_balances::Call::transfer { .. }
+                    | pallet_balances::Call::transfer_keep_alive { .. }
+                    | pallet_balances::Call::transfer_all { .. }
+            )
+        ) {
+            InvalidTransaction::Call.into()
+        } else {
+            Ok(ValidTransaction::default())
+        }
+    }
+
+    fn pre_dispatch(
+        self,
+        who: &Self::AccountId,
+        call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
     ) -> Result<Self::Pre, TransactionValidityError> {
+        self.validate(who, call, info, len)?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR removes the existing `CallFilter` by reimplementing it in the signed extension `DisablePallets`, and also enables the transfer for the dev network by default.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
