### PR TITLE
Ensure the new block is fully processed by the executor before MockPrimaryNode::produce_blocks is returned in the test

### DIFF
--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -133,6 +133,14 @@ pub(crate) async fn handle_block_import_notifications<
 
     loop {
         tokio::select! {
+            // Ensure the `blocks_imported` branch will be checked before the `blocks_importing` branch.
+            // Currently this is only necessary for the test to ensure when both `block_imported` notification
+            // and `blocks_importing` notification are arrived, the `block_imported` notification will be processed
+            // first, such that we can ensure when the `blocks_importing` acknowledgement is responded, the
+            // imported block must being processed by the executor.
+            // Please see https://github.com/subspace/subspace/pull/1363#discussion_r1162571291 for more details.
+            biased;
+
             maybe_block_imported = blocks_imported.next() => {
                 let block_imported = match maybe_block_imported {
                     Some(block_imported) => block_imported,


### PR DESCRIPTION
This is implemented by:
- adding biased; to the tokio::select usage in the executor
- notify the subscriber twice for each importing block in the test 
 
Please see https://github.com/subspace/subspace/pull/1363#discussion_r1162571291 for more details.

With this ability, the bundle production won't fail due to `Receipt not found`, this PR also cleans up the previous workaround in the test.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
