### PR TITLE
Refactor gossip message validator

### DIFF
--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -307,18 +307,10 @@ where
             .runtime_api
             .construct_submit_core_bundle_extrinsics(domain_hash, core_bundles)?
             .into_iter()
-            .filter_map(
-                |uxt| match <<Block as BlockT>::Extrinsic>::decode(&mut uxt.as_slice()) {
-                    Ok(uxt) => Some(uxt),
-                    Err(e) => {
-                        tracing::error!(
-                            error = ?e,
-                            "Failed to decode the opaque extrisic in bundle, this should not happen"
-                        );
-                        None
-                    }
-                },
-            )
+            .map(|uxt| {
+                <<Block as BlockT>::Extrinsic>::decode(&mut uxt.as_slice())
+                    .expect("Internally constructed extrinsic must be valid; qed")
+            })
             .chain(origin_system_extrinsics)
             .collect::<Vec<_>>();
 

--- a/domains/client/block-preprocessor/src/runtime_api_light.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_light.rs
@@ -85,7 +85,6 @@ impl<Executor> RuntimeApiLight<Executor>
 where
     Executor: CodeExecutor,
 {
-    #[allow(unused)]
     pub fn new(executor: Arc<Executor>, runtime_code: Cow<'static, [u8]>) -> Self {
         Self {
             executor,

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -86,8 +86,8 @@ pub(super) async fn start_worker<
 ) where
     Block: BlockT,
     SBlock: BlockT,
-    Block::Extrinsic: Into<SBlock::Extrinsic>,
     PBlock: BlockT,
+    Block::Extrinsic: Into<SBlock::Extrinsic>,
     Client: HeaderBackend<Block>
         + BlockBackend<Block>
         + AuxStore

--- a/domains/client/domain-executor/src/core_executor.rs
+++ b/domains/client/domain-executor/src/core_executor.rs
@@ -57,8 +57,8 @@ impl<Block, SBlock, PBlock, Client, SClient, PClient, TransactionPool, Backend, 
 where
     Block: BlockT,
     SBlock: BlockT,
-    Block::Extrinsic: Into<SBlock::Extrinsic>,
     PBlock: BlockT,
+    Block::Extrinsic: Into<SBlock::Extrinsic>,
     Client: HeaderBackend<Block>
         + BlockBackend<Block>
         + AuxStore

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -31,9 +31,7 @@ pub struct CoreGossipMessageValidator<
     SBlock: BlockT,
     PBlock: BlockT,
 {
-    parent_chain: ParentChain,
     client: Arc<Client>,
-    transaction_pool: Arc<TransactionPool>,
     gossip_message_validator: GossipMessageValidator<
         Block,
         PBlock,
@@ -45,7 +43,7 @@ pub struct CoreGossipMessageValidator<
         TransactionPool,
         ParentChain,
     >,
-    _phantom_data: PhantomData<(SBlock, SClient, PClient)>,
+    _phantom_data: PhantomData<SClient>,
 }
 
 impl<Block, SBlock, PBlock, Client, SClient, PClient, TransactionPool, Backend, E, ParentChain>
@@ -70,9 +68,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            parent_chain: self.parent_chain.clone(),
             client: self.client.clone(),
-            transaction_pool: self.transaction_pool.clone(),
             gossip_message_validator: self.gossip_message_validator.clone(),
             _phantom_data: self._phantom_data,
         }
@@ -123,14 +119,12 @@ where
         let gossip_message_validator = GossipMessageValidator::new(
             client.clone(),
             spawner,
-            parent_chain.clone(),
-            transaction_pool.clone(),
+            parent_chain,
+            transaction_pool,
             fraud_proof_generator,
         );
         Self {
-            parent_chain,
             client,
-            transaction_pool,
             gossip_message_validator,
             _phantom_data: PhantomData::default(),
         }

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -214,10 +214,8 @@ where
             // TODO: Validate the receipts correctly when the bundle gossip is re-enabled.
             let domain_id = bundle_solution.proof_of_election().domain_id;
 
-            for receipt in &bundle.receipts {
-                self.gossip_message_validator
-                    .validate_gossiped_execution_receipt(receipt, domain_id)?;
-            }
+            self.gossip_message_validator
+                .validate_bundle_receipts(&bundle.receipts, domain_id)?;
 
             for extrinsic in bundle.extrinsics.iter() {
                 let tx_hash = self.transaction_pool.hash_of(extrinsic);

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -26,11 +26,7 @@ pub struct CoreGossipMessageValidator<
     Backend,
     E,
     ParentChain,
-> where
-    Block: BlockT,
-    SBlock: BlockT,
-    PBlock: BlockT,
-{
+> {
     client: Arc<Client>,
     gossip_message_validator: GossipMessageValidator<
         Block,
@@ -61,9 +57,6 @@ impl<Block, SBlock, PBlock, Client, SClient, PClient, TransactionPool, Backend, 
         ParentChain,
     >
 where
-    Block: BlockT,
-    SBlock: BlockT,
-    PBlock: BlockT,
     ParentChain: Clone,
 {
     fn clone(&self) -> Self {

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -7,8 +7,7 @@ use sc_client_api::{AuxStore, BlockBackend, ProofProvider, StateBackendFor};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CodeExecutor, SpawnNamed};
-use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof};
-use sp_domains::{Bundle, SignedBundle};
+use sp_domains::SignedBundle;
 use sp_runtime::traits::{Block as BlockT, HashFor, NumberFor};
 use sp_runtime::RuntimeAppPublic;
 use std::marker::PhantomData;
@@ -190,23 +189,8 @@ where
             signature,
         } = signed_bundle;
 
-        let check_equivocation =
-            |_bundle: &Bundle<Block::Extrinsic, NumberFor<PBlock>, PBlock::Hash, Block::Hash>| {
-                // TODO: check bundle equivocation
-                let bundle_is_an_equivocation = false;
-                if bundle_is_an_equivocation {
-                    Some(BundleEquivocationProof::dummy_at(bundle.header.slot_number))
-                } else {
-                    None
-                }
-            };
-
-        // A bundle equivocation occurs.
-        if let Some(equivocation_proof) = check_equivocation(bundle) {
-            let fraud_proof = FraudProof::BundleEquivocation(equivocation_proof);
-            self.parent_chain.submit_fraud_proof_unsigned(fraud_proof)?;
-            return Err(GossipMessageError::BundleEquivocation);
-        }
+        self.gossip_message_validator
+            .check_bundle_equivocation(bundle)?;
 
         let bundle_exists = false;
 

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -528,7 +528,7 @@ where
 
             let fraud_proof = self
                 .fraud_proof_generator
-                .generate_proof::<PCB>(
+                .generate_invalid_state_transition_proof::<PCB>(
                     self.domain_id,
                     trace_mismatch_index,
                     &local_receipt,

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -30,10 +30,7 @@ where
 }
 
 /// A common component shared between the system and core domain bundle processor.
-pub(crate) struct DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>
-where
-    PBlock: BlockT,
-{
+pub(crate) struct DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E> {
     domain_id: DomainId,
     client: Arc<Client>,
     primary_chain_client: Arc<PClient>,
@@ -44,8 +41,6 @@ where
 
 impl<Block, PBlock, Client, PClient, Backend, E> Clone
     for DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>
-where
-    PBlock: BlockT,
 {
     fn clone(&self) -> Self {
         Self {
@@ -219,8 +214,8 @@ where
 
         if to_number_primitive(parent_number) + 1 != primary_number {
             return Err(sp_blockchain::Error::Application(Box::from(format!(
-                "Wrong domain parent block #{parent_number},{parent_hash:?} for \
-                primary block #{primary_number},{primary_hash:?}, the number of new \
+                "Wrong domain parent block #{parent_number},{parent_hash} for \
+                primary block #{primary_number},{primary_hash}, the number of new \
                 domain block must match the number of corresponding primary block."
             ))));
         }
@@ -236,8 +231,8 @@ where
             .await?;
 
         tracing::debug!(
-            "Built new domain block #{header_number},{header_hash} \
-            from primary block #{primary_number},{primary_hash}",
+            "Built new domain block #{header_number},{header_hash} from primary block #{primary_number},{primary_hash} \
+            on top of parent block #{header_number},{header_hash}"
         );
 
         let mut roots = self.client.runtime_api().intermediate_roots(header_hash)?;

--- a/domains/client/domain-executor/src/domain_bundle_producer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_producer.rs
@@ -48,7 +48,7 @@ pub(super) struct DomainBundleProducer<
     keystore: KeystorePtr,
     bundle_election_solver: BundleElectionSolver<SBlock, PBlock, SClient>,
     domain_bundle_proposer: DomainBundleProposer<Block, Client, PBlock, PClient, TransactionPool>,
-    _phantom_data: PhantomData<(SBlock, ParentChainBlock)>,
+    _phantom_data: PhantomData<ParentChainBlock>,
 }
 
 impl<
@@ -166,7 +166,7 @@ where
         self,
         primary_info: (PBlock::Hash, NumberFor<PBlock>),
         slot_info: ExecutorSlotInfo,
-    ) -> Result<Option<SignedOpaqueBundle<Block, PBlock>>, sp_blockchain::Error> {
+    ) -> sp_blockchain::Result<Option<SignedOpaqueBundle<Block, PBlock>>> {
         let ExecutorSlotInfo {
             slot,
             global_challenge,
@@ -220,7 +220,7 @@ where
     fn construct_bundle_solution(
         &self,
         preliminary_bundle_solution: PreliminaryBundleSolution<Block::Hash>,
-    ) -> Result<BundleSolution<Block::Hash>, sp_blockchain::Error> {
+    ) -> sp_blockchain::Result<BundleSolution<Block::Hash>> {
         match preliminary_bundle_solution {
             PreliminaryBundleSolution::System {
                 authority_stake_weight,
@@ -254,7 +254,7 @@ pub(crate) fn sign_new_bundle<Block: BlockT, PBlock: BlockT>(
     bundle: Bundle<Block::Extrinsic, NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
     keystore: KeystorePtr,
     bundle_solution: BundleSolution<Block::Hash>,
-) -> Result<SignedOpaqueBundle<Block, PBlock>, sp_blockchain::Error> {
+) -> sp_blockchain::Result<SignedOpaqueBundle<Block, PBlock>> {
     let to_sign = bundle.hash();
     let bundle_author = bundle_solution
         .proof_of_election()

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -19,7 +19,7 @@ pub(super) struct DomainBundleProposer<Block, Client, PBlock, PClient, Transacti
     client: Arc<Client>,
     primary_chain_client: Arc<PClient>,
     transaction_pool: Arc<TransactionPool>,
-    _phantom_data: PhantomData<(Block, PBlock, PClient)>,
+    _phantom_data: PhantomData<(Block, PBlock)>,
 }
 
 impl<Block, Client, PBlock, PClient, TransactionPool> Clone
@@ -65,7 +65,6 @@ where
         parent_chain: ParentChain,
     ) -> sp_blockchain::Result<Bundle<Block::Extrinsic, NumberFor<PBlock>, PBlock::Hash, Block::Hash>>
     where
-        PBlock: BlockT,
         ParentChainBlock: BlockT,
         ParentChain: ParentChainInterface<ParentChainBlock>,
     {
@@ -79,8 +78,7 @@ where
             res = t1 => res,
             _ = t2 => {
                 tracing::warn!(
-                    "Timeout fired waiting for transaction pool at #{}, proceeding with production.",
-                    parent_number,
+                    "Timeout fired waiting for transaction pool at #{parent_number}, proceeding with production."
                 );
                 self.transaction_pool.ready()
             }
@@ -142,7 +140,6 @@ where
         parent_chain: ParentChain,
     ) -> sp_blockchain::Result<Vec<ExecutionReceiptFor<PBlock, Block::Hash>>>
     where
-        PBlock: BlockT,
         ParentChainBlock: BlockT,
         ParentChain: ParentChainInterface<ParentChainBlock>,
     {

--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -37,11 +37,15 @@ pub(crate) async fn handle_slot_notifications<Block, PBlock, PClient, BundlerFn>
         + Sync,
 {
     while let Some((executor_slot_info, slot_acknowledgement_sender)) = slots.next().await {
+        let slot = executor_slot_info.slot;
         if let Err(error) =
             on_new_slot::<Block, PBlock, _, _>(primary_chain_client, &bundler, executor_slot_info)
                 .await
         {
-            tracing::error!(?error, "Failed to submit bundle");
+            tracing::error!(
+                ?error,
+                "Error occurred on producing a bundle at slot {slot}"
+            );
             break;
         }
         if let Some(mut sender) = slot_acknowledgement_sender {

--- a/domains/client/domain-executor/src/fraud_proof.rs
+++ b/domains/client/domain-executor/src/fraud_proof.rs
@@ -87,7 +87,7 @@ where
         }
     }
 
-    pub(crate) fn generate_proof<PCB>(
+    pub(crate) fn generate_invalid_state_transition_proof<PCB>(
         &self,
         domain_id: DomainId,
         local_trace_index: u32,

--- a/domains/client/domain-executor/src/gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/gossip_message_validator.rs
@@ -225,12 +225,14 @@ where
         if local_receipt.trace.len() != execution_receipt.trace.len() {}
 
         if let Some(trace_mismatch_index) = find_trace_mismatch(&local_receipt, execution_receipt) {
-            let fraud_proof = self.fraud_proof_generator.generate_proof::<PCB>(
-                domain_id,
-                trace_mismatch_index,
-                &local_receipt,
-                execution_receipt.hash(),
-            )?;
+            let fraud_proof = self
+                .fraud_proof_generator
+                .generate_invalid_state_transition_proof::<PCB>(
+                    domain_id,
+                    trace_mismatch_index,
+                    &local_receipt,
+                    execution_receipt.hash(),
+                )?;
             Ok(Some(fraud_proof))
         } else {
             Ok(None)

--- a/domains/client/domain-executor/src/gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/gossip_message_validator.rs
@@ -7,8 +7,8 @@ use sc_client_api::{AuxStore, BlockBackend, ProofProvider, StateBackendFor};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CodeExecutor, SpawnNamed};
-use sp_domains::fraud_proof::{FraudProof, InvalidTransactionProof};
-use sp_domains::{DomainId, ExecutorPublicKey};
+use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
+use sp_domains::{Bundle, DomainId, ExecutorPublicKey};
 use sp_runtime::traits::{Block as BlockT, HashFor, Header as HeaderT, NumberFor};
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -156,6 +156,23 @@ where
             transaction_pool,
             fraud_proof_generator,
             _phantom_data: Default::default(),
+        }
+    }
+
+    pub(crate) fn check_bundle_equivocation(
+        &self,
+        bundle: &Bundle<Block::Extrinsic, NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
+    ) -> Result<(), GossipMessageError> {
+        // TODO: check bundle equivocation
+        let bundle_is_an_equivocation = false;
+
+        if bundle_is_an_equivocation {
+            let equivocation_proof = BundleEquivocationProof::dummy_at(bundle.header.slot_number);
+            let fraud_proof = FraudProof::BundleEquivocation(equivocation_proof);
+            self.parent_chain.submit_fraud_proof_unsigned(fraud_proof)?;
+            Err(GossipMessageError::BundleEquivocation)
+        } else {
+            Ok(())
         }
     }
 

--- a/domains/client/domain-executor/src/system_executor.rs
+++ b/domains/client/domain-executor/src/system_executor.rs
@@ -25,10 +25,7 @@ use subspace_core_primitives::Blake2b256Hash;
 use system_runtime_primitives::SystemDomainApi;
 
 /// System domain executor.
-pub struct Executor<Block, PBlock, Client, PClient, TransactionPool, Backend, E>
-where
-    PBlock: BlockT,
-{
+pub struct Executor<Block, PBlock, Client, PClient, TransactionPool, Backend, E> {
     primary_chain_client: Arc<PClient>,
     client: Arc<Client>,
     spawner: Box<dyn SpawnNamed + Send + Sync>,
@@ -40,8 +37,6 @@ where
 
 impl<Block, PBlock, Client, PClient, TransactionPool, Backend, E> Clone
     for Executor<Block, PBlock, Client, PClient, TransactionPool, Backend, E>
-where
-    PBlock: BlockT,
 {
     fn clone(&self) -> Self {
         Self {

--- a/domains/client/domain-executor/src/system_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/system_gossip_message_validator.rs
@@ -189,10 +189,9 @@ where
 
             // TODO: Validate the receipts correctly when the bundle gossip is re-enabled.
             let domain_id = bundle_solution.proof_of_election().domain_id;
-            for receipt in &bundle.receipts {
-                self.gossip_message_validator
-                    .validate_gossiped_execution_receipt(receipt, domain_id)?;
-            }
+
+            self.gossip_message_validator
+                .validate_bundle_receipts(&bundle.receipts, domain_id)?;
 
             for extrinsic in bundle.extrinsics.iter() {
                 let tx_hash = self.transaction_pool.hash_of(extrinsic);

--- a/domains/client/domain-executor/src/system_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/system_gossip_message_validator.rs
@@ -24,9 +24,7 @@ pub struct SystemGossipMessageValidator<
     E,
     ParentChain,
 > {
-    parent_chain: ParentChain,
     client: Arc<Client>,
-    transaction_pool: Arc<TransactionPool>,
     gossip_message_validator: GossipMessageValidator<
         Block,
         PBlock,
@@ -56,9 +54,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            parent_chain: self.parent_chain.clone(),
             client: self.client.clone(),
-            transaction_pool: self.transaction_pool.clone(),
             gossip_message_validator: self.gossip_message_validator.clone(),
         }
     }
@@ -104,14 +100,12 @@ where
         let gossip_message_validator = GossipMessageValidator::new(
             client.clone(),
             spawner,
-            parent_chain.clone(),
-            transaction_pool.clone(),
+            parent_chain,
+            transaction_pool,
             fraud_proof_generator,
         );
         Self {
-            parent_chain,
             client,
-            transaction_pool,
             gossip_message_validator,
         }
     }

--- a/domains/client/domain-executor/src/system_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/system_gossip_message_validator.rs
@@ -7,7 +7,7 @@ use sc_client_api::{AuxStore, BlockBackend, ProofProvider, StateBackendFor};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CodeExecutor, SpawnNamed};
-use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof, InvalidTransactionProof};
+use sp_domains::fraud_proof::{BundleEquivocationProof, FraudProof};
 use sp_domains::{Bundle, SignedBundle};
 use sp_runtime::traits::{Block as BlockT, HashFor, NumberFor};
 use sp_runtime::RuntimeAppPublic;
@@ -28,8 +28,17 @@ pub struct SystemGossipMessageValidator<
     parent_chain: ParentChain,
     client: Arc<Client>,
     transaction_pool: Arc<TransactionPool>,
-    gossip_message_validator:
-        GossipMessageValidator<Block, PBlock, PBlock, Client, PClient, Backend, E, ParentChain>,
+    gossip_message_validator: GossipMessageValidator<
+        Block,
+        PBlock,
+        PBlock,
+        Client,
+        PClient,
+        Backend,
+        E,
+        TransactionPool,
+        ParentChain,
+    >,
 }
 
 impl<Block, PBlock, Client, PClient, TransactionPool, Backend, E, ParentChain> Clone
@@ -97,6 +106,7 @@ where
             client.clone(),
             spawner,
             parent_chain.clone(),
+            transaction_pool.clone(),
             fraud_proof_generator,
         );
         Self {
@@ -193,21 +203,8 @@ where
             self.gossip_message_validator
                 .validate_bundle_receipts(&bundle.receipts, domain_id)?;
 
-            for extrinsic in bundle.extrinsics.iter() {
-                let tx_hash = self.transaction_pool.hash_of(extrinsic);
-
-                if self.transaction_pool.ready_transaction(&tx_hash).is_some() {
-                    // TODO: Set the status of each tx in the bundle to seen
-                } else {
-                    // TODO: check the legality
-                    //
-                    // if illegal => illegal tx proof
-                    let invalid_transaction_proof = InvalidTransactionProof { domain_id };
-                    let fraud_proof = FraudProof::InvalidTransaction(invalid_transaction_proof);
-
-                    self.parent_chain.submit_fraud_proof_unsigned(fraud_proof)?;
-                }
-            }
+            self.gossip_message_validator
+                .validate_bundle_transactions(&bundle.extrinsics, domain_id)?;
 
             // TODO: all checks pass, add to the bundle pool
 

--- a/domains/client/domain-executor/src/utils.rs
+++ b/domains/client/domain-executor/src/utils.rs
@@ -13,14 +13,8 @@ pub(super) struct ExecutorSlotInfo {
     pub(super) global_challenge: Blake2b256Hash,
 }
 
-/// An event telling the `Overseer` on the particular block
-/// that has been imported or finalized.
-///
-/// This structure exists solely for the purposes of decoupling
-/// `Overseer` code from the client code and the necessity to call
-/// `HeaderBackend::block_number_from_id()`.
 #[derive(Debug, Clone)]
-pub struct BlockInfo<Block>
+pub(crate) struct BlockInfo<Block>
 where
     Block: BlockT,
 {


### PR DESCRIPTION
This PR is primarily for reducing the code repetition in {core, system}_gossip_message_validator.rs in order to make #1228 easier, by moving the common logic into gossip_message_validator.rs. There is a chance that {core, system}_gossip_message_validator.rs can just be eliminated, but I'll leave it to the future once the bundle election is verified for the gossip bundle.

There are also a number of tiny refactorings along the way. No logical changes in this PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
