### PR TITLE
DSN. Restore networking parameter manager. 

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -19,7 +19,7 @@ use subspace_farmer_components::piece_caching::PieceMemoryCache;
 use subspace_networking::libp2p::identity::Keypair;
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::{
-    create, peer_id, BootstrappedNetworkingParameters, Config, Node, NodeRunner,
+    create, peer_id, Config, NetworkingParametersManager, Node, NodeRunner,
     ParityDbProviderStorage, PieceByHashRequest, PieceByHashRequestHandler, PieceByHashResponse,
     RootBlockBySegmentIndexesRequestHandler, RootBlockRequest, RootBlockResponse,
 };
@@ -57,6 +57,13 @@ pub(super) fn configure_dsn(
     ),
     anyhow::Error,
 > {
+    let networking_parameters_registry = {
+        let known_addresses_db_path = base_path.join("known_addresses_db");
+
+        NetworkingParametersManager::new(&known_addresses_db_path, bootstrap_nodes)
+            .map(|manager| manager.boxed())?
+    };
+
     let weak_readers_and_pieces = Arc::downgrade(readers_and_pieces);
 
     let piece_cache_db_path = base_path.join("piece_cache_db");
@@ -144,8 +151,7 @@ pub(super) fn configure_dsn(
         keypair,
         listen_on,
         allow_non_global_addresses_in_dht: !disable_private_ips,
-        networking_parameters_registry: BootstrappedNetworkingParameters::new(bootstrap_nodes)
-            .boxed(),
+        networking_parameters_registry,
         request_response_protocols: vec![
             PieceByHashRequestHandler::create(move |&PieceByHashRequest { piece_index_hash }| {
                 debug!(?piece_index_hash, "Piece request received. Trying cache...");

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -72,6 +72,8 @@ pub struct BootstrappedNetworkingParameters {
 
 impl BootstrappedNetworkingParameters {
     pub fn new(bootstrap_addresses: Vec<Multiaddr>) -> Self {
+        debug!("In-memory networking parameters manager instantiated.");
+
         Self {
             bootstrap_addresses,
         }
@@ -159,12 +161,17 @@ impl NetworkingParametersManager {
                     .map(|data| data.to_cache());
 
                 if result.is_ok() {
-                    trace!("Networking parameters loaded from DB");
+                    debug!("Networking parameters loaded from DB");
                 }
 
                 result
             })
             .unwrap_or_else(|| Ok(LruCache::new(PEER_CACHE_SIZE)))?;
+
+        debug!(
+            ?path,
+            "Persistent networking parameters manager instantiated."
+        );
 
         Ok(Self {
             cache_need_saving: false,

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -20,6 +20,8 @@ use thiserror::Error;
 use tokio::time::{sleep, Sleep};
 use tracing::{debug, trace};
 
+pub type ParityDbError = parity_db::Error;
+
 // Defines optional time for address dial failure
 type FailureTime = Option<DateTime<Utc>>;
 
@@ -75,8 +77,6 @@ pub struct BootstrappedNetworkingParameters {
 
 impl BootstrappedNetworkingParameters {
     pub fn new(bootstrap_addresses: Vec<Multiaddr>) -> Self {
-        debug!("In-memory networking parameters manager instantiated.");
-
         Self {
             bootstrap_addresses,
         }
@@ -170,11 +170,6 @@ impl NetworkingParametersManager {
                 result
             })
             .unwrap_or_else(|| Ok(LruCache::new(PEER_CACHE_SIZE)))?;
-
-        debug!(
-            ?path,
-            "Persistent networking parameters manager instantiated."
-        );
 
         Ok(Self {
             cache_need_saving: false,

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -101,17 +101,19 @@ async fn main() -> anyhow::Result<()> {
             };
 
             let networking_parameters_registry = {
-                let in_memory_registry =
-                    BootstrappedNetworkingParameters::new(bootstrap_nodes.clone()).boxed();
-
                 db_path
                     .map(|path| {
                         let known_addresses_db = path.join("known_addresses_db");
 
-                        NetworkingParametersManager::new(&known_addresses_db, bootstrap_nodes)
-                            .map(|manager| manager.boxed())
+                        NetworkingParametersManager::new(
+                            &known_addresses_db,
+                            bootstrap_nodes.clone(),
+                        )
+                        .map(|manager| manager.boxed())
                     })
-                    .unwrap_or(Ok(in_memory_registry))
+                    .unwrap_or(Ok(
+                        BootstrappedNetworkingParameters::new(bootstrap_nodes).boxed()
+                    ))
                     .map_err(|err| anyhow!(err))?
             };
 

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::{
     peer_id, BootstrappedNetworkingParameters, Config, MemoryProviderStorage,
-    ParityDbProviderStorage,
+    NetworkingParametersManager, ParityDbProviderStorage,
 };
 use tracing::info;
 
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
             let keypair = Keypair::decode(hex::decode(keypair)?.as_mut_slice())?;
             let local_peer_id = peer_id(&libp2p::identity::Keypair::Ed25519(keypair.clone()));
 
-            let provider_storage = if let Some(path) = db_path {
+            let provider_storage = if let Some(path) = &db_path {
                 let db_path = path.join("subspace_storage_providers_db");
 
                 Either::Left(ParityDbProviderStorage::new(
@@ -100,11 +100,23 @@ async fn main() -> anyhow::Result<()> {
                 Either::Right(MemoryProviderStorage::new(local_peer_id))
             };
 
+            let networking_parameters_registry = {
+                let in_memory_registry =
+                    BootstrappedNetworkingParameters::new(bootstrap_nodes.clone()).boxed();
+
+                db_path
+                    .map(|path| {
+                        let known_addresses_db = path.join("known_addresses_db");
+
+                        NetworkingParametersManager::new(&known_addresses_db, bootstrap_nodes)
+                            .map(|manager| manager.boxed())
+                    })
+                    .unwrap_or(Ok(in_memory_registry))
+                    .map_err(|err| anyhow!(err))?
+            };
+
             let config = Config {
-                networking_parameters_registry: BootstrappedNetworkingParameters::new(
-                    bootstrap_nodes,
-                )
-                .boxed(),
+                networking_parameters_registry,
                 listen_on,
                 allow_non_global_addresses_in_dht: !disable_private_ips,
                 reserved_peers,

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -32,6 +32,7 @@ use libp2p::yamux::YamuxConfig;
 use libp2p::{identity, Multiaddr, PeerId, TransportError};
 use parking_lot::Mutex;
 use std::borrow::Cow;
+use std::error::Error;
 use std::iter::Empty;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -315,6 +316,9 @@ pub enum CreationError {
     /// ParityDb storage error
     #[error("ParityDb storage error: {0}")]
     ParityDbStorageError(#[from] parity_db::Error),
+    /// Custom error
+    #[error("Custom error: {0}")]
+    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Converts public key from keypair to PeerId.

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -32,7 +32,6 @@ use libp2p::yamux::YamuxConfig;
 use libp2p::{identity, Multiaddr, PeerId, TransportError};
 use parking_lot::Mutex;
 use std::borrow::Cow;
-use std::error::Error;
 use std::iter::Empty;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -321,9 +320,6 @@ pub enum CreationError {
     /// ParityDb storage error
     #[error("ParityDb storage error: {0}")]
     ParityDbStorageError(#[from] parity_db::Error),
-    /// Custom error
-    #[error("Custom error: {0}")]
-    Other(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// Converts public key from keypair to PeerId.

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -33,7 +33,8 @@ mod shared;
 pub mod utils;
 
 pub use crate::behavior::persistent_parameters::{
-    BootstrappedNetworkingParameters, NetworkingParametersManager,
+    BootstrappedNetworkingParameters, NetworkParametersPersistenceError,
+    NetworkingParametersManager, ParityDbError,
 };
 pub use crate::node::{
     CircuitRelayClientError, GetClosestPeersError, Node, SendRequestError, SubscribeError,

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -20,9 +20,10 @@ use subspace_core_primitives::{PieceIndex, RootBlock, PIECES_IN_SEGMENT};
 use subspace_networking::libp2p::{identity, Multiaddr};
 use subspace_networking::utils::pieces::announce_single_piece_index_with_backoff;
 use subspace_networking::{
-    peer_id, BootstrappedNetworkingParameters, CreationError, MemoryProviderStorage, Node,
-    NodeRunner, ParityDbProviderStorage, PieceByHashRequestHandler, PieceByHashResponse,
-    RootBlockBySegmentIndexesRequestHandler, RootBlockRequest, RootBlockResponse,
+    peer_id, BootstrappedNetworkingParameters, CreationError, MemoryProviderStorage,
+    NetworkingParametersManager, Node, NodeRunner, ParityDbProviderStorage,
+    PieceByHashRequestHandler, PieceByHashResponse, RootBlockBySegmentIndexesRequestHandler,
+    RootBlockRequest, RootBlockResponse,
 };
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, trace, warn, Instrument};
@@ -76,7 +77,7 @@ where
 
     let peer_id = peer_id(&dsn_config.keypair);
 
-    let external_provider_storage = if let Some(path) = dsn_config.base_path {
+    let external_provider_storage = if let Some(path) = &dsn_config.base_path {
         let db_path = path.join("storage_providers_db");
 
         let cache_size: NonZeroUsize = NonZeroUsize::new(MAX_PROVIDER_RECORDS_LIMIT)
@@ -87,6 +88,22 @@ where
         Either::Right(MemoryProviderStorage::new(peer_id))
     };
 
+    let networking_parameters_registry = {
+        let in_memory_registry =
+            BootstrappedNetworkingParameters::new(dsn_config.bootstrap_nodes.clone()).boxed();
+
+        dsn_config
+            .base_path
+            .map(|path| {
+                let db_path = path.join("known_addresses_db");
+
+                NetworkingParametersManager::new(&db_path, dsn_config.bootstrap_nodes)
+                    .map(|manager| manager.boxed())
+            })
+            .unwrap_or(Ok(in_memory_registry))
+            .map_err(|err| CreationError::Other(err.into()))?
+    };
+
     let provider_storage =
         NodeProviderStorage::new(peer_id, piece_cache.clone(), external_provider_storage);
 
@@ -94,10 +111,7 @@ where
         keypair: dsn_config.keypair.clone(),
         listen_on: dsn_config.listen_on,
         allow_non_global_addresses_in_dht: dsn_config.allow_non_global_addresses_in_dht,
-        networking_parameters_registry: BootstrappedNetworkingParameters::new(
-            dsn_config.bootstrap_nodes,
-        )
-        .boxed(),
+        networking_parameters_registry,
         request_response_protocols: vec![
             PieceByHashRequestHandler::create(move |req| {
                 let result = match piece_cache.get_piece(req.piece_index_hash) {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -22,8 +22,8 @@ pub mod piece_cache;
 pub mod root_blocks;
 pub mod rpc;
 
-use crate::dsn::create_dsn_instance;
 use crate::dsn::import_blocks::import_blocks as import_blocks_from_dsn;
+use crate::dsn::{create_dsn_instance, DsnConfigurationError};
 use crate::piece_cache::PieceCache;
 use crate::root_blocks::{start_root_block_archiver, RootBlockCache};
 use derive_more::{Deref, DerefMut, Into};
@@ -108,7 +108,7 @@ pub enum Error {
 
     /// Subspace networking (DSN) error.
     #[error(transparent)]
-    SubspaceDsn(#[from] subspace_networking::CreationError),
+    SubspaceDsn(#[from] DsnConfigurationError),
 
     /// Other.
     #[error(transparent)]


### PR DESCRIPTION
This PR restores the existing code of the persistent networking parameter manager and adds it to our applications: node, farmer, and subspace-bootstrap-node. Fixes https://github.com/subspace/subspace/issues/1252

This refactoring will be addressed separately - https://github.com/subspace/subspace/issues/1266

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
