### PR TITLE
Refactor solution verification to move KZG into separate parameter

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1368,10 +1368,10 @@ fn check_vote<T: Config>(
             solution_range: vote_verification_data.solution_range,
             piece_check_params: Some(PieceCheckParams {
                 records_root: &records_root,
-                kzg: &kzg,
                 pieces_in_segment,
             }),
         },
+        Some(&kzg),
     ) {
         debug!(
             target: "runtime::subspace",

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -254,6 +254,9 @@ where
                 VerificationPrimitiveError::InvalidSolutionSignature(err) => {
                     Error::BadSolutionSignature(slot, err)
                 }
+                VerificationPrimitiveError::MissingKzgInstance => {
+                    unreachable!("Implementation bug");
+                }
             },
         }
     }
@@ -682,6 +685,7 @@ where
                     reward_signing_context: &self.reward_signing_context,
                 },
                 Some(pre_digest),
+                None,
             )
             .map_err(Error::<Block::Header>::from)?
         };

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -243,10 +243,11 @@ where
                     solution_range: voting_solution_range,
                     piece_check_params: Some(PieceCheckParams {
                         records_root: &records_root,
-                        kzg: &self.subspace_link.kzg,
+
                         pieces_in_segment: PIECES_IN_SEGMENT,
                     }),
                 },
+                Some(&self.subspace_link.kzg),
             );
 
             if let Err(error) = solution_verification_result {

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -360,10 +360,10 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
                 solution_range: header_digests.solution_range,
                 piece_check_params: Some(PieceCheckParams {
                     records_root: &records_root,
-                    kzg: &kzg,
                     pieces_in_segment: PIECES_IN_SEGMENT,
                 }),
             },
+            Some(&kzg),
         )
         .map_err(ImportError::InvalidSolution)?;
 


### PR DESCRIPTION
This is not a very nice API, but there is a reason for it.

Turns out KZG is really slow to deal with in runtime, especially with upcoming upgrade where we'll have it instantiated to support polynomials up to degree `2^15-1`. I verified, it is not possible to produce a block due to low performance.

The solution I came up with is to expose solution verification host function, but I'd also like to otherwise reuse data structures that already exist.

With KZG instance moved into separate independent argument we can use the same data structures for solution verification (in `pallet-subspace` and `sp-lightclient`) and mostly the same API as existing `verify_solution`, we'll just omit `kzg` argument. We will have to derive `Encode` and `Decode` on data structures used, but it shouldn't be a big deal.

Runtime interface and other things will come in future PRs.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
