### PR TITLE
Improve sector downloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10334,6 +10334,7 @@ name = "subspace-farmer-components"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "backoff",
  "criterion",
  "fs2",
  "futures",

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 
 [dependencies]
 async-trait = "0.1.68"
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 fs2 = "0.4.3"
 futures = "0.3.28"
 libc = "0.2.139"

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -48,7 +48,7 @@ use tracing::{debug, error, info, info_span, trace, warn, Instrument, Span};
 use ulid::Ulid;
 
 /// Get piece retry attempts number.
-const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(30).expect("Not zero; qed");
+const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");
 
 // Refuse to compile on non-64-bit platforms, offsets may fail on those when converting from u64 to
 // usize depending on chain parameters

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -12,9 +12,9 @@ use subspace_core_primitives::{Piece, PieceIndex, PieceIndexHash};
 use tracing::{debug, error, trace, warn};
 
 /// Defines initial duration between get_piece calls.
-const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
+const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(3);
 /// Defines max duration between get_piece calls.
-const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(5);
+const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(10);
 
 #[async_trait]
 pub trait PieceValidator: Sync + Send {


### PR DESCRIPTION
This should improve user experience by:
* tuning intervals and number of attempts to better adjust to network conditions and not doing too many attempts for no reason before resorting to segment reconstruction
* making farmer try to download sector pieces forever instead of exiting on error (which prevents farming for example)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
