### PR TITLE
Archived segment refactoring

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -57,8 +57,8 @@ use sp_runtime::DispatchError;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::prelude::*;
 use subspace_core_primitives::{
-    Piece, PublicKey, Randomness, RewardSignature, SectorId, SectorIndex, SegmentHeader,
-    SegmentIndex, SolutionRange, PIECES_IN_SEGMENT,
+    ArchivedHistorySegment, PublicKey, Randomness, RewardSignature, SectorId, SectorIndex,
+    SegmentHeader, SegmentIndex, SolutionRange,
 };
 use subspace_solving::REWARD_SIGNING_CONTEXT;
 use subspace_verification::{
@@ -673,7 +673,7 @@ impl<T: Config> Pallet<T> {
     pub fn total_pieces() -> NonZeroU64 {
         // Chain starts with one segment plotted, even if it is not recorded in the runtime yet
         let number_of_segments = u64::from(SegmentCommitment::<T>::count()).max(1);
-        NonZeroU64::new(number_of_segments * u64::from(PIECES_IN_SEGMENT))
+        NonZeroU64::new(number_of_segments * ArchivedHistorySegment::NUM_PIECES as u64)
             .expect("Neither of multiplied values is zero; qed")
     }
 
@@ -1036,7 +1036,7 @@ impl<T: Config> Pallet<T> {
     pub fn archived_history_size() -> u64 {
         let archived_segments = SegmentCommitment::<T>::count();
 
-        u64::from(archived_segments) * u64::from(PIECES_IN_SEGMENT) * Piece::SIZE as u64
+        u64::from(archived_segments) * ArchivedHistorySegment::SIZE as u64
     }
 
     pub fn chain_constants() -> ChainConstants {

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -37,7 +37,7 @@ use sp_runtime::traits::{Block as BlockT, Header as _, IdentityLookup};
 use sp_runtime::Perbill;
 use std::num::NonZeroU64;
 use std::sync::Once;
-use subspace_archiving::archiver::{ArchivedSegment, Archiver};
+use subspace_archiving::archiver::{Archiver, ArchiverSegment};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg, Witness};
 use subspace_core_primitives::crypto::{blake2b_256_254_hash_to_scalar, kzg, ScalarLegacy};
 use subspace_core_primitives::{
@@ -342,7 +342,7 @@ pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
     }
 }
 
-pub fn create_archived_segment() -> ArchivedSegment {
+pub fn create_archived_segment() -> ArchiverSegment {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg).unwrap();
 

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -37,7 +37,7 @@ use sp_runtime::traits::{Block as BlockT, Header as _, IdentityLookup};
 use sp_runtime::Perbill;
 use std::num::NonZeroU64;
 use std::sync::Once;
-use subspace_archiving::archiver::{Archiver, ArchiverSegment};
+use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg, Witness};
 use subspace_core_primitives::crypto::{blake2b_256_254_hash_to_scalar, kzg, ScalarLegacy};
 use subspace_core_primitives::{
@@ -342,7 +342,7 @@ pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
     }
 }
 
-pub fn create_archived_segment() -> ArchiverSegment {
+pub fn create_archived_segment() -> NewArchivedSegment {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg).unwrap();
 

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -42,7 +42,7 @@ use sp_runtime::traits::{Block as BlockT, Zero};
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_archiving::archiver::ArchivedSegment;
+use subspace_archiving::archiver::ArchiverSegment;
 use subspace_core_primitives::{SegmentCommitment, SegmentHeader, SegmentIndex, Solution};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_networking::libp2p::Multiaddr;
@@ -88,7 +88,7 @@ pub trait SubspaceRpcApi {
     #[subscription(
         name = "subspace_subscribeArchivedSegment" => "subspace_archived_segment",
         unsubscribe = "subspace_unsubscribeArchivedSegment",
-        item = ArchivedSegment,
+        item = ArchiverSegment,
     )]
     fn subscribe_archived_segment(&self);
 

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -42,7 +42,7 @@ use sp_runtime::traits::{Block as BlockT, Zero};
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_archiving::archiver::ArchiverSegment;
+use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::{SegmentCommitment, SegmentHeader, SegmentIndex, Solution};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_networking::libp2p::Multiaddr;
@@ -88,7 +88,7 @@ pub trait SubspaceRpcApi {
     #[subscription(
         name = "subspace_subscribeArchivedSegment" => "subspace_archived_segment",
         unsubscribe = "subspace_unsubscribeArchivedSegment",
-        item = ArchiverSegment,
+        item = NewArchivedSegment,
     )]
     fn subscribe_archived_segment(&self);
 

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -31,7 +31,7 @@ use sp_objects::ObjectsApi;
 use sp_runtime::generic::SignedBlock;
 use sp_runtime::traits::{Block as BlockT, CheckedSub, Header, NumberFor, One, Zero};
 use std::sync::Arc;
-use subspace_archiving::archiver::{Archiver, ArchiverSegment};
+use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{BlockNumber, SegmentHeader};
@@ -176,7 +176,7 @@ where
 {
     confirmation_depth_k: BlockNumber,
     archiver: Archiver,
-    older_archived_segments: Vec<ArchiverSegment>,
+    older_archived_segments: Vec<NewArchivedSegment>,
     best_archived_block: (Block::Hash, NumberFor<Block>),
 }
 
@@ -301,13 +301,13 @@ where
                     encoded_block.len() as f32 / 1024.0
                 );
 
-                let archiver_segments = archiver.add_block(encoded_block, block_object_mappings);
-                let new_segment_headers: Vec<SegmentHeader> = archiver_segments
+                let archived_segments = archiver.add_block(encoded_block, block_object_mappings);
+                let new_segment_headers: Vec<SegmentHeader> = archived_segments
                     .iter()
                     .map(|archived_segment| archived_segment.segment_header)
                     .collect();
 
-                older_archived_segments.extend(archiver_segments);
+                older_archived_segments.extend(archived_segments);
 
                 if !new_segment_headers.is_empty() {
                     // Set list of expected segment headers for the block where we expect segment
@@ -507,13 +507,13 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
                     );
 
                     let mut new_segment_headers = Vec::new();
-                    for archiver_segment in archiver.add_block(encoded_block, block_object_mappings)
+                    for archived_segment in archiver.add_block(encoded_block, block_object_mappings)
                     {
-                        let segment_header = archiver_segment.segment_header;
+                        let segment_header = archived_segment.segment_header;
 
                         send_archived_segment_notification(
                             &archived_segment_notification_sender,
-                            archiver_segment,
+                            archived_segment,
                         )
                         .await;
 
@@ -540,7 +540,7 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
 
 async fn send_archived_segment_notification(
     archived_segment_notification_sender: &SubspaceNotificationSender<ArchivedSegmentNotification>,
-    archived_segment: ArchiverSegment,
+    archived_segment: NewArchivedSegment,
 ) {
     let (acknowledgement_sender, mut acknowledgement_receiver) =
         tracing_unbounded::<()>("subspace_acknowledgement", 100);

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -77,7 +77,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
-use subspace_archiving::archiver::{Archiver, ArchiverSegment};
+use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
@@ -127,7 +127,7 @@ pub struct RewardSigningNotification {
 #[derive(Debug, Clone)]
 pub struct ArchivedSegmentNotification {
     /// Archived segment.
-    pub archived_segment: Arc<ArchiverSegment>,
+    pub archived_segment: Arc<NewArchivedSegment>,
     /// Sender that signified the fact of receiving archived segment by farmer.
     ///
     /// This must be used to send a message or else block import pipeline will get stuck.
@@ -917,7 +917,7 @@ where
         // extrinsics with segment headers are not yet in runtime.
         let maybe_segment_commitment = if block_number.is_one() {
             let genesis_block_hash = self.client.info().genesis_hash;
-            let archiver_segments = Archiver::new(self.subspace_link.kzg.clone())
+            let archived_segments = Archiver::new(self.subspace_link.kzg.clone())
                 .expect("Incorrect parameters for archiver")
                 .add_block(
                     self.client
@@ -926,9 +926,9 @@ where
                         .encode(),
                     BlockObjectMapping::default(),
                 );
-            archiver_segments.into_iter().find_map(|archiver_segment| {
-                if archiver_segment.segment_header.segment_index() == segment_index {
-                    Some(archiver_segment.segment_header.segment_commitment())
+            archived_segments.into_iter().find_map(|archived_segment| {
+                if archived_segment.segment_header.segment_index() == segment_index {
+                    Some(archived_segment.segment_header.segment_commitment())
                 } else {
                     None
                 }

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -77,7 +77,7 @@ use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
-use subspace_archiving::archiver::{ArchivedSegment, Archiver};
+use subspace_archiving::archiver::{Archiver, ArchiverSegment};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
@@ -127,7 +127,7 @@ pub struct RewardSigningNotification {
 #[derive(Debug, Clone)]
 pub struct ArchivedSegmentNotification {
     /// Archived segment.
-    pub archived_segment: Arc<ArchivedSegment>,
+    pub archived_segment: Arc<ArchiverSegment>,
     /// Sender that signified the fact of receiving archived segment by farmer.
     ///
     /// This must be used to send a message or else block import pipeline will get stuck.
@@ -917,7 +917,7 @@ where
         // extrinsics with segment headers are not yet in runtime.
         let maybe_segment_commitment = if block_number.is_one() {
             let genesis_block_hash = self.client.info().genesis_hash;
-            let archived_segments = Archiver::new(self.subspace_link.kzg.clone())
+            let archiver_segments = Archiver::new(self.subspace_link.kzg.clone())
                 .expect("Incorrect parameters for archiver")
                 .add_block(
                     self.client
@@ -926,9 +926,9 @@ where
                         .encode(),
                     BlockObjectMapping::default(),
                 );
-            archived_segments.into_iter().find_map(|archived_segment| {
-                if archived_segment.segment_header.segment_index() == segment_index {
-                    Some(archived_segment.segment_header.segment_commitment())
+            archiver_segments.into_iter().find_map(|archiver_segment| {
+                if archiver_segment.segment_header.segment_index() == segment_index {
+                    Some(archiver_segment.segment_header.segment_commitment())
                 } else {
                     None
                 }

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -434,7 +434,7 @@ fn get_archived_segments(client: &TestClient) -> Vec<ArchivedHistorySegment> {
     archiver
         .add_block(genesis_block.encode(), BlockObjectMapping::default())
         .into_iter()
-        .map(|archiver_segment| archiver_segment.pieces)
+        .map(|archived_segment| archived_segment.pieces)
         .collect()
 }
 

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -74,7 +74,9 @@ use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
-use subspace_core_primitives::{ChunkSignature, FlatPieces, Piece, PieceIndex, Solution};
+use subspace_core_primitives::{
+    ArchivedHistorySegment, ChunkSignature, FlatPieces, Piece, PieceIndex, Solution,
+};
 use subspace_solving::{create_chunk_signature, REWARD_SIGNING_CONTEXT};
 use substrate_test_runtime::{Block as TestBlock, Hash};
 use tokio::runtime::{Handle, Runtime};
@@ -424,7 +426,7 @@ fn rejects_empty_block() {
     })
 }
 
-fn get_archived_pieces(client: &TestClient) -> Vec<FlatPieces> {
+fn get_archived_segments(client: &TestClient) -> Vec<ArchivedHistorySegment> {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg).expect("Incorrect parameters for archiver");
 
@@ -432,7 +434,7 @@ fn get_archived_pieces(client: &TestClient) -> Vec<FlatPieces> {
     archiver
         .add_block(genesis_block.encode(), BlockObjectMapping::default())
         .into_iter()
-        .map(|archived_segment| archived_segment.pieces)
+        .map(|archiver_segment| archiver_segment.pieces)
         .collect()
 }
 
@@ -505,7 +507,7 @@ async fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + '
             let client = Arc::clone(&client);
 
             move || {
-                let archived_pieces = get_archived_pieces(&client);
+                let archived_pieces = get_archived_segments(&client);
                 archived_pieces_sender.send(archived_pieces).unwrap();
             }
         });

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -36,8 +36,8 @@ use sp_std::cmp::Ordering;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::marker::PhantomData;
 use subspace_core_primitives::{
-    BlockWeight, PublicKey, Randomness, RewardSignature, SectorId, SegmentCommitment, SegmentIndex,
-    SolutionRange, PIECES_IN_SEGMENT,
+    ArchivedHistorySegment, BlockWeight, PublicKey, Randomness, RewardSignature, SectorId,
+    SegmentCommitment, SegmentIndex, SolutionRange,
 };
 use subspace_solving::{derive_global_challenge, REWARD_SIGNING_CONTEXT};
 use subspace_verification::{
@@ -666,7 +666,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
                 .ok_or_else(|| ImportError::MissingParent(header.header.hash()))?;
         }
 
-        Ok(segment_commitments_count * u64::from(PIECES_IN_SEGMENT))
+        Ok(segment_commitments_count * ArchivedHistorySegment::NUM_PIECES as u64)
     }
 
     /// Finds a segment commitment mapped against a segment index in the chain with chain_tip as the

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -24,7 +24,7 @@ use sp_runtime::{Digest, DigestItem};
 use std::error::Error;
 use std::io::Cursor;
 use std::num::NonZeroU64;
-use subspace_archiving::archiver::{Archiver, ArchiverSegment};
+use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
@@ -65,7 +65,7 @@ fn derive_solution_range(
     subspace_core_primitives::bidirectional_distance(local_challenge, audit_chunk) * 2
 }
 
-fn archiver_segment(kzg: Kzg) -> ArchiverSegment {
+fn archived_segment(kzg: Kzg) -> NewArchivedSegment {
     // we don't care about the block data
     let mut rng = StdRng::seed_from_u64(0);
     let mut block = vec![0u8; RecordedHistorySegment::SIZE];
@@ -89,15 +89,13 @@ struct Farmer {
 impl Farmer {
     fn new(keypair: &Keypair) -> Self {
         let kzg = Kzg::new(kzg::embedded_kzg_settings());
-        let archiver_segment = archiver_segment(kzg.clone());
-        let segment_header = archiver_segment.segment_header;
-        let total_pieces = NonZeroU64::new(archiver_segment.pieces.len() as u64).unwrap();
+        let archived_segment = archived_segment(kzg.clone());
+        let segment_header = archived_segment.segment_header;
+        let total_pieces = NonZeroU64::new(archived_segment.pieces.len() as u64).unwrap();
         let mut sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
         let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
         let sector_index = 0;
-        let piece_getter = TestPieceGetter {
-            archived_segment: archiver_segment,
-        };
+        let piece_getter = TestPieceGetter { archived_segment };
         let public_key = PublicKey::from(keypair.public.to_bytes());
         let farmer_protocol_info = FarmerProtocolInfo {
             total_pieces,
@@ -137,7 +135,7 @@ struct ValidHeaderParams<'a> {
 }
 
 struct TestPieceGetter {
-    archived_segment: ArchiverSegment,
+    archived_segment: NewArchivedSegment,
 }
 
 #[async_trait]

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -170,12 +170,13 @@ pub enum SegmentItem {
     ParentSegmentHeader(SegmentHeader),
 }
 
-/// Archived segment as a combination of segment header hash, segment index and corresponding pieces
+/// Newly archived segment as a combination of segment header hash, segment index and corresponding
+/// archived history segment containing pieces
 #[derive(Debug, Clone, Eq, PartialEq, Decode, Encode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct ArchiverSegment {
-    /// Segment header of the segment
+pub struct NewArchivedSegment {
+    /// Segment header
     pub segment_header: SegmentHeader,
     /// Segment of archived history containing pieces
     pub pieces: ArchivedHistorySegment,
@@ -347,7 +348,7 @@ impl Archiver {
         &mut self,
         bytes: Vec<u8>,
         object_mapping: BlockObjectMapping,
-    ) -> Vec<ArchiverSegment> {
+    ) -> Vec<NewArchivedSegment> {
         // Append new block to the buffer
         self.buffer.push_back(SegmentItem::Block {
             bytes,
@@ -609,7 +610,7 @@ impl Archiver {
     }
 
     // Take segment as an input, apply necessary transformations and produce archived segment
-    fn produce_archived_segment(&mut self, segment: Segment) -> ArchiverSegment {
+    fn produce_archived_segment(&mut self, segment: Segment) -> NewArchivedSegment {
         // Create mappings
         let object_mapping = {
             let mut corrected_object_mapping =
@@ -784,7 +785,7 @@ impl Archiver {
         self.buffer
             .push_front(SegmentItem::ParentSegmentHeader(segment_header));
 
-        ArchiverSegment {
+        NewArchivedSegment {
             segment_header,
             pieces,
             object_mapping,

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -33,9 +33,8 @@ use subspace_core_primitives::objects::{
     BlockObject, BlockObjectMapping, PieceObject, PieceObjectMapping,
 };
 use subspace_core_primitives::{
-    ArchivedBlockProgress, Blake2b256Hash, BlockNumber, FlatPieces, LastArchivedBlock, PieceArray,
-    RawRecord, RecordedHistorySegment, SegmentCommitment, SegmentHeader, SegmentIndex,
-    PIECES_IN_SEGMENT,
+    ArchivedBlockProgress, ArchivedHistorySegment, Blake2b256Hash, BlockNumber, LastArchivedBlock,
+    PieceArray, RawRecord, RecordedHistorySegment, SegmentCommitment, SegmentHeader, SegmentIndex,
 };
 use subspace_erasure_coding::ErasureCoding;
 
@@ -175,11 +174,11 @@ pub enum SegmentItem {
 #[derive(Debug, Clone, Eq, PartialEq, Decode, Encode)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct ArchivedSegment {
+pub struct ArchiverSegment {
     /// Segment header of the segment
     pub segment_header: SegmentHeader,
-    /// Pieces that correspond to this segment
-    pub pieces: FlatPieces,
+    /// Segment of archived history containing pieces
+    pub pieces: ArchivedHistorySegment,
     /// Mappings for objects stored in corresponding pieces.
     ///
     /// NOTE: Only half (source pieces) will have corresponding mapping item in this `Vec`.
@@ -255,7 +254,7 @@ impl Archiver {
         //  message in `.expect()`
 
         let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(PIECES_IN_SEGMENT.ilog2() as usize)
+            NonZeroUsize::new(ArchivedHistorySegment::NUM_PIECES.ilog2() as usize)
                 .expect("Recorded history segment contains at very least one record; qed"),
         )
         .map_err(ArchiverInstantiationError::FailedToInitializeErasureCoding)?;
@@ -263,7 +262,7 @@ impl Archiver {
         Ok(Self {
             buffer: VecDeque::default(),
             incremental_record_commitments: IncrementalRecordCommitmentsState::with_capacity(
-                RecordedHistorySegment::RAW_RECORDS,
+                RecordedHistorySegment::NUM_RAW_RECORDS,
             ),
             erasure_coding,
             kzg,
@@ -348,7 +347,7 @@ impl Archiver {
         &mut self,
         bytes: Vec<u8>,
         object_mapping: BlockObjectMapping,
-    ) -> Vec<ArchivedSegment> {
+    ) -> Vec<ArchiverSegment> {
         // Append new block to the buffer
         self.buffer.push_back(SegmentItem::Block {
             bytes,
@@ -610,11 +609,11 @@ impl Archiver {
     }
 
     // Take segment as an input, apply necessary transformations and produce archived segment
-    fn produce_archived_segment(&mut self, segment: Segment) -> ArchivedSegment {
+    fn produce_archived_segment(&mut self, segment: Segment) -> ArchiverSegment {
         // Create mappings
         let object_mapping = {
             let mut corrected_object_mapping =
-                vec![PieceObjectMapping::default(); RecordedHistorySegment::RAW_RECORDS];
+                vec![PieceObjectMapping::default(); RecordedHistorySegment::NUM_RAW_RECORDS];
             let Segment::V0 { items } = &segment;
             // `+1` corresponds to enum variant encoding
             let mut base_offset_in_segment = 1;
@@ -677,11 +676,11 @@ impl Archiver {
             // Segment is quite big and no longer necessary
             drop(segment);
 
-            let mut pieces = FlatPieces::new(PIECES_IN_SEGMENT as usize);
+            let mut pieces = ArchivedHistorySegment::default();
 
             // Scratch buffer to avoid re-allocation
             let mut tmp_source_shards_scalars =
-                Vec::<Scalar>::with_capacity(RecordedHistorySegment::RAW_RECORDS);
+                Vec::<Scalar>::with_capacity(RecordedHistorySegment::NUM_RAW_RECORDS);
             // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
             for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
                 // Collect chunks of each record at the same offset
@@ -785,7 +784,7 @@ impl Archiver {
         self.buffer
             .push_front(SegmentItem::ParentSegmentHeader(segment_header));
 
-        ArchivedSegment {
+        ArchiverSegment {
             segment_header,
             pieces,
             object_mapping,
@@ -846,7 +845,7 @@ pub fn is_piece_valid(
 
     kzg.verify(
         segment_commitment,
-        PIECES_IN_SEGMENT as usize,
+        ArchivedHistorySegment::NUM_PIECES,
         position,
         &commitment_hash,
         &witness,
@@ -863,7 +862,7 @@ pub fn is_record_commitment_hash_valid(
 ) -> bool {
     kzg.verify(
         commitment,
-        PIECES_IN_SEGMENT as usize,
+        ArchivedHistorySegment::NUM_PIECES,
         position,
         commitment_hash,
         witness,

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -9,8 +9,8 @@ use core::num::NonZeroUsize;
 use parity_scale_codec::Decode;
 use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::{
-    ArchivedBlockProgress, BlockNumber, LastArchivedBlock, Piece, RawRecord,
-    RecordedHistorySegment, SegmentHeader, SegmentIndex, PIECES_IN_SEGMENT,
+    ArchivedBlockProgress, ArchivedHistorySegment, BlockNumber, LastArchivedBlock, Piece,
+    RawRecord, RecordedHistorySegment, SegmentHeader, SegmentIndex,
 };
 use subspace_erasure_coding::ErasureCoding;
 
@@ -77,7 +77,7 @@ impl Reconstructor {
         //  message in `.expect()`
 
         let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(PIECES_IN_SEGMENT.ilog2() as usize)
+            NonZeroUsize::new(ArchivedHistorySegment::NUM_PIECES.ilog2() as usize)
                 .expect("Recorded history segment contains at very least one record; qed"),
         )
         .map_err(ReconstructorInstantiationError::FailedToInitializeErasureCoding)?;
@@ -129,7 +129,7 @@ impl Reconstructor {
 
             // Scratch buffer to avoid re-allocation
             let mut tmp_shards_scalars =
-                Vec::<Option<Scalar>>::with_capacity(PIECES_IN_SEGMENT as usize);
+                Vec::<Option<Scalar>>::with_capacity(ArchivedHistorySegment::NUM_PIECES);
             // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
             for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
                 // Collect chunks of each record at the same offset

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -131,37 +131,37 @@ fn archiver() {
         (block, object_mapping)
     };
     // This should produce 1 archived segment
-    let archiver_segments = archiver.add_block(block_1.clone(), block_1_object_mapping.clone());
-    assert_eq!(archiver_segments.len(), 1);
+    let archived_segments = archiver.add_block(block_1.clone(), block_1_object_mapping.clone());
+    assert_eq!(archived_segments.len(), 1);
 
-    let first_archiver_segment = archiver_segments.into_iter().next().unwrap();
+    let first_archived_segment = archived_segments.into_iter().next().unwrap();
     assert_eq!(
-        first_archiver_segment.pieces.len(),
+        first_archived_segment.pieces.len(),
         ArchivedHistorySegment::NUM_PIECES
     );
     assert_eq!(
-        first_archiver_segment.segment_header.segment_index(),
+        first_archived_segment.segment_header.segment_index(),
         SegmentIndex::ZERO
     );
     assert_eq!(
-        first_archiver_segment
+        first_archived_segment
             .segment_header
             .prev_segment_header_hash(),
         [0u8; BLAKE2B_256_HASH_SIZE]
     );
     {
-        let last_archived_block = first_archiver_segment.segment_header.last_archived_block();
+        let last_archived_block = first_archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 1);
         assert_eq!(last_archived_block.partial_archived(), Some(1962165));
     }
 
     assert_eq!(
-        first_archiver_segment.object_mapping.len(),
+        first_archived_segment.object_mapping.len(),
         RecordedHistorySegment::NUM_RAW_RECORDS
     );
     // 4 objects fit into the first segment
     assert_eq!(
-        first_archiver_segment
+        first_archived_segment
             .object_mapping
             .iter()
             .filter(|object_mapping| !object_mapping.objects.is_empty())
@@ -172,21 +172,21 @@ fn archiver() {
         let block_objects = iter::repeat(block_0.as_ref())
             .zip(&block_0_object_mapping.objects)
             .chain(iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects.iter()));
-        let piece_objects = first_archiver_segment
+        let piece_objects = first_archived_segment
             .pieces
             .source()
-            .zip(&first_archiver_segment.object_mapping)
+            .zip(&first_archived_segment.object_mapping)
             .flat_map(|(piece, object_mapping)| iter::repeat(piece).zip(&object_mapping.objects));
 
         compare_block_objects_to_piece_objects(block_objects, piece_objects);
     }
 
     // Check that all pieces are valid
-    for (position, piece) in first_archiver_segment.pieces.iter().enumerate() {
+    for (position, piece) in first_archived_segment.pieces.iter().enumerate() {
         assert!(archiver::is_piece_valid(
             &kzg,
             piece,
-            &first_archiver_segment.segment_header.segment_commitment(),
+            &first_archived_segment.segment_header.segment_commitment(),
             position as u32,
         ));
     }
@@ -197,15 +197,15 @@ fn archiver() {
         block
     };
     // This should be big enough to produce two archived segments in one go
-    let archiver_segments = archiver.add_block(block_2.clone(), BlockObjectMapping::default());
-    assert_eq!(archiver_segments.len(), 2);
+    let archived_segments = archiver.add_block(block_2.clone(), BlockObjectMapping::default());
+    assert_eq!(archived_segments.len(), 2);
 
     // Check that initializing archiver with initial state before last block results in the same
     // archived segments once last block is added
     {
         let mut archiver_with_initial_state = Archiver::with_initial_state(
             kzg.clone(),
-            first_archiver_segment.segment_header,
+            first_archived_segment.segment_header,
             &block_1,
             block_1_object_mapping.clone(),
         )
@@ -213,17 +213,17 @@ fn archiver() {
 
         assert_eq!(
             archiver_with_initial_state.add_block(block_2.clone(), BlockObjectMapping::default()),
-            archiver_segments,
+            archived_segments,
         );
     }
 
     assert_eq!(
-        archiver_segments[0].object_mapping.len(),
+        archived_segments[0].object_mapping.len(),
         RecordedHistorySegment::NUM_RAW_RECORDS
     );
     // 1 object fits into the second segment
     assert_eq!(
-        archiver_segments[0]
+        archived_segments[0]
             .object_mapping
             .iter()
             .filter(|object_mapping| !object_mapping.objects.is_empty())
@@ -231,12 +231,12 @@ fn archiver() {
         1
     );
     assert_eq!(
-        archiver_segments[1].object_mapping.len(),
+        archived_segments[1].object_mapping.len(),
         RecordedHistorySegment::NUM_RAW_RECORDS
     );
     // 0 object fits into the second segment
     assert_eq!(
-        archiver_segments[1]
+        archived_segments[1]
             .object_mapping
             .iter()
             .filter(|object_mapping| !object_mapping.objects.is_empty())
@@ -246,10 +246,10 @@ fn archiver() {
     {
         let block_objects =
             iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects.iter().skip(2));
-        let piece_objects = archiver_segments[0]
+        let piece_objects = archived_segments[0]
             .pieces
             .source()
-            .zip(&archiver_segments[0].object_mapping)
+            .zip(&archived_segments[0].object_mapping)
             .flat_map(|(piece, object_mapping)| iter::repeat(piece).zip(&object_mapping.objects));
 
         compare_block_objects_to_piece_objects(block_objects, piece_objects);
@@ -257,47 +257,47 @@ fn archiver() {
 
     // Check archived bytes for block with index `2` in each archived segment
     {
-        let archiver_segment = archiver_segments.get(0).unwrap();
-        let last_archived_block = archiver_segment.segment_header.last_archived_block();
+        let archived_segment = archived_segments.get(0).unwrap();
+        let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
         assert_eq!(last_archived_block.partial_archived(), Some(3270173));
     }
     {
-        let archiver_segment = archiver_segments.get(1).unwrap();
-        let last_archived_block = archiver_segment.segment_header.last_archived_block();
+        let archived_segment = archived_segments.get(1).unwrap();
+        let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
         assert_eq!(last_archived_block.partial_archived(), Some(7194420));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
     let mut expected_segment_index = SegmentIndex::ONE;
-    let mut previous_segment_header_hash = first_archiver_segment.segment_header.hash();
-    let last_segment_header = archiver_segments.iter().last().unwrap().segment_header;
-    for archiver_segment in archiver_segments {
+    let mut previous_segment_header_hash = first_archived_segment.segment_header.hash();
+    let last_segment_header = archived_segments.iter().last().unwrap().segment_header;
+    for archived_segment in archived_segments {
         assert_eq!(
-            archiver_segment.pieces.len(),
+            archived_segment.pieces.len(),
             ArchivedHistorySegment::NUM_PIECES
         );
         assert_eq!(
-            archiver_segment.segment_header.segment_index(),
+            archived_segment.segment_header.segment_index(),
             expected_segment_index
         );
         assert_eq!(
-            archiver_segment.segment_header.prev_segment_header_hash(),
+            archived_segment.segment_header.prev_segment_header_hash(),
             previous_segment_header_hash
         );
 
-        for (position, piece) in archiver_segment.pieces.iter().enumerate() {
+        for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 &kzg,
                 piece,
-                &archiver_segment.segment_header.segment_commitment(),
+                &archived_segment.segment_header.segment_commitment(),
                 position as u32,
             ));
         }
 
         expected_segment_index += SegmentIndex::ONE;
-        previous_segment_header_hash = archiver_segment.segment_header.hash();
+        previous_segment_header_hash = archived_segment.segment_header.hash();
     }
 
     // Add a block such that it fits in the next segment exactly
@@ -306,8 +306,8 @@ fn archiver() {
         thread_rng().fill(block.as_mut_slice());
         block
     };
-    let archiver_segments = archiver.add_block(block_3.clone(), BlockObjectMapping::default());
-    assert_eq!(archiver_segments.len(), 1);
+    let archived_segments = archiver.add_block(block_3.clone(), BlockObjectMapping::default());
+    assert_eq!(archived_segments.len(), 1);
 
     // Check that initializing archiver with initial state before last block results in the same
     // archived segments once last block is added
@@ -322,22 +322,22 @@ fn archiver() {
 
         assert_eq!(
             archiver_with_initial_state.add_block(block_3, BlockObjectMapping::default()),
-            archiver_segments,
+            archived_segments,
         );
     }
 
     // Archived segment should fit exactly into the last archived segment (rare case)
     {
-        let archiver_segment = archiver_segments.get(0).unwrap();
-        let last_archived_block = archiver_segment.segment_header.last_archived_block();
+        let archived_segment = archived_segments.get(0).unwrap();
+        let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 3);
         assert_eq!(last_archived_block.partial_archived(), None);
 
-        for (position, piece) in archiver_segment.pieces.iter().enumerate() {
+        for (position, piece) in archived_segment.pieces.iter().enumerate() {
             assert!(archiver::is_piece_valid(
                 &kzg,
                 piece,
-                &archiver_segment.segment_header.segment_commitment(),
+                &archived_segment.segment_header.segment_commitment(),
                 position as u32,
             ));
         }
@@ -468,7 +468,7 @@ fn spill_over_edge_case() {
     // encoding + one more for enum variant, this should result in new segment being created, but
     // the very first segment item will not include newly added block because it would result in
     // subtracting with overflow when trying to slice internal bytes of the segment item
-    let archiver_segments = archiver.add_block(
+    let archived_segments = archiver.add_block(
         vec![0u8; RecordedHistorySegment::SIZE],
         BlockObjectMapping {
             objects: vec![BlockObject::V0 {
@@ -477,10 +477,10 @@ fn spill_over_edge_case() {
             }],
         },
     );
-    assert_eq!(archiver_segments.len(), 2);
+    assert_eq!(archived_segments.len(), 2);
     // If spill over actually happened, we'll not find object mapping in the first segment
     assert_eq!(
-        archiver_segments[0]
+        archived_segments[0]
             .object_mapping
             .iter()
             .filter(|o| !o.objects.is_empty())
@@ -488,7 +488,7 @@ fn spill_over_edge_case() {
         0
     );
     assert_eq!(
-        archiver_segments[1]
+        archived_segments[1]
             .object_mapping
             .iter()
             .filter(|o| !o.objects.is_empty())
@@ -502,11 +502,11 @@ fn object_on_the_edge_of_segment() {
     let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg).unwrap();
     let first_block = vec![0u8; RecordedHistorySegment::SIZE];
-    let archiver_segments = archiver.add_block(first_block.clone(), BlockObjectMapping::default());
-    assert_eq!(archiver_segments.len(), 1);
-    let archiver_segment = archiver_segments.into_iter().next().unwrap();
+    let archived_segments = archiver.add_block(first_block.clone(), BlockObjectMapping::default());
+    assert_eq!(archived_segments.len(), 1);
+    let archived_segment = archived_segments.into_iter().next().unwrap();
     let left_unarchived_from_first_block = first_block.len() as u32
-        - archiver_segment
+        - archived_segment
             .segment_header
             .last_archived_block()
             .archived_progress
@@ -555,7 +555,7 @@ fn object_on_the_edge_of_segment() {
     // First ensure that any smaller offset will get translated into the first archived segment,
     // this is a protection against code regressions
     {
-        let archiver_segments = archiver.clone().add_block(
+        let archived_segments = archiver.clone().add_block(
             second_block.clone(),
             BlockObjectMapping {
                 objects: vec![BlockObject::V0 {
@@ -565,9 +565,9 @@ fn object_on_the_edge_of_segment() {
             },
         );
 
-        assert_eq!(archiver_segments.len(), 2);
+        assert_eq!(archived_segments.len(), 2);
         assert_eq!(
-            archiver_segments[0]
+            archived_segments[0]
                 .object_mapping
                 .iter()
                 .filter(|o| !o.objects.is_empty())
@@ -576,16 +576,16 @@ fn object_on_the_edge_of_segment() {
         );
     }
 
-    let archiver_segments = archiver.add_block(
+    let archived_segments = archiver.add_block(
         second_block,
         BlockObjectMapping {
             objects: vec![object_mapping],
         },
     );
 
-    assert_eq!(archiver_segments.len(), 2);
+    assert_eq!(archived_segments.len(), 2);
     assert_eq!(
-        archiver_segments[0]
+        archived_segments[0]
             .object_mapping
             .iter()
             .filter(|o| !o.objects.is_empty())
@@ -594,19 +594,19 @@ fn object_on_the_edge_of_segment() {
     );
     // Object should fall in the next archived segment
     assert_eq!(
-        archiver_segments[1]
+        archived_segments[1]
             .object_mapping
             .iter()
             .filter(|o| !o.objects.is_empty())
             .count(),
         1
     );
-    assert_eq!(archiver_segments[1].object_mapping[0].objects.len(), 1);
+    assert_eq!(archived_segments[1].object_mapping[0].objects.len(), 1);
 
     // Ensure bytes are mapped correctly
     assert_eq!(
-        record_to_raw_record_bytes(archiver_segments[1].pieces[0].record())
-            .skip(archiver_segments[1].object_mapping[0].objects[0].offset() as usize)
+        record_to_raw_record_bytes(archived_segments[1].pieces[0].record())
+            .skip(archived_segments[1].object_mapping[0].objects[0].offset() as usize)
             .take(mapped_bytes.len())
             .collect::<Vec<_>>(),
         mapped_bytes

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -6,8 +6,8 @@ use subspace_archiving::reconstructor::{Reconstructor, ReconstructorError};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    ArchivedBlockProgress, FlatPieces, LastArchivedBlock, Piece, RecordedHistorySegment,
-    SegmentIndex, PIECES_IN_SEGMENT,
+    ArchivedBlockProgress, ArchivedHistorySegment, FlatPieces, LastArchivedBlock, Piece,
+    RecordedHistorySegment, SegmentIndex,
 };
 
 fn pieces_to_option_of_pieces(pieces: &FlatPieces) -> Vec<Option<Piece>> {
@@ -275,7 +275,7 @@ fn partial_data() {
                     .source()
                     .map(Piece::from)
                     .map(Some)
-                    .zip(iter::repeat(None).take(RecordedHistorySegment::RAW_RECORDS))
+                    .zip(iter::repeat(None).take(RecordedHistorySegment::NUM_RAW_RECORDS))
                     .flat_map(|(a, b)| [a, b])
                     .collect::<Vec<_>>(),
             )
@@ -290,11 +290,11 @@ fn partial_data() {
             .unwrap()
             .add_segment(
                 &iter::repeat(None)
-                    .take(RecordedHistorySegment::RAW_RECORDS)
+                    .take(RecordedHistorySegment::NUM_RAW_RECORDS)
                     .chain(
                         pieces
                             .iter()
-                            .skip(RecordedHistorySegment::RAW_RECORDS)
+                            .skip(RecordedHistorySegment::NUM_RAW_RECORDS)
                             .map(Piece::from)
                             .map(Some),
                     )
@@ -308,9 +308,9 @@ fn partial_data() {
     {
         // Mix of data and parity shards
         let mut pieces = pieces.iter().map(Piece::from).map(Some).collect::<Vec<_>>();
-        pieces[PIECES_IN_SEGMENT as usize / 4..]
+        pieces[ArchivedHistorySegment::NUM_PIECES / 4..]
             .iter_mut()
-            .take(RecordedHistorySegment::RAW_RECORDS)
+            .take(RecordedHistorySegment::NUM_RAW_RECORDS)
             .for_each(|piece| {
                 piece.take();
             });
@@ -342,11 +342,11 @@ fn invalid_usage() {
             &archived_segments[0]
                 .pieces
                 .iter()
-                .take(RecordedHistorySegment::RAW_RECORDS - 1)
+                .take(RecordedHistorySegment::NUM_RAW_RECORDS - 1)
                 .map(Piece::from)
                 .map(Some)
                 .chain(iter::repeat(None))
-                .take(PIECES_IN_SEGMENT as usize)
+                .take(ArchivedHistorySegment::NUM_PIECES)
                 .collect::<Vec<_>>(),
         );
 
@@ -361,7 +361,7 @@ fn invalid_usage() {
                 thread_rng().fill(piece.as_mut());
                 Some(piece)
             })
-            .take(PIECES_IN_SEGMENT as usize)
+            .take(ArchivedHistorySegment::NUM_PIECES)
             .collect::<Vec<_>>(),
         );
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -48,8 +48,8 @@ use derive_more::{
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 pub use pieces::{
-    FlatPieces, Piece, PieceArray, RawRecord, Record, RecordWitness, RecordedHistorySegment,
-    PIECES_IN_SEGMENT,
+    ArchivedHistorySegment, FlatPieces, Piece, PieceArray, RawRecord, Record, RecordWitness,
+    RecordedHistorySegment,
 };
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
@@ -160,12 +160,12 @@ impl SegmentIndex {
 
     /// Get the first piece index in this segment.
     pub const fn first_piece_index(&self) -> PieceIndex {
-        PieceIndex::from(self.0 * PIECES_IN_SEGMENT as u64)
+        PieceIndex::from(self.0 * ArchivedHistorySegment::NUM_PIECES as u64)
     }
 
     /// Iterator over piece indexes that belong to this segment.
     pub fn segment_piece_indexes(&self) -> impl Iterator<Item = PieceIndex> {
-        (self.first_piece_index()..).take(PIECES_IN_SEGMENT as usize)
+        (self.first_piece_index()..).take(ArchivedHistorySegment::NUM_PIECES)
     }
 
     /// Iterator over piece indexes that belong to this segment with source pieces first.
@@ -500,13 +500,13 @@ impl PieceIndex {
 
     /// Segment index piece index corresponds to
     pub const fn segment_index(&self) -> SegmentIndex {
-        SegmentIndex::from(self.0 / u64::from(PIECES_IN_SEGMENT))
+        SegmentIndex::from(self.0 / ArchivedHistorySegment::NUM_PIECES as u64)
     }
 
     /// Position of a piece in a segment
     pub const fn position(&self) -> u32 {
         // Position is statically guaranteed to fit into u32
-        (self.0 % u64::from(PIECES_IN_SEGMENT)) as u32
+        (self.0 % ArchivedHistorySegment::NUM_PIECES as u64) as u32
     }
 }
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -31,6 +31,7 @@ pub mod crypto;
 pub mod objects;
 mod pieces;
 pub mod sector_codec;
+mod segments;
 #[cfg(test)]
 mod tests;
 
@@ -39,19 +40,16 @@ extern crate alloc;
 use crate::crypto::kzg::{Commitment, Witness};
 use crate::crypto::{blake2b_256_hash, blake2b_256_hash_with_key, Scalar, ScalarLegacy};
 use core::convert::AsRef;
-use core::iter::Step;
+use core::fmt;
 use core::num::NonZeroU64;
-use core::{fmt, mem};
-use derive_more::{
-    Add, AddAssign, Deref, Display, Div, DivAssign, From, Into, Mul, MulAssign, Rem, Sub, SubAssign,
-};
+use derive_more::{Add, Deref, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, Encode};
 pub use pieces::{
-    ArchivedHistorySegment, FlatPieces, Piece, PieceArray, RawRecord, Record, RecordWitness,
-    RecordedHistorySegment,
+    FlatPieces, Piece, PieceArray, PieceIndex, PieceIndexHash, RawRecord, Record, RecordWitness,
 };
 use scale_info::TypeInfo;
+pub use segments::{ArchivedHistorySegment, RecordedHistorySegment, SegmentIndex};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use uint::static_assertions::const_assert;
@@ -96,85 +94,6 @@ pub type SolutionRange = u64;
 ///
 /// The closer solution's tag is to the target, the heavier it is.
 pub type BlockWeight = u128;
-
-/// Segment index type.
-#[derive(
-    Debug,
-    Display,
-    Default,
-    Copy,
-    Clone,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    Encode,
-    Decode,
-    Add,
-    AddAssign,
-    Sub,
-    SubAssign,
-    Mul,
-    MulAssign,
-    Div,
-    DivAssign,
-    TypeInfo,
-    MaxEncodedLen,
-)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(transparent)]
-pub struct SegmentIndex(u64);
-
-impl Step for SegmentIndex {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        u64::steps_between(&start.0, &end.0)
-    }
-
-    fn forward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::forward_checked(start.0, count).map(Self)
-    }
-
-    fn backward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::backward_checked(start.0, count).map(Self)
-    }
-}
-
-impl const From<u64> for SegmentIndex {
-    fn from(original: u64) -> Self {
-        Self(original)
-    }
-}
-
-impl const From<SegmentIndex> for u64 {
-    fn from(original: SegmentIndex) -> Self {
-        original.0
-    }
-}
-
-impl SegmentIndex {
-    /// Segment index 0.
-    pub const ZERO: SegmentIndex = SegmentIndex(0);
-    /// Segment index 1.
-    pub const ONE: SegmentIndex = SegmentIndex(1);
-
-    /// Get the first piece index in this segment.
-    pub const fn first_piece_index(&self) -> PieceIndex {
-        PieceIndex::from(self.0 * ArchivedHistorySegment::NUM_PIECES as u64)
-    }
-
-    /// Iterator over piece indexes that belong to this segment.
-    pub fn segment_piece_indexes(&self) -> impl Iterator<Item = PieceIndex> {
-        (self.first_piece_index()..).take(ArchivedHistorySegment::NUM_PIECES)
-    }
-
-    /// Iterator over piece indexes that belong to this segment with source pieces first.
-    pub fn segment_piece_indexes_source_first(&self) -> impl Iterator<Item = PieceIndex> {
-        self.segment_piece_indexes()
-            .step_by(2)
-            .chain(self.segment_piece_indexes().skip(1).step_by(2))
-    }
-}
 
 // TODO: New type
 /// Segment commitment type.
@@ -432,104 +351,8 @@ impl SegmentHeader {
     }
 }
 
-/// Piece index in consensus
-#[derive(
-    Debug,
-    Display,
-    Default,
-    Copy,
-    Clone,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    Encode,
-    Decode,
-    Add,
-    AddAssign,
-    Sub,
-    SubAssign,
-    Mul,
-    MulAssign,
-    Div,
-    DivAssign,
-    TypeInfo,
-    MaxEncodedLen,
-)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(transparent)]
-pub struct PieceIndex(u64);
-
-impl Step for PieceIndex {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        u64::steps_between(&start.0, &end.0)
-    }
-
-    fn forward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::forward_checked(start.0, count).map(Self)
-    }
-
-    fn backward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::backward_checked(start.0, count).map(Self)
-    }
-}
-
-impl const From<u64> for PieceIndex {
-    fn from(original: u64) -> Self {
-        Self(original)
-    }
-}
-
-impl const From<PieceIndex> for u64 {
-    fn from(original: PieceIndex) -> Self {
-        original.0
-    }
-}
-
-impl PieceIndex {
-    /// Piece index 0.
-    pub const ZERO: PieceIndex = PieceIndex(0);
-    /// Piece index 1.
-    pub const ONE: PieceIndex = PieceIndex(1);
-
-    /// Convert piece index into bytes.
-    pub const fn to_bytes(&self) -> [u8; mem::size_of::<u64>()] {
-        self.0.to_le_bytes()
-    }
-
-    /// Segment index piece index corresponds to
-    pub const fn segment_index(&self) -> SegmentIndex {
-        SegmentIndex::from(self.0 / ArchivedHistorySegment::NUM_PIECES as u64)
-    }
-
-    /// Position of a piece in a segment
-    pub const fn position(&self) -> u32 {
-        // Position is statically guaranteed to fit into u32
-        (self.0 % ArchivedHistorySegment::NUM_PIECES as u64) as u32
-    }
-}
-
 /// Sector index in consensus
 pub type SectorIndex = u64;
-
-/// Hash of `PieceIndex`
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode, From, Into)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PieceIndexHash(Blake2b256Hash);
-
-impl AsRef<[u8]> for PieceIndexHash {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl PieceIndexHash {
-    /// Constructs `PieceIndexHash` from `PieceIndex`
-    pub fn from_index(index: PieceIndex) -> Self {
-        Self(blake2b_256_hash(&index.to_bytes()))
-    }
-}
 
 // TODO: Versioned solution enum
 /// Farmer solution for slot challenge.
@@ -786,14 +609,14 @@ impl From<u128> for U256 {
 }
 
 impl From<PieceIndexHash> for U256 {
-    fn from(PieceIndexHash(hash): PieceIndexHash) -> Self {
-        Self(private_u256::U256::from_big_endian(&hash))
+    fn from(hash: PieceIndexHash) -> Self {
+        Self(private_u256::U256::from_big_endian(hash.as_ref()))
     }
 }
 
 impl From<U256> for PieceIndexHash {
     fn from(number: U256) -> Self {
-        Self(number.to_be_bytes())
+        Self::from(number.to_be_bytes())
     }
 }
 

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -1,17 +1,22 @@
 #[cfg(feature = "serde")]
 mod serde;
 
-use crate::crypto::Scalar;
+use crate::crypto::{blake2b_256_hash, Scalar};
+use crate::segments::{ArchivedHistorySegment, SegmentIndex};
+use crate::Blake2b256Hash;
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::array::TryFromSliceError;
+use core::iter::Step;
 use core::mem;
-use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
-use derive_more::{AsMut, AsRef, Deref, DerefMut};
+use derive_more::{
+    Add, AddAssign, AsMut, AsRef, Deref, DerefMut, Display, Div, DivAssign, From, Into, Mul,
+    MulAssign, Sub, SubAssign,
+};
 use parity_scale_codec::{Decode, Encode, Input, MaxEncodedLen};
 use scale_info::TypeInfo;
 
@@ -29,6 +34,102 @@ const PIECE_SIZE: usize = 31_744;
 /// Size of a segment record given the global piece size (in bytes), is guaranteed to be multiple
 /// of [`Scalar::FULL_BYTES`].
 const RECORD_SIZE: usize = Piece::SIZE - RecordCommitment::SIZE - RecordWitness::SIZE;
+
+/// Piece index in consensus
+#[derive(
+    Debug,
+    Display,
+    Default,
+    Copy,
+    Clone,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash,
+    Encode,
+    Decode,
+    Add,
+    AddAssign,
+    Sub,
+    SubAssign,
+    Mul,
+    MulAssign,
+    Div,
+    DivAssign,
+    TypeInfo,
+    MaxEncodedLen,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(transparent)]
+pub struct PieceIndex(u64);
+
+impl Step for PieceIndex {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u64::steps_between(&start.0, &end.0)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::forward_checked(start.0, count).map(Self)
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::backward_checked(start.0, count).map(Self)
+    }
+}
+
+impl const From<u64> for PieceIndex {
+    fn from(original: u64) -> Self {
+        Self(original)
+    }
+}
+
+impl const From<PieceIndex> for u64 {
+    fn from(original: PieceIndex) -> Self {
+        original.0
+    }
+}
+
+impl PieceIndex {
+    /// Piece index 0.
+    pub const ZERO: PieceIndex = PieceIndex(0);
+    /// Piece index 1.
+    pub const ONE: PieceIndex = PieceIndex(1);
+
+    /// Convert piece index into bytes.
+    pub const fn to_bytes(&self) -> [u8; mem::size_of::<u64>()] {
+        self.0.to_le_bytes()
+    }
+
+    /// Segment index piece index corresponds to
+    pub const fn segment_index(&self) -> SegmentIndex {
+        SegmentIndex::from(self.0 / ArchivedHistorySegment::NUM_PIECES as u64)
+    }
+
+    /// Position of a piece in a segment
+    pub const fn position(&self) -> u32 {
+        // Position is statically guaranteed to fit into u32
+        (self.0 % ArchivedHistorySegment::NUM_PIECES as u64) as u32
+    }
+}
+
+/// Hash of `PieceIndex`
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Decode, Encode, From, Into)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PieceIndexHash(Blake2b256Hash);
+
+impl AsRef<[u8]> for PieceIndexHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl PieceIndexHash {
+    /// Constructs `PieceIndexHash` from `PieceIndex`
+    pub fn from_index(index: PieceIndex) -> Self {
+        Self(blake2b_256_hash(&index.to_bytes()))
+    }
+}
 
 /// Raw record contained within recorded history segment before archiving is applied.
 ///
@@ -58,79 +159,6 @@ impl AsMut<[u8]> for RawRecord {
 impl RawRecord {
     /// Size of raw record in bytes, is guaranteed to be a multiple of [`Scalar::SAFE_BYTES`].
     pub const SIZE: usize = Record::SIZE / Scalar::FULL_BYTES * Scalar::SAFE_BYTES;
-}
-
-/// Recorded history segment before archiving is applied.
-///
-/// NOTE: This is a stack-allocated data structure and can cause stack overflow!
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Deref, DerefMut)]
-#[repr(transparent)]
-pub struct RecordedHistorySegment([RawRecord; Self::NUM_RAW_RECORDS]);
-
-impl Default for RecordedHistorySegment {
-    fn default() -> Self {
-        Self([RawRecord::default(); Self::NUM_RAW_RECORDS])
-    }
-}
-
-impl AsRef<[u8]> for RecordedHistorySegment {
-    fn as_ref(&self) -> &[u8] {
-        // SAFETY: Same memory layout due to `#[repr(transparent)]`
-        let raw_records: &[[u8; RawRecord::SIZE]] = unsafe { mem::transmute(self.0.as_slice()) };
-        raw_records.flatten()
-    }
-}
-
-impl AsMut<[u8]> for RecordedHistorySegment {
-    fn as_mut(&mut self) -> &mut [u8] {
-        // SAFETY: Same memory layout due to `#[repr(transparent)]`
-        let raw_records: &mut [[u8; RawRecord::SIZE]] =
-            unsafe { mem::transmute(self.0.as_mut_slice()) };
-        raw_records.flatten_mut()
-    }
-}
-
-impl RecordedHistorySegment {
-    /// Number of raw records in one segment of recorded history.
-    pub const NUM_RAW_RECORDS: usize = 128;
-    /// Erasure coding rate for records during archiving process.
-    pub const ERASURE_CODING_RATE: (usize, usize) = (1, 2);
-    /// Size of recorded history segment in bytes.
-    ///
-    /// It includes half of the records (just source records) that will later be erasure coded and
-    /// together with corresponding commitments and witnesses will result in
-    /// [`ArchivedHistorySegment::NUM_PIECES`] [`Piece`]s of archival history.
-    pub const SIZE: usize = RawRecord::SIZE * Self::NUM_RAW_RECORDS;
-}
-
-/// Archived history segment after archiving is applied.
-#[derive(Debug, Clone, Eq, PartialEq, Deref, DerefMut, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(transparent)]
-pub struct ArchivedHistorySegment(FlatPieces);
-
-impl Default for ArchivedHistorySegment {
-    fn default() -> Self {
-        Self(FlatPieces::new(Self::NUM_PIECES))
-    }
-}
-
-impl MaxEncodedLen for ArchivedHistorySegment {
-    fn max_encoded_len() -> usize {
-        Self::SIZE
-    }
-}
-
-impl ArchivedHistorySegment {
-    /// Number of pieces in one segment of archived history.
-    pub const NUM_PIECES: usize = RecordedHistorySegment::NUM_RAW_RECORDS
-        * RecordedHistorySegment::ERASURE_CODING_RATE.1
-        / RecordedHistorySegment::ERASURE_CODING_RATE.0;
-    /// Size of archived history segment in bytes.
-    ///
-    /// It includes erasure coded [`PieceArray`]s (both source and parity) that are composed from
-    /// [`Record`]s together with corresponding commitments and witnesses.
-    pub const SIZE: usize = Piece::SIZE * Self::NUM_PIECES;
 }
 
 /// Record contained within a piece.
@@ -269,7 +297,7 @@ impl Decode for Piece {
     fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
         let piece = parity_scale_codec::decode_vec_with_len::<u8, _>(input, Self::SIZE)
             .map_err(|error| error.chain("Could not decode `Piece.0`"))?;
-        let mut piece = ManuallyDrop::new(piece);
+        let mut piece = mem::ManuallyDrop::new(piece);
         // SAFETY: Original memory is not dropped and guaranteed to be allocated
         let piece = unsafe { Box::from_raw(piece.as_mut_ptr() as *mut PieceArray) };
         Ok(Piece(piece))

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -1,0 +1,162 @@
+use crate::pieces::{FlatPieces, Piece, PieceIndex, RawRecord};
+use core::iter::Step;
+use core::mem;
+use derive_more::{
+    Add, AddAssign, Deref, DerefMut, Display, Div, DivAssign, Mul, MulAssign, Sub, SubAssign,
+};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Segment index type.
+#[derive(
+    Debug,
+    Display,
+    Default,
+    Copy,
+    Clone,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash,
+    Encode,
+    Decode,
+    Add,
+    AddAssign,
+    Sub,
+    SubAssign,
+    Mul,
+    MulAssign,
+    Div,
+    DivAssign,
+    TypeInfo,
+    MaxEncodedLen,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(transparent)]
+pub struct SegmentIndex(u64);
+
+impl Step for SegmentIndex {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u64::steps_between(&start.0, &end.0)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::forward_checked(start.0, count).map(Self)
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::backward_checked(start.0, count).map(Self)
+    }
+}
+
+impl const From<u64> for SegmentIndex {
+    fn from(original: u64) -> Self {
+        Self(original)
+    }
+}
+
+impl const From<SegmentIndex> for u64 {
+    fn from(original: SegmentIndex) -> Self {
+        original.0
+    }
+}
+
+impl SegmentIndex {
+    /// Segment index 0.
+    pub const ZERO: SegmentIndex = SegmentIndex(0);
+    /// Segment index 1.
+    pub const ONE: SegmentIndex = SegmentIndex(1);
+
+    /// Get the first piece index in this segment.
+    pub const fn first_piece_index(&self) -> PieceIndex {
+        PieceIndex::from(self.0 * ArchivedHistorySegment::NUM_PIECES as u64)
+    }
+
+    /// Iterator over piece indexes that belong to this segment.
+    pub fn segment_piece_indexes(&self) -> impl Iterator<Item = PieceIndex> {
+        (self.first_piece_index()..).take(ArchivedHistorySegment::NUM_PIECES)
+    }
+
+    /// Iterator over piece indexes that belong to this segment with source pieces first.
+    pub fn segment_piece_indexes_source_first(&self) -> impl Iterator<Item = PieceIndex> {
+        self.segment_piece_indexes()
+            .step_by(2)
+            .chain(self.segment_piece_indexes().skip(1).step_by(2))
+    }
+}
+
+/// Recorded history segment before archiving is applied.
+///
+/// NOTE: This is a stack-allocated data structure and can cause stack overflow!
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deref, DerefMut)]
+#[repr(transparent)]
+pub struct RecordedHistorySegment([RawRecord; Self::NUM_RAW_RECORDS]);
+
+impl Default for RecordedHistorySegment {
+    fn default() -> Self {
+        Self([RawRecord::default(); Self::NUM_RAW_RECORDS])
+    }
+}
+
+impl AsRef<[u8]> for RecordedHistorySegment {
+    fn as_ref(&self) -> &[u8] {
+        // SAFETY: Same memory layout due to `#[repr(transparent)]`
+        let raw_records: &[[u8; RawRecord::SIZE]] = unsafe { mem::transmute(self.0.as_slice()) };
+        raw_records.flatten()
+    }
+}
+
+impl AsMut<[u8]> for RecordedHistorySegment {
+    fn as_mut(&mut self) -> &mut [u8] {
+        // SAFETY: Same memory layout due to `#[repr(transparent)]`
+        let raw_records: &mut [[u8; RawRecord::SIZE]] =
+            unsafe { mem::transmute(self.0.as_mut_slice()) };
+        raw_records.flatten_mut()
+    }
+}
+
+impl RecordedHistorySegment {
+    /// Number of raw records in one segment of recorded history.
+    pub const NUM_RAW_RECORDS: usize = 128;
+    /// Erasure coding rate for records during archiving process.
+    pub const ERASURE_CODING_RATE: (usize, usize) = (1, 2);
+    /// Size of recorded history segment in bytes.
+    ///
+    /// It includes half of the records (just source records) that will later be erasure coded and
+    /// together with corresponding commitments and witnesses will result in
+    /// [`ArchivedHistorySegment::NUM_PIECES`] [`Piece`]s of archival history.
+    pub const SIZE: usize = RawRecord::SIZE * Self::NUM_RAW_RECORDS;
+}
+
+/// Archived history segment after archiving is applied.
+#[derive(Debug, Clone, Eq, PartialEq, Deref, DerefMut, Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(transparent)]
+pub struct ArchivedHistorySegment(FlatPieces);
+
+impl Default for ArchivedHistorySegment {
+    fn default() -> Self {
+        Self(FlatPieces::new(Self::NUM_PIECES))
+    }
+}
+
+impl MaxEncodedLen for ArchivedHistorySegment {
+    fn max_encoded_len() -> usize {
+        Self::SIZE
+    }
+}
+
+impl ArchivedHistorySegment {
+    /// Number of pieces in one segment of archived history.
+    pub const NUM_PIECES: usize = RecordedHistorySegment::NUM_RAW_RECORDS
+        * RecordedHistorySegment::ERASURE_CODING_RATE.1
+        / RecordedHistorySegment::ERASURE_CODING_RATE.0;
+    /// Size of archived history segment in bytes.
+    ///
+    /// It includes erasure coded [`crate::pieces::PieceArray`]s (both source and parity) that are
+    /// composed from [`crate::pieces::Record`]s together with corresponding commitments and witnesses.
+    pub const SIZE: usize = Piece::SIZE * Self::NUM_PIECES;
+}

--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -33,7 +33,7 @@ pub async fn recover_missing_piece<PG: PieceGetter>(
 
     let semaphore = Semaphore::new(PARALLELISM_LEVEL);
     let acquired_pieces_counter = AtomicUsize::default();
-    let required_pieces_number = RecordedHistorySegment::RAW_RECORDS;
+    let required_pieces_number = RecordedHistorySegment::NUM_RAW_RECORDS;
 
     // This is so we can move references into the future below
     let semaphore = &semaphore;

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -3,7 +3,7 @@ pub(crate) mod node_rpc_client;
 use async_trait::async_trait;
 use futures::Stream;
 use std::pin::Pin;
-use subspace_archiving::archiver::ArchiverSegment;
+use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::{SegmentCommitment, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
@@ -43,7 +43,7 @@ pub trait NodeClient: Clone + Send + Sync + 'static {
     /// Subscribe to archived segments
     async fn subscribe_archived_segments(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = ArchiverSegment> + Send + 'static>>, Error>;
+    ) -> Result<Pin<Box<dyn Stream<Item = NewArchivedSegment> + Send + 'static>>, Error>;
 
     /// Get segment commitments for the segments
     async fn segment_commitments(

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -3,7 +3,7 @@ pub(crate) mod node_rpc_client;
 use async_trait::async_trait;
 use futures::Stream;
 use std::pin::Pin;
-use subspace_archiving::archiver::ArchivedSegment;
+use subspace_archiving::archiver::ArchiverSegment;
 use subspace_core_primitives::{SegmentCommitment, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
@@ -43,7 +43,7 @@ pub trait NodeClient: Clone + Send + Sync + 'static {
     /// Subscribe to archived segments
     async fn subscribe_archived_segments(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = ArchivedSegment> + Send + 'static>>, Error>;
+    ) -> Result<Pin<Box<dyn Stream<Item = ArchiverSegment> + Send + 'static>>, Error>;
 
     /// Get segment commitments for the segments
     async fn segment_commitments(

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -7,7 +7,7 @@ use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use std::pin::Pin;
 use std::sync::Arc;
-use subspace_archiving::archiver::ArchivedSegment;
+use subspace_archiving::archiver::ArchiverSegment;
 use subspace_core_primitives::{SegmentCommitment, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
@@ -109,7 +109,7 @@ impl NodeClient for NodeRpcClient {
 
     async fn subscribe_archived_segments(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = ArchivedSegment> + Send + 'static>>, RpcError> {
+    ) -> Result<Pin<Box<dyn Stream<Item = ArchiverSegment> + Send + 'static>>, RpcError> {
         let subscription = self
             .client
             .subscribe(

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -7,7 +7,7 @@ use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use std::pin::Pin;
 use std::sync::Arc;
-use subspace_archiving::archiver::ArchiverSegment;
+use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::{SegmentCommitment, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
@@ -109,7 +109,7 @@ impl NodeClient for NodeRpcClient {
 
     async fn subscribe_archived_segments(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = ArchiverSegment> + Send + 'static>>, RpcError> {
+    ) -> Result<Pin<Box<dyn Stream<Item = NewArchivedSegment> + Send + 'static>>, RpcError> {
         let subscription = self
             .client
             .subscribe(

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -213,7 +213,7 @@ impl RpcServerImpl {
         // How much bytes are definitely available starting at `piece_index` and `offset` without
         // crossing segment boundary
         let bytes_available_in_segment = {
-            let data_shards = RecordedHistorySegment::RAW_RECORDS as u32;
+            let data_shards = RecordedHistorySegment::NUM_RAW_RECORDS as u32;
             let piece_position = piece_index.position();
 
             // `-2` is because last 2 bytes might contain padding if a piece is the last piece in
@@ -400,7 +400,7 @@ impl RpcServerImpl {
             Vec::<u8>::with_capacity((self.pieces_in_segment * self.record_size) as usize);
 
         for piece_index in
-            (segment_index.first_piece_index()..).take(RecordedHistorySegment::RAW_RECORDS)
+            (segment_index.first_piece_index()..).take(RecordedHistorySegment::NUM_RAW_RECORDS)
         {
             let piece = self.read_and_decode_piece(piece_index)?;
             segment_bytes.extend_from_slice(piece.record().as_ref());

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -15,7 +15,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use subspace_archiving::archiver::ArchiverSegment;
+use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::{PieceIndex, SegmentHeader, SegmentIndex};
 use subspace_networking::libp2p::{identity, Multiaddr};
 use subspace_networking::utils::pieces::announce_single_piece_index_with_backoff;
@@ -279,7 +279,7 @@ pub(crate) async fn publish_pieces(
     node: &Node,
     first_piece_index: PieceIndex,
     segment_index: SegmentIndex,
-    archived_segment: Arc<ArchiverSegment>,
+    archived_segment: Arc<NewArchivedSegment>,
 ) {
     let pieces_indexes = (first_piece_index..).take(archived_segment.pieces.len());
 

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -15,7 +15,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
-use subspace_archiving::archiver::ArchivedSegment;
+use subspace_archiving::archiver::ArchiverSegment;
 use subspace_core_primitives::{PieceIndex, SegmentHeader, SegmentIndex};
 use subspace_networking::libp2p::{identity, Multiaddr};
 use subspace_networking::utils::pieces::announce_single_piece_index_with_backoff;
@@ -279,7 +279,7 @@ pub(crate) async fn publish_pieces(
     node: &Node,
     first_piece_index: PieceIndex,
     segment_index: SegmentIndex,
-    archived_segment: Arc<ArchivedSegment>,
+    archived_segment: Arc<ArchiverSegment>,
 ) {
     let pieces_indexes = (first_piece_index..).take(archived_segment.pieces.len());
 

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -31,7 +31,7 @@ use std::task::Poll;
 use subspace_archiving::reconstructor::Reconstructor;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::{
-    Piece, RecordedHistorySegment, SegmentHeader, SegmentIndex, PIECES_IN_SEGMENT,
+    ArchivedHistorySegment, Piece, RecordedHistorySegment, SegmentHeader, SegmentIndex,
 };
 use subspace_networking::utils::piece_provider::{PieceProvider, RetryPolicy};
 use subspace_networking::Node;
@@ -121,7 +121,7 @@ where
     for segment_index in (SegmentIndex::ZERO..).take(segments_found) {
         let pieces_indices = segment_index.segment_piece_indexes_source_first();
 
-        let mut pieces = vec![None::<Piece>; PIECES_IN_SEGMENT as usize];
+        let mut pieces = vec![None::<Piece>; ArchivedHistorySegment::NUM_PIECES];
         let mut pieces_received = 0;
 
         for (piece_index, piece) in pieces_indices.zip(pieces.iter_mut()) {
@@ -142,7 +142,7 @@ where
                 pieces_received += 1;
             }
 
-            if pieces_received >= RecordedHistorySegment::RAW_RECORDS {
+            if pieces_received >= RecordedHistorySegment::NUM_RAW_RECORDS {
                 trace!(%segment_index, "Received half of the segment.");
                 break;
             }

--- a/crates/subspace-service/src/piece_cache/tests.rs
+++ b/crates/subspace-service/src/piece_cache/tests.rs
@@ -3,7 +3,9 @@ use sc_client_api::AuxStore;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
-use subspace_core_primitives::{FlatPieces, Piece, PieceIndex, PieceIndexHash, PIECES_IN_SEGMENT};
+use subspace_core_primitives::{
+    ArchivedHistorySegment, FlatPieces, Piece, PieceIndex, PieceIndexHash,
+};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::multihash::ToMultihash;
 
@@ -46,15 +48,12 @@ impl AuxStore for TestAuxStore {
 fn basic() {
     let mut store = PieceCache::new(
         Arc::new(TestAuxStore::default()),
-        u64::from(PIECES_IN_SEGMENT) * Piece::SIZE as u64,
+        ArchivedHistorySegment::SIZE as u64,
         PeerId::random(),
     );
 
     store
-        .add_pieces(
-            PieceIndex::default(),
-            &FlatPieces::new(PIECES_IN_SEGMENT as usize),
-        )
+        .add_pieces(PieceIndex::default(), &ArchivedHistorySegment::default())
         .unwrap();
 
     let piece_index = PieceIndex::default();
@@ -80,10 +79,7 @@ fn cache_nothing() {
     let mut store = PieceCache::new(Arc::new(TestAuxStore::default()), 0, PeerId::random());
 
     store
-        .add_pieces(
-            PieceIndex::default(),
-            &FlatPieces::new(PIECES_IN_SEGMENT as usize),
-        )
+        .add_pieces(PieceIndex::default(), &ArchivedHistorySegment::default())
         .unwrap();
 
     let piece_index = PieceIndex::default();

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -33,7 +33,7 @@ use std::error::Error;
 use std::io::Cursor;
 use std::num::NonZeroU64;
 use std::sync::Arc;
-use subspace_archiving::archiver::ArchiverSegment;
+use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
@@ -196,7 +196,7 @@ async fn start_farming<Client>(
 }
 
 struct TestPieceGetter {
-    archived_segment: ArchiverSegment,
+    archived_segment: NewArchivedSegment,
 }
 
 #[async_trait]
@@ -228,18 +228,16 @@ where
         .expect("Incorrect parameters for archiver");
 
     let genesis_block = client.block(client.info().genesis_hash).unwrap().unwrap();
-    let archiver_segment = archiver
+    let archived_segment = archiver
         .add_block(genesis_block.encode(), BlockObjectMapping::default())
         .into_iter()
         .next()
         .expect("First block is always producing one segment; qed");
-    let total_pieces = NonZeroU64::new(archiver_segment.pieces.len() as u64).unwrap();
+    let total_pieces = NonZeroU64::new(archived_segment.pieces.len() as u64).unwrap();
     let mut sector = vec![0u8; PLOT_SECTOR_SIZE as usize];
     let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
     let sector_index = 0;
-    let piece_getter = TestPieceGetter {
-        archived_segment: archiver_segment,
-    };
+    let piece_getter = TestPieceGetter { archived_segment };
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let farmer_protocol_info = FarmerProtocolInfo {
         total_pieces,


### PR DESCRIPTION
Three step refactoring, likely the last one for now.

The main changes are:
* `subspace_archiver::archiver::ArchivedSegment` renamed into `NewArchivedSegment`
* `ArchivedHistorySegment` is introduced similarly to already existing `RecordedHistorySegment`
* `PIECES_IN_SEGMENT` is replaces with `ArchivedHistorySegment::NUM_PIECES`
* new `segments` module in `subspace-core-primitives` and moving types around

cc @dariolina 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
