### PR TITLE
Small networking tweaks

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -271,6 +271,7 @@ pub(crate) async fn farm_multi_disk(
                         return;
                     }
 
+                    // TODO: Skip those that were already announced (because they cached)
                     let publish_fut = async move {
                         let mut pieces_publishing_futures = new_pieces
                             .into_iter()
@@ -283,7 +284,7 @@ pub(crate) async fn farm_multi_disk(
                             // Nothing is needed here, just driving all futures to completion
                         }
 
-                        info!("Piece publishing was successful.");
+                        info!(?sector_index, "Sector publishing was successful.");
 
                         // Release only after publishing is finished
                         drop(plotting_permit);

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -57,16 +57,13 @@ const YAMUX_MAX_STREAMS: usize = 256;
 
 /// Base limit for number of concurrent tasks initiated towards Kademlia.
 ///
-/// Kademlia has 32 substream as a hardcoded constant, we leave 2 for auxiliary internal functions
-/// like periodic random walk.
-///
-/// We restrict this so we don't exceed number of incoming streams for single peer, but this value
-/// will be boosted depending on number of connected peers.
-const KADEMLIA_BASE_CONCURRENT_TASKS: NonZeroUsize = NonZeroUsize::new(30).expect("Not zero; qed");
+/// We restrict this so we can manage outgoing requests a bit better by cancelling low-priority
+/// requests, but this value will be boosted depending on number of connected peers.
+const KADEMLIA_BASE_CONCURRENT_TASKS: NonZeroUsize = NonZeroUsize::new(25).expect("Not zero; qed");
 /// Above base limit will be boosted by specified number for every peer connected starting with
 /// second peer, such that it scaled with network connectivity, but the exact coefficient might need
 /// to be tweaked in the future.
-pub(crate) const KADEMLIA_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 3;
+pub(crate) const KADEMLIA_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 25;
 /// Base limit for number of any concurrent tasks except Kademlia.
 ///
 /// We configure total number of streams per connection to 256. Here we assume half of them might be
@@ -75,11 +72,11 @@ pub(crate) const KADEMLIA_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 3;
 /// We restrict this so we don't exceed number of streams for single peer, but this value will be
 /// boosted depending on number of connected peers.
 const REGULAR_BASE_CONCURRENT_TASKS: NonZeroUsize =
-    NonZeroUsize::new(120 - KADEMLIA_BASE_CONCURRENT_TASKS.get()).expect("Not zero; qed");
+    NonZeroUsize::new(80 - KADEMLIA_BASE_CONCURRENT_TASKS.get()).expect("Not zero; qed");
 /// Above base limit will be boosted by specified number for every peer connected starting with
 /// second peer, such that it scaled with network connectivity, but the exact coefficient might need
 /// to be tweaked in the future.
-pub(crate) const REGULAR_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 5;
+pub(crate) const REGULAR_CONCURRENT_TASKS_BOOST_PER_PEER: usize = 50;
 
 /// Record store that can't be created, only
 pub(crate) struct ProviderOnlyRecordStore<ProviderStorage> {

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -209,5 +209,5 @@ pub(crate) async fn publish_pieces(
         // empty body
     }
 
-    info!(%segment_index, "Piece publishing was successful.");
+    info!(%segment_index, "Segment publishing was successful.");
 }


### PR DESCRIPTION
Some random suff. The biggest change is tasks limits and boosting. The rationale is that we no longer have hard limits on Kademlia side with buffering and stream reuse, the only limit is the global one. So in order to be able to do more stuff with Kademlia and otherwise concurrently I decided to decrease base values, but increase boosting allowed with more peers. Seems to work for me on Gemini 3c much better than before.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
