### PR TITLE
Add network partitioning for DSN (part 1).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10573,6 +10573,7 @@ dependencies = [
  "frame-support",
  "frame-system-rpc-runtime-api",
  "futures",
+ "hex",
  "jsonrpsee",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -81,16 +81,17 @@ pub(crate) async fn farm_multi_disk(
         let identity = Identity::open_or_create(&directory).unwrap();
         let keypair = derive_libp2p_keypair(identity.secret_key());
 
+        let farmer_app_info = node_client
+            .farmer_app_info()
+            .await
+            .map_err(|error| anyhow::anyhow!(error))?;
+
         if dsn.bootstrap_nodes.is_empty() {
-            dsn.bootstrap_nodes = {
-                node_client
-                    .farmer_app_info()
-                    .await
-                    .map_err(|error| anyhow::anyhow!(error))?
-                    .dsn_bootstrap_nodes
-            };
+            dsn.bootstrap_nodes = farmer_app_info.dsn_bootstrap_nodes;
         }
+
         configure_dsn(
+            hex::encode(farmer_app_info.genesis_hash),
             base_path,
             keypair,
             dsn,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -38,6 +38,7 @@ const ROOT_BLOCK_NUMBER_LIMIT: u64 = 1000;
 
 #[allow(clippy::type_complexity)]
 pub(super) fn configure_dsn(
+    protocol_prefix: String,
     base_path: PathBuf,
     keypair: Keypair,
     DsnArgs {
@@ -59,6 +60,8 @@ pub(super) fn configure_dsn(
     ),
     anyhow::Error,
 > {
+    let peer_id = peer_id(&keypair);
+
     let networking_parameters_registry = {
         let known_addresses_db_path = base_path.join("known_addresses_db");
 
@@ -84,9 +87,6 @@ pub(super) fn configure_dsn(
             fs::rename(&provider_cache_db_path, &provider_db_path)?;
         }
     }
-
-    let default_config = Config::default();
-    let peer_id = peer_id(&keypair);
 
     info!(
         db_path = ?provider_db_path,
@@ -151,9 +151,9 @@ pub(super) fn configure_dsn(
         }
     });
 
+    let default_config = Config::new(protocol_prefix, keypair, farmer_provider_storage);
     let config = Config {
         reserved_peers,
-        keypair,
         listen_on,
         allow_non_global_addresses_in_dht: !disable_private_ips,
         networking_parameters_registry,
@@ -276,7 +276,6 @@ pub(super) fn configure_dsn(
                 .instrument(Span::current())
             }),
         ],
-        provider_storage: farmer_provider_storage,
         ..default_config
     };
 

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -159,7 +159,7 @@ async fn main() -> anyhow::Result<()> {
                 max_established_outgoing_connections: out_peers,
                 max_pending_incoming_connections: pending_in_peers,
                 max_pending_outgoing_connections: pending_out_peers,
-                ..Config::with_keypair_and_provider_storage(keypair, provider_storage)
+                ..Config::new(keypair, provider_storage)
             };
             let (node, mut node_runner) =
                 subspace_networking::create(config).expect("Networking stack creation failed.");

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -61,7 +61,7 @@ enum Command {
         piece_providers_cache_size: ByteSize,
         /// Protocol prefix for libp2p stack, should be set as genesis hash of the blockchain for
         /// production use.
-        #[arg(long, default_value = "dev")]
+        #[arg(long)]
         protocol_prefix: String,
     },
     /// Generate a new keypair

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -549,14 +549,14 @@ where
             }
 
             let kademlia = &mut self.swarm.behaviour_mut().kademlia;
-            let kademlia_enabled = info.protocols.iter().any(|protocol_a| {
-                kademlia
-                    .protocol_names()
+            // We use kademlia support as a flag for the correct network in general.
+            let full_kademlia_support = kademlia.protocol_names().iter().all(|local_protocol| {
+                info.protocols
                     .iter()
-                    .any(|protocol_b| protocol_a.as_bytes() == protocol_b.as_ref())
+                    .any(|remote_protocol| remote_protocol.as_bytes() == local_protocol.as_ref())
             });
 
-            if kademlia_enabled {
+            if full_kademlia_support {
                 for address in info.listen_addrs {
                     if !self.allow_non_global_addresses_in_dht
                         && !is_global_address_or_dns(&address)
@@ -584,16 +584,23 @@ where
                     kademlia.add_address(&peer_id, address);
                 }
             } else {
-                trace!(
+                info!(
                     %local_peer_id,
                     %peer_id,
-                    "Peer doesn't support our Kademlia DHT protocol ({:?}). Adding to the DHT skipped.",
+                    peer_protocols=?info.protocols,
+                    "Peer doesn't support our Kademlia DHT protocol ({:?}). Peer was banned.",
                     kademlia
                         .protocol_names()
                         .iter()
                         .map(|p| String::from_utf8_lossy(p.as_ref()))
                         .collect::<Vec<_>>(),
-                )
+                );
+
+                kademlia.remove_peer(&peer_id);
+                self.networking_parameters_registry
+                    .remove_all_known_peer_addresses(peer_id)
+                    .await;
+                self.swarm.ban_peer_id(peer_id);
             }
         }
     }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -584,7 +584,7 @@ where
                     kademlia.add_address(&peer_id, address);
                 }
             } else {
-                info!(
+                debug!(
                     %local_peer_id,
                     %peer_id,
                     peer_protocols=?info.protocols,

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -22,6 +22,7 @@ domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitive
 either = "1.8.1"
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 futures = "0.3.28"
+hex = "0.4.3"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 parity-scale-codec = "3.4.0"

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -514,11 +514,22 @@ where
             bootstrap_nodes,
         } => (node, bootstrap_nodes),
         SubspaceNetworking::Create {
-            config,
+            config: dsn_config,
             piece_cache_size,
         } => {
-            let piece_cache =
-                PieceCache::new(client.clone(), piece_cache_size, peer_id(&config.keypair));
+            let dsn_protocol_prefix = hex::encode(client.chain_info().genesis_hash);
+
+            info!(
+                chain_type=?config.chain_spec.chain_type(),
+                genesis_hash=%hex::encode(client.chain_info().genesis_hash),
+                "Setting DSN protocol prefix..."
+            );
+
+            let piece_cache = PieceCache::new(
+                client.clone(),
+                piece_cache_size,
+                peer_id(&dsn_config.keypair),
+            );
 
             // Start before archiver below, so we don't have potential race condition and miss pieces
             task_manager
@@ -551,8 +562,12 @@ where
                     }
                 });
 
-            let (node, mut node_runner) =
-                create_dsn_instance(config.clone(), piece_cache, segment_header_cache.clone())?;
+            let (node, mut node_runner) = create_dsn_instance(
+                dsn_protocol_prefix,
+                dsn_config.clone(),
+                piece_cache,
+                segment_header_cache.clone(),
+            )?;
 
             info!("Subspace networking initialized: Node ID is {}", node.id());
 
@@ -591,7 +606,7 @@ where
                 ),
             );
 
-            (node, config.bootstrap_nodes)
+            (node, dsn_config.bootstrap_nodes)
         }
     };
 


### PR DESCRIPTION
This PR introduces the network partitioning for DSN dependent on the primary chain's genesis hash. Farmers get this hash automatically via their `node-client`. Bootstrap nodes got a new CLI argument for this purpose. The genesis hash serves as a part of the protocol's names. If we encounter (via `Identify` protocol) a peer with a different genesis hash - we ban this peer in our local data structures and disconnect it.

This PR adds the genesis-hash prefix to kademlia and gossibsub protocols. Request-response protocol partition will be added in a separate PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
