### PR TITLE
Update `rust-kzg` to newer version with performance improvements for polynomial recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "blst_from_scratch"
 version = "0.1.0"
-source = "git+https://github.com/subspace/rust-kzg?rev=fad8d358548301424f20f7fc7aaa02e75041d03b#fad8d358548301424f20f7fc7aaa02e75041d03b"
+source = "git+https://github.com/subspace/rust-kzg?rev=b71e7ace37420db889488cbd64d53eea38176111#b71e7ace37420db889488cbd64d53eea38176111"
 dependencies = [
  "blst",
  "kzg",
@@ -923,6 +923,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "rayon",
+ "smallvec",
 ]
 
 [[package]]
@@ -4702,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/subspace/rust-kzg?rev=fad8d358548301424f20f7fc7aaa02e75041d03b#fad8d358548301424f20f7fc7aaa02e75041d03b"
+source = "git+https://github.com/subspace/rust-kzg?rev=b71e7ace37420db889488cbd64d53eea38176111#b71e7ace37420db889488cbd64d53eea38176111"
 dependencies = [
  "blst",
  "sha2 0.10.6",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -18,11 +18,11 @@ bench = false
 [dependencies]
 blake2 = { version = "0.10.6", default-features = false }
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "b71e7ace37420db889488cbd64d53eea38176111", default-features = false }
 derive_more = "0.99.17"
 hex = { version  = "0.4.3", default-features = false, features = ["alloc"] }
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-kzg = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
+kzg = { git = "https://github.com/subspace/rust-kzg", rev = "b71e7ace37420db889488cbd64d53eea38176111", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
 parking_lot = { version = "0.12.1", optional = true }

--- a/crates/subspace-erasure-coding/Cargo.toml
+++ b/crates/subspace-erasure-coding/Cargo.toml
@@ -16,14 +16,14 @@ bench = false
 
 [dependencies]
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "b71e7ace37420db889488cbd64d53eea38176111", default-features = false }
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-kzg = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b", default-features = false }
+kzg = { git = "https://github.com/subspace/rust-kzg", rev = "b71e7ace37420db889488cbd64d53eea38176111", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
 # TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "fad8d358548301424f20f7fc7aaa02e75041d03b" }
+blst_from_scratch = { git = "https://github.com/subspace/rust-kzg", rev = "b71e7ace37420db889488cbd64d53eea38176111" }
 criterion = "0.4.0"
 rand = "0.8.5"
 


### PR DESCRIPTION
Performance improved a bit since https://github.com/subspace/subspace/pull/1417:
```
proving/memory          time:   [539.17 ms 576.00 ms 607.35 ms]
                        thrpt:  [1.6465  elem/s 1.7361  elem/s 1.8547  elem/s]
```

Basically pulled in changes from https://github.com/sifraitech/rust-kzg/pull/224 and https://github.com/sifraitech/rust-kzg/pull/226

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
