### PR TITLE
Rename `ImportedBlockNotification` into `BlockImportingNotification` to reduce confusion about what it is

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -134,10 +134,12 @@ pub struct ArchivedSegmentNotification {
     pub acknowledgement_sender: TracingUnboundedSender<()>,
 }
 
-/// Notification with imported block header hash that needs to be archived and sender for
-/// segment headers.
+/// Notification with number of the block that is about to be imported and acknowledgement sender
+/// that can be used to pause block production if desired.
+///
+/// NOTE: Block is not fully imported yet!
 #[derive(Debug, Clone)]
-pub struct ImportedBlockNotification<Block>
+pub struct BlockImportingNotification<Block>
 where
     Block: BlockT,
 {
@@ -145,7 +147,7 @@ where
     pub block_number: NumberFor<Block>,
     /// Sender for pausing the block import when executor is not fast enough to process
     /// the primary block.
-    pub block_import_acknowledgement_sender: mpsc::Sender<()>,
+    pub acknowledgement_sender: mpsc::Sender<()>,
 }
 
 /// Errors encountered by the Subspace authorship task.
@@ -446,8 +448,8 @@ pub struct SubspaceLink<Block: BlockT> {
     reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
     archived_segment_notification_sender: SubspaceNotificationSender<ArchivedSegmentNotification>,
     archived_segment_notification_stream: SubspaceNotificationStream<ArchivedSegmentNotification>,
-    imported_block_notification_stream:
-        SubspaceNotificationStream<ImportedBlockNotification<Block>>,
+    block_importing_notification_stream:
+        SubspaceNotificationStream<BlockImportingNotification<Block>>,
     /// Segment headers that are expected to appear in the corresponding blocks, used for block
     /// production and validation
     segment_headers: Arc<Mutex<LruCache<NumberFor<Block>, Vec<SegmentHeader>>>>,
@@ -481,10 +483,10 @@ impl<Block: BlockT> SubspaceLink<Block> {
     }
 
     /// Get stream with notifications about each imported block.
-    pub fn imported_block_notification_stream(
+    pub fn block_importing_notification_stream(
         &self,
-    ) -> SubspaceNotificationStream<ImportedBlockNotification<Block>> {
-        self.imported_block_notification_stream.clone()
+    ) -> SubspaceNotificationStream<BlockImportingNotification<Block>> {
+        self.block_importing_notification_stream.clone()
     }
 
     /// Get blocks that are expected to be included at specified block number.
@@ -753,8 +755,8 @@ where
 pub struct SubspaceBlockImport<Block: BlockT, Client, I, CIDP> {
     inner: I,
     client: Arc<Client>,
-    imported_block_notification_sender:
-        SubspaceNotificationSender<ImportedBlockNotification<Block>>,
+    block_importing_notification_sender:
+        SubspaceNotificationSender<BlockImportingNotification<Block>>,
     subspace_link: SubspaceLink<Block>,
     create_inherent_data_providers: CIDP,
 }
@@ -769,7 +771,7 @@ where
         SubspaceBlockImport {
             inner: self.inner.clone(),
             client: self.client.clone(),
-            imported_block_notification_sender: self.imported_block_notification_sender.clone(),
+            block_importing_notification_sender: self.block_importing_notification_sender.clone(),
             subspace_link: self.subspace_link.clone(),
             create_inherent_data_providers: self.create_inherent_data_providers.clone(),
         }
@@ -786,8 +788,8 @@ where
     fn new(
         client: Arc<Client>,
         block_import: I,
-        imported_block_notification_sender: SubspaceNotificationSender<
-            ImportedBlockNotification<Block>,
+        block_importing_notification_sender: SubspaceNotificationSender<
+            BlockImportingNotification<Block>,
         >,
         subspace_link: SubspaceLink<Block>,
         create_inherent_data_providers: CIDP,
@@ -795,7 +797,7 @@ where
         SubspaceBlockImport {
             client,
             inner: block_import,
-            imported_block_notification_sender,
+            block_importing_notification_sender,
             subspace_link,
             create_inherent_data_providers,
         }
@@ -1160,17 +1162,16 @@ where
         block.fork_choice = Some(fork_choice);
 
         let import_result = self.inner.import_block(block, new_cache).await?;
-        let (block_import_acknowledgement_sender, mut block_import_acknowledgement_receiver) =
-            mpsc::channel(0);
+        let (acknowledgement_sender, mut acknowledgement_receiver) = mpsc::channel(0);
 
-        self.imported_block_notification_sender
-            .notify(move || ImportedBlockNotification {
+        self.block_importing_notification_sender
+            .notify(move || BlockImportingNotification {
                 block_number,
-                block_import_acknowledgement_sender,
+                acknowledgement_sender,
             });
 
-        while (block_import_acknowledgement_receiver.next().await).is_some() {
-            // Wait for all the acknowledgements to progress.
+        while (acknowledgement_receiver.next().await).is_some() {
+            // Wait for all the acknowledgements to finish.
         }
 
         Ok(import_result)
@@ -1244,8 +1245,8 @@ where
         notification::channel("subspace_reward_signing_notification_stream");
     let (archived_segment_notification_sender, archived_segment_notification_stream) =
         notification::channel("subspace_archived_segment_notification_stream");
-    let (imported_block_notification_sender, imported_block_notification_stream) =
-        notification::channel("subspace_imported_block_notification_stream");
+    let (block_importing_notification_sender, block_importing_notification_stream) =
+        notification::channel("subspace_block_importing_notification_stream");
 
     let confirmation_depth_k = get_chain_constants(client.as_ref())
         .expect("Must always be able to get chain constants")
@@ -1262,7 +1263,7 @@ where
         reward_signing_notification_stream,
         archived_segment_notification_sender,
         archived_segment_notification_stream,
-        imported_block_notification_stream,
+        block_importing_notification_stream,
         // TODO: Consider making `confirmation_depth_k` non-zero
         segment_headers: Arc::new(Mutex::new(LruCache::new(
             NonZeroUsize::new(confirmation_depth_k as usize)
@@ -1274,7 +1275,7 @@ where
     let import = SubspaceBlockImport::new(
         client,
         wrapped_block_import,
-        imported_block_notification_sender,
+        block_importing_notification_sender,
         link.clone(),
         create_inherent_data_providers,
     );

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -519,14 +519,14 @@ fn main() -> Result<(), Error> {
                             ))
                         })?;
 
-                    let imported_block_notification_stream = || {
+                    let block_importing_notification_stream = || {
                         primary_chain_node
-                            .imported_block_notification_stream
+                            .block_importing_notification_stream
                             .subscribe()
-                            .then(|imported_block_notification| async move {
+                            .then(|block_importing_notification| async move {
                                 (
-                                    imported_block_notification.block_number,
-                                    imported_block_notification.block_import_acknowledgement_sender,
+                                    block_importing_notification.block_number,
+                                    block_importing_notification.acknowledgement_sender,
                                 )
                             })
                     };
@@ -549,9 +549,8 @@ fn main() -> Result<(), Error> {
 
                     let executor_streams = ExecutorStreams {
                         primary_block_import_throttling_buffer_size,
-                        subspace_imported_block_notification_stream:
-                            imported_block_notification_stream(),
-                        client_imported_block_notification_stream: primary_chain_node
+                        block_importing_notification_stream: block_importing_notification_stream(),
+                        imported_block_notification_stream: primary_chain_node
                             .client
                             .every_import_notification_stream(),
                         new_slot_notification_stream: new_slot_notification_stream(),
@@ -601,9 +600,9 @@ fn main() -> Result<(), Error> {
 
                         let executor_streams = ExecutorStreams {
                             primary_block_import_throttling_buffer_size,
-                            subspace_imported_block_notification_stream:
-                                imported_block_notification_stream(),
-                            client_imported_block_notification_stream: primary_chain_node
+                            block_importing_notification_stream:
+                                block_importing_notification_stream(),
+                            imported_block_notification_stream: primary_chain_node
                                 .client
                                 .every_import_notification_stream(),
                             new_slot_notification_stream: new_slot_notification_stream(),

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -46,7 +46,7 @@ use sc_consensus::{BlockImport, DefaultImportQueue};
 use sc_consensus_slots::SlotProportion;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::{
-    ArchivedSegmentNotification, ImportedBlockNotification, NewSlotNotification,
+    ArchivedSegmentNotification, BlockImportingNotification, NewSlotNotification,
     RewardSigningNotification, SubspaceLink, SubspaceParams,
 };
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
@@ -406,9 +406,9 @@ where
     pub new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     /// Block signing stream.
     pub reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
-    /// Imported block stream.
-    pub imported_block_notification_stream:
-        SubspaceNotificationStream<ImportedBlockNotification<Block>>,
+    /// Stream of notifications about blocks about to be imported.
+    pub block_importing_notification_stream:
+        SubspaceNotificationStream<BlockImportingNotification<Block>>,
     /// Archived segment stream.
     pub archived_segment_notification_stream:
         SubspaceNotificationStream<ArchivedSegmentNotification>,
@@ -708,7 +708,7 @@ where
 
     let new_slot_notification_stream = subspace_link.new_slot_notification_stream();
     let reward_signing_notification_stream = subspace_link.reward_signing_notification_stream();
-    let imported_block_notification_stream = subspace_link.imported_block_notification_stream();
+    let block_importing_notification_stream = subspace_link.block_importing_notification_stream();
     let archived_segment_notification_stream = subspace_link.archived_segment_notification_stream();
 
     if config.role.is_authority() || config.force_new_slot_notifications {
@@ -825,7 +825,7 @@ where
         backend,
         new_slot_notification_stream,
         reward_signing_notification_stream,
-        imported_block_notification_stream,
+        block_importing_notification_stream,
         archived_segment_notification_stream,
         network_starter,
         transaction_pool,

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -124,8 +124,8 @@ pub(super) async fn start_worker<
 
     let ExecutorStreams {
         primary_block_import_throttling_buffer_size,
-        subspace_imported_block_notification_stream,
-        client_imported_block_notification_stream,
+        block_importing_notification_stream,
+        imported_block_notification_stream,
         new_slot_notification_stream,
         _phantom,
     } = executor_streams;
@@ -156,8 +156,8 @@ pub(super) async fn start_worker<
                      }| (hash, number),
                 )
                 .collect(),
-            Box::pin(subspace_imported_block_notification_stream),
-            Box::pin(client_imported_block_notification_stream),
+            Box::pin(block_importing_notification_stream),
+            Box::pin(imported_block_notification_stream),
             primary_block_import_throttling_buffer_size,
         );
     let handle_slot_notifications_fut = handle_slot_notifications::<Block, PBlock, _, _>(

--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -56,16 +56,16 @@ pub(crate) async fn handle_block_import_notifications<
     PBlock,
     PClient,
     ProcessorFn,
-    SubspaceBlockImports,
-    ClientBlockImports,
+    BlocksImporting,
+    BlocksImported,
 >(
     spawn_essential: Box<dyn SpawnEssentialNamed>,
     primary_chain_client: &PClient,
     best_domain_number: NumberFor<Block>,
     processor: ProcessorFn,
     mut leaves: Vec<(PBlock::Hash, NumberFor<PBlock>)>,
-    mut subspace_block_imports: SubspaceBlockImports,
-    mut client_block_imports: ClientBlockImports,
+    mut blocks_importing: BlocksImporting,
+    mut blocks_imported: BlocksImported,
     primary_block_import_throttling_buffer_size: u32,
 ) where
     Block: BlockT,
@@ -81,8 +81,8 @@ pub(crate) async fn handle_block_import_notifications<
         + Send
         + Sync
         + 'static,
-    SubspaceBlockImports: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Unpin,
-    ClientBlockImports: Stream<Item = BlockImportNotification<PBlock>> + Unpin,
+    BlocksImporting: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Unpin,
+    BlocksImported: Stream<Item = BlockImportNotification<PBlock>> + Unpin,
 {
     let mut active_leaves = HashMap::with_capacity(leaves.len());
 
@@ -136,20 +136,20 @@ pub(crate) async fn handle_block_import_notifications<
 
     loop {
         tokio::select! {
-            maybe_client_block_import = client_block_imports.next() => {
-                let notification = match maybe_client_block_import {
-                    Some(block_import) => block_import,
+            maybe_block_imported = blocks_imported.next() => {
+                let block_imported = match maybe_block_imported {
+                    Some(block_imported) => block_imported,
                     None => {
                         // Can be None on graceful shutdown.
                         break;
                     }
                 };
-                let header = match primary_chain_client.header(notification.hash) {
+                let header = match primary_chain_client.header(block_imported.hash) {
                     Ok(Some(header)) => header,
                     res => {
                         tracing::error!(
                             result = ?res,
-                            header = ?notification.header,
+                            header = ?block_imported.header,
                             "Imported primary block header not found",
                         );
                         return;
@@ -162,10 +162,10 @@ pub(crate) async fn handle_block_import_notifications<
                 };
                 let _ = block_info_sender.feed(Some(block_info)).await;
             }
-            maybe_subspace_block_import = subspace_block_imports.next() => {
-                let (_block_number, mut block_import_acknowledgement_sender) =
-                    match maybe_subspace_block_import {
-                        Some(block_import) => block_import,
+            maybe_block_importing = blocks_importing.next() => {
+                let (_block_number, mut acknowledgement_sender) =
+                    match maybe_block_importing {
+                        Some(block_importing) => block_importing,
                         None => {
                             // Can be None on graceful shutdown.
                             break;
@@ -173,7 +173,7 @@ pub(crate) async fn handle_block_import_notifications<
                     };
                 // Pause the primary block import when the sink is full.
                 let _ = block_info_sender.feed(None).await;
-                let _ = block_import_acknowledgement_sender.send(()).await;
+                let _ = acknowledgement_sender.send(()).await;
             }
         }
     }

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -147,14 +147,14 @@ pub struct ExecutorStreams<PBlock, IBNS, CIBNS, NSNS> {
     /// Pause the primary block import when the primary chain client
     /// runs much faster than the domain client.
     pub primary_block_import_throttling_buffer_size: u32,
-    /// Primary block import notification from `sc-consensus-subspace`.
+    /// Notification about to be imported.
     ///
     /// Fired before the completion of entire block import pipeline.
-    pub subspace_imported_block_notification_stream: IBNS,
-    /// Primary block import nofication from the native client.
+    pub block_importing_notification_stream: IBNS,
+    /// Primary block import notification from the client.
     ///
     /// Fired after the completion of entire block import pipeline.
-    pub client_imported_block_notification_stream: CIBNS,
+    pub imported_block_notification_stream: CIBNS,
     /// New slot arrives.
     pub new_slot_notification_stream: NSNS,
     pub _phantom: PhantomData<PBlock>,

--- a/domains/client/domain-executor/src/system_domain_worker.rs
+++ b/domains/client/domain-executor/src/system_domain_worker.rs
@@ -111,8 +111,8 @@ pub(super) async fn start_worker<
 
     let ExecutorStreams {
         primary_block_import_throttling_buffer_size,
-        subspace_imported_block_notification_stream,
-        client_imported_block_notification_stream,
+        block_importing_notification_stream,
+        imported_block_notification_stream,
         new_slot_notification_stream,
         _phantom,
     } = executor_streams;
@@ -143,8 +143,8 @@ pub(super) async fn start_worker<
                      }| (hash, number),
                 )
                 .collect(),
-            Box::pin(subspace_imported_block_notification_stream),
-            Box::pin(client_imported_block_notification_stream),
+            Box::pin(block_importing_notification_stream),
+            Box::pin(imported_block_notification_stream),
             primary_block_import_throttling_buffer_size,
         );
     let handle_slot_notifications_fut = handle_slot_notifications::<Block, PBlock, _, _>(

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -180,16 +180,16 @@ async fn run_executor(
     };
     let executor_streams = ExecutorStreams {
         primary_block_import_throttling_buffer_size: 10,
-        subspace_imported_block_notification_stream: primary_chain_full_node
-            .imported_block_notification_stream
+        block_importing_notification_stream: primary_chain_full_node
+            .block_importing_notification_stream
             .subscribe()
-            .then(|imported_block_notification| async move {
+            .then(|block_importing_notification| async move {
                 (
-                    imported_block_notification.block_number,
-                    imported_block_notification.block_import_acknowledgement_sender,
+                    block_importing_notification.block_number,
+                    block_importing_notification.acknowledgement_sender,
                 )
             }),
-        client_imported_block_notification_stream: primary_chain_full_node
+        imported_block_notification_stream: primary_chain_full_node
             .client
             .every_import_notification_stream(),
         new_slot_notification_stream: primary_chain_full_node
@@ -289,9 +289,9 @@ async fn run_executor_with_mock_primary_node(
         // Set `primary_block_import_throttling_buffer_size` to 0 to ensure the primary chain will not be
         // ahead of the execution chain by more than one block, thus slot will not be skipped in test.
         primary_block_import_throttling_buffer_size: 0,
-        subspace_imported_block_notification_stream: mock_primary_node
-            .imported_block_notification_stream(),
-        client_imported_block_notification_stream: mock_primary_node
+        block_importing_notification_stream: mock_primary_node
+            .block_importing_notification_stream(),
+        imported_block_notification_stream: mock_primary_node
             .client
             .every_import_notification_stream(),
         new_slot_notification_stream: mock_primary_node.new_slot_notification_stream(),


### PR DESCRIPTION
Both name and comment were misleading, trying to fix that.

Now we'll have separation between "block importing" and "imported block".

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
