### PR TITLE
Change the default provider storage for subspace-bootstrap-node.

### DIFF
--- a/crates/subspace-networking/src/behavior/provider_storage.rs
+++ b/crates/subspace-networking/src/behavior/provider_storage.rs
@@ -5,7 +5,7 @@ use libp2p::kad::{store, ProviderRecord};
 use libp2p::PeerId;
 #[cfg(test)]
 pub(crate) use providers::{instant_to_micros, micros_to_instant};
-pub use providers::{MemoryProviderStorage, ParityDbProviderStorage};
+pub use providers::{MemoryProviderStorage, ParityDbProviderStorage, VoidProviderStorage};
 use std::borrow::Cow;
 
 pub trait ProviderStorage {

--- a/crates/subspace-networking/src/behavior/provider_storage/providers.rs
+++ b/crates/subspace-networking/src/behavior/provider_storage/providers.rs
@@ -25,6 +25,28 @@ const MEMORY_STORE_PROVIDED_KEY_LIMIT: usize = 100000; // ~100 MB
 const PARITY_DB_ALL_PROVIDERS_COLUMN_NAME: u8 = 0;
 const PARITY_DB_LOCAL_PROVIDER_COLUMN_NAME: u8 = 1;
 
+/// Stub provider storage implementation.
+/// All operations have no effect or return empty collections/iterators.
+pub struct VoidProviderStorage;
+
+impl ProviderStorage for VoidProviderStorage {
+    type ProvidedIter<'a> = iter::Empty<Cow<'a, ProviderRecord>>;
+
+    fn add_provider(&mut self, _: ProviderRecord) -> store::Result<()> {
+        Ok(())
+    }
+
+    fn providers(&self, _: &Key) -> Vec<ProviderRecord> {
+        Default::default()
+    }
+
+    fn provided(&self) -> Self::ProvidedIter<'_> {
+        iter::empty()
+    }
+
+    fn remove_provider(&mut self, _: &Key, _: &PeerId) {}
+}
+
 /// Memory based provider records storage.
 pub struct MemoryProviderStorage {
     inner: store::MemoryStore,

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -13,8 +13,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::{
-    peer_id, BootstrappedNetworkingParameters, Config, MemoryProviderStorage,
-    NetworkingParametersManager, ParityDbProviderStorage,
+    peer_id, BootstrappedNetworkingParameters, Config, NetworkingParametersManager,
+    ParityDbProviderStorage, VoidProviderStorage,
 };
 use tracing::info;
 
@@ -50,7 +50,6 @@ enum Command {
         #[arg(long, default_value_t = false)]
         disable_private_ips: bool,
         /// Defines path for the provider record storage DB (optional).
-        /// No value will enable memory storage instead.
         #[arg(long, value_hint = ValueHint::FilePath)]
         db_path: Option<PathBuf>,
         /// Piece providers cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
@@ -100,7 +99,7 @@ async fn main() -> anyhow::Result<()> {
                     local_peer_id,
                 )?)
             } else {
-                Either::Right(MemoryProviderStorage::new(local_peer_id))
+                Either::Right(VoidProviderStorage)
             };
 
             let networking_parameters_registry = {

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -42,7 +42,7 @@ pub use crate::node::{
 };
 pub use crate::node_runner::NodeRunner;
 pub use behavior::provider_storage::{
-    MemoryProviderStorage, ParityDbProviderStorage, ProviderStorage,
+    MemoryProviderStorage, ParityDbProviderStorage, ProviderStorage, VoidProviderStorage,
 };
 pub use create::{create, peer_id, Config, CreationError, RelayMode};
 pub use libp2p;


### PR DESCRIPTION
This PR changes the default provider storage from memory based to just void (no-op) provider which ignores all operations and returns empty collections/iterators. It will disable the `subspace-bootstrap-node's` ability to participate in `get_providers` call from Kademlia peers.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
