### PR TITLE
Use cache for providers

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -45,7 +45,7 @@ pub(super) async fn configure_dsn(
 ) -> Result<
     (
         Node,
-        NodeRunner<FarmerProviderStorage<ParityDbProviderStorage>>,
+        NodeRunner<FarmerProviderStorage<ParityDbProviderStorage, FarmerPieceCache>>,
         FarmerPieceCache,
     ),
     anyhow::Error,
@@ -81,12 +81,16 @@ pub(super) async fn configure_dsn(
         ParityDbProviderStorage::new(&provider_cache_db_path, provider_cache_size, peer_id)
             .map_err(|err| anyhow::anyhow!(err.to_string()))?;
 
-    let farmer_provider_storage =
-        FarmerProviderStorage::new(peer_id, readers_and_pieces.clone(), db_provider_storage);
-
     let piece_store =
         ParityDbStore::new(&piece_cache_db_path).map_err(|err| anyhow::anyhow!(err.to_string()))?;
     let piece_cache = FarmerPieceCache::new(piece_store.clone(), piece_cache_size, peer_id);
+
+    let farmer_provider_storage = FarmerProviderStorage::new(
+        peer_id,
+        readers_and_pieces.clone(),
+        db_provider_storage,
+        piece_cache.clone(),
+    );
 
     let config = Config {
         reserved_peers,

--- a/crates/subspace-farmer/src/utils/parity_db_store.rs
+++ b/crates/subspace-farmer/src/utils/parity_db_store.rs
@@ -1,6 +1,5 @@
 use parity_db::{ColumnOptions, Db, Options};
 use std::error::Error;
-use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -71,9 +70,9 @@ where
         }
     }
 
-    pub fn update<'a, I>(&'a mut self, values: I) -> bool
+    pub fn update<'a, I>(&'a self, values: I) -> bool
     where
-        I: IntoIterator<Item = (&'a StoreKey, Option<Vec<u8>>)> + fmt::Debug,
+        I: IntoIterator<Item = (&'a StoreKey, Option<Vec<u8>>)> + Debug,
     {
         trace!(?values, "Updating records in DB");
 

--- a/crates/subspace-farmer/src/utils/piece_cache.rs
+++ b/crates/subspace-farmer/src/utils/piece_cache.rs
@@ -4,6 +4,8 @@ use subspace_networking::libp2p::kad::record::Key;
 /// Defines persistent piece cache interface.
 // TODO: This should be elsewhere, like in `subspace-dsn`
 pub trait PieceCache: Sync + Send + 'static {
+    type KeysIterator: IntoIterator<Item = Key>;
+
     /// Check whether key should be cached based on current cache size and key-to-peer-id distance.
     fn should_cache(&self, key: &Key) -> bool;
 
@@ -12,4 +14,7 @@ pub trait PieceCache: Sync + Send + 'static {
 
     /// Get piece from the cache.
     fn get_piece(&self, key: &Key) -> Option<Piece>;
+
+    /// Iterator over pieces in cache
+    fn keys(&self) -> Self::KeysIterator;
 }

--- a/crates/subspace-networking/src/utils/record_binary_heap.rs
+++ b/crates/subspace-networking/src/utils/record_binary_heap.rs
@@ -106,6 +106,11 @@ impl RecordBinaryHeap {
         }
     }
 
+    /// Iterator over all keys in arbitrary order
+    pub fn keys(&self) -> impl Iterator<Item = &'_ Key> {
+        self.max_heap.iter().map(|key| key.key.preimage())
+    }
+
     fn is_limit_reached(&self) -> bool {
         self.size() >= self.limit
     }


### PR DESCRIPTION
This builds on #1131 and fixes #1133.

The approach here is the following:
* `PieceCache` trait was extended with iteration support
* `FarmerProviderStorage` no longer persists locally provided records, instead it implicitly derives it from local cache instead (SDK will will have to also account for pieces cached by the node, so piece cache argument should be a wrapper that combines both piece and farmer cache in this particular scenario)

I did some tiny cleanups along the way when I saw them, hope they are not too distracting (I was intending to do some changes there, but they ended up being unnecessary, but cleanups seemed useful).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
