### PR TITLE
Publish `NodeProviderStorage`

### DIFF
--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -1,5 +1,5 @@
 pub mod import_blocks;
-mod node_provider_storage;
+pub mod node_provider_storage;
 
 use crate::dsn::node_provider_storage::NodeProviderStorage;
 use crate::piece_cache::PieceCache;

--- a/crates/subspace-service/src/dsn/node_provider_storage.rs
+++ b/crates/subspace-service/src/dsn/node_provider_storage.rs
@@ -3,7 +3,7 @@ use subspace_networking::libp2p::kad::ProviderRecord;
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::ProviderStorage;
 
-pub(crate) struct NodeProviderStorage<ImplicitProviderStorage, PersistentProviderStorage> {
+pub struct NodeProviderStorage<ImplicitProviderStorage, PersistentProviderStorage> {
     local_peer_id: PeerId,
     /// Provider records from local cache
     implicit_provider_storage: ImplicitProviderStorage,
@@ -16,7 +16,7 @@ impl<ImplicitProviderStorage, PersistentProviderStorage>
 where
     PersistentProviderStorage: ProviderStorage,
 {
-    pub(crate) fn new(
+    pub fn new(
         local_peer_id: PeerId,
         implicit_provider_storage: ImplicitProviderStorage,
         mut persistent_provider_storage: PersistentProviderStorage,


### PR DESCRIPTION
This pr publishes `NodeProviderStorage`, so that it can be imported in SDK rather than be copied and reimplemented.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
