### PR TITLE
Initial version of incremental record commitment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,12 +5157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
-name = "merkle_light"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b879f617ec392ad9c11a50356ca373009c52363c0953b34c2e1b2234037a26a9"
-
-[[package]]
 name = "merkletree"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9546,8 +9540,8 @@ dependencies = [
 name = "subspace-archiving"
 version = "0.1.0"
 dependencies = [
+ "blake2",
  "criterion",
- "merkle_light",
  "parity-scale-codec",
  "rand 0.8.5",
  "reed-solomon-erasure",

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 bench = false
 
 [dependencies]
-merkle_light = { version = "0.4.0", default-features = false }
+blake2 = { version = "0.10.5", default-features = false }
 parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
 reed-solomon-erasure = { version = "6.0.0", default-features = false }
 serde = { version = "1.0.147", optional = true, features = ["derive"] }
@@ -31,7 +31,7 @@ rand = { version = "0.8.5", features = ["min_const_gen"] }
 [features]
 default = ["std"]
 std = [
-    "merkle_light/std",
+    "blake2/std",
     "parity-scale-codec/std",
     "reed-solomon-erasure/simd-accel",
     "reed-solomon-erasure/std",

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -13,10 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod incremental_record_commitments;
 mod record_shards;
 
 extern crate alloc;
 
+use crate::archiver::incremental_record_commitments::{
+    update_record_commitments, IncrementalRecordCommitmentsState,
+};
 use crate::archiver::record_shards::RecordShards;
 use crate::utils::GF_16_ELEMENT_BYTES;
 use alloc::collections::VecDeque;
@@ -182,6 +186,8 @@ pub struct Archiver {
     /// Buffer containing blocks and other buffered items that are pending to be included into the
     /// next segment
     buffer: VecDeque<SegmentItem>,
+    /// Intermediate record commitments that are built incrementally as above buffer fills up.
+    incremental_record_commitments: IncrementalRecordCommitmentsState,
     /// Configuration parameter defining the size of one record (data in one piece excluding witness
     /// size)
     record_size: u32,
@@ -245,6 +251,9 @@ impl Archiver {
 
         Ok(Self {
             buffer: VecDeque::default(),
+            incremental_record_commitments: IncrementalRecordCommitmentsState::with_capacity(
+                data_shards as usize,
+            ),
             record_size,
             data_shards,
             parity_shards,
@@ -367,6 +376,13 @@ impl Archiver {
             let segment_item = match self.buffer.pop_front() {
                 Some(segment_item) => segment_item,
                 None => {
+                    update_record_commitments(
+                        &mut self.incremental_record_commitments,
+                        &segment,
+                        false,
+                        self.record_size as usize,
+                    );
+
                     let Segment::V0 { items } = segment;
                     // Push all of the items back into the buffer, we don't have enough data yet
                     for segment_item in items.into_iter().rev() {
@@ -571,6 +587,13 @@ impl Archiver {
 
         self.last_archived_block = last_archived_block;
 
+        update_record_commitments(
+            &mut self.incremental_record_commitments,
+            &segment,
+            true,
+            self.record_size as usize,
+        );
+
         Some(segment)
     }
 
@@ -650,12 +673,21 @@ impl Archiver {
         let mut pieces = FlatPieces::new(record_shards_slices.len());
         drop(record_shards_slices);
 
-        let record_shards_hashes = record_shards
-            .as_bytes()
-            .as_ref()
-            .chunks_exact(self.record_size as usize)
-            .map(blake2b_256_254_hash)
+        // We take hashes of source records computed incrementally
+        // TODO: Parity hashes will be erasure coded in the future
+        let record_shards_hashes = self
+            .incremental_record_commitments
+            .drain()
+            .chain(
+                record_shards
+                    .as_bytes()
+                    .as_ref()
+                    .chunks_exact(self.record_size as usize)
+                    .skip(self.data_shards as usize)
+                    .map(blake2b_256_254_hash),
+            )
             .collect::<Vec<_>>();
+
         let data = {
             let mut data = Vec::with_capacity(
                 (self.data_shards + self.parity_shards) as usize * BLAKE2B_256_HASH_SIZE,

--- a/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
+++ b/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
@@ -1,0 +1,194 @@
+extern crate alloc;
+
+use crate::archiver::Segment;
+use alloc::collections::VecDeque;
+use blake2::digest::typenum::U32;
+use blake2::digest::{FixedOutput, Update};
+use blake2::Blake2b;
+use core::mem;
+use parity_scale_codec::{Encode, Output};
+use subspace_core_primitives::Blake2b256Hash;
+
+/// State of incremental record commitments, encapsulated to hide implementation details and
+/// encapsulate tricky logic
+#[derive(Debug, Default, Clone)]
+pub(super) struct IncrementalRecordCommitmentsState {
+    /// State contains record commitments.
+    ///
+    /// NOTE: Until full segment is processed, this will not contain commitment to the first record
+    /// since it is not ready yet. This in turn means all commitments will be at `-1` offset.
+    state: VecDeque<Blake2b256Hash>,
+}
+
+impl IncrementalRecordCommitmentsState {
+    /// Creates an empty state with space for at least capacity records.
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            state: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    pub(super) fn drain(&mut self) -> impl Iterator<Item = Blake2b256Hash> + '_ {
+        self.state.drain(..)
+    }
+}
+
+/// Update internal record commitments state based on (full or partial) segment.
+pub(super) fn update_record_commitments(
+    incremental_record_commitments: &mut IncrementalRecordCommitmentsState,
+    segment: &Segment,
+    full: bool,
+    record_size: usize,
+) {
+    segment.encode_to(&mut IncrementalRecordCommitmentsProcessor::new(
+        incremental_record_commitments,
+        record_size,
+        full,
+    ));
+}
+
+/// Processor is hidden to not expose unnecessary implementation details (like `Output` trait
+/// implementation)
+struct IncrementalRecordCommitmentsProcessor<'a> {
+    /// Processed bytes in the segment so far
+    processed: usize,
+    /// Record commitments already created
+    incremental_record_commitments: &'a mut IncrementalRecordCommitmentsState,
+    /// Record size
+    record_size: usize,
+    /// Whether segment is full or partial
+    full: bool,
+    /// Intermediate hashing state that computes Blake2-256-254.
+    ///
+    /// See [`subspace_core_primitives::crypto::blake2b_256_254_hash`] for details.
+    hashing_state: Blake2b<U32>,
+}
+
+impl<'a> Drop for IncrementalRecordCommitmentsProcessor<'a> {
+    fn drop(&mut self) {
+        if self.full {
+            // How many bytes to read before the start of the next record
+            let bytes_until_full_record = self.bytes_until_full_record();
+            if bytes_until_full_record > 0 {
+                // This is fine since we'll have at most a few iterations and allocation is less
+                // desirable than a loop here
+                for _ in 0..bytes_until_full_record {
+                    self.update_hashing_state(&[0]);
+                }
+                self.finish_hash();
+            }
+        }
+    }
+}
+
+impl<'a> Output for IncrementalRecordCommitmentsProcessor<'a> {
+    fn write(&mut self, bytes: &[u8]) {
+        // Try to finish last partial record if possible
+        let bytes = {
+            let bytes_until_full_record =
+                ((self.processed / self.record_size) + 1) * self.record_size - self.processed;
+            let (remaining_record_bytes, bytes) =
+                bytes.split_at(if bytes.len() >= bytes_until_full_record {
+                    bytes_until_full_record
+                } else {
+                    bytes.len()
+                });
+
+            self.update_hashing_state(remaining_record_bytes);
+
+            if remaining_record_bytes.len() == bytes_until_full_record {
+                self.finish_hash();
+            }
+
+            bytes
+        };
+
+        // Continue processing records (full and partial) from remaining data
+        bytes.chunks(self.record_size).for_each(|record| {
+            self.update_hashing_state(record);
+
+            // Store hashes of full records
+            if record.len() == self.record_size {
+                self.finish_hash();
+            }
+        });
+    }
+}
+
+impl<'a> IncrementalRecordCommitmentsProcessor<'a> {
+    fn new(
+        incremental_record_commitments: &'a mut IncrementalRecordCommitmentsState,
+        record_size: usize,
+        full: bool,
+    ) -> Self {
+        Self {
+            processed: 0,
+            incremental_record_commitments,
+            record_size,
+            full,
+            hashing_state: Blake2b::<U32>::default(),
+        }
+    }
+
+    /// How many bytes to read before the start of the next record
+    fn bytes_until_full_record(&self) -> usize {
+        let bytes_to_next_record =
+            ((self.processed / self.record_size) + 1) * self.record_size - self.processed;
+        bytes_to_next_record % self.record_size
+    }
+
+    /// Whether commitment for current record needs to be created
+    fn should_commit_to_record(&self, record_position: usize) -> bool {
+        if self.full {
+            // For full segment we need to create the first record and any that are not present yet
+            record_position == 0
+                || self
+                    .incremental_record_commitments
+                    .state
+                    .get(record_position)
+                    .is_none()
+        } else {
+            // For partial segment we need to skip the first record (it is not final) and generate
+            // any other that are currently missing
+            record_position
+                .checked_sub(1)
+                .map(|shifted_position| {
+                    self.incremental_record_commitments
+                        .state
+                        .get(shifted_position)
+                        .is_none()
+                })
+                .unwrap_or_default()
+        }
+    }
+
+    /// In case commitment is necessary for currently processed record, internal hashing state will
+    /// be updated with provided bytes.
+    fn update_hashing_state(&mut self, bytes: &[u8]) {
+        if self.should_commit_to_record(self.processed / self.record_size) {
+            self.hashing_state.update(bytes);
+        }
+        self.processed += bytes.len();
+    }
+
+    /// In case commitment is necessary for currently processed record, internal hashing state will
+    /// be finalized and commitment will be stored in shared state.
+    fn finish_hash(&mut self) {
+        if self.should_commit_to_record(self.processed / self.record_size - 1) {
+            let hashing_state = mem::take(&mut self.hashing_state);
+
+            let mut hash = Blake2b256Hash::from(hashing_state.finalize_fixed());
+            // Erase last 2 bits to effectively truncate the hash (number is interpreted as
+            // little-endian)
+            hash[31] &= 0b00111111;
+
+            // In case full segment was provided, the very first record should be processed and inserted
+            // in front of everything
+            if self.full && self.processed == self.record_size {
+                self.incremental_record_commitments.state.push_front(hash);
+            } else {
+                self.incremental_record_commitments.state.push_back(hash);
+            }
+        }
+    }
+}

--- a/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
+++ b/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
@@ -85,8 +85,7 @@ impl<'a> Output for IncrementalRecordCommitmentsProcessor<'a> {
     fn write(&mut self, bytes: &[u8]) {
         // Try to finish last partial record if possible
         let bytes = {
-            let bytes_until_full_record =
-                ((self.processed / self.record_size) + 1) * self.record_size - self.processed;
+            let bytes_until_full_record = self.bytes_until_full_record();
             let (remaining_record_bytes, bytes) =
                 bytes.split_at(if bytes.len() >= bytes_until_full_record {
                     bytes_until_full_record


### PR DESCRIPTION
This is a simple implementation of incremental commitment to pieces. Granted, commitment here is laughable (just a hash), but it is a stepping stone into the future where commitment will be much heavier and we'll be able to update commitment mechanism while the rest will remain the same.

Implementation takes advantage of the fact that we are using SCALE codec for data encoding/decoding during archiving. I created processor that implements `Output` trait, meaning it can be used as SCALE encoding output. Then as we send bytes through it, we keep track of which records are still lacking commitments and create them as needed incrementally. Shared state struct is just a wrapper that reduces possibility of incorrect usage.

There are numerous comments that should help navigating implementation. The changes here are 100% compatible with the previous implementation and produce identical results.

I have considered an alternative approach with wider scope: to produce not just commitments, but whole pieces incrementally, which we might need for DSN in the future. I decided to not do that for now due to much higher complexity (especially around object mappings) and unclear future as to whether well need it.

We have a bunch of tests with all edge cases related to archiving itself covered and they still pass, implementation after a few iterations is fairly straightforward, so I didn't add any extra tests on top.

Resolves #1160

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
