### PR TITLE
Add QUIC transport support for DSN. 

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -17,6 +17,7 @@ use subspace_farmer::utils::readers_and_pieces::ReadersAndPieces;
 use subspace_farmer::{NodeClient, NodeRpcClient};
 use subspace_farmer_components::piece_caching::PieceMemoryCache;
 use subspace_networking::libp2p::identity::Keypair;
+use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::{
     create, peer_id, BootstrappedNetworkingParameters, Config, Node, NodeRunner,
@@ -263,7 +264,21 @@ pub(super) fn configure_dsn(
     };
 
     create(config)
-        .map(|(node, node_runner)| (node, node_runner, piece_cache))
+        .map(|(node, node_runner)| {
+            node.on_new_listener(Arc::new({
+                let node = node.clone();
+
+                move |address| {
+                    info!(
+                        "DSN listening on {}",
+                        address.clone().with(Protocol::P2p(node.id().into()))
+                    );
+                }
+            }))
+            .detach();
+
+            (node, node_runner, piece_cache)
+        })
         .map_err(Into::into)
 }
 

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -60,6 +60,7 @@ features = [
     "metrics",
     "noise",
     "ping",
+    "quic",
     "request-response",
     "serde",
     "tcp",

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -501,6 +501,18 @@ where
 
             info!("Subspace networking initialized: Node ID is {}", node.id());
 
+            node.on_new_listener(Arc::new({
+                let node = node.clone();
+
+                move |address| {
+                    info!(
+                        "DSN listening on {}",
+                        address.clone().with(Protocol::P2p(node.id().into()))
+                    );
+                }
+            }))
+            .detach();
+
             task_manager.spawn_essential_handle().spawn_essential(
                 "node-runner",
                 Some("subspace-networking"),


### PR DESCRIPTION
This PR adds QUIC support for all DSN apps. It also adds logging of the DSN listening addresses for apps.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
