### PR TITLE
Memory mapped I/O all the way

### DIFF
--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use memmap2::Mmap;
-use rand::{thread_rng, Rng};
+use rand::prelude::*;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -44,7 +44,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::default();
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
-    thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
+    StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let erasure_coding = ErasureCoding::new(

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -6,7 +6,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::time::Instant;
-use std::{env, fs, io};
+use std::{env, fs};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -105,9 +105,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     } else {
         println!("Plotting one sector...");
 
-        let mut plotted_sector_bytes = Vec::with_capacity(sector_size);
+        let mut plotted_sector_bytes = vec![0; sector_size];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
 
-        let plotted_sector = block_on(plot_sector::<_, _, _, PosTable>(
+        let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
             sector_index,
             &archived_history_segment,
@@ -117,7 +118,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &erasure_coding,
             pieces_in_sector,
             &mut plotted_sector_bytes,
-            &mut io::sink(),
+            &mut plotted_sector_metadata_bytes,
             Default::default(),
         ))
         .unwrap();
@@ -144,10 +145,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 black_box(sector_index),
                 black_box(&global_challenge),
                 black_box(solution_range),
-                black_box(&mut io::Cursor::new(&plotted_sector_bytes)),
+                black_box(&plotted_sector_bytes),
                 black_box(&plotted_sector.sector_metadata),
-            )
-            .unwrap();
+            );
         })
     });
 
@@ -196,10 +196,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             black_box(sector_index),
                             black_box(&global_challenge),
                             black_box(solution_range),
-                            black_box(&mut io::Cursor::new(sector)),
+                            black_box(sector),
                             black_box(&plotted_sector.sector_metadata),
-                        )
-                        .unwrap();
+                        );
                     }
                 }
                 start.elapsed()

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
-use rand::{thread_rng, Rng};
+use rand::prelude::*;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::{env, io};
 use subspace_archiving::archiver::Archiver;
@@ -28,7 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::default();
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
-    thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
+    StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let erasure_coding = ErasureCoding::new(

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -1,8 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use rand::prelude::*;
+use std::env;
 use std::num::{NonZeroU64, NonZeroUsize};
-use std::{env, io};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -11,7 +11,7 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
-use subspace_farmer_components::sector::sector_size;
+use subspace_farmer_components::sector::{sector_size, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 
@@ -51,11 +51,15 @@ fn criterion_benchmark(c: &mut Criterion) {
         sector_expiration: SegmentIndex::ONE,
     };
 
+    let sector_size = sector_size(pieces_in_sector);
+    let mut sector_bytes = vec![0; sector_size];
+    let mut sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+
     let mut group = c.benchmark_group("plotting");
-    group.throughput(Throughput::Bytes(sector_size(pieces_in_sector) as u64));
-    group.bench_function("no-writes", |b| {
+    group.throughput(Throughput::Bytes(sector_size as u64));
+    group.bench_function("in-memory", |b| {
         b.iter(|| {
-            block_on(plot_sector::<_, _, _, PosTable>(
+            block_on(plot_sector::<_, PosTable>(
                 black_box(&public_key),
                 black_box(sector_index),
                 black_box(&archived_history_segment),
@@ -64,8 +68,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&kzg),
                 black_box(&erasure_coding),
                 black_box(pieces_in_sector),
-                black_box(&mut io::sink()),
-                black_box(&mut io::sink()),
+                black_box(&mut sector_bytes),
+                black_box(&mut sector_metadata_bytes),
                 Default::default(),
             ))
             .unwrap();

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use memmap2::Mmap;
-use rand::{thread_rng, Rng, RngCore};
+use rand::prelude::*;
 use schnorrkel::Keypair;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -46,7 +46,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
-    thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
+    let mut rng = StdRng::seed_from_u64(42);
+    rng.fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let erasure_coding = ErasureCoding::new(
@@ -140,7 +141,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     println!("Searching for solutions");
     let solution_candidates = loop {
         let mut global_challenge = Blake2b256Hash::default();
-        thread_rng().fill_bytes(&mut global_challenge);
+        rng.fill_bytes(&mut global_challenge);
 
         let maybe_solution_candidates = audit_sector(
             &public_key,

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -6,7 +6,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::time::Instant;
-use std::{env, fs, io};
+use std::{env, fs};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -102,9 +102,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     } else {
         println!("Plotting one sector...");
 
-        let mut plotted_sector_bytes = Vec::with_capacity(sector_size);
+        let mut plotted_sector_bytes = vec![0; sector_size];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
 
-        let plotted_sector = block_on(plot_sector::<_, _, _, PosTable>(
+        let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
             sector_index,
             &archived_history_segment,
@@ -114,7 +115,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &erasure_coding,
             pieces_in_sector,
             &mut plotted_sector_bytes,
-            &mut io::sink(),
+            &mut plotted_sector_metadata_bytes,
             Default::default(),
         ))
         .unwrap();

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use memmap2::Mmap;
-use rand::{thread_rng, Rng};
+use rand::prelude::*;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -43,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let public_key = PublicKey::default();
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
-    thread_rng().fill(AsMut::<[u8]>::as_mut(input.as_mut()));
+    StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
     let kzg = Kzg::new(kzg::embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg.clone()).unwrap();
     let erasure_coding = ErasureCoding::new(

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -15,7 +15,7 @@ use futures::channel::{mpsc, oneshot};
 use futures::future::{select, Either};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use memmap2::{Mmap, MmapMut, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 use parity_scale_codec::{Decode, Encode};
 use parking_lot::{Mutex, RwLock};
 use serde::{Deserialize, Serialize};
@@ -390,6 +390,9 @@ pub enum PlottingError {
         /// Lower-level error
         error: node_client::Error,
     },
+    /// I/O error occurred
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
     /// Low-level plotting error
     #[error("Low-level plotting error: {0}")]
     LowLevel(#[from] plotting::PlottingError),
@@ -612,6 +615,7 @@ impl SingleDiskPlot {
 
         let pieces_in_sector = single_disk_plot_info.pieces_in_sector();
         let sector_size = sector_size(max_pieces_in_sector);
+        let sector_metadata_size = SectorMetadata::encoded_size();
         let target_sector_count =
             (single_disk_plot_info.allocated_space() / sector_size as u64) as usize;
         let first_sector_index = single_disk_plot_info.first_sector_index();
@@ -623,58 +627,58 @@ impl SingleDiskPlot {
             .create(true)
             .open(directory.join(Self::METADATA_FILE))?;
 
-        let (mut metadata_header, mut metadata_header_mmap) =
-            if metadata_file.seek(SeekFrom::End(0))? == 0 {
-                let metadata_header = PlotMetadataHeader {
-                    version: 0,
-                    sector_count: 0,
-                };
-
-                metadata_file.preallocate(
-                    RESERVED_PLOT_METADATA
-                        + SectorMetadata::encoded_size() as u64 * target_sector_count as u64,
-                )?;
-                metadata_file.write_all_at(metadata_header.encode().as_slice(), 0)?;
-
-                let metadata_header_mmap = unsafe {
-                    MmapOptions::new()
-                        .len(PlotMetadataHeader::encoded_size())
-                        .map_mut(&metadata_file)?
-                };
-
-                (metadata_header, metadata_header_mmap)
-            } else {
-                let metadata_header_mmap = unsafe {
-                    MmapOptions::new()
-                        .len(PlotMetadataHeader::encoded_size())
-                        .map_mut(&metadata_file)?
-                };
-
-                let metadata_header =
-                    PlotMetadataHeader::decode(&mut metadata_header_mmap.as_ref())
-                        .map_err(SingleDiskPlotError::FailedToDecodeMetadataHeader)?;
-
-                if metadata_header.version != Self::SUPPORTED_PLOT_VERSION {
-                    return Err(SingleDiskPlotError::UnexpectedMetadataVersion(
-                        metadata_header.version,
-                    ));
-                }
-
-                (metadata_header, metadata_header_mmap)
+        let (mut metadata_header, mut metadata_header_mmap) = if metadata_file
+            .seek(SeekFrom::End(0))?
+            == 0
+        {
+            let metadata_header = PlotMetadataHeader {
+                version: 0,
+                sector_count: 0,
             };
 
-        let mut metadata_mmap_mut = unsafe {
-            MmapOptions::new()
-                .offset(RESERVED_PLOT_METADATA)
-                .len(SectorMetadata::encoded_size() * target_sector_count)
-                .map_mut(&metadata_file)?
+            metadata_file.preallocate(
+                RESERVED_PLOT_METADATA + sector_metadata_size as u64 * target_sector_count as u64,
+            )?;
+            metadata_file.write_all_at(metadata_header.encode().as_slice(), 0)?;
+
+            let metadata_header_mmap = unsafe {
+                MmapOptions::new()
+                    .len(PlotMetadataHeader::encoded_size())
+                    .map_mut(&metadata_file)?
+            };
+
+            (metadata_header, metadata_header_mmap)
+        } else {
+            let metadata_header_mmap = unsafe {
+                MmapOptions::new()
+                    .len(PlotMetadataHeader::encoded_size())
+                    .map_mut(&metadata_file)?
+            };
+
+            let metadata_header = PlotMetadataHeader::decode(&mut metadata_header_mmap.as_ref())
+                .map_err(SingleDiskPlotError::FailedToDecodeMetadataHeader)?;
+
+            if metadata_header.version != Self::SUPPORTED_PLOT_VERSION {
+                return Err(SingleDiskPlotError::UnexpectedMetadataVersion(
+                    metadata_header.version,
+                ));
+            }
+
+            (metadata_header, metadata_header_mmap)
         };
 
         let sectors_metadata = {
+            let metadata_mmap = unsafe {
+                MmapOptions::new()
+                    .offset(RESERVED_PLOT_METADATA)
+                    .len(sector_metadata_size * target_sector_count)
+                    .map(&metadata_file)?
+            };
+
             let mut sectors_metadata = Vec::<SectorMetadata>::with_capacity(target_sector_count);
 
-            for mut sector_metadata_bytes in metadata_mmap_mut
-                .chunks_exact(SectorMetadata::encoded_size())
+            for mut sector_metadata_bytes in metadata_mmap
+                .chunks_exact(sector_metadata_size)
                 .take(metadata_header.sector_count as usize)
             {
                 sectors_metadata.push(
@@ -686,11 +690,13 @@ impl SingleDiskPlot {
             Arc::new(RwLock::new(sectors_metadata))
         };
 
-        let plot_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(directory.join(Self::PLOT_FILE))?;
+        let plot_file = Arc::new(
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(directory.join(Self::PLOT_FILE))?,
+        );
 
         plot_file.preallocate(sector_size as u64 * target_sector_count as u64)?;
 
@@ -716,14 +722,13 @@ impl SingleDiskPlot {
         let plotting_join_handle = thread::Builder::new()
             .name(format!("plotting-{disk_farm_index}"))
             .spawn({
-                let mut plot_mmap_mut = unsafe { MmapMut::map_mut(&plot_file)? };
-
                 let handle = handle.clone();
                 let sectors_metadata = Arc::clone(&sectors_metadata);
                 let kzg = kzg.clone();
                 let erasure_coding = erasure_coding.clone();
                 let handlers = Arc::clone(&handlers);
                 let node_client = node_client.clone();
+                let plot_file = Arc::clone(&plot_file);
                 let error_sender = Arc::clone(&error_sender);
                 let span = span.clone();
 
@@ -738,32 +743,30 @@ impl SingleDiskPlot {
                             return Ok(());
                         }
 
-                        let chunked_sectors = plot_mmap_mut.as_mut().chunks_exact_mut(sector_size);
-                        let chunked_metadata = metadata_mmap_mut
-                            .as_mut()
-                            .chunks_exact_mut(SectorMetadata::encoded_size());
-                        let plot_initial_sector = chunked_sectors
-                            .zip(chunked_metadata)
-                            .enumerate()
-                            .skip(
-                                // Some sectors may already be plotted, skip them
-                                metadata_header.sector_count as usize,
-                            )
-                            .map(|(sector_offset, (sector, metadata))| {
-                                (
-                                    sector_offset,
-                                    sector_offset as u64 + first_sector_index,
-                                    sector,
-                                    metadata,
-                                )
-                            });
+                        // Some sectors may already be plotted, skip them
+                        let sectors_offsets_left_to_plot =
+                            metadata_header.sector_count as usize..target_sector_count;
 
                         // TODO: Concurrency
-                        for (sector_offset, sector_index, sector, sector_metadata) in
-                            plot_initial_sector
-                        {
+                        for sector_offset in sectors_offsets_left_to_plot {
+                            let sector_index = sector_offset as u64 + first_sector_index;
                             trace!(%sector_offset, %sector_index, "Preparing to plot sector");
 
+                            let mut sector = unsafe {
+                                MmapOptions::new()
+                                    .offset((sector_offset * sector_size) as u64)
+                                    .len(sector_size)
+                                    .map_mut(&*plot_file)?
+                            };
+                            let mut sector_metadata = unsafe {
+                                MmapOptions::new()
+                                    .offset(
+                                        RESERVED_PLOT_METADATA
+                                            + (sector_offset * sector_metadata_size) as u64,
+                                    )
+                                    .len(sector_metadata_size)
+                                    .map_mut(&metadata_file)?
+                            };
                             let plotting_permit =
                                 match concurrent_plotting_semaphore.clone().acquire_owned().await {
                                     Ok(plotting_permit) => plotting_permit,
@@ -793,12 +796,13 @@ impl SingleDiskPlot {
                                 &kzg,
                                 &erasure_coding,
                                 pieces_in_sector,
-                                sector,
-                                sector_metadata,
+                                &mut sector,
+                                &mut sector_metadata,
                                 piece_memory_cache.clone(),
                             );
                             let plotted_sector = plot_sector_fut.await?;
-                            // TODO: Flushing is necessary here for both sector and sector metadata
+                            sector.flush()?;
+                            sector_metadata.flush()?;
 
                             metadata_header.sector_count += 1;
                             metadata_header_mmap
@@ -865,7 +869,7 @@ impl SingleDiskPlot {
         let farming_join_handle = thread::Builder::new()
             .name(format!("farming-{disk_farm_index}"))
             .spawn({
-                let plot_mmap = unsafe { Mmap::map(&plot_file)? };
+                let plot_mmap = unsafe { Mmap::map(&*plot_file)? };
                 #[cfg(unix)]
                 {
                     plot_mmap.advise(memmap2::Advice::Random)?;
@@ -994,7 +998,7 @@ impl SingleDiskPlot {
         let reading_join_handle = thread::Builder::new()
             .name(format!("reading-{disk_farm_index}"))
             .spawn({
-                let global_plot_mmap = unsafe { Mmap::map(&plot_file)? };
+                let global_plot_mmap = unsafe { Mmap::map(&*plot_file)? };
                 #[cfg(unix)]
                 {
                     global_plot_mmap.advise(memmap2::Advice::Random)?;


### PR DESCRIPTION
By not abstracting memory-mapped I/O behind `std::io` we can gain efficiency by shortening proving time and reducing memory usage.

Also flushing wasn't done before after each sector, so I'm not 100% sure it was guaranteed that plotted sectors were readable. Intuitively they probably were due to everything happening within the same process, but at the same time there were separate memory mappings into the same data, so maybe that wasn't the case. Either way, now we flush the data before moving forward.

If you ignore whitespaces, diff will get smaller.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
