### PR TITLE
Add DSN connection limits parameters for subspace-node.

### DIFF
--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -432,6 +432,8 @@ fn main() -> Result<(), Error> {
                             bootstrap_nodes: dsn_bootstrap_nodes,
                             reserved_peers: cli.dsn_reserved_peers,
                             allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ips,
+                            max_in_connections: cli.dsn_max_in_connections,
+                            max_out_connections: cli.dsn_max_out_connections,
                         }
                     };
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -194,6 +194,14 @@ pub struct Cli {
     #[arg(long)]
     pub dsn_reserved_peers: Vec<Multiaddr>,
 
+    /// Defines max established incoming connection limit for DSN.
+    #[arg(long, default_value_t = 100)]
+    pub dsn_max_in_connections: u32,
+
+    /// Defines max established outgoing swarm connection limit for DSN.
+    #[arg(long, default_value_t = 100)]
+    pub dsn_max_out_connections: u32,
+
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
     /// in Kademlia DHT for the DSN.
     #[arg(long, default_value_t = false)]

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -52,6 +52,12 @@ pub struct DsnConfig {
 
     /// System base path.
     pub base_path: Option<PathBuf>,
+
+    /// Defines max established incoming swarm connection limit.
+    pub max_in_connections: u32,
+
+    /// Defines max established outgoing swarm connection limit.
+    pub max_out_connections: u32,
 }
 
 type DsnProviderStorage<AS> =
@@ -148,6 +154,9 @@ where
             }),
         ],
         provider_storage,
+        max_established_incoming_connections: dsn_config.max_in_connections,
+        max_established_outgoing_connections: dsn_config.max_out_connections,
+
         ..subspace_networking::Config::default()
     };
 

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -136,6 +136,8 @@ async fn run_executor(
                     reserved_peers: vec![],
                     keypair: identity::Keypair::generate_ed25519(),
                     allow_non_global_addresses_in_dht: true,
+                    max_out_connections: 50,
+                    max_in_connections: 50,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -205,6 +205,8 @@ pub async fn run_validator_node(
                     reserved_peers: vec![],
                     keypair: identity::Keypair::generate_ed25519(),
                     allow_non_global_addresses_in_dht: true,
+                    max_out_connections: 50,
+                    max_in_connections: 50,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },


### PR DESCRIPTION
This PR exposes connection limits for DSN integrated into the `subspace-node` app.

The new CLI arguments are:
--dsn-max-in-connections
--dsn-max-out-connections

Both parameters are set to 100 by default.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
