### PR TITLE
Threading improvements for farmer and networking

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -93,8 +93,7 @@ pub(crate) async fn farm_multi_disk(
             &readers_and_pieces,
             node_client.clone(),
             piece_memory_cache.clone(),
-        )
-        .await?
+        )?
     };
 
     let piece_cache = Arc::new(tokio::sync::Mutex::new(piece_cache));

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -31,7 +31,8 @@ const MAX_CONCURRENT_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
 const MAX_CONCURRENT_RE_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(100).expect("Not zero; qed");
 
-pub(super) async fn configure_dsn(
+#[allow(clippy::type_complexity)]
+pub(super) fn configure_dsn(
     base_path: PathBuf,
     keypair: Keypair,
     DsnArgs {
@@ -180,7 +181,6 @@ pub(super) async fn configure_dsn(
     };
 
     create(config)
-        .await
         .map(|(node, node_runner)| (node, node_runner, piece_cache))
         .map_err(Into::into)
 }

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -7,11 +7,20 @@ pub mod parity_db_store;
 pub mod piece_cache;
 pub mod piece_validator;
 pub mod readers_and_pieces;
+#[cfg(test)]
+mod tests;
 
+use futures::channel::oneshot;
+use futures::channel::oneshot::Canceled;
+use futures::future::Either;
+use std::future::Future;
 use std::ops::Deref;
+use std::{io, thread};
+use tokio::runtime::Handle;
+use tracing::debug;
 
 /// Joins synchronous join handle on drop
-pub(crate) struct JoinOnDrop(Option<std::thread::JoinHandle<()>>);
+pub(crate) struct JoinOnDrop(Option<thread::JoinHandle<()>>);
 
 impl Drop for JoinOnDrop {
     fn drop(&mut self) {
@@ -19,20 +28,60 @@ impl Drop for JoinOnDrop {
             .take()
             .expect("Always called exactly once; qed")
             .join()
-            .expect("DSN archiving must not panic");
+            .expect("Panic if background thread panicked");
     }
 }
 
 impl JoinOnDrop {
-    pub(crate) fn new(handle: std::thread::JoinHandle<()>) -> Self {
+    // Create new instance
+    pub(crate) fn new(handle: thread::JoinHandle<()>) -> Self {
         Self(Some(handle))
     }
 }
 
 impl Deref for JoinOnDrop {
-    type Target = std::thread::JoinHandle<()>;
+    type Target = thread::JoinHandle<()>;
 
     fn deref(&self) -> &Self::Target {
         self.0.as_ref().expect("Only dropped in Drop impl; qed")
     }
+}
+
+/// Runs future on a dedicated thread with the specified name, will block on drop until background
+/// thread with future is stopped too, ensuring nothing is left in memory
+pub fn run_future_in_dedicated_thread<Fut, T>(
+    future: Fut,
+    thread_name: String,
+) -> io::Result<impl Future<Output = Result<T, Canceled>> + Send>
+where
+    Fut: Future<Output = T> + Unpin + Send + 'static,
+    T: Send + 'static,
+{
+    let (drop_tx, drop_rx) = oneshot::channel::<()>();
+    let (result_tx, result_rx) = oneshot::channel();
+    let handle = Handle::current();
+    let join_handle = thread::Builder::new().name(thread_name).spawn(move || {
+        let result = match handle.block_on(futures::future::select(future, drop_rx)) {
+            Either::Left((result, _)) => result,
+            Either::Right(_) => {
+                // Outer future was dropped, nothing left to do
+                return;
+            }
+        };
+        if let Err(_error) = result_tx.send(result) {
+            debug!(
+                thread_name = ?thread::current().name(),
+                "Future finished, but receiver was already dropped",
+            );
+        }
+    })?;
+    // Ensure thread will not be left hanging forever
+    let join_on_drop = JoinOnDrop::new(join_handle);
+
+    Ok(async move {
+        let result = result_rx.await;
+        drop(drop_tx);
+        drop(join_on_drop);
+        result
+    })
 }

--- a/crates/subspace-farmer/src/utils/tests.rs
+++ b/crates/subspace-farmer/src/utils/tests.rs
@@ -1,0 +1,27 @@
+use crate::utils::run_future_in_dedicated_thread;
+use std::future;
+
+#[tokio::test]
+async fn run_future_in_dedicated_thread_ready() {
+    let value = run_future_in_dedicated_thread(
+        Box::pin(async { future::ready(1).await }),
+        "ready".to_string(),
+    )
+    .unwrap()
+    .await
+    .unwrap();
+
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn run_future_in_dedicated_thread_cancellation() {
+    // This may hang if not implemented correctly
+    drop(
+        run_future_in_dedicated_thread(
+            Box::pin(async { future::pending::<()>().await }),
+            "cancellation".to_string(),
+        )
+        .unwrap(),
+    );
+}

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -28,7 +28,7 @@ async fn main() {
             ..Config::default()
         };
 
-        let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+        let (node, mut node_runner) = subspace_networking::create(config).unwrap();
 
         println!("Node {} ID is {}", i, node.id());
 
@@ -71,7 +71,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+    let (node, mut node_runner) = subspace_networking::create(config).unwrap();
 
     tokio::spawn(async move {
         node_runner.run().await;

--- a/crates/subspace-networking/examples/announce-piece.rs
+++ b/crates/subspace-networking/examples/announce-piece.rs
@@ -17,7 +17,7 @@ async fn main() {
         allow_non_global_addresses_in_dht: true,
         ..Config::default()
     };
-    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).unwrap();
 
     println!("Node 1 ID is {}", node_1.id());
 
@@ -52,7 +52,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -33,7 +33,7 @@ async fn main() {
         };
         let libp2p::identity::Keypair::Ed25519(keypair) = config.keypair.clone();
 
-        let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+        let (node, mut node_runner) = subspace_networking::create(config).unwrap();
 
         println!("Node {} ID is {}", i, node.id());
 
@@ -92,7 +92,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (node, mut node_runner) = subspace_networking::create(config).await.unwrap();
+    let (node, mut node_runner) = subspace_networking::create(config).unwrap();
 
     println!("Source Node ID is {}", node.id());
     println!("Expected Peer ID:{expected_node_id}");

--- a/crates/subspace-networking/examples/get-peers.rs
+++ b/crates/subspace-networking/examples/get-peers.rs
@@ -17,7 +17,7 @@ async fn main() {
         allow_non_global_addresses_in_dht: true,
         ..Config::default()
     };
-    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).unwrap();
 
     println!("Node 1 ID is {}", node_1.id());
 
@@ -52,7 +52,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -20,7 +20,7 @@ async fn main() {
         allow_non_global_addresses_in_dht: true,
         ..Config::default()
     };
-    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).unwrap();
 
     println!("Node 1 ID is {}", node_1.id());
 
@@ -57,7 +57,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/examples/requests.rs
+++ b/crates/subspace-networking/examples/requests.rs
@@ -41,7 +41,7 @@ async fn main() {
         metrics: Some(metrics),
         ..Config::default()
     };
-    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).await.unwrap();
+    let (node_1, mut node_runner_1) = subspace_networking::create(config_1).unwrap();
 
     // Init prometheus
     let prometheus_metrics_server_address = "127.0.0.1:63000".parse().unwrap();
@@ -94,7 +94,7 @@ async fn main() {
         ..Config::default()
     };
 
-    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).await.unwrap();
+    let (node_2, mut node_runner_2) = subspace_networking::create(config_2).unwrap();
 
     println!("Node 2 ID is {}", node_2.id());
 

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -114,9 +114,8 @@ async fn main() -> anyhow::Result<()> {
                     .unwrap_or(MAX_ESTABLISHED_OUTGOING_CONNECTIONS),
                 ..Config::with_keypair_and_provider_storage(keypair, provider_storage)
             };
-            let (node, mut node_runner) = subspace_networking::create(config)
-                .await
-                .expect("Networking stack creation failed.");
+            let (node, mut node_runner) =
+                subspace_networking::create(config).expect("Networking stack creation failed.");
 
             node.on_new_listener(Arc::new({
                 let node_id = node.id();

--- a/crates/subspace-networking/src/utils/prometheus.rs
+++ b/crates/subspace-networking/src/utils/prometheus.rs
@@ -40,6 +40,7 @@ pub async fn start_prometheus_metrics_server(
     let runtime = tokio::runtime::Runtime::new()?;
 
     // We need a dedicated thread because actix-web App is !Send and won't work with tokio.
+    // TODO: This is not cancellable, it should be though
     thread::spawn(move || {
         if let Err(err) = runtime.block_on(server) {
             error!(

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -70,7 +70,6 @@ impl ImportBlocksFromDsnCmd {
             })],
             ..Config::default()
         })
-        .await
         .map_err(|error| sc_service::Error::Other(error.to_string()))?;
 
         spawner.spawn_essential(

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -55,7 +55,7 @@ pub struct DsnConfig {
 type DsnProviderStorage<AS> =
     NodeProviderStorage<PieceCache<AS>, Either<ParityDbProviderStorage, MemoryProviderStorage>>;
 
-pub(crate) async fn create_dsn_instance<Block, AS>(
+pub(crate) fn create_dsn_instance<Block, AS>(
     dsn_config: DsnConfig,
     piece_cache: PieceCache<AS>,
     root_block_cache: RootBlockCache<AS>,
@@ -125,7 +125,7 @@ where
         ..subspace_networking::Config::default()
     };
 
-    subspace_networking::create(networking_config).await
+    subspace_networking::create(networking_config)
 }
 
 /// Start an archiver that will listen for archived segments and send it to DSN network using

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -491,14 +491,9 @@ where
 
             let (node, mut node_runner) = create_dsn_instance::<Block, _>(
                 config.clone(),
-                piece_cache.clone(),
+                piece_cache,
                 root_block_cache.clone(),
-            )
-            .instrument(tracing::info_span!(
-                sc_tracing::logging::PREFIX_LOG_SPAN,
-                name = "DSN"
-            ))
-            .await?;
+            )?;
 
             info!("Subspace networking initialized: Node ID is {}", node.id());
 


### PR DESCRIPTION
There are two changes here:
* first I looked and decided that there is nothing blocking happening during networking creation that requires a dedicated thread
* then I introduced an abstraction that allows to move farm and networking futures to their dedicated threads, while still allowing us to to cancel them on shutdown if necessary

Primitive is re-exported from farmer since it will likely be useful for SDK as well

Should help with https://github.com/subspace/subspace/issues/1144, but we'll need to do more extensive testing before closing it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
