### PR TITLE
Tweak networking parameters for DSN.

### DIFF
--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -51,6 +51,9 @@ pub trait NetworkingParametersRegistry: Send + Sync {
     /// It removes p2p-protocol suffix.
     async fn next_known_addresses_batch(&mut self) -> Vec<PeerAddress>;
 
+    /// Reset the inner batcher to the initial state.
+    fn reset_batcher(&mut self);
+
     /// Drive async work in the persistence provider
     async fn run(&mut self);
 
@@ -97,6 +100,8 @@ impl NetworkingParametersRegistry for BootstrappedNetworkingParameters {
     async fn next_known_addresses_batch(&mut self) -> Vec<PeerAddress> {
         self.bootstrap_addresses()
     }
+
+    fn reset_batcher(&mut self) {}
 
     async fn run(&mut self) {
         futures::future::pending().await // never resolves
@@ -301,6 +306,10 @@ impl NetworkingParametersRegistry for NetworkingParametersManager {
         );
 
         self.collection_batcher.next_batch(combined_addresses)
+    }
+
+    fn reset_batcher(&mut self) {
+        self.collection_batcher.reset();
     }
 
     async fn run(&mut self) {

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -51,8 +51,8 @@ pub trait NetworkingParametersRegistry: Send + Sync {
     /// It removes p2p-protocol suffix.
     async fn next_known_addresses_batch(&mut self) -> Vec<PeerAddress>;
 
-    /// Reset the inner batcher to the initial state.
-    fn reset_batcher(&mut self);
+    /// Reset the batching process to the initial state.
+    fn start_over_address_batching(&mut self) {}
 
     /// Drive async work in the persistence provider
     async fn run(&mut self);
@@ -100,8 +100,6 @@ impl NetworkingParametersRegistry for BootstrappedNetworkingParameters {
     async fn next_known_addresses_batch(&mut self) -> Vec<PeerAddress> {
         self.bootstrap_addresses()
     }
-
-    fn reset_batcher(&mut self) {}
 
     async fn run(&mut self) {
         futures::future::pending().await // never resolves
@@ -308,7 +306,7 @@ impl NetworkingParametersRegistry for NetworkingParametersManager {
         self.collection_batcher.next_batch(combined_addresses)
     }
 
-    fn reset_batcher(&mut self) {
+    fn start_over_address_batching(&mut self) {
         self.collection_batcher.reset();
     }
 

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -50,6 +50,8 @@ const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 50;
 // The default maximum incoming connection number for the swarm.
 const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 50;
+// The default maximum connection number to be maintained for the swarm.
+const SWARM_TARGET_CONNECTION_NUMBER: u32 = 50;
 // Defines an expiration interval for item providers in Kademlia network.
 const KADEMLIA_PROVIDER_TTL_IN_SECS: Option<Duration> = Some(Duration::from_secs(86400)); /* 1 day */
 // Defines a republication interval for item providers in Kademlia network.
@@ -200,6 +202,8 @@ pub struct Config<ProviderStorage> {
     pub max_established_incoming_connections: u32,
     /// Outgoing swarm connection limit.
     pub max_established_outgoing_connections: u32,
+    /// Defines target total (in and out) connection number that should be maintained.
+    pub target_connection_number: u32,
     /// How many temporarily banned unreachable peers to keep in memory.
     pub temporary_bans_cache_size: NonZeroUsize,
     /// Backoff policy for temporary banning of unreachable peers.
@@ -290,6 +294,7 @@ where
             reserved_peers: Vec::new(),
             max_established_incoming_connections: SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS,
             max_established_outgoing_connections: SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS,
+            target_connection_number: SWARM_TARGET_CONNECTION_NUMBER,
             temporary_bans_cache_size: TEMPORARY_BANS_CACHE_SIZE,
             temporary_ban_backoff,
             metrics: None,
@@ -347,6 +352,7 @@ where
         reserved_peers,
         max_established_incoming_connections,
         max_established_outgoing_connections,
+        target_connection_number,
         temporary_bans_cache_size,
         temporary_ban_backoff,
         metrics,
@@ -426,6 +432,7 @@ where
         reserved_peers: convert_multiaddresses(reserved_peers).into_iter().collect(),
         max_established_incoming_connections,
         max_established_outgoing_connections,
+        target_connection_number,
         temporary_bans,
         metrics,
     });

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -203,7 +203,7 @@ pub struct Config<ProviderStorage> {
     /// Outgoing swarm connection limit.
     pub max_established_outgoing_connections: u32,
     /// Defines target total (in and out) connection number that should be maintained.
-    pub target_connection_number: u32,
+    pub target_connections: u32,
     /// How many temporarily banned unreachable peers to keep in memory.
     pub temporary_bans_cache_size: NonZeroUsize,
     /// Backoff policy for temporary banning of unreachable peers.
@@ -294,7 +294,7 @@ where
             reserved_peers: Vec::new(),
             max_established_incoming_connections: SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS,
             max_established_outgoing_connections: SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS,
-            target_connection_number: SWARM_TARGET_CONNECTION_NUMBER,
+            target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             temporary_bans_cache_size: TEMPORARY_BANS_CACHE_SIZE,
             temporary_ban_backoff,
             metrics: None,
@@ -352,7 +352,7 @@ where
         reserved_peers,
         max_established_incoming_connections,
         max_established_outgoing_connections,
-        target_connection_number,
+        target_connections,
         temporary_bans_cache_size,
         temporary_ban_backoff,
         metrics,
@@ -432,7 +432,7 @@ where
         reserved_peers: convert_multiaddresses(reserved_peers).into_iter().collect(),
         max_established_incoming_connections,
         max_established_outgoing_connections,
-        target_connection_number,
+        target_connections,
         temporary_bans,
         metrics,
     });

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -211,7 +211,7 @@ where
                     self.handle_peer_dialing().await;
 
                     self.peer_dialing_timeout =
-                        Box::pin(tokio::time::sleep(Duration::from_secs(3)).fuse());
+                        Box::pin(tokio::time::sleep(Duration::from_secs(15)).fuse());
                 },
             }
         }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -289,6 +289,8 @@ where
 
                 self.dial_peer(peer_id, addr)
             }
+        } else {
+            self.networking_parameters_registry.reset_batcher()
         }
     }
 

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -43,6 +43,12 @@ impl<T: Clone> CollectionBatcher<T> {
             _marker: PhantomData,
         }
     }
+
+    /// Sets the last batch number to zero.
+    pub fn reset(&mut self) {
+        self.last_batch_number = 0;
+    }
+
     /// Extract the next batch from the collection
     pub fn next_batch(&mut self, collection: Vec<T>) -> Vec<T> {
         // Collection is empty or less than batch size.

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -434,7 +434,7 @@ fn main() -> Result<(), Error> {
                             allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ips,
                             max_in_connections: cli.dsn_in_connections,
                             max_out_connections: cli.dsn_out_connections,
-                            target_connection_number: cli.dsn_target_connection_number,
+                            target_connections: cli.dsn_target_connections,
                         }
                     };
 

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -432,8 +432,9 @@ fn main() -> Result<(), Error> {
                             bootstrap_nodes: dsn_bootstrap_nodes,
                             reserved_peers: cli.dsn_reserved_peers,
                             allow_non_global_addresses_in_dht: !cli.dsn_disable_private_ips,
-                            max_in_connections: cli.dsn_max_in_connections,
-                            max_out_connections: cli.dsn_max_out_connections,
+                            max_in_connections: cli.dsn_in_connections,
+                            max_out_connections: cli.dsn_out_connections,
+                            target_connection_number: cli.dsn_target_connection_number,
                         }
                     };
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -204,7 +204,7 @@ pub struct Cli {
 
     /// Defines target total (in and out) connection number for DSN that should be maintained.
     #[arg(long, default_value_t = 50)]
-    pub dsn_target_connection_number: u32,
+    pub dsn_target_connections: u32,
 
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
     /// in Kademlia DHT for the DSN.

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -196,11 +196,15 @@ pub struct Cli {
 
     /// Defines max established incoming connection limit for DSN.
     #[arg(long, default_value_t = 100)]
-    pub dsn_max_in_connections: u32,
+    pub dsn_in_connections: u32,
 
     /// Defines max established outgoing swarm connection limit for DSN.
     #[arg(long, default_value_t = 100)]
-    pub dsn_max_out_connections: u32,
+    pub dsn_out_connections: u32,
+
+    /// Defines target total (in and out) connection number for DSN that should be maintained.
+    #[arg(long, default_value_t = 50)]
+    pub dsn_target_connection_number: u32,
 
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
     /// in Kademlia DHT for the DSN.

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -60,7 +60,7 @@ pub struct DsnConfig {
     pub max_out_connections: u32,
 
     /// Defines target total (in and out) connection number for DSN that should be maintained.
-    pub target_connection_number: u32,
+    pub target_connections: u32,
 }
 
 type DsnProviderStorage<AS> =
@@ -159,6 +159,7 @@ where
         provider_storage,
         max_established_incoming_connections: dsn_config.max_in_connections,
         max_established_outgoing_connections: dsn_config.max_out_connections,
+        target_connections: dsn_config.target_connections,
 
         ..subspace_networking::Config::default()
     };

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -58,6 +58,9 @@ pub struct DsnConfig {
 
     /// Defines max established outgoing swarm connection limit.
     pub max_out_connections: u32,
+
+    /// Defines target total (in and out) connection number for DSN that should be maintained.
+    pub target_connection_number: u32,
 }
 
 type DsnProviderStorage<AS> =

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -138,6 +138,7 @@ async fn run_executor(
                     allow_non_global_addresses_in_dht: true,
                     max_out_connections: 50,
                     max_in_connections: 50,
+                    target_connection_number: 50,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -138,7 +138,7 @@ async fn run_executor(
                     allow_non_global_addresses_in_dht: true,
                     max_out_connections: 50,
                     max_in_connections: 50,
-                    target_connection_number: 50,
+                    target_connections: 50,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -207,6 +207,7 @@ pub async fn run_validator_node(
                     allow_non_global_addresses_in_dht: true,
                     max_out_connections: 50,
                     max_in_connections: 50,
+                    target_connection_number: 50,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -207,7 +207,7 @@ pub async fn run_validator_node(
                     allow_non_global_addresses_in_dht: true,
                     max_out_connections: 50,
                     max_in_connections: 50,
-                    target_connection_number: 50,
+                    target_connections: 50,
                 },
                 piece_cache_size: 1024 * 1024 * 1024,
             },


### PR DESCRIPTION
This PR introduces several minor tweaks for the networking parameters of the DSN:
- change `subspace-node` parameters 
  - rename `dsn_max_in_connections -> dsn_in_connections`
  - rename `dsn_max_out_connections -> dsn_out_connections`
  - add `dsn_target_connection_number`
- change the "reconnection to known peers" limit from max outgoing connections to the new `target_connection_number` parameter
- change known peers batching method - reset the batcher on achieving target connectivity
- increase the interval between connection to known peers from 3s to 15s


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
