### PR TITLE
Fix announcements concurrency/performance

### DIFF
--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -58,6 +58,8 @@ where
                 let mut piece_cache = self.piece_cache.lock().await;
                 if piece_cache.should_cache(&key) && piece_cache.get_piece(&key).is_none() {
                     piece_cache.add_piece(key, piece.clone());
+                    drop(piece_cache);
+
                     if let Err(error) =
                         announce_single_piece_index_hash_with_backoff(piece_index_hash, &self.node)
                             .await

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -66,7 +66,7 @@ const KADEMLIA_BASE_CONCURRENT_TASKS: NonZeroUsize = NonZeroUsize::new(30).expec
 /// Above base limit will be boosted by specified number for every peer connected starting with
 /// second peer, such that it scaled with network connectivity, but the exact coefficient might need
 /// to be tweaked in the future.
-pub(crate) const KADEMLIA_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 1;
+pub(crate) const KADEMLIA_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 3;
 /// Base limit for number of any concurrent tasks except Kademlia.
 ///
 /// We configure total number of streams per connection to 256. Here we assume half of them might be
@@ -79,7 +79,7 @@ const REGULAR_BASE_CONCURRENT_TASKS: NonZeroUsize =
 /// Above base limit will be boosted by specified number for every peer connected starting with
 /// second peer, such that it scaled with network connectivity, but the exact coefficient might need
 /// to be tweaked in the future.
-pub(crate) const REGULAR_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 2;
+pub(crate) const REGULAR_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 5;
 
 /// Record store that can't be created, only
 pub(crate) struct ProviderOnlyRecordStore<ProviderStorage> {

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -760,7 +760,7 @@ where
                 {
                     match result {
                         Ok(AddProviderOk { key }) => {
-                            trace!("Start providing query for {} succeeded", hex::encode(&key),);
+                            trace!("Start providing query for {} succeeded", hex::encode(&key));
 
                             cancelled = Self::unbounded_send_and_cancel_on_error(
                                 &mut self.swarm.behaviour_mut().kademlia,
@@ -773,7 +773,7 @@ where
                         Err(error) => {
                             let AddProviderError::Timeout { key } = error;
 
-                            debug!("Start providing query for {} failed.", hex::encode(&key),);
+                            debug!("Start providing query for {} failed.", hex::encode(&key));
                         }
                     }
                 }
@@ -795,7 +795,7 @@ where
                 {
                     match result {
                         Ok(PutRecordOk { key, .. }) => {
-                            trace!("Put record query for {} succeeded", hex::encode(&key),);
+                            trace!("Put record query for {} succeeded", hex::encode(&key));
 
                             cancelled = Self::unbounded_send_and_cancel_on_error(
                                 &mut self.swarm.behaviour_mut().kademlia,

--- a/crates/subspace-runtime/tests/integration/object_mapping.rs
+++ b/crates/subspace-runtime/tests/integration/object_mapping.rs
@@ -114,7 +114,7 @@ fn object_mapping() {
     assert_eq!(objects.len(), 7);
 
     // Hashes should be computed correctly.
-    assert_eq!(objects[0].hash(), crypto::blake2b_256_hash(&data0),);
+    assert_eq!(objects[0].hash(), crypto::blake2b_256_hash(&data0));
     assert_eq!(objects[1].hash(), crypto::blake2b_256_hash(&data1));
     assert_eq!(objects[2].hash(), crypto::blake2b_256_hash(&data2));
     assert_eq!(objects[3].hash(), crypto::blake2b_256_hash(&data3));

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -383,6 +383,6 @@ mod tests {
         assert!(backend
             .storage(sp_core::storage::well_known_keys::CODE)
             .unwrap_err()
-            .contains("Database missing expected key"),);
+            .contains("Database missing expected key"));
     }
 }


### PR DESCRIPTION
This fixes farmer plotting. Second commit is a famous type of fixes that is just one line, but has so big impact.

I also bumped boosting in networking, with recent improvements it seems to work just fine.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
