### PR TITLE
DSN. Add simple piece verification for the block import.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9770,6 +9770,7 @@ dependencies = [
 name = "subspace-service"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "derive_more",
  "domain-runtime-primitives",
  "either",
@@ -9777,6 +9778,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.25",
  "jsonrpsee",
+ "lru 0.8.1",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -16,12 +16,14 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+async-trait = "0.1.58"
 derive_more = "0.99.17"
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 either = "1.8.0"
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 futures = "0.3.25"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
+lru = "0.8.1"
 pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "100d6c90d4122578006a47c1dcaf155b9c685f34" }
 parity-scale-codec = "3.2.1"
 parking_lot = "0.12.1"

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -27,7 +27,9 @@ use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::Arc;
 use std::task::Poll;
 use subspace_archiving::reconstructor::Reconstructor;
-use subspace_core_primitives::{Piece, PieceIndex, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE};
+use subspace_core_primitives::{
+    Piece, PieceIndex, PIECES_IN_SEGMENT, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
+};
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_networking::Node;
 
@@ -113,7 +115,7 @@ where
         });
 
         let mut pieces = vec![None::<Piece>; pieces_in_segment as usize];
-        let mut found_one_piece = false;
+        let mut pieces_received = 0;
 
         for (piece_index, piece) in pieces_indexes.zip(pieces.iter_mut()) {
             let maybe_piece = piece_provider
@@ -128,13 +130,18 @@ where
             );
 
             if let Some(received_piece) = maybe_piece {
-                found_one_piece = true;
-
                 piece.replace(received_piece);
+
+                pieces_received += 1;
+            }
+
+            if pieces_received >= PIECES_IN_SEGMENT / 2 {
+                trace!(%segment_index, "Received half of the segment.");
+                break;
             }
         }
 
-        if !found_one_piece {
+        if pieces_received == 0 {
             info!("Found no pieces for segment index {}", segment_index);
             break;
         }

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -27,6 +27,7 @@ use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::Arc;
 use std::task::Poll;
 use subspace_archiving::reconstructor::Reconstructor;
+use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
 use subspace_core_primitives::{
     Piece, PieceIndex, PIECES_IN_SEGMENT, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
 };
@@ -88,7 +89,10 @@ where
 {
     let piece_provider = PieceProvider::<RecordsRootPieceValidator>::new(
         node.clone(),
-        Some(RecordsRootPieceValidator::new(node.clone())),
+        Some(RecordsRootPieceValidator::new(
+            node.clone(),
+            Kzg::new(test_public_parameters()),
+        )),
         false,
     );
 

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use std::error::Error;
 use std::num::NonZeroUsize;
 use subspace_archiving::archiver::is_piece_valid;
-use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
+use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{
     Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT, RECORD_SIZE,
 };
@@ -23,10 +23,10 @@ pub struct RecordsRootPieceValidator {
 }
 
 impl RecordsRootPieceValidator {
-    pub fn new(dsn_node: Node) -> Self {
+    pub fn new(dsn_node: Node, kzg: Kzg) -> Self {
         Self {
             dsn_node,
-            kzg: Kzg::new(test_public_parameters()),
+            kzg,
             records_root_cache: Mutex::new(LruCache::new(RECORDS_ROOTS_CACHE_SIZE)),
         }
     }

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -1,0 +1,148 @@
+use async_trait::async_trait;
+use futures::StreamExt;
+use lru::LruCache;
+use parking_lot::Mutex;
+use std::error::Error;
+use std::num::NonZeroUsize;
+use subspace_archiving::archiver::is_piece_valid;
+use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
+use subspace_core_primitives::{
+    Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT, RECORD_SIZE,
+};
+use subspace_networking::libp2p::PeerId;
+use subspace_networking::utils::piece_provider::PieceValidator;
+use subspace_networking::{Node, RootBlockRequest, RootBlockResponse};
+use tracing::{debug, error, trace, warn};
+
+const RECORDS_ROOTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000_000).expect("Not zero; qed");
+
+pub struct RecordsRootPieceValidator {
+    dsn_node: Node,
+    kzg: Kzg,
+    records_root_cache: Mutex<LruCache<SegmentIndex, RecordsRoot>>,
+}
+
+impl RecordsRootPieceValidator {
+    pub fn new(dsn_node: Node) -> Self {
+        Self {
+            dsn_node,
+            kzg: Kzg::new(test_public_parameters()),
+            records_root_cache: Mutex::new(LruCache::new(RECORDS_ROOTS_CACHE_SIZE)),
+        }
+    }
+
+    async fn get_records_root(
+        &self,
+        segment_index: SegmentIndex,
+    ) -> Result<RecordsRoot, Box<dyn Error>> {
+        // Get random peers. Some of them could be bootstrap nodes with no support for
+        // request-response protocol for records root.
+        let get_peers_result = self
+            .dsn_node
+            .get_closest_peers(PeerId::random().into())
+            .await;
+
+        match get_peers_result {
+            Ok(mut get_peers_stream) => {
+                while let Some(peer_id) = get_peers_stream.next().await {
+                    trace!(%peer_id, "get_closest_peers returned an item");
+
+                    let request_result = self
+                        .dsn_node
+                        .send_generic_request(
+                            peer_id,
+                            RootBlockRequest {
+                                segment_indexes: vec![segment_index],
+                            },
+                        )
+                        .await;
+
+                    match request_result {
+                        Ok(RootBlockResponse { root_blocks }) => {
+                            trace!(%peer_id, %segment_index, "Root block request succeeded.");
+
+                            if let Some(Some(root_block)) = root_blocks.first() {
+                                trace!(%peer_id, %segment_index, "Root block was obtained.");
+
+                                return Ok(root_block.records_root());
+                            } else {
+                                debug!(%peer_id, %segment_index, "Root block was not received.");
+                            }
+                        }
+                        Err(error) => {
+                            debug!(%peer_id, %segment_index, ?error, "Root block request failed.");
+                        }
+                    };
+                }
+                Err("No more peers for root blocks.".into())
+            }
+            Err(err) => {
+                warn!(?err, "get_closest_peers returned an error");
+
+                Err(err.into())
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl PieceValidator for RecordsRootPieceValidator {
+    async fn validate_piece(
+        &self,
+        source_peer_id: PeerId,
+        piece_index: PieceIndex,
+        piece: Piece,
+    ) -> Option<Piece> {
+        if source_peer_id != self.dsn_node.id() {
+            let segment_index: SegmentIndex = piece_index / PieceIndex::from(PIECES_IN_SEGMENT);
+
+            let maybe_records_root =
+                { self.records_root_cache.lock().get(&segment_index).copied() };
+            let records_root = match maybe_records_root {
+                Some(records_root) => records_root,
+                None => {
+                    let records_root_result = self.get_records_root(segment_index).await;
+
+                    match records_root_result {
+                        Ok(records_root) => {
+                            self.records_root_cache
+                                .lock()
+                                .push(segment_index, records_root);
+
+                            trace!(%segment_index, "Records root was received successfully.");
+
+                            records_root
+                        }
+                        Err(err) => {
+                            debug!(?err, %segment_index, "Records root receiving failed.");
+
+                            return None;
+                        }
+                    }
+                }
+            };
+
+            if !is_piece_valid(
+                &self.kzg,
+                PIECES_IN_SEGMENT,
+                &piece,
+                records_root,
+                u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
+                    .expect("Always fix into u32; qed"),
+                RECORD_SIZE,
+            ) {
+                error!(
+                    %piece_index,
+                    %source_peer_id,
+                    "Received invalid piece from peer"
+                );
+
+                // We don't care about result here
+                let _ = self.dsn_node.ban_peer(source_peer_id).await;
+                return None;
+            }
+        }
+
+        Some(piece)
+    }
+}

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
-#![feature(type_alias_impl_trait, type_changing_struct_update)]
+#![feature(const_option, type_alias_impl_trait, type_changing_struct_update)]
 
 pub mod dsn;
 pub mod piece_cache;
@@ -546,7 +546,9 @@ where
                             .expect("Must not be poisoned here")
                             .take()
                         {
-                            node_address_sender.send(address.clone()).unwrap();
+                            node_address_sender
+                                .send(address.clone())
+                                .expect("Channel must allow sending at this point.");
                         }
                     }
                 }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -75,7 +75,7 @@ use subspace_networking::{peer_id, Node};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Hash, Index as Nonce};
 use subspace_transaction_pool::FullPool;
-use tracing::{error, info, Instrument};
+use tracing::{debug, error, info, Instrument};
 
 /// Error type for Subspace service.
 #[derive(thiserror::Error, Debug)]
@@ -546,9 +546,9 @@ where
                             .expect("Must not be poisoned here")
                             .take()
                         {
-                            node_address_sender
-                                .send(address.clone())
-                                .expect("Channel must allow sending at this point.");
+                            if let Err(err) = node_address_sender.send(address.clone()) {
+                                debug!(?err, "Couldn't send a node address to the channel.");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds pieces` verification from the DSN using root blocks(records root). It also optimizes the import by requiring only half of a segment. Fixes https://github.com/subspace/subspace/issues/1149

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
