### PR TITLE
Use correct API for derivation of libp2p identity on the farmer

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -18,6 +18,7 @@ use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
 use tracing::{debug, error, info};
+use zeroize::Zeroizing;
 
 #[derive(Debug, Copy, Clone)]
 struct PieceDetails {
@@ -256,18 +257,12 @@ pub(crate) async fn farm_multi_disk(
     anyhow::Ok(())
 }
 
-// TODO: implement proper conversion function with crypto entropy generator and zeroizing
 fn derive_libp2p_keypair(schnorrkel_sk: &schnorrkel::SecretKey) -> Keypair {
-    const SECRET_KEY_LENGTH: usize = 32;
+    let mut secret_bytes = Zeroizing::new(schnorrkel_sk.to_ed25519_bytes());
 
-    let schnorrkel_sk_bytes: [u8; SECRET_KEY_LENGTH] = schnorrkel_sk.to_bytes()
-        [..SECRET_KEY_LENGTH]
-        .try_into()
-        .expect("Should be correct array length here.");
-
-    let sk = ed25519::SecretKey::from_bytes(schnorrkel_sk_bytes)
-        .expect("Bytes array length should be compatible");
-    let ed25519_keypair: ed25519::Keypair = sk.into();
-
-    Keypair::Ed25519(ed25519_keypair)
+    Keypair::Ed25519(
+        ed25519::SecretKey::from_bytes(&mut secret_bytes.as_mut()[..32])
+            .expect("Secret key is exactly 32 bytes in size; qed")
+            .into(),
+    )
 }


### PR DESCRIPTION
We were not calling the correct function and some conversions were unnecessary. While at it I've also resolved TODO we had there.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
