### PR TITLE
Optimize proving

### DIFF
--- a/crates/subspace-erasure-coding/src/lib.rs
+++ b/crates/subspace-erasure-coding/src/lib.rs
@@ -72,9 +72,13 @@ impl ErasureCoding {
 
     /// Recovery of source shards from given shards (at least 1/2 should be `Some`).
     ///
-    /// The same as [`ErasureCoding::recover()`], but returns only source shards.
-    pub fn recover_source(&self, shards: &[Option<Scalar>]) -> Result<Vec<Scalar>, String> {
-        Ok(self.recover(shards)?.into_iter().step_by(2).collect())
+    /// The same as [`ErasureCoding::recover()`], but returns only source shards in form of an
+    /// iterator.
+    pub fn recover_source(
+        &self,
+        shards: &[Option<Scalar>],
+    ) -> Result<impl ExactSizeIterator<Item = Scalar>, String> {
+        Ok(self.recover(shards)?.into_iter().step_by(2))
     }
 
     /// Extend commitments using erasure coding.

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -104,7 +104,12 @@ where
     record_chunks
         .par_iter_mut()
         .zip(sector_contents_map.par_iter_record_chunk_to_plot(piece_offset))
-        .zip(s_bucket_offsets.par_iter().enumerate())
+        .zip(
+            (u16::from(SBucket::ZERO)..=u16::from(SBucket::MAX))
+                .into_par_iter()
+                .map(SBucket::from)
+                .zip(s_bucket_offsets.par_iter()),
+        )
         .try_for_each(
             |((maybe_record_chunk, maybe_chunk_details), (s_bucket, &s_bucket_offset))| {
                 let (chunk_offset, encoded_chunk_used) = match maybe_chunk_details {
@@ -115,7 +120,6 @@ where
                 };
 
                 let chunk_location = chunk_offset + s_bucket_offset as usize;
-                let s_bucket = SBucket::try_from(s_bucket).expect("Enumerated s-buckets; qed");
 
                 let mut record_chunk = sector[SectorContentsMap::encoded_size(pieces_in_sector)..]
                     .array_chunks::<{ Scalar::FULL_BYTES }>()

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -189,12 +189,12 @@ pub fn recover_extended_record_chunks(
     Ok(record_chunks)
 }
 
-/// Given sector record chunks recover source record chunks
+/// Given sector record chunks recover source record chunks in form of an iterator.
 pub fn recover_source_record_chunks(
     sector_record_chunks: &[Option<Scalar>; Record::NUM_S_BUCKETS],
     piece_offset: PieceOffset,
     erasure_coding: &ErasureCoding,
-) -> Result<Box<[Scalar; Record::NUM_CHUNKS]>, ReadingError> {
+) -> Result<impl ExactSizeIterator<Item = Scalar>, ReadingError> {
     // Restore source record scalars
     let record_chunks = erasure_coding
         .recover_source(sector_record_chunks)
@@ -210,12 +210,6 @@ pub fn recover_source_record_chunks(
             actual: record_chunks.len(),
         });
     }
-
-    let mut record_chunks = ManuallyDrop::new(record_chunks);
-
-    // SAFETY: Original memory is not dropped, size of the data checked above
-    let record_chunks =
-        unsafe { Box::from_raw(record_chunks.as_mut_ptr() as *mut [Scalar; Record::NUM_CHUNKS]) };
 
     Ok(record_chunks)
 }
@@ -302,7 +296,7 @@ where
     piece
         .record_mut()
         .iter_mut()
-        .zip(record_chunks.iter())
+        .zip(record_chunks)
         .for_each(|(output, input)| {
             *output = input.to_bytes();
         });


### PR DESCRIPTION
Found two ways to reduce allocations and computation, results in small, but improvements.

Together with all of the other PRs on top of base `consensus-v2.3` I'm getting following in-memory proving for 1300 pieces in sector:
```
proving/memory          time:   [662.42 ms 725.68 ms 786.95 ms]
                        thrpt:  [1.2707  elem/s 1.3780  elem/s 1.5096  elem/s]
```

Now it is consistently proving in under 1 second on my machine, but there is still work to be done to make it viable on less powerful machines.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
