### PR TITLE
Update `subspace-chiapos` to version that doesn't cause panics when searching for qualities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "subspace-chiapos"
 version = "0.1.0"
-source = "git+https://github.com/subspace/chiapos?rev=a239ddf83b4d8420f23616d604af83c756c40116#a239ddf83b4d8420f23616d604af83c756c40116"
+source = "git+https://github.com/subspace/chiapos?rev=7eeb29380eb6f8036d4f980e8d15038bda1184f7#7eeb29380eb6f8036d4f980e8d15038bda1184f7"
 dependencies = [
  "cc",
 ]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [dependencies]
-subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "a239ddf83b4d8420f23616d604af83c756c40116" }
+subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "7eeb29380eb6f8036d4f980e8d15038bda1184f7" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Code seems to work by accident... most of the time. When it doesn't, it throws exceptions and it is [unlikely to be fixed upstream](https://github.com/Chia-Network/chiapos/issues/352).

I [decided to catch exceptions](https://github.com/subspace/chiapos/commit/7eeb29380eb6f8036d4f980e8d15038bda1184f7?w=1) and just treat those qualities as missing, we will likely rewrite/replace C++ implementation in future completely.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
