### PR TITLE
Consensus 2.3 preparation (part 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "subspace-chiapos"
 version = "0.1.0"
-source = "git+https://github.com/subspace/chiapos?rev=100f861378c3f450434ef9e94723f50c804d333f#100f861378c3f450434ef9e94723f50c804d333f"
+source = "git+https://github.com/subspace/chiapos?rev=3b1ab3ca24764d25da30e0c8243e0bf304b776a5#3b1ab3ca24764d25da30e0c8243e0bf304b776a5"
 dependencies = [
  "cc",
  "zstd-sys",

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -798,7 +798,11 @@ impl Archiver {
                 witness.copy_from_slice(
                     &self
                         .kzg
-                        .create_witness(&polynomial, position as u32)
+                        .create_witness(
+                            &polynomial,
+                            ArchivedHistorySegment::NUM_PIECES,
+                            position as u32,
+                        )
                         .expect("Position is statically known to be valid; qed")
                         .to_bytes(),
                 );

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -234,7 +234,11 @@ impl PiecesReconstructor {
             piece.witness_mut().copy_from_slice(
                 &self
                     .kzg
-                    .create_witness(&polynomial, position as u32)
+                    .create_witness(
+                        &polynomial,
+                        ArchivedHistorySegment::NUM_PIECES,
+                        position as u32,
+                    )
                     // TODO: Update this proof here and in other places, we don't use Merkle
                     //  trees anymore
                     .expect("Position is statically known to be valid; qed")
@@ -263,7 +267,11 @@ impl PiecesReconstructor {
         piece.witness_mut().copy_from_slice(
             &self
                 .kzg
-                .create_witness(&polynomial, piece_position as u32)
+                .create_witness(
+                    &polynomial,
+                    ArchivedHistorySegment::NUM_PIECES,
+                    piece_position as u32,
+                )
                 .expect("Position is verified to be valid above; qed")
                 .to_bytes(),
         );

--- a/crates/subspace-core-primitives/benches/kzg.rs
+++ b/crates/subspace-core-primitives/benches/kzg.rs
@@ -23,11 +23,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    let num_values = values.len();
+
     c.bench_function("create-witness", |b| {
         let polynomial = kzg.poly(&values).unwrap();
 
         b.iter(|| {
-            kzg.create_witness(black_box(&polynomial), black_box(0))
+            kzg.create_witness(black_box(&polynomial), black_box(num_values), black_box(0))
                 .unwrap();
         })
     });
@@ -36,8 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let polynomial = kzg.poly(&values).unwrap();
         let commitment = kzg.commit(&polynomial).unwrap();
         let index = 0;
-        let witness = kzg.create_witness(&polynomial, index).unwrap();
-        let num_values = values.len();
+        let witness = kzg.create_witness(&polynomial, num_values, index).unwrap();
         let value = values.first().unwrap();
 
         b.iter(|| {

--- a/crates/subspace-core-primitives/src/crypto/kzg/tests.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg/tests.rs
@@ -24,7 +24,7 @@ fn basic() {
     for (index, value) in values.iter().enumerate() {
         let index = index.try_into().unwrap();
 
-        let witness = kzg.create_witness(&polynomial, index).unwrap();
+        let witness = kzg.create_witness(&polynomial, num_values, index).unwrap();
 
         assert!(
             kzg.verify(&commitment, num_values, index, value, &witness),

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -451,11 +451,7 @@ impl<PublicKey, RewardAddressA> Solution<PublicKey, RewardAddressA> {
     }
 }
 
-impl<PublicKey, RewardAddress> Solution<PublicKey, RewardAddress>
-where
-    PublicKey: Clone,
-    RewardAddress: Clone,
-{
+impl<PublicKey, RewardAddress> Solution<PublicKey, RewardAddress> {
     /// Dummy solution for the genesis block
     pub fn genesis_solution(public_key: PublicKey, reward_address: RewardAddress) -> Self {
         Self {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -113,52 +113,65 @@ pub const REWARD_SIGNATURE_LENGTH: usize = 64;
 const VRF_OUTPUT_LENGTH: usize = 32;
 const VRF_PROOF_LENGTH: usize = 64;
 
-/// Size of proof of space seed in bytes.
-const POS_SEED_SIZE: usize = 32;
-
 /// Proof of space seed.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
-pub struct PosSeed(pub [u8; POS_SEED_SIZE]);
+pub struct PosSeed([u8; Self::SIZE]);
+
+impl const From<[u8; PosSeed::SIZE]> for PosSeed {
+    fn from(value: [u8; Self::SIZE]) -> Self {
+        Self(value)
+    }
+}
+
+impl const From<PosSeed> for [u8; PosSeed::SIZE] {
+    fn from(value: PosSeed) -> Self {
+        value.0
+    }
+}
 
 impl PosSeed {
     /// Size of proof of space seed in bytes.
-    pub const SIZE: usize = POS_SEED_SIZE;
+    pub const SIZE: usize = 32;
 }
-
-/// Size of proof of space quality in bytes.
-const POS_QUALITY_SIZE: usize = 32;
 
 /// Proof of space quality.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
-pub struct PosQualityBytes(pub [u8; POS_QUALITY_SIZE]);
+pub struct PosQualityBytes([u8; Self::SIZE]);
+
+impl const From<[u8; PosQualityBytes::SIZE]> for PosQualityBytes {
+    fn from(value: [u8; Self::SIZE]) -> Self {
+        Self(value)
+    }
+}
+
+impl const From<PosQualityBytes> for [u8; PosQualityBytes::SIZE] {
+    fn from(value: PosQualityBytes) -> Self {
+        value.0
+    }
+}
 
 impl PosQualityBytes {
     /// Size of proof of space quality in bytes.
-    pub const SIZE: usize = POS_QUALITY_SIZE;
-
-    /// Quality hash.
-    pub fn hash(&self) -> Blake2b256Hash {
-        blake2b_256_hash(&self.0)
-    }
+    pub const SIZE: usize = 32;
 }
 
 /// Proof of space proof bytes.
 #[derive(
-    Debug,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    From,
-    Into,
-    Deref,
-    DerefMut,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+    Debug, Copy, Clone, Eq, PartialEq, Deref, DerefMut, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
-pub struct PosProof([u8; PosProof::SIZE]);
+pub struct PosProof([u8; Self::SIZE]);
+
+impl const From<[u8; PosProof::SIZE]> for PosProof {
+    fn from(value: [u8; Self::SIZE]) -> Self {
+        Self(value)
+    }
+}
+
+impl const From<PosProof> for [u8; PosProof::SIZE] {
+    fn from(value: PosProof) -> Self {
+        value.0
+    }
+}
 
 impl Default for PosProof {
     fn default() -> Self {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -313,7 +313,7 @@ pub(crate) async fn farm_multi_disk(
                     tokio::spawn(async move {
                         let result =
                             select(Box::pin(publish_fut), Box::pin(dropped_receiver.recv())).await;
-                        if !matches!(result, Either::Right(_)) {
+                        if matches!(result, Either::Right(_)) {
                             debug!("Piece publishing was cancelled due to shutdown.");
                         }
                     });

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [dependencies]
-subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "3b1ab3ca24764d25da30e0c8243e0bf304b776a5" }
+subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "3b1ab3ca24764d25da30e0c8243e0bf304b776a5", optional = true }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
@@ -21,3 +21,10 @@ criterion = "0.4.0"
 [[bench]]
 name = "pos"
 harness = false
+
+[features]
+default = ["std"]
+std = [
+    "subspace-chiapos",
+    "subspace-core-primitives/std",
+]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -11,6 +11,10 @@ include = [
     "/Cargo.toml",
 ]
 
+[lib]
+# Necessary for CLI options to work on benches
+bench = false
+
 [dependencies]
 subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "3b1ab3ca24764d25da30e0c8243e0bf304b776a5", optional = true }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
@@ -28,3 +32,6 @@ std = [
     "subspace-chiapos",
     "subspace-core-primitives/std",
 ]
+# Enables shim proof of space that works much faster than original and can be used for testing purposes to reduce memory
+# and CPU usage
+shim = []

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [dependencies]
-subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "100f861378c3f450434ef9e94723f50c804d333f" }
+subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "3b1ab3ca24764d25da30e0c8243e0bf304b776a5" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -50,7 +50,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("verification", |b| {
         b.iter(|| {
-            assert!(is_proof_valid(&seed, challenge_index_with_solution, &proof));
+            assert!(is_proof_valid(&seed, challenge_index_with_solution, &proof).is_some());
         });
     });
     group.finish();

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -1,9 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use subspace_core_primitives::PosSeed;
-use subspace_proof_of_space::{is_proof_valid, Table};
+use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::{Quality, Table};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let seed = PosSeed([
+    let seed = PosSeed::from([
         35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
         198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
     ]);
@@ -16,11 +17,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("table", |b| {
         b.iter(|| {
-            Table::generate(black_box(&seed));
+            ChiaTable::generate(black_box(&seed));
         });
     });
 
-    let table = Table::generate(&seed);
+    let table = ChiaTable::generate(&seed);
 
     group.bench_function("quality/no-solution", |b| {
         b.iter(|| {
@@ -50,7 +51,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("verification", |b| {
         b.iter(|| {
-            assert!(is_proof_valid(&seed, challenge_index_with_solution, &proof).is_some());
+            assert!(
+                ChiaTable::is_proof_valid(&seed, challenge_index_with_solution, &proof).is_some()
+            );
         });
     });
     group.finish();

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -1,6 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use subspace_core_primitives::PosSeed;
 use subspace_proof_of_space::chia::ChiaTable;
+#[cfg(feature = "shim")]
+use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::{Quality, Table};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -8,55 +10,111 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
         198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
     ]);
-    // This challenge index with above seed is known to not have a solution
-    let challenge_index_without_solution = 0;
-    // This challenge index with above seed is known to have a solution
-    let challenge_index_with_solution = 1;
+    {
+        // This challenge index with above seed is known to not have a solution
+        let challenge_index_without_solution = 0;
+        // This challenge index with above seed is known to have a solution
+        let challenge_index_with_solution = 1;
 
-    let mut group = c.benchmark_group("pos");
+        let mut group = c.benchmark_group("chia");
 
-    group.bench_function("table", |b| {
-        b.iter(|| {
-            ChiaTable::generate(black_box(&seed));
+        group.bench_function("table", |b| {
+            b.iter(|| {
+                ChiaTable::generate(black_box(&seed));
+            });
         });
-    });
 
-    let table = ChiaTable::generate(&seed);
+        let table = ChiaTable::generate(&seed);
 
-    group.bench_function("quality/no-solution", |b| {
-        b.iter(|| {
-            assert!(table
-                .find_quality(black_box(challenge_index_without_solution))
-                .is_none());
+        group.bench_function("quality/no-solution", |b| {
+            b.iter(|| {
+                assert!(table
+                    .find_quality(black_box(challenge_index_without_solution))
+                    .is_none());
+            });
         });
-    });
 
-    group.bench_function("quality/solution", |b| {
-        b.iter(|| {
-            assert!(table
-                .find_quality(black_box(challenge_index_with_solution))
-                .is_some());
+        group.bench_function("quality/solution", |b| {
+            b.iter(|| {
+                assert!(table
+                    .find_quality(black_box(challenge_index_with_solution))
+                    .is_some());
+            });
         });
-    });
 
-    let quality = table.find_quality(challenge_index_with_solution).unwrap();
+        let quality = table.find_quality(challenge_index_with_solution).unwrap();
 
-    group.bench_function("proof", |b| {
-        b.iter(|| {
-            quality.create_proof();
+        group.bench_function("proof", |b| {
+            b.iter(|| {
+                quality.create_proof();
+            });
         });
-    });
 
-    let proof = quality.create_proof();
+        let proof = quality.create_proof();
 
-    group.bench_function("verification", |b| {
-        b.iter(|| {
-            assert!(
-                ChiaTable::is_proof_valid(&seed, challenge_index_with_solution, &proof).is_some()
-            );
+        group.bench_function("verification", |b| {
+            b.iter(|| {
+                assert!(
+                    ChiaTable::is_proof_valid(&seed, challenge_index_with_solution, &proof)
+                        .is_some()
+                );
+            });
         });
-    });
-    group.finish();
+        group.finish();
+    }
+    #[cfg(feature = "shim")]
+    {
+        // This challenge index with above seed is known to not have a solution
+        let challenge_index_without_solution = 0;
+        // This challenge index with above seed is known to have a solution
+        let challenge_index_with_solution = 2;
+
+        let mut group = c.benchmark_group("shim");
+
+        group.bench_function("table", |b| {
+            b.iter(|| {
+                ShimTable::generate(black_box(&seed));
+            });
+        });
+
+        let table = ShimTable::generate(&seed);
+
+        group.bench_function("quality/no-solution", |b| {
+            b.iter(|| {
+                assert!(table
+                    .find_quality(black_box(challenge_index_without_solution))
+                    .is_none());
+            });
+        });
+
+        group.bench_function("quality/solution", |b| {
+            b.iter(|| {
+                assert!(table
+                    .find_quality(black_box(challenge_index_with_solution))
+                    .is_some());
+            });
+        });
+
+        let quality = table.find_quality(challenge_index_with_solution).unwrap();
+
+        group.bench_function("proof", |b| {
+            b.iter(|| {
+                quality.create_proof();
+            });
+        });
+
+        let proof = quality.create_proof();
+
+        group.bench_function("verification", |b| {
+            b.iter(|| {
+                assert!(
+                    ShimTable::is_proof_valid(&seed, challenge_index_with_solution, &proof)
+                        .is_some()
+                );
+            });
+        });
+        group.finish();
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/crates/subspace-proof-of-space/src/chia.rs
+++ b/crates/subspace-proof-of-space/src/chia.rs
@@ -1,0 +1,80 @@
+//! Chia proof of space implementation
+
+use crate::{Quality, Table};
+use subspace_core_primitives::{PosProof, PosQualityBytes, PosSeed};
+
+/// Abstraction that represents quality of the solution in the table.
+///
+/// Chia implementation.
+#[derive(Debug)]
+#[must_use]
+pub struct ChiaQuality<'a> {
+    quality: subspace_chiapos::Quality<'a>,
+}
+
+impl<'a> Quality for ChiaQuality<'a> {
+    fn to_bytes(&self) -> PosQualityBytes {
+        PosQualityBytes::from(self.quality.to_bytes())
+    }
+
+    fn create_proof(&self) -> PosProof {
+        PosProof::from(self.quality.create_proof())
+    }
+}
+
+/// Subspace proof of space table
+///
+/// Chia implementation.
+#[derive(Debug)]
+pub struct ChiaTable {
+    table: subspace_chiapos::Table,
+}
+
+impl Table for ChiaTable {
+    type Quality<'a> = ChiaQuality<'a>;
+
+    fn generate(seed: &PosSeed) -> ChiaTable {
+        Self {
+            table: subspace_chiapos::Table::generate(seed),
+        }
+    }
+
+    fn find_quality(&self, challenge_index: u32) -> Option<Self::Quality<'_>> {
+        self.table
+            .find_quality(challenge_index)
+            .map(|quality| ChiaQuality { quality })
+    }
+
+    fn is_proof_valid(
+        seed: &PosSeed,
+        challenge_index: u32,
+        proof: &PosProof,
+    ) -> Option<PosQualityBytes> {
+        subspace_chiapos::is_proof_valid(seed, challenge_index, proof).map(PosQualityBytes::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SEED: PosSeed = PosSeed::from([
+        35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
+        198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
+    ]);
+
+    #[test]
+    fn basic() {
+        let table = ChiaTable::generate(&SEED);
+
+        assert!(table.find_quality(0).is_none());
+
+        {
+            let challenge_index = 1;
+            let quality = table.find_quality(challenge_index).unwrap();
+            let proof = quality.create_proof();
+            let maybe_quality = ChiaTable::is_proof_valid(&SEED, challenge_index, &proof);
+            assert_eq!(maybe_quality, Some(quality.to_bytes()));
+        }
+    }
+}

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -5,6 +5,8 @@
 
 #[cfg(feature = "std")]
 pub mod chia;
+#[cfg(feature = "shim")]
+pub mod shim;
 
 use subspace_core_primitives::{PosProof, PosQualityBytes, PosSeed};
 

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -44,9 +44,13 @@ impl Table {
     }
 }
 
-/// Check whether proof created earlier is valid
-pub fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
-    subspace_chiapos::is_proof_valid(seed, challenge_index, proof)
+/// Check whether proof created earlier is valid and return quality bytes if yes
+pub fn is_proof_valid(
+    seed: &PosSeed,
+    challenge_index: u32,
+    proof: &PosProof,
+) -> Option<PosQualityBytes> {
+    subspace_chiapos::is_proof_valid(seed, challenge_index, proof).map(PosQualityBytes::from)
 }
 
 #[cfg(test)]
@@ -68,7 +72,8 @@ mod tests {
             let challenge_index = 1;
             let quality = table.find_quality(challenge_index).unwrap();
             let proof = quality.create_proof();
-            assert!(is_proof_valid(&SEED, challenge_index, &proof));
+            let maybe_quality = is_proof_valid(&SEED, challenge_index, &proof);
+            assert_eq!(maybe_quality, Some(quality.to_bytes()));
         }
     }
 }

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -1,79 +1,39 @@
 //! Subspace proof of space implementation based on Chia
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
+#![feature(const_trait_impl)]
+
+#[cfg(feature = "std")]
+pub mod chia;
 
 use subspace_core_primitives::{PosProof, PosQualityBytes, PosSeed};
 
 /// Abstraction that represents quality of the solution in the table
-#[derive(Debug)]
-#[must_use]
-pub struct Quality<'a> {
-    quality: subspace_chiapos::Quality<'a>,
-}
-
-impl<'a> Quality<'a> {
+pub trait Quality {
     /// Get underlying bytes representation of the quality
-    pub fn to_bytes(&self) -> PosQualityBytes {
-        PosQualityBytes(self.quality.to_bytes())
-    }
+    fn to_bytes(&self) -> PosQualityBytes;
 
     /// Create proof for this solution
-    pub fn create_proof(&self) -> PosProof {
-        PosProof::from(self.quality.create_proof())
-    }
+    fn create_proof(&self) -> PosProof;
 }
 
-/// Subspace proof of space table
-#[derive(Debug)]
-pub struct Table {
-    table: subspace_chiapos::Table,
-}
+/// Proof of space kind
+pub trait Table: Send + Sync {
+    /// Abstraction that represents quality of the solution in the table
+    type Quality<'a>: Quality
+    where
+        Self: 'a;
 
-impl Table {
     /// Generate new table with 32 bytes seed
-    pub fn generate(seed: &PosSeed) -> Table {
-        Self {
-            table: subspace_chiapos::Table::generate(seed),
-        }
-    }
+    fn generate(seed: &PosSeed) -> Self;
 
     /// Try to find quality of the proof at `challenge_index` if proof exists
-    pub fn find_quality(&self, challenge_index: u32) -> Option<Quality<'_>> {
-        self.table
-            .find_quality(challenge_index)
-            .map(|quality| Quality { quality })
-    }
-}
+    fn find_quality(&self, challenge_index: u32) -> Option<Self::Quality<'_>>;
 
-/// Check whether proof created earlier is valid and return quality bytes if yes
-pub fn is_proof_valid(
-    seed: &PosSeed,
-    challenge_index: u32,
-    proof: &PosProof,
-) -> Option<PosQualityBytes> {
-    subspace_chiapos::is_proof_valid(seed, challenge_index, proof).map(PosQualityBytes::from)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const SEED: PosSeed = PosSeed([
-        35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
-        198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
-    ]);
-
-    #[test]
-    fn basic() {
-        let table = Table::generate(&SEED);
-
-        assert!(table.find_quality(0).is_none());
-
-        {
-            let challenge_index = 1;
-            let quality = table.find_quality(challenge_index).unwrap();
-            let proof = quality.create_proof();
-            let maybe_quality = is_proof_valid(&SEED, challenge_index, &proof);
-            assert_eq!(maybe_quality, Some(quality.to_bytes()));
-        }
-    }
+    /// Check whether proof created earlier is valid and return quality bytes if yes
+    fn is_proof_valid(
+        seed: &PosSeed,
+        challenge_index: u32,
+        proof: &PosProof,
+    ) -> Option<PosQualityBytes>;
 }

--- a/crates/subspace-proof-of-space/src/shim.rs
+++ b/crates/subspace-proof-of-space/src/shim.rs
@@ -1,0 +1,105 @@
+//! Shim proof of space implementation
+
+use crate::{Quality, Table};
+use core::iter;
+use subspace_core_primitives::crypto::blake2b_256_hash;
+use subspace_core_primitives::{Blake2b256Hash, PosProof, PosQualityBytes, PosSeed, U256};
+
+/// Abstraction that represents quality of the solution in the table.
+///
+/// Shim implementation.
+#[derive(Debug)]
+#[must_use]
+pub struct ShimQuality<'a> {
+    seed: &'a PosSeed,
+    quality: Blake2b256Hash,
+}
+
+impl<'a> Quality for ShimQuality<'a> {
+    fn to_bytes(&self) -> PosQualityBytes {
+        PosQualityBytes::from(self.quality)
+    }
+
+    fn create_proof(&self) -> PosProof {
+        let mut proof = PosProof::default();
+        proof
+            .iter_mut()
+            .zip(
+                self.seed
+                    .iter()
+                    .chain(iter::repeat(self.quality.iter()).flatten()),
+            )
+            .for_each(|(output, input)| {
+                *output = *input;
+            });
+        proof
+    }
+}
+
+/// Subspace proof of space table.
+///
+/// Shim implementation.
+#[derive(Debug)]
+pub struct ShimTable {
+    seed: PosSeed,
+}
+
+impl Table for ShimTable {
+    type Quality<'a> = ShimQuality<'a>;
+
+    fn generate(seed: &PosSeed) -> ShimTable {
+        Self { seed: *seed }
+    }
+
+    fn find_quality(&self, challenge_index: u32) -> Option<Self::Quality<'_>> {
+        find_quality(&self.seed, challenge_index)
+    }
+
+    fn is_proof_valid(
+        seed: &PosSeed,
+        challenge_index: u32,
+        proof: &PosProof,
+    ) -> Option<PosQualityBytes> {
+        let quality = find_quality(&seed, challenge_index)?;
+
+        proof[..seed.len()]
+            .iter()
+            .zip(
+                seed.iter()
+                    .chain(iter::repeat(quality.quality.iter()).flatten()),
+            )
+            .all(|(a, b)| a == b)
+            .then_some(PosQualityBytes::from(quality.quality))
+    }
+}
+
+fn find_quality(seed: &PosSeed, challenge_index: u32) -> Option<ShimQuality<'_>> {
+    let quality = blake2b_256_hash(&challenge_index.to_le_bytes());
+    (U256::from_le_bytes(quality) % U256::from(3u32) > U256::zero())
+        .then_some(ShimQuality { seed, quality })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SEED: PosSeed = PosSeed::from([
+        35, 2, 52, 4, 51, 55, 23, 84, 91, 10, 111, 12, 13, 222, 151, 16, 228, 211, 254, 45, 92,
+        198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
+    ]);
+
+    #[test]
+    fn basic() {
+        let table = ShimTable::generate(&SEED);
+
+        assert!(table.find_quality(0).is_none());
+
+        {
+            let challenge_index = 2;
+            let quality = table.find_quality(challenge_index).unwrap();
+            let proof = quality.create_proof();
+            let maybe_quality = ShimTable::is_proof_valid(&SEED, challenge_index, &proof);
+            assert_eq!(maybe_quality, Some(quality.to_bytes()));
+        }
+    }
+}


### PR DESCRIPTION
More non-breaking changes extracted from local branch.

On chiapos side we now [returning quality during proof verification](https://github.com/subspace/chiapos/commit/f82464a2227f56bc565e72ce9c61659aa0c4f8b3) and [check `quality_index` to make sure it is `0`](https://github.com/subspace/chiapos/commit/3b1ab3ca24764d25da30e0c8243e0bf304b776a5).

For KZG side there is a case (in v2.3) where we have polynomial with zero coefficients at the end that can be normalized to smaller polynomial, but wanted to deal with witnesses generated for larger index (this allows us to have public parameters for 2^15, but deal with 2^16 indices). Public API of `create_witness` now requires `num_values` explicitly just like verification.

There are a few other small tweaks here and there that are all non-breaking.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
