### PR TITLE
Better unified piece abstractions using a tiny bit of `unsafe`

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -41,7 +41,7 @@ use subspace_archiving::archiver::{ArchivedSegment, Archiver};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg, Witness};
 use subspace_core_primitives::crypto::{blake2b_256_254_hash_to_scalar, kzg, ScalarLegacy};
 use subspace_core_primitives::{
-    ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, Piece, Randomness, RecordsRoot,
+    ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, PieceArray, Randomness, RecordsRoot,
     RootBlock, SegmentIndex, Solution, SolutionRange, PIECE_SIZE, RECORDED_HISTORY_SEGMENT_SIZE,
 };
 use subspace_solving::{create_chunk_signature, derive_global_challenge, REWARD_SIGNING_CONTEXT};
@@ -362,7 +362,7 @@ pub fn create_signed_vote(
     parent_hash: <Block as BlockT>::Hash,
     slot: Slot,
     global_randomnesses: &Randomness,
-    piece: Piece,
+    piece: &PieceArray,
     reward_address: <Test as frame_system::Config>::AccountId,
 ) -> SignedVote<u64, <Block as BlockT>::Hash, <Test as frame_system::Config>::AccountId> {
     let reward_signing_context = schnorrkel::signing_context(REWARD_SIGNING_CONTEXT);
@@ -382,8 +382,8 @@ pub fn create_signed_vote(
             sector_index: 0,
             total_pieces: NonZeroU64::new(1).unwrap(),
             piece_offset: 0,
-            piece_record_hash: blake2b_256_254_hash_to_scalar(&piece.record()),
-            piece_witness: Witness::try_from_bytes(&piece.witness()).unwrap(),
+            piece_record_hash: blake2b_256_254_hash_to_scalar(piece.record().as_ref()),
+            piece_witness: Witness::try_from_bytes(piece.witness()).unwrap(),
             chunk_offset: 0,
             chunk,
             chunk_signature: create_chunk_signature(keypair, &chunk.to_bytes()),

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -44,7 +44,6 @@ use sp_runtime::transaction_validity::{
 use sp_runtime::DispatchError;
 use std::assert_matches::assert_matches;
 use std::collections::BTreeMap;
-use subspace_core_primitives::Piece;
 use subspace_runtime_primitives::{FindBlockRewardAddress, FindVotingRewardAddresses};
 use subspace_solving::REWARD_SIGNING_CONTEXT;
 use subspace_verification::Error as VerificationError;
@@ -628,7 +627,7 @@ fn vote_block_listed() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         BlockList::<Test>::insert(
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
@@ -658,7 +657,7 @@ fn vote_after_genesis() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         // Can't submit vote right after genesis block
         let signed_vote = create_signed_vote(
@@ -683,7 +682,7 @@ fn vote_too_low_height() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 1, 1);
 
@@ -696,7 +695,7 @@ fn vote_too_low_height() {
                 <Test as frame_system::Config>::Hash::default(),
                 Subspace::current_slot() + 1,
                 &Subspace::global_randomnesses().current,
-                piece.clone(),
+                piece,
                 1,
             );
 
@@ -713,7 +712,7 @@ fn vote_past_future_height() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 4, 1);
 
@@ -725,7 +724,7 @@ fn vote_past_future_height() {
                 <Test as frame_system::Config>::Hash::default(),
                 Subspace::current_slot() + 1,
                 &Subspace::global_randomnesses().current,
-                piece.clone(),
+                piece,
                 1,
             );
 
@@ -760,7 +759,7 @@ fn vote_wrong_parent() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -787,7 +786,7 @@ fn vote_past_future_slot() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         RecordsRoot::<Test>::insert(
             archived_segment.root_block.segment_index(),
@@ -809,7 +808,7 @@ fn vote_past_future_slot() {
                 frame_system::Pallet::<Test>::block_hash(2),
                 2.into(),
                 &Subspace::global_randomnesses().current,
-                piece.clone(),
+                piece,
                 1,
             );
 
@@ -845,7 +844,7 @@ fn vote_past_future_slot() {
         // in that context it is valid
         {
             let keypair = Keypair::generate();
-            let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+            let piece = &archived_segment.pieces[0];
 
             let signed_vote = create_signed_vote(
                 &keypair,
@@ -885,7 +884,7 @@ fn vote_same_slot() {
         // Same time slot in the vote as in the block is fine if height is the same (pre-dispatch)
         {
             let keypair = Keypair::generate();
-            let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+            let piece = &archived_segment.pieces[0];
             let signed_vote = create_signed_vote(
                 &keypair,
                 3,
@@ -903,7 +902,7 @@ fn vote_same_slot() {
         // (pre-dispatch)
         {
             let keypair = Keypair::generate();
-            let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+            let piece = &archived_segment.pieces[0];
             let signed_vote = create_signed_vote(
                 &keypair,
                 2,
@@ -927,7 +926,7 @@ fn vote_bad_reward_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -956,7 +955,7 @@ fn vote_unknown_records_root() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -983,7 +982,7 @@ fn vote_outside_of_solution_range() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1017,7 +1016,7 @@ fn vote_invalid_solution_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1070,7 +1069,7 @@ fn vote_correct_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1104,7 +1103,7 @@ fn vote_randomness_update() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         RecordsRoot::<Test>::insert(
             archived_segment.root_block.segment_index(),
@@ -1141,7 +1140,7 @@ fn vote_equivocation_current_block_plus_vote() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1192,7 +1191,7 @@ fn vote_equivocation_parent_block_plus_vote() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1252,7 +1251,7 @@ fn vote_equivocation_parent_block_plus_vote() {
 fn vote_equivocation_current_voters_duplicate() {
     new_test_ext().execute_with(|| {
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&Keypair::generate(), 2, 1);
 
@@ -1332,7 +1331,7 @@ fn vote_equivocation_parent_voters_duplicate() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
-        let piece = Piece::from(archived_segment.pieces.as_pieces().next().unwrap());
+        let piece = &archived_segment.pieces[0];
 
         progress_to_block(&keypair, 2, 1);
 

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -549,7 +549,7 @@ async fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + '
                 .await
                 .unwrap()
                 .iter()
-                .flat_map(|flat_pieces| flat_pieces.as_pieces())
+                .flat_map(|flat_pieces| flat_pieces.iter())
                 .enumerate()
                 .choose(&mut thread_rng())
                 .map(|(piece_index, piece)| (piece_index as u64, Piece::from(piece)))

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -91,7 +91,7 @@ impl Farmer {
         let kzg = Kzg::new(kzg::embedded_kzg_settings());
         let archived_segment = archived_segment(kzg.clone());
         let root_block = archived_segment.root_block;
-        let total_pieces = NonZeroU64::new(archived_segment.pieces.count() as u64).unwrap();
+        let total_pieces = NonZeroU64::new(archived_segment.pieces.len() as u64).unwrap();
         let mut sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
         let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
         let sector_index = 0;
@@ -150,7 +150,7 @@ impl PieceGetter for TestPieceGetter {
         Ok(self
             .archived_segment
             .pieces
-            .as_pieces()
+            .iter()
             .nth(piece_index as usize)
             .map(Piece::from))
     }

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -117,7 +117,7 @@ impl Reconstructor {
             .take(self.reed_solomon.data_shard_count())
             .all(|maybe_piece| {
                 if let Some(piece) = maybe_piece {
-                    segment_data.extend_from_slice(&piece.record());
+                    segment_data.extend_from_slice(piece.record().as_ref());
                     true
                 } else {
                     false

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -7,7 +7,7 @@ use subspace_archiving::archiver::{Archiver, ArchiverInstantiationError, Segment
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Commitment, Kzg};
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, PieceObject};
 use subspace_core_primitives::{
-    ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, PieceRef, RootBlock,
+    ArchivedBlockProgress, Blake2b256Hash, LastArchivedBlock, PieceArray, RootBlock,
     BLAKE2B_256_HASH_SIZE, RECORD_SIZE,
 };
 
@@ -25,7 +25,7 @@ fn extract_data<O: Into<u64>>(data: &[u8], offset: O) -> &[u8] {
 #[track_caller]
 fn compare_block_objects_to_piece_objects<'a>(
     block_objects: impl Iterator<Item = (&'a [u8], &'a BlockObject)>,
-    piece_objects: impl Iterator<Item = (PieceRef<'a>, &'a PieceObject)>,
+    piece_objects: impl Iterator<Item = (&'a PieceArray, &'a PieceObject)>,
 ) {
     block_objects.zip(piece_objects).for_each(
         |((block, block_object_mapping), (piece, piece_object_mapping))| {
@@ -110,7 +110,7 @@ fn archiver() {
 
     let first_archived_segment = archived_segments.into_iter().next().unwrap();
     assert_eq!(
-        first_archived_segment.pieces.count(),
+        first_archived_segment.pieces.len(),
         PIECES_IN_SEGMENT as usize
     );
     assert_eq!(first_archived_segment.root_block.segment_index(), 0);
@@ -136,7 +136,7 @@ fn archiver() {
             .chain(iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects.iter()));
         let piece_objects = first_archived_segment
             .pieces
-            .as_pieces()
+            .iter()
             .zip(&first_archived_segment.object_mapping)
             .flat_map(|(piece, object_mapping)| iter::repeat(piece).zip(&object_mapping.objects));
 
@@ -144,7 +144,7 @@ fn archiver() {
     }
 
     // Check that all pieces are valid
-    for (position, piece) in first_archived_segment.pieces.as_pieces().enumerate() {
+    for (position, piece) in first_archived_segment.pieces.iter().enumerate() {
         assert!(archiver::is_piece_valid(
             &kzg,
             PIECES_IN_SEGMENT as usize,
@@ -194,7 +194,7 @@ fn archiver() {
             iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects.iter().skip(2));
         let piece_objects = archived_segments[0]
             .pieces
-            .as_pieces()
+            .iter()
             .zip(&archived_segments[0].object_mapping)
             .flat_map(|(piece, object_mapping)| iter::repeat(piece).zip(&object_mapping.objects));
 
@@ -220,7 +220,7 @@ fn archiver() {
     let mut previous_root_block_hash = first_archived_segment.root_block.hash();
     let last_root_block = archived_segments.iter().last().unwrap().root_block;
     for archived_segment in archived_segments {
-        assert_eq!(archived_segment.pieces.count(), PIECES_IN_SEGMENT as usize);
+        assert_eq!(archived_segment.pieces.len(), PIECES_IN_SEGMENT as usize);
         assert_eq!(
             archived_segment.root_block.segment_index(),
             expected_segment_index
@@ -230,7 +230,7 @@ fn archiver() {
             previous_root_block_hash
         );
 
-        for (position, piece) in archived_segment.pieces.as_pieces().enumerate() {
+        for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 &kzg,
                 PIECES_IN_SEGMENT as usize,
@@ -274,7 +274,7 @@ fn archiver() {
         assert_eq!(last_archived_block.number, 3);
         assert_eq!(last_archived_block.partial_archived(), None);
 
-        for (position, piece) in archived_segment.pieces.as_pieces().enumerate() {
+        for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 &kzg,
                 PIECES_IN_SEGMENT as usize,
@@ -559,7 +559,7 @@ fn object_on_the_edge_of_segment() {
 
     // Ensure bytes are mapped correctly
     assert_eq!(
-        &archived_segments[1].pieces
+        &archived_segments[1].pieces.as_ref()
             [archived_segments[1].object_mapping[0].objects[0].offset() as usize..]
             [..mapped_bytes.len()],
         mapped_bytes.as_slice()

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -11,7 +11,7 @@ use subspace_core_primitives::{
 };
 
 fn flat_pieces_to_regular(pieces: &FlatPieces) -> Vec<Piece> {
-    pieces.as_pieces().map(Piece::from).collect()
+    pieces.iter().map(Piece::from).collect()
 }
 
 fn pieces_to_option_of_pieces(pieces: &[Piece]) -> Vec<Option<Piece>> {
@@ -59,8 +59,8 @@ fn segment_reconstruction_works() {
     pieces.iter().zip(reconstructed_pieces.iter()).for_each(
         |(original_piece, reconstructed_piece)| {
             assert_eq!(
-                blake2b_256_254_hash(original_piece),
-                blake2b_256_254_hash(reconstructed_piece)
+                blake2b_256_254_hash(original_piece.as_ref()),
+                blake2b_256_254_hash(reconstructed_piece.as_ref())
             );
         },
     );
@@ -98,8 +98,8 @@ fn piece_reconstruction_works() {
         .unwrap();
 
     assert_eq!(
-        blake2b_256_254_hash(&pieces[missing_piece_position]),
-        blake2b_256_254_hash(&missing_piece)
+        blake2b_256_254_hash(pieces[missing_piece_position].as_ref()),
+        blake2b_256_254_hash(missing_piece.as_ref())
     );
 }
 

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -17,7 +17,7 @@ const PIECES_IN_SEGMENT: u32 = 8;
 const SEGMENT_SIZE: u32 = RECORD_SIZE * PIECES_IN_SEGMENT / 2;
 
 fn flat_pieces_to_regular(pieces: &FlatPieces) -> Vec<Piece> {
-    pieces.as_pieces().map(Piece::from).collect()
+    pieces.iter().map(Piece::from).collect()
 }
 
 fn pieces_to_option_of_pieces(pieces: &[Piece]) -> Vec<Option<Piece>> {
@@ -341,7 +341,7 @@ fn invalid_usage() {
         let result = Reconstructor::new(SEGMENT_SIZE).unwrap().add_segment(
             &iter::repeat_with(|| {
                 let mut piece = Piece::default();
-                thread_rng().fill(*piece.as_mut());
+                thread_rng().fill(piece.as_mut());
                 Some(piece)
             })
             .take(PIECES_IN_SEGMENT as usize)

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms, missing_docs)]
 #![cfg_attr(feature = "std", warn(missing_debug_implementations))]
+#![feature(slice_flatten)]
 
 pub mod crypto;
 pub mod objects;
@@ -37,8 +38,7 @@ use derive_more::{Add, Deref, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode};
 pub use pieces::{
-    FlatPieces, Piece, PieceRef, PieceRefMut, RecordRef, RecordRefMut, WitnessRef, WitnessRefMut,
-    PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE,
+    FlatPieces, Piece, PieceArray, Record, RecordWitness, PIECE_SIZE, RECORD_SIZE, WITNESS_SIZE,
 };
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]

--- a/crates/subspace-core-primitives/src/pieces/serde.rs
+++ b/crates/subspace-core-primitives/src/pieces/serde.rs
@@ -1,0 +1,102 @@
+use crate::{FlatPieces, PIECE_SIZE};
+use hex::{decode_to_slice, FromHex, FromHexError};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+impl FromHex for FlatPieces {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let hex = hex.as_ref();
+        if hex.len() % 2 != 0 {
+            return Err(FromHexError::OddLength);
+        }
+        if hex.len() % (2 * PIECE_SIZE) != 0 {
+            return Err(FromHexError::InvalidStringLength);
+        }
+
+        let mut out = FlatPieces::new(hex.len() / 2 / PIECE_SIZE);
+
+        hex.chunks_exact(2 * PIECE_SIZE)
+            .zip(out.iter_mut())
+            .try_for_each(|(bytes, piece)| decode_to_slice(bytes, piece.as_mut()))?;
+
+        Ok(out)
+    }
+}
+
+impl Serialize for FlatPieces {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serializer::serialize_newtype_struct(serializer, "FlatPieces", {
+            struct SerializeWith<'a> {
+                values: &'a [u8],
+            }
+            impl<'a> Serialize for SerializeWith<'a> {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    hex::serde::serialize(self.values, serializer)
+                }
+            }
+            &SerializeWith {
+                values: self.as_ref(),
+            }
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for FlatPieces {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = FlatPieces;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("tuple struct FlatPieces")
+            }
+
+            #[inline]
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                hex::serde::deserialize(deserializer)
+            }
+
+            #[inline]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                struct DeserializeWith {
+                    value: FlatPieces,
+                }
+                impl<'de> Deserialize<'de> for DeserializeWith {
+                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where
+                        D: Deserializer<'de>,
+                    {
+                        Ok(DeserializeWith {
+                            value: hex::serde::deserialize(deserializer)?,
+                        })
+                    }
+                }
+
+                de::SeqAccess::next_element::<DeserializeWith>(&mut seq)?
+                    .map(|wrap| wrap.value)
+                    .ok_or(de::Error::invalid_length(
+                        0usize,
+                        &"tuple struct FlatPieces with 1 element",
+                    ))
+            }
+        }
+        Deserializer::deserialize_newtype_struct(deserializer, "FlatPieces", Visitor)
+    }
+}

--- a/crates/subspace-core-primitives/src/pieces/serde.rs
+++ b/crates/subspace-core-primitives/src/pieces/serde.rs
@@ -1,6 +1,103 @@
-use crate::{FlatPieces, PIECE_SIZE};
+use crate::{FlatPieces, PieceArray, PIECE_SIZE};
 use hex::{decode_to_slice, FromHex, FromHexError};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+impl FromHex for PieceArray {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let hex = hex.as_ref();
+        if hex.len() % 2 != 0 {
+            return Err(FromHexError::OddLength);
+        }
+        if hex.len() != 2 * PIECE_SIZE {
+            return Err(FromHexError::InvalidStringLength);
+        }
+
+        let mut out = Self::default();
+
+        decode_to_slice(hex, out.as_mut_slice())?;
+
+        Ok(out)
+    }
+}
+
+impl Serialize for PieceArray {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serializer::serialize_newtype_struct(serializer, "PieceArray", {
+            struct SerializeWith<'a> {
+                values: &'a [u8],
+            }
+            impl<'a> Serialize for SerializeWith<'a> {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    hex::serde::serialize(self.values, serializer)
+                }
+            }
+            &SerializeWith {
+                values: self.as_ref(),
+            }
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for PieceArray {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = PieceArray;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("tuple struct PieceArray")
+            }
+
+            #[inline]
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                hex::serde::deserialize(deserializer)
+            }
+
+            #[inline]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                struct DeserializeWith {
+                    value: PieceArray,
+                }
+                impl<'de> Deserialize<'de> for DeserializeWith {
+                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where
+                        D: Deserializer<'de>,
+                    {
+                        Ok(DeserializeWith {
+                            value: hex::serde::deserialize(deserializer)?,
+                        })
+                    }
+                }
+
+                de::SeqAccess::next_element::<DeserializeWith>(&mut seq)?
+                    .map(|wrap| wrap.value)
+                    .ok_or(de::Error::invalid_length(
+                        0usize,
+                        &"tuple struct PieceArray with 1 element",
+                    ))
+            }
+        }
+        Deserializer::deserialize_newtype_struct(deserializer, "PieceArray", Visitor)
+    }
+}
 
 impl FromHex for FlatPieces {
     type Error = FromHexError;

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -11,8 +11,7 @@ use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
-    Blake2b256Hash, Piece, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE,
-    RECORD_SIZE,
+    Blake2b256Hash, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE, RECORD_SIZE,
 };
 use subspace_farmer_components::farming::audit_sector;
 use subspace_farmer_components::file_ext::FileExt;
@@ -39,17 +38,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = Piece::from(
-        archiver
-            .add_block(input, Default::default())
-            .into_iter()
-            .next()
-            .unwrap()
-            .pieces
-            .as_pieces()
-            .next()
-            .unwrap(),
-    );
+    let piece = archiver
+        .add_block(input, Default::default())
+        .into_iter()
+        .next()
+        .unwrap()
+        .pieces[0]
+        .into();
 
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -10,9 +10,7 @@ use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
-use subspace_core_primitives::{
-    Piece, PublicKey, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE, RECORD_SIZE,
-};
+use subspace_core_primitives::{PublicKey, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE, RECORD_SIZE};
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
 use subspace_farmer_components::FarmerProtocolInfo;
 use utils::BenchPieceGetter;
@@ -30,17 +28,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = Piece::from(
-        archiver
-            .add_block(input, Default::default())
-            .into_iter()
-            .next()
-            .unwrap()
-            .pieces
-            .as_pieces()
-            .next()
-            .unwrap(),
-    );
+    let piece = archiver
+        .add_block(input, Default::default())
+        .into_iter()
+        .next()
+        .unwrap()
+        .pieces[0]
+        .into();
 
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -12,8 +12,7 @@ use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
-    Blake2b256Hash, Piece, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE,
-    RECORD_SIZE,
+    Blake2b256Hash, PublicKey, SolutionRange, PIECES_IN_SEGMENT, PLOT_SECTOR_SIZE, RECORD_SIZE,
 };
 use subspace_farmer_components::farming::audit_sector;
 use subspace_farmer_components::file_ext::FileExt;
@@ -41,17 +40,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(RECORDED_HISTORY_SEGMENT_SIZE, kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = Piece::from(
-        archiver
-            .add_block(input, Default::default())
-            .into_iter()
-            .next()
-            .unwrap()
-            .pieces
-            .as_pieces()
-            .next()
-            .unwrap(),
-    );
+    let piece = archiver
+        .add_block(input, Default::default())
+        .into_iter()
+        .next()
+        .unwrap()
+        .pieces[0]
+        .into();
 
     let farmer_protocol_info = FarmerProtocolInfo {
         record_size: NonZeroU32::new(RECORD_SIZE).unwrap(),

--- a/crates/subspace-farmer-components/src/farming.rs
+++ b/crates/subspace-farmer-components/src/farming.rs
@@ -115,7 +115,7 @@ impl EligibleSector {
             });
 
         let (record, witness) = piece.split();
-        let piece_witness = match Witness::try_from_bytes(&witness) {
+        let piece_witness = match Witness::try_from_bytes(witness) {
             Ok(piece_witness) => piece_witness,
             Err(error) => {
                 let piece_index = self
@@ -143,7 +143,7 @@ impl EligibleSector {
                 sector_index: self.sector_index,
                 total_pieces: sector_metadata.total_pieces,
                 piece_offset: self.audit_piece_offset,
-                piece_record_hash: blake2b_256_254_hash_to_scalar(&record),
+                piece_record_hash: blake2b_256_254_hash_to_scalar(record.as_ref()),
                 piece_witness,
                 chunk_offset: offset,
                 chunk,
@@ -178,7 +178,7 @@ where
 
     let mut piece = Piece::default();
     sector.seek(SeekFrom::Current(audit_piece_bytes_offset as i64))?;
-    sector.read_exact(&mut piece)?;
+    sector.read_exact(piece.as_mut())?;
 
     let chunks = piece
         .chunks_exact(ScalarLegacy::FULL_BYTES)

--- a/crates/subspace-farmer/src/utils/piece_validator.rs
+++ b/crates/subspace-farmer/src/utils/piece_validator.rs
@@ -87,7 +87,7 @@ where
             if !is_piece_valid(
                 &self.kzg,
                 PIECES_IN_SEGMENT as usize,
-                piece.as_ref(),
+                &piece,
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
                     .expect("Always fix into u32; qed"),

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -228,7 +228,7 @@ impl RpcServerImpl {
 
         let piece = self.read_and_decode_piece(next_piece_index)?;
         next_piece_index += 1;
-        read_records_data.extend_from_slice(&piece.record());
+        read_records_data.extend_from_slice(piece.record().as_ref());
 
         // Let's see how many bytes encode compact length encoding of the data, see
         // https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers for
@@ -261,7 +261,7 @@ impl RpcServerImpl {
                 // Need the next piece to read the length of data
                 let piece = self.read_and_decode_piece(next_piece_index)?;
                 next_piece_index += 1;
-                read_records_data.extend_from_slice(&piece.record());
+                read_records_data.extend_from_slice(piece.record().as_ref());
             }
 
             Compact::<u32>::decode(&mut &read_records_data[offset as usize..])
@@ -395,7 +395,7 @@ impl RpcServerImpl {
 
         for piece_index in (first_piece_in_segment..).take(self.pieces_in_segment as usize / 2) {
             let piece = self.read_and_decode_piece(piece_index)?;
-            segment_bytes.extend_from_slice(&piece.record());
+            segment_bytes.extend_from_slice(piece.record().as_ref());
         }
 
         let segment = Segment::decode(&mut segment_bytes.as_slice()).map_err(|error| {

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -274,7 +274,7 @@ pub(crate) async fn publish_pieces(
     segment_index: u64,
     archived_segment: Arc<ArchivedSegment>,
 ) {
-    let pieces_indexes = (first_piece_index..).take(archived_segment.pieces.count());
+    let pieces_indexes = (first_piece_index..).take(archived_segment.pieces.len());
 
     let mut pieces_publishing_futures = pieces_indexes
         .map(|piece_index| announce_single_piece_index_with_backoff(piece_index, node))

--- a/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/piece_validator.rs
@@ -48,7 +48,7 @@ impl PieceValidator for RecordsRootPieceValidator {
             if !is_piece_valid(
                 &self.kzg,
                 PIECES_IN_SEGMENT as usize,
-                piece.as_ref(),
+                &piece,
                 records_root,
                 u32::try_from(piece_index % PieceIndex::from(PIECES_IN_SEGMENT))
                     .expect("Always fix into u32; qed"),

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -120,9 +120,7 @@ where
             return Ok(());
         }
 
-        let insert_indexes = (first_piece_index..)
-            .take(pieces.count())
-            .collect::<Vec<_>>();
+        let insert_indexes = (first_piece_index..).take(pieces.len()).collect::<Vec<_>>();
 
         let delete_indexes = first_piece_index
             .checked_sub(self.max_pieces_in_cache)
@@ -146,8 +144,8 @@ where
         self.aux_store.insert_aux(
             &insert_keys
                 .iter()
-                .zip(pieces.as_pieces())
-                .map(|(key, piece)| (key.as_slice(), (*piece).as_ref()))
+                .zip(pieces.iter())
+                .map(|(key, piece)| (key.as_slice(), piece.as_ref()))
                 .collect::<Vec<_>>(),
             &delete_keys
                 .iter()

--- a/crates/subspace-service/src/piece_cache/tests.rs
+++ b/crates/subspace-service/src/piece_cache/tests.rs
@@ -69,7 +69,7 @@ fn basic() {
         .unwrap();
     let piece = piece_res.unwrap();
 
-    assert_eq!(piece_by_kad_key.as_ref(), piece.as_ref());
+    assert_eq!(piece_by_kad_key, piece);
 }
 
 #[test]

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -210,7 +210,7 @@ impl PieceGetter for TestPieceGetter {
         Ok(self
             .archived_segment
             .pieces
-            .as_pieces()
+            .iter()
             .nth(piece_index as usize)
             .map(Piece::from))
     }
@@ -235,7 +235,7 @@ where
         .into_iter()
         .next()
         .expect("First block is always producing one segment; qed");
-    let total_pieces = NonZeroU64::new(archived_segment.pieces.count() as u64).unwrap();
+    let total_pieces = NonZeroU64::new(archived_segment.pieces.len() as u64).unwrap();
     let mut sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
     let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
     let sector_index = 0;


### PR DESCRIPTION
Previous iteration relied on safe code only and had usability shortcomings. With just a bit of `unsafe` in strategic places it was possible to make API **A LOT** better. I'm actually proud of what I have achieved here in the end.

The main changes are in `pieces.rs`. Many of the methods were wrappers round memory slices, but with `transmute` we can turn references to arrays of bytes into references to transparent data structures containing arrays of bytes. With reference out of the data structure we don't need a pair of data structures for mutable and immutable reference scenarios.

The biggest piece of code is related to serde support. I basically took previous expanded version and adjusted it to new internal layout of `FlatPieces` because derivation was no longer possible.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
