### PR TITLE
Introduce `ExecutorStreams` and fix the client block import notification subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9906,6 +9906,7 @@ dependencies = [
  "core-payments-domain-runtime",
  "cross-domain-message-gossip",
  "dirs",
+ "domain-client-executor",
  "domain-runtime-primitives",
  "domain-service",
  "frame-benchmarking",

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "4.1.6", features = ["derive"] }
 cross-domain-message-gossip = { version = "0.1.0", path = "../../domains/client/cross-domain-message-gossip" }
 core-payments-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/core-payments" }
 dirs = "4.0.0"
+domain-client-executor = { version = "0.1.0", path = "../../domains/client/domain-executor" }
 domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232", default-features = false }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -22,6 +22,7 @@ use frame_benchmarking_cli::BenchmarkCmd;
 use futures::future::TryFutureExt;
 use futures::StreamExt;
 use sc_cli::{ChainSpec, CliConfiguration, SubstrateCli};
+use sc_client_api::BlockchainEvents;
 use sc_consensus_slots::SlotProportion;
 use sc_executor::NativeExecutionDispatch;
 use sc_service::PartialComponents;
@@ -549,11 +550,15 @@ fn main() -> Result<(), Error> {
                         primary_block_import_throttling_buffer_size,
                         subspace_imported_block_notification_stream:
                             imported_block_notification_stream(),
+                        client_imported_block_notification_stream: primary_chain_node
+                            .client
+                            .every_import_notification_stream(),
                         new_slot_notification_stream: new_slot_notification_stream(),
                         _phantom: Default::default(),
                     };
 
                     let system_domain_node = domain_service::new_full_system::<
+                        _,
                         _,
                         _,
                         _,
@@ -597,6 +602,9 @@ fn main() -> Result<(), Error> {
                             primary_block_import_throttling_buffer_size,
                             subspace_imported_block_notification_stream:
                                 imported_block_notification_stream(),
+                            client_imported_block_notification_stream: primary_chain_node
+                                .client
+                                .every_import_notification_stream(),
                             new_slot_notification_stream: new_slot_notification_stream(),
                             _phantom: Default::default(),
                         };
@@ -617,6 +625,7 @@ fn main() -> Result<(), Error> {
                             DomainId::CORE_PAYMENTS => {
                                 let core_domain_node =
                                     domain_service::new_full_core::<
+                                        _,
                                         _,
                                         _,
                                         _,

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -373,7 +373,7 @@ fn main() -> Result<(), Error> {
                     .cloned();
 
                 // TODO: proper value
-                let block_import_throttling_buffer_size = 10;
+                let primary_block_import_throttling_buffer_size = 10;
 
                 let mut primary_chain_node = {
                     let span = sc_tracing::tracing::info_span!(
@@ -546,8 +546,9 @@ fn main() -> Result<(), Error> {
                         tracing_unbounded("cross_domain_gossip_messages", 100);
 
                     let executor_streams = ExecutorStreams {
-                        block_import_throttling_buffer_size,
-                        imported_block_notification_stream: imported_block_notification_stream(),
+                        primary_block_import_throttling_buffer_size,
+                        subspace_imported_block_notification_stream:
+                            imported_block_notification_stream(),
                         new_slot_notification_stream: new_slot_notification_stream(),
                         _phantom: Default::default(),
                     };
@@ -593,9 +594,9 @@ fn main() -> Result<(), Error> {
                             })?;
 
                         let executor_streams = ExecutorStreams {
-                            block_import_throttling_buffer_size,
-                            imported_block_notification_stream: imported_block_notification_stream(
-                            ),
+                            primary_block_import_throttling_buffer_size,
+                            subspace_imported_block_notification_stream:
+                                imported_block_notification_stream(),
                             new_slot_notification_stream: new_slot_notification_stream(),
                             _phantom: Default::default(),
                         };

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -23,7 +23,10 @@ use crate::{ExecutorStreams, TransactionFor};
 use domain_runtime_primitives::{AccountId, DomainCoreApi};
 use futures::channel::mpsc;
 use futures::{future, FutureExt, Stream, StreamExt, TryFutureExt};
-use sc_client_api::{AuxStore, BlockBackend, BlockchainEvents, ProofProvider, StateBackendFor};
+use sc_client_api::{
+    AuxStore, BlockBackend, BlockImportNotification, BlockchainEvents, ProofProvider,
+    StateBackendFor,
+};
 use sc_consensus::BlockImport;
 use sp_api::{BlockT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
@@ -49,6 +52,7 @@ pub(super) async fn start_worker<
     TransactionPool,
     Backend,
     IBNS,
+    CIBNS,
     NSNS,
     E,
 >(
@@ -75,7 +79,7 @@ pub(super) async fn start_worker<
         Backend,
         E,
     >,
-    executor_streams: ExecutorStreams<PBlock, IBNS, NSNS>,
+    executor_streams: ExecutorStreams<PBlock, IBNS, CIBNS, NSNS>,
     active_leaves: Vec<BlockInfo<PBlock>>,
 ) where
     Block: BlockT,
@@ -110,6 +114,7 @@ pub(super) async fn start_worker<
     TransactionPool: sc_transaction_pool_api::TransactionPool<Block = Block> + 'static,
     Backend: sc_client_api::Backend<Block> + 'static,
     IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
+    CIBNS: Stream<Item = BlockImportNotification<PBlock>> + Send + 'static,
     NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
     TransactionFor<Backend, Block>: sp_trie::HashDBT<HashFor<Block>, sp_trie::DBValue>,
     E: CodeExecutor,
@@ -119,12 +124,13 @@ pub(super) async fn start_worker<
     let ExecutorStreams {
         primary_block_import_throttling_buffer_size,
         subspace_imported_block_notification_stream,
+        client_imported_block_notification_stream,
         new_slot_notification_stream,
         _phantom,
     } = executor_streams;
 
     let handle_block_import_notifications_fut =
-        handle_block_import_notifications::<Block, PBlock, _, _, _>(
+        handle_block_import_notifications::<Block, PBlock, _, _, _, _>(
             primary_chain_client.as_ref(),
             client.info().best_number,
             {
@@ -149,6 +155,7 @@ pub(super) async fn start_worker<
                 )
                 .collect(),
             Box::pin(subspace_imported_block_notification_stream),
+            Box::pin(client_imported_block_notification_stream),
             primary_block_import_throttling_buffer_size,
         );
     let handle_slot_notifications_fut = handle_slot_notifications::<Block, PBlock, _, _>(

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -117,8 +117,8 @@ pub(super) async fn start_worker<
     let span = tracing::Span::current();
 
     let ExecutorStreams {
-        block_import_throttling_buffer_size,
-        imported_block_notification_stream,
+        primary_block_import_throttling_buffer_size,
+        subspace_imported_block_notification_stream,
         new_slot_notification_stream,
         _phantom,
     } = executor_streams;
@@ -148,8 +148,8 @@ pub(super) async fn start_worker<
                      }| (hash, number),
                 )
                 .collect(),
-            Box::pin(imported_block_notification_stream),
-            block_import_throttling_buffer_size,
+            Box::pin(subspace_imported_block_notification_stream),
+            primary_block_import_throttling_buffer_size,
         );
     let handle_slot_notifications_fut = handle_slot_notifications::<Block, PBlock, _, _>(
         primary_chain_client.as_ref(),

--- a/domains/client/domain-executor/src/core_executor.rs
+++ b/domains/client/domain-executor/src/core_executor.rs
@@ -161,10 +161,8 @@ where
                 params.is_authority,
                 bundle_producer,
                 bundle_processor,
-                params.imported_block_notification_stream,
-                params.new_slot_notification_stream,
+                params.executor_streams,
                 active_leaves,
-                params.block_import_throttling_buffer_size,
             )
             .boxed(),
         );

--- a/domains/client/domain-executor/src/core_executor.rs
+++ b/domains/client/domain-executor/src/core_executor.rs
@@ -7,7 +7,10 @@ use crate::{active_leaves, EssentialExecutorParams, TransactionFor};
 use domain_runtime_primitives::{AccountId, DomainCoreApi};
 use futures::channel::mpsc;
 use futures::{FutureExt, Stream};
-use sc_client_api::{AuxStore, BlockBackend, BlockchainEvents, ProofProvider, StateBackendFor};
+use sc_client_api::{
+    AuxStore, BlockBackend, BlockImportNotification, BlockchainEvents, ProofProvider,
+    StateBackendFor,
+};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::SelectChain;
@@ -88,7 +91,7 @@ where
     E: CodeExecutor,
 {
     /// Create a new instance.
-    pub async fn new<SE, SC, IBNS, NSNS>(
+    pub async fn new<SE, SC, IBNS, CIBNS, NSNS>(
         domain_id: DomainId,
         system_domain_client: Arc<SClient>,
         spawn_essential: &SE,
@@ -102,6 +105,7 @@ where
             Backend,
             E,
             IBNS,
+            CIBNS,
             NSNS,
         >,
     ) -> Result<Self, sp_consensus::Error>
@@ -109,6 +113,7 @@ where
         SE: SpawnEssentialNamed,
         SC: SelectChain<PBlock>,
         IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
+        CIBNS: Stream<Item = BlockImportNotification<PBlock>> + Send + 'static,
         NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
     {
         let active_leaves =

--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -58,7 +58,7 @@ pub(crate) async fn handle_block_import_notifications<
     processor: ProcessorFn,
     mut leaves: Vec<(PBlock::Hash, NumberFor<PBlock>)>,
     mut block_imports: BlockImports,
-    block_import_throttling_buffer_size: u32,
+    primary_block_import_throttling_buffer_size: u32,
 ) where
     Block: BlockT,
     PBlock: BlockT,
@@ -97,7 +97,7 @@ pub(crate) async fn handle_block_import_notifications<
     // consumed by the domain processor, the other from `sc-consensus-subspace` is used to discontinue
     // the primary block import in case the primary chain runs much faster than the domain.).
     let (mut block_info_sender, mut block_info_receiver) =
-        mpsc::channel(block_import_throttling_buffer_size as usize);
+        mpsc::channel(primary_block_import_throttling_buffer_size as usize);
 
     let mut client_block_import = primary_chain_client.every_import_notification_stream();
 

--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -2,7 +2,7 @@ use crate::utils::{to_number_primitive, BlockInfo, ExecutorSlotInfo};
 use codec::{Decode, Encode};
 use futures::channel::mpsc;
 use futures::{SinkExt, Stream, StreamExt};
-use sc_client_api::{BlockBackend, BlockchainEvents};
+use sc_client_api::{BlockBackend, BlockImportNotification, BlockchainEvents};
 use sp_api::{ApiError, BlockT, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_domains::{ExecutorApi, SignedOpaqueBundle};
@@ -51,13 +51,15 @@ pub(crate) async fn handle_block_import_notifications<
     PBlock,
     PClient,
     ProcessorFn,
-    BlockImports,
+    SubspaceBlockImports,
+    ClientBlockImports,
 >(
     primary_chain_client: &PClient,
     best_domain_number: NumberFor<Block>,
     processor: ProcessorFn,
     mut leaves: Vec<(PBlock::Hash, NumberFor<PBlock>)>,
-    mut block_imports: BlockImports,
+    mut subspace_block_imports: SubspaceBlockImports,
+    mut client_block_imports: ClientBlockImports,
     primary_block_import_throttling_buffer_size: u32,
 ) where
     Block: BlockT,
@@ -72,7 +74,8 @@ pub(crate) async fn handle_block_import_notifications<
         ) -> Pin<Box<dyn Future<Output = Result<(), sp_blockchain::Error>> + Send>>
         + Send
         + Sync,
-    BlockImports: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Unpin,
+    SubspaceBlockImports: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Unpin,
+    ClientBlockImports: Stream<Item = BlockImportNotification<PBlock>> + Unpin,
 {
     let mut active_leaves = HashMap::with_capacity(leaves.len());
 
@@ -99,11 +102,9 @@ pub(crate) async fn handle_block_import_notifications<
     let (mut block_info_sender, mut block_info_receiver) =
         mpsc::channel(primary_block_import_throttling_buffer_size as usize);
 
-    let mut client_block_import = primary_chain_client.every_import_notification_stream();
-
     loop {
         tokio::select! {
-            maybe_client_block_import = client_block_import.next() => {
+            maybe_client_block_import = client_block_imports.next() => {
                 let notification = match maybe_client_block_import {
                     Some(block_import) => block_import,
                     None => {
@@ -129,7 +130,7 @@ pub(crate) async fn handle_block_import_notifications<
                 };
                 let _ = block_info_sender.feed(Some(block_info)).await;
             }
-            maybe_subspace_block_import = block_imports.next() => {
+            maybe_subspace_block_import = subspace_block_imports.next() => {
                 let (_block_number, mut block_import_acknowledgement_sender) =
                     match maybe_subspace_block_import {
                         Some(block_import) => block_import,

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -111,6 +111,7 @@ pub use self::system_gossip_message_validator::SystemGossipMessageValidator;
 use crate::utils::BlockInfo;
 use futures::channel::mpsc;
 use futures::Stream;
+use sc_client_api::BlockImportNotification;
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -144,7 +145,7 @@ type BundleSender<Block, PBlock> = TracingUnboundedSender<
 >;
 
 /// Notification streams from the primary chain driving the executor.
-pub struct ExecutorStreams<PBlock, IBNS, NSNS> {
+pub struct ExecutorStreams<PBlock, IBNS, CIBNS, NSNS> {
     /// Pause the primary block import when the primary chain client
     /// runs much faster than the domain client.
     pub primary_block_import_throttling_buffer_size: u32,
@@ -152,6 +153,10 @@ pub struct ExecutorStreams<PBlock, IBNS, NSNS> {
     ///
     /// Fired before the completion of entire block import pipeline.
     pub subspace_imported_block_notification_stream: IBNS,
+    /// Primary block import nofication from the native client.
+    ///
+    /// Fired after the completion of entire block import pipeline.
+    pub client_imported_block_notification_stream: CIBNS,
     /// New slot arrives.
     pub new_slot_notification_stream: NSNS,
     pub _phantom: PhantomData<PBlock>,
@@ -166,11 +171,13 @@ pub struct EssentialExecutorParams<
     Backend,
     E,
     IBNS,
+    CIBNS,
     NSNS,
 > where
     Block: BlockT,
     PBlock: BlockT,
     IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
+    CIBNS: Stream<Item = BlockImportNotification<PBlock>> + Send + 'static,
     NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
 {
     pub primary_chain_client: Arc<PClient>,
@@ -183,7 +190,7 @@ pub struct EssentialExecutorParams<
     pub keystore: SyncCryptoStorePtr,
     pub spawner: Box<dyn SpawnNamed + Send + Sync>,
     pub bundle_sender: Arc<BundleSender<Block, PBlock>>,
-    pub executor_streams: ExecutorStreams<PBlock, IBNS, NSNS>,
+    pub executor_streams: ExecutorStreams<PBlock, IBNS, CIBNS, NSNS>,
 }
 
 /// Returns the active leaves the overseer should start with.

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -122,6 +122,7 @@ use sp_keystore::SyncCryptoStorePtr;
 use sp_runtime::traits::{
     Block as BlockT, HashFor, Header as HeaderT, NumberFor, One, Saturating, Zero,
 };
+use std::marker::PhantomData;
 use std::sync::Arc;
 use subspace_core_primitives::Blake2b256Hash;
 
@@ -141,6 +142,13 @@ type BundleSender<Block, PBlock> = TracingUnboundedSender<
         <Block as BlockT>::Hash,
     >,
 >;
+
+pub struct ExecutorStreams<PBlock, IBNS, NSNS> {
+    pub block_import_throttling_buffer_size: u32,
+    pub imported_block_notification_stream: IBNS,
+    pub new_slot_notification_stream: NSNS,
+    pub _phantom: PhantomData<PBlock>,
+}
 
 pub struct EssentialExecutorParams<
     Block,
@@ -168,9 +176,7 @@ pub struct EssentialExecutorParams<
     pub keystore: SyncCryptoStorePtr,
     pub spawner: Box<dyn SpawnNamed + Send + Sync>,
     pub bundle_sender: Arc<BundleSender<Block, PBlock>>,
-    pub block_import_throttling_buffer_size: u32,
-    pub imported_block_notification_stream: IBNS,
-    pub new_slot_notification_stream: NSNS,
+    pub executor_streams: ExecutorStreams<PBlock, IBNS, NSNS>,
 }
 
 /// Returns the active leaves the overseer should start with.

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -143,9 +143,16 @@ type BundleSender<Block, PBlock> = TracingUnboundedSender<
     >,
 >;
 
+/// Notification streams from the primary chain driving the executor.
 pub struct ExecutorStreams<PBlock, IBNS, NSNS> {
-    pub block_import_throttling_buffer_size: u32,
-    pub imported_block_notification_stream: IBNS,
+    /// Pause the primary block import when the primary chain client
+    /// runs much faster than the domain client.
+    pub primary_block_import_throttling_buffer_size: u32,
+    /// Primary block import notification from `sc-consensus-subspace`.
+    ///
+    /// Fired before the completion of entire block import pipeline.
+    pub subspace_imported_block_notification_stream: IBNS,
+    /// New slot arrives.
     pub new_slot_notification_stream: NSNS,
     pub _phantom: PhantomData<PBlock>,
 }

--- a/domains/client/domain-executor/src/system_domain_worker.rs
+++ b/domains/client/domain-executor/src/system_domain_worker.rs
@@ -19,7 +19,7 @@ use crate::domain_worker::{handle_block_import_notifications, handle_slot_notifi
 use crate::parent_chain::SystemDomainParentChain;
 use crate::system_bundle_processor::SystemBundleProcessor;
 use crate::utils::{BlockInfo, ExecutorSlotInfo};
-use crate::TransactionFor;
+use crate::{ExecutorStreams, TransactionFor};
 use domain_runtime_primitives::{AccountId, DomainCoreApi};
 use futures::channel::mpsc;
 use futures::{future, FutureExt, Stream, StreamExt, TryFutureExt};
@@ -38,7 +38,6 @@ use subspace_core_primitives::Blake2b256Hash;
 use system_runtime_primitives::SystemDomainApi;
 use tracing::Instrument;
 
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub(super) async fn start_worker<
     Block,
@@ -65,10 +64,8 @@ pub(super) async fn start_worker<
         TransactionPool,
     >,
     bundle_processor: SystemBundleProcessor<Block, PBlock, Client, PClient, Backend, E>,
-    imported_block_notification_stream: IBNS,
-    new_slot_notification_stream: NSNS,
+    executor_streams: ExecutorStreams<PBlock, IBNS, NSNS>,
     active_leaves: Vec<BlockInfo<PBlock>>,
-    block_import_throttling_buffer_size: u32,
 ) where
     Block: BlockT,
     PBlock: BlockT,
@@ -105,6 +102,13 @@ pub(super) async fn start_worker<
     E: CodeExecutor,
 {
     let span = tracing::Span::current();
+
+    let ExecutorStreams {
+        block_import_throttling_buffer_size,
+        imported_block_notification_stream,
+        new_slot_notification_stream,
+        _phantom,
+    } = executor_streams;
 
     let handle_block_import_notifications_fut =
         handle_block_import_notifications::<Block, _, _, _, _>(

--- a/domains/client/domain-executor/src/system_domain_worker.rs
+++ b/domains/client/domain-executor/src/system_domain_worker.rs
@@ -104,8 +104,8 @@ pub(super) async fn start_worker<
     let span = tracing::Span::current();
 
     let ExecutorStreams {
-        block_import_throttling_buffer_size,
-        imported_block_notification_stream,
+        primary_block_import_throttling_buffer_size,
+        subspace_imported_block_notification_stream,
         new_slot_notification_stream,
         _phantom,
     } = executor_streams;
@@ -135,8 +135,8 @@ pub(super) async fn start_worker<
                      }| (hash, number),
                 )
                 .collect(),
-            Box::pin(imported_block_notification_stream),
-            block_import_throttling_buffer_size,
+            Box::pin(subspace_imported_block_notification_stream),
+            primary_block_import_throttling_buffer_size,
         );
     let handle_slot_notifications_fut = handle_slot_notifications::<Block, PBlock, _, _>(
         primary_chain_client.as_ref(),

--- a/domains/client/domain-executor/src/system_executor.rs
+++ b/domains/client/domain-executor/src/system_executor.rs
@@ -7,7 +7,10 @@ use crate::{active_leaves, EssentialExecutorParams, TransactionFor};
 use domain_runtime_primitives::{AccountId, DomainCoreApi};
 use futures::channel::mpsc;
 use futures::{FutureExt, Stream};
-use sc_client_api::{AuxStore, BlockBackend, BlockchainEvents, ProofProvider, StateBackendFor};
+use sc_client_api::{
+    AuxStore, BlockBackend, BlockImportNotification, BlockchainEvents, ProofProvider,
+    StateBackendFor,
+};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::SelectChain;
@@ -90,7 +93,7 @@ where
     E: CodeExecutor,
 {
     /// Create a new instance.
-    pub async fn new<SE, SC, IBNS, NSNS>(
+    pub async fn new<SE, SC, IBNS, CIBNS, NSNS>(
         spawn_essential: &SE,
         select_chain: &SC,
         params: EssentialExecutorParams<
@@ -102,6 +105,7 @@ where
             Backend,
             E,
             IBNS,
+            CIBNS,
             NSNS,
         >,
     ) -> Result<Self, sp_consensus::Error>
@@ -109,6 +113,7 @@ where
         SE: SpawnEssentialNamed,
         SC: SelectChain<PBlock>,
         IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
+        CIBNS: Stream<Item = BlockImportNotification<PBlock>> + Send + 'static,
         NSNS: Stream<Item = (Slot, Blake2b256Hash)> + Send + 'static,
     {
         let active_leaves =

--- a/domains/client/domain-executor/src/system_executor.rs
+++ b/domains/client/domain-executor/src/system_executor.rs
@@ -159,10 +159,8 @@ where
                 params.is_authority,
                 bundle_producer,
                 bundle_processor.clone(),
-                params.imported_block_notification_stream,
-                params.new_slot_notification_stream,
+                params.executor_streams,
                 active_leaves,
-                params.block_import_throttling_buffer_size,
             )
             .boxed(),
         );

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -3,6 +3,7 @@ use cross_domain_message_gossip::{DomainTxPoolSink, Message as GossipMessage};
 use domain_client_executor::xdm_verifier::CoreDomainXDMVerifier;
 use domain_client_executor::{
     CoreDomainParentChain, CoreExecutor, CoreGossipMessageValidator, EssentialExecutorParams,
+    ExecutorStreams,
 };
 use domain_client_executor_gossip::ExecutorGossipParams;
 use domain_client_message_relayer::GossipMessageSink;
@@ -214,9 +215,10 @@ where
     Ok(params)
 }
 
-pub struct CoreDomainParams<SBlock, SClient, PClient, SC, IBNS, NSNS>
+pub struct CoreDomainParams<SBlock, PBlock, SClient, PClient, SC, IBNS, NSNS>
 where
     SBlock: BlockT,
+    PBlock: BlockT,
 {
     pub domain_id: DomainId,
     pub core_domain_config: DomainConfiguration,
@@ -225,9 +227,7 @@ where
     pub primary_chain_client: Arc<PClient>,
     pub primary_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
     pub select_chain: SC,
-    pub imported_block_notification_stream: IBNS,
-    pub new_slot_notification_stream: NSNS,
-    pub block_import_throttling_buffer_size: u32,
+    pub executor_streams: ExecutorStreams<PBlock, IBNS, NSNS>,
     pub gossip_message_sink: GossipMessageSink,
 }
 
@@ -246,7 +246,7 @@ pub async fn new_full_core<
     RuntimeApi,
     ExecutorDispatch,
 >(
-    core_domain_params: CoreDomainParams<SBlock, SClient, PClient, SC, IBNS, NSNS>,
+    core_domain_params: CoreDomainParams<SBlock, PBlock, SClient, PClient, SC, IBNS, NSNS>,
 ) -> sc_service::error::Result<
     NewFullCore<
         Arc<FullClient<RuntimeApi, ExecutorDispatch>>,
@@ -306,9 +306,7 @@ where
         primary_chain_client,
         primary_network_sync_oracle,
         select_chain,
-        imported_block_notification_stream,
-        new_slot_notification_stream,
-        block_import_throttling_buffer_size,
+        executor_streams,
         gossip_message_sink,
     } = core_domain_params;
 
@@ -399,9 +397,7 @@ where
             keystore: params.keystore_container.sync_keystore(),
             spawner: Box::new(task_manager.spawn_handle()),
             bundle_sender: Arc::new(bundle_sender),
-            block_import_throttling_buffer_size,
-            imported_block_notification_stream,
-            new_slot_notification_stream,
+            executor_streams,
         },
     )
     .await?;

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -176,8 +176,8 @@ async fn run_executor(
         maybe_relayer_id: None,
     };
     let executor_streams = ExecutorStreams {
-        block_import_throttling_buffer_size: 10,
-        imported_block_notification_stream: primary_chain_full_node
+        primary_block_import_throttling_buffer_size: 10,
+        subspace_imported_block_notification_stream: primary_chain_full_node
             .imported_block_notification_stream
             .subscribe()
             .then(|imported_block_notification| async move {

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -25,6 +25,7 @@ use domain_test_runtime::opaque::Block;
 use domain_test_runtime::Hash;
 use futures::StreamExt;
 use sc_client_api::execution_extensions::ExecutionStrategies;
+use sc_client_api::BlockchainEvents;
 use sc_consensus_slots::SlotProportion;
 use sc_network::{multiaddr, NetworkService, NetworkStateInfo};
 use sc_network_common::config::{NonReservedPeerMode, TransportConfig};
@@ -186,6 +187,9 @@ async fn run_executor(
                     imported_block_notification.block_import_acknowledgement_sender,
                 )
             }),
+        client_imported_block_notification_stream: primary_chain_full_node
+            .client
+            .every_import_notification_stream(),
         new_slot_notification_stream: primary_chain_full_node
             .new_slot_notification_stream
             .subscribe()
@@ -198,6 +202,7 @@ async fn run_executor(
         _phantom: Default::default(),
     };
     let system_domain_node = domain_service::new_full_system::<
+        _,
         _,
         _,
         _,


### PR DESCRIPTION
The first two commits are pure refactoring to introduce `ExecutorStreams`, the last commit resolves #1283 by moving the subscription of block import notification from the client earlier before the start of primary network.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
