### PR TITLE
Improve archiver performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9948,6 +9948,7 @@ dependencies = [
  "criterion",
  "parity-scale-codec",
  "rand 0.8.5",
+ "rayon",
  "serde",
  "subspace-core-primitives",
  "subspace-erasure-coding",

--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -18,6 +18,7 @@ bench = false
 
 [dependencies]
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
+rayon = { version = "1.7.0", optional = true }
 serde = { version = "1.0.152", optional = true, features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding", default-features = false }
@@ -30,8 +31,13 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 
 [features]
 default = ["std"]
+rayon = [
+    "dep:rayon",
+    "subspace-core-primitives/rayon",
+]
 std = [
     "parity-scale-codec/std",
+    "rayon",
     "serde",
     "subspace-core-primitives/std",
     "subspace-erasure-coding/std",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -56,8 +56,9 @@ default = [
 ]
 # Parallel decoding will use all CPUs available, but will allocate a memory of a size of a sector instead of square root
 # of that
-parallel-decoding = ["rayon"]
+parallel-decoding = ["dep:rayon"]
 embedded-kzg-settings = []
+rayon = ["dep:rayon"]
 serde = [
     "dep:serde",
     # TODO: `serde_arrays` doesn't support `no_std` right now: https://github.com/Kromey/serde_arrays/issues/8

--- a/crates/subspace-core-primitives/benches/kzg.rs
+++ b/crates/subspace-core-primitives/benches/kzg.rs
@@ -1,9 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::crypto::Scalar;
+use subspace_core_primitives::RawRecord;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let values = (0..8)
+    let values = (0..RawRecord::SIZE / Scalar::SAFE_BYTES)
         .map(|_| Scalar::from(rand::random::<[u8; Scalar::SAFE_BYTES]>()))
         .collect::<Vec<_>>();
 

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -18,6 +18,8 @@ use derive_more::{
     MulAssign, Sub, SubAssign,
 };
 use parity_scale_codec::{Decode, Encode, Input, MaxEncodedLen};
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
 use scale_info::TypeInfo;
 
 // TODO: Remove once we redefine it through raw record
@@ -538,6 +540,33 @@ impl FlatPieces {
     /// Mutable iterator over parity pieces (odd indices).
     pub fn parity_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
         self.0.iter_mut().skip(1).step_by(2)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl FlatPieces {
+    /// Parallel iterator over source pieces (even indices).
+    pub fn par_source(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
+        self.0.par_iter().step_by(2)
+    }
+
+    /// Mutable parallel iterator over source pieces (even indices).
+    pub fn par_source_mut(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
+        self.0.par_iter_mut().step_by(2)
+    }
+
+    /// Parallel iterator over parity pieces (odd indices).
+    pub fn par_parity(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
+        self.0.par_iter().skip(1).step_by(2)
+    }
+
+    /// Mutable parallel iterator over parity pieces (odd indices).
+    pub fn par_parity_mut(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
+        self.0.par_iter_mut().skip(1).step_by(2)
     }
 }
 

--- a/crates/subspace-erasure-coding/Cargo.toml
+++ b/crates/subspace-erasure-coding/Cargo.toml
@@ -10,6 +10,10 @@ include = [
     "/Cargo.toml",
 ]
 
+[lib]
+# Necessary for CLI options to work on benches
+bench = false
+
 [dependencies]
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
 blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }

--- a/crates/subspace-erasure-coding/benches/commitments.rs
+++ b/crates/subspace-erasure-coding/benches/commitments.rs
@@ -3,11 +3,13 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use kzg::G1;
 use std::num::NonZeroUsize;
 use subspace_core_primitives::crypto::kzg::Commitment;
+use subspace_core_primitives::ArchivedHistorySegment;
 use subspace_erasure_coding::ErasureCoding;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let scale = NonZeroUsize::new(8).unwrap();
-    let num_shards = 2usize.pow(scale.get() as u32);
+    let num_shards = ArchivedHistorySegment::NUM_PIECES;
+    let scale = NonZeroUsize::new(num_shards.ilog2() as usize)
+        .expect("Recorded history segment contains at very least one record; qed");
     let ec = ErasureCoding::new(scale).unwrap();
 
     let source_commitments = (0..num_shards / 2)


### PR DESCRIPTION
I have increased parameters to the consensus v2.3 level and archiving benchmark shown that archiving of a single segment takes about half a minute. That not really usable for testing or benchmarking purposes.

One discovery with that particular use case is that we have a big blob we're adding to the history all at once, so we can actually skip incremental commitments (that is sequential, though can be a bit parallelized and I'll do that later at some point) and instead do commitments in parallel, which depending on number of cores reduces time significantly, here is results on my machine:
```
segment-archiving       time:   [6.7308 s 6.7501 s 6.7746 s]
```

NOTE: This PR doesn't change constants, it only addresses performance concerns.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
