### PR TITLE
Cancel older jobs for the same branch automatically

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: rust-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Not needed in CI, should make things a bit faster
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -5,6 +5,10 @@ on:
    branches:
    - main
 
+concurrency:
+  group: rustdoc-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10


### PR DESCRIPTION
As title says, we will no longer need to cancel older jobs manually when pushing new things on top.

Assigned a bunch of people just FYI.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
