### PR TITLE
Proactively drop closed subscribers while waiting slot/block import acknowledgements in `MockPrimaryNode`

### DIFF
--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -340,8 +340,6 @@ async fn execution_proof_creation_and_verification_should_work() {
 }
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
-// TODO: Un-ignore when fixed, see https://github.com/subspace/subspace/pull/1347 for details
-#[ignore]
 async fn invalid_execution_proof_should_not_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -27,8 +27,6 @@ use subspace_wasm_tools::read_core_domain_runtime_blob;
 use tempfile::TempDir;
 
 #[substrate_test_utils::test(flavor = "multi_thread")]
-// TODO: Un-ignore when fixed, see https://github.com/subspace/subspace/pull/1347 for details
-#[ignore]
 async fn test_executor_full_node_catching_up() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 


### PR DESCRIPTION
Fix #1352 

It is possible that the slot/block import subscriber is dropped after notification then we will block on waiting for acknowledgment forever, see https://github.com/subspace/subspace/issues/1352#issuecomment-1499292448 for more details. This commit fixes this issue by proactively drop closed subscribers while waiting for acknowledgements.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
