### PR TITLE
notify cargo to regenerate inclusion files when WASM changes

### DIFF
--- a/crates/subspace-wasm-tools/src/lib.rs
+++ b/crates/subspace-wasm-tools/src/lib.rs
@@ -85,6 +85,10 @@ pub fn create_runtime_bundle_inclusion_file(
     .unwrap_or_else(|error| {
         panic!("Must be able to write to {target_file_name}: {error}");
     });
+
+    // Ensure this build script is re-run when runtime wasm contents changes.
+    // This will ensure the inclusion file will be updated with updated WASM contents.
+    println!("cargo:rerun-if-changed={execution_wasm_bundle_path}");
 }
 
 /// Read the core domain runtime blob from the system domain runtime blob.


### PR DESCRIPTION
This was not the case earlier since the inclusion file that contains WASM was not updated even when WASM was updated because the cargo was not watching the change to re-run the build script that actually updates the inclusion file.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
