### PR TITLE
Bump ReceiptsApi version for gemini-3d

### DIFF
--- a/crates/sp-receipts/src/lib.rs
+++ b/crates/sp-receipts/src/lib.rs
@@ -24,6 +24,7 @@ use sp_runtime::traits::NumberFor;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
+    #[api_version(2)]
     pub trait ReceiptsApi<DomainHash: Encode + Decode> {
         /// Returns the trace of given domain receipt hash.
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<DomainHash>;

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -403,11 +403,29 @@ where
     let spawn_essential = task_manager.spawn_essential_handle();
     let (bundle_sender, bundle_receiver) = tracing_unbounded("system_domain_bundle_stream", 100);
 
-    let domain_confirmation_depth = primary_chain_client
+    let primary_chain_best_hash = primary_chain_client.info().best_hash;
+    let receipts_api_version = primary_chain_client
         .runtime_api()
-        .receipts_pruning_depth(primary_chain_client.info().best_hash)
-        .map_err(|err| sc_service::error::Error::Application(Box::new(err)))?
-        .into();
+        .api_version::<dyn ReceiptsApi<Block, Hash>>(primary_chain_best_hash)
+        .ok()
+        .flatten()
+        .ok_or_else(|| {
+            sp_blockchain::Error::RuntimeApiError(sp_api::ApiError::Application(
+                format!("Could not find `ReceiptsApi` api version at {primary_chain_best_hash}.",)
+                    .into(),
+            ))
+        })?;
+
+    let domain_confirmation_depth = if receipts_api_version >= 2 {
+        primary_chain_client
+            .runtime_api()
+            .receipts_pruning_depth(primary_chain_best_hash)
+            .map_err(|err| sc_service::error::Error::Application(Box::new(err)))?
+            .into()
+    } else {
+        // TODO: Remove the api version check once gemini-3d is retired.
+        256u32
+    };
 
     let executor = SystemExecutor::new(
         Box::new(task_manager.spawn_essential_handle()),


### PR DESCRIPTION
This PR fixes the compatibility issue for gemini-3d caused by recent changes in `ReceiptsApi`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
