### PR TITLE
Avoid stack overflows

### DIFF
--- a/crates/subspace-archiving/benches/archiving.rs
+++ b/crates/subspace-archiving/benches/archiving.rs
@@ -1,5 +1,3 @@
-#![feature(new_uninit)]
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 use subspace_archiving::archiver::Archiver;
@@ -8,9 +6,7 @@ use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::RecordedHistorySegment;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
-    // SAFETY: Data structure filled with zeroes is a valid invariant
-    let mut input = unsafe { Box::<RecordedHistorySegment>::new_zeroed().assume_init() };
+    let mut input = RecordedHistorySegment::new_boxed();
     thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg).unwrap();

--- a/crates/subspace-archiving/src/lib.rs
+++ b/crates/subspace-archiving/src/lib.rs
@@ -15,13 +15,7 @@
 
 //! Collection of modules used for dealing with archived state of Subspace Network.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(
-    array_chunks,
-    drain_filter,
-    iter_collect_into,
-    new_uninit,
-    slice_flatten
-)]
+#![feature(array_chunks, drain_filter, iter_collect_into, slice_flatten)]
 
 pub mod archiver;
 pub mod piece_reconstructor;

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -259,7 +259,7 @@ impl PiecesReconstructor {
             return Err(ReconstructorError::IncorrectPiecePosition);
         }
 
-        let mut piece = Piece::from(reconstructed_records[piece_position]);
+        let mut piece = Piece::from(&reconstructed_records[piece_position]);
 
         piece.witness_mut().copy_from_slice(
             &self

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -1,7 +1,6 @@
 extern crate alloc;
 
 use crate::archiver::{Segment, SegmentItem};
-use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::mem;
@@ -100,9 +99,7 @@ impl Reconstructor {
         &mut self,
         segment_pieces: &[Option<Piece>],
     ) -> Result<ReconstructedContents, ReconstructorError> {
-        // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
-        // SAFETY: Data structure filled with zeroes is a valid invariant
-        let mut segment_data = unsafe { Box::<RecordedHistorySegment>::new_zeroed().assume_init() };
+        let mut segment_data = RecordedHistorySegment::new_boxed();
 
         if !segment_pieces
             .iter()

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -348,6 +348,14 @@ impl TryFrom<Vec<u8>> for Piece {
     }
 }
 
+impl From<&PieceArray> for Piece {
+    fn from(value: &PieceArray) -> Self {
+        let mut piece = Piece::default();
+        piece.as_mut().copy_from_slice(value.as_ref());
+        piece
+    }
+}
+
 impl Deref for Piece {
     type Target = PieceArray;
 
@@ -422,18 +430,6 @@ impl AsRef<[u8]> for PieceArray {
 impl AsMut<[u8]> for PieceArray {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
-    }
-}
-
-impl From<&PieceArray> for Piece {
-    fn from(value: &PieceArray) -> Self {
-        Piece(Box::new(*value))
-    }
-}
-
-impl From<PieceArray> for Piece {
-    fn from(value: PieceArray) -> Self {
-        Piece(Box::new(value))
     }
 }
 

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -1,4 +1,5 @@
 use crate::pieces::{FlatPieces, Piece, PieceIndex, RawRecord};
+use alloc::boxed::Box;
 use core::iter::Step;
 use core::mem;
 use derive_more::{
@@ -129,6 +130,13 @@ impl RecordedHistorySegment {
     /// together with corresponding commitments and witnesses will result in
     /// [`ArchivedHistorySegment::NUM_PIECES`] [`Piece`]s of archival history.
     pub const SIZE: usize = RawRecord::SIZE * Self::NUM_RAW_RECORDS;
+
+    /// Create boxed value without hitting stack overflow
+    pub fn new_boxed() -> Box<Self> {
+        // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
+        // SAFETY: Data structure filled with zeroes is a valid invariant
+        unsafe { Box::<Self>::new_zeroed().assume_init() }
+    }
 }
 
 /// Archived history segment after archiving is applied.

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -12,7 +12,7 @@ use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
-    Blake2b256Hash, PublicKey, RecordedHistorySegment, SegmentIndex, SolutionRange,
+    Blake2b256Hash, Piece, PublicKey, RecordedHistorySegment, SegmentIndex, SolutionRange,
     PLOT_SECTOR_SIZE,
 };
 use subspace_farmer_components::farming::audit_sector;
@@ -38,16 +38,17 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = archiver
-        .add_block(
-            AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
-            Default::default(),
-        )
-        .into_iter()
-        .next()
-        .unwrap()
-        .pieces[0]
-        .into();
+    let piece = Piece::from(
+        &archiver
+            .add_block(
+                AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
+                Default::default(),
+            )
+            .into_iter()
+            .next()
+            .unwrap()
+            .pieces[0],
+    );
 
     let farmer_protocol_info = FarmerProtocolInfo {
         total_pieces: NonZeroU64::new(1).unwrap(),

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -1,5 +1,3 @@
-#![feature(new_uninit)]
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use memmap2::Mmap;
@@ -35,9 +33,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let public_key = PublicKey::default();
     let sector_index = 0;
-    // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
-    // SAFETY: Data structure filled with zeroes is a valid invariant
-    let mut input = unsafe { Box::<RecordedHistorySegment>::new_zeroed().assume_init() };
+    let mut input = RecordedHistorySegment::new_boxed();
     thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -1,5 +1,3 @@
-#![feature(new_uninit)]
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use rand::{thread_rng, Rng};
@@ -22,9 +20,7 @@ mod utils;
 fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::default();
     let sector_index = 0;
-    // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
-    // SAFETY: Data structure filled with zeroes is a valid invariant
-    let mut input = unsafe { Box::<RecordedHistorySegment>::new_zeroed().assume_init() };
+    let mut input = RecordedHistorySegment::new_boxed();
     thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -10,7 +10,9 @@ use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
-use subspace_core_primitives::{PublicKey, RecordedHistorySegment, SegmentIndex, PLOT_SECTOR_SIZE};
+use subspace_core_primitives::{
+    Piece, PublicKey, RecordedHistorySegment, SegmentIndex, PLOT_SECTOR_SIZE,
+};
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
 use subspace_farmer_components::FarmerProtocolInfo;
 use utils::BenchPieceGetter;
@@ -25,16 +27,17 @@ fn criterion_benchmark(c: &mut Criterion) {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = archiver
-        .add_block(
-            AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
-            Default::default(),
-        )
-        .into_iter()
-        .next()
-        .unwrap()
-        .pieces[0]
-        .into();
+    let piece = Piece::from(
+        &archiver
+            .add_block(
+                AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
+                Default::default(),
+            )
+            .into_iter()
+            .next()
+            .unwrap()
+            .pieces[0],
+    );
 
     let farmer_protocol_info = FarmerProtocolInfo {
         total_pieces: NonZeroU64::new(1).unwrap(),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -1,5 +1,3 @@
-#![feature(new_uninit)]
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use memmap2::Mmap;
@@ -37,9 +35,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let keypair = Keypair::from_bytes(&[0; 96]).unwrap();
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let sector_index = 0;
-    // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
-    // SAFETY: Data structure filled with zeroes is a valid invariant
-    let mut input = unsafe { Box::<RecordedHistorySegment>::new_zeroed().assume_init() };
+    let mut input = RecordedHistorySegment::new_boxed();
     thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -13,7 +13,7 @@ use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::sector_codec::SectorCodec;
 use subspace_core_primitives::{
-    Blake2b256Hash, PublicKey, RecordedHistorySegment, SegmentIndex, SolutionRange,
+    Blake2b256Hash, Piece, PublicKey, RecordedHistorySegment, SegmentIndex, SolutionRange,
     PLOT_SECTOR_SIZE,
 };
 use subspace_farmer_components::farming::audit_sector;
@@ -40,16 +40,17 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let sector_codec = SectorCodec::new(PLOT_SECTOR_SIZE as usize).unwrap();
-    let piece = archiver
-        .add_block(
-            AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
-            Default::default(),
-        )
-        .into_iter()
-        .next()
-        .unwrap()
-        .pieces[0]
-        .into();
+    let piece = Piece::from(
+        &archiver
+            .add_block(
+                AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
+                Default::default(),
+            )
+            .into_iter()
+            .next()
+            .unwrap()
+            .pieces[0],
+    );
 
     let farmer_protocol_info = FarmerProtocolInfo {
         total_pieces: NonZeroU64::new(1).unwrap(),


### PR DESCRIPTION
With large piece size when dereferencing big array before storing it in a `Box` I was getting stack overflow in some cases.

I decided to remove `impl From<PieceArray> for Piece` and also created helper methods `new_boxed` on several data structures to safely allocate boxed versions of them without resorting to `unsafe` during use.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
