### PR TITLE
Make block import a shared component and use it in domain block processor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "parking_lot 0.12.1",
  "sc-consensus",
  "sc-utils",
@@ -2403,6 +2404,7 @@ dependencies = [
  "crossbeam",
  "domain-block-builder",
  "domain-block-preprocessor",
+ "domain-client-consensus-relay-chain",
  "domain-client-executor-gossip",
  "domain-runtime-primitives",
  "domain-test-service",

--- a/domains/client/consensus-relay-chain/Cargo.toml
+++ b/domains/client/consensus-relay-chain/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.68"
+futures = "0.3.28"
 parking_lot = "0.12.1"
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }

--- a/domains/client/consensus-relay-chain/src/lib.rs
+++ b/domains/client/consensus-relay-chain/src/lib.rs
@@ -35,4 +35,4 @@
 
 mod import_queue;
 
-pub use import_queue::{import_queue, Verifier};
+pub use import_queue::{import_queue, DomainBlockImport, Verifier};

--- a/domains/client/domain-executor/Cargo.toml
+++ b/domains/client/domain-executor/Cargo.toml
@@ -9,6 +9,7 @@ codec = { package = "parity-scale-codec", version = "3.4.0", features = [ "deriv
 crossbeam = "0.8.2"
 domain-block-builder = { version = "0.1.0", path = "../block-builder" }
 domain-block-preprocessor = { version = "0.1.0", path = "../block-preprocessor" }
+domain-client-consensus-relay-chain = { version = "0.1.0", path = "../consensus-relay-chain" }
 domain-client-executor-gossip = { version = "0.1.0", path = "../executor-gossip" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime" }
 futures = "0.3.28"

--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -17,8 +17,17 @@ use sp_runtime::traits::{Block as BlockT, HashFor};
 use std::sync::Arc;
 use system_runtime_primitives::SystemDomainApi;
 
-pub(crate) struct CoreBundleProcessor<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E>
-where
+pub(crate) struct CoreBundleProcessor<
+    Block,
+    SBlock,
+    PBlock,
+    Client,
+    SClient,
+    PClient,
+    Backend,
+    E,
+    BI,
+> where
     Block: BlockT,
 {
     domain_id: DomainId,
@@ -36,11 +45,11 @@ where
         SClient,
         RuntimeApiFull<Client>,
     >,
-    domain_block_processor: DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>,
+    domain_block_processor: DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E, BI>,
 }
 
-impl<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E> Clone
-    for CoreBundleProcessor<Block, SBlock, PBlock, SClient, Client, PClient, Backend, E>
+impl<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E, BI> Clone
+    for CoreBundleProcessor<Block, SBlock, PBlock, SClient, Client, PClient, Backend, E, BI>
 where
     Block: BlockT,
 {
@@ -59,8 +68,8 @@ where
     }
 }
 
-impl<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E>
-    CoreBundleProcessor<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E>
+impl<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E, BI>
+    CoreBundleProcessor<Block, SBlock, PBlock, Client, SClient, PClient, Backend, E, BI>
 where
     Block: BlockT,
     SBlock: BlockT,
@@ -77,7 +86,7 @@ where
         + MessengerApi<Block, NumberFor<Block>>
         + sp_block_builder::BlockBuilder<Block>
         + sp_api::ApiExt<Block, StateBackend = StateBackendFor<Backend, Block>>,
-    for<'b> &'b Client: BlockImport<
+    for<'b> &'b BI: BlockImport<
         Block,
         Transaction = sp_api::TransactionFor<Client, Block>,
         Error = sp_consensus::Error,
@@ -103,7 +112,15 @@ where
         client: Arc<Client>,
         backend: Arc<Backend>,
         keystore: KeystorePtr,
-        domain_block_processor: DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>,
+        domain_block_processor: DomainBlockProcessor<
+            Block,
+            PBlock,
+            Client,
+            PClient,
+            Backend,
+            E,
+            BI,
+        >,
     ) -> Self {
         let parent_chain = CoreDomainParentChain::<SClient, SBlock, PBlock>::new(
             system_domain_client.clone(),

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -55,6 +55,7 @@ pub(super) async fn start_worker<
     CIBNS,
     NSNS,
     E,
+    BI,
 >(
     spawn_essential: Box<dyn SpawnEssentialNamed>,
     primary_chain_client: Arc<PClient>,
@@ -80,6 +81,7 @@ pub(super) async fn start_worker<
         PClient,
         Backend,
         E,
+        BI,
     >,
     executor_streams: ExecutorStreams<PBlock, IBNS, CIBNS, NSNS>,
     active_leaves: Vec<BlockInfo<PBlock>>,
@@ -100,11 +102,12 @@ pub(super) async fn start_worker<
         + BlockBuilder<Block>
         + MessengerApi<Block, NumberFor<Block>>
         + sp_api::ApiExt<Block, StateBackend = StateBackendFor<Backend, Block>>,
-    for<'b> &'b Client: BlockImport<
+    for<'b> &'b BI: BlockImport<
         Block,
         Transaction = sp_api::TransactionFor<Client, Block>,
         Error = sp_consensus::Error,
     >,
+    BI: Sync + Send + 'static,
     SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock> + ProofProvider<SBlock> + 'static,
     SClient::Api: DomainCoreApi<SBlock>
         + SystemDomainApi<SBlock, NumberFor<PBlock>, PBlock::Hash>

--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -1,10 +1,10 @@
 use crate::fraud_proof::{find_trace_mismatch, FraudProofGenerator};
 use crate::utils::{to_number_primitive, translate_number_type};
-use crate::{ExecutionReceiptFor, TransactionFor};
+use crate::ExecutionReceiptFor;
 use codec::{Decode, Encode};
 use domain_block_builder::{BlockBuilder, BuiltBlock, RecordProof};
 use domain_runtime_primitives::DomainCoreApi;
-use sc_client_api::{AuxStore, BlockBackend, Finalizer, StateBackendFor};
+use sc_client_api::{AuxStore, BlockBackend, Finalizer, StateBackendFor, TransactionFor};
 use sc_consensus::{
     BlockImport, BlockImportParams, ForkChoiceStrategy, ImportResult, StateAction, StorageChanges,
 };
@@ -30,21 +30,23 @@ where
 }
 
 /// A common component shared between the system and core domain bundle processor.
-pub(crate) struct DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>
+pub(crate) struct DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E, BI>
 where
     Block: BlockT,
 {
-    domain_id: DomainId,
-    client: Arc<Client>,
-    primary_chain_client: Arc<PClient>,
-    primary_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
-    backend: Arc<Backend>,
-    fraud_proof_generator: FraudProofGenerator<Block, PBlock, Client, PClient, Backend, E>,
-    domain_confirmation_depth: NumberFor<Block>,
+    pub(crate) domain_id: DomainId,
+    pub(crate) client: Arc<Client>,
+    pub(crate) primary_chain_client: Arc<PClient>,
+    pub(crate) primary_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
+    pub(crate) backend: Arc<Backend>,
+    pub(crate) fraud_proof_generator:
+        FraudProofGenerator<Block, PBlock, Client, PClient, Backend, E>,
+    pub(crate) domain_confirmation_depth: NumberFor<Block>,
+    pub(crate) block_import: Arc<BI>,
 }
 
-impl<Block, PBlock, Client, PClient, Backend, E> Clone
-    for DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>
+impl<Block, PBlock, Client, PClient, Backend, E, BI> Clone
+    for DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E, BI>
 where
     Block: BlockT,
 {
@@ -57,6 +59,7 @@ where
             backend: self.backend.clone(),
             fraud_proof_generator: self.fraud_proof_generator.clone(),
             domain_confirmation_depth: self.domain_confirmation_depth,
+            block_import: self.block_import.clone(),
         }
     }
 }
@@ -75,8 +78,8 @@ pub(crate) struct PendingPrimaryBlocks<Block: BlockT, PBlock: BlockT> {
     pub primary_imports: Vec<HashAndNumber<PBlock>>,
 }
 
-impl<Block, PBlock, Client, PClient, Backend, E>
-    DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>
+impl<Block, PBlock, Client, PClient, Backend, E, BI>
+    DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E, BI>
 where
     Block: BlockT,
     PBlock: BlockT,
@@ -89,7 +92,7 @@ where
     Client::Api: DomainCoreApi<Block>
         + sp_block_builder::BlockBuilder<Block>
         + sp_api::ApiExt<Block, StateBackend = StateBackendFor<Backend, Block>>,
-    for<'b> &'b Client: BlockImport<
+    for<'b> &'b BI: BlockImport<
         Block,
         Transaction = sp_api::TransactionFor<Client, Block>,
         Error = sp_consensus::Error,
@@ -104,26 +107,6 @@ where
     TransactionFor<Backend, Block>: sp_trie::HashDBT<HashFor<Block>, sp_trie::DBValue>,
     E: CodeExecutor,
 {
-    pub(crate) fn new(
-        domain_id: DomainId,
-        client: Arc<Client>,
-        primary_chain_client: Arc<PClient>,
-        primary_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
-        backend: Arc<Backend>,
-        fraud_proof_generator: FraudProofGenerator<Block, PBlock, Client, PClient, Backend, E>,
-        domain_confirmation_depth: NumberFor<Block>,
-    ) -> Self {
-        Self {
-            domain_id,
-            client,
-            primary_chain_client,
-            primary_network_sync_oracle,
-            backend,
-            fraud_proof_generator,
-            domain_confirmation_depth,
-        }
-    }
-
     /// Returns a list of primary blocks waiting to be processed if any.
     ///
     /// It's possible to have multiple pending primary blocks that need to be processed in case
@@ -344,7 +327,9 @@ where
             import_block
         };
 
-        let import_result = (&*self.client).import_block(block_import_params).await?;
+        let import_result = (&*self.block_import)
+            .import_block(block_import_params)
+            .await?;
 
         match import_result {
             ImportResult::Imported(..) => {}

--- a/domains/client/domain-executor/src/lib.rs
+++ b/domains/client/domain-executor/src/lib.rs
@@ -171,6 +171,7 @@ pub struct EssentialExecutorParams<
     IBNS,
     CIBNS,
     NSNS,
+    BI,
 > where
     Block: BlockT,
     PBlock: BlockT,
@@ -190,6 +191,7 @@ pub struct EssentialExecutorParams<
     pub bundle_sender: Arc<BundleSender<Block, PBlock>>,
     pub executor_streams: ExecutorStreams<PBlock, IBNS, CIBNS, NSNS>,
     pub domain_confirmation_depth: NumberFor<Block>,
+    pub block_import: Arc<BI>,
 }
 
 /// Returns the active leaves the overseer should start with.

--- a/domains/client/domain-executor/src/system_bundle_processor.rs
+++ b/domains/client/domain-executor/src/system_bundle_processor.rs
@@ -28,7 +28,8 @@ where
     keystore: KeystorePtr,
     system_domain_block_preprocessor:
         SystemDomainBlockPreprocessor<Block, PBlock, PClient, RuntimeApiFull<Client>>,
-    domain_block_processor: DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>,
+    domain_block_processor:
+        DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E, Client>,
 }
 
 impl<Block, PBlock, Client, PClient, Backend, E> Clone
@@ -86,7 +87,15 @@ where
         client: Arc<Client>,
         backend: Arc<Backend>,
         keystore: KeystorePtr,
-        domain_block_processor: DomainBlockProcessor<Block, PBlock, Client, PClient, Backend, E>,
+        domain_block_processor: DomainBlockProcessor<
+            Block,
+            PBlock,
+            Client,
+            PClient,
+            Backend,
+            E,
+            Client,
+        >,
     ) -> Self {
         let system_domain_block_preprocessor = SystemDomainBlockPreprocessor::new(
             primary_chain_client.clone(),

--- a/domains/client/domain-executor/src/system_executor.rs
+++ b/domains/client/domain-executor/src/system_executor.rs
@@ -109,6 +109,7 @@ where
             IBNS,
             CIBNS,
             NSNS,
+            Client,
         >,
     ) -> Result<Self, sp_consensus::Error>
     where
@@ -146,15 +147,16 @@ where
             params.code_executor,
         );
 
-        let domain_block_processor = DomainBlockProcessor::new(
-            DomainId::SYSTEM,
-            params.client.clone(),
-            params.primary_chain_client.clone(),
-            params.primary_network_sync_oracle,
-            params.backend.clone(),
-            fraud_proof_generator.clone(),
-            params.domain_confirmation_depth,
-        );
+        let domain_block_processor = DomainBlockProcessor {
+            domain_id: DomainId::SYSTEM,
+            client: params.client.clone(),
+            primary_chain_client: params.primary_chain_client.clone(),
+            primary_network_sync_oracle: params.primary_network_sync_oracle,
+            backend: params.backend.clone(),
+            fraud_proof_generator: fraud_proof_generator.clone(),
+            domain_confirmation_depth: params.domain_confirmation_depth,
+            block_import: params.block_import,
+        };
 
         let bundle_processor = SystemBundleProcessor::new(
             params.primary_chain_client.clone(),

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -2,6 +2,7 @@ use crate::core_domain_tx_pre_validator::CoreDomainTxPreValidator;
 use crate::providers::{BlockImportProvider, RpcProvider};
 use crate::{DomainConfiguration, FullBackend, FullClient};
 use cross_domain_message_gossip::{DomainTxPoolSink, Message as GossipMessage};
+use domain_client_consensus_relay_chain::DomainBlockImport;
 use domain_client_executor::{
     CoreDomainParentChain, CoreExecutor, CoreGossipMessageValidator, EssentialExecutorParams,
     ExecutorStreams,
@@ -53,7 +54,9 @@ use subspace_transaction_pool::{FullChainApiWrapper, FullPool};
 use substrate_frame_rpc_system::AccountNonceApi;
 use system_runtime_primitives::SystemDomainApi;
 
-type CoreDomainExecutor<Block, SBlock, PBlock, SClient, PClient, RuntimeApi, ExecutorDispatch> =
+type BlockImportOf<Block, Client, Provider> = <Provider as BlockImportProvider<Block, Client>>::BI;
+
+type CoreDomainExecutor<Block, SBlock, PBlock, SClient, PClient, RuntimeApi, ExecutorDispatch, BI> =
     CoreExecutor<
         Block,
         SBlock,
@@ -74,6 +77,7 @@ type CoreDomainExecutor<Block, SBlock, PBlock, SClient, PClient, RuntimeApi, Exe
         >,
         FullBackend<Block>,
         NativeElseWasmExecutor<ExecutorDispatch>,
+        DomainBlockImport<BI>,
     >;
 
 /// Core domain full node along with some other components.
@@ -88,6 +92,7 @@ pub struct NewFullCore<
     RuntimeApi,
     ExecutorDispatch,
     AccountId,
+    BI,
 > where
     SBlock: BlockT,
     PBlock: BlockT,
@@ -132,8 +137,16 @@ pub struct NewFullCore<
     /// Network starter.
     pub network_starter: NetworkStarter,
     /// Executor.
-    pub executor:
-        CoreDomainExecutor<Block, SBlock, PBlock, SClient, PClient, RuntimeApi, ExecutorDispatch>,
+    pub executor: CoreDomainExecutor<
+        Block,
+        SBlock,
+        PBlock,
+        SClient,
+        PClient,
+        RuntimeApi,
+        ExecutorDispatch,
+        BI,
+    >,
     /// Transaction pool sink
     pub tx_pool_sink: DomainTxPoolSink,
     _data: PhantomData<AccountId>,
@@ -166,6 +179,7 @@ fn new_partial<RuntimeApi, Executor, SDC, Block, SBlock, PBlock, BIMP>(
             Option<Telemetry>,
             Option<TelemetryWorkerHandle>,
             NativeElseWasmExecutor<Executor>,
+            Arc<DomainBlockImport<BIMP::BI>>,
         ),
     >,
     sc_service::Error,
@@ -229,10 +243,12 @@ where
         client.clone(),
         core_domain_tx_pre_validator,
     );
-
-    let block_import = BlockImportProvider::block_import(block_import_provider, client.clone());
+    let block_import = Arc::new(DomainBlockImport::new(BlockImportProvider::block_import(
+        block_import_provider,
+        client.clone(),
+    )));
     let import_queue = domain_client_consensus_relay_chain::import_queue(
-        block_import,
+        block_import.clone(),
         &task_manager.spawn_essential_handle(),
         config.prometheus_registry(),
     )?;
@@ -245,7 +261,7 @@ where
         task_manager,
         transaction_pool,
         select_chain: (),
-        other: (telemetry, telemetry_worker_handle, executor),
+        other: (telemetry, telemetry_worker_handle, executor, block_import),
     };
 
     Ok(params)
@@ -321,6 +337,7 @@ pub async fn new_full_core<
         RuntimeApi,
         ExecutorDispatch,
         AccountId,
+        BlockImportOf<Block, FullClient<Block, RuntimeApi, ExecutorDispatch>, Provider>,
     >,
 >
 where
@@ -435,7 +452,7 @@ where
         &provider,
     )?;
 
-    let (mut telemetry, _telemetry_worker_handle, code_executor) = params.other;
+    let (mut telemetry, _telemetry_worker_handle, code_executor, block_import) = params.other;
 
     let client = params.client.clone();
     let backend = params.backend.clone();
@@ -541,7 +558,19 @@ where
         system_domain_client.clone(),
         Box::new(task_manager.spawn_essential_handle()),
         &select_chain,
-        EssentialExecutorParams::<Block, _, _, _, _, _, _, _, _, _> {
+        EssentialExecutorParams::<
+            Block,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            DomainBlockImport<Provider::BI>,
+        > {
             primary_chain_client: primary_chain_client.clone(),
             primary_network_sync_oracle,
             client: client.clone(),
@@ -554,6 +583,7 @@ where
             bundle_sender: Arc::new(bundle_sender),
             executor_streams,
             domain_confirmation_depth,
+            block_import,
         },
     )
     .await?;


### PR DESCRIPTION
Turns out domain block processor is using client's BlockImport instead of the provided block import. I have made DomainBlockImport as shared between all the required tasks. If you think this could be simplified, open to suggestions.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
