### PR TITLE
Modify `generate-keypair` command output for subspace-bootstrap-node app.

### DIFF
--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -9,6 +9,7 @@ use either::Either;
 use libp2p::identity::ed25519::Keypair;
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -71,6 +72,13 @@ enum Command {
 struct KeypairOutput {
     keypair: String,
     peer_id: String,
+}
+
+impl Display for KeypairOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "PeerId: {}", self.peer_id)?;
+        writeln!(f, "Keypair: {}", self.keypair)
+    }
 }
 
 impl KeypairOutput {
@@ -177,7 +185,7 @@ async fn main() -> anyhow::Result<()> {
 
                 println!("{json_output}")
             } else {
-                println!("{}", output.keypair)
+                println!("{output}")
             }
         }
     }


### PR DESCRIPTION
This PR modifies the  `generate-keypair` command output - it adds `PeerId` and related titles.

Follows the discussion from [here](https://github.com/subspace/subspace/pull/1319#pullrequestreview-1362907342).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
