### PR TITLE
Refactor the parameters of the executor construction

### DIFF
--- a/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
+++ b/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
@@ -173,21 +173,19 @@ impl<'a> FetchRuntimeCode for RuntimCodeFetcher<'a> {
 }
 
 /// Fraud proof verifier.
-pub struct InvalidStateTransitionProofVerifier<PBlock, C, B, Exec, Spawn, Hash> {
+pub struct InvalidStateTransitionProofVerifier<PBlock, C, Exec, Spawn, Hash> {
     client: Arc<C>,
-    backend: Arc<B>,
     executor: Exec,
     spawn_handle: Spawn,
     _phantom: PhantomData<(PBlock, Hash)>,
 }
 
-impl<PBlock, C, B, Exec: Clone, Spawn: Clone, Hash> Clone
-    for InvalidStateTransitionProofVerifier<PBlock, C, B, Exec, Spawn, Hash>
+impl<PBlock, C, Exec: Clone, Spawn: Clone, Hash> Clone
+    for InvalidStateTransitionProofVerifier<PBlock, C, Exec, Spawn, Hash>
 {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
-            backend: self.backend.clone(),
             executor: self.executor.clone(),
             spawn_handle: self.spawn_handle.clone(),
             _phantom: self._phantom,
@@ -195,22 +193,19 @@ impl<PBlock, C, B, Exec: Clone, Spawn: Clone, Hash> Clone
     }
 }
 
-impl<PBlock, C, B, Exec, Spawn, Hash>
-    InvalidStateTransitionProofVerifier<PBlock, C, B, Exec, Spawn, Hash>
+impl<PBlock, C, Exec, Spawn, Hash> InvalidStateTransitionProofVerifier<PBlock, C, Exec, Spawn, Hash>
 where
     PBlock: BlockT,
     C: ProvideRuntimeApi<PBlock> + Send + Sync,
     C::Api: ExecutorApi<PBlock, Hash>,
-    B: backend::Backend<PBlock>,
     Exec: CodeExecutor + Clone + 'static,
     Spawn: SpawnNamed + Clone + Send + 'static,
     Hash: Encode + Decode,
 {
     /// Constructs a new instance of [`InvalidStateTransitionProofVerifier`].
-    pub fn new(client: Arc<C>, backend: Arc<B>, executor: Exec, spawn_handle: Spawn) -> Self {
+    pub fn new(client: Arc<C>, executor: Exec, spawn_handle: Spawn) -> Self {
         Self {
             client,
-            backend,
             executor,
             spawn_handle,
             _phantom: PhantomData::<(PBlock, Hash)>,

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -190,9 +190,8 @@ async fn execution_proof_creation_and_verification_should_work() {
         .unwrap();
     assert_eq!(post_execution_root, intermediate_roots[0].into());
 
-    let proof_verifier = ProofVerifier::<Block, _, _, _, _, _, _>::new(
+    let proof_verifier = ProofVerifier::<Block, _, _, _, _, _>::new(
         ferdie.client.clone(),
-        ferdie.backend.clone(),
         ferdie.executor.clone(),
         ferdie.task_manager.spawn_handle(),
     );
@@ -471,9 +470,8 @@ async fn invalid_execution_proof_should_not_work() {
     assert!(check_proof_executor(post_delta_root0, proof0.clone()).is_ok());
     assert!(check_proof_executor(post_delta_root1, proof1.clone()).is_ok());
 
-    let proof_verifier = ProofVerifier::<Block, _, _, _, _, _, _>::new(
+    let proof_verifier = ProofVerifier::<Block, _, _, _, _, _>::new(
         ferdie.client.clone(),
-        ferdie.backend.clone(),
         ferdie.executor.clone(),
         ferdie.task_manager.spawn_handle(),
     );

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -587,7 +587,7 @@ fn main() -> Result<(), Error> {
                             system_domain_client: system_domain_node.client.clone(),
                             system_domain_network: system_domain_node.network.clone(),
                             primary_chain_client: primary_chain_node.client.clone(),
-                            primary_network: primary_chain_node.network.clone(),
+                            primary_network_sync_oracle: primary_chain_node.network.clone(),
                             select_chain: primary_chain_node.select_chain.clone(),
                             imported_block_notification_stream: imported_block_notification_stream(
                             ),

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -550,7 +550,6 @@ fn main() -> Result<(), Error> {
                     >(
                         system_domain_config,
                         primary_chain_node.client.clone(),
-                        primary_chain_node.backend.clone(),
                         primary_chain_node.network.clone(),
                         &primary_chain_node.select_chain,
                         imported_block_notification_stream(),

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -125,7 +125,6 @@ pub type FraudProofVerifier<RuntimeApi, ExecutorDispatch> = subspace_fraud_proof
     Block,
     Block,
     FullClient<RuntimeApi, ExecutorDispatch>,
-    FullBackend,
     NativeElseWasmExecutor<ExecutorDispatch>,
     SpawnTaskHandle,
     Hash,
@@ -256,7 +255,6 @@ where
 
     let proof_verifier = subspace_fraud_proof::ProofVerifier::new(
         client.clone(),
-        backend.clone(),
         executor,
         task_manager.spawn_handle(),
     );

--- a/domains/client/domain-executor/src/core_executor.rs
+++ b/domains/client/domain-executor/src/core_executor.rs
@@ -137,7 +137,7 @@ where
             domain_id,
             params.client.clone(),
             params.primary_chain_client.clone(),
-            params.primary_network,
+            params.primary_network_sync_oracle,
             params.backend.clone(),
             fraud_proof_generator.clone(),
         );

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -110,11 +110,10 @@ pub use self::system_gossip_message_validator::SystemGossipMessageValidator;
 use crate::utils::BlockInfo;
 use futures::channel::mpsc;
 use futures::Stream;
-use sc_network::NetworkService;
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
-use sp_consensus::SelectChain;
+use sp_consensus::{SelectChain, SyncOracle};
 use sp_consensus_slots::Slot;
 use sp_core::traits::SpawnNamed;
 use sp_domains::{ExecutionReceipt, SignedBundle};
@@ -159,7 +158,7 @@ pub struct EssentialExecutorParams<
     NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
 {
     pub primary_chain_client: Arc<PClient>,
-    pub primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
+    pub primary_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
     pub client: Arc<Client>,
     pub transaction_pool: Arc<TransactionPool>,
     pub backend: Arc<Backend>,

--- a/domains/client/domain-executor/src/system_executor.rs
+++ b/domains/client/domain-executor/src/system_executor.rs
@@ -137,7 +137,7 @@ where
             DomainId::SYSTEM,
             params.client.clone(),
             params.primary_chain_client.clone(),
-            params.primary_network,
+            params.primary_network_sync_oracle,
             params.backend.clone(),
             fraud_proof_generator.clone(),
         );

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -122,7 +122,6 @@ type FraudProofVerifier<PBlock, PClient, Executor> = subspace_fraud_proof::Proof
     Block,
     PBlock,
     PClient,
-    TFullBackend<PBlock>,
     NativeElseWasmExecutor<Executor>,
     SpawnTaskHandle,
     Hash,
@@ -133,7 +132,6 @@ type FraudProofVerifier<PBlock, PClient, Executor> = subspace_fraud_proof::Proof
 fn new_partial<RuntimeApi, Executor, PBlock, PClient>(
     config: &ServiceConfiguration,
     primary_chain_client: Arc<PClient>,
-    primary_backend: Arc<TFullBackend<PBlock>>,
 ) -> Result<
     PartialComponents<
         FullClient<RuntimeApi, Executor>,
@@ -200,7 +198,6 @@ where
 
     let proof_verifier = subspace_fraud_proof::ProofVerifier::new(
         primary_chain_client.clone(),
-        primary_backend,
         executor.clone(),
         task_manager.spawn_handle(),
     );
@@ -249,7 +246,6 @@ where
 pub async fn new_full_system<PBlock, PClient, SC, IBNS, NSNS, RuntimeApi, ExecutorDispatch>(
     mut system_domain_config: DomainConfiguration,
     primary_chain_client: Arc<PClient>,
-    primary_backend: Arc<TFullBackend<PBlock>>,
     primary_network: Arc<NetworkService<PBlock, PBlock::Hash>>,
     select_chain: &SC,
     imported_block_notification_stream: IBNS,
@@ -313,7 +309,6 @@ where
     let params = new_partial(
         &system_domain_config.service_config,
         primary_chain_client.clone(),
-        primary_backend,
     )?;
 
     let (mut telemetry, _telemetry_worker_handle, code_executor) = params.other;

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -181,7 +181,6 @@ async fn run_executor(
     >(
         system_domain_config,
         primary_chain_full_node.client.clone(),
-        primary_chain_full_node.backend.clone(),
         primary_chain_full_node.network.clone(),
         &primary_chain_full_node.select_chain,
         primary_chain_full_node


### PR DESCRIPTION
This PR is part of https://github.com/subspace/subspace/issues/1213

This PR contains changes of:
- Remove unused backend field from fraud proof verifier
- Replace the unnecessary `primary_network` with `primary_network_sync_oracle` in the domain client
    - the `primary_network` is only used as a sync oracle in the domain client
    - the mock primary chain in the new domain testing framework doesn't set up the networking layer (thus we can easily mock the different situations of the primary chain networking), and a sync oracle is easier to mock.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
