### PR TITLE
Ensure `total_stake_weight ` will not overflow

### DIFF
--- a/domains/pallets/executor-registry/src/lib.rs
+++ b/domains/pallets/executor-registry/src/lib.rs
@@ -549,14 +549,17 @@ mod pallet {
                     "Genesis executor does not have enough balance to stake."
                 );
 
-                Pallet::<T>::apply_register(
-                    &executor,
-                    public_key.clone(),
-                    reward_address,
-                    true,
-                    initial_stake,
-                )
-                .expect("Initial total stake weight can not be overflow");
+                assert!(
+                    Pallet::<T>::apply_register(
+                        &executor,
+                        public_key.clone(),
+                        reward_address,
+                        true,
+                        initial_stake,
+                    )
+                    .is_ok(),
+                    "Initial total stake weight can not be overflow"
+                );
 
                 let stake_weight: T::StakeWeight = initial_stake.into();
                 authorities.push((public_key, stake_weight));

--- a/domains/pallets/executor-registry/src/lib.rs
+++ b/domains/pallets/executor-registry/src/lib.rs
@@ -556,7 +556,7 @@ mod pallet {
                     true,
                     initial_stake,
                 )
-                .expect("Initial executor register can not fail");
+                .expect("Genesis executor registration can not fail");
 
                 let stake_weight: T::StakeWeight = initial_stake.into();
                 authorities.push((public_key, stake_weight));

--- a/domains/pallets/executor-registry/src/lib.rs
+++ b/domains/pallets/executor-registry/src/lib.rs
@@ -549,17 +549,14 @@ mod pallet {
                     "Genesis executor does not have enough balance to stake."
                 );
 
-                assert!(
-                    Pallet::<T>::apply_register(
-                        &executor,
-                        public_key.clone(),
-                        reward_address,
-                        true,
-                        initial_stake,
-                    )
-                    .is_ok(),
-                    "Initial total stake weight can not be overflow"
-                );
+                Pallet::<T>::apply_register(
+                    &executor,
+                    public_key.clone(),
+                    reward_address,
+                    true,
+                    initial_stake,
+                )
+                .expect("Initial executor register can not fail");
 
                 let stake_weight: T::StakeWeight = initial_stake.into();
                 authorities.push((public_key, stake_weight));


### PR DESCRIPTION
close #1082 

This PR utilizes an existing storage item `TotalActiveStake` to update `TotalStakeWeight` upon epoch change as `TotalActiveStake` will track every action that increase/decrease the total active stake in real-time and it is exactly what we want.

This PR also adds arithmetic overflow/underflow checks for `TotalActiveStake` to ensure an error will return in these cases, and a test case is added to cover cases that may cause arithmetic overflow.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
