### PR TITLE
networking: Unite requests for storage types.

### DIFF
--- a/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
@@ -7,7 +7,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{PieceIndex, PieceIndexHash};
-use subspace_networking::utils::multihash::MultihashCode;
 use subspace_networking::{Node, ToMultihash};
 use tokio::time::error::Elapsed;
 use tokio::time::timeout;
@@ -104,8 +103,7 @@ impl PieceSectorPublisher {
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         self.check_cancellation()?;
 
-        let key =
-            PieceIndexHash::from_index(piece_index).to_multihash_by_code(MultihashCode::Sector);
+        let key = PieceIndexHash::from_index(piece_index).to_multihash();
 
         let result = self.dsn_node.start_announcing(key).await;
 

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -53,7 +53,7 @@ pub use request_handlers::peer_info::{
     PeerInfo, PeerInfoRequest, PeerInfoRequestHandler, PeerInfoResponse, PeerSyncStatus,
 };
 pub use request_handlers::piece_by_key::{
-    PieceByHashRequest, PieceByHashRequestHandler, PieceByHashResponse, PieceKey,
+    PieceByHashRequest, PieceByHashRequestHandler, PieceByHashResponse,
 };
 pub use request_handlers::pieces_by_range::{
     PiecesByRangeRequest, PiecesByRangeRequestHandler, PiecesByRangeResponse, PiecesToPlot,

--- a/crates/subspace-networking/src/request_handlers/piece_by_key.rs
+++ b/crates/subspace-networking/src/request_handlers/piece_by_key.rs
@@ -7,19 +7,11 @@ use crate::request_handlers::generic_request_handler::{GenericRequest, GenericRe
 use parity_scale_codec::{Decode, Encode};
 use subspace_core_primitives::{Piece, PieceIndexHash};
 
-//TODO: rename all module names if we keep this enum
-#[derive(Debug, Clone, Eq, PartialEq, Copy, Encode, Decode)]
-pub enum PieceKey {
-    Cache(PieceIndexHash),
-    ArchivalStorage(PieceIndexHash),
-}
-
 /// Piece-by-hash protocol request.
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
 pub struct PieceByHashRequest {
-    //TODO: rename if we keep the enum
-    /// Piece index hash
-    pub key: PieceKey,
+    /// Request key - piece index hash
+    pub piece_index_hash: PieceIndexHash,
 }
 
 impl GenericRequest for PieceByHashRequest {

--- a/crates/subspace-networking/src/utils/multihash.rs
+++ b/crates/subspace-networking/src/utils/multihash.rs
@@ -1,6 +1,6 @@
 use libp2p::multihash::Multihash;
 use std::error::Error;
-use subspace_core_primitives::{Blake2b256Hash, PieceIndexHash};
+use subspace_core_primitives::PieceIndexHash;
 
 /// Start of Subspace Network multicodec namespace (+1000 to distinguish from future stable values):
 /// https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -9,9 +9,7 @@ const SUBSPACE_MULTICODEC_NAMESPACE_START: u64 = 0xb39910 + 1000;
 #[derive(Debug, Clone, PartialEq)]
 #[repr(u64)]
 pub enum MultihashCode {
-    Piece = SUBSPACE_MULTICODEC_NAMESPACE_START,
-    PieceIndex = SUBSPACE_MULTICODEC_NAMESPACE_START + 1,
-    Sector = SUBSPACE_MULTICODEC_NAMESPACE_START + 2,
+    PieceIndexHash = SUBSPACE_MULTICODEC_NAMESPACE_START,
 }
 
 impl From<MultihashCode> for u64 {
@@ -25,9 +23,7 @@ impl TryFrom<u64> for MultihashCode {
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
-            x if x == MultihashCode::Piece as u64 => Ok(MultihashCode::Piece),
-            x if x == MultihashCode::PieceIndex as u64 => Ok(MultihashCode::PieceIndex),
-            x if x == MultihashCode::Sector as u64 => Ok(MultihashCode::Sector),
+            x if x == MultihashCode::PieceIndexHash as u64 => Ok(MultihashCode::PieceIndexHash),
             _ => Err("Unexpected multihash code".into()),
         }
     }
@@ -39,15 +35,6 @@ pub fn create_multihash_by_piece_index(piece_index: u64) -> Multihash {
     piece_index_hash.to_multihash()
 }
 
-pub fn create_multihash_by_piece(records_root: &Blake2b256Hash, piece_index: u64) -> Multihash {
-    let piece_index_bytes = piece_index.to_le_bytes();
-    let mut input = Vec::with_capacity(records_root.len() + piece_index_bytes.len());
-    input.extend_from_slice(records_root);
-    input.extend_from_slice(&piece_index_bytes);
-    Multihash::wrap(u64::from(MultihashCode::Piece), &input)
-        .expect("Input never exceeds allocated size; qed")
-}
-
 pub trait ToMultihash {
     fn to_multihash(&self) -> Multihash;
     fn to_multihash_by_code(&self, code: MultihashCode) -> Multihash;
@@ -55,7 +42,7 @@ pub trait ToMultihash {
 
 impl ToMultihash for PieceIndexHash {
     fn to_multihash(&self) -> Multihash {
-        self.to_multihash_by_code(MultihashCode::PieceIndex)
+        self.to_multihash_by_code(MultihashCode::PieceIndexHash)
     }
 
     fn to_multihash_by_code(&self, code: MultihashCode) -> Multihash {

--- a/crates/subspace-networking/src/utils/piece_receiver.rs
+++ b/crates/subspace-networking/src/utils/piece_receiver.rs
@@ -1,26 +1,20 @@
-use crate::utils::multihash::MultihashCode;
-use crate::{Node, PieceByHashRequest, PieceByHashResponse, PieceKey, ToMultihash};
+use crate::{Node, PieceByHashRequest, PieceByHashResponse, ToMultihash};
 use async_trait::async_trait;
 use backoff::future::retry;
 use backoff::ExponentialBackoff;
-use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use libp2p::PeerId;
 use std::error::Error;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
 /// Defines initial duration between get_piece calls.
 const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
 /// Defines max duration between get_piece calls.
 const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(5);
-/// Delay for getting piece from cache before resorting to archival storage
-const GET_PIECE_ARCHIVAL_STORAGE_DELAY: Duration = Duration::from_secs(2);
 /// Max time allocated for getting piece from DSN before attempt is considered to fail
 const GET_PIECE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -32,24 +26,6 @@ pub trait PieceReceiver: Send + Sync {
         &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
-}
-
-// Defines target storage type for requets.
-#[derive(Debug, Copy, Clone)]
-enum StorageType {
-    // L2 piece cache
-    Cache,
-    // L1 archival storage for pieces
-    ArchivalStorage,
-}
-
-impl From<StorageType> for MultihashCode {
-    fn from(storage_type: StorageType) -> Self {
-        match storage_type {
-            StorageType::Cache => MultihashCode::PieceIndex,
-            StorageType::ArchivalStorage => MultihashCode::Sector,
-        }
-    }
 }
 
 #[async_trait]
@@ -89,17 +65,9 @@ impl<'a, PV: PieceValidator> PieceProvider<'a, PV> {
     }
 
     // Get from piece cache (L2) or archival storage (L1)
-    async fn get_piece_from_storage(
-        &self,
-        piece_index: PieceIndex,
-        storage_type: StorageType,
-    ) -> Option<Piece> {
+    async fn get_piece_from_storage(&self, piece_index: PieceIndex) -> Option<Piece> {
         let piece_index_hash = PieceIndexHash::from_index(piece_index);
-        let key = piece_index_hash.to_multihash_by_code(storage_type.into());
-        let piece_key = match storage_type {
-            StorageType::Cache => PieceKey::Cache(piece_index_hash),
-            StorageType::ArchivalStorage => PieceKey::ArchivalStorage(piece_index_hash),
-        };
+        let key = piece_index_hash.to_multihash();
 
         let get_providers_result = self.dsn_node.get_providers(key).await;
 
@@ -110,7 +78,7 @@ impl<'a, PV: PieceValidator> PieceProvider<'a, PV> {
 
                     let request_result = self
                         .dsn_node
-                        .send_generic_request(provider_id, PieceByHashRequest { key: piece_key })
+                        .send_generic_request(provider_id, PieceByHashRequest { piece_index_hash })
                         .await;
 
                     match request_result {
@@ -163,32 +131,11 @@ impl<'a, PV: PieceValidator> PieceReceiver for PieceProvider<'a, PV> {
             self.check_cancellation()
                 .map_err(backoff::Error::Permanent)?;
 
-            // Try to pull pieces in two ways, whichever is faster
-            let mut piece_attempts = [
-                timeout(
-                    GET_PIECE_TIMEOUT,
-                    Box::pin(self.get_piece_from_storage(piece_index, StorageType::Cache))
-                        as Pin<Box<dyn Future<Output = _> + Send>>,
-                ),
-                //TODO: verify "broken pipe" error cause
-                timeout(
-                    GET_PIECE_TIMEOUT,
-                    Box::pin(async {
-                        // Prefer cache if it can return quickly, otherwise fall back to archival storage
-                        sleep(GET_PIECE_ARCHIVAL_STORAGE_DELAY).await;
-                        self.get_piece_from_storage(piece_index, StorageType::ArchivalStorage)
-                            .await
-                    }) as Pin<Box<dyn Future<Output = _> + Send>>,
-                ),
-            ]
-            .into_iter()
-            .collect::<FuturesUnordered<_>>();
+            let maybe_piece = timeout(GET_PIECE_TIMEOUT, self.get_piece_from_storage(piece_index));
 
-            while let Some(maybe_piece) = piece_attempts.next().await {
-                if let Ok(Some(piece)) = maybe_piece {
-                    trace!(%piece_index, "Got piece");
-                    return Ok(Some(piece));
-                }
+            if let Ok(Some(piece)) = maybe_piece.await {
+                trace!(%piece_index, "Got piece");
+                return Ok(Some(piece));
             }
 
             warn!(%piece_index, "Couldn't get a piece from DSN. Retrying...");


### PR DESCRIPTION
This PR changes the handling of pieces cache and archival storage layers. Now, we have a singular namespace for both storage types in the DHT. We also return pieces either from the cache or archival storage on the same request from peers.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
