### PR TITLE
Fix potential error of receipt not found in bundle production

### DIFF
--- a/domains/client/domain-executor/src/domain_bundle_producer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_producer.rs
@@ -183,7 +183,7 @@ where
             tracing::warn!(
                 head_receipt_number = ?head_receipt_number,
                 domain_best_number = ?domain_best_number,
-                "Skip slot {slot} due to executor is lagging behind the receipt chain on its parent chain"
+                "Skip slot {slot} because executor is lagging behind the receipt chain on its parent chain"
             );
             return Ok(None);
         }

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -154,7 +154,7 @@ where
             "Collecting receipts at {parent_chain_block_hash:?}"
         );
 
-        let load_receipt = |primary_block_hash| {
+        let load_receipt = |primary_block_hash, block_number| {
             crate::aux_schema::load_execution_receipt::<
                 _,
                 Block::Hash,
@@ -163,7 +163,7 @@ where
             >(&*self.client, primary_block_hash)?
             .ok_or_else(|| {
                 sp_blockchain::Error::Backend(format!(
-                    "Receipt of primary block #{primary_block_hash} not found"
+                    "Receipt of primary block #{block_number},{primary_block_hash} not found"
                 ))
             })
         };
@@ -180,7 +180,7 @@ where
                             "Primary block hash for #{to_send:?} not found"
                         ))
                     })?;
-            receipts.push(load_receipt(primary_block_hash)?);
+            receipts.push(load_receipt(primary_block_hash, to_send)?);
             to_send += 1;
 
             if to_send > max_allowed {

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -10,7 +10,7 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
 use sp_consensus_slots::Slot;
 use sp_domains::{Bundle, BundleHeader};
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, One, Zero};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, One, Saturating, Zero};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time;
@@ -69,6 +69,7 @@ where
         ParentChain: ParentChainInterface<ParentChainBlock>,
     {
         let parent_number = self.client.info().best_number;
+        let parent_hash = self.client.info().best_hash;
 
         let mut t1 = self.transaction_pool.ready_at(parent_number).fuse();
         // TODO: proper timeout
@@ -114,7 +115,7 @@ where
         let receipts = if primary_number.is_zero() {
             Vec::new()
         } else {
-            self.collect_bundle_receipts(parent_number, parent_chain)?
+            self.collect_bundle_receipts(parent_number, parent_hash, parent_chain)?
         };
 
         receipts_sanity_check::<Block, PBlock>(&receipts)?;
@@ -134,9 +135,12 @@ where
     }
 
     /// Returns the receipts in the next domain bundle.
+    ///
+    /// There will be at least one receipt in the collected receipts.
     fn collect_bundle_receipts<ParentChain, ParentChainBlock>(
         &self,
         header_number: NumberFor<Block>,
+        header_hash: Block::Hash,
         parent_chain: ParentChain,
     ) -> sp_blockchain::Result<Vec<ExecutionReceiptFor<PBlock, Block::Hash>>>
     where
@@ -170,7 +174,27 @@ where
 
         let mut receipts = Vec::new();
         let mut to_send = head_receipt_number + 1;
-        let max_allowed = (head_receipt_number + max_drift).min(to_number_primitive(header_number));
+
+        let header_block_receipt_is_written =
+            crate::aux_schema::primary_hash_for::<_, _, PBlock::Hash>(&*self.client, header_hash)?
+                .is_some();
+
+        // TODO: remove once the receipt generation can be done before the domain block is
+        // committed to the database, in other words, only when the receipt of block N+1 has
+        // been generated can the `client.info().best_number` be updated from N to N+1.
+        //
+        // This requires:
+        // 1. Reimplement `runtime_api.intermediate_roots()` on the client side.
+        // 2. Add a hook before the upstream `client.commit_operation(op)`.
+        let available_best_receipt_number = if header_block_receipt_is_written {
+            header_number
+        } else {
+            header_number.saturating_sub(One::one())
+        };
+
+        let max_allowed = (head_receipt_number + max_drift)
+            .min(to_number_primitive(available_best_receipt_number));
+
         loop {
             let primary_block_hash =
                 self.primary_chain_client

--- a/domains/client/domain-executor/src/domain_worker.rs
+++ b/domains/client/domain-executor/src/domain_worker.rs
@@ -1,5 +1,4 @@
 use crate::utils::{to_number_primitive, BlockInfo, ExecutorSlotInfo};
-use codec::{Decode, Encode};
 use futures::channel::mpsc;
 use futures::{SinkExt, Stream, StreamExt};
 use sc_client_api::{BlockBackend, BlockImportNotification, BlockchainEvents};
@@ -214,10 +213,6 @@ where
 {
     let best_hash = primary_chain_client.info().best_hash;
     let best_number = primary_chain_client.info().best_number;
-
-    let best_hash = PBlock::Hash::decode(&mut best_hash.encode().as_slice())
-        .expect("Hash type must be correct");
-    let best_number = crate::utils::translate_number_type(best_number);
 
     let opaque_bundle = match bundler((best_hash, best_number), executor_slot_info).await {
         Some(opaque_bundle) => opaque_bundle,


### PR DESCRIPTION
There is an edge case that when a domain block is imported to the blockchain database, typically, when we observe the domain client moving from N -> N+1, it's possible the receipt of N is still under processing and unavailable, but we require this receipt in some situations, causing the racy behavior. Theoretically, the receipt generation should be done before actually applying the domain block into the database, however, it's not feasible to do so in substrate. This PR tries to treat its parent as the virtual domain block that has been fully processed, specifically, given domain block N+1:
- If the receipt of N+1 is available, proceed with N+1.
- If the receipt of N+1 is unavailable, proceed with N.

Close #1418

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
