### PR TITLE
Fix spamming of `pallet-domain` submit_bundle transaction

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -195,7 +195,7 @@ mod pallet {
         #[pallet::weight((10_000, Pays::No))]
         pub fn submit_bundle_equivocation_proof(
             origin: OriginFor<T>,
-            bundle_equivocation_proof: BundleEquivocationProof<T::Hash>,
+            bundle_equivocation_proof: BundleEquivocationProof<T::BlockNumber, T::Hash>,
         ) -> DispatchResult {
             ensure_none(origin)?;
 
@@ -618,7 +618,7 @@ impl<T: Config> Pallet<T> {
 
     // TODO: Checks if the bundle equivocation proof is valid.
     fn validate_bundle_equivocation_proof(
-        _bundle_equivocation_proof: &BundleEquivocationProof<T::Hash>,
+        _bundle_equivocation_proof: &BundleEquivocationProof<T::BlockNumber, T::Hash>,
     ) -> Result<(), Error<T>> {
         Ok(())
     }
@@ -669,7 +669,7 @@ where
 
     /// Submits an unsigned extrinsic [`Call::submit_bundle_equivocation_proof`].
     pub fn submit_bundle_equivocation_proof_unsigned(
-        bundle_equivocation_proof: BundleEquivocationProof<T::Hash>,
+        bundle_equivocation_proof: BundleEquivocationProof<T::BlockNumber, T::Hash>,
     ) {
         let call = Call::submit_bundle_equivocation_proof {
             bundle_equivocation_proof,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -60,7 +60,7 @@ mod pallet {
     #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
-    #[derive(TypeInfo, Encode, Decode, PalletError, Debug)]
+    #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
         /// The signer of bundle is unexpected.
         UnexpectedSigner,
@@ -88,7 +88,7 @@ mod pallet {
         }
     }
 
-    #[derive(TypeInfo, Encode, Decode, PalletError, Debug)]
+    #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum ExecutionReceiptError {
         /// The parent execution receipt is unknown.
         MissingParent,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -30,7 +30,7 @@ use sp_domains::bundle_election::{verify_system_bundle_solution, verify_vrf_proo
 use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
 use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{DomainId, ExecutionReceipt, ProofOfElection, SignedOpaqueBundle};
-use sp_runtime::traits::{BlockNumberProvider, One, Zero};
+use sp_runtime::traits::{BlockNumberProvider, CheckedSub, One, Zero};
 use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_runtime::RuntimeAppPublic;
 
@@ -78,6 +78,8 @@ mod pallet {
         BadElectionSolution,
         /// An invalid execution receipt found in the bundle.
         Receipt(ExecutionReceiptError),
+        /// The Bundle is created too long ago.
+        StaleBundle,
     }
 
     impl<T> From<BundleError> for Error<T> {
@@ -540,6 +542,16 @@ impl<T: Config> Pallet<T> {
             signature,
         }: &SignedOpaqueBundle<T::BlockNumber, T::Hash, T::DomainHash>,
     ) -> Result<(), BundleError> {
+        let current_block_number = frame_system::Pallet::<T>::current_block_number();
+
+        if let Some(last_finalized) =
+            current_block_number.checked_sub(&T::ConfirmationDepthK::get())
+        {
+            if bundle.header.primary_number <= last_finalized {
+                return Err(BundleError::StaleBundle);
+            }
+        }
+
         let proof_of_election = bundle_solution.proof_of_election();
 
         if !proof_of_election
@@ -561,8 +573,6 @@ impl<T: Config> Pallet<T> {
 
         if proof_of_election.domain_id.is_system() {
             Self::validate_system_bundle_solution(&bundle.receipts, proof_of_election)?;
-
-            let current_block_number = frame_system::Pallet::<T>::current_block_number();
 
             let best_number = Self::head_receipt_number();
             let max_allowed = best_number + T::MaximumReceiptDrift::get();

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -115,6 +115,7 @@ fn create_dummy_bundle(
 
     let bundle = Bundle {
         header: BundleHeader {
+            primary_number,
             primary_hash,
             slot_number: 0u64,
             extrinsics_root: Default::default(),
@@ -149,12 +150,14 @@ fn create_dummy_bundle(
 
 fn create_dummy_bundle_with_receipts(
     domain_id: DomainId,
+    primary_number: BlockNumber,
     primary_hash: Hash,
     receipts: Vec<ExecutionReceipt<BlockNumber, Hash, H256>>,
 ) -> SignedOpaqueBundle<BlockNumber, Hash, H256> {
     let pair = ExecutorPair::from_seed(&U256::from(0u32).into());
 
     let header = BundleHeader {
+        primary_number,
         primary_hash,
         slot_number: 0u64,
         extrinsics_root: Default::default(),
@@ -337,7 +340,8 @@ fn submit_bundle_with_many_reeipts_should_work() {
         .unzip();
 
     let primary_hash_255 = *block_hashes.last().unwrap();
-    let bundle1 = create_dummy_bundle_with_receipts(DomainId::SYSTEM, primary_hash_255, receipts);
+    let bundle1 =
+        create_dummy_bundle_with_receipts(DomainId::SYSTEM, 255u64, primary_hash_255, receipts);
 
     let primary_hash_256 = Hash::random();
     block_hashes.push(primary_hash_256);
@@ -402,12 +406,14 @@ fn only_system_domain_receipts_are_maintained_on_primary_chain() {
     let system_receipt = create_dummy_receipt(1, primary_hash);
     let system_bundle = create_dummy_bundle_with_receipts(
         DomainId::SYSTEM,
+        1,
         primary_hash,
         vec![system_receipt.clone()],
     );
     let core_receipt = create_dummy_receipt(1, primary_hash);
     let core_bundle = create_dummy_bundle_with_receipts(
         DomainId::new(1),
+        1,
         primary_hash,
         vec![core_receipt.clone()],
     );

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -156,18 +156,20 @@ pub struct FraudProof {
 /// are the given distinct bundle headers that were signed by the validator and which
 /// include the slot number.
 #[derive(Clone, Debug, Decode, Encode, PartialEq, TypeInfo)]
-pub struct BundleEquivocationProof<Hash> {
+pub struct BundleEquivocationProof<Number, Hash> {
     /// The authority id of the equivocator.
     pub offender: AccountId,
     /// The slot at which the equivocation happened.
     pub slot: Slot,
     /// The first header involved in the equivocation.
-    pub first_header: BundleHeader<Hash>,
+    pub first_header: BundleHeader<Number, Hash>,
     /// The second header involved in the equivocation.
-    pub second_header: BundleHeader<Hash>,
+    pub second_header: BundleHeader<Number, Hash>,
 }
 
-impl<Hash: Clone + Default + Encode> BundleEquivocationProof<Hash> {
+impl<Number: Clone + From<u32> + Encode, Hash: Clone + Default + Encode>
+    BundleEquivocationProof<Number, Hash>
+{
     /// Returns the hash of this bundle equivocation proof.
     pub fn hash(&self) -> H256 {
         BlakeTwo256::hash_of(self)
@@ -177,6 +179,7 @@ impl<Hash: Clone + Default + Encode> BundleEquivocationProof<Hash> {
     /// Constructs a dummy bundle equivocation proof.
     pub fn dummy_at(slot_number: u64) -> Self {
         let dummy_header = BundleHeader {
+            primary_number: Number::from(0u32),
             primary_hash: Hash::default(),
             slot_number,
             extrinsics_root: H256::default(),

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -269,12 +269,12 @@ pub struct Bundle<Extrinsic, Number, Hash, DomainHash> {
     pub extrinsics: Vec<Extrinsic>,
 }
 
-impl<Extrinsic, Number: Encode, Hash: Encode, DomainHash>
+impl<Extrinsic: Encode, Number: Encode, Hash: Encode, DomainHash: Encode>
     Bundle<Extrinsic, Number, Hash, DomainHash>
 {
     /// Returns the hash of this bundle.
     pub fn hash(&self) -> H256 {
-        self.header.hash()
+        BlakeTwo256::hash_of(self)
     }
 }
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -168,7 +168,9 @@ pub struct DomainConfig<Hash, Balance, Weight> {
 
 /// Header of bundle.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
-pub struct BundleHeader<Hash> {
+pub struct BundleHeader<Number, Hash> {
+    /// The block number of primary block at which the bundle was created.
+    pub primary_number: Number,
     /// The hash of primary block at which the bundle was created.
     pub primary_hash: Hash,
     /// The slot number.
@@ -177,7 +179,7 @@ pub struct BundleHeader<Hash> {
     pub extrinsics_root: H256,
 }
 
-impl<Hash: Encode> BundleHeader<Hash> {
+impl<Number: Encode, Hash: Encode> BundleHeader<Number, Hash> {
     /// Returns the hash of this header.
     pub fn hash(&self) -> H256 {
         BlakeTwo256::hash_of(self)
@@ -256,7 +258,7 @@ impl<DomainHash> BundleSolution<DomainHash> {
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct Bundle<Extrinsic, Number, Hash, DomainHash> {
     /// The bundle header.
-    pub header: BundleHeader<Hash>,
+    pub header: BundleHeader<Number, Hash>,
     /// Expected receipts by the primay chain when the bundle was created.
     ///
     /// NOTE: It's fine to `Vec` instead of `BoundedVec` as each bundle is
@@ -267,7 +269,9 @@ pub struct Bundle<Extrinsic, Number, Hash, DomainHash> {
     pub extrinsics: Vec<Extrinsic>,
 }
 
-impl<Extrinsic, Number, Hash: Encode, DomainHash> Bundle<Extrinsic, Number, Hash, DomainHash> {
+impl<Extrinsic, Number: Encode, Hash: Encode, DomainHash>
+    Bundle<Extrinsic, Number, Hash, DomainHash>
+{
     /// Returns the hash of this bundle.
     pub fn hash(&self) -> H256 {
         self.header.hash()
@@ -395,7 +399,7 @@ sp_api::decl_runtime_apis! {
 
         /// Submits the bundle equivocation proof via an unsigned extrinsic.
         fn submit_bundle_equivocation_proof_unsigned(
-            bundle_equivocation_proof: BundleEquivocationProof<Block::Hash>,
+            bundle_equivocation_proof: BundleEquivocationProof<NumberFor<Block>, Block::Hash>,
         );
 
         /// Submits the invalid transaction proof via an unsigned extrinsic.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -706,7 +706,7 @@ impl_runtime_apis! {
         }
 
         fn submit_bundle_equivocation_proof_unsigned(
-            bundle_equivocation_proof: BundleEquivocationProof<<Block as BlockT>::Hash>,
+            bundle_equivocation_proof: BundleEquivocationProof<NumberFor<Block>, <Block as BlockT>::Hash>,
         ) {
             Domains::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof)
         }

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -113,6 +113,7 @@ where
 
         let bundle = Bundle {
             header: BundleHeader {
+                primary_number,
                 primary_hash,
                 slot_number: slot.into(),
                 extrinsics_root,

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -405,6 +405,7 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
 
         let bundle = Bundle {
             header: BundleHeader {
+                primary_number,
                 primary_hash: ferdie.client.hash(primary_number).unwrap().unwrap(),
                 slot_number: (std::time::SystemTime::now()
                     .duration_since(std::time::SystemTime::UNIX_EPOCH)

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -332,7 +332,7 @@ mod pallet {
         #[pallet::weight((10_000, Pays::No))]
         pub fn submit_bundle_equivocation_proof(
             origin: OriginFor<T>,
-            _bundle_equivocation_proof: BundleEquivocationProof<T::Hash>,
+            _bundle_equivocation_proof: BundleEquivocationProof<T::BlockNumber, T::Hash>,
         ) -> DispatchResult {
             ensure_none(origin)?;
 
@@ -1014,7 +1014,7 @@ impl<T: Config> Pallet<T> {
 
     // TODO: Verify bundle_equivocation_proof.
     fn validate_bundle_equivocation_proof(
-        _bundle_equivocation_proof: &BundleEquivocationProof<T::Hash>,
+        _bundle_equivocation_proof: &BundleEquivocationProof<T::BlockNumber, T::Hash>,
     ) -> Result<(), Error<T>> {
         Ok(())
     }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1137,7 +1137,7 @@ impl_runtime_apis! {
         }
 
         fn submit_bundle_equivocation_proof_unsigned(
-            bundle_equivocation_proof: BundleEquivocationProof<<Block as BlockT>::Hash>,
+            bundle_equivocation_proof: BundleEquivocationProof<NumberFor<Block>, <Block as BlockT>::Hash>,
         ) {
             Domains::submit_bundle_equivocation_proof_unsigned(bundle_equivocation_proof)
         }


### PR DESCRIPTION
fix #1137 

This PR fixes the spamming bundle issue as the way mentioned in the issue:
- Add the `primary_number` field to the bundle header
- Use the `primary_number` field to check if a bundle is created too long ago, and reject it if so
- Revise `Bundle::hash` to return the hash of the whole bundle instead of just the bundle header, the bundle hash is used to create the bundle signature, such that the bundle signature will include the whole bundle instead of just the bundle header

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
