### PR TITLE
Publish core domain tx prevalidator

### DIFF
--- a/domains/client/eth-service/src/lib.rs
+++ b/domains/client/eth-service/src/lib.rs
@@ -6,3 +6,4 @@ pub(crate) mod rpc;
 mod service;
 
 pub use rpc::DefaultEthConfig;
+pub use service::EthConfiguration;

--- a/domains/client/eth-service/src/provider.rs
+++ b/domains/client/eth-service/src/provider.rs
@@ -43,6 +43,10 @@ pub struct EthProvider<CT, EC> {
 impl<CT, EC> EthProvider<CT, EC> {
     pub fn new(base_path: Option<BasePath>, eth_cli: impl Iterator<Item = String>) -> Self {
         let eth_config = EthConfiguration::parse_from(eth_cli);
+        Self::with_configuration(base_path, eth_config)
+    }
+
+    pub fn with_configuration(base_path: Option<BasePath>, eth_config: EthConfiguration) -> Self {
         Self {
             eth_config,
             base_path: base_path.map(|base_path| BasePath::new(base_path.path().join("evm"))),

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -8,6 +8,7 @@ mod system_domain;
 mod system_domain_tx_pre_validator;
 
 pub use self::core_domain::{new_full_core, CoreDomainParams, NewFullCore};
+pub use self::core_domain_tx_pre_validator::CoreDomainTxPreValidator;
 pub use self::system_domain::{new_full_system, FullPool, NewFullSystem};
 use sc_executor::NativeElseWasmExecutor;
 use sc_service::{Configuration as ServiceConfiguration, TFullClient};


### PR DESCRIPTION
Small followup on #1402. Sdk needs it published, as it also abstracts core domains logic and core domain tx prevalidator is used in trait bounds for core domains.

Check out [this commit](https://github.com/subspace/subspace-sdk/pull/183/commits/c6ecf6bd63b5fe6f51a5726a64c67719dd87b198) to see how those published things are used.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
