### PR TITLE
integrate core eth relay domain runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10156,6 +10156,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "clap 4.1.13",
+ "core-eth-relay-runtime",
  "core-payments-domain-runtime",
  "cross-domain-message-gossip",
  "dirs",

--- a/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
+++ b/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
@@ -415,7 +415,7 @@ where
 
         let wasm_bundle = match *domain_id {
             DomainId::SYSTEM => system_wasm_bundle,
-            DomainId::CORE_PAYMENTS => {
+            DomainId::CORE_PAYMENTS | DomainId::CORE_ETH_RELAY => {
                 read_core_domain_runtime_blob(system_wasm_bundle.as_ref(), *domain_id)
                     .map_err(|err| {
                         VerificationError::RuntimeCode(format!(

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -23,6 +23,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 bytesize = "1.2.0"
 clap = { version = "4.1.6", features = ["derive"] }
 cross-domain-message-gossip = { version = "0.1.0", path = "../../domains/client/cross-domain-message-gossip" }
+core-eth-relay-runtime = { version = "0.1.0", path = "../../domains/runtime/core-eth-relay" }
 core-payments-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/core-payments" }
 dirs = "4.0.0"
 domain-client-executor = { version = "0.1.0", path = "../../domains/client/domain-executor" }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -75,6 +75,24 @@ impl NativeExecutionDispatch for CorePaymentsDomainExecutorDispatch {
     }
 }
 
+/// Core eth relay domain executor instance.
+pub struct CoreEthRelayDomainExecutorDispatch;
+
+impl NativeExecutionDispatch for CoreEthRelayDomainExecutorDispatch {
+    #[cfg(feature = "runtime-benchmarks")]
+    type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type ExtendHostFunctions = ();
+
+    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+        core_eth_relay_runtime::api::dispatch(method, data)
+    }
+
+    fn native_version() -> sc_executor::NativeVersion {
+        core_eth_relay_runtime::native_version()
+    }
+}
+
 /// Subspace node error.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -635,6 +653,32 @@ fn main() -> Result<(), Error> {
                                         _,
                                         core_payments_domain_runtime::RuntimeApi,
                                         CorePaymentsDomainExecutorDispatch,
+                                    >(core_domain_params)
+                                    .await?;
+
+                                domain_tx_pool_sinks.insert(
+                                    core_domain_cli.domain_id,
+                                    core_domain_node.tx_pool_sink,
+                                );
+                                primary_chain_node
+                                    .task_manager
+                                    .add_child(core_domain_node.task_manager);
+
+                                core_domain_node.network_starter.start_network();
+                            }
+                            DomainId::CORE_ETH_RELAY => {
+                                let core_domain_node =
+                                    domain_service::new_full_core::<
+                                        _,
+                                        _,
+                                        _,
+                                        _,
+                                        _,
+                                        _,
+                                        _,
+                                        _,
+                                        core_eth_relay_runtime::RuntimeApi,
+                                        CoreEthRelayDomainExecutorDispatch,
                                     >(core_domain_params)
                                     .await?;
 

--- a/crates/subspace-node/src/core_domain.rs
+++ b/crates/subspace-node/src/core_domain.rs
@@ -1,2 +1,3 @@
 pub(crate) mod cli;
+pub(crate) mod core_eth_relay_chain_spec;
 pub(crate) mod core_payments_chain_spec;

--- a/crates/subspace-node/src/core_domain/cli.rs
+++ b/crates/subspace-node/src/core_domain/cli.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::core_domain::core_payments_chain_spec;
+use crate::core_domain::{core_eth_relay_chain_spec, core_payments_chain_spec};
 use crate::parser::parse_relayer_id;
 use clap::Parser;
 use domain_runtime_primitives::RelayerId;
@@ -153,6 +153,7 @@ impl SubstrateCli for CoreDomainCli {
         // TODO: add core domain chain spec an extension of system domain chain spec.
         match self.domain_id {
             DomainId::CORE_PAYMENTS => core_payments_chain_spec::load_chain_spec(id),
+            DomainId::CORE_ETH_RELAY => core_eth_relay_chain_spec::load_chain_spec(id),
             domain_id => unreachable!("Unsupported core domain: {domain_id:?}"),
         }
     }
@@ -163,6 +164,7 @@ impl SubstrateCli for CoreDomainCli {
             .expect("Initialized when constructing this struct")
         {
             &DomainId::CORE_PAYMENTS => &core_payments_domain_runtime::VERSION,
+            &DomainId::CORE_ETH_RELAY => &core_eth_relay_runtime::VERSION,
             domain_id => unreachable!("Unsupported core domain: {domain_id:?}"),
         }
     }

--- a/crates/subspace-node/src/core_domain/core_eth_relay_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_eth_relay_chain_spec.rs
@@ -110,13 +110,13 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
     )
 }
 
-pub fn gemini_3c_config() -> ExecutionChainSpec<GenesisConfig> {
+pub fn gemini_3d_config() -> ExecutionChainSpec<GenesisConfig> {
     ExecutionChainSpec::from_genesis(
         // Name
-        "Subspace Gemini 3c Core Eth Relay Domain",
+        "Subspace Gemini 3d Core Eth Relay Domain",
         // ID
-        "subspace_gemini_3c_core_eth_relay_domain",
-        ChainType::Local,
+        "subspace_gemini_3d_core_eth_relay_domain",
+        ChainType::Live,
         move || {
             let sudo_account =
                 AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
@@ -138,7 +138,7 @@ pub fn gemini_3c_config() -> ExecutionChainSpec<GenesisConfig> {
         // Telemetry
         None,
         // Protocol ID
-        Some("subspace-gemini-3c-core-core-eth-relay-domain"),
+        Some("subspace-gemini-3d-core-core-eth-relay-domain"),
         None,
         // Properties
         Some(chain_spec_properties()),
@@ -191,7 +191,7 @@ pub fn devnet_config() -> ExecutionChainSpec<GenesisConfig> {
 pub fn load_chain_spec(spec_id: &str) -> std::result::Result<Box<dyn sc_cli::ChainSpec>, String> {
     let chain_spec = match spec_id {
         "dev" => development_config(),
-        "gemini-3c" => gemini_3c_config(),
+        "gemini-3d" => gemini_3d_config(),
         "devnet" => devnet_config(),
         "" | "local" => local_testnet_config(),
         path => ChainSpec::from_json_file(std::path::PathBuf::from(path))?,

--- a/crates/subspace-node/src/core_domain/core_eth_relay_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_eth_relay_chain_spec.rs
@@ -1,0 +1,229 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Core eth relay domain configurations.
+
+use crate::chain_spec_utils::{chain_spec_properties, get_account_id_from_seed};
+use core_eth_relay_runtime::{
+    AccountId, BalancesConfig, EthereumBeaconClientConfig, GenesisConfig, MessengerConfig,
+    SudoConfig, SystemConfig, WASM_BINARY,
+};
+use domain_runtime_primitives::RelayerId;
+use sc_service::ChainType;
+use sc_subspace_chain_specs::ExecutionChainSpec;
+use sp_core::crypto::Ss58Codec;
+use subspace_runtime_primitives::SSC;
+
+pub type ChainSpec = ExecutionChainSpec<GenesisConfig>;
+
+pub fn development_config() -> ExecutionChainSpec<GenesisConfig> {
+    ExecutionChainSpec::from_genesis(
+        // Name
+        "Development",
+        // ID
+        "core_eth_relay_domain_dev",
+        ChainType::Development,
+        move || {
+            testnet_genesis(
+                vec![
+                    get_account_id_from_seed("Alice"),
+                    get_account_id_from_seed("Bob"),
+                    get_account_id_from_seed("Alice//stash"),
+                    get_account_id_from_seed("Bob//stash"),
+                ],
+                Some(get_account_id_from_seed("Alice")),
+                vec![(
+                    get_account_id_from_seed("Alice"),
+                    get_account_id_from_seed("Alice"),
+                )],
+            )
+        },
+        vec![],
+        None,
+        None,
+        None,
+        Some(chain_spec_properties()),
+        None,
+    )
+}
+
+pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
+    ExecutionChainSpec::from_genesis(
+        // Name
+        "Local Testnet",
+        // ID
+        "core_eth_relay_domain_local_testnet",
+        ChainType::Local,
+        move || {
+            testnet_genesis(
+                vec![
+                    get_account_id_from_seed("Alice"),
+                    get_account_id_from_seed("Bob"),
+                    get_account_id_from_seed("Charlie"),
+                    get_account_id_from_seed("Dave"),
+                    get_account_id_from_seed("Eve"),
+                    get_account_id_from_seed("Ferdie"),
+                    get_account_id_from_seed("Alice//stash"),
+                    get_account_id_from_seed("Bob//stash"),
+                    get_account_id_from_seed("Charlie//stash"),
+                    get_account_id_from_seed("Dave//stash"),
+                    get_account_id_from_seed("Eve//stash"),
+                    get_account_id_from_seed("Ferdie//stash"),
+                ],
+                Some(get_account_id_from_seed("Alice")),
+                vec![
+                    (
+                        get_account_id_from_seed("Alice"),
+                        get_account_id_from_seed("Alice"),
+                    ),
+                    (
+                        get_account_id_from_seed("Bob"),
+                        get_account_id_from_seed("Bob"),
+                    ),
+                ],
+            )
+        },
+        // Bootnodes
+        vec![],
+        // Telemetry
+        None,
+        // Protocol ID
+        Some("template-local"),
+        None,
+        // Properties
+        Some(chain_spec_properties()),
+        // Extensions
+        None,
+    )
+}
+
+pub fn gemini_3c_config() -> ExecutionChainSpec<GenesisConfig> {
+    ExecutionChainSpec::from_genesis(
+        // Name
+        "Subspace Gemini 3c Core Eth Relay Domain",
+        // ID
+        "subspace_gemini_3c_core_eth_relay_domain",
+        ChainType::Local,
+        move || {
+            let sudo_account =
+                AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
+                    .expect("Invalid Sudo account");
+            testnet_genesis(
+                vec![
+                    // Genesis executor
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
+                        .expect("Wrong executor account address"),
+                    // Sudo account
+                    sudo_account.clone(),
+                ],
+                Some(sudo_account),
+                Default::default(),
+            )
+        },
+        // Bootnodes
+        vec![],
+        // Telemetry
+        None,
+        // Protocol ID
+        Some("subspace-gemini-3c-core-core-eth-relay-domain"),
+        None,
+        // Properties
+        Some(chain_spec_properties()),
+        // Extensions
+        None,
+    )
+}
+
+pub fn devnet_config() -> ExecutionChainSpec<GenesisConfig> {
+    ExecutionChainSpec::from_genesis(
+        // Name
+        "Subspace Devnet Core Eth Relay Domain",
+        // ID
+        "subspace_devnet_core_eth_relay_domain",
+        ChainType::Custom("Testnet".to_string()),
+        move || {
+            let sudo_account =
+                AccountId::from_ss58check("5CXTmJEusve5ixyJufqHThmy4qUrrm6FyLCR7QfE4bbyMTNC")
+                    .expect("Invalid Sudo account");
+            testnet_genesis(
+                vec![
+                    // Genesis executor
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
+                        .expect("Wrong executor account address"),
+                    // Sudo account
+                    sudo_account.clone(),
+                ],
+                Some(sudo_account.clone()),
+                vec![(
+                    sudo_account,
+                    RelayerId::from_ss58check("5D7kgfacBsP6pkMB628221HG98mz2euaytthdoeZPGceQusS")
+                        .expect("Wrong relayer account address"),
+                )],
+            )
+        },
+        // Bootnodes
+        vec![],
+        // Telemetry
+        None,
+        // Protocol ID
+        Some("subspace-devnet-core-eth-relay-domain"),
+        None,
+        // Properties
+        Some(chain_spec_properties()),
+        // Extensions
+        None,
+    )
+}
+
+pub fn load_chain_spec(spec_id: &str) -> std::result::Result<Box<dyn sc_cli::ChainSpec>, String> {
+    let chain_spec = match spec_id {
+        "dev" => development_config(),
+        "gemini-3c" => gemini_3c_config(),
+        "devnet" => devnet_config(),
+        "" | "local" => local_testnet_config(),
+        path => ChainSpec::from_json_file(std::path::PathBuf::from(path))?,
+    };
+    Ok(Box::new(chain_spec))
+}
+
+fn testnet_genesis(
+    endowed_accounts: Vec<AccountId>,
+    maybe_sudo_account: Option<AccountId>,
+    relayers: Vec<(AccountId, RelayerId)>,
+) -> GenesisConfig {
+    GenesisConfig {
+        system: SystemConfig {
+            code: WASM_BINARY
+                .expect("WASM binary was not build, please build it!")
+                .to_vec(),
+        },
+        sudo: SudoConfig {
+            key: maybe_sudo_account,
+        },
+        transaction_payment: Default::default(),
+        balances: BalancesConfig {
+            balances: endowed_accounts
+                .iter()
+                .cloned()
+                .map(|k| (k, 1_000_000 * SSC))
+                .collect(),
+        },
+        messenger: MessengerConfig { relayers },
+        ethereum_beacon_client: EthereumBeaconClientConfig {
+            initial_sync: Default::default(),
+        },
+    }
+}

--- a/crates/subspace-node/src/system_domain/chain_spec.rs
+++ b/crates/subspace-node/src/system_domain/chain_spec.rs
@@ -230,24 +230,52 @@ pub fn gemini_3d_config() -> ExecutionChainSpec<GenesisConfig> {
                     )
                     .expect("Wrong executor public key"),
                 )],
-                vec![(
-                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
-                        .expect("Wrong executor account address"),
-                    1_000 * SSC,
-                    DomainConfig {
-                        wasm_runtime_hash: blake2b_256_hash(
-                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                vec![
+                    (
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
                         )
-                        .into(),
-                        max_bundle_size: 4 * 1024 * 1024,
-                        bundle_slot_probability: (1, 1),
-                        max_bundle_weight: Weight::MAX,
-                        min_operator_stake: 100 * SSC,
-                    },
-                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
                         .expect("Wrong executor account address"),
-                    Percent::from_percent(10),
-                )],
+                        1_000 * SSC,
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 4 * 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                        )
+                        .expect("Wrong executor account address"),
+                        Percent::from_percent(10),
+                    ),
+                    (
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                        )
+                        .expect("Wrong executor account address"),
+                        1_000 * SSC,
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_ETH_RELAY_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 4 * 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                        )
+                        .expect("Wrong executor account address"),
+                        Percent::from_percent(10),
+                    ),
+                ],
                 Some(sudo_account),
                 Default::default(),
             )
@@ -296,24 +324,52 @@ pub fn devnet_config() -> ExecutionChainSpec<GenesisConfig> {
                     )
                     .expect("Wrong executor public key"),
                 )],
-                vec![(
-                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
-                        .expect("Wrong executor account address"),
-                    1_000 * SSC,
-                    DomainConfig {
-                        wasm_runtime_hash: blake2b_256_hash(
-                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                vec![
+                    (
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
                         )
-                        .into(),
-                        max_bundle_size: 4 * 1024 * 1024,
-                        bundle_slot_probability: (1, 1),
-                        max_bundle_weight: Weight::MAX,
-                        min_operator_stake: 100 * SSC,
-                    },
-                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
                         .expect("Wrong executor account address"),
-                    Percent::from_percent(10),
-                )],
+                        1_000 * SSC,
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 4 * 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                        )
+                        .expect("Wrong executor account address"),
+                        Percent::from_percent(10),
+                    ),
+                    (
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                        )
+                        .expect("Wrong executor account address"),
+                        1_000 * SSC,
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_ETH_RELAY_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 4 * 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        AccountId::from_ss58check(
+                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                        )
+                        .expect("Wrong executor account address"),
+                        Percent::from_percent(10),
+                    ),
+                ],
                 Some(sudo_account.clone()),
                 vec![(
                     sudo_account,

--- a/crates/subspace-node/src/system_domain/chain_spec.rs
+++ b/crates/subspace-node/src/system_domain/chain_spec.rs
@@ -230,52 +230,24 @@ pub fn gemini_3d_config() -> ExecutionChainSpec<GenesisConfig> {
                     )
                     .expect("Wrong executor public key"),
                 )],
-                vec![
-                    (
-                        AccountId::from_ss58check(
-                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
-                        )
+                vec![(
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
                         .expect("Wrong executor account address"),
-                        1_000 * SSC,
-                        DomainConfig {
-                            wasm_runtime_hash: blake2b_256_hash(
-                                system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
-                            )
-                            .into(),
-                            max_bundle_size: 4 * 1024 * 1024,
-                            bundle_slot_probability: (1, 1),
-                            max_bundle_weight: Weight::MAX,
-                            min_operator_stake: 100 * SSC,
-                        },
-                        AccountId::from_ss58check(
-                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
+                    1_000 * SSC,
+                    DomainConfig {
+                        wasm_runtime_hash: blake2b_256_hash(
+                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
                         )
+                        .into(),
+                        max_bundle_size: 4 * 1024 * 1024,
+                        bundle_slot_probability: (1, 1),
+                        max_bundle_weight: Weight::MAX,
+                        min_operator_stake: 100 * SSC,
+                    },
+                    AccountId::from_ss58check("5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ")
                         .expect("Wrong executor account address"),
-                        Percent::from_percent(10),
-                    ),
-                    (
-                        AccountId::from_ss58check(
-                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
-                        )
-                        .expect("Wrong executor account address"),
-                        1_000 * SSC,
-                        DomainConfig {
-                            wasm_runtime_hash: blake2b_256_hash(
-                                system_domain_runtime::CORE_ETH_RELAY_WASM_BUNDLE,
-                            )
-                            .into(),
-                            max_bundle_size: 4 * 1024 * 1024,
-                            bundle_slot_probability: (1, 1),
-                            max_bundle_weight: Weight::MAX,
-                            min_operator_stake: 100 * SSC,
-                        },
-                        AccountId::from_ss58check(
-                            "5Df6w8CgYY8kTRwCu8bjBsFu46fy4nFa61xk6dUbL6G4fFjQ",
-                        )
-                        .expect("Wrong executor account address"),
-                        Percent::from_percent(10),
-                    ),
-                ],
+                    Percent::from_percent(10),
+                )],
                 Some(sudo_account),
                 Default::default(),
             )

--- a/crates/subspace-node/src/system_domain/chain_spec.rs
+++ b/crates/subspace-node/src/system_domain/chain_spec.rs
@@ -56,23 +56,42 @@ pub fn development_config() -> ExecutionChainSpec<GenesisConfig> {
                     get_account_id_from_seed("Alice"),
                     get_public_key_from_seed::<ExecutorPublicKey>("Alice"),
                 )],
-                vec![(
-                    get_account_id_from_seed("Alice"),
-                    1_000 * SSC,
-                    // TODO: proper genesis domain config
-                    DomainConfig {
-                        wasm_runtime_hash: blake2b_256_hash(
-                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
-                        )
-                        .into(),
-                        max_bundle_size: 1024 * 1024,
-                        bundle_slot_probability: (1, 1),
-                        max_bundle_weight: Weight::MAX,
-                        min_operator_stake: 100 * SSC,
-                    },
-                    get_account_id_from_seed("Alice"),
-                    Percent::from_percent(10),
-                )],
+                vec![
+                    (
+                        get_account_id_from_seed("Alice"),
+                        1_000 * SSC,
+                        // TODO: proper genesis domain config
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        get_account_id_from_seed("Alice"),
+                        Percent::from_percent(10),
+                    ),
+                    (
+                        get_account_id_from_seed("Alice"),
+                        1_000 * SSC,
+                        // TODO: proper genesis domain config
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_ETH_RELAY_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        get_account_id_from_seed("Alice"),
+                        Percent::from_percent(10),
+                    ),
+                ],
                 Some(get_account_id_from_seed("Alice")),
                 vec![(
                     get_account_id_from_seed("Alice"),
@@ -118,23 +137,42 @@ pub fn local_testnet_config() -> ExecutionChainSpec<GenesisConfig> {
                     get_account_id_from_seed("Alice"),
                     get_public_key_from_seed::<ExecutorPublicKey>("Alice"),
                 )],
-                vec![(
-                    get_account_id_from_seed("Alice"),
-                    1_000 * SSC,
-                    // TODO: proper genesis domain config
-                    DomainConfig {
-                        wasm_runtime_hash: blake2b_256_hash(
-                            system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
-                        )
-                        .into(),
-                        max_bundle_size: 1024 * 1024,
-                        bundle_slot_probability: (1, 1),
-                        max_bundle_weight: Weight::MAX,
-                        min_operator_stake: 100 * SSC,
-                    },
-                    get_account_id_from_seed("Alice"),
-                    Percent::from_percent(10),
-                )],
+                vec![
+                    (
+                        get_account_id_from_seed("Alice"),
+                        1_000 * SSC,
+                        // TODO: proper genesis domain config
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_PAYMENTS_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        get_account_id_from_seed("Alice"),
+                        Percent::from_percent(10),
+                    ),
+                    (
+                        get_account_id_from_seed("Alice"),
+                        1_000 * SSC,
+                        // TODO: proper genesis domain config
+                        DomainConfig {
+                            wasm_runtime_hash: blake2b_256_hash(
+                                system_domain_runtime::CORE_ETH_RELAY_WASM_BUNDLE,
+                            )
+                            .into(),
+                            max_bundle_size: 1024 * 1024,
+                            bundle_slot_probability: (1, 1),
+                            max_bundle_weight: Weight::MAX,
+                            min_operator_stake: 100 * SSC,
+                        },
+                        get_account_id_from_seed("Alice"),
+                        Percent::from_percent(10),
+                    ),
+                ],
                 Some(get_account_id_from_seed("Alice")),
                 vec![
                     (

--- a/domains/client/block-preprocessor/src/preprocessor.rs
+++ b/domains/client/block-preprocessor/src/preprocessor.rs
@@ -68,7 +68,7 @@ where
 
         let new_runtime = match domain_id {
             DomainId::SYSTEM => system_domain_runtime,
-            DomainId::CORE_PAYMENTS => {
+            DomainId::CORE_PAYMENTS | DomainId::CORE_ETH_RELAY => {
                 read_core_domain_runtime_blob(system_domain_runtime.as_ref(), domain_id)
                     .map_err(|err| sp_blockchain::Error::Application(Box::new(err)))?
                     .into()

--- a/domains/runtime/system/build.rs
+++ b/domains/runtime/system/build.rs
@@ -6,6 +6,13 @@ fn main() {
         "core_payments_wasm_bundle.rs",
     );
 
+    subspace_wasm_tools::create_runtime_bundle_inclusion_file(
+        "core-eth-relay-runtime",
+        "CORE_ETH_RELAY_WASM_BUNDLE",
+        Some(&sp_domains::DomainId::CORE_ETH_RELAY.link_section_name()),
+        "core_eth_relay_wasm_bundle.rs",
+    );
+
     #[cfg(feature = "std")]
     {
         substrate_wasm_builder::WasmBuilder::new()

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -36,6 +36,7 @@ use subspace_runtime_primitives::{SHANNON, SSC};
 
 // Make core-payments WASM runtime available.
 include!(concat!(env!("OUT_DIR"), "/core_payments_wasm_bundle.rs"));
+include!(concat!(env!("OUT_DIR"), "/core_eth_relay_wasm_bundle.rs"));
 
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;

--- a/domains/test/runtime/build.rs
+++ b/domains/test/runtime/build.rs
@@ -6,6 +6,13 @@ fn main() {
         "core_payments_wasm_bundle.rs",
     );
 
+    subspace_wasm_tools::create_runtime_bundle_inclusion_file(
+        "core-eth-relay-runtime",
+        "CORE_ETH_RELAY_WASM_BUNDLE",
+        Some(&sp_domains::DomainId::CORE_ETH_RELAY.link_section_name()),
+        "core_eth_relay_wasm_bundle.rs",
+    );
+
     #[cfg(feature = "std")]
     {
         substrate_wasm_builder::WasmBuilder::new()


### PR DESCRIPTION
### Description
This PR integrates core eth relay domain into subspace node as well as domain cli. 

Marking this PR as draft till the issue with macos compilation is resolved
- [x] Test that the domain is working through CLI (This is blocked by compilation issue on macos)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
