### PR TITLE
Basic Proof-of-Space implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9732,6 +9732,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "subspace-chiapos"
+version = "0.1.0"
+source = "git+https://github.com/subspace/chiapos?rev=a239ddf83b4d8420f23616d604af83c756c40116#a239ddf83b4d8420f23616d604af83c756c40116"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
@@ -9951,6 +9959,15 @@ dependencies = [
  "system-domain-runtime",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "subspace-proof-of-space"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "subspace-chiapos",
+ "subspace-core-primitives",
 ]
 
 [[package]]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -37,7 +37,7 @@ use core::convert::AsRef;
 use core::fmt;
 use core::num::NonZeroU64;
 use core::ops::{Deref, DerefMut};
-use derive_more::{Add, Display, Div, Mul, Rem, Sub};
+use derive_more::{Add, Deref, Display, Div, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input};
 use scale_info::{Type, TypeInfo};
@@ -118,6 +118,42 @@ pub const RANDOMNESS_CONTEXT: &[u8] = b"subspace_randomness";
 pub const REWARD_SIGNATURE_LENGTH: usize = 64;
 const VRF_OUTPUT_LENGTH: usize = 32;
 const VRF_PROOF_LENGTH: usize = 64;
+
+/// Size of proof of space seed in bytes.
+const POS_SEED_SIZE: usize = 32;
+
+/// Proof of space seed.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
+pub struct PosSeed(pub [u8; POS_SEED_SIZE]);
+
+impl PosSeed {
+    /// Size of proof of space seed in bytes.
+    pub const SIZE: usize = POS_SEED_SIZE;
+}
+
+/// Size of proof of space quality in bytes.
+const POS_QUALITY_SIZE: usize = 32;
+
+/// Proof of space quality.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
+pub struct PosQualityBytes(pub [u8; POS_QUALITY_SIZE]);
+
+impl PosQualityBytes {
+    /// Size of proof of space quality in bytes.
+    pub const SIZE: usize = POS_QUALITY_SIZE;
+}
+
+/// Length of proof of space proof in bytes.
+const POS_PROOF_LENGTH: usize = 17 * 8;
+
+/// Proof of space proof bytes.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
+pub struct PosProof(pub [u8; POS_PROOF_LENGTH]);
+
+impl PosProof {
+    /// Size of proof of space proof in bytes.
+    pub const SIZE: usize = POS_PROOF_LENGTH;
+}
 
 /// Representation of a single BLS12-381 scalar value.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-proof-of-space"
-description = ""
+description = "Subspace proof of space implementation based on Chia"
 license = "Apache-2.0"
 version = "0.1.0"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "subspace-proof-of-space"
+description = ""
+license = "Apache-2.0"
+version = "0.1.0"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2021"
+include = [
+    "/benches",
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "a239ddf83b4d8420f23616d604af83c756c40116" }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
+
+[dev-dependencies]
+criterion = "0.4.0"
+
+[[bench]]
+name = "pos"
+harness = false

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use subspace_core_primitives::PosSeed;
-use subspace_proof_of_space::Table;
+use subspace_proof_of_space::{is_proof_valid, Table};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let seed = PosSeed([
@@ -43,6 +43,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("proof", |b| {
         b.iter(|| {
             quality.create_proof();
+        });
+    });
+
+    let proof = quality.create_proof();
+
+    group.bench_function("verification", |b| {
+        b.iter(|| {
+            assert!(is_proof_valid(&seed, challenge_index_with_solution, &proof));
         });
     });
     group.finish();

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -1,0 +1,52 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use subspace_core_primitives::PosSeed;
+use subspace_proof_of_space::Table;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let seed = PosSeed([
+        35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
+        198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
+    ]);
+    // This challenge index with above seed is known to not have a solution
+    let challenge_index_without_solution = 0;
+    // This challenge index with above seed is known to have a solution
+    let challenge_index_with_solution = 1;
+
+    let mut group = c.benchmark_group("pos");
+
+    group.bench_function("table", |b| {
+        b.iter(|| {
+            Table::generate(black_box(&seed));
+        });
+    });
+
+    let table = Table::generate(&seed);
+
+    group.bench_function("quality/no-solution", |b| {
+        b.iter(|| {
+            assert!(table
+                .find_quality(black_box(challenge_index_without_solution))
+                .is_none());
+        });
+    });
+
+    group.bench_function("quality/solution", |b| {
+        b.iter(|| {
+            assert!(table
+                .find_quality(black_box(challenge_index_with_solution))
+                .is_some());
+        });
+    });
+
+    let quality = table.find_quality(challenge_index_with_solution).unwrap();
+
+    group.bench_function("proof", |b| {
+        b.iter(|| {
+            quality.create_proof();
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -1,3 +1,6 @@
+//! Subspace proof of space implementation based on Chia
+#![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
+
 use subspace_core_primitives::{PosProof, PosQualityBytes, PosSeed};
 
 /// Abstraction that represents quality of the solution in the table

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -1,0 +1,71 @@
+use subspace_core_primitives::{PosProof, PosQualityBytes, PosSeed};
+
+/// Abstraction that represents quality of the solution in the table
+#[derive(Debug)]
+#[must_use]
+pub struct Quality<'a> {
+    quality: subspace_chiapos::Quality<'a>,
+}
+
+impl<'a> Quality<'a> {
+    /// Get underlying bytes representation of the quality
+    pub fn to_bytes(&self) -> PosQualityBytes {
+        PosQualityBytes(self.quality.to_bytes())
+    }
+
+    /// Create proof for this solution
+    pub fn create_proof(&self) -> PosProof {
+        PosProof(self.quality.create_proof())
+    }
+}
+
+/// Subspace proof of space table
+#[derive(Debug)]
+pub struct Table {
+    table: subspace_chiapos::Table,
+}
+
+impl Table {
+    /// Generate new table with 32 bytes seed
+    pub fn generate(seed: &PosSeed) -> Table {
+        Self {
+            table: subspace_chiapos::Table::generate(seed),
+        }
+    }
+
+    /// Try to find quality of the proof at `challenge_index` if proof exists
+    pub fn find_quality(&self, challenge_index: u32) -> Option<Quality<'_>> {
+        self.table
+            .find_quality(challenge_index)
+            .map(|quality| Quality { quality })
+    }
+}
+
+/// Check whether proof created earlier is valid
+pub fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
+    subspace_chiapos::is_proof_valid(seed, challenge_index, proof)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SEED: PosSeed = PosSeed([
+        35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
+        198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
+    ]);
+
+    #[test]
+    fn basic() {
+        let table = Table::generate(&SEED);
+
+        assert!(table.find_quality(0).is_none());
+
+        {
+            let challenge_index = 1;
+            let quality = table.find_quality(challenge_index).unwrap();
+            let proof = quality.create_proof();
+            assert!(is_proof_valid(&SEED, challenge_index, &proof));
+        }
+    }
+}


### PR DESCRIPTION
This implements Proof of Space as a basic wrapper about [chiapos fork](https://github.com/subspace/chiapos/tree/subspace-v1) with k17. If you want to see changes relatively to upstream then check https://github.com/subspace/chiapos/pull/1

I included some benchmarks, but tests that existed in chiapos before are still there, so most of the testing is happening in C++, we're just calling into it.

The API is lower level, we can implement sampling on the higher level (otherwise for efficiency we'd probably need to write iterators manually, which is never fun), we can revisit this later if necessary.

Basic benchmarks for exposed API are provided to get a baseline and measure future improvements.

NOTE: For now we're using k17 and full chia implementation rather than the first table because removing tables is a lot of effort and we'll probably do that during Rust rewrite of the whole thing.

Resolves https://github.com/subspace/subspace/issues/1164

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
