### PR TITLE
Refactor subspace-fraud-proof

### DIFF
--- a/crates/subspace-fraud-proof/src/domain_extrinsics_builder.rs
+++ b/crates/subspace-fraud-proof/src/domain_extrinsics_builder.rs
@@ -1,0 +1,187 @@
+//! This module defines a trait for building the domain extrinsics from the original
+//! primary block and provides the implementation for both system domain and core domain.
+
+use domain_block_preprocessor::runtime_api_light::RuntimeApiLight;
+use domain_block_preprocessor::{CoreDomainBlockPreprocessor, SystemDomainBlockPreprocessor};
+use domain_runtime_primitives::opaque::Block;
+use sc_client_api::{BlockBackend, HeaderBackend};
+use sp_api::ProvideRuntimeApi;
+use sp_core::traits::CodeExecutor;
+use sp_core::H256;
+use sp_domains::{DomainId, ExecutorApi};
+use sp_messenger::MessengerApi;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::marker::PhantomData;
+use std::sync::Arc;
+use system_runtime_primitives::SystemDomainApi;
+
+/// Trait to build the extrinsics of domain block derived from the original primary block.
+pub trait BuildDomainExtrinsics<PBlock: BlockT> {
+    /// Returns the final list of encoded domain-specific extrinsics.
+    fn build_domain_extrinsics(
+        &self,
+        domain_id: DomainId,
+        primary_hash: PBlock::Hash,
+        domain_runtime: Vec<u8>,
+    ) -> sp_blockchain::Result<Vec<Vec<u8>>>;
+}
+
+/// Utility to build the system domain extrinsics.
+pub struct SystemDomainExtrinsicsBuilder<PBlock, PClient, Executor> {
+    primary_chain_client: Arc<PClient>,
+    executor: Arc<Executor>,
+    _phantom: PhantomData<PBlock>,
+}
+
+impl<PBlock, PClient, Executor> SystemDomainExtrinsicsBuilder<PBlock, PClient, Executor>
+where
+    PBlock: BlockT,
+    PBlock::Hash: From<H256>,
+    PClient: HeaderBackend<PBlock>
+        + BlockBackend<PBlock>
+        + ProvideRuntimeApi<PBlock>
+        + Send
+        + Sync
+        + 'static,
+    PClient::Api: ExecutorApi<PBlock, domain_runtime_primitives::Hash>,
+    Executor: CodeExecutor,
+{
+    /// Constructs a new instance of [`SystemDomainExtrinsicsBuilder`].
+    pub fn new(primary_chain_client: Arc<PClient>, executor: Arc<Executor>) -> Self {
+        Self {
+            primary_chain_client,
+            executor,
+            _phantom: Default::default(),
+        }
+    }
+
+    fn build_system_domain_extrinsics(
+        &self,
+        primary_hash: PBlock::Hash,
+        runtime_code: Vec<u8>,
+    ) -> sp_blockchain::Result<Vec<Vec<u8>>> {
+        let system_runtime_api_light =
+            RuntimeApiLight::new(self.executor.clone(), runtime_code.into());
+        let domain_extrinsics = SystemDomainBlockPreprocessor::<Block, _, _, _>::new(
+            self.primary_chain_client.clone(),
+            system_runtime_api_light,
+        )
+        .preprocess_primary_block_for_verifier(primary_hash)?;
+        Ok(domain_extrinsics)
+    }
+}
+
+impl<PBlock, PClient, Executor> BuildDomainExtrinsics<PBlock>
+    for SystemDomainExtrinsicsBuilder<PBlock, PClient, Executor>
+where
+    PBlock: BlockT,
+    PBlock::Hash: From<H256>,
+    PClient: HeaderBackend<PBlock>
+        + BlockBackend<PBlock>
+        + ProvideRuntimeApi<PBlock>
+        + Send
+        + Sync
+        + 'static,
+    PClient::Api: ExecutorApi<PBlock, domain_runtime_primitives::Hash>,
+    Executor: CodeExecutor,
+{
+    fn build_domain_extrinsics(
+        &self,
+        _domain_id: DomainId,
+        primary_hash: <PBlock as BlockT>::Hash,
+        domain_runtime: Vec<u8>,
+    ) -> sp_blockchain::Result<Vec<Vec<u8>>> {
+        self.build_system_domain_extrinsics(primary_hash, domain_runtime)
+    }
+}
+
+/// Utility to build the core domain extrinsics.
+pub struct CoreDomainExtrinsicsBuilder<PBlock, SBlock, PClient, SClient, Executor> {
+    primary_chain_client: Arc<PClient>,
+    system_domain_client: Arc<SClient>,
+    executor: Arc<Executor>,
+    _phantom: PhantomData<(PBlock, SBlock)>,
+}
+
+impl<PBlock, SBlock, PClient, SClient, Executor>
+    CoreDomainExtrinsicsBuilder<PBlock, SBlock, PClient, SClient, Executor>
+where
+    PBlock: BlockT,
+    PBlock::Hash: From<H256>,
+    SBlock: BlockT,
+    NumberFor<SBlock>: From<NumberFor<Block>>,
+    SBlock::Hash: From<<Block as BlockT>::Hash>,
+    PClient: HeaderBackend<PBlock>
+        + BlockBackend<PBlock>
+        + ProvideRuntimeApi<PBlock>
+        + Send
+        + Sync
+        + 'static,
+    PClient::Api: ExecutorApi<PBlock, <Block as BlockT>::Hash>,
+    SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock> + 'static,
+    SClient::Api: SystemDomainApi<SBlock, NumberFor<PBlock>, PBlock::Hash>
+        + MessengerApi<SBlock, NumberFor<SBlock>>,
+    Executor: CodeExecutor,
+{
+    /// Constructs a new instance of [`CoreDomainExtrinsicsBuilder`].
+    pub fn new(
+        primary_chain_client: Arc<PClient>,
+        system_domain_client: Arc<SClient>,
+        executor: Arc<Executor>,
+    ) -> Self {
+        Self {
+            primary_chain_client,
+            system_domain_client,
+            executor,
+            _phantom: Default::default(),
+        }
+    }
+
+    fn build_core_domain_extrinsics(
+        &self,
+        domain_id: DomainId,
+        primary_hash: PBlock::Hash,
+        runtime_code: Vec<u8>,
+    ) -> sp_blockchain::Result<Vec<Vec<u8>>> {
+        let core_runtime_api_light =
+            RuntimeApiLight::new(self.executor.clone(), runtime_code.into());
+        let domain_extrinsics = CoreDomainBlockPreprocessor::<Block, _, _, _, _, _>::new(
+            domain_id,
+            core_runtime_api_light,
+            self.primary_chain_client.clone(),
+            self.system_domain_client.clone(),
+        )
+        .preprocess_primary_block_for_verifier(primary_hash)?;
+        Ok(domain_extrinsics)
+    }
+}
+
+impl<PBlock, SBlock, PClient, SClient, Executor> BuildDomainExtrinsics<PBlock>
+    for CoreDomainExtrinsicsBuilder<PBlock, SBlock, PClient, SClient, Executor>
+where
+    PBlock: BlockT,
+    PBlock::Hash: From<H256>,
+    SBlock: BlockT,
+    NumberFor<SBlock>: From<NumberFor<Block>>,
+    SBlock::Hash: From<<Block as BlockT>::Hash>,
+    PClient: HeaderBackend<PBlock>
+        + BlockBackend<PBlock>
+        + ProvideRuntimeApi<PBlock>
+        + Send
+        + Sync
+        + 'static,
+    PClient::Api: ExecutorApi<PBlock, <Block as BlockT>::Hash>,
+    SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock> + 'static,
+    SClient::Api: SystemDomainApi<SBlock, NumberFor<PBlock>, PBlock::Hash>
+        + MessengerApi<SBlock, NumberFor<SBlock>>,
+    Executor: CodeExecutor,
+{
+    fn build_domain_extrinsics(
+        &self,
+        domain_id: DomainId,
+        primary_hash: <PBlock as BlockT>::Hash,
+        domain_runtime: Vec<u8>,
+    ) -> sp_blockchain::Result<Vec<Vec<u8>>> {
+        self.build_core_domain_extrinsics(domain_id, primary_hash, domain_runtime)
+    }
+}

--- a/crates/subspace-fraud-proof/src/domain_runtime_code.rs
+++ b/crates/subspace-fraud-proof/src/domain_runtime_code.rs
@@ -1,0 +1,68 @@
+use codec::{Decode, Encode};
+use sp_api::ProvideRuntimeApi;
+use sp_core::traits::FetchRuntimeCode;
+use sp_domains::fraud_proof::VerificationError;
+use sp_domains::{DomainId, ExecutorApi};
+use sp_runtime::traits::Block as BlockT;
+use std::borrow::Cow;
+use std::sync::Arc;
+use subspace_wasm_tools::read_core_domain_runtime_blob;
+
+pub(crate) struct RuntimeCodeFetcher<'a> {
+    pub(crate) wasm_bundle: &'a [u8],
+}
+
+impl<'a> FetchRuntimeCode for RuntimeCodeFetcher<'a> {
+    fn fetch_runtime_code(&self) -> Option<Cow<[u8]>> {
+        Some(self.wasm_bundle.into())
+    }
+}
+
+pub(crate) struct DomainRuntimeCode {
+    pub(crate) wasm_bundle: Cow<'static, [u8]>,
+}
+
+impl DomainRuntimeCode {
+    pub(crate) fn as_runtime_code_fetcher(&self) -> RuntimeCodeFetcher {
+        RuntimeCodeFetcher {
+            wasm_bundle: &self.wasm_bundle,
+        }
+    }
+}
+
+pub(crate) fn retrieve_domain_runtime_code<PBlock, PClient, Hash>(
+    domain_id: DomainId,
+    at: PBlock::Hash,
+    primary_chain_client: &Arc<PClient>,
+) -> Result<DomainRuntimeCode, VerificationError>
+where
+    PBlock: BlockT,
+    Hash: Encode + Decode,
+    PClient: ProvideRuntimeApi<PBlock>,
+    PClient::Api: ExecutorApi<PBlock, Hash>,
+{
+    let system_wasm_bundle = primary_chain_client
+        .runtime_api()
+        .system_domain_wasm_bundle(at)
+        .map_err(VerificationError::RuntimeApi)?;
+
+    let wasm_bundle = match domain_id {
+        DomainId::SYSTEM => system_wasm_bundle,
+        DomainId::CORE_PAYMENTS | DomainId::CORE_ETH_RELAY => {
+            read_core_domain_runtime_blob(system_wasm_bundle.as_ref(), domain_id)
+                .map_err(|err| {
+                    VerificationError::RuntimeCode(format!(
+                        "failed to read core domain {domain_id:?} runtime blob file, error {err:?}"
+                    ))
+                })?
+                .into()
+        }
+        _ => {
+            return Err(VerificationError::RuntimeCode(format!(
+                "No runtime code for {domain_id:?}"
+            )));
+        }
+    };
+
+    Ok(DomainRuntimeCode { wasm_bundle })
+}

--- a/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
+++ b/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
@@ -189,14 +189,14 @@ where
 /// Invalid state transition proof verifier.
 pub struct InvalidStateTransitionProofVerifier<
     PBlock,
-    C,
+    PClient,
     Exec,
     Spawn,
     Hash,
     VerifierClient,
     DomainExtrinsicsBuilder,
 > {
-    client: Arc<C>,
+    primary_chain_client: Arc<PClient>,
     executor: Exec,
     spawn_handle: Spawn,
     verifier_client: VerifierClient,
@@ -204,10 +204,10 @@ pub struct InvalidStateTransitionProofVerifier<
     _phantom: PhantomData<(PBlock, Hash)>,
 }
 
-impl<PBlock, C, Exec, Spawn, Hash, VerifierClient, DomainExtrinsicsBuilder> Clone
+impl<PBlock, PClient, Exec, Spawn, Hash, VerifierClient, DomainExtrinsicsBuilder> Clone
     for InvalidStateTransitionProofVerifier<
         PBlock,
-        C,
+        PClient,
         Exec,
         Spawn,
         Hash,
@@ -222,7 +222,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            client: self.client.clone(),
+            primary_chain_client: self.primary_chain_client.clone(),
             executor: self.executor.clone(),
             spawn_handle: self.spawn_handle.clone(),
             verifier_client: self.verifier_client.clone(),
@@ -232,10 +232,10 @@ where
     }
 }
 
-impl<PBlock, C, Exec, Spawn, Hash, VerifierClient, DomainExtrinsicsBuilder>
+impl<PBlock, PClient, Exec, Spawn, Hash, VerifierClient, DomainExtrinsicsBuilder>
     InvalidStateTransitionProofVerifier<
         PBlock,
-        C,
+        PClient,
         Exec,
         Spawn,
         Hash,
@@ -245,8 +245,8 @@ impl<PBlock, C, Exec, Spawn, Hash, VerifierClient, DomainExtrinsicsBuilder>
 where
     PBlock: BlockT,
     H256: Into<PBlock::Hash>,
-    C: ProvideRuntimeApi<PBlock> + Send + Sync,
-    C::Api: ExecutorApi<PBlock, Hash>,
+    PClient: ProvideRuntimeApi<PBlock> + Send + Sync,
+    PClient::Api: ExecutorApi<PBlock, Hash>,
     Exec: CodeExecutor + Clone + 'static,
     Spawn: SpawnNamed + Clone + Send + 'static,
     Hash: Encode + Decode,
@@ -255,14 +255,14 @@ where
 {
     /// Constructs a new instance of [`InvalidStateTransitionProofVerifier`].
     pub fn new(
-        client: Arc<C>,
+        primary_chain_client: Arc<PClient>,
         executor: Exec,
         spawn_handle: Spawn,
         verifier_client: VerifierClient,
         domain_extrinsics_builder: DomainExtrinsicsBuilder,
     ) -> Self {
         Self {
-            client,
+            primary_chain_client,
             executor,
             spawn_handle,
             verifier_client,
@@ -296,7 +296,7 @@ where
         let domain_runtime_code = crate::domain_runtime_code::retrieve_domain_runtime_code(
             *domain_id,
             (*primary_parent_hash).into(),
-            &self.client,
+            &self.primary_chain_client,
         )?;
 
         let runtime_code = RuntimeCode {

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs)]
 
+pub mod domain_extrinsics_builder;
 pub mod invalid_state_transition_proof;
 #[cfg(test)]
 mod tests;

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 
 pub mod domain_extrinsics_builder;
+mod domain_runtime_code;
 pub mod invalid_state_transition_proof;
 #[cfg(test)]
 mod tests;

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -19,21 +19,23 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// Verify fraud proof.
-pub trait VerifyFraudProof<FPBlock: BlockT> {
+///
+/// Verifier is either the primary chain client or the system domain client.
+pub trait VerifyFraudProof<VerifierBlock: BlockT> {
     /// Verifies fraud proof.
     fn verify_fraud_proof(
         &self,
-        proof: &FraudProof<NumberFor<FPBlock>, FPBlock::Hash>,
+        proof: &FraudProof<NumberFor<VerifierBlock>, VerifierBlock::Hash>,
     ) -> Result<(), VerificationError>;
 }
 
 /// Fraud proof verifier.
-pub struct ProofVerifier<FPBlock, ISTPVerifier> {
+pub struct ProofVerifier<VerifierBlock, ISTPVerifier> {
     invalid_state_transition_proof_verifier: Arc<ISTPVerifier>,
-    _phantom: PhantomData<FPBlock>,
+    _phantom: PhantomData<VerifierBlock>,
 }
 
-impl<FPBlock, ISTPVerifier> Clone for ProofVerifier<FPBlock, ISTPVerifier> {
+impl<VerifierBlock, ISTPVerifier> Clone for ProofVerifier<VerifierBlock, ISTPVerifier> {
     fn clone(&self) -> Self {
         Self {
             invalid_state_transition_proof_verifier: self
@@ -44,9 +46,9 @@ impl<FPBlock, ISTPVerifier> Clone for ProofVerifier<FPBlock, ISTPVerifier> {
     }
 }
 
-impl<FPBlock, ISTPVerifier> ProofVerifier<FPBlock, ISTPVerifier>
+impl<VerifierBlock, ISTPVerifier> ProofVerifier<VerifierBlock, ISTPVerifier>
 where
-    FPBlock: BlockT,
+    VerifierBlock: BlockT,
     ISTPVerifier: VerifyInvalidStateTransitionProof,
 {
     /// Constructs a new instance of [`ProofVerifier`].
@@ -60,7 +62,7 @@ where
     /// Verifies the fraud proof.
     pub fn verify(
         &self,
-        fraud_proof: &FraudProof<NumberFor<FPBlock>, FPBlock::Hash>,
+        fraud_proof: &FraudProof<NumberFor<VerifierBlock>, VerifierBlock::Hash>,
     ) -> Result<(), VerificationError> {
         match fraud_proof {
             FraudProof::InvalidStateTransition(proof) => self
@@ -71,14 +73,15 @@ where
     }
 }
 
-impl<FPBlock, ISTPVerifier> VerifyFraudProof<FPBlock> for ProofVerifier<FPBlock, ISTPVerifier>
+impl<VerifierBlock, ISTPVerifier> VerifyFraudProof<VerifierBlock>
+    for ProofVerifier<VerifierBlock, ISTPVerifier>
 where
-    FPBlock: BlockT,
+    VerifierBlock: BlockT,
     ISTPVerifier: VerifyInvalidStateTransitionProof,
 {
     fn verify_fraud_proof(
         &self,
-        proof: &FraudProof<NumberFor<FPBlock>, FPBlock::Hash>,
+        proof: &FraudProof<NumberFor<VerifierBlock>, VerifierBlock::Hash>,
     ) -> Result<(), VerificationError> {
         self.verify(proof)
     }

--- a/crates/subspace-fraud-proof/src/lib.rs
+++ b/crates/subspace-fraud-proof/src/lib.rs
@@ -7,6 +7,7 @@ mod domain_runtime_code;
 pub mod invalid_state_transition_proof;
 #[cfg(test)]
 mod tests;
+pub mod verifier_api;
 
 use futures::channel::oneshot;
 use futures::FutureExt;

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -1,6 +1,6 @@
+use crate::domain_extrinsics_builder::SystemDomainExtrinsicsBuilder;
 use crate::invalid_state_transition_proof::{
-    ExecutionProver, InvalidStateTransitionProofVerifier, SystemDomainExtrinsicsBuilder,
-    VerifyPrePostStateRoot,
+    ExecutionProver, InvalidStateTransitionProofVerifier, VerifyPrePostStateRoot,
 };
 use crate::ProofVerifier;
 use codec::Encode;

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -1,7 +1,6 @@
 use crate::domain_extrinsics_builder::SystemDomainExtrinsicsBuilder;
-use crate::invalid_state_transition_proof::{
-    ExecutionProver, InvalidStateTransitionProofVerifier, VerifyPrePostStateRoot,
-};
+use crate::invalid_state_transition_proof::{ExecutionProver, InvalidStateTransitionProofVerifier};
+use crate::verifier_api::VerifierApi;
 use crate::ProofVerifier;
 use codec::Encode;
 use domain_block_builder::{BlockBuilder, RecordProof};
@@ -25,11 +24,11 @@ use subspace_test_client::Client;
 use subspace_test_service::mock::MockPrimaryNode;
 use tempfile::TempDir;
 
-struct SkipPreStateRootVerification {
+struct TestVerifierClient {
     primary_chain_client: Arc<Client>,
 }
 
-impl SkipPreStateRootVerification {
+impl TestVerifierClient {
     fn new(primary_chain_client: Arc<Client>) -> Self {
         Self {
             primary_chain_client,
@@ -37,7 +36,7 @@ impl SkipPreStateRootVerification {
     }
 }
 
-impl VerifyPrePostStateRoot for SkipPreStateRootVerification {
+impl VerifierApi for TestVerifierClient {
     fn verify_pre_state_root(
         &self,
         _invalid_state_transition_proof: &InvalidStateTransitionProof,
@@ -263,7 +262,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         ferdie.client.clone(),
         ferdie.executor.clone(),
         ferdie.task_manager.spawn_handle(),
-        SkipPreStateRootVerification::new(ferdie.client.clone()),
+        TestVerifierClient::new(ferdie.client.clone()),
         SystemDomainExtrinsicsBuilder::new(
             ferdie.client.clone(),
             Arc::new(ferdie.executor.clone()),
@@ -565,7 +564,7 @@ async fn invalid_execution_proof_should_not_work() {
         ferdie.client.clone(),
         ferdie.executor.clone(),
         ferdie.task_manager.spawn_handle(),
-        SkipPreStateRootVerification::new(ferdie.client.clone()),
+        TestVerifierClient::new(ferdie.client.clone()),
         SystemDomainExtrinsicsBuilder::new(
             ferdie.client.clone(),
             Arc::new(ferdie.executor.clone()),

--- a/crates/subspace-fraud-proof/src/verifier_api.rs
+++ b/crates/subspace-fraud-proof/src/verifier_api.rs
@@ -1,0 +1,176 @@
+//! This module derives an trait [`VerifierApi`] from the runtime api `ReceiptsApi`
+//! as well as the implementation to provide convenient interfaces used in the fraud
+//! proof verification.
+
+use codec::{Decode, Encode};
+use sc_client_api::HeaderBackend;
+use sp_api::ProvideRuntimeApi;
+use sp_core::H256;
+use sp_domains::fraud_proof::{ExecutionPhase, InvalidStateTransitionProof, VerificationError};
+use sp_domains::DomainId;
+use sp_receipts::ReceiptsApi;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// This trait abstracts convenient APIs for the fraud proof verifier.
+pub trait VerifierApi {
+    /// Verifies whether `pre_state_root` declared in the proof is same as the one recorded on chain.
+    fn verify_pre_state_root(
+        &self,
+        invalid_state_transition_proof: &InvalidStateTransitionProof,
+    ) -> Result<(), VerificationError>;
+
+    /// Verifies whether `post_state_root` declared in the proof is different from the one recorded on chain.
+    fn verify_post_state_root(
+        &self,
+        invalid_state_transition_proof: &InvalidStateTransitionProof,
+    ) -> Result<(), VerificationError>;
+
+    /// Returns the hash of primary block at height `domain_block_number`.
+    fn primary_hash(
+        &self,
+        domain_id: DomainId,
+        domain_block_number: u32,
+    ) -> Result<H256, VerificationError>;
+}
+
+/// A wrapper of primary chain client/system domain client in common.
+///
+/// Both primary chain client and system domain client maintains the state of receipts, i.e., implements `ReceiptsApi`.
+pub struct VerifierClient<Client, Block> {
+    client: Arc<Client>,
+    _phantom: PhantomData<Block>,
+}
+
+impl<Client, Block> Clone for VerifierClient<Client, Block> {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            _phantom: self._phantom,
+        }
+    }
+}
+
+impl<Client, Block> VerifierClient<Client, Block> {
+    /// Constructs a new instance of [`VerifierClient`].
+    pub fn new(client: Arc<Client>) -> Self {
+        Self {
+            client,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<Client, Block> VerifierApi for VerifierClient<Client, Block>
+where
+    Block: BlockT,
+    Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+    Client::Api: ReceiptsApi<Block, domain_runtime_primitives::Hash>,
+{
+    // TODO: It's not necessary to require `pre_state_root` in the proof and then verify, it can
+    // be just retrieved by the verifier itself according the execution phase, which requires some
+    // fixes in tests however, we can do this refactoring once we have or are able to construct a
+    // proper `VerifierApi` implementation in test.
+    //
+    // Related: https://github.com/subspace/subspace/pull/1240#issuecomment-1476212007
+    fn verify_pre_state_root(
+        &self,
+        invalid_state_transition_proof: &InvalidStateTransitionProof,
+    ) -> Result<(), VerificationError> {
+        let InvalidStateTransitionProof {
+            domain_id,
+            parent_number,
+            bad_receipt_hash,
+            pre_state_root,
+            execution_phase,
+            ..
+        } = invalid_state_transition_proof;
+
+        let pre_state_root_onchain = match execution_phase {
+            ExecutionPhase::InitializeBlock { domain_parent_hash } => {
+                self.client.runtime_api().state_root(
+                    self.client.info().best_hash,
+                    *domain_id,
+                    NumberFor::<Block>::from(*parent_number),
+                    Block::Hash::decode(&mut domain_parent_hash.encode().as_slice())?,
+                )?
+            }
+            ExecutionPhase::ApplyExtrinsic(trace_index_of_pre_state_root)
+            | ExecutionPhase::FinalizeBlock {
+                total_extrinsics: trace_index_of_pre_state_root,
+            } => {
+                let trace = self.client.runtime_api().execution_trace(
+                    self.client.info().best_hash,
+                    *domain_id,
+                    *bad_receipt_hash,
+                )?;
+
+                trace.get(*trace_index_of_pre_state_root as usize).copied()
+            }
+        };
+
+        match pre_state_root_onchain {
+            Some(expected_pre_state_root) if expected_pre_state_root == *pre_state_root => Ok(()),
+            res => {
+                tracing::debug!(
+                    "Invalid `pre_state_root` in InvalidStateTransitionProof for {domain_id:?}, expected: {res:?}, got: {pre_state_root:?}",
+                );
+                Err(VerificationError::InvalidPreStateRoot)
+            }
+        }
+    }
+
+    fn verify_post_state_root(
+        &self,
+        invalid_state_transition_proof: &InvalidStateTransitionProof,
+    ) -> Result<(), VerificationError> {
+        let InvalidStateTransitionProof {
+            domain_id,
+            bad_receipt_hash,
+            execution_phase,
+            post_state_root,
+            ..
+        } = invalid_state_transition_proof;
+
+        let trace = self.client.runtime_api().execution_trace(
+            self.client.info().best_hash,
+            *domain_id,
+            *bad_receipt_hash,
+        )?;
+
+        let post_state_root_onchain = match execution_phase {
+            ExecutionPhase::InitializeBlock { .. } => trace
+                .get(0)
+                .ok_or(VerificationError::PostStateRootNotFound)?,
+            ExecutionPhase::ApplyExtrinsic(trace_index_of_post_state_root)
+            | ExecutionPhase::FinalizeBlock {
+                total_extrinsics: trace_index_of_post_state_root,
+            } => trace
+                .get(*trace_index_of_post_state_root as usize + 1)
+                .ok_or(VerificationError::PostStateRootNotFound)?,
+        };
+
+        if post_state_root_onchain == post_state_root {
+            Err(VerificationError::SamePostStateRoot)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn primary_hash(
+        &self,
+        domain_id: DomainId,
+        domain_block_number: u32,
+    ) -> Result<H256, VerificationError> {
+        self.client
+            .runtime_api()
+            .primary_hash(
+                self.client.info().best_hash,
+                domain_id,
+                domain_block_number.into(),
+            )?
+            .and_then(|primary_hash| Decode::decode(&mut primary_hash.encode().as_slice()).ok())
+            .ok_or(VerificationError::PrimaryHashNotFound)
+    }
+}

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -76,9 +76,8 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
-use subspace_fraud_proof::invalid_state_transition_proof::{
-    PrePostStateRootVerifier, SystemDomainExtrinsicsBuilder,
-};
+use subspace_fraud_proof::domain_extrinsics_builder::SystemDomainExtrinsicsBuilder;
+use subspace_fraud_proof::invalid_state_transition_proof::PrePostStateRootVerifier;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::utils::online_status_informer;

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -77,7 +77,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_fraud_proof::domain_extrinsics_builder::SystemDomainExtrinsicsBuilder;
-use subspace_fraud_proof::invalid_state_transition_proof::PrePostStateRootVerifier;
+use subspace_fraud_proof::verifier_api::VerifierClient;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::utils::online_status_informer;
@@ -138,7 +138,7 @@ pub type InvalidStateTransitionProofVerifier<RuntimeApi, ExecutorDispatch> =
         NativeElseWasmExecutor<ExecutorDispatch>,
         SpawnTaskHandle,
         Hash,
-        PrePostStateRootVerifier<FullClient<RuntimeApi, ExecutorDispatch>, Block>,
+        VerifierClient<FullClient<RuntimeApi, ExecutorDispatch>, Block>,
         SystemDomainExtrinsicsBuilder<
             Block,
             FullClient<RuntimeApi, ExecutorDispatch>,
@@ -310,7 +310,7 @@ where
             client.clone(),
             executor.clone(),
             task_manager.spawn_handle(),
-            PrePostStateRootVerifier::new(client.clone()),
+            VerifierClient::new(client.clone()),
             SystemDomainExtrinsicsBuilder::new(client.clone(), Arc::new(executor)),
         ),
     ));

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -39,9 +39,8 @@ use sp_session::SessionKeys;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
 use subspace_core_primitives::Blake2b256Hash;
-use subspace_fraud_proof::invalid_state_transition_proof::{
-    CoreDomainExtrinsicsBuilder, PrePostStateRootVerifier,
-};
+use subspace_fraud_proof::domain_extrinsics_builder::CoreDomainExtrinsicsBuilder;
+use subspace_fraud_proof::invalid_state_transition_proof::PrePostStateRootVerifier;
 use subspace_runtime_primitives::Index as Nonce;
 use substrate_frame_rpc_system::AccountNonceApi;
 use system_runtime_primitives::SystemDomainApi;

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -40,7 +40,7 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
 use subspace_core_primitives::Blake2b256Hash;
 use subspace_fraud_proof::domain_extrinsics_builder::CoreDomainExtrinsicsBuilder;
-use subspace_fraud_proof::invalid_state_transition_proof::PrePostStateRootVerifier;
+use subspace_fraud_proof::verifier_api::VerifierClient;
 use subspace_runtime_primitives::Index as Nonce;
 use substrate_frame_rpc_system::AccountNonceApi;
 use system_runtime_primitives::SystemDomainApi;
@@ -131,7 +131,7 @@ type InvalidStateTransitionProofVerifier<PBlock, PClient, RuntimeApi, Executor> 
         NativeElseWasmExecutor<Executor>,
         SpawnTaskHandle,
         Hash,
-        PrePostStateRootVerifier<FullClient<Block, RuntimeApi, Executor>, Block>,
+        VerifierClient<FullClient<Block, RuntimeApi, Executor>, Block>,
         CoreDomainExtrinsicsBuilder<
             PBlock,
             Block,
@@ -229,7 +229,7 @@ where
             primary_chain_client.clone(),
             executor.clone(),
             task_manager.spawn_handle(),
-            PrePostStateRootVerifier::new(client.clone()),
+            VerifierClient::new(client.clone()),
             CoreDomainExtrinsicsBuilder::new(
                 primary_chain_client.clone(),
                 client.clone(),

--- a/test/subspace-test-service/src/mock.rs
+++ b/test/subspace-test-service/src/mock.rs
@@ -32,8 +32,9 @@ use std::error::Error;
 use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::{Blake2b256Hash, Solution};
+use subspace_fraud_proof::domain_extrinsics_builder::SystemDomainExtrinsicsBuilder;
 use subspace_fraud_proof::invalid_state_transition_proof::{
-    InvalidStateTransitionProofVerifier, PrePostStateRootVerifier, SystemDomainExtrinsicsBuilder,
+    InvalidStateTransitionProofVerifier, PrePostStateRootVerifier,
 };
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Hash};

--- a/test/subspace-test-service/src/mock.rs
+++ b/test/subspace-test-service/src/mock.rs
@@ -33,9 +33,8 @@ use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::{Blake2b256Hash, Solution};
 use subspace_fraud_proof::domain_extrinsics_builder::SystemDomainExtrinsicsBuilder;
-use subspace_fraud_proof::invalid_state_transition_proof::{
-    InvalidStateTransitionProofVerifier, PrePostStateRootVerifier,
-};
+use subspace_fraud_proof::invalid_state_transition_proof::InvalidStateTransitionProofVerifier;
+use subspace_fraud_proof::verifier_api::VerifierClient;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Hash};
 use subspace_service::tx_pre_validator::PrimaryChainTxPreValidator;
@@ -116,7 +115,7 @@ impl MockPrimaryNode {
                 client.clone(),
                 executor.clone(),
                 task_manager.spawn_handle(),
-                PrePostStateRootVerifier::new(client.clone()),
+                VerifierClient::new(client.clone()),
                 SystemDomainExtrinsicsBuilder::new(client.clone(), Arc::new(executor.clone())),
             ),
         ));


### PR DESCRIPTION
This PR is a pure refactoring, aiming to extract the shared components in the fraud proof verification from the existing `invalid_state_transition_proof` module. `VerifierApi` in the `verifier_api` module will be extended with a new method `state_root(domain_id, domain_block_number, domain_block_hash)` for the upcoming invalid transaction proof verifier. 

Feel free to share any thoughts on the verifier_api abstraction as I'm not honestly satisfied with it too.

Part of #1228 (still trying to figure out some problems popped while working on the tests).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
