### PR TITLE
DSN optimizations (part 1)

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -87,6 +87,9 @@ pub(crate) async fn farm_multi_disk(
         }
         configure_dsn(base_path, keypair, dsn, &readers_and_pieces).await?
     };
+    let mut provider_records_receiver = node_runner
+        .take_provider_records_receiver()
+        .expect("Provider record receiver exists right after initialization; qed");
 
     let mut single_disk_plots = Vec::with_capacity(disk_farms.len());
 
@@ -218,9 +221,6 @@ pub(crate) async fn farm_multi_disk(
     // event handlers
     drop(readers_and_pieces);
 
-    let mut provider_records_receiver = node_runner
-        .take_provider_records_receiver()
-        .expect("Provider record receiver should exist on initiatialization.");
     let mut provider_record_processor =
         FarmerProviderRecordProcessor::new(node.clone(), wrapped_piece_storage);
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,4 +1,4 @@
-#![feature(type_alias_impl_trait, type_changing_struct_update)]
+#![feature(const_option, type_alias_impl_trait, type_changing_struct_update)]
 
 mod commands;
 mod ss58;

--- a/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
@@ -99,7 +99,7 @@ impl PieceSectorPublisher {
 
         let key = PieceIndexHash::from_index(piece_index).to_multihash();
 
-        let result = self.dsn_node.start_announcing(key).await;
+        let result = self.dsn_node.start_announcing(key.into()).await;
 
         match result {
             Err(error) => {

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -84,7 +84,11 @@ async fn main() {
         piece_index_hash.to_multihash()
     };
 
-    node.start_announcing(key).await.unwrap().next().await;
+    node.start_announcing(key.into())
+        .await
+        .unwrap()
+        .next()
+        .await;
     println!("Node announced key: {key:?}");
 
     tokio::time::sleep(Duration::from_secs(15)).await;

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -67,7 +67,12 @@ async fn main() {
         piece_index_hash.to_multihash()
     };
 
-    node_2.start_announcing(key).await.unwrap().next().await;
+    node_2
+        .start_announcing(key.into())
+        .await
+        .unwrap()
+        .next()
+        .await;
     println!("Node 2 announced key: {key:?}");
 
     tokio::time::sleep(Duration::from_secs(2)).await;

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -10,6 +10,7 @@ use futures::{SinkExt, Stream};
 use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::error::SubscriptionError;
 use libp2p::gossipsub::Sha256Topic;
+use libp2p::kad::record::Key;
 use libp2p::kad::PeerRecord;
 use libp2p::{Multiaddr, PeerId};
 use parity_scale_codec::Decode;
@@ -449,7 +450,7 @@ impl Node {
     /// Start announcing item by its key. Initiate 'start_providing' Kademlia operation.
     pub async fn start_announcing(
         &self,
-        key: Multihash,
+        key: Key,
     ) -> Result<impl Stream<Item = ()>, AnnounceError> {
         let permit = self.kademlia_tasks_semaphore.acquire().await;
         let (result_sender, result_receiver) = mpsc::unbounded();

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1023,7 +1023,7 @@ where
                     .swarm
                     .behaviour_mut()
                     .kademlia
-                    .start_providing(key.into());
+                    .start_providing(key.clone());
 
                 match res {
                     Ok(query_id) => {

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -174,6 +174,9 @@ where
     }
 
     pub fn take_provider_records_receiver(&mut self) -> Option<mpsc::Receiver<ProviderRecord>> {
+        // TODO: This should be handled by constructor, otherwise receiver that is not consumed will
+        //  cause message buffering and later printing of large amounts of warnings. API should be
+        //  clearer around this.
         self.provider_records_receiver.take()
     }
 

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -9,6 +9,7 @@ use futures::channel::{mpsc, oneshot};
 use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::error::{PublishError, SubscriptionError};
 use libp2p::gossipsub::Sha256Topic;
+use libp2p::kad::record::Key;
 use libp2p::kad::PeerRecord;
 use libp2p::{Multiaddr, PeerId};
 use parking_lot::Mutex;
@@ -64,7 +65,7 @@ pub(crate) enum Command {
         result_sender: oneshot::Sender<bool>,
     },
     StartAnnouncing {
-        key: Multihash,
+        key: Key,
         result_sender: mpsc::UnboundedSender<()>,
         permit: ResizableSemaphorePermit,
     },

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -238,7 +238,7 @@ async fn publish_single_piece(
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let key = PieceIndexHash::from_index(piece_index).to_multihash();
 
-    match node.start_announcing(key).await {
+    match node.start_announcing(key.into()).await {
         Ok(mut stream) => {
             if stream.next().await.is_some() {
                 trace!(%piece_index, ?key, "Piece announcing succeeded");


### PR DESCRIPTION
These are some optimizations related to resolving #1080. It improves situation a tiny bit, but doesn't resolve.

We need tighter coupling between plot and cache on the farmer (fill cache with plotted pieces so we don't have to pull them from announcer later), but it'll require some significant refactoring, so I decided to publish this for now.

I also noticed a lot of logic is in the binary part of `subspace-farmer` that I suspect SDK may forget to import, so we need to make API clearer and expose more things. Added TODOs about those.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
