### PR TITLE
Verify root blocks using DSN on block import.

### DIFF
--- a/crates/subspace-networking/src/request_handlers/root_block.rs
+++ b/crates/subspace-networking/src/request_handlers/root_block.rs
@@ -9,9 +9,14 @@ use subspace_core_primitives::{RootBlock, SegmentIndex};
 
 /// Root block by segment indexes protocol request.
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
-pub struct RootBlockRequest {
-    /// Request key - piece index hash
-    pub segment_indexes: Vec<SegmentIndex>,
+pub enum RootBlockRequest {
+    SegmentIndexes {
+        segment_indexes: Vec<SegmentIndex>,
+    },
+    /// Defines how many root blocks to return.
+    LastRootBlocks {
+        root_block_number: u64,
+    },
 }
 
 impl GenericRequest for RootBlockRequest {

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -22,13 +22,15 @@ use subspace_networking::utils::pieces::announce_single_piece_index_with_backoff
 use subspace_networking::{
     peer_id, BootstrappedNetworkingParameters, CreationError, MemoryProviderStorage, Node,
     NodeRunner, ParityDbProviderStorage, PieceByHashRequestHandler, PieceByHashResponse,
-    RootBlockBySegmentIndexesRequestHandler, RootBlockResponse,
+    RootBlockBySegmentIndexesRequestHandler, RootBlockRequest, RootBlockResponse,
 };
 use tokio::sync::Semaphore;
 use tracing::{error, info, trace, warn, Instrument};
 
 /// Provider records cache size
 const MAX_PROVIDER_RECORDS_LIMIT: usize = 100000; // ~ 10 MB
+
+const ROOT_BLOCK_NUMBER_LIMIT: u64 = 100;
 
 /// DSN configuration parameters.
 #[derive(Clone, Debug)]
@@ -103,8 +105,25 @@ where
                 Some(PieceByHashResponse { piece: result })
             }),
             RootBlockBySegmentIndexesRequestHandler::create(move |req| {
-                let internal_result = req
-                    .segment_indexes
+                let segment_indexes = match req {
+                    RootBlockRequest::SegmentIndexes { segment_indexes } => segment_indexes.clone(),
+                    RootBlockRequest::LastRootBlocks { root_block_number } => {
+                        if *root_block_number > ROOT_BLOCK_NUMBER_LIMIT {
+                            error!(%root_block_number, "Root block number exceeded the limit.");
+                            return None;
+                        }
+
+                        let max_segment_index = root_block_cache.max_segment_index();
+
+                        // several last segment indexes
+                        (0..=max_segment_index)
+                            .rev()
+                            .take(*root_block_number as usize)
+                            .collect::<Vec<_>>()
+                    }
+                };
+
+                let internal_result = segment_indexes
                     .iter()
                     .map(|segment_index| root_block_cache.get_root_block(*segment_index))
                     .collect::<Result<Vec<Option<RootBlock>>, _>>();

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -1,86 +1,40 @@
 use async_trait::async_trait;
-use futures::StreamExt;
-use lru::LruCache;
-use parking_lot::Mutex;
-use std::error::Error;
+use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use subspace_archiving::archiver::is_piece_valid;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{
-    Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT, RECORD_SIZE,
+    Piece, PieceIndex, RecordsRoot, RootBlock, SegmentIndex, PIECES_IN_SEGMENT, RECORD_SIZE,
 };
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::piece_provider::PieceValidator;
-use subspace_networking::{Node, RootBlockRequest, RootBlockResponse};
-use tracing::{debug, error, trace, warn};
+use subspace_networking::Node;
+use tracing::{error, warn};
 
 const RECORDS_ROOTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000_000).expect("Not zero; qed");
 
 pub struct RecordsRootPieceValidator {
     dsn_node: Node,
     kzg: Kzg,
-    records_root_cache: Mutex<LruCache<SegmentIndex, RecordsRoot>>,
+    records_root_cache: BTreeMap<SegmentIndex, RecordsRoot>,
 }
 
 impl RecordsRootPieceValidator {
-    pub fn new(dsn_node: Node, kzg: Kzg) -> Self {
+    pub fn new(dsn_node: Node, kzg: Kzg, root_blocks: Vec<RootBlock>) -> Self {
+        if root_blocks.len() > RECORDS_ROOTS_CACHE_SIZE.get() {
+            error!(size=%root_blocks.len(), "Records root cache size exceeded the limit.");
+        }
+
+        let records_root_cache = BTreeMap::from_iter(
+            root_blocks
+                .iter()
+                .map(|rb| (rb.segment_index(), rb.records_root())),
+        );
+
         Self {
             dsn_node,
             kzg,
-            records_root_cache: Mutex::new(LruCache::new(RECORDS_ROOTS_CACHE_SIZE)),
-        }
-    }
-
-    async fn get_records_root(
-        &self,
-        segment_index: SegmentIndex,
-    ) -> Result<RecordsRoot, Box<dyn Error>> {
-        // Get random peers. Some of them could be bootstrap nodes with no support for
-        // request-response protocol for records root.
-        let get_peers_result = self
-            .dsn_node
-            .get_closest_peers(PeerId::random().into())
-            .await;
-
-        match get_peers_result {
-            Ok(mut get_peers_stream) => {
-                while let Some(peer_id) = get_peers_stream.next().await {
-                    trace!(%peer_id, "get_closest_peers returned an item");
-
-                    let request_result = self
-                        .dsn_node
-                        .send_generic_request(
-                            peer_id,
-                            RootBlockRequest::SegmentIndexes {
-                                segment_indexes: vec![segment_index],
-                            },
-                        )
-                        .await;
-
-                    match request_result {
-                        Ok(RootBlockResponse { root_blocks }) => {
-                            trace!(%peer_id, %segment_index, "Root block request succeeded.");
-
-                            if let Some(Some(root_block)) = root_blocks.first() {
-                                trace!(%peer_id, %segment_index, "Root block was obtained.");
-
-                                return Ok(root_block.records_root());
-                            } else {
-                                debug!(%peer_id, %segment_index, "Root block was not received.");
-                            }
-                        }
-                        Err(error) => {
-                            debug!(%peer_id, %segment_index, ?error, "Root block request failed.");
-                        }
-                    };
-                }
-                Err("No more peers for root blocks.".into())
-            }
-            Err(err) => {
-                warn!(?err, "get_closest_peers returned an error");
-
-                Err(err.into())
-            }
+            records_root_cache,
         }
     }
 }
@@ -96,29 +50,13 @@ impl PieceValidator for RecordsRootPieceValidator {
         if source_peer_id != self.dsn_node.id() {
             let segment_index: SegmentIndex = piece_index / PieceIndex::from(PIECES_IN_SEGMENT);
 
-            let maybe_records_root =
-                { self.records_root_cache.lock().get(&segment_index).copied() };
+            let maybe_records_root = self.records_root_cache.get(&segment_index);
             let records_root = match maybe_records_root {
-                Some(records_root) => records_root,
+                Some(records_root) => *records_root,
                 None => {
-                    let records_root_result = self.get_records_root(segment_index).await;
+                    warn!(%segment_index, "No records root in the cache.");
 
-                    match records_root_result {
-                        Ok(records_root) => {
-                            self.records_root_cache
-                                .lock()
-                                .push(segment_index, records_root);
-
-                            trace!(%segment_index, "Records root was received successfully.");
-
-                            records_root
-                        }
-                        Err(err) => {
-                            debug!(?err, %segment_index, "Records root receiving failed.");
-
-                            return None;
-                        }
-                    }
+                    return None;
                 }
             };
 

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -51,7 +51,7 @@ impl RecordsRootPieceValidator {
                         .dsn_node
                         .send_generic_request(
                             peer_id,
-                            RootBlockRequest {
+                            RootBlockRequest::SegmentIndexes {
                                 segment_indexes: vec![segment_index],
                             },
                         )

--- a/crates/subspace-service/src/dsn/import_blocks/root_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/root_blocks.rs
@@ -1,12 +1,17 @@
 use futures::StreamExt;
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
+use std::collections::BTreeMap;
 use std::error::Error;
-use subspace_core_primitives::{RootBlock, SegmentIndex};
+use subspace_core_primitives::{Blake2b256Hash, RootBlock, SegmentIndex};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::{Node, RootBlockRequest, RootBlockResponse};
 use tracing::{debug, error, trace, warn};
 
 const ROOT_BLOCK_NUMBER_PER_REQUEST: u64 = 10;
+/// Minimum peers number to participate in root block election.
+const ROOT_BLOCK_CONSENSUS_MIN_SET: u64 = 2; //TODO: change the value
+/// Threshold for the root block election success (minimum peer number with the same root block).
+const ROOT_BLOCK_CONSENSUS_THRESHOLD: u64 = 2; //TODO: change the value
 
 /// Helps gathering root blocks from DSN
 pub struct RootBlockHandler {
@@ -46,6 +51,7 @@ impl RootBlockHandler {
                         warn!("Root block request returned None.");
                     }
                     Some(root_block) => {
+                        //TODO: add peer ban
                         if root_block.hash() != last_root_block.prev_root_block_hash() {
                             error!(
                                 hash=?root_block.hash(),
@@ -69,7 +75,14 @@ impl RootBlockHandler {
         Ok(result)
     }
 
+    //TODO: add peer ban
+    /// Return last root block known to DSN. We ask several peers for the highest root block
+    /// known to them. Target root block should be known to at least ROOT_BLOCK_CONSENSUS_THRESHOLD
+    /// among peer set with minimum size of ROOT_BLOCK_CONSENSUS_MIN_SET peers.
     async fn get_last_root_block(&self) -> Result<RootBlock, Box<dyn Error>> {
+        let mut root_block_score: BTreeMap<Blake2b256Hash, u64> = BTreeMap::new();
+        let mut root_block_dict: BTreeMap<Blake2b256Hash, RootBlock> = BTreeMap::new();
+        let mut participating_peers = 0u64;
         trace!("Getting last root block...");
 
         // Get random peers. Some of them could be bootstrap nodes with no support for
@@ -97,21 +110,35 @@ impl RootBlockHandler {
                     match request_result {
                         Ok(RootBlockResponse { root_blocks }) => {
                             trace!(%peer_id, "Last root block request succeeded.");
+                            if root_blocks.iter().any(|rb| rb.is_some()) {
+                                participating_peers += 1;
+                            }
 
-                            let last_root_block = root_blocks
-                                .iter()
-                                .max_by(|rb1, rb2| compare_optional_root_blocks(rb1, rb2));
+                            let root_block_deduplication_map = BTreeMap::from_iter(
+                                root_blocks
+                                    .iter()
+                                    .filter_map(|rb| rb.map(|rb| (rb.hash(), rb))),
+                            );
+                            let sanitized_root_blocks = root_block_deduplication_map
+                            .values()
+                            .collect::<Vec<_>>();
 
-                            if let Some(Some(root_block)) = last_root_block {
+                            // Collect root block votes from the peer.
+                            for root_block in sanitized_root_blocks {
                                 trace!(
-                                    %peer_id,
-                                    segment_index=root_block.segment_index(),
-                                    "Last root block was obtained."
-                                );
+                                        %peer_id,
+                                        segment_index=root_block.segment_index(),
+                                        hash=?root_block.hash(),
+                                        "Last root block was obtained."
+                                    );
 
-                                return Ok(*root_block);
-                            } else {
-                                debug!(%peer_id, "Last root block was not received.");
+                                root_block_score
+                                    .entry(root_block.hash())
+                                    .and_modify(|val| *val += 1)
+                                    .or_insert(1);
+                                root_block_dict
+                                    .entry(root_block.hash())
+                                    .or_insert(*root_block);
                             }
                         }
                         Err(error) => {
@@ -119,14 +146,38 @@ impl RootBlockHandler {
                         }
                     };
                 }
-                Err("No more peers for root blocks.".into())
             }
             Err(err) => {
                 warn!(?err, "get_closest_peers returned an error");
 
-                Err(err.into())
+                return Err(err.into());
             }
         }
+
+        // TODO: Consider adding attempts to increase the initial peer set.
+        if participating_peers < ROOT_BLOCK_CONSENSUS_MIN_SET {
+            return Err(format!(
+                "Root block consensus failed: not enough peers ({}).",
+                root_block_score.len()
+            )
+            .into());
+        }
+
+        // Sort the collection to get highest blocks first.
+        let mut root_blocks = root_block_dict.values().collect::<Vec<_>>();
+        root_blocks.sort_by_key(|rb| Reverse(rb.segment_index()));
+
+        for root_block in root_blocks {
+            let score = root_block_score
+                .get(&root_block.hash())
+                .expect("Must be present because of the manual adding.");
+
+            if *score >= ROOT_BLOCK_CONSENSUS_THRESHOLD {
+                return Ok(*root_block);
+            }
+        }
+
+        Err("Root block consensus failed: can't pass the threshold.".into())
     }
 
     async fn get_root_blocks_batch(

--- a/crates/subspace-service/src/dsn/import_blocks/root_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/root_blocks.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use subspace_core_primitives::{RootBlock, SegmentIndex};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::{Node, RootBlockRequest, RootBlockResponse};
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 const ROOT_BLOCK_NUMBER_PER_REQUEST: u64 = 10;
 
@@ -46,6 +46,19 @@ impl RootBlockHandler {
                         warn!("Root block request returned None.");
                     }
                     Some(root_block) => {
+                        if root_block.hash() != last_root_block.prev_root_block_hash() {
+                            error!(
+                                hash=?root_block.hash(),
+                                prev_hash=?last_root_block.prev_root_block_hash(),
+                                "Root block hash doesn't match expected hash from the last block."
+                            );
+
+                            return Err(
+                                "Root block hash doesn't match expected hash from the last block."
+                                    .into(),
+                            );
+                        }
+
                         last_root_block = root_block;
                         result.push(root_block);
                     }

--- a/crates/subspace-service/src/dsn/import_blocks/root_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/root_blocks.rs
@@ -1,0 +1,177 @@
+use futures::StreamExt;
+use std::cmp::Ordering;
+use std::error::Error;
+use subspace_core_primitives::{RootBlock, SegmentIndex};
+use subspace_networking::libp2p::PeerId;
+use subspace_networking::{Node, RootBlockRequest, RootBlockResponse};
+use tracing::{debug, trace, warn};
+
+const ROOT_BLOCK_NUMBER_PER_REQUEST: u64 = 10;
+
+/// Helps gathering root blocks from DSN
+pub struct RootBlockHandler {
+    dsn_node: Node,
+}
+
+impl RootBlockHandler {
+    pub fn new(dsn_node: Node) -> Self {
+        Self { dsn_node }
+    }
+
+    /// Returns root blocks known to DSN.
+    pub async fn get_root_blocks(&self) -> Result<Vec<RootBlock>, Box<dyn Error>> {
+        trace!("Getting root blocks...");
+
+        let mut result = Vec::new();
+        let mut last_root_block = self.get_last_root_block().await?;
+        debug!(
+            "Getting root blocks starting from segment_index={}",
+            last_root_block.segment_index()
+        );
+
+        result.push(last_root_block);
+
+        while last_root_block.segment_index() > 0 {
+            let segment_indexes: Vec<_> = (0..last_root_block.segment_index())
+                .rev()
+                .take(ROOT_BLOCK_NUMBER_PER_REQUEST as usize)
+                .collect();
+
+            let mut root_blocks = self.get_root_blocks_batch(segment_indexes).await?;
+            root_blocks.sort_by(|rb1, rb2| compare_optional_root_blocks(rb1, rb2).reverse());
+
+            for root_block in root_blocks {
+                match root_block {
+                    None => {
+                        warn!("Root block request returned None.");
+                    }
+                    Some(root_block) => {
+                        last_root_block = root_block;
+                        result.push(root_block);
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn get_last_root_block(&self) -> Result<RootBlock, Box<dyn Error>> {
+        trace!("Getting last root block...");
+
+        // Get random peers. Some of them could be bootstrap nodes with no support for
+        // request-response protocol for records root.
+        let get_peers_result = self
+            .dsn_node
+            .get_closest_peers(PeerId::random().into())
+            .await;
+
+        match get_peers_result {
+            Ok(mut get_peers_stream) => {
+                while let Some(peer_id) = get_peers_stream.next().await {
+                    trace!(%peer_id, "get_closest_peers returned an item");
+
+                    let request_result = self
+                        .dsn_node
+                        .send_generic_request(
+                            peer_id,
+                            RootBlockRequest::LastRootBlocks {
+                                root_block_number: ROOT_BLOCK_NUMBER_PER_REQUEST,
+                            },
+                        )
+                        .await;
+
+                    match request_result {
+                        Ok(RootBlockResponse { root_blocks }) => {
+                            trace!(%peer_id, "Last root block request succeeded.");
+
+                            let last_root_block = root_blocks
+                                .iter()
+                                .max_by(|rb1, rb2| compare_optional_root_blocks(rb1, rb2));
+
+                            if let Some(Some(root_block)) = last_root_block {
+                                trace!(
+                                    %peer_id,
+                                    segment_index=root_block.segment_index(),
+                                    "Last root block was obtained."
+                                );
+
+                                return Ok(*root_block);
+                            } else {
+                                debug!(%peer_id, "Last root block was not received.");
+                            }
+                        }
+                        Err(error) => {
+                            debug!(%peer_id, ?error, "Last root block request failed.");
+                        }
+                    };
+                }
+                Err("No more peers for root blocks.".into())
+            }
+            Err(err) => {
+                warn!(?err, "get_closest_peers returned an error");
+
+                Err(err.into())
+            }
+        }
+    }
+
+    async fn get_root_blocks_batch(
+        &self,
+        segment_indexes: Vec<SegmentIndex>,
+    ) -> Result<Vec<Option<RootBlock>>, Box<dyn Error>> {
+        trace!(?segment_indexes, "Getting root block batch...");
+
+        // Get random peers. Some of them could be bootstrap nodes with no support for
+        // request-response protocol for records root.
+        let get_peers_result = self
+            .dsn_node
+            .get_closest_peers(PeerId::random().into())
+            .await;
+
+        match get_peers_result {
+            Ok(mut get_peers_stream) => {
+                while let Some(peer_id) = get_peers_stream.next().await {
+                    trace!(%peer_id, "get_closest_peers returned an item");
+
+                    let request_result = self
+                        .dsn_node
+                        .send_generic_request(
+                            peer_id,
+                            RootBlockRequest::SegmentIndexes {
+                                segment_indexes: segment_indexes.clone(),
+                            },
+                        )
+                        .await;
+
+                    match request_result {
+                        Ok(RootBlockResponse { root_blocks }) => {
+                            trace!(%peer_id, ?segment_indexes, "Root block request succeeded.");
+
+                            return Ok(root_blocks);
+                        }
+                        Err(error) => {
+                            debug!(%peer_id, ?segment_indexes, ?error, "Root block request failed.");
+                        }
+                    };
+                }
+                Err("No more peers for root blocks.".into())
+            }
+            Err(err) => {
+                warn!(?err, "get_closest_peers returned an error");
+
+                Err(err.into())
+            }
+        }
+    }
+}
+
+/// Compares two root blocks by segment indexes. None are less then Some.
+fn compare_optional_root_blocks(rb1: &Option<RootBlock>, rb2: &Option<RootBlock>) -> Ordering {
+    match (rb1, rb2) {
+        (None, None) => Ordering::Equal,
+        (Some(_), None) => Ordering::Greater,
+        (None, Some(_)) => Ordering::Less,
+        (Some(rb1), Some(rb2)) => rb1.segment_index().cmp(&rb2.segment_index()),
+    }
+}


### PR DESCRIPTION
This PR continues pieces validation on block import following https://github.com/subspace/subspace/pull/1150 Fixes https://github.com/subspace/subspace/issues/1117

#### Changes
- root block cache is now populated before the block import
- root block collection is verified using chained block hashes 
- peers must agree on the initial highest known to DSN root block - agreement algorithm demands minimum peer set size and minimum votes for the block 

#### Open questions
- last known  root block (segment) is set during the archiving process which won't be initialized after the restart
- a similar issue is related to the `SubspaceLink` and its `records_root` cache.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
