### PR TITLE
Change dialling error messages for DSN.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -36,6 +36,9 @@ const MAX_CONCURRENT_RE_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(100).expect("Not zero; qed");
 const ROOT_BLOCK_NUMBER_LIMIT: u64 = 1000;
 
+const MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 100;
+const MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 100;
+
 #[allow(clippy::type_complexity)]
 pub(super) fn configure_dsn(
     base_path: PathBuf,
@@ -277,6 +280,8 @@ pub(super) fn configure_dsn(
             }),
         ],
         provider_storage: farmer_provider_storage,
+        max_established_outgoing_connections: MAX_ESTABLISHED_OUTGOING_CONNECTIONS,
+        max_pending_outgoing_connections: MAX_PENDING_OUTGOING_CONNECTIONS,
         ..default_config
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -36,9 +36,6 @@ const MAX_CONCURRENT_RE_ANNOUNCEMENTS_PROCESSING: NonZeroUsize =
     NonZeroUsize::new(100).expect("Not zero; qed");
 const ROOT_BLOCK_NUMBER_LIMIT: u64 = 1000;
 
-const MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 100;
-const MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 100;
-
 #[allow(clippy::type_complexity)]
 pub(super) fn configure_dsn(
     base_path: PathBuf,
@@ -50,6 +47,11 @@ pub(super) fn configure_dsn(
         provided_keys_limit,
         disable_private_ips,
         reserved_peers,
+        in_connections,
+        out_connections,
+        pending_in_connections,
+        pending_out_connections,
+        target_connections,
     }: DsnArgs,
     readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
     node_client: NodeRpcClient,
@@ -280,8 +282,11 @@ pub(super) fn configure_dsn(
             }),
         ],
         provider_storage: farmer_provider_storage,
-        max_established_outgoing_connections: MAX_ESTABLISHED_OUTGOING_CONNECTIONS,
-        max_pending_outgoing_connections: MAX_PENDING_OUTGOING_CONNECTIONS,
+        max_established_outgoing_connections: out_connections,
+        max_pending_outgoing_connections: pending_out_connections,
+        max_established_incoming_connections: in_connections,
+        max_pending_incoming_connections: pending_in_connections,
+        target_connections,
         ..default_config
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -82,6 +82,21 @@ struct DsnArgs {
     /// Multiaddrs of reserved nodes to maintain a connection to, multiple are supported
     #[arg(long)]
     reserved_peers: Vec<Multiaddr>,
+    /// Defines max established incoming connection limit.
+    #[arg(long, default_value_t = 50)]
+    in_connections: u32,
+    /// Defines max established outgoing swarm connection limit.
+    #[arg(long, default_value_t = 50)]
+    out_connections: u32,
+    /// Defines max pending incoming connection limit.
+    #[arg(long, default_value_t = 50)]
+    pending_in_connections: u32,
+    /// Defines max pending outgoing swarm connection limit.
+    #[arg(long, default_value_t = 50)]
+    pending_out_connections: u32,
+    /// Defines target total (in and out) connection number that should be maintained.
+    #[arg(long, default_value_t = 50)]
+    target_connections: u32,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -252,7 +252,11 @@ where
             let network_info = self.swarm.network_info();
             let connections = network_info.connection_counters();
 
-            debug!(?connections, "Current connections and limits.");
+            debug!(
+                ?connections,
+                target_connections = self.target_connections,
+                "Current connections and limits."
+            );
 
             (
                 connections.num_pending_outgoing()

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -317,12 +317,12 @@ where
             .build();
 
         if let Err(err) = self.swarm.dial(dial_opts) {
-            warn!(
+            debug!(
                 %err,
                 %local_peer_id,
                 remote_peer_id = %peer_id,
                 %addr,
-                "Unexpected error: failed to dial an address."
+                "Dialing error: failed to dial an address."
             );
         }
     }


### PR DESCRIPTION
This PR fixes dialing errors for farmers. It downgrades the warning to debug level and changes the default constants for outgoing connections for farmers.

<details>

```
2023-04-07T13:02:55.363608Z  WARN subspace_networking::node_runner: Unexpected error: failed to dial an address. err=Dial error: connection limit exceeded (50/50) local_peer_id=12D3KooWA8xJftxXqAu8VoEoumqbGyrUry7F3tCY1F9K5kCxRWdk remote_peer_id=12D3KooWKb8sn6qntNWY4rG6reRZ6HiuRCP3fmhGUpeLJFjkHMLQ addr=/ip4/89.223.70.59/tcp/30433
2023-04-07T13:02:55.364551Z  WARN subspace_networking::node_runner: Unexpected error: failed to dial an address. err=Dial error: connection limit exceeded (50/50) local_peer_id=12D3KooWA8xJftxXqAu8VoEoumqbGyrUry7F3tCY1F9K5kCxRWdk remote_peer_id=12D3KooWJCqGqeqhDiXMj9YRJ9q4YqoL11n61etnfaP1YiLc2bn7 addr=/ip4/193.187.129.232/tcp/30433
```

</details>

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
