### PR TITLE
Build x86-64-v2 and x86-64-v3 rather than default targets

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -33,6 +33,7 @@ jobs:
             dockerfile-suffix: ''
             suffix: ubuntu-x86_64-${{ github.ref_name }}
             image-suffix: ''
+            rustflags: '-C target-cpu=x86-64-v2'
           # We build AArch64
           - arch: linux/amd64
             dockerfile-suffix: '.aarch64'
@@ -66,7 +67,6 @@ jobs:
             suffix=${{ matrix.platform.image-suffix }}
 
       - name: Build and push ${{ matrix.image }} image
-        id: build
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # @v3.2.0
         with:
           file: Dockerfile-${{ matrix.image }}${{ matrix.platform.dockerfile-suffix }}
@@ -77,6 +77,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
+            RUSTFLAGS=${{ matrix.platform.rustflags }}
 
   executables:
     strategy:
@@ -84,8 +85,12 @@ jobs:
         build:
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-            suffix: ubuntu-x86_64-${{ github.ref_name }}
-            rustflags: ''
+            suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
+            rustflags: '-C target-cpu=x86-64-v2'
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            suffix: ubuntu-x86_64-v3-${{ github.ref_name }}
+            rustflags: '-C target-cpu=x86-64-v3'
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             suffix: ubuntu-aarch64-${{ github.ref_name }}
@@ -100,8 +105,12 @@ jobs:
             rustflags: ''
           - os: windows-2022
             target: x86_64-pc-windows-msvc
-            suffix: windows-x86_64-${{ github.ref_name }}
-            rustflags: ''
+            suffix: windows-x86_64-v2-${{ github.ref_name }}
+            rustflags: '-C target-cpu=x86-64-v2'
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
+            suffix: windows-x86_64-v3-${{ github.ref_name }}
+            rustflags: '-C target-cpu=x86-64-v3'
     runs-on: ${{ matrix.build.os }}
     env:
       PRODUCTION_TARGET: target/${{ matrix.build.target }}/production


### PR DESCRIPTION
This will result in more optimized (read "faster") builds: https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
The drawback is that CPUs that are build before ~2009 and some not so modern VMs will not longer be able to run pre-built executables.

This is based on feedback on Discord about significant (~2x) improvements in sync speed (that is heavy on computation).

Fixes #1263

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
