### PR TITLE
Primitives refactoring (pieces)

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -375,11 +375,8 @@ pub fn create_signed_vote(
             sector_index: 0,
             total_pieces: NonZeroU64::new(1).unwrap(),
             piece_offset: 0,
-            piece_record_hash: blake2b_256_254_hash(&piece[..RECORD_SIZE as usize]),
-            piece_witness: Witness::try_from_bytes(
-                &piece[RECORD_SIZE as usize..].try_into().unwrap(),
-            )
-            .unwrap(),
+            piece_record_hash: blake2b_256_254_hash(&piece.record()),
+            piece_witness: Witness::try_from_bytes(&piece.witness()).unwrap(),
             chunk_offset: 0,
             chunk,
             chunk_signature: create_chunk_signature(keypair, &chunk.to_bytes()),

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -628,7 +628,7 @@ fn vote_block_listed() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         BlockList::<Test>::insert(
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
@@ -658,7 +658,7 @@ fn vote_after_genesis() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         // Can't submit vote right after genesis block
         let signed_vote = create_signed_vote(
@@ -683,7 +683,7 @@ fn vote_too_low_height() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 1, 1);
 
@@ -713,7 +713,7 @@ fn vote_past_future_height() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 4, 1);
 
@@ -760,7 +760,7 @@ fn vote_wrong_parent() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -787,7 +787,7 @@ fn vote_past_future_slot() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         RecordsRoot::<Test>::insert(
             archived_segment.root_block.segment_index(),
@@ -845,8 +845,7 @@ fn vote_past_future_slot() {
         // in that context it is valid
         {
             let keypair = Keypair::generate();
-            let piece =
-                Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+            let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
             let signed_vote = create_signed_vote(
                 &keypair,
@@ -886,8 +885,7 @@ fn vote_same_slot() {
         // Same time slot in the vote as in the block is fine if height is the same (pre-dispatch)
         {
             let keypair = Keypair::generate();
-            let piece =
-                Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+            let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
             let signed_vote = create_signed_vote(
                 &keypair,
                 3,
@@ -905,8 +903,7 @@ fn vote_same_slot() {
         // (pre-dispatch)
         {
             let keypair = Keypair::generate();
-            let piece =
-                Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+            let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
             let signed_vote = create_signed_vote(
                 &keypair,
                 2,
@@ -930,7 +927,7 @@ fn vote_bad_reward_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -959,7 +956,7 @@ fn vote_unknown_records_root() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -986,7 +983,7 @@ fn vote_outside_of_solution_range() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1020,7 +1017,7 @@ fn vote_invalid_solution_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1072,7 +1069,7 @@ fn vote_correct_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1106,7 +1103,7 @@ fn vote_randomness_update() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         RecordsRoot::<Test>::insert(
             archived_segment.root_block.segment_index(),
@@ -1143,7 +1140,7 @@ fn vote_equivocation_current_block_plus_vote() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1194,7 +1191,7 @@ fn vote_equivocation_parent_block_plus_vote() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1254,7 +1251,7 @@ fn vote_equivocation_parent_block_plus_vote() {
 fn vote_equivocation_current_voters_duplicate() {
     new_test_ext().execute_with(|| {
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&Keypair::generate(), 2, 1);
 
@@ -1334,7 +1331,7 @@ fn vote_equivocation_parent_voters_duplicate() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::try_from(archived_segment.pieces.as_pieces().next().unwrap()).unwrap();
+        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
 
         progress_to_block(&keypair, 2, 1);
 

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -281,10 +281,11 @@ where
                     let forward_solution_fut = async move {
                         if let Ok(solution_response) = response_receiver.await {
                             for solution in solution_response.solutions {
-                                let public_key = FarmerPublicKey::from_slice(&solution.public_key)
-                                    .expect("Always correct length; qed");
+                                let public_key =
+                                    FarmerPublicKey::from_slice(solution.public_key.as_ref())
+                                        .expect("Always correct length; qed");
                                 let reward_address =
-                                    FarmerPublicKey::from_slice(&solution.reward_address)
+                                    FarmerPublicKey::from_slice(solution.reward_address.as_ref())
                                         .expect("Always correct length; qed");
 
                                 let solution = Solution {

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -551,8 +551,8 @@ async fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + '
                 .iter()
                 .flat_map(|flat_pieces| flat_pieces.as_pieces())
                 .enumerate()
-                .choose(&mut rand::thread_rng())
-                .map(|(piece_index, piece)| (piece_index as u64, Piece::try_from(piece).unwrap()))
+                .choose(&mut thread_rng())
+                .map(|(piece_index, piece)| (piece_index as u64, Piece::from(piece)))
                 .unwrap();
 
             while let Some(NewSlotNotification {

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -154,7 +154,7 @@ impl PieceGetter for TestPieceGetter {
             .pieces
             .as_pieces()
             .nth(piece_index as usize)
-            .map(|piece_bytes| Piece::try_from(piece_bytes).unwrap()))
+            .map(Piece::from))
     }
 }
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -82,7 +82,6 @@ fn archived_segment(kzg: Kzg) -> ArchivedSegment {
 
 struct Farmer {
     root_block: RootBlock,
-    farmer_protocol_info: FarmerProtocolInfo,
     sector: Vec<u8>,
     sector_metadata: Vec<u8>,
 }
@@ -122,7 +121,6 @@ impl Farmer {
 
         Self {
             root_block,
-            farmer_protocol_info,
             sector,
             sector_metadata,
         }
@@ -191,7 +189,6 @@ fn valid_header(
         .try_into_solutions(
             keypair,
             public_key,
-            &farmer.farmer_protocol_info,
             &sector_codec,
             farmer.sector.as_slice(),
             farmer.sector_metadata.as_slice(),

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -36,7 +36,7 @@ use subspace_core_primitives::objects::{
 };
 use subspace_core_primitives::{
     ArchivedBlockProgress, Blake2b256Hash, BlockNumber, FlatPieces, LastArchivedBlock, PieceRef,
-    RecordsRoot, RootBlock, BLAKE2B_256_HASH_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, WITNESS_SIZE,
+    RecordsRoot, RootBlock, BLAKE2B_256_HASH_SIZE, RECORDED_HISTORY_SEGMENT_SIZE,
 };
 
 const INITIAL_LAST_ARCHIVED_BLOCK: LastArchivedBlock = LastArchivedBlock {
@@ -838,12 +838,7 @@ pub fn is_piece_valid(
     piece: PieceRef<'_>,
     commitment: RecordsRoot,
     position: u32,
-    record_size: u32,
 ) -> bool {
-    if piece.len() != (record_size + WITNESS_SIZE) as usize {
-        return false;
-    }
-
     let (record, witness) = piece.split();
     let witness = match Witness::try_from_bytes(&witness) {
         Ok(witness) => witness,

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -116,7 +116,7 @@ impl PiecesReconstructor {
             .as_pieces_mut()
             .zip(polynomial_data.chunks_exact_mut(BLAKE2B_256_HASH_SIZE))
             .zip(shards)
-            .for_each(|((piece, polynomial_data), record)| {
+            .for_each(|((mut piece, polynomial_data), record)| {
                 let record =
                     record.expect("Reconstruction just happened and all records are present; qed");
                 let record = record.flatten();
@@ -144,7 +144,7 @@ impl PiecesReconstructor {
         pieces
             .as_pieces_mut()
             .enumerate()
-            .for_each(|(position, piece)| {
+            .for_each(|(position, mut piece)| {
                 piece[self.record_size as usize..].copy_from_slice(
                     &self
                         .kzg
@@ -172,15 +172,14 @@ impl PiecesReconstructor {
             return Err(ReconstructorError::IncorrectPiecePosition);
         }
 
-        let mut piece = Piece::try_from(
+        let mut piece = Piece::from(
             reconstructed_records
                 .as_pieces()
                 .nth(piece_position)
                 .expect(
                 "Piece exists at the position within segment after successful reconstruction; qed",
             ),
-        )
-        .expect("Piece in `FlatPieces` always has correct length; qed");
+        );
 
         piece[self.record_size as usize..].copy_from_slice(
             &self

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -121,7 +121,7 @@ impl Reconstructor {
             .take(self.reed_solomon.data_shard_count())
             .all(|maybe_piece| {
                 if let Some(piece) = maybe_piece {
-                    segment_data.extend_from_slice(&piece[..self.record_size as usize]);
+                    segment_data.extend_from_slice(&piece.record());
                     true
                 } else {
                     false

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -30,7 +30,7 @@ fn compare_block_objects_to_piece_objects<'a>(
     block_objects.zip(piece_objects).for_each(
         |((block, block_object_mapping), (piece, piece_object_mapping))| {
             assert_eq!(
-                extract_data(&piece, piece_object_mapping.offset()),
+                extract_data(piece.as_ref(), piece_object_mapping.offset()),
                 extract_data(block, block_object_mapping.offset())
             );
         },

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -151,7 +151,6 @@ fn archiver() {
             piece,
             first_archived_segment.root_block.records_root(),
             position as u32,
-            RECORD_SIZE,
         ));
     }
 
@@ -239,7 +238,6 @@ fn archiver() {
                 piece,
                 archived_segment.root_block.records_root(),
                 position as u32,
-                RECORD_SIZE,
             ));
         }
 
@@ -285,7 +283,6 @@ fn archiver() {
                 piece,
                 archived_segment.root_block.records_root(),
                 position as u32,
-                RECORD_SIZE,
             ));
         }
     }

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -7,8 +7,8 @@ use subspace_archiving::archiver::{Archiver, ArchiverInstantiationError, Segment
 use subspace_core_primitives::crypto::kzg::{Commitment, Kzg};
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, PieceObject};
 use subspace_core_primitives::{
-    ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, RootBlock, BLAKE2B_256_HASH_SIZE,
-    RECORD_SIZE,
+    ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, PieceRef, RootBlock,
+    BLAKE2B_256_HASH_SIZE, RECORD_SIZE,
 };
 
 // This is data + parity shards
@@ -25,12 +25,12 @@ fn extract_data<O: Into<u64>>(data: &[u8], offset: O) -> &[u8] {
 #[track_caller]
 fn compare_block_objects_to_piece_objects<'a>(
     block_objects: impl Iterator<Item = (&'a [u8], &'a BlockObject)>,
-    piece_objects: impl Iterator<Item = (&'a [u8], &'a PieceObject)>,
+    piece_objects: impl Iterator<Item = (PieceRef<'a>, &'a PieceObject)>,
 ) {
     block_objects.zip(piece_objects).for_each(
         |((block, block_object_mapping), (piece, piece_object_mapping))| {
             assert_eq!(
-                extract_data(piece, piece_object_mapping.offset()),
+                extract_data(&piece, piece_object_mapping.offset()),
                 extract_data(block, block_object_mapping.offset())
             );
         },

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -67,8 +67,8 @@ fn segment_reconstruction_works() {
     pieces.iter().zip(reconstructed_pieces.iter()).for_each(
         |(original_piece, reconstructed_piece)| {
             assert_eq!(
-                blake2b_256_254_hash(original_piece.as_ref()),
-                blake2b_256_254_hash(reconstructed_piece.as_ref())
+                blake2b_256_254_hash(original_piece),
+                blake2b_256_254_hash(reconstructed_piece)
             );
         },
     );
@@ -108,8 +108,8 @@ fn piece_reconstruction_works() {
         .unwrap();
 
     assert_eq!(
-        blake2b_256_254_hash(pieces[missing_piece_position].as_ref()),
-        blake2b_256_254_hash(missing_piece.as_ref())
+        blake2b_256_254_hash(&pieces[missing_piece_position]),
+        blake2b_256_254_hash(&missing_piece)
     );
 }
 

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -11,10 +11,7 @@ use subspace_core_primitives::{
 };
 
 fn flat_pieces_to_regular(pieces: &FlatPieces) -> Vec<Piece> {
-    pieces
-        .as_pieces()
-        .map(|piece| piece.try_into().unwrap())
-        .collect()
+    pieces.as_pieces().map(Piece::from).collect()
 }
 
 fn pieces_to_option_of_pieces(pieces: &[Piece]) -> Vec<Option<Piece>> {
@@ -58,10 +55,7 @@ fn segment_reconstruction_works() {
 
     let flat_pieces = reconstructor.reconstruct_segment(&maybe_pieces).unwrap();
 
-    let reconstructed_pieces = flat_pieces
-        .as_pieces()
-        .map(|bytes| Piece::try_from(bytes).expect("Piece must have the correct size"))
-        .collect::<Vec<_>>();
+    let reconstructed_pieces = flat_pieces_to_regular(&flat_pieces);
 
     assert_eq!(reconstructed_pieces.len(), PIECES_IN_SEGMENT as usize);
     pieces.iter().zip(reconstructed_pieces.iter()).for_each(

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -16,10 +16,7 @@ const PIECES_IN_SEGMENT: u32 = 8;
 const SEGMENT_SIZE: u32 = RECORD_SIZE * PIECES_IN_SEGMENT / 2;
 
 fn flat_pieces_to_regular(pieces: &FlatPieces) -> Vec<Piece> {
-    pieces
-        .as_pieces()
-        .map(|piece| piece.try_into().unwrap())
-        .collect()
+    pieces.as_pieces().map(Piece::from).collect()
 }
 
 fn pieces_to_option_of_pieces(pieces: &[Piece]) -> Vec<Option<Piece>> {

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -1,3 +1,4 @@
+use rand::{thread_rng, Rng};
 use std::assert_matches::assert_matches;
 use std::iter;
 use subspace_archiving::archiver::Archiver;
@@ -7,7 +8,7 @@ use subspace_archiving::reconstructor::{
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    ArchivedBlockProgress, FlatPieces, LastArchivedBlock, Piece, PIECE_SIZE, RECORD_SIZE,
+    ArchivedBlockProgress, FlatPieces, LastArchivedBlock, Piece, RECORD_SIZE,
 };
 
 // This is data + parity shards
@@ -346,9 +347,13 @@ fn invalid_usage() {
         let result = Reconstructor::new(RECORD_SIZE, SEGMENT_SIZE)
             .unwrap()
             .add_segment(
-                &iter::repeat_with(|| Some(rand::random::<[u8; PIECE_SIZE]>().into()))
-                    .take(PIECES_IN_SEGMENT as usize)
-                    .collect::<Vec<_>>(),
+                &iter::repeat_with(|| {
+                    let mut piece = Piece::default();
+                    thread_rng().fill(*piece.as_mut());
+                    Some(piece)
+                })
+                .take(PIECES_IN_SEGMENT as usize)
+                .collect::<Vec<_>>(),
             );
 
         assert_matches!(result, Err(ReconstructorError::SegmentDecoding(_)));

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -38,7 +38,10 @@ use core::num::NonZeroU64;
 use derive_more::{Add, Deref, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input};
-pub use pieces::{FlatPieces, Piece, PieceRef, PieceRefMut, PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE};
+pub use pieces::{
+    FlatPieces, Piece, PieceRef, PieceRefMut, RecordRef, RecordRefMut, WitnessRef, WitnessRefMut,
+    PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE,
+};
 use scale_info::{Type, TypeInfo};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -35,8 +35,7 @@ use ark_ff::{BigInteger, PrimeField};
 use core::convert::AsRef;
 use core::fmt;
 use core::num::NonZeroU64;
-use core::ops::Deref;
-use derive_more::{Add, Deref, Display, Div, Mul, Rem, Sub};
+use derive_more::{Add, Deref, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input};
 pub use pieces::{FlatPieces, Piece, PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE};
@@ -280,7 +279,21 @@ impl Scalar {
 
 /// A Ristretto Schnorr public key as bytes produced by `schnorrkel` crate.
 #[derive(
-    Debug, Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo,
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Encode,
+    Decode,
+    TypeInfo,
+    Deref,
+    From,
+    Into,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PublicKey(
@@ -293,26 +306,6 @@ impl fmt::Display for PublicKey {
     }
 }
 
-impl From<[u8; PUBLIC_KEY_LENGTH]> for PublicKey {
-    fn from(bytes: [u8; PUBLIC_KEY_LENGTH]) -> Self {
-        Self(bytes)
-    }
-}
-
-impl From<PublicKey> for [u8; PUBLIC_KEY_LENGTH] {
-    fn from(public_key: PublicKey) -> Self {
-        public_key.0
-    }
-}
-
-impl Deref for PublicKey {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
         &self.0
@@ -320,31 +313,26 @@ impl AsRef<[u8]> for PublicKey {
 }
 
 /// A Ristretto Schnorr signature as bytes produced by `schnorrkel` crate.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Encode,
+    Decode,
+    TypeInfo,
+    Deref,
+    From,
+    Into,
+)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RewardSignature(
     #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))] [u8; REWARD_SIGNATURE_LENGTH],
 );
-
-impl From<[u8; REWARD_SIGNATURE_LENGTH]> for RewardSignature {
-    fn from(bytes: [u8; REWARD_SIGNATURE_LENGTH]) -> Self {
-        Self(bytes)
-    }
-}
-
-impl From<RewardSignature> for [u8; REWARD_SIGNATURE_LENGTH] {
-    fn from(signature: RewardSignature) -> Self {
-        signature.0
-    }
-}
-
-impl Deref for RewardSignature {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl AsRef<[u8]> for RewardSignature {
     fn as_ref(&self) -> &[u8] {
@@ -499,21 +487,9 @@ pub type PieceIndex = u64;
 pub type SectorIndex = u64;
 
 /// Hash of `PieceIndex`
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode, From, Into)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PieceIndexHash(Blake2b256Hash);
-
-impl From<PieceIndexHash> for Blake2b256Hash {
-    fn from(piece_index_hash: PieceIndexHash) -> Self {
-        piece_index_hash.0
-    }
-}
-
-impl From<Blake2b256Hash> for PieceIndexHash {
-    fn from(hash: Blake2b256Hash) -> Self {
-        Self(hash)
-    }
-}
 
 impl AsRef<[u8]> for PieceIndexHash {
     fn as_ref(&self) -> &[u8] {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod crypto;
 pub mod objects;
+mod pieces;
 pub mod sector_codec;
 #[cfg(test)]
 mod tests;
@@ -29,17 +30,16 @@ extern crate alloc;
 
 use crate::crypto::kzg::{Commitment, Witness};
 use crate::crypto::{blake2b_256_hash, blake2b_256_hash_with_key};
-use alloc::vec;
-use alloc::vec::Vec;
 use ark_bls12_381::Fr;
 use ark_ff::{BigInteger, PrimeField};
 use core::convert::AsRef;
 use core::fmt;
 use core::num::NonZeroU64;
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
 use derive_more::{Add, Deref, Display, Div, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input};
+pub use pieces::{FlatPieces, Piece, PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE};
 use scale_info::{Type, TypeInfo};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -47,19 +47,6 @@ use serde::{Deserialize, Serialize};
 /// Size of BLAKE2b-256 hash output (in bytes).
 pub const BLAKE2B_256_HASH_SIZE: usize = 32;
 
-/// Byte size of a piece in Subspace Network, ~32KiB (a bit less due to requirement of being a
-/// multiple of 2 bytes for erasure coding as well as multiple of 31 bytes in order to fit into
-/// BLS12-381 scalar safely).
-///
-/// TODO: Requirement of being a multiple of 2 bytes may go away eventually as we switch erasure
-///  coding implementation, so we might be able to bump it by one field element in size.
-///
-/// This can not changed after the network is launched.
-pub const PIECE_SIZE: usize = 31_744;
-/// Size of witness for a segment record (in bytes).
-pub const WITNESS_SIZE: u32 = 48;
-/// Size of a segment record given the global piece size (in bytes).
-pub const RECORD_SIZE: u32 = PIECE_SIZE as u32 - WITNESS_SIZE;
 /// Size of one plotted sector.
 ///
 /// If we imagine sector as a grid containing pieces as columns, number of scalar in column must be
@@ -374,159 +361,6 @@ pub struct ChunkSignature {
     /// VRF proof bytes.
     #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
     pub proof: [u8; VRF_PROOF_LENGTH],
-}
-
-/// A piece of archival history in Subspace Network.
-///
-/// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
-/// the segment this piece belongs to can be used to verify that a piece belongs to the actual
-/// archival history of the blockchain.
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Piece(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] Vec<u8>);
-
-impl Default for Piece {
-    fn default() -> Self {
-        Self(vec![0u8; PIECE_SIZE])
-    }
-}
-
-impl From<[u8; PIECE_SIZE]> for Piece {
-    fn from(piece: [u8; PIECE_SIZE]) -> Self {
-        Self(piece.to_vec())
-    }
-}
-
-impl From<Piece> for Vec<u8> {
-    fn from(piece: Piece) -> Self {
-        piece.0
-    }
-}
-
-impl TryFrom<&[u8]> for Piece {
-    type Error = &'static str;
-    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        if slice.len() != PIECE_SIZE {
-            Err("Wrong piece size, expected: 32768")
-        } else {
-            Ok(Self(slice.to_vec()))
-        }
-    }
-}
-
-impl TryFrom<Vec<u8>> for Piece {
-    type Error = &'static str;
-
-    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
-        if vec.len() != PIECE_SIZE {
-            Err("Wrong piece size, expected: 32768")
-        } else {
-            Ok(Self(vec))
-        }
-    }
-}
-
-impl Deref for Piece {
-    type Target = [u8];
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for Piece {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl AsRef<[u8]> for Piece {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl AsMut<[u8]> for Piece {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.0
-    }
-}
-
-/// Flat representation of multiple pieces concatenated for higher efficient for processing.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct FlatPieces(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] Vec<u8>);
-
-// TODO: Introduce `PieceRef` and `PieceRefMut` that can be converted into `Piece` without
-//  `.expect()` and maybe add convenience methods for accessing record and witness parts of it
-impl FlatPieces {
-    /// Allocate `FlatPieces` that will hold `piece_count` pieces filled with zeroes.
-    pub fn new(piece_count: usize) -> Self {
-        Self(vec![0u8; piece_count * PIECE_SIZE])
-    }
-
-    /// Number of pieces contained.
-    pub fn count(&self) -> usize {
-        self.0.len() / PIECE_SIZE
-    }
-
-    /// Extract internal flat representation of bytes.
-    pub fn into_inner(self) -> Vec<u8> {
-        self.0
-    }
-
-    /// Iterator over individual pieces as byte slices.
-    pub fn as_pieces(&self) -> impl ExactSizeIterator<Item = &[u8]> {
-        self.0.chunks_exact(PIECE_SIZE)
-    }
-
-    /// Iterator over individual pieces as byte slices.
-    pub fn as_pieces_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [u8]> {
-        self.0.chunks_exact_mut(PIECE_SIZE)
-    }
-}
-
-impl From<Piece> for FlatPieces {
-    fn from(Piece(piece): Piece) -> Self {
-        Self(piece)
-    }
-}
-
-impl TryFrom<Vec<u8>> for FlatPieces {
-    type Error = Vec<u8>;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        if value.len() % PIECE_SIZE != 0 {
-            return Err(value);
-        }
-
-        Ok(Self(value))
-    }
-}
-
-impl Deref for FlatPieces {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for FlatPieces {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl AsRef<[u8]> for FlatPieces {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl AsMut<[u8]> for FlatPieces {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.0
-    }
 }
 
 /// Progress of an archived block.

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -38,7 +38,7 @@ use core::num::NonZeroU64;
 use derive_more::{Add, Deref, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input};
-pub use pieces::{FlatPieces, Piece, PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE};
+pub use pieces::{FlatPieces, Piece, PieceRef, PieceRefMut, PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE};
 use scale_info::{Type, TypeInfo};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -36,12 +36,6 @@ impl Default for Piece {
     }
 }
 
-impl From<[u8; PIECE_SIZE]> for Piece {
-    fn from(piece: [u8; PIECE_SIZE]) -> Self {
-        Self(piece.to_vec())
-    }
-}
-
 impl From<Piece> for Vec<u8> {
     fn from(piece: Piece) -> Self {
         piece.0

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -1,0 +1,174 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::{Deref, DerefMut};
+use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Byte size of a piece in Subspace Network, ~32KiB (a bit less due to requirement of being a
+/// multiple of 2 bytes for erasure coding as well as multiple of 31 bytes in order to fit into
+/// BLS12-381 scalar safely).
+///
+/// TODO: Requirement of being a multiple of 2 bytes may go away eventually as we switch erasure
+///  coding implementation, so we might be able to bump it by one field element in size.
+///
+/// This can not changed after the network is launched.
+pub const PIECE_SIZE: usize = 31_744;
+/// Size of witness for a segment record (in bytes).
+pub const WITNESS_SIZE: u32 = 48;
+/// Size of a segment record given the global piece size (in bytes).
+pub const RECORD_SIZE: u32 = PIECE_SIZE as u32 - WITNESS_SIZE;
+
+/// A piece of archival history in Subspace Network.
+///
+/// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
+/// the segment this piece belongs to can be used to verify that a piece belongs to the actual
+/// archival history of the blockchain.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Piece(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] Vec<u8>);
+
+impl Default for Piece {
+    fn default() -> Self {
+        Self(vec![0u8; PIECE_SIZE])
+    }
+}
+
+impl From<[u8; PIECE_SIZE]> for Piece {
+    fn from(piece: [u8; PIECE_SIZE]) -> Self {
+        Self(piece.to_vec())
+    }
+}
+
+impl From<Piece> for Vec<u8> {
+    fn from(piece: Piece) -> Self {
+        piece.0
+    }
+}
+
+impl TryFrom<&[u8]> for Piece {
+    type Error = &'static str;
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() != PIECE_SIZE {
+            Err("Wrong piece size, expected: 32768")
+        } else {
+            Ok(Self(slice.to_vec()))
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for Piece {
+    type Error = &'static str;
+
+    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+        if vec.len() != PIECE_SIZE {
+            Err("Wrong piece size, expected: 32768")
+        } else {
+            Ok(Self(vec))
+        }
+    }
+}
+
+impl Deref for Piece {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Piece {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for Piece {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for Piece {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+/// Flat representation of multiple pieces concatenated for higher efficient for processing.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct FlatPieces(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] Vec<u8>);
+
+// TODO: Introduce `PieceRef` and `PieceRefMut` that can be converted into `Piece` without
+//  `.expect()` and maybe add convenience methods for accessing record and witness parts of it
+impl FlatPieces {
+    /// Allocate `FlatPieces` that will hold `piece_count` pieces filled with zeroes.
+    pub fn new(piece_count: usize) -> Self {
+        Self(vec![0u8; piece_count * PIECE_SIZE])
+    }
+
+    /// Number of pieces contained.
+    pub fn count(&self) -> usize {
+        self.0.len() / PIECE_SIZE
+    }
+
+    /// Extract internal flat representation of bytes.
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Iterator over individual pieces as byte slices.
+    pub fn as_pieces(&self) -> impl ExactSizeIterator<Item = &[u8]> {
+        self.0.chunks_exact(PIECE_SIZE)
+    }
+
+    /// Iterator over individual pieces as byte slices.
+    pub fn as_pieces_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [u8]> {
+        self.0.chunks_exact_mut(PIECE_SIZE)
+    }
+}
+
+impl From<Piece> for FlatPieces {
+    fn from(Piece(piece): Piece) -> Self {
+        Self(piece)
+    }
+}
+
+impl TryFrom<Vec<u8>> for FlatPieces {
+    type Error = Vec<u8>;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() % PIECE_SIZE != 0 {
+            return Err(value);
+        }
+
+        Ok(Self(value))
+    }
+}
+
+impl Deref for FlatPieces {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for FlatPieces {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for FlatPieces {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for FlatPieces {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -75,7 +75,7 @@ impl<'a> AsMut<[u8]> for WitnessRefMut<'a> {
 
 /// A piece of archival history in Subspace Network.
 ///
-/// Internally piece contains a record and corresponding witness that together with [`RootBlock`] of
+/// Internally piece contains a record and corresponding witness that together with `RootBlock` of
 /// the segment this piece belongs to can be used to verify that a piece belongs to the actual
 /// archival history of the blockchain.
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -145,12 +145,22 @@ impl AsMut<[u8]> for Piece {
 impl Piece {
     /// Get piece reference.
     pub fn as_ref(&self) -> PieceRef<'_> {
-        PieceRef(&self.0)
+        PieceRef(
+            self.0
+                .as_slice()
+                .try_into()
+                .expect("Piece has correct size; qed"),
+        )
     }
 
     /// Get mutable piece reference.
     pub fn as_mut(&mut self) -> PieceRefMut<'_> {
-        PieceRefMut(&mut self.0)
+        PieceRefMut(
+            self.0
+                .as_mut_slice()
+                .try_into()
+                .expect("Piece has correct size; qed"),
+        )
     }
 
     /// Split piece into underlying components.
@@ -202,7 +212,7 @@ impl Piece {
 
 /// Reference to piece sized slice of memory.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
-pub struct PieceRef<'a>(&'a [u8]);
+pub struct PieceRef<'a>(&'a [u8; PIECE_SIZE]);
 
 impl<'a> AsRef<[u8]> for PieceRef<'a> {
     fn as_ref(&self) -> &[u8] {
@@ -212,7 +222,13 @@ impl<'a> AsRef<[u8]> for PieceRef<'a> {
 
 impl<'a> From<&'a Piece> for PieceRef<'a> {
     fn from(value: &'a Piece) -> Self {
-        PieceRef(&value.0)
+        PieceRef(
+            value
+                .0
+                .as_slice()
+                .try_into()
+                .expect("Piece has correct size; qed"),
+        )
     }
 }
 
@@ -249,7 +265,7 @@ impl<'a> PieceRef<'a> {
 
 /// Mutable reference to piece sized slice of memory.
 #[derive(Debug, Eq, PartialEq, Deref, DerefMut)]
-pub struct PieceRefMut<'a>(&'a mut [u8]);
+pub struct PieceRefMut<'a>(&'a mut [u8; PIECE_SIZE]);
 
 impl<'a> AsRef<[u8]> for PieceRefMut<'a> {
     fn as_ref(&self) -> &[u8] {
@@ -265,7 +281,13 @@ impl<'a> AsMut<[u8]> for PieceRefMut<'a> {
 
 impl<'a> From<&'a mut Piece> for PieceRefMut<'a> {
     fn from(value: &'a mut Piece) -> Self {
-        PieceRefMut(&mut value.0)
+        PieceRefMut(
+            value
+                .0
+                .as_mut_slice()
+                .try_into()
+                .expect("Piece has correct size; qed"),
+        )
     }
 }
 
@@ -360,12 +382,16 @@ impl FlatPieces {
 
     /// Iterator over individual pieces as byte slices.
     pub fn as_pieces(&self) -> impl ExactSizeIterator<Item = PieceRef<'_>> {
-        self.0.chunks_exact(PIECE_SIZE).map(PieceRef)
+        self.0
+            .chunks_exact(PIECE_SIZE)
+            .map(|piece| PieceRef(piece.try_into().expect("Piece has correct size; qed")))
     }
 
     /// Iterator over individual pieces as byte slices.
     pub fn as_pieces_mut(&mut self) -> impl ExactSizeIterator<Item = PieceRefMut<'_>> {
-        self.0.chunks_exact_mut(PIECE_SIZE).map(PieceRefMut)
+        self.0
+            .chunks_exact_mut(PIECE_SIZE)
+            .map(|piece| PieceRefMut(piece.try_into().expect("Piece has correct size; qed")))
     }
 }
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -40,7 +40,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = Piece::try_from(
+    let piece = Piece::from(
         archiver
             .add_block(input, Default::default())
             .into_iter()
@@ -50,8 +50,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .as_pieces()
             .next()
             .unwrap(),
-    )
-    .unwrap();
+    );
 
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -31,7 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = Piece::try_from(
+    let piece = Piece::from(
         archiver
             .add_block(input, Default::default())
             .into_iter()
@@ -41,8 +41,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             .as_pieces()
             .next()
             .unwrap(),
-    )
-    .unwrap();
+    );
 
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -104,7 +104,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 .try_into_solutions(
                     black_box(&keypair),
                     black_box(reward_address),
-                    black_box(&farmer_protocol_info),
                     black_box(&sector_codec),
                     black_box(plotted_sector.as_slice()),
                     black_box(sector_metadata.as_slice()),
@@ -151,7 +150,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         .try_into_solutions(
                             black_box(&keypair),
                             black_box(reward_address),
-                            black_box(&farmer_protocol_info),
                             black_box(&sector_codec),
                             black_box(plotted_sector.as_slice()),
                             black_box(metadata),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -42,7 +42,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = Piece::try_from(
+    let piece = Piece::from(
         archiver
             .add_block(input, Default::default())
             .into_iter()
@@ -52,8 +52,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .as_pieces()
             .next()
             .unwrap(),
-    )
-    .unwrap();
+    );
 
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -897,7 +897,6 @@ impl SingleDiskPlot {
                                     .try_into_solutions(
                                         &identity,
                                         reward_address,
-                                        &farmer_app_info.protocol_info,
                                         &sector_codec,
                                         sector,
                                         sector_metadata,

--- a/crates/subspace-farmer/src/utils/piece_validator.rs
+++ b/crates/subspace-farmer/src/utils/piece_validator.rs
@@ -4,9 +4,7 @@ use lru::LruCache;
 use parking_lot::Mutex;
 use subspace_archiving::archiver::is_piece_valid;
 use subspace_core_primitives::crypto::kzg::Kzg;
-use subspace_core_primitives::{
-    Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT, RECORD_SIZE,
-};
+use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::piece_provider::PieceValidator;
 use subspace_networking::Node;
@@ -93,7 +91,6 @@ where
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
                     .expect("Always fix into u32; qed"),
-                RECORD_SIZE,
             ) {
                 error!(
                     %piece_index,

--- a/crates/subspace-farmer/src/utils/piece_validator.rs
+++ b/crates/subspace-farmer/src/utils/piece_validator.rs
@@ -89,7 +89,7 @@ where
             if !is_piece_valid(
                 &self.kzg,
                 PIECES_IN_SEGMENT,
-                &piece,
+                piece.as_ref(),
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
                     .expect("Always fix into u32; qed"),

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -228,7 +228,7 @@ impl RpcServerImpl {
 
         let piece = self.read_and_decode_piece(next_piece_index)?;
         next_piece_index += 1;
-        read_records_data.extend_from_slice(&piece[..self.record_size as usize]);
+        read_records_data.extend_from_slice(&piece.record());
 
         // Let's see how many bytes encode compact length encoding of the data, see
         // https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers for
@@ -261,7 +261,7 @@ impl RpcServerImpl {
                 // Need the next piece to read the length of data
                 let piece = self.read_and_decode_piece(next_piece_index)?;
                 next_piece_index += 1;
-                read_records_data.extend_from_slice(&piece[..self.record_size as usize]);
+                read_records_data.extend_from_slice(&piece.record());
             }
 
             Compact::<u32>::decode(&mut &read_records_data[offset as usize..])
@@ -395,7 +395,7 @@ impl RpcServerImpl {
 
         for piece_index in (first_piece_in_segment..).take(self.pieces_in_segment as usize / 2) {
             let piece = self.read_and_decode_piece(piece_index)?;
-            segment_bytes.extend_from_slice(&piece[..self.record_size as usize]);
+            segment_bytes.extend_from_slice(&piece.record());
         }
 
         let segment = Segment::decode(&mut segment_bytes.as_slice()).map_err(|error| {

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -50,7 +50,7 @@ impl PieceValidator for RecordsRootPieceValidator {
             if !is_piece_valid(
                 &self.kzg,
                 PIECES_IN_SEGMENT,
-                &piece,
+                piece.as_ref(),
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
                     .expect("Always fix into u32; qed"),

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -1,9 +1,7 @@
 use async_trait::async_trait;
 use subspace_archiving::archiver::is_piece_valid;
 use subspace_core_primitives::crypto::kzg::Kzg;
-use subspace_core_primitives::{
-    Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT, RECORD_SIZE,
-};
+use subspace_core_primitives::{Piece, PieceIndex, RecordsRoot, SegmentIndex, PIECES_IN_SEGMENT};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::piece_provider::PieceValidator;
 use subspace_networking::Node;
@@ -54,7 +52,6 @@ impl PieceValidator for RecordsRootPieceValidator {
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
                     .expect("Always fix into u32; qed"),
-                RECORD_SIZE,
             ) {
                 error!(
                     %piece_index,

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -147,7 +147,7 @@ where
             &insert_keys
                 .iter()
                 .zip(pieces.as_pieces())
-                .map(|(key, piece)| (key.as_slice(), piece))
+                .map(|(key, piece)| (key.as_slice(), *piece))
                 .collect::<Vec<_>>(),
             &delete_keys
                 .iter()

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -147,7 +147,7 @@ where
             &insert_keys
                 .iter()
                 .zip(pieces.as_pieces())
-                .map(|(key, piece)| (key.as_slice(), *piece))
+                .map(|(key, piece)| (key.as_slice(), (*piece).as_ref()))
                 .collect::<Vec<_>>(),
             &delete_keys
                 .iter()

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -213,7 +213,7 @@ impl PieceGetter for TestPieceGetter {
             .pieces
             .as_pieces()
             .nth(piece_index as usize)
-            .map(|piece_bytes| Piece::try_from(piece_bytes).unwrap()))
+            .map(Piece::from))
     }
 }
 

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -145,15 +145,15 @@ async fn start_farming<Client>(
         let keypair = keypair.clone();
 
         move || {
-            let (farmer_protocol_info, sector, sector_metadata) =
+            let (sector, sector_metadata) =
                 block_on(plot_one_segment(client.as_ref(), &keypair, &sector_codec));
             plotting_result_sender
-                .send((farmer_protocol_info, sector, sector_metadata))
+                .send((sector, sector_metadata))
                 .unwrap();
         }
     });
 
-    let (farmer_protocol_info, sector, sector_metadata) = plotting_result_receiver.await.unwrap();
+    let (sector, sector_metadata) = plotting_result_receiver.await.unwrap();
     let sector_index = 0;
     let public_key = PublicKey::from(keypair.public.to_bytes());
 
@@ -178,7 +178,6 @@ async fn start_farming<Client>(
                 .try_into_solutions(
                     &keypair,
                     public_key,
-                    &farmer_protocol_info,
                     &sector_codec,
                     sector.as_slice(),
                     sector_metadata.as_slice(),
@@ -221,7 +220,7 @@ async fn plot_one_segment<Client>(
     client: &Client,
     keypair: &schnorrkel::Keypair,
     sector_codec: &SectorCodec,
-) -> (FarmerProtocolInfo, Vec<u8>, Vec<u8>)
+) -> (Vec<u8>, Vec<u8>)
 where
     Client: BlockBackend<Block> + HeaderBackend<Block>,
 {
@@ -268,5 +267,5 @@ where
     .await
     .expect("Plotting one sector in memory must not fail");
 
-    (farmer_protocol_info, sector, sector_metadata)
+    (sector, sector_metadata)
 }


### PR DESCRIPTION
This is a pure refactoring in anticipation of piece containing not just record and witness, but also commitment to the record.

Managing bytes manually isn't very ergonomic and requires use of `.expect()` in some higher-level code, so I decided to create some additional type safe wrappers that abstract things in (hopefully) a  bit nicer way.

Rust doesn't do double-dereferencing automatically, so it is not as ergonomic as it could have been otherwise, but I think it is still quite decent.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
