### PR TITLE
Fix `no_std` serde support in `subspace-core-primitives`

### DIFF
--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -33,8 +33,8 @@ rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false, features = ["alloc"] }
 rayon = { version = "1.6.1", optional = true }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.152", optional = true, features = ["derive"] }
-serde_arrays = "0.1.0"
+serde = { version = "1.0.152", optional = true, features = ["alloc", "derive"] }
+serde_arrays = { version = "0.1.0", optional = true }
 thiserror = { version = "1.0.38", optional = true }
 uint = { version = "0.9.5", default-features = false }
 
@@ -44,11 +44,18 @@ criterion = "0.4.0"
 [features]
 default = [
     "parallel-decoding",
+    "serde",
     "std",
 ]
 # Parallel decoding will use all CPUs available, but will allocate a memory of a size of a sector instead of square root
 # of that
 parallel-decoding = ["rayon"]
+serde = [
+    "dep:serde",
+    # TODO: `serde_arrays` doesn't support `no_std` right now: https://github.com/Kromey/serde_arrays/issues/8
+    "dep:serde_arrays",
+    "hex/serde",
+]
 std = [
     "ark-bls12-381/std",
     "ark-ff/std",
@@ -56,7 +63,6 @@ std = [
     "blake2/std",
     "dusk-bls12_381/std",
     "dusk-plonk/std",
-    "hex/serde",
     "hex/std",
     "num-integer/std",
     "num-traits/std",
@@ -67,7 +73,7 @@ std = [
     "rand_chacha/std",
     "rand_core/std",
     "scale-info/std",
-    "serde",
+    "serde?/std",
     "thiserror",
     "uint/std",
 ]


### PR DESCRIPTION
Alternative solution to #1269 that doesn't require new dependencies and code changes, just `Cargo.toml`

Closes #1269

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
