### PR TITLE
Adjust query and requests` timeouts for DSN.

### DIFF
--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -58,6 +58,7 @@ const KADEMLIA_PROVIDER_REPUBLICATION_INTERVAL_IN_SECS: Option<Duration> =
 // Defines a replication factor for Kademlia on get_record operation.
 // "Good citizen" supports the network health.
 const YAMUX_MAX_STREAMS: usize = 256;
+const KADEMLIA_QUERY_TIMEOUT: Duration = Duration::from_secs(40);
 
 /// Base limit for number of concurrent tasks initiated towards Kademlia.
 ///
@@ -230,6 +231,7 @@ where
     ) -> Self {
         let mut kademlia = KademliaConfig::default();
         kademlia
+            .set_query_timeout(KADEMLIA_QUERY_TIMEOUT)
             .set_protocol_names(vec![KADEMLIA_PROTOCOL.into()])
             .set_max_packet_size(2 * PIECE_SIZE)
             .set_kbucket_inserts(KademliaBucketInserts::Manual)

--- a/crates/subspace-networking/src/request_responses.rs
+++ b/crates/subspace-networking/src/request_responses.rs
@@ -139,7 +139,7 @@ impl ProtocolConfig {
             name: protocol_name,
             max_request_size: 1024 * 1024,
             max_response_size: 16 * 1024 * 1024,
-            request_timeout: Duration::from_secs(15),
+            request_timeout: Duration::from_secs(20),
             inbound_queue: None,
         }
     }


### PR DESCRIPTION
This PR adjusts two networking parameters: 
- kademlia query timeouts from the default (60 sec) down to 40s
- request timeout for request-response protocols from 15s up to 20s.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
