### PR TITLE
Pallet Receipt cleanup

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -233,7 +233,7 @@ mod pallet {
             let parent_number = block_number - One::one();
             let parent_hash = frame_system::Pallet::<T>::block_hash(parent_number);
 
-            pallet_receipts::BlockHash::<T>::insert(DomainId::SYSTEM, parent_number, parent_hash);
+            pallet_receipts::PrimaryBlockHash::<T>::insert(DomainId::SYSTEM, parent_number, parent_hash);
 
             // The genesis block hash is not finalized until the genesis block building is done,
             // hence the genesis receipt is initialized after the genesis building.
@@ -405,7 +405,7 @@ impl<T: Config> Pallet<T> {
                             target: "runtime::domains",
                             "Invalid primary hash for #{primary_number:?} in receipt, \
                             expected: {:?}, got: {:?}",
-                            pallet_receipts::BlockHash::<T>::get(DomainId::SYSTEM, primary_number),
+                            pallet_receipts::PrimaryBlockHash::<T>::get(DomainId::SYSTEM, primary_number),
                             receipt.primary_hash,
                         );
                         return Err(TransactionValidityError::Invalid(
@@ -422,7 +422,7 @@ impl<T: Config> Pallet<T> {
                             target: "runtime::domains",
                             "Invalid primary hash for #{primary_number:?} in receipt, \
                             expected: {:?}, got: {:?}",
-                            pallet_receipts::BlockHash::<T>::get(DomainId::SYSTEM, primary_number),
+                            pallet_receipts::PrimaryBlockHash::<T>::get(DomainId::SYSTEM, primary_number),
                             receipt.primary_hash,
                         );
                         return Err(TransactionValidityError::Invalid(
@@ -596,7 +596,7 @@ impl<T: Config> Pallet<T> {
                         "Receipt of #{primary_number:?},{:?} points to an unknown primary block, \
                         expected: #{primary_number:?},{:?}",
                         execution_receipt.primary_hash,
-                        pallet_receipts::BlockHash::<T>::get(DomainId::SYSTEM, primary_number),
+                        pallet_receipts::PrimaryBlockHash::<T>::get(DomainId::SYSTEM, primary_number),
                     );
                     return Err(BundleError::Receipt(ExecutionReceiptError::UnknownBlock));
                 }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -56,7 +56,7 @@ mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::generate_store(pub (super) trait Store)]
     #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
@@ -125,7 +125,7 @@ mod pallet {
     }
 
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::generate_deposit(pub (super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// A domain bundle was included.
         BundleStored {
@@ -233,7 +233,11 @@ mod pallet {
             let parent_number = block_number - One::one();
             let parent_hash = frame_system::Pallet::<T>::block_hash(parent_number);
 
-            pallet_receipts::PrimaryBlockHash::<T>::insert(DomainId::SYSTEM, parent_number, parent_hash);
+            pallet_receipts::PrimaryBlockHash::<T>::insert(
+                DomainId::SYSTEM,
+                parent_number,
+                parent_hash,
+            );
 
             // The genesis block hash is not finalized until the genesis block building is done,
             // hence the genesis receipt is initialized after the genesis building.
@@ -412,7 +416,7 @@ impl<T: Config> Pallet<T> {
                             InvalidTransactionCode::ExecutionReceipt.into(),
                         ));
                     }
-                // New nest receipt.
+                    // New nest receipt.
                 } else if primary_number == best_number + One::one() {
                     if !pallet_receipts::Pallet::<T>::point_to_valid_primary_block(
                         DomainId::SYSTEM,
@@ -430,7 +434,7 @@ impl<T: Config> Pallet<T> {
                         ));
                     }
                     best_number += One::one();
-                // Missing receipt.
+                    // Missing receipt.
                 } else {
                     return Err(TransactionValidityError::Invalid(
                         InvalidTransactionCode::ExecutionReceipt.into(),

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{self as pallet_domains};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Hooks};
 use frame_support::{assert_noop, assert_ok, parameter_types};
-use pallet_receipts::{BlockHash, ReceiptVotes};
+use pallet_receipts::{PrimaryBlockHash, ReceiptVotes};
 use sp_core::crypto::Pair;
 use sp_core::{H256, U256};
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof};
@@ -212,12 +212,12 @@ fn submit_execution_receipt_incrementally_should_work() {
 
     new_test_ext().execute_with(|| {
         let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
-        BlockHash::<Test>::insert(DomainId::SYSTEM, 0, genesis_hash);
+        PrimaryBlockHash::<Test>::insert(DomainId::SYSTEM, 0, genesis_hash);
         Receipts::initialize_genesis_receipt(DomainId::SYSTEM, genesis_hash);
 
         (0..256).for_each(|index| {
             let block_hash = block_hashes[index];
-            BlockHash::<Test>::insert(DomainId::SYSTEM, (index + 1) as u64, block_hash);
+            PrimaryBlockHash::<Test>::insert(DomainId::SYSTEM, (index + 1) as u64, block_hash);
 
             assert_ok!(pallet_domains::Pallet::<Test>::pre_dispatch(
                 &pallet_domains::Call::submit_bundle {
@@ -303,26 +303,26 @@ fn submit_execution_receipt_with_huge_gap_should_work() {
         });
 
         // Reaching the receipts pruning depth, block hash mapping will be pruned as well.
-        assert!(BlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
+        assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
         assert_ok!(Domains::submit_bundle(
             RuntimeOrigin::none(),
             dummy_bundles[255].clone(),
         ));
-        assert!(!BlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
+        assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
 
-        assert!(BlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
+        assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
         assert_ok!(Domains::submit_bundle(
             RuntimeOrigin::none(),
             dummy_bundles[256].clone(),
         ));
-        assert!(!BlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
+        assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
 
-        assert!(BlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
+        assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
         assert_ok!(Domains::submit_bundle(
             RuntimeOrigin::none(),
             dummy_bundles[257].clone(),
         ));
-        assert!(!BlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
+        assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
         assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 2);
     });
 }
@@ -376,19 +376,19 @@ fn submit_bundle_with_many_reeipts_should_work() {
         assert_eq!(Receipts::head_receipt_number(DomainId::SYSTEM), 255);
 
         // Reaching the receipts pruning depth, block hash mapping will be pruned as well.
-        assert!(BlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
+        assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle2));
-        assert!(!BlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
+        assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
         assert_eq!(Receipts::oldest_receipt_number(DomainId::SYSTEM), 1);
 
-        assert!(BlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
+        assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle3));
-        assert!(!BlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
+        assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
         assert_eq!(Receipts::oldest_receipt_number(DomainId::SYSTEM), 2);
 
-        assert!(BlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
+        assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle4));
-        assert!(!BlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
+        assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
         assert_eq!(Receipts::oldest_receipt_number(DomainId::SYSTEM), 3);
         assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 2);
         assert_eq!(Receipts::head_receipt_number(DomainId::SYSTEM), 258);
@@ -447,7 +447,7 @@ fn submit_fraud_proof_should_work() {
     new_test_ext().execute_with(|| {
         (0usize..256usize).for_each(|index| {
             let block_hash = block_hashes[index];
-            BlockHash::<Test>::insert(DomainId::SYSTEM, (index + 1) as u64, block_hash);
+            PrimaryBlockHash::<Test>::insert(DomainId::SYSTEM, (index + 1) as u64, block_hash);
 
             assert_ok!(Domains::submit_bundle(
                 RuntimeOrigin::none(),

--- a/crates/pallet-receipts/src/lib.rs
+++ b/crates/pallet-receipts/src/lib.rs
@@ -87,7 +87,7 @@ mod pallet {
     /// growth.
     #[pallet::storage]
     #[pallet::getter(fn primary_hash)]
-    pub type BlockHash<T: Config> = StorageDoubleMap<
+    pub type PrimaryBlockHash<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,
         DomainId,
@@ -97,11 +97,11 @@ mod pallet {
         OptionQuery,
     >;
 
-    /// A pair of (block_hash, block_number) of the latest execution receipt of a domain.
+    /// Stores the latest block number for which Execution receipt(s) are available for a given Domain.
     #[pallet::storage]
     #[pallet::getter(fn receipt_head)]
-    pub(super) type ReceiptHead<T: Config> =
-        StorageMap<_, Twox64Concat, DomainId, (T::Hash, T::BlockNumber), ValueQuery>;
+    pub(super) type HeadReceiptNumber<T: Config> =
+        StorageMap<_, Twox64Concat, DomainId, T::BlockNumber, ValueQuery>;
 
     /// Block number of the oldest receipt stored in the state.
     #[pallet::storage]
@@ -204,8 +204,7 @@ impl From<FraudProofError> for Error {
 impl<T: Config> Pallet<T> {
     /// Returns the block number of the latest receipt.
     pub fn head_receipt_number(domain_id: DomainId) -> T::BlockNumber {
-        let (_, best_number) = <ReceiptHead<T>>::get(domain_id);
-        best_number
+        <HeadReceiptNumber<T>>::get(domain_id)
     }
 
     /// Returns the block number of the oldest receipt still being tracked in the state.
@@ -215,7 +214,7 @@ impl<T: Config> Pallet<T> {
 
     /// Returns the block number of latest _finalized_ receipt.
     pub fn finalized_receipt_number(domain_id: DomainId) -> T::BlockNumber {
-        let (_, best_number) = <ReceiptHead<T>>::get(domain_id);
+        let best_number = <HeadReceiptNumber<T>>::get(domain_id);
         best_number.saturating_sub(T::ReceiptsPruningDepth::get())
     }
 
@@ -249,7 +248,7 @@ impl<T: Config> Pallet<T> {
         receipts: &[ExecutionReceipt<T::BlockNumber, T::Hash, T::DomainHash>],
     ) -> Result<(), Error> {
         let oldest_receipt_number = <OldestReceiptNumber<T>>::get(domain_id);
-        let (_, mut best_number) = <ReceiptHead<T>>::get(domain_id);
+        let mut best_number = <HeadReceiptNumber<T>>::get(domain_id);
 
         for receipt in receipts {
             let primary_number = receipt.primary_number;
@@ -278,16 +277,16 @@ impl<T: Config> Pallet<T> {
     pub fn process_fraud_proof(fraud_proof: FraudProof) -> Result<(), Error> {
         // Revert the execution chain.
         let domain_id = fraud_proof.domain_id;
-        let (_, mut to_remove) = <ReceiptHead<T>>::get(domain_id);
+        let mut to_remove = <HeadReceiptNumber<T>>::get(domain_id);
 
         let new_best_number: T::BlockNumber = fraud_proof.parent_number.into();
-        let new_best_hash = BlockHash::<T>::get(domain_id, new_best_number)
+        let new_best_hash = PrimaryBlockHash::<T>::get(domain_id, new_best_number)
             .ok_or(Error::UnavailablePrimaryBlockHash)?;
 
-        <ReceiptHead<T>>::insert(domain_id, (new_best_hash, new_best_number));
+        <HeadReceiptNumber<T>>::insert(domain_id, new_best_number);
 
         while to_remove > new_best_number {
-            let block_hash = BlockHash::<T>::get(domain_id, to_remove)
+            let block_hash = PrimaryBlockHash::<T>::get(domain_id, to_remove)
                 .ok_or(Error::UnavailablePrimaryBlockHash)?;
             for (receipt_hash, _) in <ReceiptVotes<T>>::drain_prefix((domain_id, block_hash)) {
                 <Receipts<T>>::remove(domain_id, receipt_hash);
@@ -334,7 +333,7 @@ impl<T: Config> Pallet<T> {
     /// Remove the expired receipts once the receipts cache is full.
     fn remove_expired_receipts(domain_id: DomainId, primary_number: T::BlockNumber) {
         if let Some(to_prune) = primary_number.checked_sub(&T::ReceiptsPruningDepth::get()) {
-            BlockHash::<T>::mutate_exists(domain_id, to_prune, |maybe_block_hash| {
+            PrimaryBlockHash::<T>::mutate_exists(domain_id, to_prune, |maybe_block_hash| {
                 if let Some(block_hash) = maybe_block_hash.take() {
                     for (receipt_hash, _) in
                         <ReceiptVotes<T>>::drain_prefix((domain_id, block_hash))
@@ -358,7 +357,7 @@ impl<T: Config> Pallet<T> {
 
         // Apply the new best receipt.
         <Receipts<T>>::insert(domain_id, receipt_hash, execution_receipt);
-        <ReceiptHead<T>>::insert(domain_id, (primary_hash, primary_number));
+        <HeadReceiptNumber<T>>::insert(domain_id, primary_number);
         <ReceiptVotes<T>>::mutate((domain_id, primary_hash, receipt_hash), |count| {
             *count += 1;
         });

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -131,7 +131,7 @@ pub enum VerificationError {
 /// Fraud proof for the state computation.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct FraudProof {
-    /// The id of the domain this fraud proof targetted
+    /// The id of the domain this fraud proof targeted
     pub domain_id: DomainId,
     /// Hash of the signed bundle in which an invalid state transition occurred.
     pub bad_signed_bundle_hash: H256,

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -371,7 +371,7 @@ mod pallet {
 
             let mut consumed_weight = Weight::zero();
             for domain_id in Domains::<T>::iter_keys() {
-                pallet_receipts::BlockHash::<T>::insert(domain_id, primary_number, primary_hash);
+                pallet_receipts::PrimaryBlockHash::<T>::insert(domain_id, primary_number, primary_hash);
                 consumed_weight += T::DbWeight::get().reads_writes(1, 1);
             }
 
@@ -779,7 +779,7 @@ impl<T: Config> Pallet<T> {
                     "Receipt of {domain_id:?} #{primary_number:?},{:?} points to an unknown primary block, \
                     expected: #{primary_number:?},{:?}",
                     receipt.primary_hash,
-                    pallet_receipts::BlockHash::<T>::get(domain_id, primary_number),
+                    pallet_receipts::PrimaryBlockHash::<T>::get(domain_id, primary_number),
                 );
                 return Err(Error::<T>::Receipt(ReceiptError::UnknownBlock));
             }

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -108,7 +108,7 @@ mod pallet {
     }
 
     #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::generate_store(pub (super) trait Store)]
     #[pallet::without_storage_info]
     pub struct Pallet<T>(_);
 
@@ -371,7 +371,11 @@ mod pallet {
 
             let mut consumed_weight = Weight::zero();
             for domain_id in Domains::<T>::iter_keys() {
-                pallet_receipts::PrimaryBlockHash::<T>::insert(domain_id, primary_number, primary_hash);
+                pallet_receipts::PrimaryBlockHash::<T>::insert(
+                    domain_id,
+                    primary_number,
+                    primary_hash,
+                );
                 consumed_weight += T::DbWeight::get().reads_writes(1, 1);
             }
 
@@ -519,7 +523,7 @@ mod pallet {
     }
 
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::generate_deposit(pub (super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// A new domain was created.
         NewDomain {
@@ -757,10 +761,10 @@ impl<T: Config> Pallet<T> {
             // Non-best receipt
             if receipt.primary_number <= new_best_number {
                 continue;
-            // New nest receipt.
+                // New nest receipt.
             } else if receipt.primary_number == new_best_number + One::one() {
                 new_best_number += One::one();
-            // Missing receipt.
+                // Missing receipt.
             } else {
                 let missing_receipt_number = new_best_number + One::one();
                 log::error!(
@@ -845,16 +849,16 @@ impl<T: Config> Pallet<T> {
                     core_block_number,
                     core_block_hash,
                 ))
-                .ok_or(Error::<T>::StateRootNotFound)
-                .map_err(|err|{
-                    log::error!(
+                    .ok_or(Error::<T>::StateRootNotFound)
+                    .map_err(|err| {
+                        log::error!(
                         target: "runtime::domain-registry",
                         "State root for {domain_id:?} #{core_block_number:?},{core_block_hash:?} not found, \
                         current head receipt: {:?}",
                         pallet_receipts::Pallet::<T>::receipt_head(domain_id),
                     );
-                    err
-                })?,
+                        err
+                    })?,
             };
 
             if expected_state_root != *core_state_root {


### PR DESCRIPTION
This PR changes following:
- Cleanup some receipt import code
- Prune State root when fraud proof is valid. Only Receipts are pruned but state root is not.

At the moment, we seem to prune all of the receipts at a given height instead of keeping the correct ER as is. All the nodes would need to reconcile and submit the correct ERs again. This is inefficient. We also do not have a link between two consecutive ERs when there are forks. 

So if we can link two consecutive ER, and since we already know what is the correct ER from the fraud proof, we can only prune the all the receipts that are derived from the invalid ER including the invalid ER itself. At this point, honest nodes can continue to build from the latest known head

Thoughts @liuchengxu @NingLin-P 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
