### PR TITLE
Fix stack overflow during piece decoding

### DIFF
--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms, missing_docs)]
 #![cfg_attr(feature = "std", warn(missing_debug_implementations))]
-#![feature(slice_flatten)]
+#![feature(new_uninit, slice_flatten)]
 
 pub mod crypto;
 pub mod objects;


### PR DESCRIPTION
@i1i1's suggestion in https://github.com/subspace/subspace/pull/1287 lead to https://github.com/paritytech/parity-scale-codec/issues/419, which is in fact long standing https://github.com/rust-lang/rust/issues/53827. Workaround with manual implementation is applied to avoid stack overflow for now.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
