### PR TITLE
Ensure info as default log level for Bootstrap node

### DIFF
--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -43,7 +43,7 @@ tempfile = "3.5.0"
 thiserror = "1.0.38"
 tokio = { version = "1.27.0", features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"]}
 unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_codec"] }
 
 [dependencies.libp2p]


### PR DESCRIPTION
At the moment, the default logging when RUST_LOG is not set is `error`.  Changed it `info` as default log level.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
