### PR TITLE
DSN optimizations (part 4)

### DIFF
--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -24,7 +24,6 @@ use sp_runtime::{Digest, DigestItem};
 use std::error::Error;
 use std::io::Cursor;
 use std::num::{NonZeroU32, NonZeroU64};
-use std::sync::atomic::AtomicBool;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -111,7 +110,6 @@ impl Farmer {
             &public_key,
             sector_index,
             &piece_receiver,
-            &AtomicBool::new(false),
             &farmer_protocol_info,
             &kzg,
             &sector_codec,

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -4,7 +4,6 @@ use memmap2::Mmap;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU32, NonZeroU64};
-use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 use std::{env, fs, io};
 use subspace_archiving::archiver::Archiver;
@@ -54,7 +53,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     )
     .unwrap();
 
-    let cancelled = AtomicBool::new(false);
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
         recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
@@ -71,7 +69,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &public_key,
             sector_index,
             &BenchPieceReceiver::new(piece),
-            &cancelled,
             &farmer_protocol_info,
             &kzg,
             &sector_codec,

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -5,7 +5,6 @@ use rayon::current_num_threads;
 use rayon::prelude::*;
 use std::io;
 use std::num::{NonZeroU32, NonZeroU64};
-use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
@@ -45,7 +44,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     )
     .unwrap();
 
-    let cancelled = AtomicBool::new(false);
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
         recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
@@ -62,7 +60,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&public_key),
                 black_box(sector_index),
                 black_box(&piece_receiver),
-                black_box(&cancelled),
                 black_box(&farmer_protocol_info),
                 black_box(&kzg),
                 black_box(&sector_codec),
@@ -85,7 +82,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&public_key),
                         black_box(sector_index),
                         black_box(&piece_receiver),
-                        black_box(&cancelled),
                         black_box(&farmer_protocol_info),
                         black_box(&kzg),
                         black_box(&sector_codec),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -5,7 +5,6 @@ use schnorrkel::Keypair;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU32, NonZeroU64};
-use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 use std::{env, fs, io};
 use subspace_archiving::archiver::Archiver;
@@ -56,7 +55,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     )
     .unwrap();
 
-    let cancelled = AtomicBool::new(false);
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),
         recorded_history_segment_size: RECORDED_HISTORY_SEGMENT_SIZE,
@@ -75,7 +73,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &public_key,
             sector_index,
             &BenchPieceReceiver::new(piece),
-            &cancelled,
             &farmer_protocol_info,
             &kzg,
             &sector_codec,

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -5,6 +5,7 @@ use futures::StreamExt;
 use parity_scale_codec::Encode;
 use std::error::Error;
 use std::io;
+use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::{Commitment, Kzg};
 use subspace_core_primitives::sector_codec::{SectorCodec, SectorCodecError};
@@ -22,6 +23,19 @@ pub trait PieceReceiver {
         &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
+}
+
+#[async_trait]
+impl<T> PieceReceiver for Arc<T>
+where
+    T: PieceReceiver + Send + Sync,
+{
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+        self.as_ref().get_piece(piece_index).await
+    }
 }
 
 /// Information about sector that was plotted

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -5,7 +5,6 @@ use futures::StreamExt;
 use parity_scale_codec::Encode;
 use std::error::Error;
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::{Commitment, Kzg};
 use subspace_core_primitives::sector_codec::{SectorCodec, SectorCodecError};
@@ -13,7 +12,7 @@ use subspace_core_primitives::{
     Piece, PieceIndex, PublicKey, Scalar, SectorId, SectorIndex, PIECE_SIZE, PLOT_SECTOR_SIZE,
 };
 use thiserror::Error;
-use tracing::{debug, info};
+use tracing::info;
 
 /// Duplicate trait for the subspace_networking::PieceReceiver. The goal of this trait is
 /// simplifying dependency graph.
@@ -41,9 +40,6 @@ pub struct PlottedSector {
 /// Plotting status
 #[derive(Debug, Error)]
 pub enum PlottingError {
-    /// Plotting was cancelled
-    #[error("Plotting was cancelled")]
-    Cancelled,
     /// Piece not found, can't create sector, this should never happen
     #[error("Piece {piece_index} not found, can't create sector, this should never happen")]
     PieceNotFound {
@@ -79,7 +75,6 @@ pub async fn plot_sector<PR, S, SM>(
     public_key: &PublicKey,
     sector_index: u64,
     piece_receiver: &PR,
-    cancelled: &AtomicBool,
     farmer_protocol_info: &FarmerProtocolInfo,
     kzg: &Kzg,
     sector_codec: &SectorCodec,
@@ -119,7 +114,6 @@ where
         sector_index,
         piece_receiver,
         &piece_indexes,
-        cancelled,
     )
     .await?;
 
@@ -181,22 +175,16 @@ async fn plot_pieces_in_batches_non_blocking<PR: PieceReceiver>(
     sector_index: u64,
     piece_receiver: &PR,
     piece_indexes: &[PieceIndex],
-    cancelled: &AtomicBool,
 ) -> Result<(), PlottingError> {
     let mut pieces_receiving_futures = piece_indexes
         .iter()
         .map(|piece_index| async {
-            let piece_result = match check_cancellation(cancelled, sector_index) {
-                Ok(()) => piece_receiver.get_piece(*piece_index).await,
-                Err(error) => Err(error.into()),
-            };
+            let piece_result = piece_receiver.get_piece(*piece_index).await;
             (*piece_index, piece_result)
         })
         .collect::<FuturesOrdered<_>>();
 
     while let Some((piece_index, piece_result)) = pieces_receiving_futures.next().await {
-        check_cancellation(cancelled, sector_index)?;
-
         let piece = piece_result
             .map_err(|error| PlottingError::FailedToRetrievePiece { piece_index, error })?
             .ok_or(PlottingError::PieceNotFound { piece_index })?;
@@ -210,18 +198,6 @@ async fn plot_pieces_in_batches_non_blocking<PR: PieceReceiver>(
     }
 
     info!(%sector_index, "Plotting was successful.");
-
-    Ok(())
-}
-
-fn check_cancellation(cancelled: &AtomicBool, sector_index: u64) -> Result<(), PlottingError> {
-    if cancelled.load(Ordering::Acquire) {
-        debug!(
-            %sector_index,
-            "Plotting was cancelled, interrupting plotting"
-        );
-        return Err(PlottingError::Cancelled);
-    }
 
     Ok(())
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -91,8 +91,11 @@ pub(crate) async fn farm_multi_disk(
         configure_dsn(base_path, keypair, dsn, &readers_and_pieces).await?
     };
 
-    let _announcements_processing_handler =
-        start_announcements_processor(node.clone(), wrapped_piece_storage)?;
+    let _announcements_processing_handler = start_announcements_processor(
+        node.clone(),
+        wrapped_piece_storage,
+        Arc::downgrade(&readers_and_pieces),
+    )?;
 
     let mut single_disk_plots = Vec::with_capacity(disk_farms.len());
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -2,7 +2,7 @@ mod dsn;
 mod farmer_provider_storage;
 mod piece_storage;
 
-use crate::commands::farm::dsn::{configure_dsn, start_announcements_processor};
+use crate::commands::farm::dsn::{configure_dsn, start_announcements_processor, PieceStorage};
 use crate::utils::{get_required_plot_space_with_overhead, shutdown_signal};
 use crate::{DiskFarm, FarmingArgs};
 use anyhow::{anyhow, Result};
@@ -25,32 +25,81 @@ use subspace_farmer::utils::piece_validator::RecordsRootPieceValidator;
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_farmer_components::plotting::PieceReceiver;
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
-use subspace_networking::utils::pieces::announce_single_piece_index_with_backoff;
-use subspace_networking::PieceProvider;
+use subspace_networking::utils::pieces::{
+    announce_single_piece_index_hash_with_backoff, announce_single_piece_index_with_backoff,
+};
+use subspace_networking::{Node, PieceProvider, ToMultihash};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info};
 
 const RECORDS_ROOTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000_000).expect("Not zero; qed");
 
-/// Adapter struct used to implement `PieceReceiver` trait for `PieceProvider`.
-struct PieceReceiverWrapper<PV>(PieceProvider<PV>);
+struct FarmerPieceReceiver<PV, PS> {
+    piece_provider: PieceProvider<PV>,
+    piece_storage: Arc<tokio::sync::Mutex<PS>>,
+    node: Node,
+}
 
-impl<PV> PieceReceiverWrapper<PV> {
-    fn new(piece_provider: PieceProvider<PV>) -> Self {
-        Self(piece_provider)
+impl<PV, PS> FarmerPieceReceiver<PV, PS> {
+    fn new(
+        piece_provider: PieceProvider<PV>,
+        piece_storage: Arc<tokio::sync::Mutex<PS>>,
+        node: Node,
+    ) -> Self {
+        Self {
+            piece_provider,
+            piece_storage,
+            node,
+        }
     }
 }
 
 #[async_trait]
-impl<PV> PieceReceiver for PieceReceiverWrapper<PV>
+impl<PV, PS> PieceReceiver for FarmerPieceReceiver<PV, PS>
 where
     PV: subspace_networking::PieceValidator,
+    PS: PieceStorage + Send + 'static,
 {
     async fn get_piece(
         &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
-        self.0.get_piece(piece_index).await
+        let piece_index_hash = PieceIndexHash::from_index(piece_index);
+        let key = piece_index_hash.to_multihash().into();
+
+        let maybe_should_store = {
+            let piece_storage = self.piece_storage.lock().await;
+            if let Some(piece) = piece_storage.get_piece(&key) {
+                return Ok(Some(piece));
+            }
+
+            piece_storage.should_include_in_storage(&key)
+        };
+
+        let maybe_piece = self.piece_provider.get_piece(piece_index).await?;
+
+        if let Some(piece) = &maybe_piece {
+            if maybe_should_store {
+                let mut piece_storage = self.piece_storage.lock().await;
+                if piece_storage.should_include_in_storage(&key)
+                    && piece_storage.get_piece(&key).is_none()
+                {
+                    piece_storage.add_piece(key, piece.clone());
+                    if let Err(error) =
+                        announce_single_piece_index_hash_with_backoff(piece_index_hash, &self.node)
+                            .await
+                    {
+                        debug!(
+                            ?error,
+                            ?piece_index_hash,
+                            "Announcing retrieved and cached piece index hash failed"
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(maybe_piece)
     }
 }
 
@@ -100,7 +149,7 @@ pub(crate) async fn farm_multi_disk(
         farming_args.max_concurrent_plots.get(),
     ));
 
-    let (node, mut node_runner, wrapped_piece_storage) = {
+    let (node, mut node_runner, piece_storage) = {
         // TODO: Temporary networking identity derivation from the first disk farm identity.
         let directory = disk_farms
             .first()
@@ -123,15 +172,17 @@ pub(crate) async fn farm_multi_disk(
         configure_dsn(base_path, keypair, dsn, &readers_and_pieces).await?
     };
 
+    let piece_storage = Arc::new(tokio::sync::Mutex::new(piece_storage));
+
     let _announcements_processing_handler = start_announcements_processor(
         node.clone(),
-        wrapped_piece_storage,
+        Arc::clone(&piece_storage),
         Arc::downgrade(&readers_and_pieces),
     )?;
 
     let kzg = Kzg::new(test_public_parameters());
     let records_roots_cache = Mutex::new(LruCache::new(RECORDS_ROOTS_CACHE_SIZE));
-    let piece_receiver = Arc::new(PieceReceiverWrapper::new(PieceProvider::new(
+    let piece_provider = PieceProvider::new(
         node.clone(),
         Some(RecordsRootPieceValidator::new(
             node.clone(),
@@ -139,7 +190,12 @@ pub(crate) async fn farm_multi_disk(
             kzg.clone(),
             records_roots_cache,
         )),
-    )));
+    );
+    let piece_receiver = Arc::new(FarmerPieceReceiver::new(
+        piece_provider,
+        piece_storage,
+        node.clone(),
+    ));
 
     let mut single_disk_plots = Vec::with_capacity(disk_farms.len());
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -27,7 +27,6 @@ use tokio::runtime::Handle;
 use tokio::sync::Semaphore;
 use tracing::{debug, info, trace, warn, Instrument, Span};
 
-const MAX_KADEMLIA_RECORDS_NUMBER: usize = 32768;
 const MAX_CONCURRENT_ANNOUNCEMENTS_QUEUE: usize = 2000;
 const MAX_CONCURRENT_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(20).expect("Not zero; qed");
@@ -51,10 +50,6 @@ pub(super) async fn configure_dsn(
     ),
     anyhow::Error,
 > {
-    let record_cache_size = NonZeroUsize::new(record_cache_size).unwrap_or(
-        NonZeroUsize::new(MAX_KADEMLIA_RECORDS_NUMBER)
-            .expect("We don't expect an error on manually set value."),
-    );
     let weak_readers_and_pieces = Arc::downgrade(readers_and_pieces);
 
     let record_cache_db_path = base_path.join("records_cache_db").into_boxed_path();

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -69,8 +69,8 @@ struct DsnArgs {
     #[arg(long, default_value = "/ip4/0.0.0.0/tcp/30533")]
     listen_on: Vec<Multiaddr>,
     /// Record cache size in items.
-    #[arg(long, default_value_t = 65536)]
-    record_cache_size: usize,
+    #[arg(long, default_value = "65536")]
+    record_cache_size: NonZeroUsize,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
     #[arg(long, default_value_t = false)]
     disable_private_ips: bool,

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -35,7 +35,7 @@ pub mod node_client;
 pub(crate) mod object_mappings;
 pub mod reward_signing;
 pub mod single_disk_plot;
-mod utils;
+pub mod utils;
 pub mod ws_rpc_server;
 
 pub use identity::Identity;

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -42,6 +42,7 @@ use subspace_core_primitives::{
     PLOT_SECTOR_SIZE,
 };
 use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::plotting::PieceReceiver;
 use subspace_farmer_components::{farming, plotting, SectorMetadata};
 use subspace_networking::{Node, PieceProvider};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
@@ -423,16 +424,19 @@ struct Handlers {
 
 /// Adapter struct for the PieceReceiver trait for subspace-networking
 /// and subspace-farmer-components crates.
-struct PieceReceiverWrapper<PR>(PR);
+struct PieceReceiverWrapper<'a, PV>(PieceProvider<'a, PV>);
 
-impl<PR: subspace_networking::PieceReceiver> PieceReceiverWrapper<PR> {
-    fn new(piece_getter: PR) -> Self {
-        Self(piece_getter)
+impl<'a, PV> PieceReceiverWrapper<'a, PV> {
+    fn new(piece_provider: PieceProvider<'a, PV>) -> Self {
+        Self(piece_provider)
     }
 }
 
 #[async_trait]
-impl<PR: subspace_networking::PieceReceiver> plotting::PieceReceiver for PieceReceiverWrapper<PR> {
+impl<'a, PV> PieceReceiver for PieceReceiverWrapper<'a, PV>
+where
+    PV: subspace_networking::PieceValidator,
+{
     async fn get_piece(
         &self,
         piece_index: PieceIndex,

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -15,6 +15,7 @@ use bytesize::ByteSize;
 use derive_more::{Display, From};
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::{mpsc, oneshot};
+use futures::future::{select, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use lru::LruCache;
@@ -30,7 +31,6 @@ use std::io::{Seek, SeekFrom};
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::{fmt, fs, io, thread};
@@ -460,16 +460,17 @@ pub struct SingleDiskPlot {
     _reading_join_handle: JoinOnDrop,
     /// Sender that will be used to signal to background threads that they should start
     start_sender: Option<broadcast::Sender<()>>,
-    shutting_down: Arc<AtomicBool>,
+    /// Sender that will be used to signal to background threads that they must stop
+    stop_sender: Option<broadcast::Sender<()>>,
 }
 
 impl Drop for SingleDiskPlot {
     fn drop(&mut self) {
         self.piece_reader.close_all_readers();
-        // Make background threads that are doing something exit as soon as possible
-        self.shutting_down.store(true, Ordering::SeqCst);
         // Make background threads that are waiting to do something exit immediately
         self.start_sender.take();
+        // Notify background tasks that they must stop
+        self.stop_sender.take();
     }
 }
 
@@ -654,11 +655,11 @@ impl SingleDiskPlot {
         }));
 
         let handlers = Arc::<Handlers>::default();
-        let shutting_down = Arc::new(AtomicBool::new(false));
         let kzg = Kzg::new(test_public_parameters());
         let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize)
             .expect("Protocol constant must be correct; qed");
         let (start_sender, mut start_receiver) = broadcast::channel::<()>(1);
+        let (stop_sender, mut stop_receiver) = broadcast::channel::<()>(1);
 
         let plotting_join_handle = thread::Builder::new()
             .name(format!("p-{single_disk_plot_id}"))
@@ -666,7 +667,6 @@ impl SingleDiskPlot {
                 let handle = handle.clone();
                 let metadata_header = Arc::clone(&metadata_header);
                 let handlers = Arc::clone(&handlers);
-                let shutting_down = Arc::clone(&shutting_down);
                 let node_client = node_client.clone();
                 let error_sender = Arc::clone(&error_sender);
 
@@ -710,7 +710,6 @@ impl SingleDiskPlot {
                                 &kzg,
                                 &records_roots_cache,
                             )),
-                            &shutting_down,
                         );
 
                         let piece_receiver_wrapper = PieceReceiverWrapper::new(piece_receiver);
@@ -732,14 +731,6 @@ impl SingleDiskPlot {
                                     }
                                 };
 
-                            if shutting_down.load(Ordering::Acquire) {
-                                debug!(
-                                    %sector_index,
-                                    "Instance is shutting down, interrupting plotting"
-                                );
-                                return Ok(());
-                            }
-
                             debug!(%sector_index, "Plotting sector");
 
                             let farmer_app_info = node_client
@@ -751,7 +742,6 @@ impl SingleDiskPlot {
                                 &public_key,
                                 sector_index,
                                 &piece_receiver_wrapper,
-                                &shutting_down,
                                 &farmer_app_info.protocol_info,
                                 &kzg,
                                 &sector_codec,
@@ -763,9 +753,6 @@ impl SingleDiskPlot {
                                     debug!(%sector_index, "Sector plotted");
 
                                     plotted_sector
-                                }
-                                Err(plotting::PlottingError::Cancelled) => {
-                                    return Ok(());
                                 }
                                 Err(error) => Err(PlottingError::LowLevel(error))?,
                             };
@@ -785,10 +772,12 @@ impl SingleDiskPlot {
                         Ok(())
                     };
 
-                    // TODO: Race this with shutdown signal
-                    let initial_plotting_result = handle.block_on(initial_plotting_fut);
+                    let initial_plotting_result = handle.block_on(select(
+                        Box::pin(initial_plotting_fut),
+                        Box::pin(stop_receiver.recv()),
+                    ));
 
-                    if let Err(error) = initial_plotting_result {
+                    if let Either::Left((Err(error), _)) = initial_plotting_result {
                         if let Some(error_sender) = error_sender.lock().take() {
                             if let Err(error) = error_sender.send(error) {
                                 error!(%error, "Plotting failed to send error to background task");
@@ -818,7 +807,6 @@ impl SingleDiskPlot {
             mpsc::channel::<SlotInfo>(0);
 
         tasks.push(Box::pin({
-            let shutting_down = Arc::clone(&shutting_down);
             let node_client = node_client.clone();
 
             async move {
@@ -830,11 +818,6 @@ impl SingleDiskPlot {
                     .map_err(|error| FarmingError::FailedToSubscribeSlotInfo { error })?;
 
                 while let Some(slot_info) = slot_info_notifications.next().await {
-                    if shutting_down.load(Ordering::Acquire) {
-                        debug!("Instance is shutting down, interrupting slot info forwarding");
-                        return Ok(());
-                    }
-
                     debug!(?slot_info, "New slot");
 
                     let slot = slot_info.slot_number;
@@ -857,7 +840,7 @@ impl SingleDiskPlot {
                 let handlers = Arc::clone(&handlers);
                 let metadata_header = Arc::clone(&metadata_header);
                 let mut start_receiver = start_sender.subscribe();
-                let shutting_down = Arc::clone(&shutting_down);
+                let mut stop_receiver = stop_sender.subscribe();
                 let identity = identity.clone();
                 let node_client = node_client.clone();
 
@@ -873,11 +856,6 @@ impl SingleDiskPlot {
                         }
 
                         while let Some(slot_info) = slot_info_forwarder_receiver.next().await {
-                            if shutting_down.load(Ordering::Acquire) {
-                                debug!("Instance is shutting down, interrupting farming");
-                                return Ok(());
-                            }
-
                             let slot = slot_info.slot_number;
                             let sector_count = metadata_header.lock().sector_count;
 
@@ -908,7 +886,6 @@ impl SingleDiskPlot {
                                     .advise(memmap2::Advice::Random)
                                     .map_err(FarmingError::Io)?;
                             }
-                            let shutting_down = Arc::clone(&shutting_down);
 
                             let mut solutions = Vec::<Solution<PublicKey, PublicKey>>::new();
 
@@ -920,14 +897,6 @@ impl SingleDiskPlot {
                                     (sector_index as u64 + first_sector_index, sector, metadata)
                                 })
                             {
-                                if shutting_down.load(Ordering::Acquire) {
-                                    debug!(
-                                        %sector_index,
-                                        "Instance is shutting down, interrupting plotting"
-                                    );
-                                    return Ok(());
-                                }
-
                                 trace!(%slot, %sector_index, "Auditing sector");
 
                                 let maybe_eligible_sector = audit_sector(
@@ -991,10 +960,12 @@ impl SingleDiskPlot {
                         Ok(())
                     };
 
-                    // TODO: Race this with shutdown signal
-                    let farming_result = handle.block_on(farming_fut);
+                    let farming_result = handle.block_on(select(
+                        Box::pin(farming_fut),
+                        Box::pin(stop_receiver.recv()),
+                    ));
 
-                    if let Err(error) = farming_result {
+                    if let Either::Left((Err(error), _)) = farming_result {
                         if let Some(error_sender) = error_sender.lock().take() {
                             if let Err(error) = error_sender.send(error) {
                                 error!(%error, "Farming failed to send error to background task");
@@ -1010,7 +981,7 @@ impl SingleDiskPlot {
             .name(format!("r-{single_disk_plot_id}"))
             .spawn({
                 let metadata_header = Arc::clone(&metadata_header);
-                let shutting_down = Arc::clone(&shutting_down);
+                let mut stop_receiver = stop_sender.subscribe();
 
                 move || {
                     let _tokio_handle_guard = handle.enter();
@@ -1024,15 +995,6 @@ impl SingleDiskPlot {
                                 piece_offset,
                                 response_sender,
                             } = read_piece_request;
-
-                            if shutting_down.load(Ordering::Acquire) {
-                                debug!(
-                                    %sector_index,
-                                    %piece_offset,
-                                    "Instance is shutting down, interrupting piece reading"
-                                );
-                                return;
-                            }
 
                             if response_sender.is_canceled() {
                                 continue;
@@ -1052,8 +1014,10 @@ impl SingleDiskPlot {
                         }
                     };
 
-                    // TODO: Race this with shutdown signal
-                    handle.block_on(reading_fut);
+                    handle.block_on(select(
+                        Box::pin(reading_fut),
+                        Box::pin(stop_receiver.recv()),
+                    ));
                 }
             })?;
 
@@ -1076,7 +1040,7 @@ impl SingleDiskPlot {
             _farming_join_handle: JoinOnDrop::new(farming_join_handle),
             _reading_join_handle: JoinOnDrop::new(reading_join_handle),
             start_sender: Some(start_sender),
-            shutting_down,
+            stop_sender: Some(stop_sender),
         };
 
         Ok(farm)
@@ -1176,10 +1140,6 @@ impl SingleDiskPlot {
         }
 
         while let Some(result) = self.tasks.next().instrument(self.span.clone()).await {
-            if result.is_err() {
-                // Nothing left to do after error
-                self.shutting_down.store(true, Ordering::SeqCst);
-            }
             result?;
         }
 

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -1,3 +1,5 @@
+pub mod piece_validator;
+
 use std::ops::Deref;
 
 /// Joins synchronous join handle on drop

--- a/crates/subspace-farmer/src/utils/piece_validator.rs
+++ b/crates/subspace-farmer/src/utils/piece_validator.rs
@@ -11,19 +11,19 @@ use subspace_networking::libp2p::PeerId;
 use subspace_networking::{Node, PieceValidator};
 use tracing::error;
 
-pub(crate) struct RecordsRootPieceValidator<'a, NC> {
-    dsn_node: &'a Node,
-    node_client: &'a NC,
-    kzg: &'a Kzg,
-    records_root_cache: &'a Mutex<LruCache<SegmentIndex, RecordsRoot>>,
+pub struct RecordsRootPieceValidator<NC> {
+    dsn_node: Node,
+    node_client: NC,
+    kzg: Kzg,
+    records_root_cache: Mutex<LruCache<SegmentIndex, RecordsRoot>>,
 }
 
-impl<'a, NC> RecordsRootPieceValidator<'a, NC> {
-    pub(crate) fn new(
-        dsn_node: &'a Node,
-        node_client: &'a NC,
-        kzg: &'a Kzg,
-        records_root_cache: &'a Mutex<LruCache<SegmentIndex, RecordsRoot>>,
+impl<NC> RecordsRootPieceValidator<NC> {
+    pub fn new(
+        dsn_node: Node,
+        node_client: NC,
+        kzg: Kzg,
+        records_root_cache: Mutex<LruCache<SegmentIndex, RecordsRoot>>,
     ) -> Self {
         Self {
             dsn_node,
@@ -35,7 +35,7 @@ impl<'a, NC> RecordsRootPieceValidator<'a, NC> {
 }
 
 #[async_trait]
-impl<'a, NC> PieceValidator for RecordsRootPieceValidator<'a, NC>
+impl<NC> PieceValidator for RecordsRootPieceValidator<NC>
 where
     NC: NodeClient,
 {
@@ -86,7 +86,7 @@ where
             };
 
             if !is_piece_valid(
-                self.kzg,
+                &self.kzg,
                 PIECES_IN_SEGMENT,
                 &piece,
                 records_root,

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -60,6 +60,6 @@ pub use request_handlers::pieces_by_range::{
 };
 pub use utils::deconstruct_record_key;
 pub use utils::multihash::ToMultihash;
-pub use utils::piece_receiver::{PieceProvider, PieceReceiver, PieceValidator};
+pub use utils::piece_receiver::{PieceProvider, PieceValidator};
 pub use utils::prometheus::start_prometheus_metrics_server;
 pub use utils::record_binary_heap::RecordBinaryHeap;

--- a/crates/subspace-networking/src/utils/piece_receiver.rs
+++ b/crates/subspace-networking/src/utils/piece_receiver.rs
@@ -14,16 +14,6 @@ const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
 /// Defines max duration between get_piece calls.
 const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(5);
 
-/// An abstraction for piece receiving.
-#[async_trait]
-pub trait PieceReceiver: Send + Sync {
-    /// Returns optional piece from the DSN. None means - no piece was found.
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
-}
-
 #[async_trait]
 pub trait PieceValidator: Sync + Send {
     async fn validate_piece(
@@ -93,11 +83,8 @@ impl<'a, PV: PieceValidator> PieceProvider<'a, PV> {
 
         None
     }
-}
 
-#[async_trait]
-impl<'a, PV: PieceValidator> PieceReceiver for PieceProvider<'a, PV> {
-    async fn get_piece(
+    pub async fn get_piece(
         &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -32,7 +32,6 @@ use sp_core::{Decode, Encode};
 use std::error::Error;
 use std::io::Cursor;
 use std::num::{NonZeroU32, NonZeroU64};
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use subspace_archiving::archiver::ArchivedSegment;
 use subspace_core_primitives::crypto::kzg;
@@ -254,7 +253,6 @@ where
         &public_key,
         sector_index,
         &piece_receiver,
-        &AtomicBool::new(false),
         &farmer_protocol_info,
         &kzg,
         sector_codec,


### PR DESCRIPTION
This is where refactoring was going up until this point.

During plotting:
* farmer will only announce pieces that were not plotted (and thus announced before)
* pieces that satisfy caching policy will be cached and announced right away
* cached pieces are returned from cache without reaching to the network at all

During announcements:
* pieces that were previously announced are ignored
* announced pieces are retrieved from announcer only (instead of making full network retrieval with lookup)

There is still one more optimization I came up with, but left it for later in https://github.com/subspace/subspace/issues/1100

Fixes #1076

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
