### PR TITLE
Alternate block relay path (initial changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,13 +672,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1290,7 +1290,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1490,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1857,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1869,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1879,24 +1879,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -3832,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -7170,7 +7170,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -7187,9 +7187,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8772,7 +8772,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -9960,6 +9960,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "subspace-block-relay"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures 0.3.27",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-subspace",
+ "sc-network",
+ "sc-network-common",
+ "sc-network-gossip",
+ "sc-service",
+ "sc-utils",
+ "sp-consensus",
+ "sp-runtime",
+ "tracing",
+]
+
+[[package]]
 name = "subspace-chiapos"
 version = "0.1.0"
 source = "git+https://github.com/subspace/chiapos?rev=a239ddf83b4d8420f23616d604af83c756c40116#a239ddf83b4d8420f23616d604af83c756c40116"
@@ -10343,6 +10364,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie",
  "subspace-archiving",
+ "subspace-block-relay",
  "subspace-core-primitives",
  "subspace-fraud-proof",
  "subspace-networking",
@@ -10762,9 +10784,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10922,7 +10944,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -143,6 +143,10 @@ where
 {
     /// Block number
     pub block_number: NumberFor<Block>,
+    /// Block hash
+    pub block_hash: Block::Hash,
+    /// Parent block hash
+    pub parent_hash: Block::Hash,
     /// Sender for pausing the block import when executor is not fast enough to process
     /// the primary block.
     pub block_import_acknowledgement_sender: mpsc::Sender<()>,
@@ -1029,6 +1033,7 @@ where
         new_cache: HashMap<CacheKeyId, Vec<u8>>,
     ) -> Result<ImportResult, Self::Error> {
         let block_hash = block.post_hash();
+        let parent_hash = *block.header.parent_hash();
         let block_number = *block.header.number();
 
         // Early exit if block already in chain
@@ -1169,6 +1174,8 @@ where
         self.imported_block_notification_sender
             .notify(move || ImportedBlockNotification {
                 block_number,
+                block_hash,
+                parent_hash,
                 block_import_acknowledgement_sender,
             });
 

--- a/crates/subspace-block-relay/Cargo.toml
+++ b/crates/subspace-block-relay/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "subspace-block-relay"
+version = "0.1.0"
+authors = ["Subspace Labs <https://subspace.network>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace"
+description = "Subspace block relay implementation"
+
+[dependencies]
+async-trait = "0.1.64"
+futures = "0.3.26"
+parity-scale-codec = { version = "3.4.0", features = ["derive"] }
+parking_lot = "0.12.1"
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232", default-features = false }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+tracing = "0.1.37"
+

--- a/crates/subspace-block-relay/Cargo.toml
+++ b/crates/subspace-block-relay/Cargo.toml
@@ -19,9 +19,8 @@ sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
-sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232", default-features = false }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
+sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 tracing = "0.1.37"
-

--- a/crates/subspace-block-relay/src/lib.rs
+++ b/crates/subspace-block-relay/src/lib.rs
@@ -1,0 +1,6 @@
+mod protocol;
+mod runner;
+
+pub(crate) const LOG_TARGET: &str = "block_relay";
+
+pub use crate::protocol::{build_block_relay, init_block_relay_config};

--- a/crates/subspace-block-relay/src/protocol.rs
+++ b/crates/subspace-block-relay/src/protocol.rs
@@ -1,4 +1,7 @@
-/// Common define for the block relay.
+//! Common defines for the block relay.
+
+use crate::protocol::full_block::{init_full_block_config, FullBlockRelay};
+use crate::runner::BlockRelayRunner;
 use async_trait::async_trait;
 use futures::channel::mpsc::Receiver;
 use parity_scale_codec::{Decode, Encode};
@@ -17,9 +20,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 mod full_block;
-
-use crate::protocol::full_block::{init_full_block_config, FullBlockRelay};
-use crate::runner::BlockRelayRunner;
 
 pub(crate) type GossipNetworkService<Block> =
     sc_network::NetworkService<Block, <Block as BlockT>::Hash>;

--- a/crates/subspace-block-relay/src/protocol.rs
+++ b/crates/subspace-block-relay/src/protocol.rs
@@ -1,0 +1,127 @@
+/// Common define for the block relay.
+use async_trait::async_trait;
+use futures::channel::mpsc::Receiver;
+use parity_scale_codec::{Decode, Encode};
+use sc_client_api::{BlockBackend, HeaderBackend};
+use sc_consensus::import_queue::ImportQueueService;
+use sc_consensus_subspace::ImportedBlockNotification;
+use sc_network::{PeerId, RequestFailure};
+use sc_network_gossip::TopicNotification;
+use sc_service::config::IncomingRequest;
+use sc_service::Configuration;
+use sc_utils::mpsc::TracingUnboundedReceiver;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::time::Instant;
+
+mod full_block;
+
+use crate::protocol::full_block::{init_full_block_config, FullBlockRelay};
+use crate::runner::BlockRelayRunner;
+
+pub(crate) type GossipNetworkService<Block> =
+    sc_network::NetworkService<Block, <Block as BlockT>::Hash>;
+
+#[async_trait]
+pub trait BlockRelayProtocol<Block: BlockT>: Send {
+    /// The gossip topic to be used for announcements.
+    fn block_announcement_topic(&self) -> Block::Hash;
+
+    /// Handles the block import notifications.
+    async fn on_block_import(&mut self, notification: ImportedBlockNotification<Block>);
+
+    /// Handles the block announcements from peers.
+    async fn on_block_announcement(&mut self, message: TopicNotification);
+
+    /// Handles the protocol handshake messages from peers.
+    async fn on_protocol_message(&mut self, request: IncomingRequest);
+
+    /// Interface to drive any protocol specific polling.
+    async fn poll(&mut self);
+}
+
+/// Async response to start_request().
+pub(crate) struct ProtocolResponse<ReqId> {
+    /// Peer to which the request was sent.
+    peer_id: PeerId,
+
+    /// Protocol specific request identifier.
+    request_id: ReqId,
+
+    /// The response. Set to None if the oneshot receiver returned Canceled.
+    response: Option<Result<Vec<u8>, RequestFailure>>,
+
+    /// When the request was sent.
+    request_ts: Instant,
+}
+
+/// Block identifier.
+#[derive(Clone, Encode, Decode, Eq, PartialEq)]
+pub(crate) struct BlockInfo<Block: BlockT> {
+    /// Block number
+    pub block_number: NumberFor<Block>,
+
+    /// Block hash
+    pub block_hash: Block::Hash,
+
+    /// Parent block hash
+    pub parent_hash: Block::Hash,
+}
+
+impl<Block: BlockT> From<&ImportedBlockNotification<Block>> for BlockInfo<Block> {
+    fn from(notification: &ImportedBlockNotification<Block>) -> Self {
+        Self {
+            block_number: notification.block_number,
+            block_hash: notification.block_hash,
+            parent_hash: notification.parent_hash,
+        }
+    }
+}
+
+impl<Block: BlockT> Hash for BlockInfo<Block> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.block_number.hash(state);
+        self.block_hash.hash(state);
+        self.parent_hash.hash(state);
+    }
+}
+
+impl<Block: BlockT> fmt::Display for BlockInfo<Block> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Block[number = {}, hash = {}, parent = {}]",
+            self.block_number, self.block_hash, self.parent_hash
+        )
+    }
+}
+
+/// Initializes the block relay specific parts in the network config.
+pub fn init_block_relay_config(config: &mut Configuration) -> Receiver<IncomingRequest> {
+    init_full_block_config(config)
+}
+
+/// Creates the protocol implementation and the runner to drive the protocol.
+/// Takes the receive endpoint previously created by init_block_relay_config() as
+/// input.
+pub fn build_block_relay<Block, Client>(
+    network: Arc<GossipNetworkService<Block>>,
+    client: Arc<Client>,
+    import_queue: Box<dyn ImportQueueService<Block>>,
+    import_notifications: TracingUnboundedReceiver<ImportedBlockNotification<Block>>,
+    receiver: Receiver<IncomingRequest>,
+) -> BlockRelayRunner<Block>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+{
+    let (protocol, gossip_engine) = FullBlockRelay::new(network, client, import_queue);
+    BlockRelayRunner::new(
+        Box::new(protocol),
+        gossip_engine,
+        import_notifications,
+        receiver,
+    )
+}

--- a/crates/subspace-block-relay/src/protocol/full_block.rs
+++ b/crates/subspace-block-relay/src/protocol/full_block.rs
@@ -1,0 +1,512 @@
+//! Implementation of the full block protocol.
+
+use crate::protocol::{BlockInfo, BlockRelayProtocol, GossipNetworkService, ProtocolResponse};
+use crate::LOG_TARGET;
+use async_trait::async_trait;
+use futures::channel::mpsc::{self, Receiver};
+use futures::channel::oneshot;
+use futures::future::pending;
+use futures::stream::FuturesUnordered;
+use futures::{Future, StreamExt};
+use parity_scale_codec::{Decode, Encode};
+use parking_lot::Mutex;
+use sc_client_api::{BlockBackend, HeaderBackend};
+use sc_consensus::import_queue::ImportQueueService;
+use sc_consensus::IncomingBlock;
+use sc_consensus_subspace::ImportedBlockNotification;
+use sc_network::{IfDisconnected, NetworkRequest, PeerId};
+use sc_network_common::config::NonDefaultSetConfig;
+use sc_network_gossip::{
+    GossipEngine, MessageIntent, TopicNotification, ValidationResult, Validator, ValidatorContext,
+};
+use sc_service::config::{IncomingRequest, OutgoingResponse, RequestResponseConfig};
+use sc_service::Configuration;
+use sp_consensus::BlockOrigin;
+use sp_runtime::generic::SignedBlock;
+use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
+use std::collections::HashSet;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tracing::{info, trace, warn};
+
+const ANNOUNCE_PROTOCOL: &str = "/subspace/full-block-relay-announces/1";
+const SYNC_PROTOCOL: &str = "/subspace/full-block-relay-sync/1";
+
+/// TODO: tentative size, to be tuned based on testing.
+const INBOUND_QUEUE_SIZE: usize = 1024;
+
+type ProtocolResponseFuture<Block> =
+    dyn Future<Output = ProtocolResponse<BlockRequest<Block>>> + Send;
+
+/// The gossiped block announcement.
+#[derive(Clone, Encode, Decode)]
+struct BlockAnnouncement<Block: BlockT>(BlockInfo<Block>);
+
+impl<Block: BlockT> From<&ImportedBlockNotification<Block>> for BlockAnnouncement<Block> {
+    fn from(import_notification: &ImportedBlockNotification<Block>) -> Self {
+        Self(import_notification.into())
+    }
+}
+
+impl<Block: BlockT> fmt::Display for BlockAnnouncement<Block> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BlockAnnouncement::{}", self.0)
+    }
+}
+
+/// The block download request.
+#[derive(Clone, Encode, Decode)]
+struct BlockRequest<Block: BlockT>(BlockInfo<Block>);
+
+impl<Block: BlockT> From<&BlockAnnouncement<Block>> for BlockRequest<Block> {
+    fn from(announcement: &BlockAnnouncement<Block>) -> Self {
+        Self(announcement.0.clone())
+    }
+}
+
+impl<Block: BlockT> fmt::Display for BlockRequest<Block> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "BlockRequest::{}", self.0)
+    }
+}
+
+/// The block download response.
+#[derive(Debug, Encode, Decode)]
+struct BlockResponse<Block: BlockT>(SignedBlock<Block>);
+
+impl<Block: BlockT> fmt::Display for BlockResponse<Block> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "BlockResponse[hash = {}, size_hint = {}]",
+            self.0.block.hash(),
+            self.0.block.size_hint()
+        )
+    }
+}
+
+pub struct FullBlockRelay<Block: BlockT, Client> {
+    /// Network handle.
+    network: Arc<GossipNetworkService<Block>>,
+
+    /// Block backend.
+    client: Arc<Client>,
+
+    /// The import queue for the downloaded blocks.
+    import_queue: Box<dyn ImportQueueService<Block>>,
+
+    /// Announcement gossip engine.
+    gossip_engine: Arc<Mutex<GossipEngine<Block>>>,
+
+    /// Announcement gossip validator.
+    _validator: Arc<FullBlockRelayValidator>,
+
+    /// Announcements in the process of being sent.
+    pending_announcements: Arc<Mutex<HashSet<Vec<u8>>>>,
+
+    /// Block downloads in progress.
+    pending_downloads: HashSet<BlockInfo<Block>>,
+
+    /// Requests waiting for responses from peers.
+    pending_responses: FuturesUnordered<Pin<Box<ProtocolResponseFuture<Block>>>>,
+}
+
+impl<Block, Client> FullBlockRelay<Block, Client>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+{
+    pub(crate) fn new(
+        network: Arc<GossipNetworkService<Block>>,
+        client: Arc<Client>,
+        import_queue: Box<dyn ImportQueueService<Block>>,
+    ) -> (Self, Arc<Mutex<GossipEngine<Block>>>) {
+        let pending_announcements = Arc::new(Mutex::new(HashSet::new()));
+        let validator = Arc::new(FullBlockRelayValidator {
+            pending_announcements: pending_announcements.clone(),
+        });
+        let gossip_engine = Arc::new(Mutex::new(GossipEngine::new(
+            network.clone(),
+            ANNOUNCE_PROTOCOL,
+            validator.clone(),
+            None,
+        )));
+
+        let protocol = Self {
+            network,
+            client,
+            import_queue,
+            gossip_engine: gossip_engine.clone(),
+            _validator: validator,
+            pending_announcements,
+            pending_downloads: HashSet::new(),
+            pending_responses: Default::default(),
+        };
+        // FuturesUnordered has the issue where polling of an empty collection returns
+        // Poll::Ready(None). This causes a busy loop from the runner, and doesn't let anything else
+        // run. To avoid this, initialize the collection with a future that never completes.
+        protocol
+            .pending_responses
+            .push(Box::pin(pending::<ProtocolResponse<BlockRequest<Block>>>()));
+        (protocol, gossip_engine)
+    }
+
+    /// Initiates the block download request.
+    fn start_block_download(&mut self, sender: PeerId, announcement: &BlockAnnouncement<Block>) {
+        if self.pending_downloads.contains(&announcement.0) {
+            return;
+        }
+        self.pending_downloads.insert(announcement.0.clone());
+
+        let block_request: BlockRequest<Block> = announcement.into();
+        let (tx, rx) = oneshot::channel();
+        let request_ts = Instant::now();
+        self.network.start_request(
+            sender,
+            SYNC_PROTOCOL.into(),
+            block_request.encode(),
+            tx,
+            IfDisconnected::ImmediateError,
+        );
+        self.pending_responses.push(Box::pin(async move {
+            ProtocolResponse {
+                peer_id: sender,
+                request_id: block_request,
+                response: rx.await.ok(),
+                request_ts,
+            }
+        }));
+    }
+
+    /// Processes the block download response.
+    async fn on_block_download_response(
+        &mut self,
+        sender: PeerId,
+        request: BlockRequest<Block>,
+        bytes: Vec<u8>,
+        elapsed: Duration,
+    ) {
+        if !self.pending_downloads.remove(&request.0) {
+            warn!(
+                target: LOG_TARGET,
+                "FullBlockRelay::on_block_download_response(): unknown request: \
+                peer = {:?}, request = {}, len = {}",
+                sender,
+                request,
+                bytes.len()
+            );
+            return;
+        }
+
+        let response_len = bytes.len();
+        let block_response = match BlockResponse::<Block>::decode(&mut bytes.as_slice()) {
+            Ok(block_response) => block_response,
+            Err(err) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "FullBlockRelay::on_block_download_response(): failed to decode response: \
+                    peer = {:?}, request = {}, len = {}, err = {:?}",
+                    sender,
+                    request,
+                    response_len,
+                    err
+                );
+                return;
+            }
+        };
+
+        // Import the downloaded block.
+        let reponse_str = format!("{block_response}");
+        self.import_block(sender, block_response.0).await;
+        trace!(
+            target: LOG_TARGET,
+            "FullBlockRelay::on_block_download_response(): {}, {}. Block downloaded/imported, \
+            response len = {}, elapsed = {:?}",
+            request,
+            reponse_str,
+            response_len,
+            elapsed,
+        );
+    }
+
+    /// Imports the block.
+    async fn import_block(&mut self, sender: PeerId, block: SignedBlock<Block>) {
+        let (header, extrinsics) = block.block.deconstruct();
+        let hash = header.hash();
+        self.import_queue.import_blocks(
+            BlockOrigin::ConsensusBroadcast,
+            vec![IncomingBlock::<Block> {
+                hash,
+                header: Some(header),
+                body: Some(extrinsics),
+                indexed_body: None,
+                justifications: block.justifications,
+                origin: Some(sender),
+                allow_missing_state: false,
+                import_existing: false,
+                state: None,
+                skip_execution: false,
+            }],
+        );
+    }
+
+    /// Sends the response to the block download request.
+    async fn send_download_response(
+        &mut self,
+        incoming: IncomingRequest,
+        request: BlockRequest<Block>,
+        response: BlockResponse<Block>,
+    ) {
+        let encoded = response.encode();
+        let encoded_len = encoded.len();
+        let outgoing = OutgoingResponse {
+            result: Ok(encoded),
+            reputation_changes: vec![],
+            sent_feedback: None,
+        };
+
+        if let Err(err) = incoming.pending_response.send(outgoing) {
+            warn!(
+                target: LOG_TARGET,
+                "FullBlockRelay::send_download_response(): {}, {}, response len = {}, err = {:?}",
+                request,
+                response,
+                encoded_len,
+                err
+            );
+        } else {
+            trace!(
+                target: LOG_TARGET,
+                "FullBlockRelay::send_download_response(): {}, {}, sent response, len = {}",
+                request,
+                response,
+                encoded_len,
+            );
+        }
+    }
+
+    /// Retrieves the requested block from the backend.
+    fn get_backend_block(
+        &mut self,
+        block_hash: Block::Hash,
+    ) -> Result<Option<SignedBlock<Block>>, String> {
+        self.client.block(block_hash).map_err(|err| {
+            format!("FullBlockRelay::get_block(): block lookup failed: {block_hash}, {err}",)
+        })
+    }
+}
+
+#[async_trait]
+impl<Block, Client> BlockRelayProtocol<Block> for FullBlockRelay<Block, Client>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+{
+    fn block_announcement_topic(&self) -> Block::Hash {
+        topic::<Block>()
+    }
+
+    async fn on_block_import(&mut self, notification: ImportedBlockNotification<Block>) {
+        // Announce the imported block.
+        let announcement: BlockAnnouncement<Block> = (&notification).into();
+        let encoded = announcement.encode();
+        let should_announce = self.pending_announcements.lock().insert(encoded.clone());
+        if should_announce {
+            self.gossip_engine
+                .lock()
+                .gossip_message(topic::<Block>(), encoded, false);
+        }
+        trace!(
+            target: LOG_TARGET,
+            "FullBlockRelay::on_block_import(): notification = {:?}, {}, announced = {}",
+            notification,
+            announcement,
+            should_announce
+        );
+    }
+
+    async fn on_block_announcement(&mut self, message: TopicNotification) {
+        let sender = match message.sender {
+            Some(sender) => sender,
+            None => return,
+        };
+
+        let announcement = match BlockAnnouncement::<Block>::decode(&mut &message.message[..]) {
+            Ok(announcement) => announcement,
+            Err(err) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "FullBlockRelay::on_block_announcement(): failed to decode {:?}, err = {:?}",
+                    message,
+                    err
+                );
+                return;
+            }
+        };
+
+        // Skip the announcement if we already have the block.
+        if let Ok(Some(_)) = self.get_backend_block(announcement.0.block_hash) {
+            info!(
+                target: LOG_TARGET,
+                "FullBlockRelay::on_block_announcement(): {}, existing block announced, skipping",
+                announcement,
+            );
+            return;
+        }
+
+        // Initiate the block download.
+        self.start_block_download(sender, &announcement);
+        trace!(
+            target: LOG_TARGET,
+            "FullBlockRelay::on_block_announcement(): {}, {}. Block download initiated",
+            sender,
+            announcement
+        );
+    }
+
+    async fn on_protocol_message(&mut self, incoming: IncomingRequest) {
+        let block_request = match BlockRequest::<Block>::decode(&mut &incoming.payload[..]) {
+            Ok(block_request) => block_request,
+            Err(err) => {
+                warn!(
+                    target: LOG_TARGET,
+                    "FullBlockRelay::on_protocol_message(): failed to decode {:?}, err = {:?}",
+                    incoming,
+                    err
+                );
+                return;
+            }
+        };
+
+        let ret = self.get_backend_block(block_request.0.block_hash);
+        if let Ok(Some(signed_block)) = ret {
+            let block_response = BlockResponse(signed_block);
+            self.send_download_response(incoming, block_request, block_response)
+                .await;
+        } else {
+            warn!(
+                target: LOG_TARGET,
+                "FullBlockRelay::on_protocol_message(): {}, backend fetch failed, ret = {:?}",
+                block_request,
+                ret
+            );
+        }
+    }
+
+    async fn poll(&mut self) {
+        let protocol_response = match self.pending_responses.next().await {
+            Some(protocol_response) => protocol_response,
+            None => return,
+        };
+
+        if let Some(Ok(response)) = protocol_response.response {
+            self.on_block_download_response(
+                protocol_response.peer_id,
+                protocol_response.request_id,
+                response,
+                protocol_response.request_ts.elapsed(),
+            )
+            .await;
+        } else {
+            warn!(
+                target: LOG_TARGET,
+                "FullBlockRelay::poll(): download request failed: sender = {:?}, request = {}, \
+                response = {:?}",
+                protocol_response.peer_id,
+                protocol_response.request_id,
+                protocol_response.response
+            );
+        }
+    }
+}
+
+struct FullBlockRelayValidator {
+    pending_announcements: Arc<Mutex<HashSet<Vec<u8>>>>,
+}
+
+impl<Block: BlockT> Validator<Block> for FullBlockRelayValidator {
+    fn validate(
+        &self,
+        _context: &mut dyn ValidatorContext<Block>,
+        sender: &PeerId,
+        mut data: &[u8],
+    ) -> ValidationResult<Block::Hash> {
+        // TODO: substrate requires decoding twice, once during validate and again
+        // during the processing.
+        if let Err(err) = BlockAnnouncement::<Block>::decode(&mut data) {
+            warn!(
+                target: LOG_TARGET,
+                "FullBlockRelayValidator::validate(): peer = {:?}, decode failed: {:?}",
+                sender,
+                err
+            );
+            ValidationResult::Discard
+        } else {
+            ValidationResult::ProcessAndKeep(topic::<Block>())
+        }
+    }
+
+    fn message_expired<'a>(&'a self) -> Box<dyn FnMut(Block::Hash, &[u8]) -> bool + 'a> {
+        Box::new(move |topic, data| {
+            trace!(
+                target: LOG_TARGET,
+                "FullBlockRelayValidator::message_expired(): topic = {:?}, data = {:?}",
+                topic,
+                data
+            );
+            !self.pending_announcements.lock().contains(data)
+        })
+    }
+
+    fn message_allowed<'a>(
+        &'a self,
+    ) -> Box<dyn FnMut(&PeerId, MessageIntent, &Block::Hash, &[u8]) -> bool + 'a> {
+        Box::new(move |peer, intent, topic, data| {
+            let i = match intent {
+                MessageIntent::Broadcast => "Broadcast",
+                MessageIntent::ForcedBroadcast => "ForcedBroadcast",
+                MessageIntent::PeriodicRebroadcast => "PeriodicRebroadcast",
+            };
+            trace!(
+                target: LOG_TARGET,
+                "FullBlockRelayValidator::message_allowed(): topic = {:?}, data = {:?}, \
+                peer = {:?}, intent = {:?}",
+                topic,
+                data,
+                peer,
+                i
+            );
+
+            let mut pending_announcements = self.pending_announcements.lock();
+            pending_announcements.remove(data)
+        })
+    }
+}
+
+/// Block relay message topic.
+fn topic<Block: BlockT>() -> Block::Hash {
+    <<Block::Header as HeaderT>::Hashing as HashT>::hash(ANNOUNCE_PROTOCOL.as_bytes())
+}
+
+/// Initializes the full block relay specific config.
+pub(crate) fn init_full_block_config(config: &mut Configuration) -> Receiver<IncomingRequest> {
+    let mut cfg = NonDefaultSetConfig::new(ANNOUNCE_PROTOCOL.into(), 1024 * 1024);
+    cfg.allow_non_reserved(25, 25);
+    config.network.extra_sets.push(cfg);
+
+    let (request_sender, request_receiver) = mpsc::channel(INBOUND_QUEUE_SIZE);
+    config
+        .network
+        .request_response_protocols
+        .push(RequestResponseConfig {
+            name: SYNC_PROTOCOL.into(),
+            fallback_names: Vec::new(),
+            max_request_size: 1024 * 1024,
+            max_response_size: 16 * 1024 * 1024,
+            request_timeout: Duration::from_secs(60),
+            inbound_queue: Some(request_sender),
+        });
+    request_receiver
+}

--- a/crates/subspace-block-relay/src/runner.rs
+++ b/crates/subspace-block-relay/src/runner.rs
@@ -75,7 +75,7 @@ impl<Block: BlockT> BlockRelayRunner<Block> {
                 }
                 _ = poll_protocol.fuse() => {}
                 _ = gossip_engine.fuse() => {
-                    error!(target: LOG_TARGET, "BlockRelayRunner(): gossip engine has terminated.");
+                    error!(target: LOG_TARGET, "Gossip engine has terminated.");
                     return;
                 }
             }

--- a/crates/subspace-block-relay/src/runner.rs
+++ b/crates/subspace-block-relay/src/runner.rs
@@ -1,0 +1,84 @@
+//! Block relay protocol runner.
+
+use crate::protocol::BlockRelayProtocol;
+use crate::LOG_TARGET;
+use futures::channel::mpsc::Receiver;
+use futures::{FutureExt, StreamExt};
+use parking_lot::Mutex;
+use sc_consensus_subspace::ImportedBlockNotification;
+use sc_network_gossip::GossipEngine;
+use sc_service::config::IncomingRequest;
+use sc_utils::mpsc::TracingUnboundedReceiver;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+use tracing::{error, info};
+
+/// The block relay runner acts as an interface between the event sources and the protocol implementation.
+pub struct BlockRelayRunner<Block: BlockT> {
+    /// The backend protocol.
+    protocol: Box<dyn BlockRelayProtocol<Block>>,
+
+    /// Block announcement stream.
+    gossip_engine: Arc<Mutex<GossipEngine<Block>>>,
+
+    /// Block import notification stream.
+    import_notifications: TracingUnboundedReceiver<ImportedBlockNotification<Block>>,
+
+    /// Protocol message stream.
+    protocol_messages: Receiver<IncomingRequest>,
+}
+
+impl<Block: BlockT> BlockRelayRunner<Block> {
+    pub fn new(
+        protocol: Box<dyn BlockRelayProtocol<Block>>,
+        gossip_engine: Arc<Mutex<GossipEngine<Block>>>,
+        import_notifications: TracingUnboundedReceiver<ImportedBlockNotification<Block>>,
+        protocol_messages: Receiver<IncomingRequest>,
+    ) -> Self {
+        Self {
+            protocol,
+            gossip_engine,
+            import_notifications,
+            protocol_messages,
+        }
+    }
+
+    /// The event loop.
+    pub async fn run(mut self) {
+        info!(target: LOG_TARGET, "BlockRelayRunner: started");
+        let mut block_announcements = Box::pin(
+            self.gossip_engine
+                .lock()
+                .messages_for(self.protocol.block_announcement_topic()),
+        );
+
+        loop {
+            let engine = self.gossip_engine.clone();
+            let gossip_engine = futures::future::poll_fn(|cx| engine.lock().poll_unpin(cx));
+            let poll_protocol = futures::future::poll_fn(|cx| self.protocol.poll().poll_unpin(cx));
+
+            futures::select! {
+                block_import = self.import_notifications.next().fuse() => {
+                    if let Some(block_import) = block_import {
+                        self.protocol.on_block_import(block_import).await;
+                    }
+                }
+                block_announcement = block_announcements.next().fuse() => {
+                    if let Some(block_announcement) = block_announcement {
+                        self.protocol.on_block_announcement(block_announcement).await;
+                    }
+                }
+                protocol_message = self.protocol_messages.next().fuse() => {
+                    if let Some(protocol_message) = protocol_message {
+                        self.protocol.on_protocol_message(protocol_message).await;
+                    }
+                }
+                _ = poll_protocol.fuse() => {}
+                _ = gossip_engine.fuse() => {
+                    error!(target: LOG_TARGET, "BlockRelayRunner(): gossip engine has terminated.");
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -461,6 +461,7 @@ fn main() -> Result<(), Error> {
                         },
                         segment_publish_concurrency: cli.segment_publish_concurrency,
                         sync_from_dsn: cli.sync_from_dsn,
+                        enable_subspace_block_relay: cli.enable_subspace_block_relay,
                     };
 
                     let partial_components = subspace_service::new_partial::<

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -447,6 +447,9 @@ fn main() -> Result<(), Error> {
                         .network
                         .extra_sets
                         .push(cdm_gossip_peers_set_config());
+                    if cli.enable_subspace_block_relay {
+                        primary_chain_config.announce_block = false;
+                    }
 
                     let primary_chain_config = SubspaceConfiguration {
                         base: primary_chain_config,

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -250,6 +250,11 @@ pub struct Cli {
     /// Parameters used to create the storage monitor.
     #[clap(flatten)]
     pub storage_monitor: StorageMonitorParams,
+
+    /// Disables the default substrate block relay path. Instead, the alternate block relay
+    /// implementation from subspace will be used.
+    #[arg(long, default_value_t = false)]
+    pub enable_subspace_block_relay: bool,
 }
 
 impl SubstrateCli for Cli {

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -61,6 +61,7 @@ sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/subst
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "456cfad45a178617f6886ec400c312f2fea59232" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
+subspace-block-relay = { version = "0.1.0", path = "../subspace-block-relay" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -40,7 +40,7 @@ use sc_client_api::execution_extensions::ExtensionsFactory;
 use sc_client_api::{
     BlockBackend, BlockchainEvents, ExecutorProvider, HeaderBackend, StateBackendFor,
 };
-use sc_consensus::{BlockImport, DefaultImportQueue};
+use sc_consensus::{BlockImport, DefaultImportQueue, ImportQueue};
 use sc_consensus_slots::SlotProportion;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::{
@@ -73,6 +73,7 @@ use sp_session::SessionKeys;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
+use subspace_block_relay::{build_block_relay, init_block_relay_config};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::PIECES_IN_SEGMENT;
 use subspace_fraud_proof::VerifyFraudProof;
@@ -420,7 +421,7 @@ type FullNode<RuntimeApi, ExecutorDispatch> = NewFull<
 /// Builds a new service for a full client.
 #[allow(clippy::type_complexity)]
 pub async fn new_full<RuntimeApi, ExecutorDispatch, I>(
-    config: SubspaceConfiguration,
+    mut config: SubspaceConfiguration,
     partial_components: PartialComponents<
         FullClient<RuntimeApi, ExecutorDispatch>,
         FullBackend,
@@ -481,6 +482,9 @@ where
     } = partial_components;
 
     let root_block_cache = RootBlockCache::new(client.clone());
+    // Enable the alternate block relay implementation if the CLI params request
+    // disabling the default path.
+    let enable_block_relay = !config.base.announce_block;
 
     let (node, bootstrap_nodes) = match config.subspace_networking.clone() {
         SubspaceNetworking::Reuse {
@@ -638,6 +642,12 @@ where
             })?;
     }
 
+    let block_relay_receiver = if enable_block_relay {
+        Some(init_block_relay_config(&mut config))
+    } else {
+        None
+    };
+    let import_queue_service = import_queue.service();
     let (network, system_rpc_tx, tx_handler_controller, network_starter) =
         sc_service::build_network(sc_service::BuildNetworkParams {
             config: &config,
@@ -788,6 +798,19 @@ where
         telemetry: telemetry.as_mut(),
         tx_handler_controller,
     })?;
+
+    if let Some(block_relay_receiver) = block_relay_receiver {
+        let block_relay_runner = build_block_relay(
+            network.clone(),
+            client.clone(),
+            import_queue_service,
+            imported_block_notification_stream.subscribe(),
+            block_relay_receiver,
+        );
+        task_manager
+            .spawn_handle()
+            .spawn("block-relay-runner", None, block_relay_runner.run());
+    }
 
     Ok(NewFull {
         task_manager,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -176,6 +176,9 @@ pub struct SubspaceConfiguration {
     pub segment_publish_concurrency: NonZeroUsize,
     /// Enables DSN-sync on startup.
     pub sync_from_dsn: bool,
+    /// Disables the default substrate block relay path. Instead, the alternate block relay
+    /// implementation from subspace will be used.
+    pub enable_subspace_block_relay: bool,
 }
 
 struct SubspaceExtensionsFactory {
@@ -482,10 +485,6 @@ where
     } = partial_components;
 
     let root_block_cache = RootBlockCache::new(client.clone());
-    // Enable the alternate block relay implementation if the CLI params request
-    // disabling the default path.
-    let enable_block_relay = !config.base.announce_block;
-
     let (node, bootstrap_nodes) = match config.subspace_networking.clone() {
         SubspaceNetworking::Reuse {
             node,
@@ -642,7 +641,7 @@ where
             })?;
     }
 
-    let block_relay_receiver = if enable_block_relay {
+    let block_relay_receiver = if config.enable_subspace_block_relay {
         Some(init_block_relay_config(&mut config))
     } else {
         None

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -150,6 +150,7 @@ async fn run_executor(
             },
             segment_publish_concurrency: NonZeroUsize::new(10).unwrap(),
             sync_from_dsn: false,
+            enable_subspace_block_relay: false,
         };
 
         let partial_components = subspace_service::new_partial::<

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -220,6 +220,7 @@ pub async fn run_validator_node(
             },
             segment_publish_concurrency: NonZeroUsize::new(10).unwrap(),
             sync_from_dsn: false,
+            enable_subspace_block_relay: false,
         };
 
         let partial_components = subspace_service::new_partial::<RuntimeApi, TestExecutorDispatch>(


### PR DESCRIPTION
This PR creates the basic framework for the alternate block relay path. The changes are controlled by the flag --enable-subspace-block-relay, which is disabled by default. When the flag is enabled:

The default block announcements in substrate are disabled
Instead of that, we implement block announcements using the substrate GossipEngine API
The block download request to be implemented using the Request Response API. In this first cut, this would just implement the existing full block request/response protocol. This would be later changed to implement compact blocks, Graphene
Testing: tested on local dev box. Benchmarking in progress

Tracking issue: https://github.com/subspace/subspace/issues/1223

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
