### PR TITLE
Temporary banning for unreachable peers

### DIFF
--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -1,3 +1,4 @@
+pub(crate) mod temporary_bans;
 mod transport;
 
 use crate::behavior::persistent_parameters::{
@@ -5,12 +6,14 @@ use crate::behavior::persistent_parameters::{
 };
 use crate::behavior::provider_storage::MemoryProviderStorage;
 use crate::behavior::{provider_storage, Behavior, BehaviorConfig};
+use crate::create::temporary_bans::TemporaryBans;
 use crate::create::transport::build_transport;
 use crate::node::{CircuitRelayClientError, Node};
 use crate::node_runner::{NodeRunner, NodeRunnerConfig};
 use crate::request_responses::RequestHandler;
 use crate::shared::Shared;
 use crate::utils::{convert_multiaddresses, ResizableSemaphore};
+use backoff::{ExponentialBackoff, SystemClock};
 use futures::channel::mpsc;
 use libp2p::gossipsub::{
     Config as GossipsubConfig, ConfigBuilder as GossipsubConfigBuilder,
@@ -27,11 +30,12 @@ use libp2p::multiaddr::Protocol;
 use libp2p::swarm::SwarmBuilder;
 use libp2p::yamux::YamuxConfig;
 use libp2p::{identity, Multiaddr, PeerId, TransportError};
+use parking_lot::Mutex;
 use std::borrow::Cow;
 use std::iter::Empty;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{fmt, io, iter};
 use subspace_core_primitives::{crypto, PIECE_SIZE};
 use thiserror::Error;
@@ -80,6 +84,12 @@ const REGULAR_BASE_CONCURRENT_TASKS: NonZeroUsize =
 /// second peer, such that it scaled with network connectivity, but the exact coefficient might need
 /// to be tweaked in the future.
 pub(crate) const REGULAR_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 5;
+
+const TEMPORARY_BANS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(10_000).expect("Not zero; qed");
+const TEMPORARY_BANS_DEFAULT_BACKOFF_INITIAL_INTERVAL: Duration = Duration::from_secs(5);
+const TEMPORARY_BANS_DEFAULT_BACKOFF_RANDOMIZATION_FACTOR: f64 = 0.1;
+const TEMPORARY_BANS_DEFAULT_BACKOFF_MULTIPLIER: f64 = 1.5;
+const TEMPORARY_BANS_DEFAULT_MAX_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
 /// Record store that can't be created, only
 pub(crate) struct ProviderOnlyRecordStore<ProviderStorage> {
@@ -191,6 +201,10 @@ pub struct Config<ProviderStorage> {
     pub max_established_incoming_connections: u32,
     /// Outgoing swarm connection limit.
     pub max_established_outgoing_connections: u32,
+    /// How many temporarily banned unreachable peers to keep in memory.
+    pub temporary_bans_cache_size: NonZeroUsize,
+    /// Backoff policy for temporary banning of unreachable peers.
+    pub temporary_ban_backoff: ExponentialBackoff,
     /// Optional external prometheus metrics. None will disable metrics gathering.
     pub metrics: Option<Metrics>,
 }
@@ -248,6 +262,17 @@ where
         let keypair = identity::Keypair::Ed25519(keypair);
         let identify = IdentifyConfig::new("ipfs/0.1.0".to_string(), keypair.public());
 
+        let temporary_ban_backoff = ExponentialBackoff {
+            current_interval: TEMPORARY_BANS_DEFAULT_BACKOFF_INITIAL_INTERVAL,
+            initial_interval: TEMPORARY_BANS_DEFAULT_BACKOFF_INITIAL_INTERVAL,
+            randomization_factor: TEMPORARY_BANS_DEFAULT_BACKOFF_RANDOMIZATION_FACTOR,
+            multiplier: TEMPORARY_BANS_DEFAULT_BACKOFF_MULTIPLIER,
+            max_interval: TEMPORARY_BANS_DEFAULT_MAX_INTERVAL,
+            start_time: Instant::now(),
+            max_elapsed_time: None,
+            clock: SystemClock::default(),
+        };
+
         Self {
             keypair,
             listen_on: vec![],
@@ -265,6 +290,8 @@ where
             reserved_peers: Vec::new(),
             max_established_incoming_connections: SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS,
             max_established_outgoing_connections: SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS,
+            temporary_bans_cache_size: TEMPORARY_BANS_CACHE_SIZE,
+            temporary_ban_backoff,
             metrics: None,
         }
     }
@@ -320,13 +347,20 @@ where
         reserved_peers,
         max_established_incoming_connections,
         max_established_outgoing_connections,
+        temporary_bans_cache_size,
+        temporary_ban_backoff,
         metrics,
     } = config;
     let local_peer_id = peer_id(&keypair);
 
+    let temporary_bans = Arc::new(Mutex::new(TemporaryBans::new(
+        temporary_bans_cache_size,
+        temporary_ban_backoff,
+    )));
     let transport = build_transport(
         allow_non_global_addresses_in_dht,
         &keypair,
+        Arc::clone(&temporary_bans),
         timeout,
         yamux_config,
     )?;
@@ -390,6 +424,7 @@ where
             reserved_peers: convert_multiaddresses(reserved_peers).into_iter().collect(),
             max_established_incoming_connections,
             max_established_outgoing_connections,
+            temporary_bans,
             metrics,
         });
 

--- a/crates/subspace-networking/src/create/temporary_bans.rs
+++ b/crates/subspace-networking/src/create/temporary_bans.rs
@@ -1,0 +1,104 @@
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoff;
+use libp2p::PeerId;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::ops::Add;
+use std::time::Instant;
+
+/// Details about temporary ban, used to track lifecycle of retries
+#[derive(Debug)]
+struct TemporaryBan {
+    backoff: ExponentialBackoff,
+    next_release: Option<Instant>,
+}
+
+impl TemporaryBan {
+    /// Create new temporary ban
+    fn new(backoff: ExponentialBackoff) -> Self {
+        let mut instance = Self {
+            backoff,
+            next_release: None,
+        };
+        instance.backoff.reset();
+        instance.next_release = instance
+            .backoff
+            .next_backoff()
+            .map(|duration| Instant::now().add(duration));
+        instance
+    }
+
+    /// Whether ban is currently active and not expired
+    fn is_active(&self) -> bool {
+        if let Some(next_release) = self.next_release {
+            next_release > Instant::now()
+        } else {
+            true
+        }
+    }
+
+    /// Extend temporary ban if it expired already expired, do nothing otherwise
+    fn try_extend(&mut self) {
+        let now = Instant::now();
+
+        if let Some(next_release) = self.next_release {
+            if next_release > now {
+                // Old ban if still active, no need to extend it
+                return;
+            }
+        } else {
+            // Ban is permanent
+            return;
+        }
+
+        self.next_release = self
+            .backoff
+            .next_backoff()
+            .map(|duration| now.add(duration));
+    }
+}
+
+/// Collection of temporary bans that help to prevent reaching out to the same peer ID over and
+/// over again.
+#[derive(Debug)]
+pub(crate) struct TemporaryBans {
+    backoff: ExponentialBackoff,
+    list: LruCache<PeerId, TemporaryBan>,
+}
+
+impl TemporaryBans {
+    pub(super) fn new(capacity: NonZeroUsize, backoff: ExponentialBackoff) -> Self {
+        Self {
+            backoff,
+            list: LruCache::new(capacity),
+        }
+    }
+
+    /// Checks if peer is currently banned.
+    ///
+    /// `false` means peer either is not banned at all or previous temporary ban has expired and
+    /// new connection attempt is allowed to be made.
+    pub(crate) fn is_banned(&self, peer_id: &PeerId) -> bool {
+        self.list
+            .peek(peer_id)
+            .map(TemporaryBan::is_active)
+            .unwrap_or_default()
+    }
+
+    /// Create temporary ban for peer or extend existing ban
+    pub(crate) fn create_or_extend(&mut self, peer_id: &PeerId) {
+        if let Some(ban) = self.list.get_mut(peer_id) {
+            ban.try_extend();
+        } else {
+            self.list
+                .put(*peer_id, TemporaryBan::new(self.backoff.clone()));
+        }
+    }
+
+    /// Remove temporary ban for peer.
+    ///
+    /// Returns `true` if there was an entry for peer during call.
+    pub(crate) fn remove(&mut self, peer_id: &PeerId) -> bool {
+        self.list.pop(peer_id).is_some()
+    }
+}

--- a/crates/subspace-networking/src/create/transport.rs
+++ b/crates/subspace-networking/src/create/transport.rs
@@ -1,3 +1,4 @@
+use crate::create::temporary_bans::TemporaryBans;
 use crate::CreationError;
 use libp2p::core::multiaddr::{Multiaddr, Protocol};
 use libp2p::core::muxing::StreamMuxerBox;
@@ -10,7 +11,10 @@ use libp2p::tcp::Config as GenTcpConfig;
 use libp2p::websocket::WsConfig;
 use libp2p::yamux::YamuxConfig;
 use libp2p::{core, identity, noise, PeerId};
+use parking_lot::Mutex;
+use std::io;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tracing::debug;
@@ -19,6 +23,7 @@ use tracing::debug;
 pub(super) fn build_transport(
     allow_non_global_addresses_in_dht: bool,
     keypair: &identity::Keypair,
+    temporary_bans: Arc<Mutex<TemporaryBans>>,
     timeout: Duration,
     yamux_config: YamuxConfig,
 ) -> Result<Boxed<(PeerId, StreamMuxerBox)>, CreationError> {
@@ -32,11 +37,12 @@ pub(super) fn build_transport(
 
         let dns_tcp_or_ws_transport = dns_tcp.or_transport(ws).boxed();
 
-        if allow_non_global_addresses_in_dht {
-            dns_tcp_or_ws_transport
-        } else {
-            GlobalIpOnlyTransport::new(dns_tcp_or_ws_transport).boxed()
-        }
+        CustomTransportWrapper::new(
+            dns_tcp_or_ws_transport,
+            allow_non_global_addresses_in_dht,
+            temporary_bans,
+        )
+        .boxed()
     };
 
     let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
@@ -51,73 +57,100 @@ pub(super) fn build_transport(
         .boxed())
 }
 
-// Wrapper around a libp2p `Transport` dropping all dial requests to non-global
-// IP addresses.
-#[derive(Debug, Clone, Default)]
-pub struct GlobalIpOnlyTransport<T> {
-    inner: T,
+#[derive(Debug, Clone)]
+struct CustomTransportWrapper<T> {
+    base_transport: T,
+    allow_non_global_addresses: bool,
+    temporary_bans: Arc<Mutex<TemporaryBans>>,
 }
 
-impl<T> GlobalIpOnlyTransport<T> {
-    pub fn new(transport: T) -> Self {
-        GlobalIpOnlyTransport { inner: transport }
+impl<T> CustomTransportWrapper<T> {
+    fn new(
+        base_transport: T,
+        allow_non_global_addresses: bool,
+        temporary_bans: Arc<Mutex<TemporaryBans>>,
+    ) -> Self {
+        CustomTransportWrapper {
+            base_transport,
+            allow_non_global_addresses,
+            temporary_bans,
+        }
     }
 }
 
-impl<T: Transport + Unpin> Transport for GlobalIpOnlyTransport<T> {
-    type Output = <T as Transport>::Output;
-    type Error = <T as Transport>::Error;
-    type ListenerUpgrade = <T as Transport>::ListenerUpgrade;
-    type Dial = <T as Transport>::Dial;
+impl<T> Transport for CustomTransportWrapper<T>
+where
+    T: Transport + Unpin,
+    T::Error: From<io::Error>,
+{
+    type Output = T::Output;
+    type Error = T::Error;
+    type ListenerUpgrade = T::ListenerUpgrade;
+    type Dial = T::Dial;
 
     fn listen_on(&mut self, addr: Multiaddr) -> Result<ListenerId, TransportError<Self::Error>> {
-        self.inner.listen_on(addr)
+        self.base_transport.listen_on(addr)
     }
 
     fn remove_listener(&mut self, id: ListenerId) -> bool {
-        self.inner.remove_listener(id)
+        self.base_transport.remove_listener(id)
     }
 
     fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        match addr.iter().next() {
+        let mut addr_iter = addr.iter();
+
+        match addr_iter.next() {
             Some(Protocol::Ip4(a)) => {
-                if a.is_global() {
-                    self.inner.dial(addr)
-                } else {
+                if !(self.allow_non_global_addresses || a.is_global()) {
                     debug!(?a, "Not dialing non global IP address.",);
-                    Err(TransportError::MultiaddrNotSupported(addr))
+                    return Err(TransportError::MultiaddrNotSupported(addr));
                 }
             }
             Some(Protocol::Ip6(a)) => {
-                if a.is_global() {
-                    self.inner.dial(addr)
-                } else {
+                if !(self.allow_non_global_addresses || a.is_global()) {
                     debug!(?a, "Not dialing non global IP address.");
-                    Err(TransportError::MultiaddrNotSupported(addr))
+                    return Err(TransportError::MultiaddrNotSupported(addr));
                 }
             }
             _ => {
                 debug!(?addr, "Not dialing unsupported Multiaddress.");
-                Err(TransportError::MultiaddrNotSupported(addr))
+                return Err(TransportError::MultiaddrNotSupported(addr));
             }
         }
+
+        {
+            let temporary_bans = self.temporary_bans.lock();
+            for protocol in addr_iter {
+                if let Protocol::P2p(multihash) = protocol {
+                    if let Ok(peer_id) = PeerId::try_from(multihash) {
+                        if temporary_bans.is_banned(&peer_id) {
+                            let error =
+                                io::Error::new(io::ErrorKind::Other, "Peer is temporarily banned");
+                            return Err(TransportError::Other(error.into()));
+                        }
+                    }
+                }
+            }
+        }
+
+        self.base_transport.dial(addr)
     }
 
     fn dial_as_listener(
         &mut self,
         addr: Multiaddr,
     ) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.inner.dial_as_listener(addr)
+        self.base_transport.dial_as_listener(addr)
     }
 
     fn address_translation(&self, listen: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
-        self.inner.address_translation(listen, observed)
+        self.base_transport.address_translation(listen, observed)
     }
 
     fn poll(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<TransportEvent<Self::ListenerUpgrade, Self::Error>> {
-        Pin::new(&mut self.inner).poll(cx)
+        Pin::new(&mut self.base_transport).poll(cx)
     }
 }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1,5 +1,6 @@
 use crate::behavior::persistent_parameters::NetworkingParametersRegistry;
 use crate::behavior::{provider_storage, Behavior, Event};
+use crate::create::temporary_bans::TemporaryBans;
 use crate::create::{
     ProviderOnlyRecordStore, KADEMLIA_CONCURRENT_TASKS_BOOST_PER_PEER,
     REGULAR_CONCURRENT_TASKS_BOOST_PER_PEER,
@@ -25,13 +26,14 @@ use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::{DialError, SwarmEvent};
 use libp2p::{futures, Multiaddr, PeerId, Swarm};
 use nohash_hasher::IntMap;
+use parking_lot::Mutex;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 use tokio::time::Sleep;
 use tracing::{debug, error, info, trace, warn};
@@ -101,6 +103,8 @@ where
     max_established_incoming_connections: u32,
     /// Outgoing swarm connection limit.
     max_established_outgoing_connections: u32,
+    /// Temporarily banned peers.
+    temporary_bans: Arc<Mutex<TemporaryBans>>,
     /// Prometheus metrics.
     metrics: Option<Metrics>,
     /// Mapping from specific peer to number of established connections
@@ -112,16 +116,17 @@ pub(crate) struct NodeRunnerConfig<ProviderStorage>
 where
     ProviderStorage: provider_storage::ProviderStorage + Send + Sync + 'static,
 {
-    pub allow_non_global_addresses_in_dht: bool,
-    pub command_receiver: mpsc::Receiver<Command>,
-    pub swarm: Swarm<Behavior<ProviderOnlyRecordStore<ProviderStorage>>>,
-    pub shared_weak: Weak<Shared>,
-    pub next_random_query_interval: Duration,
-    pub networking_parameters_registry: Box<dyn NetworkingParametersRegistry>,
-    pub reserved_peers: HashMap<PeerId, Multiaddr>,
-    pub max_established_incoming_connections: u32,
-    pub max_established_outgoing_connections: u32,
-    pub metrics: Option<Metrics>,
+    pub(crate) allow_non_global_addresses_in_dht: bool,
+    pub(crate) command_receiver: mpsc::Receiver<Command>,
+    pub(crate) swarm: Swarm<Behavior<ProviderOnlyRecordStore<ProviderStorage>>>,
+    pub(crate) shared_weak: Weak<Shared>,
+    pub(crate) next_random_query_interval: Duration,
+    pub(crate) networking_parameters_registry: Box<dyn NetworkingParametersRegistry>,
+    pub(crate) reserved_peers: HashMap<PeerId, Multiaddr>,
+    pub(crate) max_established_incoming_connections: u32,
+    pub(crate) max_established_outgoing_connections: u32,
+    pub(crate) temporary_bans: Arc<Mutex<TemporaryBans>>,
+    pub(crate) metrics: Option<Metrics>,
 }
 
 impl<ProviderStorage> NodeRunner<ProviderStorage>
@@ -139,6 +144,7 @@ where
             reserved_peers,
             max_established_incoming_connections,
             max_established_outgoing_connections,
+            temporary_bans,
             metrics,
         }: NodeRunnerConfig<ProviderStorage>,
     ) -> Self {
@@ -159,6 +165,7 @@ where
             reserved_peers,
             max_established_incoming_connections,
             max_established_outgoing_connections,
+            temporary_bans,
             metrics,
             established_connections: HashMap::new(),
         }
@@ -334,6 +341,9 @@ where
                 num_established,
                 ..
             } => {
+                // Remove temporary ban if there was any
+                self.temporary_bans.lock().remove(&peer_id);
+
                 let shared = match self.shared_weak.upgrade() {
                     Some(shared) => shared,
                     None => {
@@ -469,29 +479,42 @@ where
                     }
                 }
             }
-            SwarmEvent::OutgoingConnectionError { peer_id, error } => match error {
-                DialError::Transport(ref addresses) => {
-                    for (addr, _) in addresses {
-                        debug!(?error, ?peer_id, %addr, "SwarmEvent::OutgoingConnectionError (DialError::Transport) for peer.");
-                        if let Some(peer_id) = peer_id {
-                            self.networking_parameters_registry
-                                .remove_known_peer_addresses(peer_id, vec![addr.clone()])
-                                .await;
+            SwarmEvent::OutgoingConnectionError { peer_id, error } => {
+                if let Some(peer_id) = &peer_id {
+                    // Create or extend temporary ban, but only if we are not offline
+                    if let Some(shared) = self.shared_weak.upgrade() {
+                        // One peer is possibly a node peer is connected to, hence expecting more
+                        // than one for online status
+                        if shared.connected_peers_count.load(Ordering::Relaxed) > 1 {
+                            self.temporary_bans.lock().create_or_extend(peer_id);
+                        }
+                    };
+                }
+
+                match error {
+                    DialError::Transport(ref addresses) => {
+                        for (addr, _) in addresses {
+                            debug!(?error, ?peer_id, %addr, "SwarmEvent::OutgoingConnectionError (DialError::Transport) for peer.");
+                            if let Some(peer_id) = peer_id {
+                                self.networking_parameters_registry
+                                    .remove_known_peer_addresses(peer_id, vec![addr.clone()])
+                                    .await;
+                            }
                         }
                     }
-                }
-                DialError::WrongPeerId { obtained, .. } => {
-                    debug!(?error, ?peer_id, obtained_peer_id=?obtained, "SwarmEvent::WrongPeerId (DialError::WrongPeerId) for peer.");
+                    DialError::WrongPeerId { obtained, .. } => {
+                        debug!(?error, ?peer_id, obtained_peer_id=?obtained, "SwarmEvent::WrongPeerId (DialError::WrongPeerId) for peer.");
 
-                    if let Some(ref peer_id) = peer_id {
-                        let kademlia = &mut self.swarm.behaviour_mut().kademlia;
-                        let _ = kademlia.remove_peer(peer_id);
+                        if let Some(ref peer_id) = peer_id {
+                            let kademlia = &mut self.swarm.behaviour_mut().kademlia;
+                            let _ = kademlia.remove_peer(peer_id);
+                        }
+                    }
+                    _ => {
+                        debug!(?error, ?peer_id, "SwarmEvent::OutgoingConnectionError");
                     }
                 }
-                _ => {
-                    debug!(?error, ?peer_id, "SwarmEvent::OutgoingConnectionError");
-                }
-            },
+            }
             other => {
                 trace!("Other swarm event: {:?}", other);
             }
@@ -1099,6 +1122,9 @@ where
                 );
             }
             Command::BanPeer { peer_id } => {
+                // Remove temporary ban if there is any before creating a permanent one
+                self.temporary_bans.lock().remove(&peer_id);
+
                 info!(?peer_id, "Banning peer on network level");
                 self.swarm.ban_peer_id(peer_id);
                 self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);


### PR DESCRIPTION
Resolves https://github.com/subspace/subspace/issues/1077 by having an in-memory LRU cache with unreachable peers that we consider temporarily banned. We then check this cache before dialing to the peer and failing early rather than timing out (our timeout is 10 seconds, this is a lot of time to spend on a peer we know is likely unreachable anyway).

I also added some extra warnings that should help with debugging of https://github.com/libp2p/rust-libp2p/discussions/3418 as it might be related to banning.

I recommend reviewing with whitespaces ignored, diff is smaller that way.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
