### PR TITLE
Update Rust to the latest nightly

### DIFF
--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2022-11-16
+ARG RUSTC_VERSION=nightly-2023-01-15
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/crates/pallet-feeds/src/mock.rs
+++ b/crates/pallet-feeds/src/mock.rs
@@ -55,17 +55,12 @@ parameter_types! {
     pub const MaxFeeds: u32 = 1;
 }
 
-#[derive(Debug, Copy, Clone, Encode, Decode, TypeInfo, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, Encode, Decode, TypeInfo, Eq, PartialEq)]
 pub enum MockFeedProcessorKind {
+    #[default]
     Content,
     ContentWithin,
     Custom([u8; 32]),
-}
-
-impl Default for MockFeedProcessorKind {
-    fn default() -> Self {
-        MockFeedProcessorKind::Content
-    }
 }
 
 impl pallet_feeds::Config for Test {

--- a/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
@@ -75,5 +75,5 @@ pub(crate) fn test_keyring() -> Vec<(Account, AuthorityWeight)> {
 
 /// Get a list of "unique" accounts.
 pub(crate) fn accounts(len: u16) -> Vec<Account> {
-    (0..len).into_iter().map(Account).collect()
+    (0..len).map(Account).collect()
 }

--- a/crates/pallet-offences-subspace/src/lib.rs
+++ b/crates/pallet-offences-subspace/src/lib.rs
@@ -236,7 +236,7 @@ impl<T: Config, O: Offence<FarmerPublicKey>> ReportIndexStorage<T, O> {
         // slot.
         let pos = self
             .same_kind_reports
-            .partition_point(|&(ref when, _)| when <= time_slot);
+            .partition_point(|(when, _)| when <= time_slot);
         self.same_kind_reports
             .insert(pos, (time_slot.clone(), report_id));
 

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -455,8 +455,7 @@ where
             );
 
             return Err(JsonRpseeError::Custom(format!(
-                "segment_indexes length exceed the limit {}",
-                MAX_SEGMENT_INDEXES_PER_REQUEST
+                "segment_indexes length exceed the limit {MAX_SEGMENT_INDEXES_PER_REQUEST}"
             )));
         };
 

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -68,8 +68,8 @@ where
                 Err(error) => {
                     // TODO: Probably light client, can this even happen?
                     panic!(
-                        "Failed to make runtime API call during last archived block search: {:?}",
-                        error
+                        "Failed to make runtime API call during last archived block search: \
+                        {error:?}"
                     );
                 }
             }
@@ -240,22 +240,22 @@ where
             .last_archived_block_number()
             .map(|n| n + 1)
             .unwrap_or_default();
-        let blocks_to_archive_to = TryInto::<BlockNumber>::try_into(best_block_number)
-            .unwrap_or_else(|_| {
-                panic!(
-                    "Best block number {} can't be converted into BlockNumber",
-                    best_block_number,
-                );
-            })
-            .checked_sub(confirmation_depth_k)
-            .or({
-                if have_last_root_block {
-                    None
-                } else {
-                    // If not continuation, archive genesis block
-                    Some(0)
-                }
-            });
+        let blocks_to_archive_to =
+            TryInto::<BlockNumber>::try_into(best_block_number)
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Best block number {best_block_number} can't be converted into BlockNumber",
+                    );
+                })
+                .checked_sub(confirmation_depth_k)
+                .or({
+                    if have_last_root_block {
+                        None
+                    } else {
+                        // If not continuation, archive genesis block
+                        Some(0)
+                    }
+                });
 
         if let Some(blocks_to_archive_to) = blocks_to_archive_to {
             info!(

--- a/crates/sc-consensus-subspace/src/aux_schema.rs
+++ b/crates/sc-consensus-subspace/src/aux_schema.rs
@@ -30,7 +30,7 @@ where
 {
     match backend.get_aux(key)? {
         Some(t) => T::decode(&mut &t[..]).map(Some).map_err(|e: codec::Error| {
-            ClientError::Backend(format!("Subspace DB is corrupted. Decode error: {}", e))
+            ClientError::Backend(format!("Subspace DB is corrupted. Decode error: {e}"))
         }),
         None => Ok(None),
     }

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -593,7 +593,7 @@ async fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + '
             net.poll(cx);
             for p in net.peers() {
                 for (h, e) in p.failed_verifications() {
-                    panic!("Verification failed for {:?}: {}", h, e);
+                    panic!("Verification failed for {h:?}: {e}");
                 }
             }
 

--- a/crates/sp-consensus-subspace/src/inherents.rs
+++ b/crates/sp-consensus-subspace/src/inherents.rs
@@ -135,6 +135,6 @@ impl sp_inherents::InherentDataProvider for InherentDataProvider {
 
         let error = InherentError::decode(&mut &*error).ok()?;
 
-        Some(Err(Error::Application(Box::from(format!("{:?}", error)))))
+        Some(Err(Error::Application(Box::from(format!("{error:?}")))))
     }
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/info.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/info.rs
@@ -29,7 +29,7 @@ pub(crate) fn info(disk_farms: Vec<DiskFarm>) {
             }
             SingleDiskPlotSummary::Error { directory, error } => {
                 println!("  Ddirectory: {}", directory.display());
-                println!("  Failed to open farm info: {}", error);
+                println!("  Failed to open farm info: {error}");
             }
         }
     }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -255,10 +255,7 @@ async fn main() -> Result<()> {
             let disk_farms = if command.farm.is_empty() {
                 if !base_path.exists() {
                     fs::create_dir_all(&base_path).unwrap_or_else(|error| {
-                        panic!(
-                            "Failed to create data directory {:?}: {:?}",
-                            base_path, error
-                        )
+                        panic!("Failed to create data directory {base_path:?}: {error:?}")
                     });
                 }
 

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -1115,7 +1115,6 @@ impl SingleDiskPlot {
         let sector_count = self.metadata_header.lock().sector_count;
 
         (first_sector_index..)
-            .into_iter()
             .zip(
                 self.sector_metadata_mmap
                     .chunks_exact(SectorMetadata::encoded_size()),

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -271,7 +271,7 @@ impl RpcServerImpl {
         };
 
         let Compact(data_length) = data_length_result.map_err(|error| {
-            let error_string = format!("Failed to read object data length: {}", error);
+            let error_string = format!("Failed to read object data length: {error}");
             error!(error = %error_string);
 
             Error::Custom(error_string)
@@ -328,8 +328,8 @@ impl RpcServerImpl {
                 })
                 .ok_or_else(|| {
                     let error_string = format!(
-                        "Failed to find item at offset {} in segment {} for object {}",
-                        offset_in_segment, segment_index, object_id
+                        "Failed to find item at offset {offset_in_segment} in segment \
+                        {segment_index} for object {object_id}"
                     );
                     error!(error = %error_string);
 
@@ -352,8 +352,8 @@ impl RpcServerImpl {
                     );
 
                     return Err(Error::Custom(format!(
-                        "Unexpected segment item at offset {} in segment {} for object {}",
-                        offset_in_segment, segment_index, object_id
+                        "Unexpected segment item at offset {offset_in_segment} in segment \
+                        {segment_index} for object {object_id}"
                     )));
                 }
             }
@@ -380,7 +380,7 @@ impl RpcServerImpl {
             }
         }
 
-        error!(object_id, "Read max object size for object without success",);
+        error!(object_id, "Read max object size for object without success");
 
         Err(Error::Custom(
             "Read max object size for object without success".to_string(),
@@ -406,8 +406,7 @@ impl RpcServerImpl {
             );
 
             Error::Custom(format!(
-                "Failed to decode segment {} of archival history on retrieval",
-                segment_index
+                "Failed to decode segment {segment_index} of archival history on retrieval"
             ))
         })?;
 

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -218,10 +218,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         let storage_changes = create_block_builder()
             .prepare_storage_changes_before(target_extrinsic_index)
             .unwrap_or_else(|_| {
-                panic!(
-                    "Get StorageChanges before extrinsic #{}",
-                    target_extrinsic_index
-                )
+                panic!("Get StorageChanges before extrinsic #{target_extrinsic_index}")
             });
 
         let delta = storage_changes.transaction;
@@ -426,7 +423,7 @@ async fn invalid_execution_proof_should_not_work() {
     let create_extrinsic_proof = |extrinsic_index: usize| {
         let storage_changes = create_block_builder()
             .prepare_storage_changes_before(extrinsic_index)
-            .unwrap_or_else(|_| panic!("Get StorageChanges before extrinsic #{}", extrinsic_index));
+            .unwrap_or_else(|_| panic!("Get StorageChanges before extrinsic #{extrinsic_index}"));
 
         let delta = storage_changes.transaction;
         let post_delta_root = storage_changes.transaction_storage_root;

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -85,7 +85,7 @@ async fn main() {
     };
 
     node.start_announcing(key).await.unwrap().next().await;
-    println!("Node announced key: {:?}", key);
+    println!("Node announced key: {key:?}");
 
     tokio::time::sleep(Duration::from_secs(15)).await;
 
@@ -95,10 +95,7 @@ async fn main() {
         Err(error) => Err(error),
     };
 
-    println!(
-        "Some Node get_piece_providers result: {:?}",
-        providers_result
-    );
+    println!("Some Node get_piece_providers result: {providers_result:?}");
 
     tokio::time::sleep(Duration::from_secs(20)).await;
 
@@ -107,10 +104,7 @@ async fn main() {
         Err(error) => Err(error),
     };
 
-    println!(
-        "Some Node get_piece_providers result: {:?}",
-        providers_result
-    );
+    println!("Some Node get_piece_providers result: {providers_result:?}");
 
     println!("Exiting..");
 }

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -68,7 +68,7 @@ async fn main() {
     };
 
     node_2.start_announcing(key).await.unwrap().next().await;
-    println!("Node 2 announced key: {:?}", key);
+    println!("Node 2 announced key: {key:?}");
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -77,7 +77,7 @@ async fn main() {
         Err(error) => Err(error),
     };
 
-    println!("Node 1 get_providers result: {:?}", providers_result);
+    println!("Node 1 get_providers result: {providers_result:?}");
 
     node_2.stop_announcing(key).await.unwrap();
 
@@ -88,7 +88,7 @@ async fn main() {
         Err(error) => Err(error),
     };
 
-    println!("Node 1 get_providers result: {:?}", providers_result);
+    println!("Node 1 get_providers result: {providers_result:?}");
 
     println!("Exiting..");
 }

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -76,8 +76,8 @@ async fn main() {
         .into_boxed_path();
 
     println!(
-        "Networking parameters database path used (the app creates DB on the first run): {:?}",
-        db_path
+        "Networking parameters database path used (the app creates DB on the first run): \
+        {db_path:?}"
     );
 
     let config = Config {
@@ -95,7 +95,7 @@ async fn main() {
     let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
 
     println!("Source Node ID is {}", node.id());
-    println!("Expected Peer ID:{}", expected_node_id);
+    println!("Expected Peer ID:{expected_node_id}");
 
     tokio::spawn(async move {
         node_runner.run().await;

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -108,7 +108,7 @@ async fn main() {
             .await
             .unwrap();
 
-        println!("Response: {:?}", resp);
+        println!("Response: {resp:?}");
     });
 
     tokio::time::sleep(Duration::from_secs(50)).await;

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -7,7 +7,7 @@ use libp2p::multihash::{Code, Multihash};
 use libp2p::{Multiaddr, PeerId};
 use lru::LruCache;
 use std::num::NonZeroUsize;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 #[tokio::test()]
 async fn test_address_timed_removal_from_known_peers_cache() {
@@ -172,8 +172,21 @@ fn binary_heap_should_include_key_works() {
 fn instant_conversion() {
     let inst1 = Instant::now();
     let ms = instant_to_micros(inst1);
-    let inst2 = micros_to_instant(ms);
+    let inst2 = micros_to_instant(ms).unwrap();
 
     assert!(inst1.saturating_duration_since(inst2) < Duration::from_millis(1));
     assert!(inst2.saturating_duration_since(inst1) < Duration::from_millis(1));
+}
+
+#[test]
+fn instant_conversion_edge_cases() {
+    assert!(micros_to_instant(u64::MAX).is_none());
+    assert!(micros_to_instant(
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_micros() as u64
+            * 2
+    )
+    .is_none());
 }

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -143,7 +143,7 @@ impl SemState {
         if let Some(dec) = self.usage.checked_sub(1) {
             self.usage = dec;
         } else {
-            panic!("SemState::free_one(): invalid free, state = {:?}", self);
+            panic!("SemState::free_one(): invalid free, state = {self:?}");
         }
 
         // Notify if we did a full -> available transition.
@@ -165,7 +165,7 @@ impl SemState {
         if let Some(dec) = self.capacity.checked_sub(delta) {
             self.capacity = dec;
         } else {
-            panic!("SemState::shrink(): invalid shrink, state = {:?}", self);
+            panic!("SemState::shrink(): invalid shrink, state = {self:?}");
         }
     }
 

--- a/crates/subspace-node/src/chain_spec_utils.rs
+++ b/crates/subspace-node/src/chain_spec_utils.rs
@@ -22,7 +22,7 @@ pub(crate) fn chain_spec_properties() -> Properties {
 pub(crate) fn get_public_key_from_seed<TPublic: Public>(
     seed: &'static str,
 ) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
+    TPublic::Pair::from_string(&format!("//{seed}"), None)
         .expect("Static values are valid; qed")
         .public()
 }

--- a/crates/subspace-runtime/src/feed_processor.rs
+++ b/crates/subspace-runtime/src/feed_processor.rs
@@ -82,20 +82,15 @@ fn extract_substrate_object_mapping<C: Chain>(object: &[u8]) -> Vec<FeedObjectMa
 }
 
 /// FeedProcessorId represents the available FeedProcessor impls
-#[derive(Debug, Clone, Copy, Encode, Decode, TypeInfo, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Encode, Decode, TypeInfo, Eq, PartialEq)]
 pub enum FeedProcessorKind {
     /// Content addressable Feed processor,
+    #[default]
     ContentAddressable,
     /// Polkadot like relay chain Feed processor that validates grandpa justifications and indexes the entire block
     PolkadotLike,
     /// Parachain Feed processor that just indexes the entire block
     ParachainLike,
-}
-
-impl Default for FeedProcessorKind {
-    fn default() -> Self {
-        FeedProcessorKind::ContentAddressable
-    }
 }
 
 pub(crate) fn feed_processor(

--- a/crates/subspace-transaction-pool/src/lib.rs
+++ b/crates/subspace-transaction-pool/src/lib.rs
@@ -348,9 +348,10 @@ where
                 })
             })?;
         let (hash, bytes) = self.pool().validated_pool().api().hash_and_length(&xt);
-        let block_number = self.api().block_id_to_number(at)?.ok_or_else(|| {
-            sc_transaction_pool::error::Error::BlockIdConversion(format!("{:?}", at))
-        })?;
+        let block_number = self
+            .api()
+            .block_id_to_number(at)?
+            .ok_or_else(|| sc_transaction_pool::error::Error::BlockIdConversion(at.to_string()))?;
         let validated = ValidatedTransaction::valid_at(
             block_number.saturated_into::<u64>(),
             hash,

--- a/domains/client/domain-executor/src/aux_schema.rs
+++ b/domains/client/domain-executor/src/aux_schema.rs
@@ -43,7 +43,7 @@ fn load_decode<Backend: AuxStore, T: Decode>(
         None => Ok(None),
         Some(t) => T::decode(&mut &t[..])
             .map_err(|e| {
-                ClientError::Backend(format!("Executor DB is corrupted. Decode error: {}", e))
+                ClientError::Backend(format!("Executor DB is corrupted. Decode error: {e}"))
             })
             .map(Some),
     }

--- a/domains/client/domain-executor/src/fraud_proof.rs
+++ b/domains/client/domain-executor/src/fraud_proof.rs
@@ -210,14 +210,14 @@ where
     }
 
     fn header(&self, hash: Block::Hash) -> Result<Block::Header, sp_blockchain::Error> {
-        self.client.header(hash)?.ok_or_else(|| {
-            sp_blockchain::Error::Backend(format!("Header not found for {:?}", hash))
-        })
+        self.client
+            .header(hash)?
+            .ok_or_else(|| sp_blockchain::Error::Backend(format!("Header not found for {hash:?}")))
     }
 
     fn block_body(&self, at: Block::Hash) -> Result<Vec<Block::Extrinsic>, sp_blockchain::Error> {
         self.client.block_body(at)?.ok_or_else(|| {
-            sp_blockchain::Error::Backend(format!("Block body not found for {:?}", at))
+            sp_blockchain::Error::Backend(format!("Block body not found for {at:?}"))
         })
     }
 

--- a/domains/client/domain-executor/src/gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/gossip_message_validator.rs
@@ -134,8 +134,7 @@ where
                         )?
                         .ok_or_else(|| {
                             sp_blockchain::Error::Backend(format!(
-                                "Execution receipt not found for {:?}",
-                                local_block_hash
+                                "Execution receipt not found for {local_block_hash:?}"
                             ))
                         });
                         return tx

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -254,7 +254,7 @@ where
             .hash(confirmed_block)?
             .and_then(|block_hash| system_domain_client.header(block_hash).transpose())
             .ok_or_else(|| {
-                sp_blockchain::Error::MissingHeader(format!("number: {:?}", confirmed_block))
+                sp_blockchain::Error::MissingHeader(format!("number: {confirmed_block:?}"))
             })??)
     }
 

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -291,7 +291,7 @@ where
         );
 
         if let Err(i) = System::ensure_inherents_are_first(block) {
-            panic!("Invalid inherent position for extrinsic at index {}", i);
+            panic!("Invalid inherent position for extrinsic at index {i}");
         }
     }
 

--- a/domains/test/service/src/chain_spec.rs
+++ b/domains/test/service/src/chain_spec.rs
@@ -14,7 +14,7 @@ pub type ChainSpec = sc_service::GenericChainSpec<domain_test_runtime::GenesisCo
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
+    TPublic::Pair::from_string(&format!("//{seed}"), None)
         .expect("static values are valid; qed")
         .public()
 }

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -427,7 +427,7 @@ pub fn node_config(
     let spec = Box::new(chain_spec::get_chain_spec());
 
     let mut network_config = NetworkConfiguration::new(
-        format!("{} (SystemDomain)", key_seed),
+        format!("{key_seed} (SystemDomain)"),
         "network/test/0.1",
         Default::default(),
         None,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-16"
+channel = "nightly-2023-01-15"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"

--- a/substrate/sc-network-test/src/block_import.rs
+++ b/substrate/sc-network-test/src/block_import.rs
@@ -79,7 +79,7 @@ fn import_single_good_block_works() {
 	)) {
 		Ok(BlockImportStatus::ImportedUnknown(ref num, ref aux, ref org))
 		if *num == number && *aux == expected_aux && *org == Some(peer_id) => {},
-		r => panic!("{:?}", r),
+		r => panic!("{r:?}"),
 	}
 }
 

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -14,7 +14,7 @@ pub type TestChainSpec = sc_service::GenericChainSpec<subspace_test_runtime::Gen
 
 /// Generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
+    TPublic::Pair::from_string(&format!("//{seed}"), None)
         .expect("static values are valid; qed")
         .public()
 }


### PR DESCRIPTION
First commit fixes some panics in `subspace-networking` due to API being such that is easy to cause panics (corresponding test cases were added). It was suggested by newer Clippy (checked subtraction), but I saw a bigger problem and decided to tackle it separately.

The rest of the changes are just new default lints from Clippy.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
