### PR TITLE
Fix executor tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9613,6 +9613,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
+ "sp-domain-digests",
  "sp-domains",
  "sp-keyring",
  "sp-runtime",

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -34,6 +34,7 @@ pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/su
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34", default-features = false }
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34", default-features = false }
+sp-domain-digests = { version = "0.1.0", path = "../../domains/primitives/digests" }
 sp-keyring = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 tempfile = "3.3.0"

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -9,9 +9,10 @@ use sc_client_api::{HeaderBackend, StorageProof};
 use sc_consensus::ForkChoiceStrategy;
 use sc_service::{BasePath, Role};
 use sp_api::ProvideRuntimeApi;
+use sp_domain_digests::AsPredigest;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
 use sp_domains::DomainId;
-use sp_runtime::generic::BlockId;
+use sp_runtime::generic::{BlockId, Digest, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Header as HeaderT};
 use tempfile::TempDir;
 
@@ -407,7 +408,12 @@ async fn invalid_execution_proof_should_not_work() {
             parent_header.hash(),
             *parent_header.number(),
             RecordProof::No,
-            Default::default(),
+            Digest {
+                logs: vec![DigestItem::primary_block_info((
+                    *header.number(),
+                    header.hash(),
+                ))],
+            },
             &*alice.backend,
             test_txs.clone().into_iter().map(Into::into).collect(),
         )

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -69,12 +69,6 @@ async fn test_executor_full_node_catching_up() {
     // Bob is able to sync blocks.
     futures::future::join(alice.wait_for_blocks(3), bob.wait_for_blocks(3)).await;
 
-    assert_eq!(
-        ferdie.client.info().best_number,
-        alice.client.info().best_number,
-        "Primary chain and system domain must be on the same best height"
-    );
-
     let alice_block_hash = alice
         .client
         .expect_block_hash_from_id(&BlockId::Number(2))

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -11,13 +11,15 @@ use sc_transaction_pool_api::TransactionSource;
 use sp_api::{AsTrieBackend, ProvideRuntimeApi};
 use sp_core::traits::FetchRuntimeCode;
 use sp_core::Pair;
+use sp_domain_digests::AsPredigest;
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
+use sp_domains::state_root_tracker::StateRootUpdate;
 use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{
     Bundle, BundleHeader, BundleSolution, DomainId, ExecutorApi, ExecutorPair, ProofOfElection,
     SignedBundle,
 };
-use sp_runtime::generic::{BlockId, DigestItem};
+use sp_runtime::generic::{BlockId, Digest, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
 use std::collections::HashSet;
 use subspace_core_primitives::BlockNumber;
@@ -143,12 +145,27 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
         Box::new(alice.task_manager.spawn_handle()),
     );
 
+    let digest = {
+        let system_domain_state_root =
+            DigestItem::system_domain_state_root_update(StateRootUpdate {
+                number: 0,
+                state_root: *parent_header.state_root(),
+            });
+
+        let primary_block_info =
+            DigestItem::primary_block_info((1, ferdie.client.hash(1).unwrap().unwrap()));
+
+        Digest {
+            logs: vec![system_domain_state_root, primary_block_info],
+        }
+    };
+
     let new_header = Header::new(
         *header.number(),
-        Default::default(),
+        header.hash(),
         Default::default(),
         parent_header.hash(),
-        Default::default(),
+        digest,
     );
     let execution_phase = ExecutionPhase::InitializeBlock {
         call_data: new_header.encode(),

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -27,7 +27,6 @@ use subspace_wasm_tools::read_core_domain_runtime_blob;
 use tempfile::TempDir;
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
-#[ignore]
 async fn test_executor_full_node_catching_up() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 


### PR DESCRIPTION
This PR fixes the test `fraud_proof_verification_in_tx_pool_should_work` and `invalid_execution_proof_should_not_work` by adding the missing digest to the block header.

These tests still take ~20s to finish, so I think we should remain to ignore them.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
