### PR TITLE
Add test for the bundle validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10744,6 +10744,7 @@ dependencies = [
  "sc-service",
  "sc-tracing",
  "sc-transaction-pool",
+ "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
  "sp-application-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10743,6 +10743,7 @@ dependencies = [
  "sc-network",
  "sc-service",
  "sc-tracing",
+ "sc-transaction-pool",
  "sc-utils",
  "sp-api",
  "sp-application-crypto",

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -33,6 +33,7 @@ sc-consensus-fraud-proof = { version = "0.1.0", path = "../../crates/sc-consensu
 sc-network = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sc-service = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
 sc-tracing = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-application-crypto = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -34,6 +34,7 @@ sc-network = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6
 sc-service = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
 sc-tracing = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-application-crypto = { git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }

--- a/test/subspace-test-service/src/mock.rs
+++ b/test/subspace-test-service/src/mock.rs
@@ -85,7 +85,11 @@ impl MockPrimaryNode {
     ) -> MockPrimaryNode {
         let log_prefix = key.into();
 
-        let config = node_config(tokio_handle, key, vec![], false, false, false, base_path);
+        let mut config = node_config(tokio_handle, key, vec![], false, false, false, base_path);
+
+        // Set `transaction_pool.ban_time` to 0 such that duplicated tx will not immediately rejected
+        // by `TemporarilyBanned`
+        config.transaction_pool.ban_time = time::Duration::from_millis(0);
 
         let executor = NativeElseWasmExecutor::<TestExecutorDispatch>::new(
             config.wasm_method,

--- a/test/subspace-test-service/src/mock.rs
+++ b/test/subspace-test-service/src/mock.rs
@@ -10,6 +10,8 @@ use sc_consensus::block_import::{
 use sc_consensus::{BlockImport, BoxBlockImport, StateAction};
 use sc_executor::NativeElseWasmExecutor;
 use sc_service::{BasePath, InPoolTransaction, TaskManager, TransactionPool};
+use sc_transaction_pool::error::Error as PoolError;
+use sc_transaction_pool_api::TransactionSource;
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_api::{ApiExt, HashT, HeaderT, ProvideRuntimeApi, TransactionFor};
 use sp_application_crypto::UncheckedFrom;
@@ -302,6 +304,17 @@ impl MockPrimaryNode {
             }
         }
         None
+    }
+
+    /// Submit a tx to the tx pool
+    pub async fn submit_transaction(&self, tx: OpaqueExtrinsic) -> Result<H256, PoolError> {
+        self.transaction_pool
+            .submit_one(
+                &BlockId::Hash(self.client.info().best_hash),
+                TransactionSource::External,
+                tx,
+            )
+            .await
     }
 
     /// Remove tx from tx pool

--- a/test/subspace-test-service/src/mock.rs
+++ b/test/subspace-test-service/src/mock.rs
@@ -142,6 +142,10 @@ impl MockPrimaryNode {
             _,
         >::new(Box::new(fraud_proof_block_import), client.clone());
 
+        // The `maintain-bundles-stored-in-last-k` worker here is different from the one in the production code
+        // that it subscribes the `block_importing_notification_stream`, which is intended to ensure the bundle
+        // validator's `recent_stored_bundles` info must be updated when a new primary block is produced, this
+        // will help the test to be more deterministic.
         let mut imported_blocks_stream = client.import_notification_stream();
         let mut block_importing_stream = block_import.block_importing_notification_stream();
         task_manager.spawn_handle().spawn(


### PR DESCRIPTION
This PR adds 2 tests for the bundle validator:
- `duplicated_and_stale_bundle_should_be_rejected` testing duplicated and stale bundle will be rejected when submit to tx pool
- `existing_bundle_can_be_resubmitted_to_new_fork` testing bundle that has already been submitted to a fork can be resubmitted to another fork that does not contains this bundle


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
