### PR TITLE
Simplify cache size handling and make it explicit

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -27,7 +27,6 @@ use tokio::runtime::Handle;
 use tokio::sync::Semaphore;
 use tracing::{debug, info, trace, warn, Instrument, Span};
 
-const MAX_KADEMLIA_RECORDS_NUMBER: usize = 32768;
 const MAX_CONCURRENT_ANNOUNCEMENTS_QUEUE: usize = 2000;
 const MAX_CONCURRENT_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(20).expect("Not zero; qed");
@@ -51,10 +50,6 @@ pub(super) async fn configure_dsn(
     ),
     anyhow::Error,
 > {
-    let record_cache_size = NonZeroUsize::new(record_cache_size).unwrap_or(
-        NonZeroUsize::new(MAX_KADEMLIA_RECORDS_NUMBER)
-            .expect("We don't expect an error on manually set value."),
-    );
     let weak_readers_and_pieces = Arc::downgrade(readers_and_pieces);
 
     let record_cache_db_path = base_path.join("records_cache_db").into_boxed_path();

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -69,8 +69,8 @@ struct DsnArgs {
     #[arg(long, default_value = "/ip4/0.0.0.0/tcp/30533")]
     listen_on: Vec<Multiaddr>,
     /// Record cache size in items.
-    #[arg(long, default_value_t = 65536)]
-    record_cache_size: usize,
+    #[arg(long, default_value = "65536")]
+    record_cache_size: NonZeroUsize,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
     #[arg(long, default_value_t = false)]
     disable_private_ips: bool,


### PR DESCRIPTION
I first wanted to replace `usize` constant with `NonZeroUsize` as it should be, but then noticed that is  has confusing behavior due to fallback to default value (which is different from CLI) on zero. I decided to remove it and just rely on non-zero value in CLI instead.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
