### PR TITLE
Draft: updates for the modular block request handler change

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -720,7 +720,7 @@ where
             import_queue,
             block_announce_validator_builder: None,
             warp_sync_params: None,
-			block_relay: None,
+            block_relay: None,
         })?;
 
     let sync_oracle = sync_service.clone();

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -720,6 +720,7 @@ where
             import_queue,
             block_announce_validator_builder: None,
             warp_sync_params: None,
+			block_relay: None,
         })?;
 
     let sync_oracle = sync_service.clone();

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -347,7 +347,7 @@ where
             // TODO: we might want to re-enable this some day.
             block_announce_validator_builder: None,
             warp_sync_params: None,
-			block_relay: None,
+            block_relay: None,
         })?;
 
     let rpc_builder = {

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -347,6 +347,7 @@ where
             // TODO: we might want to re-enable this some day.
             block_announce_validator_builder: None,
             warp_sync_params: None,
+			block_relay: None,
         })?;
 
     let rpc_builder = {

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -362,6 +362,7 @@ where
             // TODO: we might want to re-enable this some day.
             block_announce_validator_builder: None,
             warp_sync_params: None,
+			block_relay: None,
         })?;
 
     let rpc_builder = {

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -362,7 +362,7 @@ where
             // TODO: we might want to re-enable this some day.
             block_announce_validator_builder: None,
             warp_sync_params: None,
-			block_relay: None,
+            block_relay: None,
         })?;
 
     let rpc_builder = {

--- a/substrate/sc-network-test/src/lib.rs
+++ b/substrate/sc-network-test/src/lib.rs
@@ -832,12 +832,9 @@ where
 
 		let fork_id = Some(String::from("test-fork-id"));
 
-		let block_request_protocol_config = {
-			let (handler, protocol_config) =
-				BlockRequestHandler::new(&protocol_id, None, client.clone(), 50);
-			self.spawn_task(handler.run().boxed());
-			protocol_config
-		};
+
+		let mut block_relay_params = BlockRequestHandler::new(&protocol_id, None, client.clone(), 50);
+		self.spawn_task(Box::pin(async move { block_relay_params.server.run().await; }));
 
 		let state_request_protocol_config = {
 			let (handler, protocol_config) =
@@ -898,7 +895,7 @@ where
 				Some(warp_sync_params),
 				chain_sync_network_handle,
 				import_queue.service(),
-				block_request_protocol_config.name.clone(),
+				block_relay_params.downloader,
 				state_request_protocol_config.name.clone(),
 				Some(warp_protocol_config.name.clone()),
 				rx,
@@ -923,7 +920,7 @@ where
 			block_announce_config,
 			tx,
 			request_response_protocol_configs: [
-				block_request_protocol_config,
+				block_relay_params.request_response_config,
 				state_request_protocol_config,
 				light_client_request_protocol_config,
 				warp_protocol_config,

--- a/substrate/sc-network-test/src/service.rs
+++ b/substrate/sc-network-test/src/service.rs
@@ -154,12 +154,10 @@ impl TestNetworkBuilder {
 		let protocol_id = ProtocolId::from("test-protocol-name");
 		let fork_id = Some(String::from("test-fork-id"));
 
-		let block_request_protocol_config = {
-			let (handler, protocol_config) =
-				BlockRequestHandler::new(&protocol_id, None, client.clone(), 50);
-			tokio::spawn(handler.run().boxed());
-			protocol_config
-		};
+		let mut block_relay_params = BlockRequestHandler::new(&protocol_id, None, client.clone(), 50);
+		tokio::spawn(async move {
+			block_relay_params.server.run().await;
+		});
 
 		let state_request_protocol_config = {
 			let (handler, protocol_config) =
@@ -190,7 +188,7 @@ impl TestNetworkBuilder {
 			None,
 			chain_sync_network_handle,
 			import_queue.service(),
-			block_request_protocol_config.name.clone(),
+			block_relay_params.downloader,
 			state_request_protocol_config.name.clone(),
 			None,
 			rx,
@@ -215,7 +213,7 @@ impl TestNetworkBuilder {
 			fork_id,
 			metrics_registry: None,
 			request_response_protocol_configs: [
-				block_request_protocol_config,
+				block_relay_params.request_response_config,
 				state_request_protocol_config,
 				light_client_request_protocol_config,
 			]


### PR DESCRIPTION
https://github.com/subspace/substrate/pull/48 is a breaking change. This PR is needed to fix it.

This PR just makes the config changes, but still uses the default substrate block request handler. The draft status will be removed when #48 is merged in the subspace-v4 branch

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
