### PR TITLE
Switch KZG implementation to `rust-kzg`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
+        with:
+          version: "15.0"
+        if: runner.os == 'macOS'
+
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # @v1.1.2
         with:
@@ -135,6 +142,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
+        with:
+          version: "15.0"
+        if: runner.os == 'macOS'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # @v1.1.2

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -120,6 +120,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
+        with:
+          version: "15.0"
+        if: runner.os == 'macOS'
+
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # @v1.1.2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,12 +330,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
-
-[[package]]
-name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
@@ -937,7 +931,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blst"
 version = "0.3.10"
-source = "git+https://github.com/supranational/blst.git#ca03e11a3ff24d818ae390a1e7f435f15bf72aee"
+source = "git+https://github.com/subspace/blst.git?rev=079887d2d05bb2d61df4ceef3d4c836228ebc6ff#079887d2d05bb2d61df4ceef3d4c836228ebc6ff"
 dependencies = [
  "cc",
  "glob",
@@ -948,7 +942,7 @@ dependencies = [
 [[package]]
 name = "blst_from_scratch"
 version = "0.1.0"
-source = "git+https://github.com/sifraitech/rust-kzg?rev=7eb52ca97576ea1eefe4dd2165f224c916f8c862#7eb52ca97576ea1eefe4dd2165f224c916f8c862"
+source = "git+https://github.com/subspace/rust-kzg?rev=49e7b60ea51d918f04779dd83191ae0e01afcb30#49e7b60ea51d918f04779dd83191ae0e01afcb30"
 dependencies = [
  "blst",
  "kzg",
@@ -1549,7 +1543,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools 0.10.5",
+ "itertools",
  "log",
  "smallvec",
  "wasmparser",
@@ -1592,7 +1586,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1613,7 +1607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1964,17 +1958,6 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive-hex"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6618553c32cd1c1f4fbdb9418cc035f3168422f24406ebb08576f6db5ed6ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2460,56 +2443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00704156a7de8df8da0911424e30c2049957b0a714542a44e05fe693dd85313"
 
 [[package]]
-name = "dusk-bls12_381"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fc81248ab76f1739dd4241ea2e7037a4d4cb0bd170443a7049e13b0e09acd6"
-dependencies = [
- "byteorder",
- "dusk-bytes",
- "rand_core 0.6.4",
- "rayon",
- "subtle",
-]
-
-[[package]]
-name = "dusk-bytes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aae12696d965c95ce5b79bc5612575e8aeac958c9e037b74ffa9e73e1cd8c7"
-dependencies = [
- "derive-hex",
-]
-
-[[package]]
-name = "dusk-jubjub"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c228f2adec5255faf67fe6d106caa093a6c2ef798dca42019b684716528250ff"
-dependencies = [
- "dusk-bls12_381",
- "dusk-bytes",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "dusk-plonk"
-version = "0.12.0"
-source = "git+https://github.com/subspace/plonk?rev=193e68ba3d20f737d730e4b6edc757e4f639e7c3#193e68ba3d20f737d730e4b6edc757e4f639e7c3"
-dependencies = [
- "cfg-if",
- "dusk-bls12_381",
- "dusk-bytes",
- "dusk-jubjub",
- "hashbrown 0.9.1",
- "itertools 0.9.0",
- "merlin 3.0.0",
- "rand_core 0.6.4",
- "rayon",
-]
-
-[[package]]
 name = "dyn-clonable"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,7 +2824,7 @@ dependencies = [
  "frame-system",
  "gethostname",
  "handlebars",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "linked-hash-map",
  "log",
@@ -2993,7 +2926,7 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse",
  "frame-support-procedural-tools",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -3460,15 +3393,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -3911,15 +3835,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
@@ -4176,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sifraitech/rust-kzg?rev=7eb52ca97576ea1eefe4dd2165f224c916f8c862#7eb52ca97576ea1eefe4dd2165f224c916f8c862"
+source = "git+https://github.com/subspace/rust-kzg?rev=49e7b60ea51d918f04779dd83191ae0e01afcb30#49e7b60ea51d918f04779dd83191ae0e01afcb30"
 
 [[package]]
 name = "language-tags"
@@ -5383,18 +5298,6 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -6668,7 +6571,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools 0.10.5",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -6834,7 +6737,7 @@ checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
  "multimap",
@@ -6880,7 +6783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -7119,7 +7022,7 @@ dependencies = [
  "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
- "spin 0.9.5",
+ "spin 0.9.6",
 ]
 
 [[package]]
@@ -8519,7 +8422,7 @@ dependencies = [
  "arrayvec 0.5.2",
  "curve25519-dalek 2.1.3",
  "getrandom 0.1.16",
- "merlin 2.0.1",
+ "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
@@ -9113,7 +9016,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "merlin 2.0.1",
+ "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "primitive-types",
@@ -9197,7 +9100,7 @@ name = "sp-domains"
 version = "0.1.0"
 dependencies = [
  "blake2",
- "merlin 2.0.1",
+ "merlin",
  "parity-scale-codec",
  "rs_merkle",
  "scale-info",
@@ -9295,7 +9198,7 @@ source = "git+https://github.com/subspace/substrate?rev=456cfad45a178617f6886ec4
 dependencies = [
  "async-trait",
  "futures 0.3.26",
- "merlin 2.0.1",
+ "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "schnorrkel",
@@ -9660,9 +9563,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -9812,15 +9718,15 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "blake2",
+ "blst_from_scratch",
  "criterion",
  "derive_more",
- "dusk-bls12_381",
- "dusk-bytes",
- "dusk-plonk",
  "hex",
+ "kzg",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -9828,7 +9734,10 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_arrays",
+ "spin 0.9.6",
+ "static_assertions",
  "thiserror",
+ "tracing",
  "uint",
 ]
 
@@ -10192,7 +10101,7 @@ dependencies = [
 name = "subspace-solving"
 version = "0.1.0"
 dependencies = [
- "merlin 2.0.1",
+ "merlin",
  "rand 0.8.5",
  "schnorrkel",
  "subspace-core-primitives",
@@ -10338,7 +10247,7 @@ dependencies = [
 name = "subspace-verification"
 version = "0.1.0"
 dependencies = [
- "merlin 2.0.1",
+ "merlin",
  "parity-scale-codec",
  "scale-info",
  "schnorrkel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ ark-serialize = { opt-level = 3 }
 ark-std = { opt-level = 3 }
 blake2 = { opt-level = 3 }
 blake2b_simd = { opt-level = 3 }
+blst = { opt-level = 3 }
+blst_from_scratch = { opt-level = 3 }
 chacha20poly1305 = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
 cranelift-wasm = { opt-level = 3 }
@@ -39,8 +41,6 @@ crc32fast = { opt-level = 3 }
 crossbeam-deque = { opt-level = 3 }
 crypto-mac = { opt-level = 3 }
 curve25519-dalek = { opt-level = 3 }
-dusk-bls12_381 = { opt-level = 3 }
-dusk-plonk = { opt-level = 3 }
 ed25519-zebra = { opt-level = 3 }
 flate2 = { opt-level = 3 }
 futures-channel = { opt-level = 3 }
@@ -51,6 +51,7 @@ httparse = { opt-level = 3 }
 integer-sqrt = { opt-level = 3 }
 k256 = { opt-level = 3 }
 keccak = { opt-level = 3 }
+kzg = { opt-level = 3 }
 libm = { opt-level = 3 }
 libsecp256k1 = { opt-level = 3 }
 libz-sys = { opt-level = 3 }

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -38,6 +38,7 @@ pallet-offences-subspace = { version = "0.1.0", path = "../pallet-offences-subsp
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -38,7 +38,7 @@ use sp_runtime::Perbill;
 use std::num::NonZeroU64;
 use std::sync::Once;
 use subspace_archiving::archiver::{ArchivedSegment, Archiver};
-use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg, Witness};
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg, Witness};
 use subspace_core_primitives::crypto::{blake2b_256_254_hash, kzg};
 use subspace_core_primitives::{
     ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, Piece, Randomness, RecordsRoot,
@@ -249,7 +249,7 @@ pub fn new_test_ext() -> TestExternalities {
 
     let mut ext = TestExternalities::from(storage);
 
-    ext.register_extension(KzgExtension::new(Kzg::new(test_public_parameters())));
+    ext.register_extension(KzgExtension::new(Kzg::new(embedded_kzg_settings())));
 
     ext
 }
@@ -344,7 +344,7 @@ pub fn create_root_block(segment_index: SegmentIndex) -> RootBlock {
 }
 
 pub fn create_archived_segment() -> ArchivedSegment {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg).unwrap();
 
     let mut block = vec![0u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -948,7 +948,7 @@ where
         // root block, check it now.
         subspace_verification::check_piece(
             &self.subspace_link.kzg,
-            PIECES_IN_SEGMENT,
+            PIECES_IN_SEGMENT as usize,
             &records_root,
             position,
             &pre_digest.solution,
@@ -1256,7 +1256,7 @@ where
         .confirmation_depth_k();
 
     // TODO: Probably should have public parameters in chain constants instead
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
 
     let link = SubspaceLink {
         slot_duration,

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -427,7 +427,7 @@ fn rejects_empty_block() {
 }
 
 fn get_archived_pieces(client: &TestClient) -> Vec<FlatPieces> {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg)
         .expect("Incorrect parameters for archiver");
 

--- a/crates/sp-lightclient/Cargo.toml
+++ b/crates/sp-lightclient/Cargo.toml
@@ -34,6 +34,7 @@ frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/subs
 futures = "0.3.26"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving"}
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }
 
 [features]

--- a/crates/sp-lightclient/src/mock.rs
+++ b/crates/sp-lightclient/src/mock.rs
@@ -6,7 +6,7 @@ use sp_arithmetic::traits::Zero;
 use sp_consensus_subspace::KzgExtension;
 use sp_runtime::traits::{BlakeTwo256, Header as HeaderT};
 use std::collections::{BTreeMap, HashMap};
-use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::{BlockWeight, RecordsRoot, SegmentIndex, SolutionRange};
 
 pub(crate) type Header = sp_runtime::generic::Header<u32, BlakeTwo256>;
@@ -185,7 +185,7 @@ impl MockStorage {
 pub fn new_test_ext() -> TestExternalities {
     let mut ext = TestExternalities::new_empty();
 
-    ext.register_extension(KzgExtension::new(Kzg::new(test_public_parameters())));
+    ext.register_extension(KzgExtension::new(Kzg::new(embedded_kzg_settings())));
 
     ext
 }

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -88,7 +88,7 @@ struct Farmer {
 
 impl Farmer {
     fn new(keypair: &Keypair) -> Self {
-        let kzg = Kzg::new(kzg::test_public_parameters());
+        let kzg = Kzg::new(kzg::embedded_kzg_settings());
         let archived_segment = archived_segment(kzg.clone());
         let root_block = archived_segment.root_block;
         let total_pieces = NonZeroU64::new(archived_segment.pieces.count() as u64).unwrap();

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = { version = "1.0.38", optional = true }
 [dev-dependencies]
 criterion = "0.4.0"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 
 [features]
 default = ["std"]

--- a/crates/subspace-archiving/benches/archiving.rs
+++ b/crates/subspace-archiving/benches/archiving.rs
@@ -11,7 +11,7 @@ const RECORDED_HISTORY_SEGMENT_SIZE: u32 = RECORD_SIZE * PIECES_IN_SEGMENT / 2;
 fn criterion_benchmark(c: &mut Criterion) {
     let mut input = vec![0u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
     thread_rng().fill(input.as_mut_slice());
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg).unwrap();
 
     c.bench_function("segment-archiving", |b| {

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -834,7 +834,7 @@ impl Archiver {
 /// Validate witness embedded within a piece produced by archiver
 pub fn is_piece_valid(
     kzg: &Kzg,
-    num_pieces_in_segment: u32,
+    num_pieces_in_segment: usize,
     piece: PieceRef<'_>,
     commitment: RecordsRoot,
     position: u32,
@@ -860,7 +860,7 @@ pub fn is_piece_valid(
 /// Validate witness for pieces record hash produced by archiver
 pub fn is_piece_record_hash_valid(
     kzg: &Kzg,
-    num_pieces_in_segment: u32,
+    num_pieces_in_segment: usize,
     piece_record_hash: &Blake2b256Hash,
     commitment: &RecordsRoot,
     witness: &Witness,

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::iter;
 use subspace_archiving::archiver;
 use subspace_archiving::archiver::{Archiver, ArchiverInstantiationError, SegmentItem};
-use subspace_core_primitives::crypto::kzg::{Commitment, Kzg};
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Commitment, Kzg};
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, PieceObject};
 use subspace_core_primitives::{
     ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, PieceRef, RootBlock,
@@ -39,7 +39,7 @@ fn compare_block_objects_to_piece_objects<'a>(
 
 #[test]
 fn archiver() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg.clone()).unwrap();
 
     let (block_0, block_0_object_mapping) = {
@@ -147,7 +147,7 @@ fn archiver() {
     for (position, piece) in first_archived_segment.pieces.as_pieces().enumerate() {
         assert!(archiver::is_piece_valid(
             &kzg,
-            PIECES_IN_SEGMENT,
+            PIECES_IN_SEGMENT as usize,
             piece,
             first_archived_segment.root_block.records_root(),
             position as u32,
@@ -234,7 +234,7 @@ fn archiver() {
         for (position, piece) in archived_segment.pieces.as_pieces().enumerate() {
             assert!(archiver::is_piece_valid(
                 &kzg,
-                PIECES_IN_SEGMENT,
+                PIECES_IN_SEGMENT as usize,
                 piece,
                 archived_segment.root_block.records_root(),
                 position as u32,
@@ -279,7 +279,7 @@ fn archiver() {
         for (position, piece) in archived_segment.pieces.as_pieces().enumerate() {
             assert!(archiver::is_piece_valid(
                 &kzg,
-                PIECES_IN_SEGMENT,
+                PIECES_IN_SEGMENT as usize,
                 piece,
                 archived_segment.root_block.records_root(),
                 position as u32,
@@ -290,7 +290,7 @@ fn archiver() {
 
 #[test]
 fn invalid_usage() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     assert_matches!(
         Archiver::new(4, SEGMENT_SIZE, kzg.clone()),
         Err(ArchiverInstantiationError::RecordSizeTooSmall),
@@ -378,7 +378,7 @@ fn invalid_usage() {
 
 #[test]
 fn one_byte_smaller_segment() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
 
     // Carefully compute the block size such that there is just 2 bytes left to fill the segment,
     // but this should already produce archived segment since just enum variant and smallest compact
@@ -410,7 +410,7 @@ fn one_byte_smaller_segment() {
 
 #[test]
 fn spill_over_edge_case() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg).unwrap();
 
     // Carefully compute the block size such that there is just 2 bytes left to fill the segment,
@@ -466,7 +466,7 @@ fn spill_over_edge_case() {
 
 #[test]
 fn object_on_the_edge_of_segment() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg).unwrap();
     let first_block = vec![0u8; SEGMENT_SIZE as usize];
     let archived_segments = archiver.add_block(first_block.clone(), BlockObjectMapping::default());

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -4,7 +4,7 @@ use subspace_archiving::piece_reconstructor::{
     PiecesReconstructor, ReconstructorError, ReconstructorInstantiationError,
 };
 use subspace_core_primitives::crypto::blake2b_256_254_hash;
-use subspace_core_primitives::crypto::kzg::Kzg;
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
     FlatPieces, Piece, PIECES_IN_SEGMENT, RECORDED_HISTORY_SEGMENT_SIZE, RECORD_SIZE,
@@ -27,7 +27,7 @@ fn get_random_block() -> Vec<u8> {
 
 #[test]
 fn segment_reconstruction_works() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
 
@@ -70,7 +70,7 @@ fn segment_reconstruction_works() {
 
 #[test]
 fn piece_reconstruction_works() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     // Block that fits into the segment fully
@@ -109,7 +109,7 @@ fn piece_reconstruction_works() {
 
 #[test]
 fn piece_reconstructor_creation_fails() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
 
     let reconstructor = PiecesReconstructor::new(10, 1, kzg.clone());
 
@@ -133,7 +133,7 @@ fn piece_reconstructor_creation_fails() {
 
 #[test]
 fn segment_reconstruction_fails() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
 
     let reconstructor =
         PiecesReconstructor::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
@@ -172,7 +172,7 @@ fn segment_reconstruction_fails() {
 
 #[test]
 fn piece_reconstruction_fails() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
 
     let reconstructor =
         PiecesReconstructor::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -5,7 +5,7 @@ use subspace_archiving::archiver::Archiver;
 use subspace_archiving::reconstructor::{
     Reconstructor, ReconstructorError, ReconstructorInstantiationError,
 };
-use subspace_core_primitives::crypto::kzg::Kzg;
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
     ArchivedBlockProgress, FlatPieces, LastArchivedBlock, Piece, RECORD_SIZE,
@@ -26,7 +26,7 @@ fn pieces_to_option_of_pieces(pieces: &[Piece]) -> Vec<Option<Piece>> {
 
 #[test]
 fn basic() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg).unwrap();
     // Block that fits into the segment fully
     let block_0 = rand::random::<[u8; SEGMENT_SIZE as usize / 2]>().to_vec();
@@ -226,7 +226,7 @@ fn basic() {
 
 #[test]
 fn partial_data() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORD_SIZE, SEGMENT_SIZE, kzg).unwrap();
     // Block that fits into the segment fully
     let block_0 = rand::random::<[u8; SEGMENT_SIZE as usize / 2]>().to_vec();
@@ -302,7 +302,7 @@ fn partial_data() {
 
 #[test]
 fn invalid_usage() {
-    let kzg = Kzg::random(PIECES_IN_SEGMENT).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     assert_matches!(
         Reconstructor::new(10, 9),
         Err(ReconstructorInstantiationError::SegmentSizeTooSmall),

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -20,36 +20,44 @@ ark-bls12-381 = "0.3.0"
 ark-ff = "0.3.0"
 ark-poly = "0.3.0"
 blake2 = { version = "0.10.6", default-features = false }
+# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
 derive_more = "0.99.17"
-dusk-bls12_381 = { version = "0.11.2", default-features = false, features = ["alloc", "groups", "pairings", "endo"] }
-dusk-bytes = "0.1"
-dusk-plonk = { version = "0.12.0", default-features = false, features = ["alloc"], git = "https://github.com/subspace/plonk", rev = "193e68ba3d20f737d730e4b6edc757e4f639e7c3" }
 hex = { version  = "0.4.3", default-features = false, features = ["alloc"] }
+# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
+kzg = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
-rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
-rand_chacha = { version = "0.3.1", default-features = false }
-rand_core = { version = "0.6.4", default-features = false, features = ["alloc"] }
+parking_lot = { version = "0.12.1", optional = true }
 rayon = { version = "1.6.1", optional = true }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.152", optional = true, features = ["alloc", "derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
+# Replacement for `parking_lot` in `no_std` environment
+spin = "0.9.6"
+static_assertions = "1.1.0"
 thiserror = { version = "1.0.38", optional = true }
+tracing = { version = "0.1.37", default-features = false }
 uint = { version = "0.9.5", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4.0"
+rand = { version = "0.8.5", features = ["min_const_gen"] }
+rand_chacha = "0.3.1"
+rand_core = "0.6.4"
 
 [features]
 default = [
     "parallel-decoding",
+    "embedded-kzg-settings",
     "serde",
     "std",
 ]
 # Parallel decoding will use all CPUs available, but will allocate a memory of a size of a sector instead of square root
 # of that
 parallel-decoding = ["rayon"]
+embedded-kzg-settings = []
 serde = [
     "dep:serde",
     # TODO: `serde_arrays` doesn't support `no_std` right now: https://github.com/Kromey/serde_arrays/issues/8
@@ -61,20 +69,18 @@ std = [
     "ark-ff/std",
     "ark-poly/std",
     "blake2/std",
-    "dusk-bls12_381/std",
-    "dusk-plonk/std",
+    "blst_from_scratch/std",
     "hex/std",
+    "kzg/std",
     "num-integer/std",
     "num-traits/std",
     "parity-scale-codec/std",
-    "rand",
-    # These two are `default`
-    "rand_chacha/simd",
-    "rand_chacha/std",
-    "rand_core/std",
+    # In no-std environment we use `spin`
+    "parking_lot",
     "scale-info/std",
     "serde?/std",
     "thiserror",
+    "tracing/std",
     "uint/std",
 ]
 

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -7,86 +7,116 @@ mod tests;
 
 extern crate alloc;
 
+use crate::Scalar;
+use alloc::collections::btree_map::Entry;
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+use blst_from_scratch::eip_4844::{bytes_from_g1_rust, bytes_to_g1_rust, bytes_to_g2_rust};
+use blst_from_scratch::types::fft_settings::FsFFTSettings;
+use blst_from_scratch::types::fr::FsFr;
+use blst_from_scratch::types::g1::FsG1;
+use blst_from_scratch::types::kzg_settings::FsKZGSettings;
+use blst_from_scratch::types::poly::FsPoly;
 use core::hash::{Hash, Hasher};
-use dusk_bls12_381::{G1Affine, G2Affine, G2Prepared};
-pub use dusk_bytes;
-use dusk_bytes::{DeserializableSlice, Serializable};
-pub use dusk_plonk::commitment_scheme::kzg10::key::{CommitKey, OpeningKey};
-pub use dusk_plonk::commitment_scheme::PublicParameters;
-pub use dusk_plonk::error::Error;
-use dusk_plonk::fft::domain::EvaluationDomain;
-use dusk_plonk::fft::evaluations::Evaluations;
-use dusk_plonk::fft::polynomial::Polynomial as PlonkPolynomial;
-use dusk_plonk::prelude::BlsScalar;
+use kzg::{FFTFr, FFTSettings, KZGSettings};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input, MaxEncodedLen};
+#[cfg(feature = "std")]
+use parking_lot::Mutex;
 use scale_info::{Type, TypeInfo};
+#[cfg(not(feature = "std"))]
+use spin::Mutex;
+use tracing::debug;
 
-const TEST_PUBLIC_PARAMETERS: &[u8] = include_bytes!("kzg/test-public-parameters.bin");
+/// Embedded KZG settings as bytes, too big for `no_std` in most cases
+#[cfg(feature = "embedded-kzg-settings")]
+pub const EMBEDDED_KZG_SETTINGS_BYTES: &[u8] = include_bytes!("kzg/test-public-parameters.bin");
+
+// Symmetric function is present in tests
+/// Function turns bytes into `FsKZGSettings`, it is up to the user to ensure that bytes make sense,
+/// otherwise result can be very wrong (but will not panic).
+pub fn bytes_to_kzg_settings(bytes: &[u8]) -> Result<FsKZGSettings, String> {
+    // 48 bytes per G1 and 96 bytes per G2;
+    if bytes.is_empty() || bytes.len() % (48 + 96) != 0 {
+        return Err("Bad bytes".to_string());
+    }
+    let secret_len = bytes.len() / (48 + 96);
+
+    let (secret_g1_bytes, secret_g2_bytes) = bytes.split_at(secret_len * 48);
+    let secret_g1 = secret_g1_bytes
+        .chunks_exact(48)
+        .map(|bytes| {
+            bytes_to_g1_rust(
+                bytes
+                    .try_into()
+                    .expect("Chunked into correct number of bytes above; qed"),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let secret_g2 = secret_g2_bytes
+        .chunks_exact(96)
+        .map(|bytes| {
+            bytes_to_g2_rust(
+                bytes
+                    .try_into()
+                    .expect("Chunked into correct number of bytes above; qed"),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let fft_settings = FsFFTSettings::new(
+        secret_len
+            .checked_sub(1)
+            .expect("Checked to be not empty above; qed")
+            .ilog2() as usize,
+    )
+    .expect("Scale is within allowed bounds; qed");
+
+    // Below is the same as `FsKZGSettings::new(&s1, &s2, secret_len, &fft_settings)`, but without
+    // extra checks (parameters are static anyway) and without unnecessary allocations
+    Ok(FsKZGSettings {
+        fs: fft_settings,
+        secret_g1,
+        secret_g2,
+    })
+}
 
 /// TODO: Test public parameters, must be replaced with proper public parameters later
-pub fn test_public_parameters() -> PublicParameters {
-    // SAFETY: Bytes were produced with below `test_public_parameters_generate()` and are guaranteed
-    // to be correct
-    unsafe { PublicParameters::from_slice_unchecked(TEST_PUBLIC_PARAMETERS) }
-}
-
-#[cfg(test)]
-fn test_public_parameters_generate() -> PublicParameters {
-    use rand_core::SeedableRng;
-
-    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1969897683899915189);
-    PublicParameters::setup(1024, &mut rng).expect("Static value, doesn't error")
-}
-
-#[test]
-fn test_public_parameters_correct() {
-    assert_eq!(
-        test_public_parameters_generate().to_raw_var_bytes(),
-        test_public_parameters().to_raw_var_bytes()
-    );
+/// Embedded KZG settings
+#[cfg(feature = "embedded-kzg-settings")]
+pub fn embedded_kzg_settings() -> FsKZGSettings {
+    bytes_to_kzg_settings(EMBEDDED_KZG_SETTINGS_BYTES)
+        .expect("Static bytes are correct, there is a test for this; qed")
 }
 
 /// Commitment to polynomial
 #[derive(Debug, Clone)]
-pub struct Polynomial(PlonkPolynomial);
-
-impl From<Polynomial> for Vec<u8> {
-    fn from(polynomial: Polynomial) -> Vec<u8> {
-        polynomial.0.to_var_bytes()
-    }
-}
-
-impl TryFrom<&[u8]> for Polynomial {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self(PlonkPolynomial::from_slice(bytes)?))
-    }
-}
+pub struct Polynomial(FsPoly);
 
 /// Commitment size in bytes.
 pub const COMMITMENT_SIZE: usize = 48;
 
 /// Commitment to polynomial
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub struct Commitment(G1Affine);
+pub struct Commitment(FsG1);
 
 impl Commitment {
     /// Convert commitment to raw bytes
     pub fn to_bytes(&self) -> [u8; COMMITMENT_SIZE] {
-        self.0.to_bytes()
+        bytes_from_g1_rust(&self.0)
     }
 
     /// Try to deserialize commitment from raw bytes
-    pub fn try_from_bytes(bytes: &[u8; COMMITMENT_SIZE]) -> Result<Self, dusk_bytes::Error> {
-        Ok(Commitment(G1Affine::from_bytes(bytes)?))
+    pub fn try_from_bytes(bytes: &[u8; COMMITMENT_SIZE]) -> Result<Self, String> {
+        Ok(Commitment(bytes_to_g1_rust(bytes)?))
     }
 }
 
 impl Hash for Commitment {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_bytes().hash(state);
+        self.to_bytes().hash(state);
     }
 }
 
@@ -103,7 +133,7 @@ impl From<&Commitment> for [u8; COMMITMENT_SIZE] {
 }
 
 impl TryFrom<&[u8; COMMITMENT_SIZE]> for Commitment {
-    type Error = dusk_bytes::Error;
+    type Error = String;
 
     fn try_from(bytes: &[u8; COMMITMENT_SIZE]) -> Result<Self, Self::Error> {
         Self::try_from_bytes(bytes)
@@ -111,7 +141,7 @@ impl TryFrom<&[u8; COMMITMENT_SIZE]> for Commitment {
 }
 
 impl TryFrom<[u8; COMMITMENT_SIZE]> for Commitment {
-    type Error = dusk_bytes::Error;
+    type Error = String;
 
     fn try_from(bytes: [u8; COMMITMENT_SIZE]) -> Result<Self, Self::Error> {
         Self::try_from(&bytes)
@@ -173,17 +203,17 @@ impl TypeInfo for Commitment {
 
 /// Witness for polynomial evaluation
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub struct Witness(G1Affine);
+pub struct Witness(FsG1);
 
 impl Witness {
     /// Convert witness to raw bytes
     pub fn to_bytes(&self) -> [u8; COMMITMENT_SIZE] {
-        self.0.to_bytes()
+        bytes_from_g1_rust(&self.0)
     }
 
     /// Try to deserialize witness from raw bytes
-    pub fn try_from_bytes(bytes: &[u8; COMMITMENT_SIZE]) -> Result<Self, dusk_bytes::Error> {
-        Ok(Witness(G1Affine::from_bytes(bytes)?))
+    pub fn try_from_bytes(bytes: &[u8; COMMITMENT_SIZE]) -> Result<Self, String> {
+        Ok(Witness(bytes_to_g1_rust(bytes)?))
     }
 }
 
@@ -200,7 +230,7 @@ impl From<&Witness> for [u8; COMMITMENT_SIZE] {
 }
 
 impl TryFrom<&[u8; COMMITMENT_SIZE]> for Witness {
-    type Error = dusk_bytes::Error;
+    type Error = String;
 
     fn try_from(bytes: &[u8; COMMITMENT_SIZE]) -> Result<Self, Self::Error> {
         Self::try_from_bytes(bytes)
@@ -208,7 +238,7 @@ impl TryFrom<&[u8; COMMITMENT_SIZE]> for Witness {
 }
 
 impl TryFrom<[u8; COMMITMENT_SIZE]> for Witness {
-    type Error = dusk_bytes::Error;
+    type Error = String;
 
     fn try_from(bytes: [u8; COMMITMENT_SIZE]) -> Result<Self, Self::Error> {
         Self::try_from(&bytes)
@@ -268,94 +298,61 @@ impl TypeInfo for Witness {
 /// Wrapper data structure for working with KZG commitment scheme
 #[derive(Debug, Clone)]
 pub struct Kzg {
-    public_parameters: PublicParameters,
+    kzg_settings: FsKZGSettings,
+    fft_settings_cache: Arc<Mutex<BTreeMap<usize, Arc<FsFFTSettings>>>>,
 }
 
-// Most of below implementation and comments are basically taken following code samples (and
-// adapted):
-// https://github.com/subspace/plonk/blob/65db5f0da6edef54048ddbf4495c6c5b4a664dff/src/commitment_scheme/kzg10/key.rs
-// https://github.com/maticnetwork/avail/blob/76e2b45d13975ba87b632f62f29497f279986cbc/kate/src/com.rs
-// https://github.com/maticnetwork/avail/blob/76e2b45d13975ba87b632f62f29497f279986cbc/kate/proof/src/lib.rs
 impl Kzg {
-    /// Create new instance with given public parameters
-    pub fn new(public_parameters: PublicParameters) -> Self {
-        Self { public_parameters }
+    /// Create new instance with given KZG settings.
+    ///
+    /// Canonical KZG settings can be obtained using `embedded_kzg_settings()` function that becomes
+    /// available with `embedded-kzg-settings` feature (enabled by default).
+    pub fn new(kzg_settings: FsKZGSettings) -> Self {
+        Self {
+            kzg_settings,
+            fft_settings_cache: Arc::default(),
+        }
     }
 
-    #[cfg(feature = "std")]
-    /// For testing purposes only.
-    ///
-    /// Returns an error if the configured degree is less than one.
-    pub fn random(max_degree: u32) -> Result<Self, Error> {
-        let public_parameters =
-            PublicParameters::setup(max_degree as usize, &mut rand::thread_rng())?;
-        Ok(Self { public_parameters })
-    }
-
-    // /// Runs a one-time trusted setup of the universal reference values `KZG_PARAMETERS`. The
-    // /// initial `seed` for value generation can be provided by a multi-party computation at genesis.
-    // fn setup(seed: &[u8]) -> PublicParameters {
-    //     todo!()
-    // }
-
-    /// Represents data as a `polynomial` needed for the rest of the scheme. The degree of the
-    /// polynomial $d$ is equal to the length of data.
-    ///
-    /// An ordered data set is treated as a set of values as `(x,y) = (w^i, data[i])`, where
-    /// `data[i]` are `DATA_CHUNK_SIZE`-byte (currently 31 bytes) chunks, and `w` is a root of unity
-    /// of degree $d$, of from which a polynomial that satisfies $p(x)=y$  for all these points is
-    /// interpolated. This may be done every time needed using a saved root of unity (one field
-    /// element).
+    /// Create polynomial from data. Data must be multiple of 32 bytes, each containing up to 254
+    /// bits of information.
     ///
     /// The resulting polynomial is in coefficient form.
-    pub fn poly(&self, data: &[u8]) -> Result<Polynomial, Error> {
+    pub fn poly(&self, data: &[u8]) -> Result<Polynomial, String> {
         let evals = data
-            .chunks(BlsScalar::SIZE)
-            .map(BlsScalar::from_slice)
-            .collect::<Result<Vec<BlsScalar>, dusk_bytes::Error>>()?;
-        let domain = EvaluationDomain::new(evals.len())?;
-        let evaluations = Evaluations::from_vec_and_domain(evals, domain);
-        Ok(Polynomial(evaluations.interpolate()))
+            .chunks(Scalar::FULL_BYTES)
+            .map(|scalar| {
+                FsFr::from_scalar(
+                    scalar
+                        .try_into()
+                        .map_err(|_| "Failed to convert value to scalar".to_string())?,
+                )
+                .map_err(|error_code| {
+                    format!("Failed to create scalar from bytes with code: {error_code}")
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        let poly = FsPoly {
+            coeffs: self.get_fft_settings(evals.len())?.fft_fr(&evals, true)?,
+        };
+        Ok(Polynomial(poly))
     }
 
     /// Computes a `Commitment` to `polynomial`
-    pub fn commit(&self, polynomial: &Polynomial) -> Result<Commitment, Error> {
-        self.public_parameters
-            .commit_key
-            .commit(&polynomial.0)
-            .map(|commitment| Commitment(commitment.0))
+    pub fn commit(&self, polynomial: &Polynomial) -> Result<Commitment, String> {
+        self.kzg_settings
+            .commit_to_poly(&polynomial.0)
+            .map(Commitment)
     }
 
     /// Computes a `Witness` of evaluation of `polynomial` at `index`
-    pub fn create_witness(&self, polynomial: &Polynomial, index: u32) -> Result<Witness, Error> {
-        let polynomial_degree = polynomial.0.degree();
-        assert!((index as usize) <= polynomial_degree);
-        // For a given polynomial `p` and a point `z`, compute the witness
-        // for p(z) using Ruffini's method for simplicity.
-        // The Witness is the quotient of f(x) - f(z) / x-z.
-        // However we note that the quotient polynomial is invariant under the value
-        // f(z) ie. only the remainder changes. We can therefore compute the
-        // witness as f(x) / x - z and only use the remainder term f(z) during
-        // verification.
-
-        // Generate all the x-axis points of the domain on which all the row polynomials reside
-        let eval_domain = EvaluationDomain::new(polynomial_degree)?;
-        let point = eval_domain
-            .elements()
-            .nth(
-                index
-                    .try_into()
-                    .expect("Always fits into usize on 32-bit+ platforms; qed"),
-            )
-            .ok_or(Error::MismatchedPolyLen)?;
-
-        // Computes `f(x) / x-z`, returning it as the witness poly
-        let witness_poly = polynomial.0.ruffini(point);
-
-        self.public_parameters
-            .commit_key
-            .commit(&witness_poly)
-            .map(|commitment| Witness(commitment.0))
+    pub fn create_witness(&self, polynomial: &Polynomial, index: u32) -> Result<Witness, String> {
+        let x = self
+            .get_fft_settings(polynomial.0.coeffs.len())?
+            .get_expanded_roots_of_unity_at(index as usize);
+        self.kzg_settings
+            .compute_proof_single(&polynomial.0, &x)
+            .map(Witness)
     }
 
     /// Verifies that `value` is the evaluation at `index` of the polynomial created from
@@ -363,61 +360,56 @@ impl Kzg {
     pub fn verify(
         &self,
         commitment: &Commitment,
-        num_values: u32,
+        num_values: usize,
         index: u32,
         value: &[u8],
         witness: &Witness,
     ) -> bool {
-        let degree_of_polynomial = match num_values.checked_sub(1) {
-            Some(degree_of_polynomial) => degree_of_polynomial,
-            None => {
+        let fft_settings = match self.get_fft_settings(num_values) {
+            Ok(fft_settings) => fft_settings,
+            Err(error) => {
+                debug!(error, "Failed to derive fft settings");
                 return false;
             }
         };
-
-        // Generate all the x-axis points of the domain on which all the row polynomials reside
-        let eval_domain = match EvaluationDomain::new(
-            degree_of_polynomial
-                .try_into()
-                .expect("Always fits into usize on 32-bit+ platforms; qed"),
-        ) {
-            Ok(eval_domain) => eval_domain,
-            Err(_error) => {
-                return false;
-            }
-        };
-        let point = eval_domain
-            .elements()
-            .nth(
-                index
-                    .try_into()
-                    .expect("Always fits into usize on 32-bit+ platforms; qed"),
-            )
-            // TODO: Remove unwrap
-            .unwrap();
-        let value = match BlsScalar::from_slice(value) {
+        let x = fft_settings.get_expanded_roots_of_unity_at(index as usize);
+        let value = match value.try_into() {
             Ok(value) => value,
-            Err(_error) => {
+            Err(_) => {
+                debug!("Failed to convert value to scalar");
+                return false;
+            }
+        };
+        let value = match FsFr::from_scalar(value) {
+            Ok(value) => value,
+            Err(error_code) => {
+                debug!(error_code, "Failed to create scalar from bytes with code");
                 return false;
             }
         };
 
-        // Checks that a polynomial `p` was evaluated at a point `z` and returned
-        // the value specified `v`. ie. v = p(z).
-        let inner_a: G1Affine =
-            (commitment.0 - (self.public_parameters.opening_key.g * value)).into();
+        match self
+            .kzg_settings
+            .check_proof_single(&commitment.0, &witness.0, &x, &value)
+        {
+            Ok(result) => result,
+            Err(error) => {
+                debug!(error, "Failed to check proof");
+                false
+            }
+        }
+    }
 
-        let inner_b: G2Affine = (self.public_parameters.opening_key.beta_h
-            - (self.public_parameters.opening_key.h * point))
-            .into();
-        let prepared_inner_b = G2Prepared::from(-inner_b);
-
-        let pairing = dusk_bls12_381::multi_miller_loop(&[
-            (&inner_a, &self.public_parameters.opening_key.prepared_h),
-            (&witness.0, &prepared_inner_b),
-        ])
-        .final_exponentiation();
-
-        pairing == dusk_bls12_381::Gt::identity()
+    /// Get FFT settings for specified number of values, uses internal cache to avoid derivation
+    /// every time.
+    pub fn get_fft_settings(&self, num_values: usize) -> Result<Arc<FsFFTSettings>, String> {
+        Ok(match self.fft_settings_cache.lock().entry(num_values) {
+            Entry::Vacant(entry) => {
+                let fft_settings = Arc::new(FsFFTSettings::new(num_values.ilog2() as usize)?);
+                entry.insert(Arc::clone(&fft_settings));
+                fft_settings
+            }
+            Entry::Occupied(entry) => Arc::clone(entry.get()),
+        })
     }
 }

--- a/crates/subspace-core-primitives/src/crypto/kzg/tests.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg/tests.rs
@@ -1,5 +1,13 @@
-use crate::crypto::kzg::dusk_bytes::Serializable;
-use crate::crypto::kzg::{BlsScalar, Kzg};
+use crate::crypto::kzg::{embedded_kzg_settings, Kzg};
+use crate::Scalar;
+use blst_from_scratch::consts::{G1_GENERATOR, G2_GENERATOR};
+use blst_from_scratch::eip_4844::{bytes_from_g1_rust, bytes_from_g2_rust};
+use blst_from_scratch::types::fft_settings::FsFFTSettings;
+use blst_from_scratch::types::fr::FsFr;
+use blst_from_scratch::types::kzg_settings::FsKZGSettings;
+use kzg::{FFTSettings, Fr, G1Mul, G2Mul};
+use rand::Rng;
+use rand_core::SeedableRng;
 
 #[test]
 fn basic() {
@@ -8,19 +16,19 @@ fn basic() {
         let mut data = rand::random::<[u8; 256]>();
 
         // We can only store 254 bits, set last byte to zero because of that
-        data.chunks_exact_mut(BlsScalar::SIZE)
+        data.chunks_exact_mut(Scalar::FULL_BYTES)
             .flat_map(|chunk| chunk.iter_mut().last())
             .for_each(|last_byte| *last_byte = 0);
 
         data
     };
 
-    let kzg = Kzg::random(256).unwrap();
+    let kzg = Kzg::new(embedded_kzg_settings());
     let polynomial = kzg.poly(&data).unwrap();
     let commitment = kzg.commit(&polynomial).unwrap();
 
-    let values = data.chunks_exact(BlsScalar::SIZE);
-    let num_values = values.len() as u32;
+    let values = data.chunks_exact(Scalar::FULL_BYTES);
+    let num_values = values.len();
 
     for (index, value) in values.enumerate() {
         let index = index.try_into().unwrap();
@@ -32,4 +40,55 @@ fn basic() {
             "failed on index {index}"
         );
     }
+}
+
+fn test_public_parameters_generate() -> FsKZGSettings {
+    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1969897683899915189);
+    let scale = 15;
+    let secret_len = 2usize.pow(scale) + 1;
+
+    let s = FsFr::hash_to_bls_field(rng.gen());
+    let mut s_pow = FsFr::one();
+
+    let mut secret_g1 = Vec::with_capacity(secret_len);
+    let mut secret_g2 = Vec::with_capacity(secret_len);
+
+    for _ in 0..secret_len {
+        secret_g1.push(G1_GENERATOR.mul(&s_pow));
+        secret_g2.push(G2_GENERATOR.mul(&s_pow));
+
+        s_pow = s_pow.mul(&s);
+    }
+
+    let fft_settings =
+        FsFFTSettings::new(scale as usize).expect("Scale is within allowed bounds; qed");
+
+    // Below is the same as `FsKZGSettings::new(&s1, &s2, secret_len, &fft_settings)`, but without
+    // extra checks (parameters are static anyway) and without unnecessary allocations
+    FsKZGSettings {
+        fs: fft_settings,
+        secret_g1,
+        secret_g2,
+    }
+}
+
+fn kzg_settings_to_bytes(kzg_settings: &FsKZGSettings) -> Vec<u8> {
+    let mut bytes =
+        Vec::with_capacity(kzg_settings.secret_g1.len() * 48 + kzg_settings.secret_g2.len() * 96);
+    for g1 in kzg_settings.secret_g1.iter().map(bytes_from_g1_rust) {
+        bytes.extend_from_slice(&g1);
+    }
+    for g2 in kzg_settings.secret_g2.iter().map(bytes_from_g2_rust) {
+        bytes.extend_from_slice(&g2);
+    }
+
+    bytes
+}
+
+#[test]
+fn test_public_parameters_correct() {
+    assert_eq!(
+        kzg_settings_to_bytes(&test_public_parameters_generate()),
+        kzg_settings_to_bytes(&embedded_kzg_settings())
+    );
 }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -45,6 +45,10 @@ pub use pieces::{
 use scale_info::{Type, TypeInfo};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use uint::static_assertions::const_assert;
+
+// Refuse to compile on lower than 32-bit platforms
+const_assert!(core::mem::size_of::<usize>() >= core::mem::size_of::<u32>());
 
 /// Size of BLAKE2b-256 hash output (in bytes).
 pub const BLAKE2B_256_HASH_SIZE: usize = 32;

--- a/crates/subspace-erasure-coding/Cargo.toml
+++ b/crates/subspace-erasure-coding/Cargo.toml
@@ -11,8 +11,10 @@ include = [
 ]
 
 [dependencies]
-blst_from_scratch = { git = "https://github.com/sifraitech/rust-kzg", rev = "7eb52ca97576ea1eefe4dd2165f224c916f8c862", default-features = false }
-kzg = { git = "https://github.com/sifraitech/rust-kzg", rev = "7eb52ca97576ea1eefe4dd2165f224c916f8c862", default-features = false }
+# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
+# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
+kzg = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
@@ -23,5 +25,6 @@ rand = "0.8.5"
 default = ["std"]
 std = [
     "blst_from_scratch/std",
+    "kzg/std",
     "subspace-core-primitives/std",
 ]

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::default();
     let sector_index = 0;
     let input = vec![1u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -27,7 +27,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let sector_index = 0;
     let mut input = vec![0u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
     thread_rng().fill(input.as_mut_slice());
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -38,7 +38,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let sector_index = 0;
     let input = vec![1u8; RECORDED_HISTORY_SEGMENT_SIZE as usize];
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver =
         Archiver::new(RECORD_SIZE, RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::{PieceIndexHash, PLOT_SECTOR_SIZE};
 use subspace_farmer::single_disk_plot::{SingleDiskPlot, SingleDiskPlotOptions};
 use subspace_farmer::utils::farmer_piece_getter::FarmerPieceGetter;
@@ -107,7 +107,7 @@ pub(crate) async fn farm_multi_disk(
         Arc::downgrade(&readers_and_pieces),
     )?;
 
-    let kzg = Kzg::new(test_public_parameters());
+    let kzg = Kzg::new(embedded_kzg_settings());
     // TODO: Consider introducing and using global in-memory root block cache (this comment is in multiple files)
     let records_roots_cache = Mutex::new(LruCache::new(RECORDS_ROOTS_CACHE_SIZE));
     let piece_provider = PieceProvider::new(

--- a/crates/subspace-farmer/src/utils/piece_validator.rs
+++ b/crates/subspace-farmer/src/utils/piece_validator.rs
@@ -86,7 +86,7 @@ where
 
             if !is_piece_valid(
                 &self.kzg,
-                PIECES_IN_SEGMENT,
+                PIECES_IN_SEGMENT as usize,
                 piece.as_ref(),
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -29,7 +29,7 @@ use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::Arc;
 use std::task::Poll;
 use subspace_archiving::reconstructor::Reconstructor;
-use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::{
     Piece, PieceIndex, RootBlock, SegmentIndex, PIECES_IN_SEGMENT, RECORDED_HISTORY_SEGMENT_SIZE,
     RECORD_SIZE,
@@ -103,7 +103,7 @@ where
         node.clone(),
         Some(RecordsRootPieceValidator::new(
             node.clone(),
-            Kzg::new(test_public_parameters()),
+            Kzg::new(embedded_kzg_settings()),
             record_roots,
         )),
     );

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -47,7 +47,7 @@ impl PieceValidator for RecordsRootPieceValidator {
 
             if !is_piece_valid(
                 &self.kzg,
-                PIECES_IN_SEGMENT,
+                PIECES_IN_SEGMENT as usize,
                 piece.as_ref(),
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -73,7 +73,7 @@ use sp_session::SessionKeys;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
-use subspace_core_primitives::crypto::kzg::{test_public_parameters, Kzg};
+use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::PIECES_IN_SEGMENT;
 use subspace_fraud_proof::VerifyFraudProof;
 use subspace_networking::libp2p::multiaddr::Protocol;
@@ -272,7 +272,7 @@ where
     client
         .execution_extensions()
         .set_extensions_factory(SubspaceExtensionsFactory {
-            kzg: Kzg::new(test_public_parameters()),
+            kzg: Kzg::new(embedded_kzg_settings()),
         });
 
     let client = Arc::new(client);

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -73,7 +73,7 @@ pub fn check_reward_signature(
 /// If `records_root` is `None`, piece validity check will be skipped.
 pub fn check_piece<'a, FarmerPublicKey, RewardAddress>(
     kzg: &Kzg,
-    pieces_in_segment: u32,
+    pieces_in_segment: usize,
     records_root: &RecordsRoot,
     position: u32,
     solution: &'a Solution<FarmerPublicKey, RewardAddress>,
@@ -198,7 +198,13 @@ where
                 return Err(Error::MissingKzgInstance);
             }
         };
-        check_piece(kzg, *pieces_in_segment, records_root, position, solution)?;
+        check_piece(
+            kzg,
+            *pieces_in_segment as usize,
+            records_root,
+            position,
+            solution,
+        )?;
     }
 
     Ok(())

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -224,7 +224,7 @@ async fn plot_one_segment<Client>(
 where
     Client: BlockBackend<Block> + HeaderBackend<Block>,
 {
-    let kzg = Kzg::new(kzg::test_public_parameters());
+    let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = subspace_archiving::archiver::Archiver::new(
         RECORD_SIZE,
         RECORDED_HISTORY_SEGMENT_SIZE,


### PR DESCRIPTION
This is an upgrade from Dusk/Plonk stack to `rust-kzg`, the same that we use in `subspace-erasure-coding` crate.

`blst` library is used from a fork that is in https://github.com/supranational/blst/pull/150 (https://github.com/subspace/blst/tree/subspace-v1) and `rust-kzg` is used from a fork that uses this fork of `blst` library (https://github.com/subspace/rust-kzg/tree/subspace-v1).

Both of those forks are, hopefully, temporary.

Trusted setup for KZG is now designed for `2^15` elements, which is much bigger and no longer embedded in runtime by default. We verify solutions with runtime interface thanks to https://github.com/subspace/subspace/pull/1278 to make it still work and be fast too.

I think API can still be improved around handling of zero bit at the end of each 32 bytes chunk at input of polynomial creation, but this is good enough replacement for now before we make further changes.

Fixes #1280.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
