### PR TITLE
Integrate existing executor tests with the new testing framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10745,6 +10745,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-subspace",
+ "sp-core",
  "sp-domains",
  "sp-inherents",
  "sp-keyring",

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -115,10 +115,8 @@ async fn execution_proof_creation_and_verification_should_work() {
 
     // Produce a domain bundle to include the above test txs and wait for `alice`
     // to apply these txs
-    let slot = ferdie.produce_slot_and_wait_for_bundle_submission().await;
-    assert!(ferdie
-        .get_bundle_from_tx_pool(slot.into(), alice.key)
-        .is_some());
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert!(bundle.is_some());
     futures::future::join(
         alice.wait_for_blocks(1),
         ferdie.produce_block_with_slot(slot),
@@ -432,10 +430,8 @@ async fn invalid_execution_proof_should_not_work() {
     }
 
     // Produce a domain bundle to include the above test tx
-    let slot = ferdie.produce_slot_and_wait_for_bundle_submission().await;
-    assert!(ferdie
-        .get_bundle_from_tx_pool(slot.into(), alice.key)
-        .is_some());
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert!(bundle.is_some());
 
     // Wait for `alice` to apply these txs
     futures::future::join(

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -419,7 +419,9 @@ async fn invalid_execution_proof_should_not_work() {
 
     // Produce a domain bundle to include the above test tx
     let slot = ferdie.produce_slot_and_wait_for_bundle_submission().await;
-    assert!(ferdie.is_bundle_present_in_tx_pool(slot.into(), alice.key));
+    assert!(ferdie
+        .get_bundle_from_tx_pool(slot.into(), alice.key)
+        .is_some());
 
     // Wait for `alice` to apply these txs
     futures::future::join(

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -26,7 +26,6 @@ use tempfile::TempDir;
 const TEST_DOMAIN_ID: DomainId = DomainId::SYSTEM;
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
-#[ignore]
 async fn execution_proof_creation_and_verification_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -37,14 +36,11 @@ async fn execution_proof_creation_and_verification_should_work() {
     let tokio_handle = tokio::runtime::Handle::current();
 
     // Start Ferdie
-    let (ferdie, ferdie_network_starter) = run_primary_chain_validator_node(
+    let mut ferdie = MockPrimaryNode::run_mock_primary_node(
         tokio_handle.clone(),
         Ferdie,
-        vec![],
         BasePath::new(directory.path().join("ferdie")),
-    )
-    .await;
-    ferdie_network_starter.start_network();
+    );
 
     // Run Alice (a system domain authority node)
     let alice = domain_test_service::SystemDomainNodeBuilder::new(
@@ -52,8 +48,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         Alice,
         BasePath::new(directory.path().join("alice")),
     )
-    .connect_to_primary_chain_node(&ferdie)
-    .build(Role::Authority, false, false)
+    .build_with_mock_primary_node(Role::Authority, &mut ferdie)
     .await;
 
     // Run Bob (a system domain full node)
@@ -62,12 +57,17 @@ async fn execution_proof_creation_and_verification_should_work() {
         Bob,
         BasePath::new(directory.path().join("bob")),
     )
-    .connect_to_primary_chain_node(&ferdie)
-    .build(Role::Full, false, false)
+    .build_with_mock_primary_node(Role::Full, &mut ferdie)
     .await;
 
     // Bob is able to sync blocks.
-    futures::future::join(alice.wait_for_blocks(1), bob.wait_for_blocks(1)).await;
+    futures::join!(
+        alice.wait_for_blocks(1),
+        bob.wait_for_blocks(1),
+        ferdie.produce_blocks(1),
+    )
+    .2
+    .unwrap();
 
     let transfer_to_charlie = domain_test_service::construct_extrinsic(
         &alice.client,
@@ -113,30 +113,38 @@ async fn execution_proof_creation_and_verification_should_work() {
             .expect("Failed to send extrinsic");
     }
 
-    // Ideally we just need to wait one block and the test txs should be all included
-    // in the next block, but the txs are probably unable to be included if the machine
-    // is overloaded, hence we manually mock the bundles processing to avoid the occasional
-    // test failure (https://github.com/subspace/subspace/runs/5663241460?check_suite_focus=true).
-    //
-    // alice.wait_for_blocks(1).await;
-
-    let primary_info = (
-        ferdie.client.info().best_hash,
-        ferdie.client.info().best_number,
-    );
-    alice.executor.clone().process_bundles(primary_info).await;
+    // Produce a domain bundle to include the above test txs and wait for `alice`
+    // to apply these txs
+    let slot = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert!(ferdie
+        .get_bundle_from_tx_pool(slot.into(), alice.key)
+        .is_some());
+    futures::future::join(
+        alice.wait_for_blocks(1),
+        ferdie.produce_block_with_slot(slot),
+    )
+    .await
+    .1
+    .unwrap();
 
     let best_hash = alice.client.info().best_hash;
     let header = alice.client.header(best_hash).unwrap().unwrap();
     let parent_header = alice.client.header(*header.parent_hash()).unwrap().unwrap();
 
     let create_block_builder = || {
+        let primary_hash = ferdie.client.hash(*header.number()).unwrap().unwrap();
+        let digest = Digest {
+            logs: vec![DigestItem::primary_block_info((
+                *header.number(),
+                primary_hash,
+            ))],
+        };
         BlockBuilder::new(
             &*alice.client,
             parent_header.hash(),
             *parent_header.number(),
             RecordProof::No,
-            Default::default(),
+            digest,
             &*alice.backend,
             test_txs.clone().into_iter().map(Into::into).collect(),
         )
@@ -156,12 +164,18 @@ async fn execution_proof_creation_and_verification_should_work() {
         );
     }
 
+    let primary_hash = ferdie.client.hash(*header.number()).unwrap().unwrap();
     let new_header = Header::new(
         *header.number(),
         Default::default(),
         Default::default(),
         parent_header.hash(),
-        Default::default(),
+        Digest {
+            logs: vec![DigestItem::primary_block_info((
+                *header.number(),
+                primary_hash,
+            ))],
+        },
     );
     let execution_phase = ExecutionPhase::InitializeBlock {
         domain_parent_hash: parent_header.hash(),

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -116,11 +116,9 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
         .unwrap();
 
     // Get a bundle from the txn pool and change its receipt to an invalid one
-    let slot = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
     let bad_bundle = {
-        let mut signed_opaque_bundle = ferdie
-            .get_bundle_from_tx_pool(slot.into(), alice.key)
-            .unwrap();
+        let mut signed_opaque_bundle = bundle.unwrap();
         signed_opaque_bundle.bundle.receipts[0].trace[0] = Default::default();
         signed_opaque_bundle
     };
@@ -422,10 +420,8 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
         .unwrap();
 
     // Get a bundle from alice's tx pool and used as bundle template.
-    let slot = ferdie.produce_slot_and_wait_for_bundle_submission().await;
-    let bundle_template = ferdie
-        .get_bundle_from_tx_pool(slot.into(), alice.key)
-        .unwrap();
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let bundle_template = bundle.unwrap();
     let alice_key = alice.key;
     // Drop alice in order to control the execution chain by submitting the receipts manually later.
     drop(alice);

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -362,13 +362,11 @@ async fn extract_core_domain_wasm_bundle_in_system_domain_runtime_should_work() 
     let tokio_handle = tokio::runtime::Handle::current();
 
     // Start Ferdie
-    let (ferdie, _ferdie_network_starter) = run_primary_chain_validator_node(
-        tokio_handle.clone(),
+    let ferdie = MockPrimaryNode::run_mock_primary_node(
+        tokio_handle,
         Ferdie,
-        vec![],
         BasePath::new(directory.path().join("ferdie")),
-    )
-    .await;
+    );
 
     let system_domain_bundle = ferdie
         .client

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -38,6 +38,7 @@ sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate",
 sp-application-crypto = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-arithmetic = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-blockchain = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-consensus = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-consensus-subspace = { version = "0.1.0", path = "../../crates/sp-consensus-subspace" }
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }


### PR DESCRIPTION
This PR integrates all the remaining executor tests with the new test framework.

The only ignored executor test is `fraud_proof_verification_in_tx_pool_should_work`, to enable it we need to support fetching the `call_data` of the fraud proof verifier from the original primary block.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
