### PR TITLE
Exit archiver task in case runtime API error happens

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -484,7 +484,7 @@ where
 
                 api_result.map(|maybe_segment_commitment| {
                     // This is not a very nice hack due to the fact that at the time first block is
-                    //  producedextrinsics with segment headers are not yet in runtime.
+                    //  produced extrinsics with segment headers are not yet in runtime.
                     if maybe_segment_commitment.is_none() && best_block_number.is_zero() {
                         self.subspace_link
                             .segment_commitment_by_segment_index(segment_index)

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -486,7 +486,7 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
 
                     best_archived_block_hash = block_hash_to_archive;
 
-                    let block_object_mappings = client
+                    let block_object_mappings = match client
                         .runtime_api()
                         .validated_object_call_hashes(block_hash_to_archive)
                         .and_then(|calls| {
@@ -495,8 +495,16 @@ pub fn start_subspace_archiver<Block, Backend, Client>(
                                 block.block.clone(),
                                 calls,
                             )
-                        })
-                        .unwrap_or_default();
+                        }) {
+                        Ok(block_object_mappings) => block_object_mappings,
+                        Err(error) => {
+                            error!(
+                                target: "subspace",
+                                "Failed to retrieve block object mappings: {error}"
+                            );
+                            return;
+                        }
+                    };
 
                     let encoded_block = block.encode();
                     debug!(

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -449,7 +449,7 @@ pub struct SubspaceLink<Block: BlockT> {
     imported_block_notification_stream:
         SubspaceNotificationStream<ImportedBlockNotification<Block>>,
     /// Segment headers that are expected to appear in the corresponding blocks, used for block
-    /// validation
+    /// production and validation
     segment_headers: Arc<Mutex<LruCache<NumberFor<Block>, Vec<SegmentHeader>>>>,
     kzg: Kzg,
 }

--- a/crates/sp-objects/src/lib.rs
+++ b/crates/sp-objects/src/lib.rs
@@ -26,7 +26,6 @@ sp_api::decl_runtime_apis! {
         /// Returns all the validated object call hashes for a given block
         fn validated_object_call_hashes() -> Vec<Hash>;
 
-
         /// Extract block object mapping for a given block
         fn extract_block_object_mapping(block: Block, validated_object_calls: Vec<Hash>) -> BlockObjectMapping;
     }


### PR DESCRIPTION
I was looking at https://github.com/subspace/subspace/issues/871 over and over and found that we may actually suppress potential runtime API errors. It has nothing to do with that issue, but still worth handling. Also fixed minor nuances I saw when reading code here and there.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
