### PR TITLE
Attempt to fix segment headers inclusion

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -448,6 +448,8 @@ pub struct SubspaceLink<Block: BlockT> {
     reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
     archived_segment_notification_sender: SubspaceNotificationSender<ArchivedSegmentNotification>,
     archived_segment_notification_stream: SubspaceNotificationStream<ArchivedSegmentNotification>,
+    block_importing_notification_sender:
+        SubspaceNotificationSender<BlockImportingNotification<Block>>,
     block_importing_notification_stream:
         SubspaceNotificationStream<BlockImportingNotification<Block>>,
     /// Segment headers that are expected to appear in the corresponding blocks, used for block
@@ -1263,6 +1265,7 @@ where
         reward_signing_notification_stream,
         archived_segment_notification_sender,
         archived_segment_notification_stream,
+        block_importing_notification_sender: block_importing_notification_sender.clone(),
         block_importing_notification_stream,
         // TODO: Consider making `confirmation_depth_k` non-zero
         segment_headers: Arc::new(Mutex::new(LruCache::new(

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -29,7 +29,7 @@ mod tests;
 
 use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream};
 use crate::slot_worker::{SlotWorkerSyncOracle, SubspaceSlotWorker};
-pub use archiver::start_subspace_archiver;
+pub use archiver::create_subspace_archiver;
 use codec::Encode;
 use futures::channel::mpsc;
 use futures::StreamExt;

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -206,12 +206,19 @@ fn main() -> Result<(), Error> {
                     ..
                 } = subspace_service::new_partial::<RuntimeApi, ExecutorDispatch>(&config)?;
 
-                sc_consensus_subspace::start_subspace_archiver(
+                let subspace_archiver = sc_consensus_subspace::create_subspace_archiver(
                     &subspace_link,
                     client.clone(),
                     None,
-                    &task_manager.spawn_essential_handle(),
                 );
+
+                task_manager
+                    .spawn_essential_handle()
+                    .spawn_essential_blocking(
+                        "subspace-archiver",
+                        None,
+                        Box::pin(subspace_archiver),
+                    );
 
                 Ok((
                     cmd.run(client, import_queue, task_manager.spawn_essential_handle())

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -650,12 +650,15 @@ where
         }
     };
 
-    sc_consensus_subspace::start_subspace_archiver(
+    let subspace_archiver = sc_consensus_subspace::create_subspace_archiver(
         &subspace_link,
         client.clone(),
         telemetry.as_ref().map(|telemetry| telemetry.handle()),
-        &task_manager.spawn_essential_handle(),
     );
+
+    task_manager
+        .spawn_essential_handle()
+        .spawn_essential_blocking("subspace-archiver", None, Box::pin(subspace_archiver));
 
     if config.sync_from_dsn {
         import_blocks_from_dsn(&node, client.clone(), &mut import_queue, false)


### PR DESCRIPTION
Not sure what happens with https://github.com/subspace/subspace/issues/871 yet, but one suspicion I have is that it is somehow related to the blocks produced locally and the fact that locally produced blocks are not imported the same exact way (since block and state are known to be valid before that).

So I started a question here: https://substrate.stackexchange.com/questions/7886/is-block-creation-guaranteed-to-be-running-after-parent-block-is-fully-imported

In the meantime I think it is worth doing an experiment and send additional notification as if it was from block import pipeline right from slot worker. It is a big ugly, but if it does resolve the issue, we'll have something specific to go with to Parity folks and ask better questions.

The first commit is a simple refactoring, I wanted to do it for a long time and it was supposed to help with second commit, but I ended up doing the other route, but kept the first commit. It is trivial if you ignore whitespace changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
