### PR TITLE
Erasure coding commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "kzg",
  "libc",
  "once_cell",
+ "rand 0.8.5",
  "sha2 0.10.6",
 ]
 

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -19,6 +19,7 @@ use blst_from_scratch::types::g1::FsG1;
 use blst_from_scratch::types::kzg_settings::FsKZGSettings;
 use blst_from_scratch::types::poly::FsPoly;
 use core::hash::{Hash, Hasher};
+use core::mem;
 use kzg::{FFTFr, FFTSettings, KZGSettings};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input, MaxEncodedLen};
 #[cfg(feature = "std")]
@@ -95,6 +96,7 @@ pub struct Polynomial(FsPoly);
 
 /// Commitment to polynomial
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct Commitment(FsG1);
 
 impl Commitment {
@@ -109,6 +111,130 @@ impl Commitment {
     /// Try to deserialize commitment from raw bytes
     pub fn try_from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, String> {
         Ok(Commitment(bytes_to_g1_rust(bytes)?))
+    }
+
+    /// Convenient conversion from slice of commitment to underlying representation for efficiency
+    /// purposes.
+    pub fn slice_to_repr(value: &[Self]) -> &[FsG1] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from slice of underlying representation to commitment for efficiency
+    /// purposes.
+    pub fn slice_from_repr(value: &[FsG1]) -> &[Self] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from slice of optional commitment to underlying representation for
+    /// efficiency purposes.
+    pub fn slice_option_to_repr(value: &[Option<Self>]) -> &[Option<FsG1>] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from slice of optional underlying representation to commitment for
+    /// efficiency purposes.
+    pub fn slice_option_from_repr(value: &[Option<FsG1>]) -> &[Option<Self>] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from mutable slice of commitment to underlying representation for
+    /// efficiency purposes.
+    pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [FsG1] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from mutable slice of underlying representation to commitment for
+    /// efficiency purposes.
+    pub fn slice_mut_from_repr(value: &mut [FsG1]) -> &mut [Self] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from optional mutable slice of commitment to underlying representation
+    /// for efficiency purposes.
+    pub fn slice_option_mut_to_repr(value: &mut [Option<Self>]) -> &mut [Option<FsG1>] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from optional mutable slice of underlying representation to commitment
+    /// for efficiency purposes.
+    pub fn slice_option_mut_from_repr(value: &mut [Option<FsG1>]) -> &mut [Option<Self>] {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from vector of commitment to underlying representation for efficiency
+    /// purposes.
+    pub fn vec_to_repr(value: Vec<Self>) -> Vec<FsG1> {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        //  layout, original vector is not dropped
+        unsafe {
+            let mut value = mem::ManuallyDrop::new(value);
+            Vec::from_raw_parts(
+                value.as_mut_ptr() as *mut FsG1,
+                value.len(),
+                value.capacity(),
+            )
+        }
+    }
+
+    /// Convenient conversion from vector of underlying representation to commitment for efficiency
+    /// purposes.
+    pub fn vec_from_repr(value: Vec<FsG1>) -> Vec<Self> {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        //  layout, original vector is not dropped
+        unsafe {
+            let mut value = mem::ManuallyDrop::new(value);
+            Vec::from_raw_parts(
+                value.as_mut_ptr() as *mut Self,
+                value.len(),
+                value.capacity(),
+            )
+        }
+    }
+
+    /// Convenient conversion from vector of optional commitment to underlying representation for
+    /// efficiency purposes.
+    pub fn vec_option_to_repr(value: Vec<Option<Self>>) -> Vec<Option<FsG1>> {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        //  layout, original vector is not dropped
+        unsafe {
+            let mut value = mem::ManuallyDrop::new(value);
+            Vec::from_raw_parts(
+                value.as_mut_ptr() as *mut Option<FsG1>,
+                value.len(),
+                value.capacity(),
+            )
+        }
+    }
+
+    /// Convenient conversion from vector of optional underlying representation to commitment for
+    /// efficiency purposes.
+    pub fn vec_option_from_repr(value: Vec<Option<FsG1>>) -> Vec<Option<Self>> {
+        // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
+        //  layout, original vector is not dropped
+        unsafe {
+            let mut value = mem::ManuallyDrop::new(value);
+            Vec::from_raw_parts(
+                value.as_mut_ptr() as *mut Option<Self>,
+                value.len(),
+                value.capacity(),
+            )
+        }
     }
 }
 
@@ -201,6 +327,7 @@ impl TypeInfo for Commitment {
 
 /// Witness for polynomial evaluation
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct Witness(FsG1);
 
 impl Witness {

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -20,6 +20,7 @@ use blst_from_scratch::types::kzg_settings::FsKZGSettings;
 use blst_from_scratch::types::poly::FsPoly;
 use core::hash::{Hash, Hasher};
 use core::mem;
+use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
 use kzg::{FFTFr, FFTSettings, KZGSettings};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input, MaxEncodedLen};
 #[cfg(feature = "std")]
@@ -95,7 +96,7 @@ pub fn embedded_kzg_settings() -> FsKZGSettings {
 pub struct Polynomial(FsPoly);
 
 /// Commitment to polynomial
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, From, Into, AsRef, AsMut, Deref, DerefMut)]
 #[repr(transparent)]
 pub struct Commitment(FsG1);
 
@@ -326,7 +327,7 @@ impl TypeInfo for Commitment {
 }
 
 /// Witness for polynomial evaluation
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, From, Into, AsRef, AsMut, Deref, DerefMut)]
 #[repr(transparent)]
 pub struct Witness(FsG1);
 

--- a/crates/subspace-erasure-coding/Cargo.toml
+++ b/crates/subspace-erasure-coding/Cargo.toml
@@ -18,6 +18,8 @@ kzg = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f047
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
+# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30" }
 criterion = "0.4.0"
 rand = "0.8.5"
 
@@ -28,3 +30,7 @@ std = [
     "kzg/std",
     "subspace-core-primitives/std",
 ]
+
+[[bench]]
+name = "commitments"
+harness = false

--- a/crates/subspace-erasure-coding/benches/commitments.rs
+++ b/crates/subspace-erasure-coding/benches/commitments.rs
@@ -1,0 +1,26 @@
+use blst_from_scratch::types::g1::FsG1;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use kzg::G1;
+use std::num::NonZeroUsize;
+use subspace_core_primitives::crypto::kzg::Commitment;
+use subspace_erasure_coding::ErasureCoding;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let scale = NonZeroUsize::new(8).unwrap();
+    let num_shards = 2usize.pow(scale.get() as u32);
+    let ec = ErasureCoding::new(scale).unwrap();
+
+    let source_commitments = (0..num_shards / 2)
+        .map(|_| Commitment::from(FsG1::rand()))
+        .collect::<Vec<_>>();
+
+    c.bench_function("extend", |b| {
+        b.iter(|| {
+            ec.extend_commitments(black_box(&source_commitments))
+                .unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This resolves 4th item from https://github.com/subspace/subspace/issues/1163 and improves archiving performance by erasure coding commitments rather than creating them for half of the records in segment.

Before (one segment start to finish, it is not as bad with incremental commitment):
```
segment-archiving       time:   [3.5598 s 3.5659 s 3.5737 s]
```
After:
```
segment-archiving       time:   [2.3499 s 2.3595 s 2.3736 s]
```

Resolves #1163

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
