### PR TITLE
Abstract and provide implementations using System domain Client and Runtime to extract state roots from XDM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6007,8 +6007,6 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "hash-db",
- "hex",
  "log",
  "pallet-balances",
  "pallet-transporter",
@@ -6016,7 +6014,6 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-domains",
- "sp-io",
  "sp-messenger",
  "sp-runtime",
  "sp-state-machine",
@@ -9292,12 +9289,14 @@ name = "sp-messenger"
 version = "0.1.0"
 dependencies = [
  "frame-support",
+ "hash-db",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-core",
  "sp-domains",
  "sp-runtime",
+ "sp-std",
  "sp-trie",
 ]
 

--- a/domains/client/domain-executor/Cargo.toml
+++ b/domains/client/domain-executor/Cargo.toml
@@ -34,6 +34,7 @@ sp-domain-digests = { version = "0.1.0", path = "../../primitives/digests" }
 sp-keystore = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -93,6 +93,7 @@ mod domain_worker;
 mod fraud_proof;
 mod gossip_message_validator;
 mod parent_chain;
+pub mod state_root_extractor;
 mod system_bundle_processor;
 mod system_domain_worker;
 mod system_executor;

--- a/domains/client/domain-executor/src/state_root_extractor.rs
+++ b/domains/client/domain-executor/src/state_root_extractor.rs
@@ -1,8 +1,14 @@
-use sp_api::{ApiError, BlockT, ProvideRuntimeApi};
+use codec::{Decode, Encode};
+use sc_executor::RuntimeVersionOf;
+use sp_api::{ApiError, BlockT, Core, ProvideRuntimeApi, RuntimeVersion};
 use sp_blockchain::HeaderBackend;
+use sp_core::traits::{CallContext, CodeExecutor, FetchRuntimeCode, RuntimeCode};
+use sp_core::{ExecutionContext, Hasher};
 use sp_messenger::messages::ExtractedStateRootsFromProof;
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
+use sp_state_machine::BasicExternalities;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 type ExtractedStateRoots<Block> = ExtractedStateRootsFromProof<
@@ -56,5 +62,127 @@ where
             .and_then(|maybe_state_roots| {
                 maybe_state_roots.ok_or(ApiError::Application("Empty state roots".into()))
             })
+    }
+}
+
+/// This is a compatibility implementation to invoke stateless functions on MessengerApi.
+/// This will stateless wrapper and, hence, the dispatch may give invalid output if the invoked function
+/// relies on state of the chain.
+/// Note: Be sure to use this only when there is no System domain client available as this holds
+/// entire system domain runtime on heap.
+pub struct StateRootExtractorWithSystemDomainRuntime<Executor> {
+    executor: Arc<Executor>,
+    runtime_code: Cow<'static, [u8]>,
+}
+
+impl<SBlock, Executor> Core<SBlock> for StateRootExtractorWithSystemDomainRuntime<Executor>
+where
+    SBlock: BlockT,
+    Executor: CodeExecutor + RuntimeVersionOf,
+{
+    fn __runtime_api_internal_call_api_at(
+        &self,
+        _at: <SBlock as BlockT>::Hash,
+        _context: ExecutionContext,
+        params: Vec<u8>,
+        fn_name: &dyn Fn(RuntimeVersion) -> &'static str,
+    ) -> Result<Vec<u8>, ApiError> {
+        self.dispatch_call(fn_name, params)
+    }
+}
+
+impl<SBlock, Executor> MessengerApi<SBlock, NumberFor<SBlock>>
+    for StateRootExtractorWithSystemDomainRuntime<Executor>
+where
+    SBlock: BlockT,
+    NumberFor<SBlock>: Encode + Decode,
+    Executor: CodeExecutor + RuntimeVersionOf,
+{
+    fn __runtime_api_internal_call_api_at(
+        &self,
+        _at: <SBlock as BlockT>::Hash,
+        _context: ExecutionContext,
+        params: Vec<u8>,
+        fn_name: &dyn Fn(RuntimeVersion) -> &'static str,
+    ) -> Result<Vec<u8>, ApiError> {
+        self.dispatch_call(fn_name, params)
+    }
+}
+
+impl<Executor> FetchRuntimeCode for StateRootExtractorWithSystemDomainRuntime<Executor> {
+    fn fetch_runtime_code(&self) -> Option<Cow<[u8]>> {
+        Some(self.runtime_code.clone())
+    }
+}
+
+impl<Executor> StateRootExtractorWithSystemDomainRuntime<Executor>
+where
+    Executor: CodeExecutor + RuntimeVersionOf,
+{
+    pub fn new(executor: Arc<Executor>, runtime_code: Cow<'static, [u8]>) -> Self {
+        Self {
+            executor,
+            runtime_code,
+        }
+    }
+
+    fn runtime_code(&self) -> RuntimeCode {
+        let code_hash = sp_core::Blake2Hasher::hash(&self.runtime_code);
+        RuntimeCode {
+            code_fetcher: self,
+            heap_pages: None,
+            hash: code_hash.encode(),
+        }
+    }
+
+    fn runtime_version(&self) -> Result<RuntimeVersion, ApiError> {
+        let mut ext = BasicExternalities::new_empty();
+        self.executor
+            .runtime_version(&mut ext, &self.runtime_code())
+            .map_err(|err| ApiError::Application(Box::new(err)))
+    }
+
+    fn dispatch_call(
+        &self,
+        fn_name: &dyn Fn(RuntimeVersion) -> &'static str,
+        input: Vec<u8>,
+    ) -> Result<Vec<u8>, ApiError> {
+        let runtime_version = self.runtime_version()?;
+        let fn_name = fn_name(runtime_version);
+        let mut ext = BasicExternalities::new_empty();
+        self.executor
+            .call(
+                &mut ext,
+                &self.runtime_code(),
+                fn_name,
+                &input,
+                false,
+                CallContext::Offchain,
+            )
+            .0
+            .map_err(|err| {
+                ApiError::Application(format!("Failed to invoke call to {fn_name}: {err}").into())
+            })
+    }
+}
+
+impl<SBlock, Executor> StateRootExtractor<SBlock>
+    for StateRootExtractorWithSystemDomainRuntime<Executor>
+where
+    SBlock: BlockT,
+    Executor: CodeExecutor + RuntimeVersionOf,
+{
+    fn extract_state_roots(
+        &self,
+        ext: &SBlock::Extrinsic,
+    ) -> Result<ExtractedStateRoots<SBlock>, ApiError> {
+        <Self as MessengerApi<SBlock, NumberFor<SBlock>>>::extract_xdm_proof_state_roots(
+            self,
+            Default::default(),
+            ext,
+        )
+        .and_then(|maybe_state_roots| {
+            maybe_state_roots.ok_or(ApiError::Application("Empty state roots".into()))
+        })
     }
 }

--- a/domains/client/domain-executor/src/state_root_extractor.rs
+++ b/domains/client/domain-executor/src/state_root_extractor.rs
@@ -1,0 +1,60 @@
+use sp_api::{ApiError, BlockT, ProvideRuntimeApi};
+use sp_blockchain::HeaderBackend;
+use sp_messenger::messages::ExtractedStateRootsFromProof;
+use sp_messenger::MessengerApi;
+use sp_runtime::traits::NumberFor;
+use std::sync::Arc;
+
+type ExtractedStateRoots<Block> = ExtractedStateRootsFromProof<
+    NumberFor<Block>,
+    <Block as BlockT>::Hash,
+    <Block as BlockT>::Hash,
+>;
+
+/// Trait to extract XDM state roots from the Extrinsic.
+pub trait StateRootExtractor<Block: BlockT> {
+    /// Extracts the state roots from the extrinsic.
+    fn extract_state_roots(
+        &self,
+        ext: &Block::Extrinsic,
+    ) -> Result<ExtractedStateRoots<Block>, ApiError>;
+}
+
+/// Implementation of state root extractor with system domain client.
+pub struct StateRootExtractorWithSystemDomainClient<SClient> {
+    client: Arc<SClient>,
+}
+
+impl<SClient> StateRootExtractorWithSystemDomainClient<SClient> {
+    pub fn new(client: Arc<SClient>) -> Self {
+        Self { client }
+    }
+}
+
+impl<SClient> Clone for StateRootExtractorWithSystemDomainClient<SClient> {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+        }
+    }
+}
+
+impl<SClient, SBlock> StateRootExtractor<SBlock>
+    for StateRootExtractorWithSystemDomainClient<SClient>
+where
+    SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock>,
+    SClient::Api: MessengerApi<SBlock, NumberFor<SBlock>>,
+    SBlock: BlockT,
+{
+    fn extract_state_roots(
+        &self,
+        ext: &SBlock::Extrinsic,
+    ) -> Result<ExtractedStateRoots<SBlock>, ApiError> {
+        let best_hash = self.client.info().best_hash;
+        let api = self.client.runtime_api();
+        api.extract_xdm_proof_state_roots(best_hash, ext)
+            .and_then(|maybe_state_roots| {
+                maybe_state_roots.ok_or(ApiError::Application("Empty state roots".into()))
+            })
+    }
+}

--- a/domains/client/domain-executor/src/xdm_verifier.rs
+++ b/domains/client/domain-executor/src/xdm_verifier.rs
@@ -100,7 +100,8 @@ where
     PBlock::Hash: From<SBlock::Hash>,
     SRE: StateRootExtractor<SBlock>,
 {
-    if let Ok(state_roots) = state_root_extractor.extract_state_roots(extrinsic) {
+    let at = state_root_extractor.block_hash();
+    if let Ok(state_roots) = state_root_extractor.extract_state_roots(at, extrinsic) {
         // verify system domain state root
         let best_hash = primary_chain_client.info().best_hash;
         let primary_runtime = primary_chain_client.runtime_api();

--- a/domains/client/domain-executor/src/xdm_verifier.rs
+++ b/domains/client/domain-executor/src/xdm_verifier.rs
@@ -1,3 +1,4 @@
+use crate::state_root_extractor::StateRootExtractor;
 use futures::FutureExt;
 use sc_client_api::BlockBackend;
 use sc_transaction_pool::{ChainApi, FullChainApi};
@@ -85,27 +86,21 @@ where
 /// This is used by the System domain to validate Extrinsics.
 /// Returns either true if the XDM is valid else false.
 /// Returns Error when required calls to fetch header info fails.
-pub(crate) fn verify_xdm_with_primary_chain_client<PClient, SClient, PBlock, SBlock>(
+pub(crate) fn verify_xdm_with_primary_chain_client<PClient, PBlock, SBlock, SRE>(
     primary_chain_client: &Arc<PClient>,
-    system_domain_client: &Arc<SClient>,
+    state_root_extractor: &SRE,
     extrinsic: &SBlock::Extrinsic,
 ) -> Result<bool, Error>
 where
     PClient: HeaderBackend<PBlock> + ProvideRuntimeApi<PBlock> + 'static,
     PClient::Api: ExecutorApi<PBlock, SBlock::Hash>,
-    SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock> + 'static,
-    SClient::Api: MessengerApi<SBlock, NumberFor<SBlock>>,
     SBlock: BlockT,
     PBlock: BlockT,
     NumberFor<PBlock>: From<NumberFor<SBlock>>,
     PBlock::Hash: From<SBlock::Hash>,
+    SRE: StateRootExtractor<SBlock>,
 {
-    let system_domain_runtime = system_domain_client.runtime_api();
-    let best_hash = system_domain_client.info().best_hash;
-    if let Ok(Some(state_roots)) =
-        system_domain_runtime.extract_xdm_proof_state_roots(best_hash, extrinsic)
-    {
-        // TODO: Can't above variable be reused here?
+    if let Ok(state_roots) = state_root_extractor.extract_state_roots(extrinsic) {
         // verify system domain state root
         let best_hash = primary_chain_client.info().best_hash;
         let primary_runtime = primary_chain_client.runtime_api();
@@ -124,48 +119,49 @@ where
 }
 
 /// A verifier for XDM messages on System domain.
-pub struct SystemDomainXDMVerifier<PClient, SClient, PBlock, SBlock, Verifier> {
+pub struct SystemDomainXDMVerifier<PClient, PBlock, SBlock, Verifier, SRE> {
     _data: PhantomData<(PBlock, SBlock)>,
     primary_chain_client: Arc<PClient>,
-    system_domain_client: Arc<SClient>,
+    state_root_extractor: SRE,
     inner_verifier: Verifier,
 }
 
-impl<PClient, SClient, PBlock, SBlock, Verifier>
-    SystemDomainXDMVerifier<PClient, SClient, PBlock, SBlock, Verifier>
+impl<PClient, PBlock, SBlock, Verifier, SRE>
+    SystemDomainXDMVerifier<PClient, PBlock, SBlock, Verifier, SRE>
 {
     pub fn new(
         primary_chain_client: Arc<PClient>,
-        system_domain_client: Arc<SClient>,
+        state_root_extractor: SRE,
         inner_verifier: Verifier,
     ) -> Self {
         Self {
             _data: Default::default(),
             primary_chain_client,
-            system_domain_client,
+            state_root_extractor,
             inner_verifier,
         }
     }
 }
 
-impl<PClient, SClient, PBlock, SBlock, Verifier> Clone
-    for SystemDomainXDMVerifier<PClient, SClient, PBlock, SBlock, Verifier>
+impl<PClient, PBlock, SBlock, Verifier, SRE> Clone
+    for SystemDomainXDMVerifier<PClient, PBlock, SBlock, Verifier, SRE>
 where
     Verifier: Clone,
+    SRE: Clone,
 {
     fn clone(&self) -> Self {
         Self {
             _data: Default::default(),
             primary_chain_client: self.primary_chain_client.clone(),
-            system_domain_client: self.system_domain_client.clone(),
+            state_root_extractor: self.state_root_extractor.clone(),
             inner_verifier: self.inner_verifier.clone(),
         }
     }
 }
 
-impl<PClient, SClient, PBlock, SBlock, Verifier>
+impl<PClient, SClient, PBlock, SBlock, Verifier, SRE>
     VerifyExtrinsic<SBlock, SClient, FullChainApi<SClient, SBlock>>
-    for SystemDomainXDMVerifier<PClient, SClient, PBlock, SBlock, Verifier>
+    for SystemDomainXDMVerifier<PClient, PBlock, SBlock, Verifier, SRE>
 where
     PClient: HeaderBackend<PBlock> + ProvideRuntimeApi<PBlock> + 'static,
     PClient::Api: ExecutorApi<PBlock, SBlock::Hash>,
@@ -177,6 +173,7 @@ where
     NumberFor<PBlock>: From<NumberFor<SBlock>>,
     PBlock::Hash: From<SBlock::Hash>,
     Verifier: VerifyExtrinsic<SBlock, SClient, FullChainApi<SClient, SBlock>>,
+    SRE: StateRootExtractor<SBlock>,
 {
     fn verify_extrinsic(
         &self,
@@ -188,7 +185,7 @@ where
     ) -> ValidationFuture {
         let result = verify_xdm_with_primary_chain_client::<_, _, _, _>(
             &self.primary_chain_client,
-            &self.system_domain_client,
+            &self.state_root_extractor,
             &uxt,
         );
 
@@ -249,7 +246,7 @@ where
         + BlockBackend<Block>
         + BlockIdTo<Block>
         + HeaderBackend<Block>
-        + HeaderMetadata<Block, Error = sp_blockchain::Error>
+        + HeaderMetadata<Block, Error = Error>
         + Send
         + Sync
         + 'static,

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -17,8 +17,6 @@ include = [
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
-hash-db = { version = "0.15.2", default-features = false }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
@@ -31,7 +29,6 @@ sp-trie = { version = "7.0.0", default-features = false, git = "https://github.c
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 pallet-transporter = { version = "0.1.0", path = "../transporter" }
-sp-io = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 
 [features]
@@ -40,8 +37,6 @@ std = [
   "codec/std",
   "frame-support/std",
   "frame-system/std",
-  "hash-db/std",
-  "hex/std",
   "log/std",
   "scale-info/std",
   "sp-core/std",

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -7,7 +7,6 @@ use crate::mock::{
     AccountId, Balance, TestExternalities,
 };
 use crate::relayer::RelayerInfo;
-use crate::verification::{StorageProofVerifier, VerificationError};
 use crate::{
     Channel, ChannelId, ChannelState, Channels, Error, FeeModel, Inbox, InboxResponses, Nonce,
     Outbox, OutboxMessageResult, OutboxResponses, U256,
@@ -23,6 +22,7 @@ use sp_messenger::messages::{
     CrossDomainMessage, DomainBlockInfo, ExecutionFee, InitiateChannelParams, Payload, Proof,
     ProtocolMessageRequest, RequestResponse, VersionedPayload,
 };
+use sp_messenger::verification::{StorageProofVerifier, VerificationError};
 use sp_runtime::traits::ValidateUnsigned;
 
 fn create_channel(domain_id: DomainId, channel_id: ChannelId, fee_model: FeeModel<Balance>) {

--- a/domains/primitives/messenger/Cargo.toml
+++ b/domains/primitives/messenger/Cargo.toml
@@ -16,11 +16,13 @@ include = [
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+hash-db = { version = "0.15.2", default-features = false }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-trie = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 
 [features]
@@ -28,10 +30,12 @@ default = ["std"]
 std = [
 	"codec/std",
 	"frame-support/std",
+	"hash-db/std",
 	"scale-info/std",
 	"sp-api/std",
 	"sp-core/std",
 	"sp-domains/std",
 	"sp-runtime/std",
+	"sp-std/std",
 	"sp-trie/std"
 ]

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod endpoint;
 pub mod messages;
+pub mod verification;
 
 use codec::{Decode, Encode};
 use messages::{

--- a/domains/primitives/messenger/src/verification.rs
+++ b/domains/primitives/messenger/src/verification.rs
@@ -19,10 +19,10 @@ pub enum VerificationError {
     FailedToDecode,
 }
 
-pub(crate) struct StorageProofVerifier<H: Hasher>(PhantomData<H>);
+pub struct StorageProofVerifier<H: Hasher>(PhantomData<H>);
 
 impl<H: Hasher> StorageProofVerifier<H> {
-    pub(crate) fn verify_and_get_value<V: Decode>(
+    pub fn verify_and_get_value<V: Decode>(
         state_root: &H::Out,
         proof: StorageProof,
         key: StorageKey,

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -654,10 +654,7 @@ impl_runtime_apis! {
         fn extract_xdm_proof_state_roots(
             extrinsic: &<Block as BlockT>::Extrinsic,
         ) -> Option<ExtractedStateRootsFromProof<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>> {
-            match &extrinsic.function {
-                RuntimeCall::Messenger(call) => call.extract_xdm_proof_state_roots(),
-                _ => None,
-            }
+            extract_xdm_proof_state_roots(extrinsic)
         }
 
         fn confirmation_depth() -> BlockNumber {
@@ -718,5 +715,19 @@ impl_runtime_apis! {
 
             Ok(batches)
         }
+    }
+}
+
+fn extract_xdm_proof_state_roots(
+    ext: &UncheckedExtrinsic,
+) -> Option<ExtractedStateRootsFromProof<BlockNumber, Hash, Hash>> {
+    match &ext.function {
+        RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg }) => {
+            msg.extract_state_roots_from_proof::<BlakeTwo256>()
+        }
+        RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+            msg.extract_state_roots_from_proof::<BlakeTwo256>()
+        }
+        _ => None,
     }
 }

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -1,5 +1,6 @@
 use crate::{DomainConfiguration, FullBackend, FullClient};
 use cross_domain_message_gossip::{DomainTxPoolSink, Message as GossipMessage};
+use domain_client_executor::state_root_extractor::StateRootExtractorWithSystemDomainClient;
 use domain_client_executor::xdm_verifier::SystemDomainXDMVerifier;
 use domain_client_executor::{
     EssentialExecutorParams, SystemDomainParentChain, SystemExecutor, SystemGossipMessageValidator,
@@ -107,7 +108,6 @@ pub type FullPool<PBlock, PClient, RuntimeApi, Executor> =
         FullClient<RuntimeApi, Executor>,
         SystemDomainXDMVerifier<
             PClient,
-            FullClient<RuntimeApi, Executor>,
             PBlock,
             Block,
             FullChainVerifier<
@@ -116,6 +116,7 @@ pub type FullPool<PBlock, PClient, RuntimeApi, Executor> =
                 FraudProofVerifier<PBlock, PClient, RuntimeApi, Executor>,
                 SkipBundleValidation,
             >,
+            StateRootExtractorWithSystemDomainClient<FullClient<RuntimeApi, Executor>>,
         >,
     >;
 
@@ -213,7 +214,7 @@ where
         FullChainVerifier::new(client.clone(), proof_verifier, SkipBundleValidation);
     let system_domain_xdm_verifier = SystemDomainXDMVerifier::new(
         primary_chain_client,
-        client.clone(),
+        StateRootExtractorWithSystemDomainClient::new(client.clone()),
         system_domain_fraud_proof_verifier,
     );
 

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -133,20 +133,20 @@ type FraudProofVerifier<PBlock, PClient, RuntimeApi, Executor> =
 
 /// Constructs a partial system domain node.
 #[allow(clippy::type_complexity)]
-fn new_partial<RuntimeApi, Executor, PBlock, PClient>(
+fn new_partial<RuntimeApi, ExecutionDispatch, PBlock, PClient>(
     config: &ServiceConfiguration,
     primary_chain_client: Arc<PClient>,
 ) -> Result<
     PartialComponents<
-        FullClient<RuntimeApi, Executor>,
+        FullClient<RuntimeApi, ExecutionDispatch>,
         FullBackend,
         (),
-        sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, Executor>>,
-        FullPool<PBlock, PClient, RuntimeApi, Executor>,
+        sc_consensus::DefaultImportQueue<Block, FullClient<RuntimeApi, ExecutionDispatch>>,
+        FullPool<PBlock, PClient, RuntimeApi, ExecutionDispatch>,
         (
             Option<Telemetry>,
             Option<TelemetryWorkerHandle>,
-            NativeElseWasmExecutor<Executor>,
+            NativeElseWasmExecutor<ExecutionDispatch>,
         ),
     >,
     sc_service::Error,
@@ -157,15 +157,17 @@ where
     PBlock::Hash: From<Hash>,
     PClient: HeaderBackend<PBlock> + ProvideRuntimeApi<PBlock> + Send + Sync + 'static,
     PClient::Api: ExecutorApi<PBlock, Hash>,
-    RuntimeApi:
-        ConstructRuntimeApi<Block, FullClient<RuntimeApi, Executor>> + Send + Sync + 'static,
+    RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi, ExecutionDispatch>>
+        + Send
+        + Sync
+        + 'static,
     RuntimeApi::RuntimeApi: TaggedTransactionQueue<Block>
         + SystemDomainApi<Block, NumberFor<PBlock>, PBlock::Hash>
         + MessengerApi<Block, NumberFor<Block>>
         + ApiExt<Block, StateBackend = StateBackendFor<TFullBackend<Block>, Block>>
         + ReceiptsApi<Block, Hash>
         + PreValidationObjectApi<Block, Hash>,
-    Executor: NativeExecutionDispatch + 'static,
+    ExecutionDispatch: NativeExecutionDispatch + 'static,
 {
     let telemetry = config
         .telemetry_endpoints

--- a/domains/test/runtime/src/runtime.rs
+++ b/domains/test/runtime/src/runtime.rs
@@ -656,7 +656,12 @@ fn extract_xdm_proof_state_roots(
     ext: &UncheckedExtrinsic,
 ) -> Option<ExtractedStateRootsFromProof<BlockNumber, Hash, Hash>> {
     match &ext.function {
-        RuntimeCall::Messenger(call) => call.extract_xdm_proof_state_roots(),
+        RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg }) => {
+            msg.extract_state_roots_from_proof::<BlakeTwo256>()
+        }
+        RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+            msg.extract_state_roots_from_proof::<BlakeTwo256>()
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
This PR removes the usage of system domain client directly, which we are using to extract state roots from XDM, by providing necessary abstraction to extract state roots using System domain Client and System domain runtime where necessary.

We need this runtime  messenger api to get to the function argument which is `Cross domain message`.  In an ideal scenario, we can just deconstruct the Extrinsic without runtime but that is not safe with refactoring.

We introduce `StateRootExtractor` and also provides implementations using `System Domain Client` with full state and `System Domain Runtime` without any state.  We use the implementation with system domain client wherever possible. In the case where it is not, such as fraud proof verification on primary chain where not all nodes might not system domain client, we expect to use the implementation with runtime as this would require loading the runtime and then running the function. This is already a sunk cost for us since we need to verify fraud proof anyway and we can reuse the executor for loading the runtime.

Discussion: https://github.com/subspace/subspace/issues/1230#issuecomment-1472208912

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
