### PR TITLE
Enable fraud proof processing in the domain block processor and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,6 +2343,7 @@ dependencies = [
  "domain-test-service",
  "futures",
  "futures-timer",
+ "pallet-balances",
  "pallet-domains",
  "parity-scale-codec",
  "sc-cli",

--- a/domains/client/domain-executor/Cargo.toml
+++ b/domains/client/domain-executor/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1.27.0", features = ["macros"] }
 [dev-dependencies]
 core-payments-domain-runtime = { version = "0.1.0", path = "../../runtime/core-payments" }
 domain-test-service = { version = "0.1.0", path = "../../test/service" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-domains = { version = "0.1.0", path = "../../../crates/pallet-domains" }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
 sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -382,10 +382,6 @@ where
 
         // TODO: The applied txs can be fully removed from the transaction pool
 
-        // TODO: Skip fraud-proof processing until
-        // https://github.com/subspace/subspace/issues/1020 is resolved.
-        return Ok(None);
-
         self.check_receipts_in_primary_block(primary_hash)?;
 
         if self.primary_network_sync_oracle.is_major_syncing() {

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -410,10 +410,10 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     let original_submit_bundle_tx = bundle_to_tx(bundle.clone().unwrap());
     let bad_submit_bundle_tx = {
         let mut signed_opaque_bundle = bundle.unwrap();
-        for rc in signed_opaque_bundle.bundle.receipts.iter_mut() {
-            if rc.primary_number == target_bundle.bundle.header.primary_number + 1 {
-                assert_eq!(rc.trace.len(), 3);
-                rc.trace[mismatch_trace_index] = Default::default();
+        for receipt in signed_opaque_bundle.bundle.receipts.iter_mut() {
+            if receipt.primary_number == target_bundle.bundle.header.primary_number + 1 {
+                assert_eq!(receipt.trace.len(), 3);
+                receipt.trace[mismatch_trace_index] = Default::default();
             }
         }
         signed_opaque_bundle.signature = alice

--- a/test/subspace-test-service/src/mock.rs
+++ b/test/subspace-test-service/src/mock.rs
@@ -291,7 +291,7 @@ impl MockPrimaryNode {
     }
 
     /// Get the bundle that created at `slot` from the transaction pool
-    fn get_bundle_from_tx_pool(
+    pub fn get_bundle_from_tx_pool(
         &self,
         slot: u64,
     ) -> Option<SignedOpaqueBundle<NumberFor<Block>, Hash, H256>> {


### PR DESCRIPTION
This PR enables fraud proof processing in the domain block processor and adds tests for invalid state transition proof creation and verification, it covers both `initialize_block`, `apply_extrinsic`, and `finalize_block` proof, but they are ignored due to fraud proof creation being disabled for executor currently.

This PR also adds digest for `apply_extrinsic`, and `finalize_block` proofs when generating them, otherwise, they will be invalid proofs as the test shows.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
