### PR TITLE
Update BlockHash to use OptionQuery

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -109,12 +109,15 @@ mod pallet {
                     Self::Bundle(BundleError::Receipt(ExecutionReceiptError::MissingParent))
                 }
                 ReceiptError::FraudProof(err) => Self::FraudProof(err),
+                ReceiptError::UnavailablePrimaryBlockHash => Self::UnavailablePrimaryBlockHash,
             }
         }
     }
 
     #[pallet::error]
     pub enum Error<T> {
+        /// Can not find the block hash of given primary block number.
+        UnavailablePrimaryBlockHash,
         /// Invalid bundle.
         Bundle(BundleError),
         /// Invalid fraud proof.
@@ -178,7 +181,8 @@ mod pallet {
             log::trace!(target: "runtime::domains", "Processing fraud proof: {fraud_proof:?}");
 
             if fraud_proof.domain_id.is_system() {
-                pallet_receipts::Pallet::<T>::process_fraud_proof(fraud_proof);
+                pallet_receipts::Pallet::<T>::process_fraud_proof(fraud_proof)
+                    .map_err(Error::<T>::from)?;
             }
 
             // TODO: slash the executor accordingly.

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -318,7 +318,8 @@ mod pallet {
             log::trace!(target: "runtime::domain-registry", "Processing fraud proof: {fraud_proof:?}");
 
             if fraud_proof.domain_id.is_core() {
-                pallet_receipts::Pallet::<T>::process_fraud_proof(fraud_proof);
+                pallet_receipts::Pallet::<T>::process_fraud_proof(fraud_proof)
+                    .map_err(Error::<T>::from)?;
             }
 
             // TODO: slash the executor accordingly.
@@ -455,6 +456,9 @@ mod pallet {
             match error {
                 PalletReceiptError::MissingParent => Self::Receipt(ReceiptError::MissingParent),
                 PalletReceiptError::FraudProof(err) => Self::FraudProof(err),
+                PalletReceiptError::UnavailablePrimaryBlockHash => {
+                    Self::UnavailablePrimaryBlockHash
+                }
             }
         }
     }
@@ -503,6 +507,9 @@ mod pallet {
 
         /// Not a core domain bundle.
         NotCoreDomainBundle,
+
+        /// Can not find the block hash of given primary block number.
+        UnavailablePrimaryBlockHash,
 
         /// Receipt error.
         Receipt(ReceiptError),


### PR DESCRIPTION
Fortunately, the difference between ValueQuery and OptionQuery is only the behavior when the value is empty, this PR does not require a runtime upgrade, bumping the runtime version is sufficient as tested locally.

Close #1089

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
