### PR TITLE
Abstract out domain_block_preprocessor module

### DIFF
--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -1,5 +1,6 @@
 use crate::domain_block_preprocessor::{
-    compile_own_domain_bundles, preprocess_primary_block, DomainBundles,
+    compile_own_domain_bundles, deduplicate_and_shuffle_extrinsics, preprocess_primary_block,
+    DomainBundles,
 };
 use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::parent_chain::{CoreDomainParentChain, ParentChainInterface};
@@ -242,8 +243,7 @@ where
             DomainBundles::Core(bundles) => bundles,
         };
         let extrinsics = compile_own_domain_bundles::<Block, PBlock>(bundles);
-        self.domain_block_processor
-            .deduplicate_and_shuffle_extrinsics(parent_hash, extrinsics, shuffling_seed)
+        deduplicate_and_shuffle_extrinsics(&self.client, parent_hash, extrinsics, shuffling_seed)
     }
 
     fn filter_invalid_xdm_extrinsics(&self, exts: Vec<Block::Extrinsic>) -> Vec<Block::Extrinsic> {

--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -1,4 +1,6 @@
-use crate::domain_block_preprocessor::{preprocess_primary_block, DomainBundles};
+use crate::domain_block_preprocessor::{
+    compile_own_domain_bundles, preprocess_primary_block, DomainBundles,
+};
 use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::parent_chain::{CoreDomainParentChain, ParentChainInterface};
 use crate::utils::translate_number_type;
@@ -239,9 +241,7 @@ where
             }
             DomainBundles::Core(bundles) => bundles,
         };
-        let extrinsics = self
-            .domain_block_processor
-            .compile_own_domain_bundles(bundles);
+        let extrinsics = compile_own_domain_bundles::<Block, PBlock>(bundles);
         self.domain_block_processor
             .deduplicate_and_shuffle_extrinsics(parent_hash, extrinsics, shuffling_seed)
     }

--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -1,8 +1,7 @@
-use crate::domain_block_processor::{
-    preprocess_primary_block, DomainBlockProcessor, PendingPrimaryBlocks,
-};
+use crate::domain_block_preprocessor::{preprocess_primary_block, DomainBundles};
+use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::parent_chain::{CoreDomainParentChain, ParentChainInterface};
-use crate::utils::{translate_number_type, DomainBundles};
+use crate::utils::translate_number_type;
 use crate::xdm_verifier::verify_xdm_with_system_domain_client;
 use crate::TransactionFor;
 use domain_runtime_primitives::{AccountId, DomainCoreApi};

--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -1,11 +1,7 @@
-use crate::domain_block_preprocessor::{
-    compile_own_domain_bundles, deduplicate_and_shuffle_extrinsics, preprocess_primary_block,
-    DomainBundles,
-};
+use crate::domain_block_preprocessor::CoreDomainBlockPreprocessor;
 use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::parent_chain::{CoreDomainParentChain, ParentChainInterface};
 use crate::utils::translate_number_type;
-use crate::xdm_verifier::verify_xdm_with_system_domain_client;
 use crate::TransactionFor;
 use domain_runtime_primitives::{AccountId, DomainCoreApi};
 use sc_client_api::{AuxStore, BlockBackend, StateBackendFor};
@@ -19,7 +15,6 @@ use sp_messenger::MessengerApi;
 use sp_runtime::traits::{Block as BlockT, HashFor};
 use std::marker::PhantomData;
 use std::sync::Arc;
-use subspace_core_primitives::Randomness;
 use system_runtime_primitives::SystemDomainApi;
 
 pub(crate) struct CoreBundleProcessor<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E>
@@ -35,6 +30,8 @@ where
     client: Arc<Client>,
     backend: Arc<Backend>,
     keystore: SyncCryptoStorePtr,
+    core_domain_block_preprocessor:
+        CoreDomainBlockPreprocessor<Block, PBlock, SBlock, Client, PClient, SClient>,
     domain_block_processor: DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>,
     _phantom_data: PhantomData<(SBlock, PBlock)>,
 }
@@ -55,6 +52,7 @@ where
             client: self.client.clone(),
             backend: self.backend.clone(),
             keystore: self.keystore.clone(),
+            core_domain_block_preprocessor: self.core_domain_block_preprocessor.clone(),
             domain_block_processor: self.domain_block_processor.clone(),
             _phantom_data: self._phantom_data,
         }
@@ -105,6 +103,12 @@ where
             system_domain_client.clone(),
             domain_id,
         );
+        let core_domain_block_preprocessor = CoreDomainBlockPreprocessor::new(
+            domain_id,
+            client.clone(),
+            primary_chain_client.clone(),
+            system_domain_client.clone(),
+        );
         Self {
             domain_id,
             primary_chain_client,
@@ -113,6 +117,7 @@ where
             client,
             backend,
             keystore,
+            core_domain_block_preprocessor,
             domain_block_processor,
             _phantom_data: PhantomData::default(),
         }
@@ -167,12 +172,9 @@ where
             on top of #{parent_number},{parent_hash}"
         );
 
-        let (bundles, shuffling_seed, maybe_new_runtime) =
-            preprocess_primary_block(self.domain_id, &*self.primary_chain_client, primary_hash)?;
-
-        let extrinsics = self
-            .bundles_to_extrinsics(parent_hash, bundles, shuffling_seed)
-            .map(|extrinsics| self.filter_invalid_xdm_extrinsics(extrinsics))?;
+        let (extrinsics, maybe_new_runtime) = self
+            .core_domain_block_preprocessor
+            .preprocess_primary_block(primary_hash, parent_hash)?;
 
         let domain_block_result = self
             .domain_block_processor
@@ -226,44 +228,5 @@ where
         }
 
         Ok(built_block_info)
-    }
-
-    fn bundles_to_extrinsics(
-        &self,
-        parent_hash: Block::Hash,
-        bundles: DomainBundles<Block, PBlock>,
-        shuffling_seed: Randomness,
-    ) -> Result<Vec<Block::Extrinsic>, sp_blockchain::Error> {
-        let bundles = match bundles {
-            DomainBundles::System(..) => {
-                return Err(sp_blockchain::Error::Application(Box::from(
-                    "Core bundle processor can not process system bundles.",
-                )));
-            }
-            DomainBundles::Core(bundles) => bundles,
-        };
-        let extrinsics = compile_own_domain_bundles::<Block, PBlock>(bundles);
-        deduplicate_and_shuffle_extrinsics(&self.client, parent_hash, extrinsics, shuffling_seed)
-    }
-
-    fn filter_invalid_xdm_extrinsics(&self, exts: Vec<Block::Extrinsic>) -> Vec<Block::Extrinsic> {
-        exts.into_iter()
-            .filter(|ext| {
-                match verify_xdm_with_system_domain_client::<_, Block, SBlock, PBlock>(
-                    &self.system_domain_client,
-                    &(ext.clone().into()),
-                ) {
-                    Ok(valid) => valid,
-                    Err(err) => {
-                        tracing::error!(
-                            target = "core_domain_xdm_filter",
-                            "failed to verify extrinsic: {}",
-                            err
-                        );
-                        false
-                    }
-                }
-            })
-            .collect()
     }
 }

--- a/domains/client/domain-executor/src/domain_block_preprocessor.rs
+++ b/domains/client/domain-executor/src/domain_block_preprocessor.rs
@@ -1,0 +1,100 @@
+use sc_client_api::BlockBackend;
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_domains::{DomainId, ExecutorApi, OpaqueBundles, SignedOpaqueBundles};
+use sp_runtime::generic::DigestItem;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use std::borrow::Cow;
+use subspace_core_primitives::Randomness;
+use subspace_wasm_tools::read_core_domain_runtime_blob;
+
+/// Domain-specific bundles extracted from the primary block.
+pub enum DomainBundles<Block, PBlock>
+where
+    Block: BlockT,
+    PBlock: BlockT,
+{
+    System(
+        OpaqueBundles<PBlock, Block::Hash>,
+        SignedOpaqueBundles<PBlock, Block::Hash>,
+    ),
+    Core(OpaqueBundles<PBlock, Block::Hash>),
+}
+
+pub type DomainBlockElements<Block, PBlock> = (
+    DomainBundles<Block, PBlock>,
+    Randomness,
+    Option<Cow<'static, [u8]>>,
+);
+
+/// Extracts the necessary materials for building a new domain block from the primary block.
+pub(crate) fn preprocess_primary_block<Block, PBlock, PClient>(
+    domain_id: DomainId,
+    primary_chain_client: &PClient,
+    block_hash: PBlock::Hash,
+) -> sp_blockchain::Result<DomainBlockElements<Block, PBlock>>
+where
+    Block: BlockT,
+    PBlock: BlockT,
+    PClient: HeaderBackend<PBlock> + BlockBackend<PBlock> + ProvideRuntimeApi<PBlock> + Send + Sync,
+    PClient::Api: ExecutorApi<PBlock, Block::Hash>,
+{
+    let extrinsics = primary_chain_client
+        .block_body(block_hash)?
+        .ok_or_else(|| {
+            sp_blockchain::Error::Backend(format!("BlockBody of {block_hash:?} unavailable"))
+        })?;
+
+    let header = primary_chain_client.header(block_hash)?.ok_or_else(|| {
+        sp_blockchain::Error::Backend(format!("BlockHeader of {block_hash:?} unavailable"))
+    })?;
+
+    let maybe_new_runtime = if header
+        .digest()
+        .logs
+        .iter()
+        .any(|item| *item == DigestItem::RuntimeEnvironmentUpdated)
+    {
+        let system_domain_runtime = primary_chain_client
+            .runtime_api()
+            .system_domain_wasm_bundle(block_hash)?;
+
+        let new_runtime = match domain_id {
+            DomainId::SYSTEM => system_domain_runtime,
+            DomainId::CORE_PAYMENTS => {
+                read_core_domain_runtime_blob(system_domain_runtime.as_ref(), domain_id)
+                    .map_err(|err| sp_blockchain::Error::Application(Box::new(err)))?
+                    .into()
+            }
+            _ => {
+                return Err(sp_blockchain::Error::Application(Box::from(format!(
+                    "No new runtime code for {domain_id:?}"
+                ))));
+            }
+        };
+
+        Some(new_runtime)
+    } else {
+        None
+    };
+
+    let shuffling_seed = primary_chain_client
+        .runtime_api()
+        .extrinsics_shuffling_seed(block_hash, header)?;
+
+    let domain_bundles = if domain_id.is_system() {
+        let (system_bundles, core_bundles) = primary_chain_client
+            .runtime_api()
+            .extract_system_bundles(block_hash, extrinsics)?;
+        DomainBundles::System(system_bundles, core_bundles)
+    } else if domain_id.is_core() {
+        let core_bundles = primary_chain_client
+            .runtime_api()
+            .extract_core_bundles(block_hash, extrinsics, domain_id)?;
+        DomainBundles::Core(core_bundles)
+    } else {
+        unreachable!("Open domains are unsupported")
+    };
+
+    Ok((domain_bundles, shuffling_seed, maybe_new_runtime))
+}

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -14,7 +14,7 @@ use sp_consensus::{BlockOrigin, SyncOracle};
 use sp_core::traits::CodeExecutor;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::merkle_tree::MerkleTree;
-use sp_domains::{DomainId, ExecutionReceipt, ExecutorApi, OpaqueBundles};
+use sp_domains::{DomainId, ExecutionReceipt, ExecutorApi};
 use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT, One, Zero};
 use sp_runtime::Digest;
 use std::borrow::Cow;
@@ -212,31 +212,6 @@ where
                 }))
             }
         }
-    }
-
-    pub(crate) fn compile_own_domain_bundles(
-        &self,
-        bundles: OpaqueBundles<PBlock, Block::Hash>,
-    ) -> Vec<Block::Extrinsic> {
-        bundles
-            .into_iter()
-            .flat_map(|bundle| {
-                bundle.extrinsics.into_iter().filter_map(|opaque_extrinsic| {
-                    match <<Block as BlockT>::Extrinsic>::decode(
-                        &mut opaque_extrinsic.encode().as_slice(),
-                    ) {
-                        Ok(uxt) => Some(uxt),
-                        Err(e) => {
-                            tracing::error!(
-                                error = ?e,
-                                "Failed to decode the opaque extrisic in bundle, this should not happen"
-                            );
-                            None
-                        },
-                    }
-                })
-            })
-            .collect::<Vec<_>>()
     }
 
     pub(crate) fn deduplicate_and_shuffle_extrinsics(

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -86,6 +86,7 @@ mod core_bundle_processor;
 mod core_domain_worker;
 mod core_executor;
 mod core_gossip_message_validator;
+mod domain_block_preprocessor;
 mod domain_block_processor;
 mod domain_bundle_producer;
 mod domain_bundle_proposer;

--- a/domains/client/domain-executor/src/system_bundle_processor.rs
+++ b/domains/client/domain-executor/src/system_bundle_processor.rs
@@ -1,4 +1,6 @@
-use crate::domain_block_preprocessor::{preprocess_primary_block, DomainBundles};
+use crate::domain_block_preprocessor::{
+    compile_own_domain_bundles, preprocess_primary_block, DomainBundles,
+};
 use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::state_root_extractor::StateRootExtractorWithSystemDomainClient;
 use crate::utils::translate_number_type;
@@ -237,9 +239,7 @@ where
             }
         };
 
-        let origin_system_extrinsics = self
-            .domain_block_processor
-            .compile_own_domain_bundles(system_bundles);
+        let origin_system_extrinsics = compile_own_domain_bundles::<Block, PBlock>(system_bundles);
         let extrinsics = self
             .client
             .runtime_api()

--- a/domains/client/domain-executor/src/system_bundle_processor.rs
+++ b/domains/client/domain-executor/src/system_bundle_processor.rs
@@ -1,5 +1,6 @@
 use crate::domain_block_preprocessor::{
-    compile_own_domain_bundles, preprocess_primary_block, DomainBundles,
+    compile_own_domain_bundles, deduplicate_and_shuffle_extrinsics, preprocess_primary_block,
+    DomainBundles,
 };
 use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::state_root_extractor::StateRootExtractorWithSystemDomainClient;
@@ -260,8 +261,7 @@ where
             .chain(origin_system_extrinsics)
             .collect::<Vec<_>>();
 
-        self.domain_block_processor
-            .deduplicate_and_shuffle_extrinsics(parent_hash, extrinsics, shuffling_seed)
+        deduplicate_and_shuffle_extrinsics(&self.client, parent_hash, extrinsics, shuffling_seed)
     }
 
     fn filter_invalid_xdm_extrinsics(&self, exts: Vec<Block::Extrinsic>) -> Vec<Block::Extrinsic> {

--- a/domains/client/domain-executor/src/system_bundle_processor.rs
+++ b/domains/client/domain-executor/src/system_bundle_processor.rs
@@ -1,8 +1,7 @@
-use crate::domain_block_processor::{
-    preprocess_primary_block, DomainBlockProcessor, PendingPrimaryBlocks,
-};
+use crate::domain_block_preprocessor::{preprocess_primary_block, DomainBundles};
+use crate::domain_block_processor::{DomainBlockProcessor, PendingPrimaryBlocks};
 use crate::state_root_extractor::StateRootExtractorWithSystemDomainClient;
-use crate::utils::{translate_number_type, DomainBundles};
+use crate::utils::translate_number_type;
 use crate::xdm_verifier::verify_xdm_with_primary_chain_client;
 use crate::TransactionFor;
 use codec::Decode;

--- a/domains/client/domain-executor/src/utils.rs
+++ b/domains/client/domain-executor/src/utils.rs
@@ -4,24 +4,11 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use sp_consensus_slots::Slot;
-use sp_domains::{OpaqueBundles, SignedOpaqueBundles};
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryInto;
 use std::fmt::Debug;
 use subspace_core_primitives::{Blake2b256Hash, BlockNumber, Randomness};
-
-pub(super) enum DomainBundles<Block, PBlock>
-where
-    Block: BlockT,
-    PBlock: BlockT,
-{
-    System(
-        OpaqueBundles<PBlock, Block::Hash>,
-        SignedOpaqueBundles<PBlock, Block::Hash>,
-    ),
-    Core(OpaqueBundles<PBlock, Block::Hash>),
-}
 
 /// Data required to produce bundles on executor node.
 #[derive(PartialEq, Clone, Debug)]

--- a/domains/client/domain-executor/src/utils.rs
+++ b/domains/client/domain-executor/src/utils.rs
@@ -1,14 +1,8 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::AccountId;
-use rand::seq::SliceRandom;
-use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 use sp_consensus_slots::Slot;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
-use std::collections::{BTreeMap, VecDeque};
 use std::convert::TryInto;
-use std::fmt::Debug;
-use subspace_core_primitives::{Blake2b256Hash, BlockNumber, Randomness};
+use subspace_core_primitives::{Blake2b256Hash, BlockNumber};
 
 /// Data required to produce bundles on executor node.
 #[derive(PartialEq, Clone, Debug)]
@@ -66,86 +60,4 @@ where
     B2: BlockT,
 {
     B2::Hash::decode(&mut block_hash.encode().as_slice()).unwrap()
-}
-
-/// Shuffles the extrinsics in a deterministic way.
-///
-/// The extrinsics are grouped by the signer. The extrinsics without a signer, i.e., unsigned
-/// extrinsics, are considered as a special group. The items in different groups are cross shuffled,
-/// while the order of items inside the same group is still maintained.
-pub(crate) fn shuffle_extrinsics<Extrinsic: Debug>(
-    extrinsics: Vec<(Option<AccountId>, Extrinsic)>,
-    shuffling_seed: Randomness,
-) -> Vec<Extrinsic> {
-    let mut rng = ChaCha8Rng::from_seed(shuffling_seed);
-
-    let mut positions = extrinsics
-        .iter()
-        .map(|(maybe_signer, _)| maybe_signer)
-        .cloned()
-        .collect::<Vec<_>>();
-
-    // Shuffles the positions using Fisher–Yates algorithm.
-    positions.shuffle(&mut rng);
-
-    let mut grouped_extrinsics: BTreeMap<Option<AccountId>, VecDeque<_>> = extrinsics
-        .into_iter()
-        .fold(BTreeMap::new(), |mut groups, (maybe_signer, tx)| {
-            groups
-                .entry(maybe_signer)
-                .or_insert_with(VecDeque::new)
-                .push_back(tx);
-            groups
-        });
-
-    // The relative ordering for the items in the same group does not change.
-    let shuffled_extrinsics = positions
-        .into_iter()
-        .map(|maybe_signer| {
-            grouped_extrinsics
-                .get_mut(&maybe_signer)
-                .expect("Extrinsics are grouped correctly; qed")
-                .pop_front()
-                .expect("Extrinsic definitely exists as it's correctly grouped above; qed")
-        })
-        .collect::<Vec<_>>();
-
-    tracing::trace!(?shuffled_extrinsics, "Shuffled extrinsics");
-
-    shuffled_extrinsics
-}
-
-#[cfg(test)]
-mod tests {
-    use super::shuffle_extrinsics;
-    use sp_keyring::sr25519::Keyring;
-    use sp_runtime::traits::{BlakeTwo256, Hash as HashT};
-
-    #[test]
-    fn shuffle_extrinsics_should_work() {
-        let alice = Keyring::Alice.to_account_id();
-        let bob = Keyring::Bob.to_account_id();
-        let charlie = Keyring::Charlie.to_account_id();
-
-        let extrinsics = vec![
-            (Some(alice.clone()), 10),
-            (None, 100),
-            (Some(bob.clone()), 1),
-            (Some(bob), 2),
-            (Some(charlie.clone()), 30),
-            (Some(alice.clone()), 11),
-            (Some(charlie), 31),
-            (None, 101),
-            (None, 102),
-            (Some(alice), 12),
-        ];
-
-        let dummy_seed = BlakeTwo256::hash_of(&[1u8; 64]).into();
-        let shuffled_extrinsics = shuffle_extrinsics(extrinsics, dummy_seed);
-
-        assert_eq!(
-            shuffled_extrinsics,
-            vec![100, 30, 10, 1, 11, 101, 31, 12, 102, 2]
-        );
-    }
 }


### PR DESCRIPTION
This PR is a pure refactoring towards a reusable component `domain_block_preprocessor` that is responsible for converting a primary block to a specific domain block. The next step will be making the runtime api usages in this process flexible to support both the client and stateless runtime alternative so that it can be used by both the executor and fraud proof verifier. 

Part of #1274

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
