### PR TITLE
Update rust-kzg, blst and build targets

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -33,7 +33,7 @@ jobs:
             dockerfile-suffix: ''
             suffix: ubuntu-x86_64-${{ github.ref_name }}
             image-suffix: ''
-            rustflags: '-C target-cpu=x86-64-v2'
+            rustflags: '-C target-cpu=skylake'
           # We build AArch64
           - arch: linux/amd64
             dockerfile-suffix: '.aarch64'
@@ -89,8 +89,8 @@ jobs:
             rustflags: '-C target-cpu=x86-64-v2'
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-            suffix: ubuntu-x86_64-v3-${{ github.ref_name }}
-            rustflags: '-C target-cpu=x86-64-v3'
+            suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
+            rustflags: '-C target-cpu=skylake'
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             suffix: ubuntu-aarch64-${{ github.ref_name }}
@@ -109,8 +109,8 @@ jobs:
             rustflags: '-C target-cpu=x86-64-v2'
           - os: windows-2022
             target: x86_64-pc-windows-msvc
-            suffix: windows-x86_64-v3-${{ github.ref_name }}
-            rustflags: '-C target-cpu=x86-64-v3'
+            suffix: windows-x86_64-skylake-${{ github.ref_name }}
+            rustflags: '-C target-cpu=skylake'
     runs-on: ${{ matrix.build.os }}
     env:
       PRODUCTION_TARGET: target/${{ matrix.build.target }}/production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "blst"
 version = "0.3.10"
-source = "git+https://github.com/subspace/blst.git?rev=079887d2d05bb2d61df4ceef3d4c836228ebc6ff#079887d2d05bb2d61df4ceef3d4c836228ebc6ff"
+source = "git+https://github.com/subspace/blst.git?rev=017edf9d7b943813b9ba2804a9eda20607b48139#017edf9d7b943813b9ba2804a9eda20607b48139"
 dependencies = [
  "cc",
  "glob",
@@ -914,15 +914,15 @@ dependencies = [
 [[package]]
 name = "blst_from_scratch"
 version = "0.1.0"
-source = "git+https://github.com/subspace/rust-kzg?rev=49e7b60ea51d918f04779dd83191ae0e01afcb30#49e7b60ea51d918f04779dd83191ae0e01afcb30"
+source = "git+https://github.com/subspace/rust-kzg?rev=fad8d358548301424f20f7fc7aaa02e75041d03b#fad8d358548301424f20f7fc7aaa02e75041d03b"
 dependencies = [
  "blst",
  "kzg",
  "libc",
+ "num_cpus",
  "once_cell",
  "rand 0.8.5",
  "rayon",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -4527,7 +4527,11 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/subspace/rust-kzg?rev=49e7b60ea51d918f04779dd83191ae0e01afcb30#49e7b60ea51d918f04779dd83191ae0e01afcb30"
+source = "git+https://github.com/subspace/rust-kzg?rev=fad8d358548301424f20f7fc7aaa02e75041d03b#fad8d358548301424f20f7fc7aaa02e75041d03b"
+dependencies = [
+ "blst",
+ "sha2 0.10.6",
+]
 
 [[package]]
 name = "language-tags"

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -18,11 +18,11 @@ bench = false
 [dependencies]
 blake2 = { version = "0.10.6", default-features = false }
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
 derive_more = "0.99.17"
 hex = { version  = "0.4.3", default-features = false, features = ["alloc"] }
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-kzg = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
+kzg = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
 parking_lot = { version = "0.12.1", optional = true }

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -13,9 +13,9 @@ use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use blst_from_scratch::eip_4844::{bytes_from_g1_rust, bytes_to_g1_rust, bytes_to_g2_rust};
 use blst_from_scratch::types::fft_settings::FsFFTSettings;
 use blst_from_scratch::types::g1::FsG1;
+use blst_from_scratch::types::g2::FsG2;
 use blst_from_scratch::types::kzg_settings::FsKZGSettings;
 use blst_from_scratch::types::poly::FsPoly;
 use core::hash::{Hash, Hasher};
@@ -48,7 +48,7 @@ pub fn bytes_to_kzg_settings(bytes: &[u8]) -> Result<FsKZGSettings, String> {
     let secret_g1 = secret_g1_bytes
         .chunks_exact(48)
         .map(|bytes| {
-            bytes_to_g1_rust(
+            FsG1::from_bytes(
                 bytes
                     .try_into()
                     .expect("Chunked into correct number of bytes above; qed"),
@@ -58,7 +58,7 @@ pub fn bytes_to_kzg_settings(bytes: &[u8]) -> Result<FsKZGSettings, String> {
     let secret_g2 = secret_g2_bytes
         .chunks_exact(96)
         .map(|bytes| {
-            bytes_to_g2_rust(
+            FsG2::from_bytes(
                 bytes
                     .try_into()
                     .expect("Chunked into correct number of bytes above; qed"),
@@ -122,12 +122,12 @@ impl Commitment {
 
     /// Convert commitment to raw bytes
     pub fn to_bytes(&self) -> [u8; Self::SIZE] {
-        bytes_from_g1_rust(&self.0)
+        self.0.to_bytes()
     }
 
     /// Try to deserialize commitment from raw bytes
     pub fn try_from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, String> {
-        Ok(Commitment(bytes_to_g1_rust(bytes)?))
+        Ok(Commitment(FsG1::from_bytes(bytes)?))
     }
 
     /// Convenient conversion from slice of commitment to underlying representation for efficiency
@@ -353,12 +353,12 @@ impl Witness {
 
     /// Convert witness to raw bytes
     pub fn to_bytes(&self) -> [u8; Self::SIZE] {
-        bytes_from_g1_rust(&self.0)
+        self.0.to_bytes()
     }
 
     /// Try to deserialize witness from raw bytes
     pub fn try_from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, String> {
-        Ok(Witness(bytes_to_g1_rust(bytes)?))
+        Ok(Witness(FsG1::from_bytes(bytes)?))
     }
 }
 

--- a/crates/subspace-core-primitives/src/crypto/kzg/tests.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg/tests.rs
@@ -1,9 +1,10 @@
 use crate::crypto::kzg::{embedded_kzg_settings, Kzg};
 use crate::crypto::Scalar;
 use blst_from_scratch::consts::{G1_GENERATOR, G2_GENERATOR};
-use blst_from_scratch::eip_4844::{bytes_from_g1_rust, bytes_from_g2_rust};
 use blst_from_scratch::types::fft_settings::FsFFTSettings;
 use blst_from_scratch::types::fr::FsFr;
+use blst_from_scratch::types::g1::FsG1;
+use blst_from_scratch::types::g2::FsG2;
 use blst_from_scratch::types::kzg_settings::FsKZGSettings;
 use kzg::{FFTSettings, Fr, G1Mul, G2Mul};
 use rand::Rng;
@@ -66,10 +67,10 @@ fn test_public_parameters_generate() -> FsKZGSettings {
 fn kzg_settings_to_bytes(kzg_settings: &FsKZGSettings) -> Vec<u8> {
     let mut bytes =
         Vec::with_capacity(kzg_settings.secret_g1.len() * 48 + kzg_settings.secret_g2.len() * 96);
-    for g1 in kzg_settings.secret_g1.iter().map(bytes_from_g1_rust) {
+    for g1 in kzg_settings.secret_g1.iter().map(FsG1::to_bytes) {
         bytes.extend_from_slice(&g1);
     }
-    for g2 in kzg_settings.secret_g2.iter().map(bytes_from_g2_rust) {
+    for g2 in kzg_settings.secret_g2.iter().map(FsG2::to_bytes) {
         bytes.extend_from_slice(&g2);
     }
 

--- a/crates/subspace-erasure-coding/Cargo.toml
+++ b/crates/subspace-erasure-coding/Cargo.toml
@@ -16,14 +16,14 @@ bench = false
 
 [dependencies]
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-kzg = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30", default-features = false }
+kzg = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "49e7b60ea51d918f04779dd83191ae0e01afcb30" }
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b" }
 criterion = "0.4.0"
 rand = "0.8.5"
 


### PR DESCRIPTION
This PR pulls latest rust-kzg with various improvements into our fork + https://github.com/sifraitech/rust-kzg/pull/220 (methods we used before were removed) + https://github.com/sifraitech/rust-kzg/pull/221 (`no_std` support got broken upstream in the meantime) + cherry-picked https://github.com/supranational/blst/commit/9bf52f8e44fc3b87a7f470f306c0aeb5b7afcdf8 into out fork of blst.

With those performance should improve.

We will also start building releases for `skylake` architecture (which is similar to `znver1`, except skylake doesn't have hardware instructions for SHA) to use A LOT more modern instructions comparing to `x86-64-v3`, while `x86-64-v2` will become compatible with actual `x86-64-v2` machines due to not using ADX instructions anymore (see above commit from blst).

And container images are now built for Skylake only, for legacy CPUs users will have to build images themselves.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
