### PR TITLE
Disable core domain fraud proof temporarily

### DIFF
--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -404,6 +404,11 @@ where
             primary_hash,
         )?;
 
+        // Disable the fraud proof except for the system domain.
+        if !self.domain_id.is_system() {
+            return Ok(None);
+        }
+
         // TODO: The applied txs can be fully removed from the transaction pool
 
         self.check_receipts_in_primary_block(primary_hash)?;
@@ -452,7 +457,8 @@ where
                 PBlock::Hash,
             >(&*self.client, primary_block_hash)?
             .ok_or(sp_blockchain::Error::Backend(format!(
-                "receipt for primary block {primary_block_hash} not found"
+                "receipt for primary block #{},{primary_block_hash} not found",
+                execution_receipt.primary_number
             )))?;
 
             if let Some(trace_mismatch_index) =


### PR DESCRIPTION
A workaround for https://github.com/subspace/subspace/issues/1406, so that we can test other things for core domain before it's addressed.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
