### PR TITLE
Improve performance by inlining code on primitives and generally methods that should be inlined

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -85,6 +85,7 @@ mod pallet {
     }
 
     impl<T> From<BundleError> for Error<T> {
+        #[inline]
         fn from(e: BundleError) -> Self {
             Self::Bundle(e)
         }
@@ -107,6 +108,7 @@ mod pallet {
     }
 
     impl<T> From<ReceiptError> for Error<T> {
+        #[inline]
         fn from(error: ReceiptError) -> Self {
             match error {
                 ReceiptError::MissingParent => {

--- a/crates/pallet-grandpa-finality-verifier/src/tests/justification.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/tests/justification.rs
@@ -35,6 +35,7 @@ pub(crate) struct JustificationGeneratorParams<H> {
 }
 
 impl<H: HeaderT> Default for JustificationGeneratorParams<H> {
+    #[inline]
     fn default() -> Self {
         Self {
             header: test_header(One::one()),

--- a/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/tests/keyring.rs
@@ -50,6 +50,7 @@ impl Account {
 }
 
 impl From<Account> for AuthorityId {
+    #[inline]
     fn from(p: Account) -> Self {
         sp_application_crypto::UncheckedFrom::unchecked_from(p.public().to_bytes())
     }

--- a/crates/pallet-receipts/src/lib.rs
+++ b/crates/pallet-receipts/src/lib.rs
@@ -200,6 +200,7 @@ pub enum Error {
 }
 
 impl From<FraudProofError> for Error {
+    #[inline]
     fn from(e: FraudProofError) -> Self {
         Self::FraudProof(e)
     }

--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -53,6 +53,7 @@ mod pallet {
 
     #[cfg(feature = "std")]
     impl<T: Config> Default for GenesisConfig<T> {
+        #[inline]
         fn default() -> Self {
             Self {
                 enable_executor: false,

--- a/crates/pallet-subspace/src/equivocation.rs
+++ b/crates/pallet-subspace/src/equivocation.rs
@@ -98,6 +98,7 @@ pub struct EquivocationHandler<R, L> {
 }
 
 impl<R, L> Default for EquivocationHandler<R, L> {
+    #[inline]
     fn default() -> Self {
         Self {
             _phantom: Default::default(),

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -277,6 +277,7 @@ mod pallet {
 
     #[cfg(feature = "std")]
     impl Default for GenesisConfig {
+        #[inline]
         fn default() -> Self {
             Self {
                 enable_rewards: true,
@@ -1214,6 +1215,7 @@ enum CheckVoteError {
 }
 
 impl From<CheckVoteError> for TransactionValidityError {
+    #[inline]
     fn from(error: CheckVoteError) -> Self {
         TransactionValidityError::Invalid(match error {
             CheckVoteError::BlockListed => InvalidTransaction::BadSigner,

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -265,6 +265,7 @@ impl<Header> From<VerificationError<Header>> for Error<Header>
 where
     Header: HeaderT,
 {
+    #[inline]
     fn from(error: VerificationError<Header>) -> Self {
         match error {
             VerificationError::NoPreRuntimeDigest => Error::NoPreRuntimeDigest,
@@ -305,6 +306,7 @@ impl<Header> From<Error<Header>> for String
 where
     Header: HeaderT,
 {
+    #[inline]
     fn from(error: Error<Header>) -> String {
         error.to_string()
     }

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -358,6 +358,7 @@ pub enum Error {
 
 #[cfg(feature = "std")]
 impl From<Error> for String {
+    #[inline]
     fn from(error: Error) -> String {
         error.to_string()
     }

--- a/crates/sp-consensus-subspace/src/inherents.rs
+++ b/crates/sp-consensus-subspace/src/inherents.rs
@@ -115,6 +115,7 @@ impl InherentDataProvider {
 impl sp_std::ops::Deref for InherentDataProvider {
     type Target = Slot;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.data.slot
     }

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -74,6 +74,7 @@ mod app {
 pub type FarmerSignature = app::Signature;
 
 impl From<&FarmerSignature> for RewardSignature {
+    #[inline]
     fn from(signature: &FarmerSignature) -> Self {
         RewardSignature::from(
             TryInto::<[u8; REWARD_SIGNATURE_LENGTH]>::try_into(AsRef::<[u8]>::as_ref(signature))
@@ -87,6 +88,7 @@ impl From<&FarmerSignature> for RewardSignature {
 pub type FarmerPublicKey = app::Public;
 
 impl From<&FarmerPublicKey> for PublicKey {
+    #[inline]
     fn from(pub_key: &FarmerPublicKey) -> Self {
         PublicKey::from(
             TryInto::<[u8; PUBLIC_KEY_LENGTH]>::try_into(AsRef::<[u8]>::as_ref(pub_key))
@@ -291,6 +293,7 @@ pub struct SolutionRanges {
 }
 
 impl Default for SolutionRanges {
+    #[inline]
     fn default() -> Self {
         Self {
             current: u64::MAX,
@@ -357,6 +360,7 @@ impl ChainConstants {
 pub struct WrappedSolution(Solution<FarmerPublicKey, ()>);
 
 impl<RewardAddress> From<&Solution<FarmerPublicKey, RewardAddress>> for WrappedSolution {
+    #[inline]
     fn from(solution: &Solution<FarmerPublicKey, RewardAddress>) -> Self {
         Self(Solution {
             public_key: solution.public_key.clone(),
@@ -383,6 +387,7 @@ impl PassBy for WrappedSolution {
 pub struct WrappedVerifySolutionParams<'a>(Cow<'a, VerifySolutionParams>);
 
 impl<'a> From<&'a VerifySolutionParams> for WrappedVerifySolutionParams<'a> {
+    #[inline]
     fn from(value: &'a VerifySolutionParams) -> Self {
         Self(Cow::Borrowed(value))
     }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -77,12 +77,14 @@ pub type StakeWeight = u128;
 pub struct DomainId(u32);
 
 impl From<u32> for DomainId {
+    #[inline]
     fn from(x: u32) -> Self {
         Self(x)
     }
 }
 
 impl From<DomainId> for u32 {
+    #[inline]
     fn from(domain_id: DomainId) -> Self {
         domain_id.0
     }

--- a/crates/sp-domains/src/merkle_tree.rs
+++ b/crates/sp-domains/src/merkle_tree.rs
@@ -30,6 +30,7 @@ pub struct Witness {
 pub struct Blake2b256Algorithm(Blake2b<U32>);
 
 impl Default for Blake2b256Algorithm {
+    #[inline]
     fn default() -> Self {
         Self(Blake2b::new())
     }

--- a/crates/sp-domains/src/transaction.rs
+++ b/crates/sp-domains/src/transaction.rs
@@ -16,12 +16,14 @@ pub enum InvalidTransactionCode {
 }
 
 impl From<InvalidTransactionCode> for InvalidTransaction {
+    #[inline]
     fn from(invalid_code: InvalidTransactionCode) -> Self {
         InvalidTransaction::Custom(invalid_code as u8)
     }
 }
 
 impl From<InvalidTransactionCode> for TransactionValidity {
+    #[inline]
     fn from(invalid_code: InvalidTransactionCode) -> Self {
         InvalidTransaction::Custom(invalid_code as u8).into()
     }

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -259,6 +259,7 @@ pub enum ImportError<Header: HeaderT> {
 }
 
 impl<Header: HeaderT> From<DigestError> for ImportError<Header> {
+    #[inline]
     fn from(error: DigestError) -> Self {
         ImportError::DigestError(error)
     }

--- a/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
+++ b/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
@@ -24,12 +24,14 @@ pub(super) struct IncrementalRecordCommitmentsState {
 impl Deref for IncrementalRecordCommitmentsState {
     type Target = Vec<Commitment>;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.state
     }
 }
 
 impl DerefMut for IncrementalRecordCommitmentsState {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.state
     }

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -116,6 +116,7 @@ impl Encode for Scalar {
         f(&self.to_bytes())
     }
 
+    #[inline]
     fn encoded_size(&self) -> usize {
         Self::FULL_BYTES
     }
@@ -131,6 +132,7 @@ impl Decode for Scalar {
         })
     }
 
+    #[inline]
     fn encoded_fixed_size() -> Option<usize> {
         Some(Self::FULL_BYTES)
     }
@@ -152,6 +154,7 @@ impl TypeInfo for Scalar {
 }
 
 impl MaxEncodedLen for Scalar {
+    #[inline]
     fn max_encoded_len() -> usize {
         Self::FULL_BYTES
     }
@@ -187,6 +190,7 @@ mod scalar_serde {
 }
 
 impl From<&[u8; Self::SAFE_BYTES]> for Scalar {
+    #[inline]
     fn from(value: &[u8; Self::SAFE_BYTES]) -> Self {
         let mut bytes = [0u8; Self::FULL_BYTES];
         bytes[..Self::SAFE_BYTES].copy_from_slice(value);
@@ -195,6 +199,7 @@ impl From<&[u8; Self::SAFE_BYTES]> for Scalar {
 }
 
 impl From<[u8; Self::SAFE_BYTES]> for Scalar {
+    #[inline]
     fn from(value: [u8; Self::SAFE_BYTES]) -> Self {
         Self::from(&value)
     }
@@ -203,6 +208,7 @@ impl From<[u8; Self::SAFE_BYTES]> for Scalar {
 impl TryFrom<&[u8; Self::FULL_BYTES]> for Scalar {
     type Error = String;
 
+    #[inline]
     fn try_from(value: &[u8; Self::FULL_BYTES]) -> Result<Self, Self::Error> {
         Self::try_from(*value)
     }
@@ -211,6 +217,7 @@ impl TryFrom<&[u8; Self::FULL_BYTES]> for Scalar {
 impl TryFrom<[u8; Self::FULL_BYTES]> for Scalar {
     type Error = String;
 
+    #[inline]
     fn try_from(value: [u8; Self::FULL_BYTES]) -> Result<Self, Self::Error> {
         FsFr::from_scalar(value)
             .map_err(|error_code| {
@@ -221,12 +228,14 @@ impl TryFrom<[u8; Self::FULL_BYTES]> for Scalar {
 }
 
 impl From<&Scalar> for [u8; Scalar::FULL_BYTES] {
+    #[inline]
     fn from(value: &Scalar) -> Self {
         value.0.to_scalar()
     }
 }
 
 impl From<Scalar> for [u8; Scalar::FULL_BYTES] {
+    #[inline]
     fn from(value: Scalar) -> Self {
         Self::from(&value)
     }
@@ -250,6 +259,7 @@ impl Scalar {
 
     /// Convenient conversion from slice of scalar to underlying representation for efficiency
     /// purposes.
+    #[inline]
     pub fn slice_to_repr(value: &[Self]) -> &[FsFr] {
         // SAFETY: `Scalar` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -257,6 +267,7 @@ impl Scalar {
 
     /// Convenient conversion from slice of underlying representation to scalar for efficiency
     /// purposes.
+    #[inline]
     pub fn slice_from_repr(value: &[FsFr]) -> &[Self] {
         // SAFETY: `Scalar` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -278,6 +289,7 @@ impl Scalar {
 
     /// Convenient conversion from mutable slice of scalar to underlying representation for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [FsFr] {
         // SAFETY: `Scalar` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -285,6 +297,7 @@ impl Scalar {
 
     /// Convenient conversion from mutable slice of underlying representation to scalar for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_mut_from_repr(value: &mut [FsFr]) -> &mut [Self] {
         // SAFETY: `Scalar` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -121,17 +121,20 @@ impl Commitment {
     const SIZE: usize = 48;
 
     /// Convert commitment to raw bytes
+    #[inline]
     pub fn to_bytes(&self) -> [u8; Self::SIZE] {
         bytes_from_g1_rust(&self.0)
     }
 
     /// Try to deserialize commitment from raw bytes
+    #[inline]
     pub fn try_from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, String> {
         Ok(Commitment(bytes_to_g1_rust(bytes)?))
     }
 
     /// Convenient conversion from slice of commitment to underlying representation for efficiency
     /// purposes.
+    #[inline]
     pub fn slice_to_repr(value: &[Self]) -> &[FsG1] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -140,6 +143,7 @@ impl Commitment {
 
     /// Convenient conversion from slice of underlying representation to commitment for efficiency
     /// purposes.
+    #[inline]
     pub fn slice_from_repr(value: &[FsG1]) -> &[Self] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -148,6 +152,7 @@ impl Commitment {
 
     /// Convenient conversion from slice of optional commitment to underlying representation for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_option_to_repr(value: &[Option<Self>]) -> &[Option<FsG1>] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -156,6 +161,7 @@ impl Commitment {
 
     /// Convenient conversion from slice of optional underlying representation to commitment for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_option_from_repr(value: &[Option<FsG1>]) -> &[Option<Self>] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -164,6 +170,7 @@ impl Commitment {
 
     /// Convenient conversion from mutable slice of commitment to underlying representation for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [FsG1] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -172,6 +179,7 @@ impl Commitment {
 
     /// Convenient conversion from mutable slice of underlying representation to commitment for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_mut_from_repr(value: &mut [FsG1]) -> &mut [Self] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -180,6 +188,7 @@ impl Commitment {
 
     /// Convenient conversion from optional mutable slice of commitment to underlying representation
     /// for efficiency purposes.
+    #[inline]
     pub fn slice_option_mut_to_repr(value: &mut [Option<Self>]) -> &mut [Option<FsG1>] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -188,6 +197,7 @@ impl Commitment {
 
     /// Convenient conversion from optional mutable slice of underlying representation to commitment
     /// for efficiency purposes.
+    #[inline]
     pub fn slice_option_mut_from_repr(value: &mut [Option<FsG1>]) -> &mut [Option<Self>] {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
@@ -196,6 +206,7 @@ impl Commitment {
 
     /// Convenient conversion from vector of commitment to underlying representation for efficiency
     /// purposes.
+    #[inline]
     pub fn vec_to_repr(value: Vec<Self>) -> Vec<FsG1> {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         //  layout, original vector is not dropped
@@ -211,6 +222,7 @@ impl Commitment {
 
     /// Convenient conversion from vector of underlying representation to commitment for efficiency
     /// purposes.
+    #[inline]
     pub fn vec_from_repr(value: Vec<FsG1>) -> Vec<Self> {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         //  layout, original vector is not dropped
@@ -226,6 +238,7 @@ impl Commitment {
 
     /// Convenient conversion from vector of optional commitment to underlying representation for
     /// efficiency purposes.
+    #[inline]
     pub fn vec_option_to_repr(value: Vec<Option<Self>>) -> Vec<Option<FsG1>> {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         //  layout, original vector is not dropped
@@ -241,6 +254,7 @@ impl Commitment {
 
     /// Convenient conversion from vector of optional underlying representation to commitment for
     /// efficiency purposes.
+    #[inline]
     pub fn vec_option_from_repr(value: Vec<Option<FsG1>>) -> Vec<Option<Self>> {
         // SAFETY: `Commitment` is `#[repr(transparent)]` and guaranteed to have the same memory
         //  layout, original vector is not dropped
@@ -262,12 +276,14 @@ impl Hash for Commitment {
 }
 
 impl From<Commitment> for [u8; Commitment::SIZE] {
+    #[inline]
     fn from(commitment: Commitment) -> Self {
         commitment.to_bytes()
     }
 }
 
 impl From<&Commitment> for [u8; Commitment::SIZE] {
+    #[inline]
     fn from(commitment: &Commitment) -> Self {
         commitment.to_bytes()
     }
@@ -276,6 +292,7 @@ impl From<&Commitment> for [u8; Commitment::SIZE] {
 impl TryFrom<&[u8; Self::SIZE]> for Commitment {
     type Error = String;
 
+    #[inline]
     fn try_from(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
         Self::try_from_bytes(bytes)
     }
@@ -284,12 +301,14 @@ impl TryFrom<&[u8; Self::SIZE]> for Commitment {
 impl TryFrom<[u8; Self::SIZE]> for Commitment {
     type Error = String;
 
+    #[inline]
     fn try_from(bytes: [u8; Self::SIZE]) -> Result<Self, Self::Error> {
         Self::try_from(&bytes)
     }
 }
 
 impl Encode for Commitment {
+    #[inline]
     fn size_hint(&self) -> usize {
         Self::SIZE
     }
@@ -298,6 +317,7 @@ impl Encode for Commitment {
         f(&self.to_bytes())
     }
 
+    #[inline]
     fn encoded_size(&self) -> usize {
         Self::SIZE
     }
@@ -306,6 +326,7 @@ impl Encode for Commitment {
 impl EncodeLike for Commitment {}
 
 impl MaxEncodedLen for Commitment {
+    #[inline]
     fn max_encoded_len() -> usize {
         Self::SIZE
     }
@@ -319,6 +340,7 @@ impl Decode for Commitment {
         })
     }
 
+    #[inline]
     fn encoded_fixed_size() -> Option<usize> {
         Some(Self::SIZE)
     }
@@ -363,12 +385,14 @@ impl Witness {
 }
 
 impl From<Witness> for [u8; Witness::SIZE] {
+    #[inline]
     fn from(witness: Witness) -> Self {
         witness.to_bytes()
     }
 }
 
 impl From<&Witness> for [u8; Witness::SIZE] {
+    #[inline]
     fn from(witness: &Witness) -> Self {
         witness.to_bytes()
     }
@@ -377,6 +401,7 @@ impl From<&Witness> for [u8; Witness::SIZE] {
 impl TryFrom<&[u8; Self::SIZE]> for Witness {
     type Error = String;
 
+    #[inline]
     fn try_from(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
         Self::try_from_bytes(bytes)
     }
@@ -385,6 +410,7 @@ impl TryFrom<&[u8; Self::SIZE]> for Witness {
 impl TryFrom<[u8; Self::SIZE]> for Witness {
     type Error = String;
 
+    #[inline]
     fn try_from(bytes: [u8; Self::SIZE]) -> Result<Self, Self::Error> {
         Self::try_from(&bytes)
     }
@@ -399,6 +425,7 @@ impl Encode for Witness {
         f(&self.to_bytes())
     }
 
+    #[inline]
     fn encoded_size(&self) -> usize {
         Self::SIZE
     }
@@ -407,6 +434,7 @@ impl Encode for Witness {
 impl EncodeLike for Witness {}
 
 impl MaxEncodedLen for Witness {
+    #[inline]
     fn max_encoded_len() -> usize {
         Self::SIZE
     }
@@ -420,6 +448,7 @@ impl Decode for Witness {
         })
     }
 
+    #[inline]
     fn encoded_fixed_size() -> Option<usize> {
         Some(Self::SIZE)
     }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -94,12 +94,14 @@ pub struct Randomness(
 );
 
 impl AsRef<[u8]> for Randomness {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl AsMut<[u8]> for Randomness {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
@@ -142,12 +144,14 @@ pub const REWARD_SIGNATURE_LENGTH: usize = 64;
 pub struct PosSeed([u8; Self::SIZE]);
 
 impl const From<[u8; PosSeed::SIZE]> for PosSeed {
+    #[inline]
     fn from(value: [u8; Self::SIZE]) -> Self {
         Self(value)
     }
 }
 
 impl const From<PosSeed> for [u8; PosSeed::SIZE] {
+    #[inline]
     fn from(value: PosSeed) -> Self {
         value.0
     }
@@ -163,12 +167,14 @@ impl PosSeed {
 pub struct PosQualityBytes([u8; Self::SIZE]);
 
 impl const From<[u8; PosQualityBytes::SIZE]> for PosQualityBytes {
+    #[inline]
     fn from(value: [u8; Self::SIZE]) -> Self {
         Self(value)
     }
 }
 
 impl const From<PosQualityBytes> for [u8; PosQualityBytes::SIZE] {
+    #[inline]
     fn from(value: PosQualityBytes) -> Self {
         value.0
     }
@@ -186,18 +192,21 @@ impl PosQualityBytes {
 pub struct PosProof([u8; Self::SIZE]);
 
 impl const From<[u8; PosProof::SIZE]> for PosProof {
+    #[inline]
     fn from(value: [u8; Self::SIZE]) -> Self {
         Self(value)
     }
 }
 
 impl const From<PosProof> for [u8; PosProof::SIZE] {
+    #[inline]
     fn from(value: PosProof) -> Self {
         value.0
     }
 }
 
 impl Default for PosProof {
+    #[inline]
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
@@ -238,6 +247,7 @@ impl fmt::Display for PublicKey {
 }
 
 impl AsRef<[u8]> for PublicKey {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
@@ -273,6 +283,7 @@ pub struct RewardSignature(
 );
 
 impl AsRef<[u8]> for RewardSignature {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
@@ -293,6 +304,7 @@ pub enum ArchivedBlockProgress {
 impl Default for ArchivedBlockProgress {
     /// We assume a block can always fit into the segment initially, but it can definitely possible
     /// to be transitioned into the partial state after some overflow checkings.
+    #[inline]
     fn default() -> Self {
         Self::Complete
     }
@@ -525,11 +537,13 @@ pub struct U256(private_u256::U256);
 
 impl U256 {
     /// Zero (additive identity) of this type.
+    #[inline]
     pub const fn zero() -> Self {
         Self(private_u256::U256::zero())
     }
 
     /// One (multiplicative identity) of this type.
+    #[inline]
     pub fn one() -> Self {
         Self(private_u256::U256::one())
     }
@@ -617,60 +631,70 @@ impl U256 {
 
 // Necessary for division derive
 impl From<U256> for private_u256::U256 {
+    #[inline]
     fn from(number: U256) -> Self {
         number.0
     }
 }
 
 impl WrappingAdd for U256 {
+    #[inline]
     fn wrapping_add(&self, other: &Self) -> Self {
         Self(self.0.overflowing_add(other.0).0)
     }
 }
 
 impl WrappingSub for U256 {
+    #[inline]
     fn wrapping_sub(&self, other: &Self) -> Self {
         Self(self.0.overflowing_sub(other.0).0)
     }
 }
 
 impl From<u8> for U256 {
+    #[inline]
     fn from(number: u8) -> Self {
         Self(number.into())
     }
 }
 
 impl From<u16> for U256 {
+    #[inline]
     fn from(number: u16) -> Self {
         Self(number.into())
     }
 }
 
 impl From<u32> for U256 {
+    #[inline]
     fn from(number: u32) -> Self {
         Self(number.into())
     }
 }
 
 impl From<u64> for U256 {
+    #[inline]
     fn from(number: u64) -> Self {
         Self(number.into())
     }
 }
 
 impl From<u128> for U256 {
+    #[inline]
     fn from(number: u128) -> Self {
         Self(number.into())
     }
 }
 
 impl From<PieceIndexHash> for U256 {
+    #[inline]
     fn from(hash: PieceIndexHash) -> Self {
         Self(private_u256::U256::from_big_endian(hash.as_ref()))
     }
 }
 
 impl From<U256> for PieceIndexHash {
+    #[inline]
     fn from(number: U256) -> Self {
         Self::from(number.to_be_bytes())
     }
@@ -679,6 +703,7 @@ impl From<U256> for PieceIndexHash {
 impl TryFrom<U256> for u8 {
     type Error = &'static str;
 
+    #[inline]
     fn try_from(value: U256) -> Result<Self, Self::Error> {
         Self::try_from(value.0)
     }
@@ -687,6 +712,7 @@ impl TryFrom<U256> for u8 {
 impl TryFrom<U256> for u16 {
     type Error = &'static str;
 
+    #[inline]
     fn try_from(value: U256) -> Result<Self, Self::Error> {
         Self::try_from(value.0)
     }
@@ -695,6 +721,7 @@ impl TryFrom<U256> for u16 {
 impl TryFrom<U256> for u32 {
     type Error = &'static str;
 
+    #[inline]
     fn try_from(value: U256) -> Result<Self, Self::Error> {
         Self::try_from(value.0)
     }
@@ -703,6 +730,7 @@ impl TryFrom<U256> for u32 {
 impl TryFrom<U256> for u64 {
     type Error = &'static str;
 
+    #[inline]
     fn try_from(value: U256) -> Result<Self, Self::Error> {
         Self::try_from(value.0)
     }
@@ -714,6 +742,7 @@ pub struct SectorSlotChallenge(Blake2b256Hash);
 
 impl SectorSlotChallenge {
     /// Index of s-bucket within sector to be audited
+    #[inline]
     pub fn s_bucket_audit_index(&self) -> SBucket {
         SBucket::from(
             u16::try_from(U256::from_le_bytes(self.0) % U256::from(Record::NUM_S_BUCKETS as u32))
@@ -731,6 +760,7 @@ impl SectorSlotChallenge {
 pub struct SectorId(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] Blake2b256Hash);
 
 impl AsRef<[u8]> for SectorId {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -55,14 +55,17 @@ use scale_info::TypeInfo;
 pub struct SBucket(u16);
 
 impl Step for SBucket {
+    #[inline]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u16::steps_between(&start.0, &end.0)
     }
 
+    #[inline]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u16::forward_checked(start.0, count).map(Self)
     }
 
+    #[inline]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u16::backward_checked(start.0, count).map(Self)
     }
@@ -71,30 +74,35 @@ impl Step for SBucket {
 impl const TryFrom<usize> for SBucket {
     type Error = TryFromIntError;
 
+    #[inline]
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         Ok(Self(u16::try_from(value)?))
     }
 }
 
 impl const From<u16> for SBucket {
+    #[inline]
     fn from(original: u16) -> Self {
         Self(original)
     }
 }
 
 impl const From<SBucket> for u16 {
+    #[inline]
     fn from(original: SBucket) -> Self {
         original.0
     }
 }
 
 impl const From<SBucket> for u32 {
+    #[inline]
     fn from(original: SBucket) -> Self {
         u32::from(original.0)
     }
 }
 
 impl const From<SBucket> for usize {
+    #[inline]
     fn from(original: SBucket) -> Self {
         usize::from(original.0)
     }
@@ -137,26 +145,31 @@ impl SBucket {
 pub struct PieceIndex(u64);
 
 impl Step for PieceIndex {
+    #[inline]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u64::steps_between(&start.0, &end.0)
     }
 
+    #[inline]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u64::forward_checked(start.0, count).map(Self)
     }
 
+    #[inline]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u64::backward_checked(start.0, count).map(Self)
     }
 }
 
 impl const From<u64> for PieceIndex {
+    #[inline]
     fn from(original: u64) -> Self {
         Self(original)
     }
 }
 
 impl const From<PieceIndex> for u64 {
+    #[inline]
     fn from(original: PieceIndex) -> Self {
         original.0
     }
@@ -174,16 +187,19 @@ impl PieceIndex {
     }
 
     /// Convert piece index to bytes.
+    #[inline]
     pub const fn to_bytes(self) -> [u8; mem::size_of::<u64>()] {
         self.0.to_le_bytes()
     }
 
     /// Segment index piece index corresponds to
+    #[inline]
     pub const fn segment_index(&self) -> SegmentIndex {
         SegmentIndex::from(self.0 / ArchivedHistorySegment::NUM_PIECES as u64)
     }
 
     /// Position of a piece in a segment
+    #[inline]
     pub const fn position(&self) -> u32 {
         // Position is statically guaranteed to fit into u32
         (self.0 % ArchivedHistorySegment::NUM_PIECES as u64) as u32
@@ -220,32 +236,38 @@ impl PieceIndex {
 pub struct PieceOffset(u16);
 
 impl Step for PieceOffset {
+    #[inline]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u16::steps_between(&start.0, &end.0)
     }
 
+    #[inline]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u16::forward_checked(start.0, count).map(Self)
     }
 
+    #[inline]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u16::backward_checked(start.0, count).map(Self)
     }
 }
 
 impl const From<u16> for PieceOffset {
+    #[inline]
     fn from(original: u16) -> Self {
         Self(original)
     }
 }
 
 impl const From<PieceOffset> for u16 {
+    #[inline]
     fn from(original: PieceOffset) -> Self {
         original.0
     }
 }
 
 impl const From<PieceOffset> for usize {
+    #[inline]
     fn from(original: PieceOffset) -> Self {
         usize::from(original.0)
     }
@@ -258,6 +280,7 @@ impl PieceOffset {
     pub const ONE: PieceOffset = PieceOffset(1);
 
     /// Convert piece offset to bytes.
+    #[inline]
     pub const fn to_bytes(self) -> [u8; mem::size_of::<u16>()] {
         self.0.to_le_bytes()
     }
@@ -269,6 +292,7 @@ impl PieceOffset {
 pub struct PieceIndexHash(Blake2b256Hash);
 
 impl AsRef<[u8]> for PieceIndexHash {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
@@ -277,6 +301,7 @@ impl AsRef<[u8]> for PieceIndexHash {
 impl PieceIndexHash {
     // TODO: Remove and replace uses with `index.hash()`
     /// Constructs `PieceIndexHash` from `PieceIndex`
+    #[inline]
     pub fn from_index(index: PieceIndex) -> Self {
         index.hash()
     }
@@ -290,18 +315,21 @@ impl PieceIndexHash {
 pub struct RawRecord([[u8; Scalar::SAFE_BYTES]; Self::NUM_CHUNKS]);
 
 impl Default for RawRecord {
+    #[inline]
     fn default() -> Self {
         Self([Default::default(); Self::NUM_CHUNKS])
     }
 }
 
 impl AsRef<[u8]> for RawRecord {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.as_slice().flatten()
     }
 }
 
 impl AsMut<[u8]> for RawRecord {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut_slice().flatten_mut()
     }
@@ -314,6 +342,7 @@ impl RawRecord {
     pub const SIZE: usize = Scalar::SAFE_BYTES * Self::NUM_CHUNKS;
 
     /// Create boxed value without hitting stack overflow
+    #[inline]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         // SAFETY: Data structure filled with zeroes is a valid invariant
@@ -329,18 +358,21 @@ impl RawRecord {
 pub struct Record([[u8; Scalar::FULL_BYTES]; Self::NUM_CHUNKS]);
 
 impl Default for Record {
+    #[inline]
     fn default() -> Self {
         Self([Default::default(); Self::NUM_CHUNKS])
     }
 }
 
 impl AsRef<[u8]> for Record {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.flatten()
     }
 }
 
 impl AsMut<[u8]> for Record {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.flatten_mut()
     }
@@ -360,6 +392,7 @@ impl Record {
     pub const SIZE: usize = Scalar::FULL_BYTES * Self::NUM_CHUNKS;
 
     /// Create boxed value without hitting stack overflow
+    #[inline]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         // SAFETY: Data structure filled with zeroes is a valid invariant
@@ -368,6 +401,7 @@ impl Record {
 
     /// Convenient conversion from slice of record to underlying representation for efficiency
     /// purposes.
+    #[inline]
     pub fn slice_to_repr(value: &[Self]) -> &[[u8; Self::SIZE]] {
         // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -375,6 +409,7 @@ impl Record {
 
     /// Convenient conversion from slice of underlying representation to record for efficiency
     /// purposes.
+    #[inline]
     pub fn slice_from_repr(value: &[[u8; Self::SIZE]]) -> &[Self] {
         // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -382,6 +417,7 @@ impl Record {
 
     /// Convenient conversion from mutable slice of record to underlying representation for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [[u8; Self::SIZE]] {
         // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -389,6 +425,7 @@ impl Record {
 
     /// Convenient conversion from mutable slice of underlying representation to record for
     /// efficiency purposes.
+    #[inline]
     pub fn slice_mut_from_repr(value: &mut [[u8; Self::SIZE]]) -> &mut [Self] {
         // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
@@ -415,6 +452,7 @@ impl Record {
 pub struct RecordCommitment([u8; RecordCommitment::SIZE]);
 
 impl Default for RecordCommitment {
+    #[inline]
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
@@ -423,18 +461,21 @@ impl Default for RecordCommitment {
 impl TryFrom<&[u8]> for RecordCommitment {
     type Error = TryFromSliceError;
 
+    #[inline]
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         <[u8; Self::SIZE]>::try_from(slice).map(Self)
     }
 }
 
 impl AsRef<[u8]> for RecordCommitment {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl AsMut<[u8]> for RecordCommitment {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
@@ -465,6 +506,7 @@ impl RecordCommitment {
 pub struct RecordWitness([u8; RecordWitness::SIZE]);
 
 impl Default for RecordWitness {
+    #[inline]
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
@@ -473,18 +515,21 @@ impl Default for RecordWitness {
 impl TryFrom<&[u8]> for RecordWitness {
     type Error = TryFromSliceError;
 
+    #[inline]
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         <[u8; Self::SIZE]>::try_from(slice).map(Self)
     }
 }
 
 impl AsRef<[u8]> for RecordWitness {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl AsMut<[u8]> for RecordWitness {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
@@ -507,6 +552,7 @@ impl RecordWitness {
 pub struct Piece(Box<PieceArray>);
 
 impl Default for Piece {
+    #[inline]
     fn default() -> Self {
         Self(PieceArray::new_boxed())
     }
@@ -526,6 +572,7 @@ impl Decode for Piece {
 }
 
 impl From<Piece> for Vec<u8> {
+    #[inline]
     fn from(piece: Piece) -> Self {
         piece.0.to_vec()
     }
@@ -533,6 +580,7 @@ impl From<Piece> for Vec<u8> {
 impl TryFrom<&[u8]> for Piece {
     type Error = TryFromSliceError;
 
+    #[inline]
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         <[u8; Self::SIZE]>::try_from(slice).map(|bytes| Piece(Box::new(PieceArray(bytes))))
     }
@@ -541,6 +589,7 @@ impl TryFrom<&[u8]> for Piece {
 impl TryFrom<Vec<u8>> for Piece {
     type Error = TryFromSliceError;
 
+    #[inline]
     fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
         // TODO: Maybe possible to transmute boxed slice into boxed array
         Self::try_from(vec.as_slice())
@@ -548,6 +597,7 @@ impl TryFrom<Vec<u8>> for Piece {
 }
 
 impl From<&PieceArray> for Piece {
+    #[inline]
     fn from(value: &PieceArray) -> Self {
         let mut piece = Piece::default();
         piece.as_mut().copy_from_slice(value.as_ref());
@@ -558,24 +608,28 @@ impl From<&PieceArray> for Piece {
 impl Deref for Piece {
     type Target = PieceArray;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl DerefMut for Piece {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
 impl AsRef<[u8]> for Piece {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.as_slice()
     }
 }
 
 impl AsMut<[u8]> for Piece {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut_slice()
     }
@@ -615,18 +669,21 @@ impl Piece {
 pub struct PieceArray([u8; Piece::SIZE]);
 
 impl Default for PieceArray {
+    #[inline]
     fn default() -> Self {
         Self([0u8; Piece::SIZE])
     }
 }
 
 impl AsRef<[u8]> for PieceArray {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl AsMut<[u8]> for PieceArray {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
@@ -634,6 +691,7 @@ impl AsMut<[u8]> for PieceArray {
 
 impl PieceArray {
     /// Create boxed value without hitting stack overflow
+    #[inline]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         // SAFETY: Data structure filled with zeroes is a valid invariant
@@ -641,6 +699,7 @@ impl PieceArray {
     }
 
     /// Split piece into underlying components.
+    #[inline]
     pub fn split(&self) -> (&Record, &RecordCommitment, &RecordWitness) {
         let (record, extra) = self.0.split_at(Record::SIZE);
         let (commitment, witness) = extra.split_at(RecordCommitment::SIZE);
@@ -663,6 +722,7 @@ impl PieceArray {
     }
 
     /// Split piece into underlying mutable components.
+    #[inline]
     pub fn split_mut(&mut self) -> (&mut Record, &mut RecordCommitment, &mut RecordWitness) {
         let (record, extra) = self.0.split_at_mut(Record::SIZE);
         let (commitment, witness) = extra.split_at_mut(RecordCommitment::SIZE);
@@ -685,31 +745,37 @@ impl PieceArray {
     }
 
     /// Record contained within a piece.
+    #[inline]
     pub fn record(&self) -> &Record {
         self.split().0
     }
 
     /// Mutable record contained within a piece.
+    #[inline]
     pub fn record_mut(&mut self) -> &mut Record {
         self.split_mut().0
     }
 
     /// Commitment contained within a piece.
+    #[inline]
     pub fn commitment(&self) -> &RecordCommitment {
         self.split().1
     }
 
     /// Mutable commitment contained within a piece.
+    #[inline]
     pub fn commitment_mut(&mut self) -> &mut RecordCommitment {
         self.split_mut().1
     }
 
     /// Witness contained within a piece.
+    #[inline]
     pub fn witness(&self) -> &RecordWitness {
         self.split().2
     }
 
     /// Mutable witness contained within a piece.
+    #[inline]
     pub fn witness_mut(&mut self) -> &mut RecordWitness {
         self.split_mut().2
     }
@@ -735,31 +801,37 @@ pub struct FlatPieces(Vec<PieceArray>);
 
 impl FlatPieces {
     /// Allocate `FlatPieces` that will hold `piece_count` pieces filled with zeroes.
+    #[inline]
     pub fn new(piece_count: usize) -> Self {
         Self(vec![PieceArray::default(); piece_count])
     }
 
     /// Extract internal representation.
+    #[inline]
     pub fn into_inner(self) -> Vec<PieceArray> {
         self.0
     }
 
     /// Iterator over source pieces (even indices).
+    #[inline]
     pub fn source(&self) -> impl ExactSizeIterator<Item = &'_ PieceArray> + '_ {
         self.0.iter().step_by(2)
     }
 
     /// Mutable iterator over source pieces (even indices).
+    #[inline]
     pub fn source_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
         self.0.iter_mut().step_by(2)
     }
 
     /// Iterator over parity pieces (odd indices).
+    #[inline]
     pub fn parity(&self) -> impl ExactSizeIterator<Item = &'_ PieceArray> + '_ {
         self.0.iter().skip(1).step_by(2)
     }
 
     /// Mutable iterator over parity pieces (odd indices).
+    #[inline]
     pub fn parity_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
         self.0.iter_mut().skip(1).step_by(2)
     }
@@ -768,11 +840,13 @@ impl FlatPieces {
 #[cfg(feature = "parallel")]
 impl FlatPieces {
     /// Parallel iterator over source pieces (even indices).
+    #[inline]
     pub fn par_source(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
         self.0.par_iter().step_by(2)
     }
 
     /// Mutable parallel iterator over source pieces (even indices).
+    #[inline]
     pub fn par_source_mut(
         &mut self,
     ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
@@ -780,11 +854,13 @@ impl FlatPieces {
     }
 
     /// Parallel iterator over parity pieces (odd indices).
+    #[inline]
     pub fn par_parity(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
         self.0.par_iter().skip(1).step_by(2)
     }
 
     /// Mutable parallel iterator over parity pieces (odd indices).
+    #[inline]
     pub fn par_parity_mut(
         &mut self,
     ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
@@ -793,12 +869,14 @@ impl FlatPieces {
 }
 
 impl From<PieceArray> for FlatPieces {
+    #[inline]
     fn from(value: PieceArray) -> Self {
         Self(vec![value])
     }
 }
 
 impl AsRef<[u8]> for FlatPieces {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         // SAFETY: Same memory layout due to `#[repr(transparent)]`
         let pieces: &[[u8; Piece::SIZE]] = unsafe { mem::transmute(self.0.as_slice()) };
@@ -807,6 +885,7 @@ impl AsRef<[u8]> for FlatPieces {
 }
 
 impl AsMut<[u8]> for FlatPieces {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         // SAFETY: Same memory layout due to `#[repr(transparent)]`
         let pieces: &mut [[u8; Piece::SIZE]] = unsafe { mem::transmute(self.0.as_mut_slice()) };

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -42,26 +42,31 @@ use serde::{Deserialize, Serialize};
 pub struct SegmentIndex(u64);
 
 impl Step for SegmentIndex {
+    #[inline]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u64::steps_between(&start.0, &end.0)
     }
 
+    #[inline]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u64::forward_checked(start.0, count).map(Self)
     }
 
+    #[inline]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u64::backward_checked(start.0, count).map(Self)
     }
 }
 
 impl const From<u64> for SegmentIndex {
+    #[inline]
     fn from(original: u64) -> Self {
         Self(original)
     }
 }
 
 impl const From<SegmentIndex> for u64 {
+    #[inline]
     fn from(original: SegmentIndex) -> Self {
         original.0
     }
@@ -92,6 +97,7 @@ impl const From<SegmentIndex> for u64 {
 pub struct HistorySize(NonZeroU64);
 
 impl From<SegmentIndex> for HistorySize {
+    #[inline]
     fn from(value: SegmentIndex) -> Self {
         Self(NonZeroU64::new(value.0 + 1).expect("Not zero; qed"))
     }
@@ -143,12 +149,14 @@ impl SegmentIndex {
 pub struct RecordedHistorySegment([RawRecord; Self::NUM_RAW_RECORDS]);
 
 impl Default for RecordedHistorySegment {
+    #[inline]
     fn default() -> Self {
         Self([RawRecord::default(); Self::NUM_RAW_RECORDS])
     }
 }
 
 impl AsRef<[u8]> for RecordedHistorySegment {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         // SAFETY: Same memory layout due to `#[repr(transparent)]`
         let raw_records: &[[u8; RawRecord::SIZE]] = unsafe { mem::transmute(self.0.as_slice()) };
@@ -157,6 +165,7 @@ impl AsRef<[u8]> for RecordedHistorySegment {
 }
 
 impl AsMut<[u8]> for RecordedHistorySegment {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         // SAFETY: Same memory layout due to `#[repr(transparent)]`
         let raw_records: &mut [[u8; RawRecord::SIZE]] =
@@ -178,6 +187,7 @@ impl RecordedHistorySegment {
     pub const SIZE: usize = RawRecord::SIZE * Self::NUM_RAW_RECORDS;
 
     /// Create boxed value without hitting stack overflow
+    #[inline]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         // SAFETY: Data structure filled with zeroes is a valid invariant
@@ -192,12 +202,14 @@ impl RecordedHistorySegment {
 pub struct ArchivedHistorySegment(FlatPieces);
 
 impl Default for ArchivedHistorySegment {
+    #[inline]
     fn default() -> Self {
         Self(FlatPieces::new(Self::NUM_PIECES))
     }
 }
 
 impl MaxEncodedLen for ArchivedHistorySegment {
+    #[inline]
     fn max_encoded_len() -> usize {
         Self::SIZE
     }

--- a/crates/subspace-farmer-components/src/piece_caching.rs
+++ b/crates/subspace-farmer-components/src/piece_caching.rs
@@ -14,6 +14,7 @@ pub struct PieceMemoryCache {
     cache: Arc<Mutex<LruCache<PieceIndexHash, Piece>>>,
 }
 impl Default for PieceMemoryCache {
+    #[inline]
     fn default() -> Self {
         Self::new(CACHE_ITEMS_LIMIT)
     }

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -47,6 +47,7 @@ pub enum PieceGetterRetryPolicy {
 }
 
 impl Default for PieceGetterRetryPolicy {
+    #[inline]
     fn default() -> Self {
         Self::Limited(0)
     }

--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -78,6 +78,7 @@ impl SectorMetadata {
     /// Size of encoded sector metadata.
     ///
     /// For sector plot size use [`sector_size()`].
+    #[inline]
     pub fn encoded_size() -> usize {
         let default = SectorMetadata {
             sector_index: 0,
@@ -216,6 +217,7 @@ pub struct SectorContentsMap {
 }
 
 impl AsRef<[u8]> for SectorContentsMap {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         let slice = self.encoded_record_chunks_used.as_slice();
         // SAFETY: `BitArray` is a transparent data structure containing array of bytes

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -112,6 +112,7 @@ enum WriteToDisk {
 }
 
 impl Default for WriteToDisk {
+    #[inline]
     fn default() -> Self {
         Self::Everything
     }

--- a/crates/subspace-farmer/src/identity.rs
+++ b/crates/subspace-farmer/src/identity.rs
@@ -38,6 +38,7 @@ pub struct Identity {
 impl Deref for Identity {
     type Target = Keypair;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.keypair
     }

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -261,6 +261,7 @@ struct PlotMetadataHeader {
 }
 
 impl PlotMetadataHeader {
+    #[inline]
     fn encoded_size() -> usize {
         let default = PlotMetadataHeader {
             version: 0,

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -42,6 +42,7 @@ impl JoinOnDrop {
 impl Deref for JoinOnDrop {
     type Target = thread::JoinHandle<()>;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0.as_ref().expect("Only dropped in Drop impl; qed")
     }

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -41,12 +41,14 @@ where
 pub struct HexPiece(#[serde(with = "hex::serde")] Vec<u8>);
 
 impl From<Piece> for HexPiece {
+    #[inline]
     fn from(piece: Piece) -> Self {
         HexPiece(piece.into())
     }
 }
 
 impl From<HexPiece> for Piece {
+    #[inline]
     fn from(piece: HexPiece) -> Self {
         piece
             .0
@@ -58,24 +60,28 @@ impl From<HexPiece> for Piece {
 
 impl Deref for HexPiece {
     type Target = [u8];
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl DerefMut for HexPiece {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
 impl AsRef<[u8]> for HexPiece {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl AsMut<[u8]> for HexPiece {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
@@ -86,12 +92,14 @@ impl AsMut<[u8]> for HexPiece {
 pub struct HexBlake2b256Hash(#[serde(with = "hex::serde")] Blake2b256Hash);
 
 impl From<Blake2b256Hash> for HexBlake2b256Hash {
+    #[inline]
     fn from(hash: Blake2b256Hash) -> Self {
         HexBlake2b256Hash(hash)
     }
 }
 
 impl From<HexBlake2b256Hash> for Blake2b256Hash {
+    #[inline]
     fn from(piece: HexBlake2b256Hash) -> Self {
         piece.0
     }
@@ -99,24 +107,28 @@ impl From<HexBlake2b256Hash> for Blake2b256Hash {
 
 impl Deref for HexBlake2b256Hash {
     type Target = [u8];
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl DerefMut for HexBlake2b256Hash {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
 impl AsRef<[u8]> for HexBlake2b256Hash {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl AsMut<[u8]> for HexBlake2b256Hash {
+    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }

--- a/crates/subspace-networking/src/behavior/provider_storage/providers.rs
+++ b/crates/subspace-networking/src/behavior/provider_storage/providers.rs
@@ -102,6 +102,7 @@ struct ParityDbProviderCollection {
 }
 
 impl From<ParityDbProviderCollection> for Vec<u8> {
+    #[inline]
     fn from(value: ParityDbProviderCollection) -> Self {
         value.encode()
     }
@@ -110,6 +111,7 @@ impl From<ParityDbProviderCollection> for Vec<u8> {
 impl TryFrom<Vec<u8>> for ParityDbProviderCollection {
     type Error = parity_scale_codec::Error;
 
+    #[inline]
     fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
         ParityDbProviderCollection::decode(&mut data.as_slice()).map(Into::into)
     }
@@ -146,6 +148,7 @@ struct ParityDbProviderRecord {
 }
 
 impl From<ParityDbProviderRecord> for Vec<u8> {
+    #[inline]
     fn from(rec: ParityDbProviderRecord) -> Self {
         rec.encode()
     }
@@ -154,12 +157,14 @@ impl From<ParityDbProviderRecord> for Vec<u8> {
 impl TryFrom<Vec<u8>> for ParityDbProviderRecord {
     type Error = parity_scale_codec::Error;
 
+    #[inline]
     fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
         ParityDbProviderRecord::decode(&mut data.as_slice()).map(Into::into)
     }
 }
 
 impl From<ProviderRecord> for ParityDbProviderRecord {
+    #[inline]
     fn from(rec: ProviderRecord) -> Self {
         Self {
             key: rec.key.to_vec(),
@@ -173,6 +178,7 @@ impl From<ProviderRecord> for ParityDbProviderRecord {
 impl From<ParityDbProviderRecord> for ProviderRecord {
     // We don't expect an error here because ParityDbRecord contains valid bytes
     // representations.
+    #[inline]
     fn from(rec: ParityDbProviderRecord) -> Self {
         Self {
             key: rec.key.into(),

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -236,6 +236,7 @@ impl<ProviderStorage> fmt::Debug for Config<ProviderStorage> {
 }
 
 impl Default for Config<MemoryProviderStorage> {
+    #[inline]
     fn default() -> Self {
         let ed25519_keypair = identity::ed25519::Keypair::generate();
 

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -82,6 +82,7 @@ pub enum GetValueError {
 }
 
 impl From<oneshot::Canceled> for GetValueError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -98,6 +99,7 @@ pub enum PutValueError {
 }
 
 impl From<oneshot::Canceled> for PutValueError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -114,6 +116,7 @@ pub enum GetClosestPeersError {
 }
 
 impl From<oneshot::Canceled> for GetClosestPeersError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -140,6 +143,7 @@ pub enum SubscribeError {
 }
 
 impl From<oneshot::Canceled> for SubscribeError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -159,6 +163,7 @@ pub enum PublishError {
 }
 
 impl From<oneshot::Canceled> for PublishError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -178,6 +183,7 @@ pub enum GetProvidersError {
 }
 
 impl From<oneshot::Canceled> for GetProvidersError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -194,6 +200,7 @@ pub enum AnnounceError {
 }
 
 impl From<oneshot::Canceled> for AnnounceError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -213,6 +220,7 @@ pub enum StopAnnouncingError {
 }
 
 impl From<oneshot::Canceled> for StopAnnouncingError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -235,6 +243,7 @@ pub enum SendRequestError {
 }
 
 impl From<oneshot::Canceled> for SendRequestError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::NodeRunnerDropped
     }
@@ -251,6 +260,7 @@ pub enum CircuitRelayClientError {
 }
 
 impl From<oneshot::Canceled> for CircuitRelayClientError {
+    #[inline]
     fn from(oneshot::Canceled: oneshot::Canceled) -> Self {
         Self::FailedToRetrieveMemoryAddress
     }

--- a/crates/subspace-networking/src/request_responses.rs
+++ b/crates/subspace-networking/src/request_responses.rs
@@ -232,6 +232,7 @@ struct ProtocolRequestId {
 }
 
 impl From<(Cow<'static, str>, RequestId)> for ProtocolRequestId {
+    #[inline]
     fn from((protocol, request_id): (Cow<'static, str>, RequestId)) -> Self {
         Self {
             protocol,

--- a/crates/subspace-networking/src/utils/multihash.rs
+++ b/crates/subspace-networking/src/utils/multihash.rs
@@ -13,6 +13,7 @@ pub enum MultihashCode {
 }
 
 impl From<MultihashCode> for u64 {
+    #[inline]
     fn from(code: MultihashCode) -> Self {
         code as u64
     }
@@ -21,6 +22,7 @@ impl From<MultihashCode> for u64 {
 impl TryFrom<u64> for MultihashCode {
     type Error = Box<dyn Error>;
 
+    #[inline]
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
             x if x == MultihashCode::PieceIndexHash as u64 => Ok(MultihashCode::PieceIndexHash),

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -39,6 +39,7 @@ pub enum RetryPolicy {
 }
 
 impl Default for RetryPolicy {
+    #[inline]
     fn default() -> Self {
         Self::Limited(0)
     }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -141,6 +141,7 @@ pub enum Error {
 }
 
 impl From<String> for Error {
+    #[inline]
     fn from(s: String) -> Self {
         Self::Other(s)
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -550,6 +550,7 @@ fn extract_segment_headers(ext: &UncheckedExtrinsic) -> Option<Vec<SegmentHeader
 struct RewardAddress([u8; 32]);
 
 impl From<FarmerPublicKey> for RewardAddress {
+    #[inline]
     fn from(farmer_public_key: FarmerPublicKey) -> Self {
         Self(
             farmer_public_key
@@ -561,6 +562,7 @@ impl From<FarmerPublicKey> for RewardAddress {
 }
 
 impl From<RewardAddress> for AccountId32 {
+    #[inline]
     fn from(reward_address: RewardAddress) -> Self {
         reward_address.0.into()
     }

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -204,6 +204,7 @@ struct ParityDbKeyCollection {
 }
 
 impl From<ParityDbKeyCollection> for Vec<u8> {
+    #[inline]
     fn from(value: ParityDbKeyCollection) -> Self {
         value.encode()
     }
@@ -212,6 +213,7 @@ impl From<ParityDbKeyCollection> for Vec<u8> {
 impl TryFrom<Vec<u8>> for ParityDbKeyCollection {
     type Error = parity_scale_codec::Error;
 
+    #[inline]
     fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
         ParityDbKeyCollection::decode(&mut data.as_slice()).map(Into::into)
     }

--- a/crates/subspace-transaction-pool/src/bundle_validator.rs
+++ b/crates/subspace-transaction-pool/src/bundle_validator.rs
@@ -292,6 +292,7 @@ pub enum BundleError {
 }
 
 impl From<sp_blockchain::Error> for BundleError {
+    #[inline]
     fn from(err: sp_blockchain::Error) -> Self {
         BundleError::BlockChain(err)
     }

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -60,12 +60,14 @@ impl RecordProof {
 
 /// Will return [`RecordProof::No`] as default value.
 impl Default for RecordProof {
+    #[inline]
     fn default() -> Self {
         Self::No
     }
 }
 
 impl From<bool> for RecordProof {
+    #[inline]
     fn from(val: bool) -> Self {
         if val {
             Self::Yes

--- a/domains/client/consensus-relay-chain/src/import_queue.rs
+++ b/domains/client/consensus-relay-chain/src/import_queue.rs
@@ -80,6 +80,7 @@ pub struct Verifier<Block> {
 
 impl<Block> Default for Verifier<Block> {
     /// Create a new instance.
+    #[inline]
     fn default() -> Self {
         Self {
             _marker: PhantomData,

--- a/domains/client/domain-executor/src/gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/gossip_message_validator.rs
@@ -44,6 +44,7 @@ pub enum GossipMessageError {
 }
 
 impl From<sp_blockchain::Error> for GossipMessageError {
+    #[inline]
     fn from(error: sp_blockchain::Error) -> Self {
         Self::Client(Box::new(error))
     }

--- a/domains/client/executor-gossip/src/lib.rs
+++ b/domains/client/executor-gossip/src/lib.rs
@@ -55,6 +55,7 @@ impl<PBlock: BlockT, Block: BlockT>
     From<SignedBundle<Block::Extrinsic, NumberFor<PBlock>, PBlock::Hash, Block::Hash>>
     for GossipMessage<PBlock, Block>
 {
+    #[inline]
     fn from(
         bundle: SignedBundle<Block::Extrinsic, NumberFor<PBlock>, PBlock::Hash, Block::Hash>,
     ) -> Self {

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -59,18 +59,21 @@ pub enum Error {
 }
 
 impl From<sp_blockchain::Error> for Error {
+    #[inline]
     fn from(err: sp_blockchain::Error) -> Self {
         Error::BlockchainError(Box::new(err))
     }
 }
 
 impl From<ArithmeticError> for Error {
+    #[inline]
     fn from(err: ArithmeticError) -> Self {
         Error::ArithmeticError(err)
     }
 }
 
 impl From<sp_api::ApiError> for Error {
+    #[inline]
     fn from(err: sp_api::ApiError) -> Self {
         Error::ApiError(err)
     }

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -409,6 +409,7 @@ mod pallet {
 
     #[cfg(feature = "std")]
     impl<T: Config> Default for GenesisConfig<T> {
+        #[inline]
         fn default() -> Self {
             Self {
                 domains: Vec::new(),
@@ -450,6 +451,7 @@ mod pallet {
     }
 
     impl<T> From<ReadBundleElectionParamsError> for Error<T> {
+        #[inline]
         fn from(_error: ReadBundleElectionParamsError) -> Self {
             Self::FailedToReadBundleElectionParams
         }
@@ -468,6 +470,7 @@ mod pallet {
     }
 
     impl<T> From<PalletReceiptError> for Error<T> {
+        #[inline]
         fn from(error: PalletReceiptError) -> Self {
             match error {
                 PalletReceiptError::MissingParent => Self::Receipt(ReceiptError::MissingParent),

--- a/domains/pallets/executor-registry/src/lib.rs
+++ b/domains/pallets/executor-registry/src/lib.rs
@@ -515,6 +515,7 @@ mod pallet {
 
     #[cfg(feature = "std")]
     impl<T: Config> Default for GenesisConfig<T> {
+        #[inline]
         fn default() -> Self {
             Self {
                 executors: Vec::new(),

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -315,6 +315,7 @@ mod pallet {
 
     #[cfg(feature = "std")]
     impl<T: Config> Default for GenesisConfig<T> {
+        #[inline]
         fn default() -> Self {
             Self {
                 relayers: Default::default(),

--- a/domains/runtime/core-evm/src/precompiles.rs
+++ b/domains/runtime/core-evm/src/precompiles.rs
@@ -26,6 +26,7 @@ where
 }
 
 impl<R> Default for FrontierPrecompiles<R> {
+    #[inline]
     fn default() -> Self {
         Self(PhantomData::default())
     }

--- a/orml/vesting/src/lib.rs
+++ b/orml/vesting/src/lib.rs
@@ -28,22 +28,21 @@
 #![allow(clippy::unused_unit)]
 
 use codec::{HasCompact, MaxEncodedLen};
-use frame_support::{
-	ensure,
-	pallet_prelude::*,
-	traits::{Currency, EnsureOrigin, ExistenceRequirement, Get, LockIdentifier, LockableCurrency, WithdrawReasons},
-	BoundedVec,
+use frame_support::pallet_prelude::*;
+use frame_support::traits::{
+    Currency, EnsureOrigin, ExistenceRequirement, Get, LockIdentifier, LockableCurrency,
+    WithdrawReasons,
 };
-use frame_system::{ensure_root, ensure_signed, pallet_prelude::*};
+use frame_support::{ensure, BoundedVec};
+use frame_system::pallet_prelude::*;
+use frame_system::{ensure_root, ensure_signed};
 use scale_info::TypeInfo;
-use sp_runtime::{
-	traits::{AtLeast32Bit, BlockNumberProvider, CheckedAdd, Saturating, StaticLookup, Zero},
-	ArithmeticError, DispatchResult, RuntimeDebug,
+use sp_runtime::traits::{
+    AtLeast32Bit, BlockNumberProvider, CheckedAdd, Saturating, StaticLookup, Zero,
 };
-use sp_std::{
-	cmp::{Eq, PartialEq},
-	vec::Vec,
-};
+use sp_runtime::{ArithmeticError, DispatchResult, RuntimeDebug};
+use sp_std::cmp::{Eq, PartialEq};
+use sp_std::vec::Vec;
 
 mod mock;
 mod tests;
@@ -60,351 +59,389 @@ pub const VESTING_LOCK_ID: LockIdentifier = *b"ormlvest";
 /// of blocks after `start`.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 pub struct VestingSchedule<BlockNumber, Balance: MaxEncodedLen + HasCompact> {
-	/// Vesting starting block
-	pub start: BlockNumber,
-	/// Number of blocks between vest
-	pub period: BlockNumber,
-	/// Number of vest
-	pub period_count: u32,
-	/// Amount of tokens to release per vest
-	#[codec(compact)]
-	pub per_period: Balance,
+    /// Vesting starting block
+    pub start: BlockNumber,
+    /// Number of blocks between vest
+    pub period: BlockNumber,
+    /// Number of vest
+    pub period_count: u32,
+    /// Amount of tokens to release per vest
+    #[codec(compact)]
+    pub per_period: Balance,
 }
 
 impl<BlockNumber: AtLeast32Bit + Copy, Balance: AtLeast32Bit + MaxEncodedLen + Copy>
-	VestingSchedule<BlockNumber, Balance>
+    VestingSchedule<BlockNumber, Balance>
 {
-	/// Returns the end of all periods, `None` if calculation overflows.
-	pub fn end(&self) -> Option<BlockNumber> {
-		// period * period_count + start
-		self.period
-			.checked_mul(&self.period_count.into())?
-			.checked_add(&self.start)
-	}
+    /// Returns the end of all periods, `None` if calculation overflows.
+    pub fn end(&self) -> Option<BlockNumber> {
+        // period * period_count + start
+        self.period
+            .checked_mul(&self.period_count.into())?
+            .checked_add(&self.start)
+    }
 
-	/// Returns all locked amount, `None` if calculation overflows.
-	pub fn total_amount(&self) -> Option<Balance> {
-		self.per_period.checked_mul(&self.period_count.into())
-	}
+    /// Returns all locked amount, `None` if calculation overflows.
+    pub fn total_amount(&self) -> Option<Balance> {
+        self.per_period.checked_mul(&self.period_count.into())
+    }
 
-	/// Returns locked amount for a given `time`.
-	///
-	/// Note this func assumes schedule is a valid one(non-zero period and
-	/// non-overflow total amount), and it should be guaranteed by callers.
-	pub fn locked_amount(&self, time: BlockNumber) -> Balance {
-		// full = (time - start) / period
-		// unrealized = period_count - full
-		// per_period * unrealized
-		let full = time
-			.saturating_sub(self.start)
-			.checked_div(&self.period)
-			.expect("ensured non-zero period; qed");
-		let unrealized = self.period_count.saturating_sub(full.unique_saturated_into());
-		self.per_period
-			.checked_mul(&unrealized.into())
-			.expect("ensured non-overflow total amount; qed")
-	}
+    /// Returns locked amount for a given `time`.
+    ///
+    /// Note this func assumes schedule is a valid one(non-zero period and
+    /// non-overflow total amount), and it should be guaranteed by callers.
+    pub fn locked_amount(&self, time: BlockNumber) -> Balance {
+        // full = (time - start) / period
+        // unrealized = period_count - full
+        // per_period * unrealized
+        let full = time
+            .saturating_sub(self.start)
+            .checked_div(&self.period)
+            .expect("ensured non-zero period; qed");
+        let unrealized = self
+            .period_count
+            .saturating_sub(full.unique_saturated_into());
+        self.per_period
+            .checked_mul(&unrealized.into())
+            .expect("ensured non-overflow total amount; qed")
+    }
 }
 
 #[frame_support::pallet]
 pub mod module {
-	use super::*;
+    use super::*;
 
-	pub(crate) type BalanceOf<T> =
-		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-	pub(crate) type VestingScheduleOf<T> = VestingSchedule<<T as frame_system::Config>::BlockNumber, BalanceOf<T>>;
-	pub type ScheduledItem<T> = (
-		<T as frame_system::Config>::AccountId,
-		<T as frame_system::Config>::BlockNumber,
-		<T as frame_system::Config>::BlockNumber,
-		u32,
-		BalanceOf<T>,
-	);
+    pub(crate) type BalanceOf<T> =
+        <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+    pub(crate) type VestingScheduleOf<T> =
+        VestingSchedule<<T as frame_system::Config>::BlockNumber, BalanceOf<T>>;
+    pub type ScheduledItem<T> = (
+        <T as frame_system::Config>::AccountId,
+        <T as frame_system::Config>::BlockNumber,
+        <T as frame_system::Config>::BlockNumber,
+        u32,
+        BalanceOf<T>,
+    );
 
-	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
+        type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
 
-		#[pallet::constant]
-		/// The minimum amount transferred to call `vested_transfer`.
-		type MinVestedTransfer: Get<BalanceOf<Self>>;
+        #[pallet::constant]
+        /// The minimum amount transferred to call `vested_transfer`.
+        type MinVestedTransfer: Get<BalanceOf<Self>>;
 
-		/// Required origin for vested transfer.
-		type VestedTransferOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
+        /// Required origin for vested transfer.
+        type VestedTransferOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
 
-		/// Weight information for extrinsics in this module.
-		type WeightInfo: WeightInfo;
+        /// Weight information for extrinsics in this module.
+        type WeightInfo: WeightInfo;
 
-		/// The maximum vesting schedules
-		type MaxVestingSchedules: Get<u32>;
+        /// The maximum vesting schedules
+        type MaxVestingSchedules: Get<u32>;
 
-		// The block number provider
-		type BlockNumberProvider: BlockNumberProvider<BlockNumber = Self::BlockNumber>;
-	}
+        // The block number provider
+        type BlockNumberProvider: BlockNumberProvider<BlockNumber = Self::BlockNumber>;
+    }
 
-	#[pallet::error]
-	pub enum Error<T> {
-		/// Vesting period is zero
-		ZeroVestingPeriod,
-		/// Number of vests is zero
-		ZeroVestingPeriodCount,
-		/// Insufficient amount of balance to lock
-		InsufficientBalanceToLock,
-		/// This account have too many vesting schedules
-		TooManyVestingSchedules,
-		/// The vested transfer amount is too low
-		AmountLow,
-		/// Failed because the maximum vesting schedules was exceeded
-		MaxVestingSchedulesExceeded,
-	}
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Vesting period is zero
+        ZeroVestingPeriod,
+        /// Number of vests is zero
+        ZeroVestingPeriodCount,
+        /// Insufficient amount of balance to lock
+        InsufficientBalanceToLock,
+        /// This account have too many vesting schedules
+        TooManyVestingSchedules,
+        /// The vested transfer amount is too low
+        AmountLow,
+        /// Failed because the maximum vesting schedules was exceeded
+        MaxVestingSchedulesExceeded,
+    }
 
-	#[pallet::event]
-	#[pallet::generate_deposit(fn deposit_event)]
-	pub enum Event<T: Config> {
-		/// Added new vesting schedule.
-		VestingScheduleAdded {
-			from: T::AccountId,
-			to: T::AccountId,
-			vesting_schedule: VestingScheduleOf<T>,
-		},
-		/// Claimed vesting.
-		Claimed { who: T::AccountId, amount: BalanceOf<T> },
-		/// Updated vesting schedules.
-		VestingSchedulesUpdated { who: T::AccountId },
-	}
+    #[pallet::event]
+    #[pallet::generate_deposit(fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// Added new vesting schedule.
+        VestingScheduleAdded {
+            from: T::AccountId,
+            to: T::AccountId,
+            vesting_schedule: VestingScheduleOf<T>,
+        },
+        /// Claimed vesting.
+        Claimed {
+            who: T::AccountId,
+            amount: BalanceOf<T>,
+        },
+        /// Updated vesting schedules.
+        VestingSchedulesUpdated { who: T::AccountId },
+    }
 
-	/// Vesting schedules of an account.
-	///
-	/// VestingSchedules: map AccountId => Vec\<VestingSchedule>
-	#[pallet::storage]
-	#[pallet::getter(fn vesting_schedules)]
-	pub type VestingSchedules<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		T::AccountId,
-		BoundedVec<VestingScheduleOf<T>, T::MaxVestingSchedules>,
-		ValueQuery,
-	>;
+    /// Vesting schedules of an account.
+    ///
+    /// VestingSchedules: map AccountId => Vec\<VestingSchedule>
+    #[pallet::storage]
+    #[pallet::getter(fn vesting_schedules)]
+    pub type VestingSchedules<T: Config> = StorageMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        BoundedVec<VestingScheduleOf<T>, T::MaxVestingSchedules>,
+        ValueQuery,
+    >;
 
-	#[pallet::genesis_config]
-	pub struct GenesisConfig<T: Config> {
-		pub vesting: Vec<ScheduledItem<T>>,
-	}
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub vesting: Vec<ScheduledItem<T>>,
+    }
 
-	#[cfg(feature = "std")]
-	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self {
-			GenesisConfig { vesting: vec![] }
-		}
-	}
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        #[inline]
+        fn default() -> Self {
+            GenesisConfig { vesting: vec![] }
+        }
+    }
 
-	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
-		fn build(&self) {
-			self.vesting
-				.iter()
-				.for_each(|(who, start, period, period_count, per_period)| {
-					let mut bounded_schedules = VestingSchedules::<T>::get(who);
-					bounded_schedules
-						.try_push(VestingSchedule {
-							start: *start,
-							period: *period,
-							period_count: *period_count,
-							per_period: *per_period,
-						})
-						.expect("Max vesting schedules exceeded");
-					let total_amount = bounded_schedules
-						.iter()
-						.try_fold::<_, _, Result<BalanceOf<T>, DispatchError>>(Zero::zero(), |acc_amount, schedule| {
-							let amount = ensure_valid_vesting_schedule::<T>(schedule)?;
-							acc_amount
-								.checked_add(&amount)
-								.ok_or_else(|| ArithmeticError::Overflow.into())
-						})
-						.expect("Invalid vesting schedule");
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            self.vesting
+                .iter()
+                .for_each(|(who, start, period, period_count, per_period)| {
+                    let mut bounded_schedules = VestingSchedules::<T>::get(who);
+                    bounded_schedules
+                        .try_push(VestingSchedule {
+                            start: *start,
+                            period: *period,
+                            period_count: *period_count,
+                            per_period: *per_period,
+                        })
+                        .expect("Max vesting schedules exceeded");
+                    let total_amount = bounded_schedules
+                        .iter()
+                        .try_fold::<_, _, Result<BalanceOf<T>, DispatchError>>(
+                            Zero::zero(),
+                            |acc_amount, schedule| {
+                                let amount = ensure_valid_vesting_schedule::<T>(schedule)?;
+                                acc_amount
+                                    .checked_add(&amount)
+                                    .ok_or_else(|| ArithmeticError::Overflow.into())
+                            },
+                        )
+                        .expect("Invalid vesting schedule");
 
-					assert!(
-						T::Currency::free_balance(who) >= total_amount,
-						"Account do not have enough balance"
-					);
+                    assert!(
+                        T::Currency::free_balance(who) >= total_amount,
+                        "Account do not have enough balance"
+                    );
 
-					T::Currency::set_lock(VESTING_LOCK_ID, who, total_amount, WithdrawReasons::all());
-					VestingSchedules::<T>::insert(who, bounded_schedules);
-				});
-		}
-	}
+                    T::Currency::set_lock(
+                        VESTING_LOCK_ID,
+                        who,
+                        total_amount,
+                        WithdrawReasons::all(),
+                    );
+                    VestingSchedules::<T>::insert(who, bounded_schedules);
+                });
+        }
+    }
 
-	#[pallet::pallet]
-	pub struct Pallet<T>(_);
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
+    #[pallet::hooks]
+    impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::claim(<T as Config>::MaxVestingSchedules::get() / 2))]
-		pub fn claim(origin: OriginFor<T>) -> DispatchResult {
-			let who = ensure_signed(origin)?;
-			let locked_amount = Self::do_claim(&who);
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::call_index(0)]
+        #[pallet::weight(T::WeightInfo::claim(<T as Config>::MaxVestingSchedules::get() / 2))]
+        pub fn claim(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+            let locked_amount = Self::do_claim(&who);
 
-			Self::deposit_event(Event::Claimed {
-				who,
-				amount: locked_amount,
-			});
-			Ok(())
-		}
+            Self::deposit_event(Event::Claimed {
+                who,
+                amount: locked_amount,
+            });
+            Ok(())
+        }
 
-		#[pallet::call_index(1)]
-		#[pallet::weight(T::WeightInfo::vested_transfer())]
-		pub fn vested_transfer(
-			origin: OriginFor<T>,
-			dest: <T::Lookup as StaticLookup>::Source,
-			schedule: VestingScheduleOf<T>,
-		) -> DispatchResult {
-			let from = T::VestedTransferOrigin::ensure_origin(origin)?;
-			let to = T::Lookup::lookup(dest)?;
+        #[pallet::call_index(1)]
+        #[pallet::weight(T::WeightInfo::vested_transfer())]
+        pub fn vested_transfer(
+            origin: OriginFor<T>,
+            dest: <T::Lookup as StaticLookup>::Source,
+            schedule: VestingScheduleOf<T>,
+        ) -> DispatchResult {
+            let from = T::VestedTransferOrigin::ensure_origin(origin)?;
+            let to = T::Lookup::lookup(dest)?;
 
-			if to == from {
-				ensure!(
-					T::Currency::free_balance(&from) >= schedule.total_amount().ok_or(ArithmeticError::Overflow)?,
-					Error::<T>::InsufficientBalanceToLock,
-				);
-			}
+            if to == from {
+                ensure!(
+                    T::Currency::free_balance(&from)
+                        >= schedule.total_amount().ok_or(ArithmeticError::Overflow)?,
+                    Error::<T>::InsufficientBalanceToLock,
+                );
+            }
 
-			Self::do_vested_transfer(&from, &to, schedule.clone())?;
+            Self::do_vested_transfer(&from, &to, schedule.clone())?;
 
-			Self::deposit_event(Event::VestingScheduleAdded {
-				from,
-				to,
-				vesting_schedule: schedule,
-			});
-			Ok(())
-		}
+            Self::deposit_event(Event::VestingScheduleAdded {
+                from,
+                to,
+                vesting_schedule: schedule,
+            });
+            Ok(())
+        }
 
-		#[pallet::call_index(2)]
-		#[pallet::weight(T::WeightInfo::update_vesting_schedules(vesting_schedules.len() as u32))]
-		pub fn update_vesting_schedules(
-			origin: OriginFor<T>,
-			who: <T::Lookup as StaticLookup>::Source,
-			vesting_schedules: Vec<VestingScheduleOf<T>>,
-		) -> DispatchResult {
-			ensure_root(origin)?;
+        #[pallet::call_index(2)]
+        #[pallet::weight(T::WeightInfo::update_vesting_schedules(vesting_schedules.len() as u32))]
+        pub fn update_vesting_schedules(
+            origin: OriginFor<T>,
+            who: <T::Lookup as StaticLookup>::Source,
+            vesting_schedules: Vec<VestingScheduleOf<T>>,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
 
-			let account = T::Lookup::lookup(who)?;
-			Self::do_update_vesting_schedules(&account, vesting_schedules)?;
+            let account = T::Lookup::lookup(who)?;
+            Self::do_update_vesting_schedules(&account, vesting_schedules)?;
 
-			Self::deposit_event(Event::VestingSchedulesUpdated { who: account });
-			Ok(())
-		}
+            Self::deposit_event(Event::VestingSchedulesUpdated { who: account });
+            Ok(())
+        }
 
-		#[pallet::call_index(3)]
-		#[pallet::weight(T::WeightInfo::claim(<T as Config>::MaxVestingSchedules::get() / 2))]
-		pub fn claim_for(origin: OriginFor<T>, dest: <T::Lookup as StaticLookup>::Source) -> DispatchResult {
-			let _ = ensure_signed(origin)?;
-			let who = T::Lookup::lookup(dest)?;
-			let locked_amount = Self::do_claim(&who);
+        #[pallet::call_index(3)]
+        #[pallet::weight(T::WeightInfo::claim(<T as Config>::MaxVestingSchedules::get() / 2))]
+        pub fn claim_for(
+            origin: OriginFor<T>,
+            dest: <T::Lookup as StaticLookup>::Source,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            let who = T::Lookup::lookup(dest)?;
+            let locked_amount = Self::do_claim(&who);
 
-			Self::deposit_event(Event::Claimed {
-				who,
-				amount: locked_amount,
-			});
-			Ok(())
-		}
-	}
+            Self::deposit_event(Event::Claimed {
+                who,
+                amount: locked_amount,
+            });
+            Ok(())
+        }
+    }
 }
 
 impl<T: Config> Pallet<T> {
-	fn do_claim(who: &T::AccountId) -> BalanceOf<T> {
-		let locked = Self::locked_balance(who);
-		if locked.is_zero() {
-			// cleanup the storage and unlock the fund
-			<VestingSchedules<T>>::remove(who);
-			T::Currency::remove_lock(VESTING_LOCK_ID, who);
-		} else {
-			T::Currency::set_lock(VESTING_LOCK_ID, who, locked, WithdrawReasons::all());
-		}
-		locked
-	}
+    fn do_claim(who: &T::AccountId) -> BalanceOf<T> {
+        let locked = Self::locked_balance(who);
+        if locked.is_zero() {
+            // cleanup the storage and unlock the fund
+            <VestingSchedules<T>>::remove(who);
+            T::Currency::remove_lock(VESTING_LOCK_ID, who);
+        } else {
+            T::Currency::set_lock(VESTING_LOCK_ID, who, locked, WithdrawReasons::all());
+        }
+        locked
+    }
 
-	/// Returns locked balance based on current block number.
-	fn locked_balance(who: &T::AccountId) -> BalanceOf<T> {
-		let now = T::BlockNumberProvider::current_block_number();
-		<VestingSchedules<T>>::mutate_exists(who, |maybe_schedules| {
-			let total = if let Some(schedules) = maybe_schedules.as_mut() {
-				let mut total: BalanceOf<T> = Zero::zero();
-				schedules.retain(|s| {
-					let amount = s.locked_amount(now);
-					total = total.saturating_add(amount);
-					!amount.is_zero()
-				});
-				total
-			} else {
-				Zero::zero()
-			};
-			if total.is_zero() {
-				*maybe_schedules = None;
-			}
-			total
-		})
-	}
+    /// Returns locked balance based on current block number.
+    fn locked_balance(who: &T::AccountId) -> BalanceOf<T> {
+        let now = T::BlockNumberProvider::current_block_number();
+        <VestingSchedules<T>>::mutate_exists(who, |maybe_schedules| {
+            let total = if let Some(schedules) = maybe_schedules.as_mut() {
+                let mut total: BalanceOf<T> = Zero::zero();
+                schedules.retain(|s| {
+                    let amount = s.locked_amount(now);
+                    total = total.saturating_add(amount);
+                    !amount.is_zero()
+                });
+                total
+            } else {
+                Zero::zero()
+            };
+            if total.is_zero() {
+                *maybe_schedules = None;
+            }
+            total
+        })
+    }
 
-	fn do_vested_transfer(from: &T::AccountId, to: &T::AccountId, schedule: VestingScheduleOf<T>) -> DispatchResult {
-		let schedule_amount = ensure_valid_vesting_schedule::<T>(&schedule)?;
+    fn do_vested_transfer(
+        from: &T::AccountId,
+        to: &T::AccountId,
+        schedule: VestingScheduleOf<T>,
+    ) -> DispatchResult {
+        let schedule_amount = ensure_valid_vesting_schedule::<T>(&schedule)?;
 
-		let total_amount = Self::locked_balance(to)
-			.checked_add(&schedule_amount)
-			.ok_or(ArithmeticError::Overflow)?;
+        let total_amount = Self::locked_balance(to)
+            .checked_add(&schedule_amount)
+            .ok_or(ArithmeticError::Overflow)?;
 
-		T::Currency::transfer(from, to, schedule_amount, ExistenceRequirement::AllowDeath)?;
-		T::Currency::set_lock(VESTING_LOCK_ID, to, total_amount, WithdrawReasons::all());
-		<VestingSchedules<T>>::try_append(to, schedule).map_err(|_| Error::<T>::MaxVestingSchedulesExceeded)?;
-		Ok(())
-	}
+        T::Currency::transfer(from, to, schedule_amount, ExistenceRequirement::AllowDeath)?;
+        T::Currency::set_lock(VESTING_LOCK_ID, to, total_amount, WithdrawReasons::all());
+        <VestingSchedules<T>>::try_append(to, schedule)
+            .map_err(|_| Error::<T>::MaxVestingSchedulesExceeded)?;
+        Ok(())
+    }
 
-	fn do_update_vesting_schedules(who: &T::AccountId, schedules: Vec<VestingScheduleOf<T>>) -> DispatchResult {
-		let bounded_schedules: BoundedVec<VestingScheduleOf<T>, T::MaxVestingSchedules> = schedules
-			.try_into()
-			.map_err(|_| Error::<T>::MaxVestingSchedulesExceeded)?;
+    fn do_update_vesting_schedules(
+        who: &T::AccountId,
+        schedules: Vec<VestingScheduleOf<T>>,
+    ) -> DispatchResult {
+        let bounded_schedules: BoundedVec<VestingScheduleOf<T>, T::MaxVestingSchedules> = schedules
+            .try_into()
+            .map_err(|_| Error::<T>::MaxVestingSchedulesExceeded)?;
 
-		// empty vesting schedules cleanup the storage and unlock the fund
-		if bounded_schedules.len().is_zero() {
-			<VestingSchedules<T>>::remove(who);
-			T::Currency::remove_lock(VESTING_LOCK_ID, who);
-			return Ok(());
-		}
+        // empty vesting schedules cleanup the storage and unlock the fund
+        if bounded_schedules.len().is_zero() {
+            <VestingSchedules<T>>::remove(who);
+            T::Currency::remove_lock(VESTING_LOCK_ID, who);
+            return Ok(());
+        }
 
-		let total_amount = bounded_schedules
-			.iter()
-			.try_fold::<_, _, Result<BalanceOf<T>, DispatchError>>(Zero::zero(), |acc_amount, schedule| {
-				let amount = ensure_valid_vesting_schedule::<T>(schedule)?;
-				acc_amount
-					.checked_add(&amount)
-					.ok_or_else(|| ArithmeticError::Overflow.into())
-			})?;
-		ensure!(
-			T::Currency::free_balance(who) >= total_amount,
-			Error::<T>::InsufficientBalanceToLock,
-		);
+        let total_amount = bounded_schedules
+            .iter()
+            .try_fold::<_, _, Result<BalanceOf<T>, DispatchError>>(
+                Zero::zero(),
+                |acc_amount, schedule| {
+                    let amount = ensure_valid_vesting_schedule::<T>(schedule)?;
+                    acc_amount
+                        .checked_add(&amount)
+                        .ok_or_else(|| ArithmeticError::Overflow.into())
+                },
+            )?;
+        ensure!(
+            T::Currency::free_balance(who) >= total_amount,
+            Error::<T>::InsufficientBalanceToLock,
+        );
 
-		T::Currency::set_lock(VESTING_LOCK_ID, who, total_amount, WithdrawReasons::all());
-		<VestingSchedules<T>>::insert(who, bounded_schedules);
+        T::Currency::set_lock(VESTING_LOCK_ID, who, total_amount, WithdrawReasons::all());
+        <VestingSchedules<T>>::insert(who, bounded_schedules);
 
-		Ok(())
-	}
+        Ok(())
+    }
 }
 
 /// Returns `Ok(total_total)` if valid schedule, or error.
-fn ensure_valid_vesting_schedule<T: Config>(schedule: &VestingScheduleOf<T>) -> Result<BalanceOf<T>, DispatchError> {
-	ensure!(!schedule.period.is_zero(), Error::<T>::ZeroVestingPeriod);
-	ensure!(!schedule.period_count.is_zero(), Error::<T>::ZeroVestingPeriodCount);
-	ensure!(schedule.end().is_some(), ArithmeticError::Overflow);
+fn ensure_valid_vesting_schedule<T: Config>(
+    schedule: &VestingScheduleOf<T>,
+) -> Result<BalanceOf<T>, DispatchError> {
+    ensure!(!schedule.period.is_zero(), Error::<T>::ZeroVestingPeriod);
+    ensure!(
+        !schedule.period_count.is_zero(),
+        Error::<T>::ZeroVestingPeriodCount
+    );
+    ensure!(schedule.end().is_some(), ArithmeticError::Overflow);
 
-	let total_total = schedule.total_amount().ok_or(ArithmeticError::Overflow)?;
+    let total_total = schedule.total_amount().ok_or(ArithmeticError::Overflow)?;
 
-	ensure!(total_total >= T::MinVestedTransfer::get(), Error::<T>::AmountLow);
+    ensure!(
+        total_total >= T::MinVestedTransfer::get(),
+        Error::<T>::AmountLow
+    );
 
-	Ok(total_total)
+    Ok(total_total)
 }

--- a/substrate/substrate-test-runtime-transaction-pool/src/lib.rs
+++ b/substrate/substrate-test-runtime-transaction-pool/src/lib.rs
@@ -23,21 +23,19 @@ use codec::Encode;
 use futures::future::ready;
 use parking_lot::RwLock;
 use sp_blockchain::{CachedHeaderMetadata, TreeRoute};
-use sp_runtime::{
-	generic::{self, BlockId},
-	traits::{
-		BlakeTwo256, Block as BlockT, Hash as HashT, Header as _, NumberFor, TrailingZeroInput,
-	},
-	transaction_validity::{
-		InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
-		ValidTransaction,
-	},
+use sp_runtime::generic::{self, BlockId};
+use sp_runtime::traits::{
+    BlakeTwo256, Block as BlockT, Hash as HashT, Header as _, NumberFor, TrailingZeroInput,
+};
+use sp_runtime::transaction_validity::{
+    InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
+    ValidTransaction,
 };
 use std::collections::{BTreeMap, HashMap, HashSet};
-use substrate_test_runtime_client::{
-	runtime::{AccountId, Block, BlockNumber, Extrinsic, Hash, Header, Index, Transfer},
-	AccountKeyring::{self, *},
+use substrate_test_runtime_client::runtime::{
+    AccountId, Block, BlockNumber, Extrinsic, Hash, Header, Index, Transfer,
 };
+use substrate_test_runtime_client::AccountKeyring::{self, *};
 
 /// Error type used by [`TestApi`].
 #[derive(Debug, thiserror::Error)]
@@ -45,327 +43,387 @@ use substrate_test_runtime_client::{
 pub struct Error(#[from] sc_transaction_pool_api::error::Error);
 
 impl sc_transaction_pool_api::error::IntoPoolError for Error {
-	fn into_pool_error(self) -> Result<sc_transaction_pool_api::error::Error, Self> {
-		Ok(self.0)
-	}
+    fn into_pool_error(self) -> Result<sc_transaction_pool_api::error::Error, Self> {
+        Ok(self.0)
+    }
 }
 
 pub enum IsBestBlock {
-	Yes,
-	No,
+    Yes,
+    No,
 }
 
 impl IsBestBlock {
-	pub fn is_best(&self) -> bool {
-		matches!(self, Self::Yes)
-	}
+    pub fn is_best(&self) -> bool {
+        matches!(self, Self::Yes)
+    }
 }
 
 impl From<bool> for IsBestBlock {
-	fn from(is_best: bool) -> Self {
-		if is_best {
-			Self::Yes
-		} else {
-			Self::No
-		}
-	}
+    #[inline]
+    fn from(is_best: bool) -> Self {
+        if is_best {
+            Self::Yes
+        } else {
+            Self::No
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct ChainState {
-	pub block_by_number: BTreeMap<BlockNumber, Vec<(Block, IsBestBlock)>>,
-	pub block_by_hash: HashMap<Hash, Block>,
-	pub nonces: HashMap<AccountId, u64>,
-	pub invalid_hashes: HashSet<Hash>,
+    pub block_by_number: BTreeMap<BlockNumber, Vec<(Block, IsBestBlock)>>,
+    pub block_by_hash: HashMap<Hash, Block>,
+    pub nonces: HashMap<AccountId, u64>,
+    pub invalid_hashes: HashSet<Hash>,
 }
 
 /// Test Api for transaction pool.
 pub struct TestApi {
-	#[allow(clippy::type_complexity)]
-	valid_modifier: RwLock<Box<dyn Fn(&mut ValidTransaction) + Send + Sync>>,
-	chain: RwLock<ChainState>,
-	validation_requests: RwLock<Vec<Extrinsic>>,
+    #[allow(clippy::type_complexity)]
+    valid_modifier: RwLock<Box<dyn Fn(&mut ValidTransaction) + Send + Sync>>,
+    chain: RwLock<ChainState>,
+    validation_requests: RwLock<Vec<Extrinsic>>,
 }
 
 impl TestApi {
-	/// Test Api with Alice nonce set initially.
-	pub fn with_alice_nonce(nonce: u64) -> Self {
-		let api = Self::empty();
+    /// Test Api with Alice nonce set initially.
+    pub fn with_alice_nonce(nonce: u64) -> Self {
+        let api = Self::empty();
 
-		api.chain.write().nonces.insert(Alice.into(), nonce);
+        api.chain.write().nonces.insert(Alice.into(), nonce);
 
-		api
-	}
+        api
+    }
 
-	/// Default Test Api
-	pub fn empty() -> Self {
-		let api = TestApi {
-			valid_modifier: RwLock::new(Box::new(|_| {})),
-			chain: Default::default(),
-			validation_requests: RwLock::new(Default::default()),
-		};
+    /// Default Test Api
+    pub fn empty() -> Self {
+        let api = TestApi {
+            valid_modifier: RwLock::new(Box::new(|_| {})),
+            chain: Default::default(),
+            validation_requests: RwLock::new(Default::default()),
+        };
 
-		// Push genesis block
-		api.push_block(0, Vec::new(), true);
+        // Push genesis block
+        api.push_block(0, Vec::new(), true);
 
-		api
-	}
+        api
+    }
 
-	/// Set hook on modify valid result of transaction.
-	pub fn set_valid_modifier(&self, modifier: Box<dyn Fn(&mut ValidTransaction) + Send + Sync>) {
-		*self.valid_modifier.write() = modifier;
-	}
+    /// Set hook on modify valid result of transaction.
+    pub fn set_valid_modifier(&self, modifier: Box<dyn Fn(&mut ValidTransaction) + Send + Sync>) {
+        *self.valid_modifier.write() = modifier;
+    }
 
-	/// Push block under given number.
-	pub fn push_block(
-		&self,
-		block_number: BlockNumber,
-		xts: Vec<Extrinsic>,
-		is_best_block: bool,
-	) -> Header {
-		let parent_hash = {
-			let chain = self.chain.read();
-			block_number
-				.checked_sub(1)
-				.and_then(|num| {
-					chain.block_by_number.get(&num).map(|blocks| blocks[0].0.header.hash())
-				})
-				.unwrap_or_default()
-		};
+    /// Push block under given number.
+    pub fn push_block(
+        &self,
+        block_number: BlockNumber,
+        xts: Vec<Extrinsic>,
+        is_best_block: bool,
+    ) -> Header {
+        let parent_hash = {
+            let chain = self.chain.read();
+            block_number
+                .checked_sub(1)
+                .and_then(|num| {
+                    chain
+                        .block_by_number
+                        .get(&num)
+                        .map(|blocks| blocks[0].0.header.hash())
+                })
+                .unwrap_or_default()
+        };
 
-		self.push_block_with_parent(parent_hash, xts, is_best_block)
-	}
+        self.push_block_with_parent(parent_hash, xts, is_best_block)
+    }
 
-	/// Push a block using the given `parent`.
-	///
-	/// Panics if `parent` does not exists.
-	pub fn push_block_with_parent(
-		&self,
-		parent: Hash,
-		xts: Vec<Extrinsic>,
-		is_best_block: bool,
-	) -> Header {
-		// `Hash::default()` is the genesis parent hash
-		let block_number = if parent == Hash::default() {
-			0
-		} else {
-			*self
-				.chain
-				.read()
-				.block_by_hash
-				.get(&parent)
-				.expect("`parent` exists")
-				.header()
-				.number() + 1
-		};
+    /// Push a block using the given `parent`.
+    ///
+    /// Panics if `parent` does not exists.
+    pub fn push_block_with_parent(
+        &self,
+        parent: Hash,
+        xts: Vec<Extrinsic>,
+        is_best_block: bool,
+    ) -> Header {
+        // `Hash::default()` is the genesis parent hash
+        let block_number = if parent == Hash::default() {
+            0
+        } else {
+            *self
+                .chain
+                .read()
+                .block_by_hash
+                .get(&parent)
+                .expect("`parent` exists")
+                .header()
+                .number()
+                + 1
+        };
 
-		let header = Header {
-			number: block_number,
-			digest: Default::default(),
-			extrinsics_root: Hash::random(),
-			parent_hash: parent,
-			state_root: Default::default(),
-		};
+        let header = Header {
+            number: block_number,
+            digest: Default::default(),
+            extrinsics_root: Hash::random(),
+            parent_hash: parent,
+            state_root: Default::default(),
+        };
 
-		self.add_block(Block::new(header.clone(), xts), is_best_block);
+        self.add_block(Block::new(header.clone(), xts), is_best_block);
 
-		header
-	}
+        header
+    }
 
-	/// Add a block to the internal state.
-	pub fn add_block(&self, block: Block, is_best_block: bool) {
-		let hash = block.header.hash();
-		let block_number = block.header.number();
+    /// Add a block to the internal state.
+    pub fn add_block(&self, block: Block, is_best_block: bool) {
+        let hash = block.header.hash();
+        let block_number = block.header.number();
 
-		let mut chain = self.chain.write();
-		chain.block_by_hash.insert(hash, block.clone());
-		chain
-			.block_by_number
-			.entry(*block_number)
-			.or_default()
-			.push((block, is_best_block.into()));
-	}
+        let mut chain = self.chain.write();
+        chain.block_by_hash.insert(hash, block.clone());
+        chain
+            .block_by_number
+            .entry(*block_number)
+            .or_default()
+            .push((block, is_best_block.into()));
+    }
 
-	fn hash_and_length_inner(ex: &Extrinsic) -> (Hash, usize) {
-		let encoded = ex.encode();
-		(BlakeTwo256::hash(&encoded), encoded.len())
-	}
+    fn hash_and_length_inner(ex: &Extrinsic) -> (Hash, usize) {
+        let encoded = ex.encode();
+        (BlakeTwo256::hash(&encoded), encoded.len())
+    }
 
-	/// Mark some transaction is invalid.
-	///
-	/// Next time transaction pool will try to validate this
-	/// extrinsic, api will return invalid result.
-	pub fn add_invalid(&self, xts: &Extrinsic) {
-		self.chain.write().invalid_hashes.insert(Self::hash_and_length_inner(xts).0);
-	}
+    /// Mark some transaction is invalid.
+    ///
+    /// Next time transaction pool will try to validate this
+    /// extrinsic, api will return invalid result.
+    pub fn add_invalid(&self, xts: &Extrinsic) {
+        self.chain
+            .write()
+            .invalid_hashes
+            .insert(Self::hash_and_length_inner(xts).0);
+    }
 
-	/// Query validation requests received.
-	pub fn validation_requests(&self) -> Vec<Extrinsic> {
-		self.validation_requests.read().clone()
-	}
+    /// Query validation requests received.
+    pub fn validation_requests(&self) -> Vec<Extrinsic> {
+        self.validation_requests.read().clone()
+    }
 
-	/// get a reference to the chain state
-	pub fn chain(&self) -> &RwLock<ChainState> {
-		&self.chain
-	}
+    /// get a reference to the chain state
+    pub fn chain(&self) -> &RwLock<ChainState> {
+        &self.chain
+    }
 
-	/// Increment nonce in the inner state.
-	pub fn increment_nonce(&self, account: AccountId) {
-		let mut chain = self.chain.write();
-		chain.nonces.entry(account).and_modify(|n| *n += 1).or_insert(1);
-	}
+    /// Increment nonce in the inner state.
+    pub fn increment_nonce(&self, account: AccountId) {
+        let mut chain = self.chain.write();
+        chain
+            .nonces
+            .entry(account)
+            .and_modify(|n| *n += 1)
+            .or_insert(1);
+    }
 
-	/// Calculate a tree route between the two given blocks.
-	pub fn tree_route(
-		&self,
-		from: Hash,
-		to: Hash,
-	) -> Result<sp_blockchain::TreeRoute<Block>, Error> {
-		sp_blockchain::tree_route(self, from, to)
-	}
+    /// Calculate a tree route between the two given blocks.
+    pub fn tree_route(
+        &self,
+        from: Hash,
+        to: Hash,
+    ) -> Result<sp_blockchain::TreeRoute<Block>, Error> {
+        sp_blockchain::tree_route(self, from, to)
+    }
 }
 
 impl sc_transaction_pool::ChainApi for TestApi {
-	type Block = Block;
-	type Error = Error;
-	type ValidationFuture = futures::future::Ready<Result<TransactionValidity, Error>>;
-	type BodyFuture = futures::future::Ready<Result<Option<Vec<Extrinsic>>, Error>>;
+    type Block = Block;
+    type Error = Error;
+    type ValidationFuture = futures::future::Ready<Result<TransactionValidity, Error>>;
+    type BodyFuture = futures::future::Ready<Result<Option<Vec<Extrinsic>>, Error>>;
 
-	fn validate_transaction(
-		&self,
-		at: &BlockId<Self::Block>,
-		_source: TransactionSource,
-		uxt: <Self::Block as BlockT>::Extrinsic,
-	) -> Self::ValidationFuture {
-		self.validation_requests.write().push(uxt.clone());
+    fn validate_transaction(
+        &self,
+        at: &BlockId<Self::Block>,
+        _source: TransactionSource,
+        uxt: <Self::Block as BlockT>::Extrinsic,
+    ) -> Self::ValidationFuture {
+        self.validation_requests.write().push(uxt.clone());
 
-		match self.block_id_to_number(at) {
-			Ok(Some(number)) => {
-				let found_best = self
-					.chain
-					.read()
-					.block_by_number
-					.get(&number)
-					.map(|blocks| blocks.iter().any(|b| b.1.is_best()))
-					.unwrap_or(false);
+        match self.block_id_to_number(at) {
+            Ok(Some(number)) => {
+                let found_best = self
+                    .chain
+                    .read()
+                    .block_by_number
+                    .get(&number)
+                    .map(|blocks| blocks.iter().any(|b| b.1.is_best()))
+                    .unwrap_or(false);
 
-				// If there is no best block, we don't know based on which block we should validate
-				// the transaction. (This is not required for this test function, but in real
-				// environment it would fail because of this).
-				if !found_best {
-					return ready(Ok(Err(TransactionValidityError::Invalid(
-						InvalidTransaction::Custom(1),
-					))))
-				}
-			},
-			Ok(None) =>
-				return ready(Ok(Err(TransactionValidityError::Invalid(
-					InvalidTransaction::Custom(2),
-				)))),
-			Err(e) => return ready(Err(e)),
-		}
+                // If there is no best block, we don't know based on which block we should validate
+                // the transaction. (This is not required for this test function, but in real
+                // environment it would fail because of this).
+                if !found_best {
+                    return ready(Ok(Err(TransactionValidityError::Invalid(
+                        InvalidTransaction::Custom(1),
+                    ))));
+                }
+            }
+            Ok(None) => {
+                return ready(Ok(Err(TransactionValidityError::Invalid(
+                    InvalidTransaction::Custom(2),
+                ))))
+            }
+            Err(e) => return ready(Err(e)),
+        }
 
-		let (requires, provides) = if let Some(transfer) = uxt.try_transfer() {
-			let chain_nonce = self.chain.read().nonces.get(&transfer.from).cloned().unwrap_or(0);
-			let requires =
-				if chain_nonce == transfer.nonce { vec![] } else { vec![vec![chain_nonce as u8]] };
-			let provides = vec![vec![transfer.nonce as u8]];
+        let (requires, provides) = if let Some(transfer) = uxt.try_transfer() {
+            let chain_nonce = self
+                .chain
+                .read()
+                .nonces
+                .get(&transfer.from)
+                .cloned()
+                .unwrap_or(0);
+            let requires = if chain_nonce == transfer.nonce {
+                vec![]
+            } else {
+                vec![vec![chain_nonce as u8]]
+            };
+            let provides = vec![vec![transfer.nonce as u8]];
 
-			(requires, provides)
-		} else {
-			(Vec::new(), vec![uxt.encode()])
-		};
+            (requires, provides)
+        } else {
+            (Vec::new(), vec![uxt.encode()])
+        };
 
-		if self.chain.read().invalid_hashes.contains(&self.hash_and_length(&uxt).0) {
-			return ready(Ok(Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(0)))))
-		}
+        if self
+            .chain
+            .read()
+            .invalid_hashes
+            .contains(&self.hash_and_length(&uxt).0)
+        {
+            return ready(Ok(Err(TransactionValidityError::Invalid(
+                InvalidTransaction::Custom(0),
+            ))));
+        }
 
-		let mut validity =
-			ValidTransaction { priority: 1, requires, provides, longevity: 64, propagate: true };
+        let mut validity = ValidTransaction {
+            priority: 1,
+            requires,
+            provides,
+            longevity: 64,
+            propagate: true,
+        };
 
-		(self.valid_modifier.read())(&mut validity);
+        (self.valid_modifier.read())(&mut validity);
 
-		ready(Ok(Ok(validity)))
-	}
+        ready(Ok(Ok(validity)))
+    }
 
-	fn block_id_to_number(
-		&self,
-		at: &BlockId<Self::Block>,
-	) -> Result<Option<NumberFor<Self::Block>>, Error> {
-		Ok(match at {
-			generic::BlockId::Hash(x) =>
-				self.chain.read().block_by_hash.get(x).map(|b| *b.header.number()),
-			generic::BlockId::Number(num) => Some(*num),
-		})
-	}
+    fn block_id_to_number(
+        &self,
+        at: &BlockId<Self::Block>,
+    ) -> Result<Option<NumberFor<Self::Block>>, Error> {
+        Ok(match at {
+            generic::BlockId::Hash(x) => self
+                .chain
+                .read()
+                .block_by_hash
+                .get(x)
+                .map(|b| *b.header.number()),
+            generic::BlockId::Number(num) => Some(*num),
+        })
+    }
 
-	fn block_id_to_hash(
-		&self,
-		at: &BlockId<Self::Block>,
-	) -> Result<Option<<Self::Block as BlockT>::Hash>, Error> {
-		Ok(match at {
-			generic::BlockId::Hash(x) => Some(*x),
-			generic::BlockId::Number(num) =>
-				self.chain.read().block_by_number.get(num).and_then(|blocks| {
-					blocks.iter().find(|b| b.1.is_best()).map(|b| b.0.header().hash())
-				}),
-		})
-	}
+    fn block_id_to_hash(
+        &self,
+        at: &BlockId<Self::Block>,
+    ) -> Result<Option<<Self::Block as BlockT>::Hash>, Error> {
+        Ok(match at {
+            generic::BlockId::Hash(x) => Some(*x),
+            generic::BlockId::Number(num) => {
+                self.chain
+                    .read()
+                    .block_by_number
+                    .get(num)
+                    .and_then(|blocks| {
+                        blocks
+                            .iter()
+                            .find(|b| b.1.is_best())
+                            .map(|b| b.0.header().hash())
+                    })
+            }
+        })
+    }
 
-	fn hash_and_length(&self, ex: &<Self::Block as BlockT>::Extrinsic) -> (Hash, usize) {
-		Self::hash_and_length_inner(ex)
-	}
+    fn hash_and_length(&self, ex: &<Self::Block as BlockT>::Extrinsic) -> (Hash, usize) {
+        Self::hash_and_length_inner(ex)
+    }
 
-	fn block_body(&self, hash: <Self::Block as BlockT>::Hash) -> Self::BodyFuture {
-		futures::future::ready(Ok(self
-			.chain
-			.read()
-			.block_by_hash
-			.get(&hash)
-			.map(|b| b.extrinsics().to_vec())))
-	}
+    fn block_body(&self, hash: <Self::Block as BlockT>::Hash) -> Self::BodyFuture {
+        futures::future::ready(Ok(self
+            .chain
+            .read()
+            .block_by_hash
+            .get(&hash)
+            .map(|b| b.extrinsics().to_vec())))
+    }
 
-	fn block_header(
-		&self,
-		hash: <Self::Block as BlockT>::Hash,
-	) -> Result<Option<<Self::Block as BlockT>::Header>, Self::Error> {
-		Ok(self.chain.read().block_by_hash.get(&hash).map(|b| b.header().clone()))
-	}
+    fn block_header(
+        &self,
+        hash: <Self::Block as BlockT>::Hash,
+    ) -> Result<Option<<Self::Block as BlockT>::Header>, Self::Error> {
+        Ok(self
+            .chain
+            .read()
+            .block_by_hash
+            .get(&hash)
+            .map(|b| b.header().clone()))
+    }
 
-	fn tree_route(
-		&self,
-		from: <Self::Block as BlockT>::Hash,
-		to: <Self::Block as BlockT>::Hash,
-	) -> Result<TreeRoute<Self::Block>, Self::Error> {
-		sp_blockchain::tree_route::<Block, TestApi>(self, from, to).map_err(Into::into)
-	}
+    fn tree_route(
+        &self,
+        from: <Self::Block as BlockT>::Hash,
+        to: <Self::Block as BlockT>::Hash,
+    ) -> Result<TreeRoute<Self::Block>, Self::Error> {
+        sp_blockchain::tree_route::<Block, TestApi>(self, from, to).map_err(Into::into)
+    }
 }
 
 impl sp_blockchain::HeaderMetadata<Block> for TestApi {
-	type Error = Error;
+    type Error = Error;
 
-	fn header_metadata(&self, hash: Hash) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
-		let chain = self.chain.read();
-		let block = chain.block_by_hash.get(&hash).expect("Hash exists");
+    fn header_metadata(&self, hash: Hash) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
+        let chain = self.chain.read();
+        let block = chain.block_by_hash.get(&hash).expect("Hash exists");
 
-		Ok(block.header().into())
-	}
+        Ok(block.header().into())
+    }
 
-	fn insert_header_metadata(&self, _: Hash, _: CachedHeaderMetadata<Block>) {
-		unimplemented!("Not implemented for tests")
-	}
+    fn insert_header_metadata(&self, _: Hash, _: CachedHeaderMetadata<Block>) {
+        unimplemented!("Not implemented for tests")
+    }
 
-	fn remove_header_metadata(&self, _: Hash) {
-		unimplemented!("Not implemented for tests")
-	}
+    fn remove_header_metadata(&self, _: Hash) {
+        unimplemented!("Not implemented for tests")
+    }
 }
 
 /// Generate transfer extrinsic with a given nonce.
 ///
 /// Part of the test api.
 pub fn uxt(who: AccountKeyring, nonce: Index) -> Extrinsic {
-	let dummy = codec::Decode::decode(&mut TrailingZeroInput::zeroes()).unwrap();
-	let transfer = Transfer { from: who.into(), to: dummy, nonce, amount: 1 };
-	let signature = transfer.using_encoded(|e| who.sign(e));
-	Extrinsic::Transfer { transfer, signature, exhaust_resources_when_not_first: false }
+    let dummy = codec::Decode::decode(&mut TrailingZeroInput::zeroes()).unwrap();
+    let transfer = Transfer {
+        from: who.into(),
+        to: dummy,
+        nonce,
+        amount: 1,
+    };
+    let signature = transfer.using_encoded(|e| who.sign(e));
+    Extrinsic::Transfer {
+        transfer,
+        signature,
+        exhaust_resources_when_not_first: false,
+    }
 }

--- a/substrate/substrate-test-runtime/src/lib.rs
+++ b/substrate/substrate-test-runtime/src/lib.rs
@@ -302,6 +302,7 @@ impl<B: BlockT> codec::EncodeLike for DecodeFails<B> {}
 
 impl<B: BlockT> Default for DecodeFails<B> {
     /// Create a new instance.
+    #[inline]
     fn default() -> DecodeFails<B> {
         DecodeFails {
             _phantom: Default::default(),
@@ -432,6 +433,7 @@ impl GetRuntimeBlockType for Runtime {
 pub struct RuntimeOrigin;
 
 impl From<RawOrigin<<Runtime as frame_system::Config>::AccountId>> for RuntimeOrigin {
+    #[inline]
     fn from(_: RawOrigin<<Runtime as frame_system::Config>::AccountId>) -> Self {
         unimplemented!("Not required in tests!")
     }
@@ -448,6 +450,7 @@ impl CallerTrait<<Runtime as frame_system::Config>::AccountId> for RuntimeOrigin
 }
 
 impl From<RuntimeOrigin> for Result<frame_system::Origin<Runtime>, RuntimeOrigin> {
+    #[inline]
     fn from(_origin: RuntimeOrigin) -> Result<frame_system::Origin<Runtime>, RuntimeOrigin> {
         unimplemented!("Not required in tests!")
     }
@@ -510,12 +513,14 @@ impl frame_support::traits::OriginTrait for RuntimeOrigin {
 pub struct RuntimeEvent;
 
 impl From<frame_system::Event<Runtime>> for RuntimeEvent {
+    #[inline]
     fn from(_evt: frame_system::Event<Runtime>) -> Self {
         unimplemented!("Not required in tests!")
     }
 }
 
 impl From<pallet_subspace::Event<Runtime>> for RuntimeEvent {
+    #[inline]
     fn from(_evt: pallet_subspace::Event<Runtime>) -> Self {
         unimplemented!("Not required in tests!")
     }
@@ -585,6 +590,7 @@ parameter_types! {
 }
 
 impl From<frame_system::Call<Runtime>> for Extrinsic {
+    #[inline]
     fn from(_: frame_system::Call<Runtime>) -> Self {
         unimplemented!("Not required in tests!")
     }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -972,6 +972,7 @@ fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness
 struct RewardAddress([u8; 32]);
 
 impl From<FarmerPublicKey> for RewardAddress {
+    #[inline]
     fn from(farmer_public_key: FarmerPublicKey) -> Self {
         Self(
             farmer_public_key
@@ -983,6 +984,7 @@ impl From<FarmerPublicKey> for RewardAddress {
 }
 
 impl From<RewardAddress> for AccountId32 {
+    #[inline]
     fn from(reward_address: RewardAddress) -> Self {
         reward_address.0.into()
     }


### PR DESCRIPTION
Doesn't matter much for "production" profile, but for all others inlining across crates is not used, which means we're loosing performance on new types, meaning our abstractions are not zero cost. This PR simply adds a bunch of `#[inline]` in useful places.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
