### PR TITLE
Refactor segment encoding in archiver to make it friendly for incremental archiving

### DIFF
--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -133,7 +133,7 @@ pub enum SegmentItem {
     #[codec(index = 0)]
     Padding,
     /// Contains full block inside
-    #[codec(index = 3)]
+    #[codec(index = 1)]
     Block {
         /// Block bytes
         bytes: Vec<u8>,
@@ -143,7 +143,7 @@ pub enum SegmentItem {
         object_mapping: BlockObjectMapping,
     },
     /// Contains the beginning of the block inside, remainder will be found in subsequent segments
-    #[codec(index = 4)]
+    #[codec(index = 2)]
     BlockStart {
         /// Block bytes
         bytes: Vec<u8>,
@@ -153,7 +153,7 @@ pub enum SegmentItem {
         object_mapping: BlockObjectMapping,
     },
     /// Continuation of the partial block spilled over into the next segment
-    #[codec(index = 5)]
+    #[codec(index = 3)]
     BlockContinuation {
         /// Block bytes
         bytes: Vec<u8>,
@@ -163,7 +163,7 @@ pub enum SegmentItem {
         object_mapping: BlockObjectMapping,
     },
     /// Root block
-    #[codec(index = 6)]
+    #[codec(index = 4)]
     RootBlock(RootBlock),
 }
 

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -23,7 +23,7 @@ use alloc::collections::VecDeque;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
-use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
+use parity_scale_codec::{Compact, CompactLen, Decode, Encode, Input, Output};
 use reed_solomon_erasure::galois_16::ReedSolomon;
 use subspace_core_primitives::crypto::blake2b_256_254_hash;
 use subspace_core_primitives::crypto::kzg::{Kzg, Witness};
@@ -32,7 +32,7 @@ use subspace_core_primitives::objects::{
 };
 use subspace_core_primitives::{
     crypto, ArchivedBlockProgress, Blake2b256Hash, BlockNumber, FlatPieces, LastArchivedBlock,
-    RecordsRoot, RootBlock, BLAKE2B_256_HASH_SIZE, WITNESS_SIZE,
+    RecordsRoot, RootBlock, BLAKE2B_256_HASH_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, WITNESS_SIZE,
 };
 
 const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
@@ -47,14 +47,71 @@ const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
 };
 
 /// Segment represents a collection of items stored in archival history of the Subspace blockchain
-#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Segment {
     // V0 of the segment data structure
-    #[codec(index = 0)]
     V0 {
         /// Segment items
         items: Vec<SegmentItem>,
     },
+}
+
+impl Encode for Segment {
+    fn size_hint(&self) -> usize {
+        RECORDED_HISTORY_SEGMENT_SIZE as usize
+    }
+
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        match self {
+            Segment::V0 { items } => {
+                dest.push_byte(0);
+                for item in items {
+                    item.encode_to(dest);
+                }
+            }
+        }
+    }
+}
+
+impl Decode for Segment {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+        let variant = input
+            .read_byte()
+            .map_err(|e| e.chain("Could not decode `Segment`, failed to read variant byte"))?;
+        match variant {
+            0 => {
+                let mut items = Vec::new();
+                loop {
+                    match input.remaining_len()? {
+                        Some(0) => {
+                            break;
+                        }
+                        Some(_) => {
+                            // Processing continues below
+                        }
+                        None => {
+                            return Err(
+                                "Source doesn't report remaining length, decoding not possible"
+                                    .into(),
+                            );
+                        }
+                    }
+
+                    match SegmentItem::decode(input) {
+                        Ok(item) => {
+                            items.push(item);
+                        }
+                        Err(error) => {
+                            return Err(error.chain("Could not decode `Segment::V0::items`"));
+                        }
+                    }
+                }
+
+                Ok(Segment::V0 { items })
+            }
+            _ => Err("Could not decode `Segment`, variant doesn't exist".into()),
+        }
+    }
 }
 
 impl Segment {
@@ -72,6 +129,9 @@ impl Segment {
 /// Kinds of items that are contained within a segment
 #[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
 pub enum SegmentItem {
+    /// Special dummy enum variant only used as an implementation detail for padding purposes
+    #[codec(index = 0)]
+    Padding,
     /// Contains full block inside
     #[codec(index = 3)]
     Block {
@@ -395,6 +455,9 @@ impl Archiver {
                 // last segment item insertion needs to be skipped to avoid out of range panic when
                 // trying to cut segment item internal bytes.
                 let inner_bytes_size = match &segment_item {
+                    SegmentItem::Padding => {
+                        unreachable!("Buffer never contains SegmentItem::Padding; qed");
+                    }
                     SegmentItem::Block { bytes, .. } => bytes.len(),
                     SegmentItem::BlockStart { .. } => {
                         unreachable!("Buffer never contains SegmentItem::BlockStart; qed");
@@ -415,6 +478,9 @@ impl Archiver {
             }
 
             match &segment_item {
+                SegmentItem::Padding => {
+                    unreachable!("Buffer never contains SegmentItem::Padding; qed");
+                }
                 SegmentItem::Block { .. } => {
                     // Skip block number increase in case of the very first block
                     if last_archived_block != INITIAL_LAST_ARCHIVED_BLOCK {
@@ -462,6 +528,9 @@ impl Archiver {
                 .expect("Segment over segment size always has at least one item; qed");
 
             let segment_item = match segment_item {
+                SegmentItem::Padding => {
+                    unreachable!("Buffer never contains SegmentItem::Padding; qed");
+                }
                 SegmentItem::Block {
                     mut bytes,
                     mut object_mapping,
@@ -584,9 +653,14 @@ impl Archiver {
             ];
             let Segment::V0 { items } = &segment;
             // `+1` corresponds to enum variant encoding
-            let mut base_offset_in_segment = 1 + Compact::compact_len(&(items.len() as u32));
+            let mut base_offset_in_segment = 1;
             for segment_item in items {
                 match segment_item {
+                    SegmentItem::Padding => {
+                        unreachable!(
+                            "Segment during archiving never contains SegmentItem::Padding; qed"
+                        );
+                    }
                     SegmentItem::Block {
                         bytes,
                         object_mapping,

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -163,6 +163,9 @@ impl Reconstructor {
 
         for segment_item in items {
             match segment_item {
+                SegmentItem::Padding => {
+                    // Doesn't contain anything
+                }
                 SegmentItem::Block { bytes, .. } => {
                     if !partial_block.is_empty() {
                         reconstructed_contents

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -121,7 +121,7 @@ fn archiver() {
     {
         let last_archived_block = first_archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 1);
-        assert_eq!(last_archived_block.partial_archived(), Some(63380));
+        assert_eq!(last_archived_block.partial_archived(), Some(63381));
     }
 
     // 4 objects fit into the first segment
@@ -208,13 +208,13 @@ fn archiver() {
         let archived_segment = archived_segments.get(0).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(105531));
+        assert_eq!(last_archived_block.partial_archived(), Some(105533));
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.root_block.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(232209));
+        assert_eq!(last_archived_block.partial_archived(), Some(232212));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -248,7 +248,7 @@ fn archiver() {
     }
 
     // Add a block such that it fits in the next segment exactly
-    let block_3 = rand::random::<[u8; SEGMENT_SIZE as usize - 21472]>().to_vec();
+    let block_3 = rand::random::<[u8; SEGMENT_SIZE as usize - 21468]>().to_vec();
     let archived_segments = archiver.add_block(block_3.clone(), BlockObjectMapping::default());
     assert_eq!(archived_segments.len(), 1);
 
@@ -295,7 +295,7 @@ fn archiver() {
 fn invalid_usage() {
     let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
     assert_matches!(
-        Archiver::new(5, SEGMENT_SIZE, kzg.clone()),
+        Archiver::new(4, SEGMENT_SIZE, kzg.clone()),
         Err(ArchiverInstantiationError::RecordSizeTooSmall),
     );
 
@@ -390,9 +390,6 @@ fn one_byte_smaller_segment() {
     let block_size = SEGMENT_SIZE as usize
         // Segment enum variant
         - 1
-        // Compact length of number of segment items
-        - 1
-        // Block continuation segment item enum variant
         - 1
         // This is a rough number (a bit fewer bytes will be included in practice), but it is
         // close enough and practically will always result in the same compact length.
@@ -425,8 +422,6 @@ fn spill_over_edge_case() {
     // internal bytes of the segment item anyway
     let block_size = SEGMENT_SIZE as usize
         // Segment enum variant
-        - 1
-        // Compact length of number of segment items
         - 1
         // Block continuation segment item enum variant
         - 1
@@ -494,8 +489,6 @@ fn object_on_the_edge_of_segment() {
         // Offset is designed to fall exactly on the edge of the segment
         offset: SEGMENT_SIZE
             // Segment enum variant
-            - 1
-            // Compact length of number of segment items
             - 1
             // Root block segment item
             - SegmentItem::RootBlock(RootBlock::V0 {

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -80,7 +80,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 1,
-                archived_progress: ArchivedBlockProgress::Partial(63380)
+                archived_progress: ArchivedBlockProgress::Partial(63381)
             }
         );
 
@@ -99,7 +99,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 1,
-                archived_progress: ArchivedBlockProgress::Partial(63380)
+                archived_progress: ArchivedBlockProgress::Partial(63381)
             }
         );
     }
@@ -119,7 +119,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(31568)
+                archived_progress: ArchivedBlockProgress::Partial(31570)
             }
         );
 
@@ -138,7 +138,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(31568)
+                archived_progress: ArchivedBlockProgress::Partial(31570)
             }
         );
     }
@@ -158,7 +158,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(158246)
+                archived_progress: ArchivedBlockProgress::Partial(158249)
             }
         );
     }
@@ -179,7 +179,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(158246)
+                archived_progress: ArchivedBlockProgress::Partial(158249)
             }
         );
     }
@@ -199,7 +199,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(284924)
+                archived_progress: ArchivedBlockProgress::Partial(284928)
             }
         );
     }
@@ -220,7 +220,7 @@ fn basic() {
             contents.root_block.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(284924)
+                archived_progress: ArchivedBlockProgress::Partial(284928)
             }
         );
     }


### PR DESCRIPTION
As described in https://github.com/subspace/subspace/issues/1160#issuecomment-1440487659, compact length encoding is our enemy if we want to archive incrementally.

I chose the option of not having length prefix for `items` vector at all, this allows us to implement incremental archiving in a much simpler way and never worry about bytes changing at the beginning of the segment later.

Due to length prefix removed some byte offsets in tests were necessary.

Important: this is a breaking change, after this change archiving is no longer compatible with previous versions of Gemini.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
