### PR TITLE
fix plot size check in farmer

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -132,11 +132,13 @@ pub(crate) async fn farm_multi_disk(
     //  fail later
     for (disk_farm_index, disk_farm) in disk_farms.into_iter().enumerate() {
         let minimum_plot_size = get_required_plot_space_with_overhead(PLOT_SECTOR_SIZE);
+        let allocated_plotting_space_with_overhead =
+            get_required_plot_space_with_overhead(disk_farm.allocated_plotting_space);
 
-        if disk_farm.allocated_plotting_space < minimum_plot_size {
+        if allocated_plotting_space_with_overhead < minimum_plot_size {
             return Err(anyhow::anyhow!(
                 "Plot size is too low ({} bytes). Minimum is {}",
-                disk_farm.allocated_plotting_space,
+                allocated_plotting_space_with_overhead,
                 minimum_plot_size
             ));
         }


### PR DESCRIPTION
### Description

While trying to run local farmer with as minimum space as possible for testing purposes, I ran following commands: 

```bash
cargo run --release --bin subspace-farmer farm --reward-address <reward_address> --plot-size 1
   # Compilation snipped #
     Running `target/release/subspace-farmer farm --reward-address <reward_address> --plot-size 1`
Error: Plot size is too low (1 bytes). Minimum is 36472208
```

Which indicates that minimum plot size should be `36472208`. So running again with that plot size, I get following output:

```bash
parth@Parths-MBP subspace % cargo run --release --bin subspace-farmer farm --reward-address <reward_address> --plot-size 36472209
     # Compilation snipped #
     Running `target/release/subspace-farmer farm --reward-address <reward_address> --plot-size 36472209`
Error: Plot size is too low (33554432 bytes). Minimum is 36472208
```

That means even after passing requested minimum the farmer returns `plot size too low` error.

#### Why this is happening?
Upon investigation, I found out that the check here compares `(minimum usable plot size + overhead)` to `input usable plot size` which fails in this case since I want to run farmer with as low plot size as possible. 

This PR modifies this check to compare `(minimum usable plot size + overhead)` with `(input usable plot size + overhead)` which fixes the issue.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
