### PR TITLE
DSN optimizations (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9792,7 +9792,6 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
- "backoff",
  "derive_more",
  "domain-runtime-primitives",
  "either",

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -15,11 +15,11 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use subspace_core_primitives::{PieceIndexHash, SectorIndex, PLOT_SECTOR_SIZE};
-use subspace_farmer::single_disk_plot::piece_publisher::PieceSectorPublisher;
 use subspace_farmer::single_disk_plot::piece_reader::PieceReader;
 use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
+use subspace_networking::utils::pieces::PieceSectorPublisher;
 use tracing::{debug, error, info, warn};
 
 const MAX_CONCURRENT_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -12,15 +12,15 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use subspace_core_primitives::{PieceIndexHash, SectorIndex, PLOT_SECTOR_SIZE};
 use subspace_farmer::single_disk_plot::piece_reader::PieceReader;
 use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
-use subspace_networking::utils::pieces::PieceSectorPublisher;
-use tracing::{debug, error, info, warn};
+use subspace_networking::utils::pieces::announce_single_piece_with_backoff;
+use tracing::{debug, error, info};
 
 const MAX_CONCURRENT_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(20).expect("Not zero; qed");
@@ -100,7 +100,6 @@ pub(crate) async fn farm_multi_disk(
     let mut single_disk_plots = Vec::with_capacity(disk_farms.len());
 
     let shutting_down = Arc::new(AtomicBool::new(false));
-    let piece_publisher = PieceSectorPublisher::new(node.clone(), shutting_down.clone());
 
     // TODO: Check plot and metadata sizes to ensure there is enough space for farmer to not
     //  fail later
@@ -193,14 +192,16 @@ pub(crate) async fn farm_multi_disk(
         .enumerate()
         .map(|(plot_offset, single_disk_plot)| {
             let readers_and_pieces = Arc::clone(&readers_and_pieces);
-            let piece_publisher = piece_publisher.clone();
+            let shutting_down = Arc::clone(&shutting_down);
+            let node = node.clone();
 
             // Collect newly plotted pieces
             // TODO: Once we have replotting, this will have to be updated
             single_disk_plot
                 .on_sector_plotted(Arc::new(move |(plotted_sector, plotting_permit)| {
                     let plotting_permit = Arc::clone(plotting_permit);
-                    let piece_publisher = piece_publisher.clone();
+                    let shutting_down = Arc::clone(&shutting_down);
+                    let node = node.clone();
                     let sector_index = plotted_sector.sector_index;
                     let piece_indexes = plotted_sector.piece_indexes.clone();
 
@@ -228,13 +229,26 @@ pub(crate) async fn farm_multi_disk(
                         );
 
                     tokio::spawn(async move {
-                        if let Err(error) = piece_publisher.publish_pieces(piece_indexes).await {
-                            warn!(
-                                %sector_index,
-                                %error,
-                                "Failed to publish pieces to DSN"
-                            );
+                        let mut pieces_publishing_futures = piece_indexes
+                            .into_iter()
+                            .map(|piece_index| {
+                                announce_single_piece_with_backoff(
+                                    piece_index,
+                                    &node,
+                                    &shutting_down,
+                                )
+                            })
+                            .collect::<FuturesUnordered<_>>();
+
+                        while pieces_publishing_futures.next().await.is_some() {
+                            if shutting_down.load(Ordering::Acquire) {
+                                debug!("Piece publishing was cancelled due to shutdown.");
+
+                                return;
+                            }
                         }
+
+                        info!("Piece publishing was successful.");
 
                         // Release only after publishing is finished
                         drop(plotting_permit);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -12,13 +12,15 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use subspace_core_primitives::{PieceIndexHash, SectorIndex, PLOT_SECTOR_SIZE};
+use subspace_farmer::single_disk_plot::piece_publisher::PieceSectorPublisher;
 use subspace_farmer::single_disk_plot::piece_reader::PieceReader;
 use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 const MAX_CONCURRENT_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(20).expect("Not zero; qed");
@@ -97,6 +99,9 @@ pub(crate) async fn farm_multi_disk(
 
     let mut single_disk_plots = Vec::with_capacity(disk_farms.len());
 
+    let shutting_down = Arc::new(AtomicBool::new(false));
+    let piece_publisher = PieceSectorPublisher::new(node.clone(), shutting_down.clone());
+
     // TODO: Check plot and metadata sizes to ensure there is enough space for farmer to not
     //  fail later
     for disk_farm in disk_farms {
@@ -120,6 +125,7 @@ pub(crate) async fn farm_multi_disk(
             reward_address,
             dsn_node: node.clone(),
             concurrent_plotting_semaphore: Arc::clone(&concurrent_plotting_semaphore),
+            shutting_down: Arc::clone(&shutting_down),
         });
 
         let single_disk_plot = single_disk_plot_fut.await?;
@@ -187,11 +193,17 @@ pub(crate) async fn farm_multi_disk(
         .enumerate()
         .map(|(plot_offset, single_disk_plot)| {
             let readers_and_pieces = Arc::clone(&readers_and_pieces);
+            let piece_publisher = piece_publisher.clone();
 
             // Collect newly plotted pieces
             // TODO: Once we have replotting, this will have to be updated
             single_disk_plot
-                .on_sector_plotted(Arc::new(move |plotted_sector| {
+                .on_sector_plotted(Arc::new(move |(plotted_sector, plotting_permit)| {
+                    let plotting_permit = Arc::clone(plotting_permit);
+                    let piece_publisher = piece_publisher.clone();
+                    let sector_index = plotted_sector.sector_index;
+                    let piece_indexes = plotted_sector.piece_indexes.clone();
+
                     readers_and_pieces
                         .lock()
                         .as_mut()
@@ -208,12 +220,25 @@ pub(crate) async fn farm_multi_disk(
                                         PieceIndexHash::from_index(piece_index),
                                         PieceDetails {
                                             plot_offset,
-                                            sector_index: plotted_sector.sector_index,
+                                            sector_index,
                                             piece_offset: piece_offset as u64,
                                         },
                                     )
                                 }),
                         );
+
+                    tokio::spawn(async move {
+                        if let Err(error) = piece_publisher.publish_pieces(piece_indexes).await {
+                            warn!(
+                                %sector_index,
+                                %error,
+                                "Failed to publish pieces to DSN"
+                            );
+                        }
+
+                        // Release only after publishing is finished
+                        drop(plotting_permit);
+                    });
                 }))
                 .detach();
 

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -1,4 +1,3 @@
-pub mod piece_publisher;
 pub mod piece_reader;
 pub(crate) mod piece_receiver;
 

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -277,8 +277,6 @@ pub struct SingleDiskPlotOptions<NC> {
     pub dsn_node: Node,
     /// Semaphore to limit concurrency of plotting process.
     pub concurrent_plotting_semaphore: Arc<tokio::sync::Semaphore>,
-    /// Boolean flag indicating that shutting down was initiated.
-    pub shutting_down: Arc<AtomicBool>,
 }
 
 /// Errors happening when trying to create/open single disk plot
@@ -495,7 +493,6 @@ impl SingleDiskPlot {
             reward_address,
             dsn_node,
             concurrent_plotting_semaphore,
-            shutting_down,
         } = options;
 
         // TODO: Account for plot overhead
@@ -657,6 +654,7 @@ impl SingleDiskPlot {
         }));
 
         let handlers = Arc::<Handlers>::default();
+        let shutting_down = Arc::new(AtomicBool::new(false));
         let kzg = Kzg::new(test_public_parameters());
         let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize)
             .expect("Protocol constant must be correct; qed");

--- a/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_publisher.rs
@@ -17,13 +17,13 @@ const PUT_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(30);
 
 // Piece-by-sector DSN publishing helper.
 #[derive(Clone)]
-pub(crate) struct PieceSectorPublisher {
+pub struct PieceSectorPublisher {
     dsn_node: Node,
     cancelled: Arc<AtomicBool>,
 }
 
 impl PieceSectorPublisher {
-    pub(crate) fn new(dsn_node: Node, cancelled: Arc<AtomicBool>) -> Self {
+    pub fn new(dsn_node: Node, cancelled: Arc<AtomicBool>) -> Self {
         Self {
             dsn_node,
             cancelled,
@@ -41,7 +41,7 @@ impl PieceSectorPublisher {
     }
 
     // Publishes pieces-by-sector to DSN in bulk. Supports cancellation.
-    pub(crate) async fn publish_pieces(
+    pub async fn publish_pieces(
         &self,
         piece_indexes: Vec<PieceIndex>,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -1,5 +1,6 @@
 pub mod multihash;
 pub mod piece_receiver;
+pub mod pieces;
 pub(crate) mod prometheus;
 pub(crate) mod record_binary_heap;
 #[cfg(test)]

--- a/crates/subspace-networking/src/utils/pieces.rs
+++ b/crates/subspace-networking/src/utils/pieces.rs
@@ -2,122 +2,67 @@ use crate::node::Node;
 use crate::utils::multihash::ToMultihash;
 use backoff::future::retry;
 use backoff::ExponentialBackoff;
-use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{PieceIndex, PieceIndexHash};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, trace};
 
 /// Defines initial duration between put_piece calls.
 const PUT_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
 /// Defines max duration between put_piece calls.
 const PUT_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(30);
 
-// Piece-by-sector DSN publishing helper.
-#[derive(Clone)]
-pub struct PieceSectorPublisher {
-    dsn_node: Node,
-    cancelled: Arc<AtomicBool>,
+pub async fn announce_single_piece_with_backoff(
+    piece_index: PieceIndex,
+    node: &Node,
+    cancelled: &AtomicBool,
+) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let backoff = ExponentialBackoff {
+        initial_interval: PUT_PIECE_INITIAL_INTERVAL,
+        max_interval: PUT_PIECE_MAX_INTERVAL,
+        // Try until we get a valid piece
+        max_elapsed_time: None,
+        ..ExponentialBackoff::default()
+    };
+
+    retry(backoff, || {
+        announce_single_piece(piece_index, node, cancelled)
+    })
+    .await
 }
 
-impl PieceSectorPublisher {
-    pub fn new(dsn_node: Node, cancelled: Arc<AtomicBool>) -> Self {
-        Self {
-            dsn_node,
-            cancelled,
+async fn announce_single_piece(
+    piece_index: PieceIndex,
+    node: &Node,
+    cancelled: &AtomicBool,
+) -> Result<(), backoff::Error<Box<dyn Error + Send + Sync + 'static>>> {
+    if cancelled.load(Ordering::Acquire) {
+        return Ok(());
+    }
+
+    let key = PieceIndexHash::from_index(piece_index).to_multihash();
+
+    let result = node.start_announcing(key.into()).await;
+
+    match result {
+        Err(error) => {
+            debug!(?error, %piece_index, ?key, "Piece publishing for a sector returned an error");
+
+            Err(backoff::Error::transient("Piece publishing failed".into()))
         }
-    }
+        Ok(mut stream) => {
+            if stream.next().await.is_some() {
+                trace!(%piece_index, ?key, "Piece publishing for a sector succeeded");
 
-    fn check_cancellation(&self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        if self.cancelled.load(Ordering::Acquire) {
-            debug!("Piece publishing was cancelled.");
+                Ok(())
+            } else {
+                debug!(%piece_index, ?key, "Piece publishing for a sector failed");
 
-            return Err("Piece publishing was cancelled.".into());
-        }
-
-        Ok(())
-    }
-
-    // Publishes pieces-by-sector to DSN in bulk. Supports cancellation.
-    pub async fn publish_pieces(
-        &self,
-        piece_indexes: Vec<PieceIndex>,
-    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        let mut pieces_publishing_futures = piece_indexes
-            .iter()
-            .map(|piece_index| self.publish_single_piece_with_backoff(*piece_index))
-            .collect::<FuturesUnordered<_>>();
-
-        while pieces_publishing_futures.next().await.is_some() {
-            self.check_cancellation()?;
-        }
-
-        info!("Piece publishing was successful.");
-
-        Ok(())
-    }
-
-    async fn publish_single_piece_with_backoff(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        let backoff = ExponentialBackoff {
-            initial_interval: PUT_PIECE_INITIAL_INTERVAL,
-            max_interval: PUT_PIECE_MAX_INTERVAL,
-            // Try until we get a valid piece
-            max_elapsed_time: None,
-            ..ExponentialBackoff::default()
-        };
-
-        retry(backoff, || async {
-            self.check_cancellation()
-                .map_err(backoff::Error::Permanent)?;
-
-            match self.publish_single_piece(piece_index).await {
-                Ok(()) => {
-                    return Ok(());
-                }
-                Err(error) => {
-                    error!(%piece_index, %error, "Couldn't publish a piece. Retrying...");
-                }
-            }
-
-            Err(backoff::Error::transient(
-                "Couldn't publish piece to DSN".into(),
-            ))
-        })
-        .await
-    }
-
-    async fn publish_single_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        self.check_cancellation()?;
-
-        let key = PieceIndexHash::from_index(piece_index).to_multihash();
-
-        let result = self.dsn_node.start_announcing(key.into()).await;
-
-        match result {
-            Err(error) => {
-                debug!(?error, %piece_index, ?key, "Piece publishing for a sector returned an error");
-
-                Err("Piece publishing failed".into())
-            }
-            Ok(mut stream) => {
-                if stream.next().await.is_some() {
-                    trace!(%piece_index, ?key, "Piece publishing for a sector succeeded");
-
-                    Ok(())
-                } else {
-                    debug!(%piece_index, ?key, "Piece publishing for a sector failed");
-
-                    Err("Piece publishing was unsuccessful".into())
-                }
+                Err(backoff::Error::transient(
+                    "Piece publishing was unsuccessful".into(),
+                ))
             }
         }
     }

--- a/crates/subspace-networking/src/utils/pieces.rs
+++ b/crates/subspace-networking/src/utils/pieces.rs
@@ -1,3 +1,5 @@
+use crate::node::Node;
+use crate::utils::multihash::ToMultihash;
 use backoff::future::retry;
 use backoff::ExponentialBackoff;
 use futures::stream::FuturesUnordered;
@@ -7,7 +9,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{PieceIndex, PieceIndexHash};
-use subspace_networking::{Node, ToMultihash};
 use tracing::{debug, error, info, trace};
 
 /// Defines initial duration between put_piece calls.

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,7 +16,6 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 derive_more = "0.99.17"
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 either = "1.8.0"

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -2,8 +2,6 @@ mod node_provider_storage;
 
 use crate::dsn::node_provider_storage::NodeProviderStorage;
 use crate::piece_cache::PieceCache;
-use backoff::future::retry;
-use backoff::ExponentialBackoff;
 use either::Either;
 use futures::stream::FuturesUnordered;
 use futures::{Stream, StreamExt};
@@ -11,30 +9,21 @@ use sc_client_api::AuxStore;
 use sc_consensus_subspace::ArchivedSegmentNotification;
 use sp_core::traits::SpawnNamed;
 use sp_runtime::traits::Block as BlockT;
-use std::error::Error;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
 use subspace_archiving::archiver::ArchivedSegment;
-use subspace_core_primitives::{PieceIndex, PieceIndexHash, PIECES_IN_SEGMENT};
+use subspace_core_primitives::{PieceIndex, PIECES_IN_SEGMENT};
 use subspace_networking::libp2p::{identity, Multiaddr};
+use subspace_networking::utils::pieces::announce_single_piece_with_backoff;
 use subspace_networking::{
     peer_id, BootstrappedNetworkingParameters, CreationError, MemoryProviderStorage, Node,
     NodeRunner, ParityDbProviderStorage, PieceByHashRequestHandler, PieceByHashResponse,
-    ToMultihash,
 };
 use tokio::sync::Semaphore;
-use tokio::time::error::Elapsed;
-use tokio::time::timeout;
-use tracing::{debug, error, info, trace, warn, Instrument};
+use tracing::{error, info, trace, warn, Instrument};
 
-/// Max time allocated for putting piece from DSN before attempt is considered to fail
-const PUBLISH_PIECE_TIMEOUT: Duration = Duration::from_secs(120);
-/// Defines initial duration between put_piece calls.
-const PUBLISH_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
-/// Defines max duration between put_piece calls.
-const PUBLISH_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(30);
 /// Provider records cache size
 const MAX_PROVIDER_RECORDS_LIMIT: usize = 100000; // ~ 10 MB
 
@@ -187,8 +176,10 @@ pub(crate) async fn publish_pieces(
 ) {
     let pieces_indexes = (first_piece_index..).take(archived_segment.pieces.count());
 
+    let cancelled = AtomicBool::new(false);
+
     let mut pieces_publishing_futures = pieces_indexes
-        .map(|piece_index| publish_single_piece_with_backoff(node, piece_index))
+        .map(|piece_index| announce_single_piece_with_backoff(piece_index, node, &cancelled))
         .collect::<FuturesUnordered<_>>();
 
     while pieces_publishing_futures.next().await.is_some() {
@@ -196,64 +187,4 @@ pub(crate) async fn publish_pieces(
     }
 
     info!(%segment_index, "Piece publishing was successful.");
-}
-
-async fn publish_single_piece_with_backoff(
-    node: &Node,
-    piece_index: PieceIndex,
-) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let backoff = ExponentialBackoff {
-        initial_interval: PUBLISH_PIECE_INITIAL_INTERVAL,
-        max_interval: PUBLISH_PIECE_MAX_INTERVAL,
-        // Try until we get a valid piece
-        max_elapsed_time: None,
-        ..ExponentialBackoff::default()
-    };
-
-    retry(backoff, || async {
-        let publish_timeout_result: Result<Result<(), _>, Elapsed> = timeout(
-            PUBLISH_PIECE_TIMEOUT,
-            publish_single_piece(node, piece_index),
-        )
-        .await;
-
-        if let Ok(publish_result) = publish_timeout_result {
-            if publish_result.is_ok() {
-                return Ok(());
-            }
-        }
-
-        debug!(%piece_index, "Couldn't publish a piece. Retrying...");
-
-        Err(backoff::Error::transient(
-            "Couldn't publish piece to DSN".into(),
-        ))
-    })
-    .await
-}
-
-async fn publish_single_piece(
-    node: &Node,
-    piece_index: PieceIndex,
-) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let key = PieceIndexHash::from_index(piece_index).to_multihash();
-
-    match node.start_announcing(key.into()).await {
-        Ok(mut stream) => {
-            if stream.next().await.is_some() {
-                trace!(%piece_index, ?key, "Piece announcing succeeded");
-
-                Ok(())
-            } else {
-                warn!(%piece_index, ?key, "Piece announcing failed");
-
-                Err("Piece publishing was unsuccessful".into())
-            }
-        }
-        Err(error) => {
-            error!( %piece_index, ?key, "Piece announcing failed with an error: {}", error);
-
-            Err("Piece publishing failed".into())
-        }
-    }
 }

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -11,7 +11,6 @@ use sp_core::traits::SpawnNamed;
 use sp_runtime::traits::Block as BlockT;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::{PieceIndex, PIECES_IN_SEGMENT};
@@ -176,10 +175,8 @@ pub(crate) async fn publish_pieces(
 ) {
     let pieces_indexes = (first_piece_index..).take(archived_segment.pieces.count());
 
-    let cancelled = AtomicBool::new(false);
-
     let mut pieces_publishing_futures = pieces_indexes
-        .map(|piece_index| announce_single_piece_with_backoff(piece_index, node, &cancelled))
+        .map(|piece_index| announce_single_piece_with_backoff(piece_index, node))
         .collect::<FuturesUnordered<_>>();
 
     while pieces_publishing_futures.next().await.is_some() {


### PR DESCRIPTION
This builds on top of https://github.com/subspace/subspace/pull/1088 and further optimizes things by ensuring we don't announce pieces we have already announced before. This is a common case during early stages of the network and with large plots, where the same pieces are plotted into multiple sectors. Skipping unnecessary announcements provides another significant boost to plotting and networking performance in general.

The next step will be to integrate plotting and caching more closely, such that pieces we pull from the network for plotting purposes will be cached (if necessary), that way we don't need to pull them later and do much work when announcements are received. Similarly locally cached pieces can be used for plotting (this might be already the case, but I'm not 100% confident in this and need to verify).

When subspace-cli adopts this it'll get the biggest performance boost as most of the pieces in case of small chain will come from the cache node already maintains.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
