### PR TITLE
Consensus 2.3 preparation (part 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10231,9 +10231,10 @@ dependencies = [
 [[package]]
 name = "subspace-chiapos"
 version = "0.1.0"
-source = "git+https://github.com/subspace/chiapos?rev=7eeb29380eb6f8036d4f980e8d15038bda1184f7#7eeb29380eb6f8036d4f980e8d15038bda1184f7"
+source = "git+https://github.com/subspace/chiapos?rev=100f861378c3f450434ef9e94723f50c804d333f#100f861378c3f450434ef9e94723f50c804d333f"
 dependencies = [
  "cc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -706,7 +706,7 @@ impl Archiver {
                 let output_chunks = pieces.iter_mut().map(|piece| {
                     piece
                         .record_mut()
-                        .full_scalar_arrays_mut()
+                        .iter_mut()
                         .nth(record_offset)
                         .expect("Statically known to exist in a record; qed")
                 });
@@ -730,7 +730,7 @@ impl Archiver {
             let iter = source_pieces
                 .skip(existing_commitments)
                 .map(|piece| {
-                    piece.record().full_scalar_arrays().map(|scalar_bytes| {
+                    piece.record().iter().map(|scalar_bytes| {
                         Scalar::try_from(scalar_bytes).expect(
                             "Source pieces were just created and are guaranteed to contain \
                             valid scalars; qed",
@@ -844,11 +844,9 @@ pub fn is_piece_valid(
         }
     };
 
-    let record_chunks = record.full_scalar_arrays();
-    let number_of_chunks = record_chunks.len();
-    let mut scalars = Vec::with_capacity(number_of_chunks.next_power_of_two());
+    let mut scalars = Vec::with_capacity(record.len().next_power_of_two());
 
-    for record_chunk in record_chunks {
+    for record_chunk in record.iter() {
         match Scalar::try_from(record_chunk) {
             Ok(scalar) => {
                 scalars.push(scalar);

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -759,8 +759,7 @@ impl Archiver {
             // TODO: `collect_into_vec()`, unfortunately, truncates input, which is not what we want
             //  can be unified when https://github.com/rayon-rs/rayon/issues/1039 is resolved
             #[cfg(feature = "rayon")]
-            self.incremental_record_commitments
-                .extend(&iter.collect::<Vec<_>>());
+            self.incremental_record_commitments.par_extend(iter);
         }
         // Collect hashes to commitments from all records
         let record_commitments = self

--- a/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
+++ b/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
@@ -110,8 +110,7 @@ impl<'a> Drop for IncrementalRecordCommitmentsProcessor<'a> {
         // TODO: `collect_into_vec()`, unfortunately, truncates input, which is not what we want
         //  can be unified when https://github.com/rayon-rs/rayon/issues/1039 is resolved
         #[cfg(feature = "rayon")]
-        self.incremental_record_commitments
-            .extend(&iter.collect::<Vec<_>>());
+        self.incremental_record_commitments.par_extend(iter);
     }
 }
 

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -83,13 +83,13 @@ impl PiecesReconstructor {
             .zip(
                 reconstructed_pieces
                     .iter_mut()
-                    .map(|piece| piece.record_mut().full_scalar_arrays_mut()),
+                    .map(|piece| piece.record_mut().iter_mut()),
             )
             .all(|(maybe_piece, raw_record)| {
                 if let Some(piece) = maybe_piece {
                     piece
                         .record()
-                        .full_scalar_arrays()
+                        .iter()
                         .zip(raw_record)
                         .for_each(|(source, target)| {
                             *target = *source;
@@ -115,7 +115,7 @@ impl PiecesReconstructor {
                         .map(|piece| {
                             piece
                                 .record()
-                                .full_scalar_arrays()
+                                .iter()
                                 .nth(record_offset)
                                 .expect("Statically guaranteed to exist in a piece; qed")
                         })
@@ -133,7 +133,7 @@ impl PiecesReconstructor {
                     .zip(reconstructed_pieces.iter_mut().map(|piece| {
                         piece
                             .record_mut()
-                            .full_scalar_arrays_mut()
+                            .iter_mut()
                             .nth(record_offset)
                             .expect("Statically guaranteed to exist in a piece; qed")
                     }))
@@ -160,11 +160,10 @@ impl PiecesReconstructor {
                         .map_err(|_error| ReconstructorError::InvalidInputPieceCommitment)
                 } else {
                     let scalars = {
-                        let record_chunks = piece.record().full_scalar_arrays();
-                        let number_of_chunks = record_chunks.len();
-                        let mut scalars = Vec::with_capacity(number_of_chunks.next_power_of_two());
+                        let mut scalars =
+                            Vec::with_capacity(piece.record().len().next_power_of_two());
 
-                        for record_chunk in record_chunks {
+                        for record_chunk in piece.record().iter() {
                             scalars.push(
                                 Scalar::try_from(record_chunk)
                                     .map_err(ReconstructorError::DataShardsReconstruction)?,

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -108,16 +108,11 @@ impl Reconstructor {
             .zip(segment_data.iter_mut())
             .all(|(maybe_piece, raw_record)| {
                 if let Some(piece) = maybe_piece {
-                    piece
-                        .record()
-                        .full_scalar_arrays()
-                        .zip(raw_record.iter_mut())
-                        .for_each(|(source, target)| {
-                            *target = *source
-                                .array_chunks()
-                                .next()
-                                .expect("Target is smaller than source; qed");
-                        });
+                    piece.record().iter().zip(raw_record.iter_mut()).for_each(
+                        |(source, target)| {
+                            target.copy_from_slice(&source[..Scalar::SAFE_BYTES]);
+                        },
+                    );
                     true
                 } else {
                     false
@@ -139,7 +134,7 @@ impl Reconstructor {
                         .map(|piece| {
                             piece
                                 .record()
-                                .full_scalar_arrays()
+                                .iter()
                                 .nth(record_offset)
                                 .expect("Statically guaranteed to exist in a piece; qed")
                         })

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -25,7 +25,7 @@ fn record_to_raw_record_bytes(record: &Record) -> impl Iterator<Item = u8> + '_ 
     // We have zero byte padding from [`Scalar::SAFE_BYTES`] to [`Scalar::FULL_BYTES`] that we need
     // to skip
     record
-        .chunks_exact(Scalar::FULL_BYTES)
+        .iter()
         .flat_map(|bytes| &bytes[..Scalar::SAFE_BYTES])
         .copied()
 }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -55,8 +55,6 @@ pub use pieces::{
 };
 use scale_info::TypeInfo;
 pub use segments::{ArchivedHistorySegment, RecordedHistorySegment, SegmentIndex};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 use uint::static_assertions::const_assert;
 
 // Refuse to compile on lower than 32-bit platforms

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 pub enum BlockObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
         /// Object hash
         hash: Blake2b256Hash,
@@ -86,6 +87,7 @@ pub struct BlockObjectMapping {
 pub enum PieceObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
         /// Object hash
         hash: Blake2b256Hash,
@@ -127,6 +129,7 @@ pub struct PieceObjectMapping {
 pub enum GlobalObject {
     /// V0 of object mapping data structure
     #[codec(index = 0)]
+    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
         /// Piece index where object is contained (at least its beginning, might not fit fully)
         piece_index: PieceIndex,

--- a/crates/subspace-core-primitives/src/serde.rs
+++ b/crates/subspace-core-primitives/src/serde.rs
@@ -1,0 +1,100 @@
+use crate::PosProof;
+use hex::{decode_to_slice, FromHex, FromHexError};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+impl FromHex for PosProof {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let hex = hex.as_ref();
+        if hex.len() % 2 != 0 {
+            return Err(FromHexError::OddLength);
+        }
+        if hex.len() != 2 * PosProof::SIZE {
+            return Err(FromHexError::InvalidStringLength);
+        }
+
+        let mut out = Self::default();
+
+        decode_to_slice(hex, out.as_mut_slice())?;
+
+        Ok(out)
+    }
+}
+
+impl Serialize for PosProof {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serializer::serialize_newtype_struct(serializer, "PosProof", {
+            struct SerializeWith<'a> {
+                values: &'a [u8],
+            }
+            impl<'a> Serialize for SerializeWith<'a> {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    hex::serde::serialize(self.values, serializer)
+                }
+            }
+            &SerializeWith {
+                values: self.as_ref(),
+            }
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for PosProof {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = PosProof;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("tuple struct PosProof")
+            }
+
+            #[inline]
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                hex::serde::deserialize(deserializer)
+            }
+
+            #[inline]
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                struct DeserializeWith {
+                    value: PosProof,
+                }
+                impl<'de> Deserialize<'de> for DeserializeWith {
+                    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                    where
+                        D: Deserializer<'de>,
+                    {
+                        Ok(DeserializeWith {
+                            value: hex::serde::deserialize(deserializer)?,
+                        })
+                    }
+                }
+
+                de::SeqAccess::next_element::<DeserializeWith>(&mut seq)?
+                    .map(|wrap| wrap.value)
+                    .ok_or(de::Error::invalid_length(
+                        0usize,
+                        &"tuple struct PosProof with 1 element",
+                    ))
+            }
+        }
+        Deserializer::deserialize_newtype_struct(deserializer, "PosProof", Visitor)
+    }
+}

--- a/crates/subspace-erasure-coding/src/lib.rs
+++ b/crates/subspace-erasure-coding/src/lib.rs
@@ -70,6 +70,13 @@ impl ErasureCoding {
         Ok(Scalar::vec_from_repr(poly.coeffs))
     }
 
+    /// Recovery of source shards from given shards (at least 1/2 should be `Some`).
+    ///
+    /// The same as [`ErasureCoding::recover()`], but returns only source shards.
+    pub fn recover_source(&self, shards: &[Option<Scalar>]) -> Result<Vec<Scalar>, String> {
+        Ok(self.recover(shards)?.into_iter().step_by(2).collect())
+    }
+
     /// Extend commitments using erasure coding.
     ///
     /// Returns both source and parity commitments interleaved.

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [dependencies]
-subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "7eeb29380eb6f8036d4f980e8d15038bda1184f7" }
+subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "100f861378c3f450434ef9e94723f50c804d333f" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -18,7 +18,7 @@ impl<'a> Quality<'a> {
 
     /// Create proof for this solution
     pub fn create_proof(&self) -> PosProof {
-        PosProof(self.quality.create_proof())
+        PosProof::from(self.quality.create_proof())
     }
 }
 


### PR DESCRIPTION
A few tweaks I did locally that are backwards compatible (technically serde changes are not, but they will not affect anything AFAIK).

`subspace-chiapos` update is caused by linking issues, both `chiapos` and Rust crate `zstd-sys` included the same function, and since C functions are all in global namespace, that was a problem. Fixed by linking otherwise unnecessary `zstd-sys` dependency: https://github.com/subspace/chiapos/commit/100f861378c3f450434ef9e94723f50c804d333f

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
