### PR TITLE
Use `bytesize` more often

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11058,6 +11058,7 @@ name = "subspace-service"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytesize",
  "derive_more",
  "domain-block-preprocessor",
  "domain-runtime-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10814,6 +10814,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "bitvec",
+ "bytesize",
  "criterion",
  "fs2",
  "futures",

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -72,6 +72,7 @@ mod pallet {
     /// Total amount of data and number of objects stored in a feed
     #[derive(Debug, Decode, Encode, TypeInfo, Default, PartialEq, Eq)]
     pub struct TotalObjectsAndSize {
+        // TODO: use `bytesize` here
         /// Total size of objects in bytes
         pub size: u64,
         /// Total number of objects

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -398,8 +398,9 @@ pub fn create_signed_vote(
     let sector_size = sector_size(pieces_in_sector);
 
     for sector_index in iter::from_fn(|| Some(rand::random())) {
-        let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_bytes = vec![0; sector_size.as_u64() as usize];
+        let mut plotted_sector_metadata_bytes =
+            vec![0; SectorMetadata::encoded_size().as_u64() as usize];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -165,6 +165,7 @@ pub struct DomainConfig<Hash, Balance, Weight> {
     /// Slot probability
     pub bundle_slot_probability: (u64, u64),
 
+    // TODO: use `bytesize` here
     /// Maximum domain bundle size in bytes.
     pub max_bundle_size: u32,
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -144,8 +144,9 @@ fn valid_header(
     let sector_size = sector_size(pieces_in_sector);
 
     for sector_index in iter::from_fn(|| Some(rand::random())) {
-        let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_bytes = vec![0; sector_size.as_u64() as _];
+        let mut plotted_sector_metadata_bytes =
+            vec![0; SectorMetadata::encoded_size().as_u64() as _];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -38,6 +38,7 @@ subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.38"
 tokio = { version = "1.27.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync"] }
 tracing = "0.1.37"
+bytesize = "1.2"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -81,7 +81,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let plotted_sector_bytes = fs::read(&persisted_sector).unwrap();
         let sector_contents_map = SectorContentsMap::from_bytes(
-            &plotted_sector_bytes[..SectorContentsMap::encoded_size(pieces_in_sector)],
+            &plotted_sector_bytes
+                [..SectorContentsMap::encoded_size(pieces_in_sector).as_u64() as _],
             pieces_in_sector,
         )
         .unwrap();
@@ -105,8 +106,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     } else {
         println!("Plotting one sector...");
 
-        let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_bytes = vec![0; sector_size.as_u64() as _];
+        let mut plotted_sector_metadata_bytes =
+            vec![0; SectorMetadata::encoded_size().as_u64() as _];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
@@ -126,7 +128,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         (plotted_sector, plotted_sector_bytes)
     };
 
-    assert_eq!(plotted_sector_bytes.len(), sector_size);
+    assert_eq!(plotted_sector_bytes.len(), sector_size.as_u64() as usize);
 
     if persist_sector && !persisted_sector.is_file() {
         println!(
@@ -164,7 +166,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
 
         plot_file
-            .preallocate(sector_size as u64 * sectors_count)
+            .preallocate(sector_size.as_u64() * sectors_count)
             .unwrap();
         plot_file.advise_random_access().unwrap();
 
@@ -187,7 +189,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 let start = Instant::now();
                 for _i in 0..iters {
                     for (sector_index, sector) in plot_mmap
-                        .chunks_exact(sector_size)
+                        .chunks_exact(sector_size.as_u64() as _)
                         .enumerate()
                         .map(|(sector_index, sector)| (sector_index as u64, sector))
                     {

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -52,11 +52,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     };
 
     let sector_size = sector_size(pieces_in_sector);
-    let mut sector_bytes = vec![0; sector_size];
-    let mut sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+    let mut sector_bytes = vec![0; sector_size.as_u64() as _];
+    let mut sector_metadata_bytes = vec![0; SectorMetadata::encoded_size().as_u64() as _];
 
     let mut group = c.benchmark_group("plotting");
-    group.throughput(Throughput::Bytes(sector_size as u64));
+    group.throughput(Throughput::Bytes(sector_size.as_u64()));
     group.bench_function("in-memory", |b| {
         b.iter(|| {
             block_on(plot_sector::<_, PosTable>(

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -84,7 +84,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let plotted_sector_bytes = fs::read(&persisted_sector).unwrap();
         let sector_contents_map = SectorContentsMap::from_bytes(
-            &plotted_sector_bytes[..SectorContentsMap::encoded_size(pieces_in_sector)],
+            &plotted_sector_bytes
+                [..SectorContentsMap::encoded_size(pieces_in_sector).as_u64() as _],
             pieces_in_sector,
         )
         .unwrap();
@@ -108,8 +109,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     } else {
         println!("Plotting one sector...");
 
-        let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_bytes = vec![0; sector_size.as_u64() as _];
+        let mut plotted_sector_metadata_bytes =
+            vec![0; SectorMetadata::encoded_size().as_u64() as _];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
@@ -129,7 +131,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         (plotted_sector, plotted_sector_bytes)
     };
 
-    assert_eq!(plotted_sector_bytes.len(), sector_size);
+    assert_eq!(plotted_sector_bytes.len(), sector_size.as_u64() as usize);
 
     if persist_sector && !persisted_sector.is_file() {
         println!(
@@ -215,7 +217,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
 
         plot_file
-            .preallocate(sector_size as u64 * sectors_count)
+            .preallocate(sector_size.as_u64() * sectors_count)
             .unwrap();
         plot_file.advise_random_access().unwrap();
 
@@ -233,7 +235,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         }
 
         let solution_candidates = plot_mmap
-            .chunks_exact(sector_size)
+            .chunks_exact(sector_size.as_u64() as _)
             .map(|sector| {
                 audit_sector(
                     &public_key,

--- a/crates/subspace-farmer-components/src/auditing.rs
+++ b/crates/subspace-farmer-components/src/auditing.rs
@@ -41,7 +41,8 @@ pub fn audit_sector<'a>(
             .sum::<usize>();
 
     let sector_contents_map_size =
-        SectorContentsMap::encoded_size(sector_metadata.pieces_in_sector);
+        usize::try_from(SectorContentsMap::encoded_size(sector_metadata.pieces_in_sector).as_u64())
+            .expect("Always fits in usize");
 
     // Read s-bucket
     let s_bucket =

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -2,6 +2,7 @@
     array_chunks,
     const_num_from_num,
     const_option,
+    const_convert,
     const_trait_impl,
     int_roundings,
     iter_collect_into,

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -391,8 +391,12 @@ where
         }
 
         let sector_contents_map = {
+            let sector_contents_map_len = usize::try_from(
+                SectorContentsMap::encoded_size(sector_metadata.pieces_in_sector).as_u64(),
+            )
+            .expect("Always fits in usize");
             SectorContentsMap::from_bytes(
-                &sector[..SectorContentsMap::encoded_size(sector_metadata.pieces_in_sector)],
+                &sector[..sector_contents_map_len],
                 sector_metadata.pieces_in_sector,
             )?
         };

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -20,9 +20,9 @@ pub enum ReadingError {
     /// Wrong sector size
     #[error("Wrong sector size: expected {expected}, actual {actual}")]
     WrongSectorSize {
-        /// Expected size in bytes
+        /// Expected size
         expected: ByteSize,
-        /// Actual size in bytes
+        /// Actual size
         actual: ByteSize,
     },
     /// Failed to read chunk.

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -188,7 +188,7 @@ where
                 min_size,
                 allocated_space,
             }) => {
-                let minimum_plot_size = get_required_plot_space_with_overhead(min_size as u64);
+                let minimum_plot_size = get_required_plot_space_with_overhead(min_size);
                 let allocated_plotting_space_with_overhead =
                     get_required_plot_space_with_overhead(allocated_space);
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
@@ -11,8 +11,8 @@ pub(crate) fn print_disk_farm_info(directory: PathBuf, disk_farm_index: usize) {
             println!("  First sector index: {}", info.first_sector_index());
             println!(
                 "  Allocated space: {} ({})",
-                bytesize::to_string(info.allocated_space(), true),
-                bytesize::to_string(info.allocated_space(), false)
+                info.allocated_space().to_string_as(true),
+                info.allocated_space().to_string_as(false),
             );
             println!("  Directory: {}", directory.display());
         }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -133,7 +133,7 @@ struct DiskFarm {
     /// Path to directory where data is stored.
     directory: PathBuf,
     /// How much space in bytes can farm use for plots (metadata space is not included)
-    allocated_plotting_space: u64,
+    allocated_plotting_space: ByteSize,
 }
 
 impl FromStr for DiskFarm {
@@ -167,12 +167,9 @@ impl FromStr for DiskFarm {
                 }
                 "size" => {
                     allocated_plotting_space.replace(
-                        value
-                            .parse::<ByteSize>()
-                            .map_err(|error| {
-                                format!("Failed to parse `size` \"{value}\": {error}")
-                            })?
-                            .as_u64(),
+                        value.parse::<ByteSize>().map_err(|error| {
+                            format!("Failed to parse `size` \"{value}\": {error}")
+                        })?,
                     );
                 }
                 key => {
@@ -260,7 +257,7 @@ async fn main() -> Result<()> {
 
                 vec![DiskFarm {
                     directory: base_path,
-                    allocated_plotting_space: get_usable_plot_space(0),
+                    allocated_plotting_space: get_usable_plot_space(ByteSize::b(0)),
                 }]
             } else {
                 for farm in &command.farm {
@@ -288,9 +285,7 @@ async fn main() -> Result<()> {
 
                 vec![DiskFarm {
                     directory: base_path.clone(),
-                    allocated_plotting_space: get_usable_plot_space(
-                        farming_args.plot_size.as_u64(),
-                    ),
+                    allocated_plotting_space: get_usable_plot_space(farming_args.plot_size),
                 }]
             } else {
                 for farm in &command.farm {
@@ -308,7 +303,7 @@ async fn main() -> Result<()> {
             let disk_farms = if command.farm.is_empty() {
                 vec![DiskFarm {
                     directory: base_path,
-                    allocated_plotting_space: get_usable_plot_space(0),
+                    allocated_plotting_space: get_usable_plot_space(ByteSize::b(0)),
                 }]
             } else {
                 command.farm

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -132,7 +132,7 @@ enum Subcommand {
 struct DiskFarm {
     /// Path to directory where data is stored.
     directory: PathBuf,
-    /// How much space in bytes can farm use for plots (metadata space is not included)
+    /// How much space can farm use for plots (metadata space is not included)
     allocated_plotting_space: ByteSize,
 }
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
@@ -1,3 +1,4 @@
+use bytesize::ByteSize;
 use std::path::PathBuf;
 use tokio::signal;
 
@@ -28,16 +29,16 @@ pub(crate) fn raise_fd_limit() {
 
 pub(crate) const DB_OVERHEAD_PERCENT: u64 = 92;
 
-pub(crate) fn get_usable_plot_space(allocated_space: u64) -> u64 {
+pub(crate) fn get_usable_plot_space(allocated_space: ByteSize) -> ByteSize {
     // TODO: Should account for database overhead of various additional databases.
     //  For now assume 92% will go for plot itself
-    allocated_space * DB_OVERHEAD_PERCENT / 100
+    ByteSize::b(allocated_space.as_u64() * DB_OVERHEAD_PERCENT / 100)
 }
 
-pub(crate) fn get_required_plot_space_with_overhead(allocated_space: u64) -> u64 {
+pub(crate) fn get_required_plot_space_with_overhead(allocated_space: ByteSize) -> ByteSize {
     // TODO: Should account for database overhead of various additional databases.
     //  For now assume 92% will go for plot itself
-    allocated_space * 100 / DB_OVERHEAD_PERCENT
+    ByteSize::b(allocated_space.as_u64() * 100 / DB_OVERHEAD_PERCENT)
 }
 
 #[cfg(unix)]

--- a/crates/subspace-farmer/src/object_mappings/tests.rs
+++ b/crates/subspace-farmer/src/object_mappings/tests.rs
@@ -1,4 +1,5 @@
 use crate::object_mappings::ObjectMappings;
+use bytesize::ByteSize;
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::Encode;
 use rand::random;
@@ -64,8 +65,12 @@ fn basic() {
     // Test basic retrievability
     {
         let base_directory = TempDir::new().unwrap();
-        let object_mappings =
-            ObjectMappings::open_or_create(base_directory.path(), public_key, u64::MAX).unwrap();
+        let object_mappings = ObjectMappings::open_or_create(
+            base_directory.path(),
+            public_key,
+            ByteSize::b(u64::MAX),
+        )
+        .unwrap();
         object_mappings.store(&global_mappings).unwrap();
 
         for (hash, global_mapping) in &global_mappings {
@@ -83,7 +88,7 @@ fn basic() {
             base_directory.path(),
             public_key,
             // Store up to 4 elements, prune down to 3
-            global_mappings[0].encoded_size() as u64 * 5 - 1,
+            ByteSize::b(global_mappings[0].encoded_size() as u64 * 5 - 1),
         )
         .unwrap();
         object_mappings.store(&global_mappings).unwrap();
@@ -151,7 +156,7 @@ fn basic() {
             base_directory.path(),
             public_key,
             // Store up to 4 elements, prune down to 3
-            global_mappings[0].encoded_size() as u64 * 5 - 1,
+            ByteSize::b(global_mappings[0].encoded_size() as u64 * 5 - 1),
         )
         .unwrap();
 

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -223,7 +223,7 @@ impl SingleDiskPlotInfo {
         *pieces_in_sector
     }
 
-    /// How much space in bytes is allocated for this plot
+    /// How much space is allocated for this plot
     pub fn allocated_space(&self) -> ByteSize {
         let Self::V0 {
             allocated_space, ..
@@ -279,7 +279,7 @@ pub struct SingleDiskPlotOptions<NC, PG> {
     pub directory: PathBuf,
     /// Information necessary for farmer application
     pub farmer_app_info: FarmerAppInfo,
-    /// How much space in bytes can plot use for plot
+    /// How much space can plot use for plot
     pub allocated_space: ByteSize,
     /// How many pieces one sector is supposed to contain (max)
     pub max_pieces_in_sector: u16,

--- a/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
@@ -101,7 +101,7 @@ where
     }
 
     let sector_id = SectorId::new(public_key.hash(), sector_index);
-    let sector_size = sector_size(pieces_in_sector);
+    let sector_size = sector_size(pieces_in_sector).as_u64() as usize;
     // TODO: Would be nicer to have list of plots here and just index it
     let sector = &global_plot[sector_size * sector_offset..][..sector_size];
 

--- a/crates/subspace-farmer/src/ws_rpc_server.rs
+++ b/crates/subspace-farmer/src/ws_rpc_server.rs
@@ -13,7 +13,7 @@ use subspace_core_primitives::{
 };
 use tracing::{debug, error};
 
-/// Maximum expected size of one object in bytes
+/// Maximum expected size of one object
 const MAX_OBJECT_SIZE: ByteSize = ByteSize::mib(5);
 
 /// Something that can be used to get decoded pieces by index

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -30,7 +30,7 @@ const PEER_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).expect("Not zero; q
 // Size of the LRU cache for addresses.
 const ADDRESSES_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(30).expect("Not zero; qed");
 // Pause duration between network parameters save.
-const DATA_FLUSH_DURATION_SECS: u64 = 5;
+const DATA_FLUSH_DURATION: Duration = Duration::from_secs(5);
 // Defines a batch size for a combined collection for known peers addresses and boostrap addresses.
 const PEERS_ADDRESSES_BATCH_SIZE: usize = 30;
 // Defines an expiration period for the peer marked for the removal.
@@ -220,7 +220,7 @@ impl NetworkingParametersManager {
 
     // Create default delay for networking parameters.
     fn default_delay() -> Pin<Box<Fuse<Sleep>>> {
-        Box::pin(sleep(Duration::from_secs(DATA_FLUSH_DURATION_SECS)).fuse())
+        Box::pin(sleep(DATA_FLUSH_DURATION).fuse())
     }
 }
 

--- a/crates/subspace-networking/src/behavior/provider_storage/providers.rs
+++ b/crates/subspace-networking/src/behavior/provider_storage/providers.rs
@@ -3,6 +3,7 @@ mod tests;
 
 use super::ProviderStorage;
 use crate::utils::unique_record_binary_heap::UniqueRecordBinaryHeap;
+use bytesize::ByteSize;
 use either::Either;
 use libp2p::kad::record::Key;
 use libp2p::kad::store::{MemoryStoreConfig, RecordStore};
@@ -20,7 +21,8 @@ use std::time::{Duration, Instant, SystemTime};
 use tracing::{debug, error, trace, warn};
 
 // Defines max provider records number. Each provider record is expected to be less than 1KB.
-const MEMORY_STORE_PROVIDED_KEY_LIMIT: usize = 100000; // ~100 MB
+const MEMORY_STORE_PROVIDED_KEY_LIMIT: usize =
+    (ByteSize::mb(100).as_u64() / ByteSize::kb(1).as_u64()) as usize;
 
 const PARITY_DB_ALL_PROVIDERS_COLUMN_NAME: u8 = 0;
 const PARITY_DB_LOCAL_PROVIDER_COLUMN_NAME: u8 = 1;

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -135,8 +135,9 @@ async fn main() -> anyhow::Result<()> {
                 protocol_version
             );
 
-            const APPROX_PROVIDER_RECORD_SIZE: u64 = 1000; // ~ 1KB
-            let recs = piece_providers_cache_size.as_u64() / APPROX_PROVIDER_RECORD_SIZE;
+            const APPROX_PROVIDER_RECORD_SIZE: ByteSize = ByteSize::kb(1);
+
+            let recs = piece_providers_cache_size.as_u64() / APPROX_PROVIDER_RECORD_SIZE.as_u64();
             let converted_cache_size =
                 NonZeroUsize::new(recs as usize).ok_or_else(|| anyhow!("Incorrect cache size."))?;
 

--- a/crates/subspace-networking/src/request_responses/tests.rs
+++ b/crates/subspace-networking/src/request_responses/tests.rs
@@ -3,6 +3,7 @@ use crate::request_responses::{
     RequestFailure, RequestHandler, RequestResponsesBehaviour,
 };
 use async_trait::async_trait;
+use bytesize::ByteSize;
 use futures::channel::{mpsc, oneshot};
 use futures::executor::LocalPool;
 use futures::task::Spawn;
@@ -93,8 +94,8 @@ async fn basic_request_response_works() {
 
             let protocol_config = ProtocolConfig {
                 name: protocol_name,
-                max_request_size: 1024,
-                max_response_size: 1024 * 1024,
+                max_request_size: ByteSize::kib(1),
+                max_response_size: ByteSize::mib(1),
                 request_timeout: Duration::from_secs(30),
                 inbound_queue: Some(tx),
             };
@@ -192,8 +193,8 @@ async fn max_response_size_exceeded() {
 
             let protocol_config = ProtocolConfig {
                 name: protocol_name,
-                max_request_size: 1024,
-                max_response_size: 8, // <-- important for the test
+                max_request_size: ByteSize::kib(1),
+                max_response_size: ByteSize::b(8), // <-- important for the test
                 request_timeout: Duration::from_secs(30),
                 inbound_queue: Some(tx),
             };
@@ -285,15 +286,15 @@ async fn request_id_collision() {
         let protocol_configs = vec![
             ProtocolConfig {
                 name: protocol_name_1,
-                max_request_size: 1024,
-                max_response_size: 1024 * 1024,
+                max_request_size: ByteSize::kib(1),
+                max_response_size: ByteSize::mib(1),
                 request_timeout: Duration::from_secs(30),
                 inbound_queue: None,
             },
             ProtocolConfig {
                 name: protocol_name_2,
-                max_request_size: 1024,
-                max_response_size: 1024 * 1024,
+                max_request_size: ByteSize::kib(1),
+                max_response_size: ByteSize::mib(1),
                 request_timeout: Duration::from_secs(30),
                 inbound_queue: None,
             },
@@ -309,15 +310,15 @@ async fn request_id_collision() {
         let protocol_configs = vec![
             ProtocolConfig {
                 name: protocol_name_1,
-                max_request_size: 1024,
-                max_response_size: 1024 * 1024,
+                max_request_size: ByteSize::kib(1),
+                max_response_size: ByteSize::mib(1),
                 request_timeout: Duration::from_secs(30),
                 inbound_queue: Some(tx_1),
             },
             ProtocolConfig {
                 name: protocol_name_2,
-                max_request_size: 1024,
-                max_response_size: 1024 * 1024,
+                max_request_size: ByteSize::kib(1),
+                max_response_size: ByteSize::mib(1),
                 request_timeout: Duration::from_secs(30),
                 inbound_queue: Some(tx_2),
             },

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -528,7 +528,7 @@ fn main() -> Result<(), Error> {
                         force_new_slot_notifications: !cli.domain_args.is_empty(),
                         subspace_networking: SubspaceNetworking::Create {
                             config: dsn_config,
-                            piece_cache_size: cli.piece_cache_size.as_u64(),
+                            piece_cache_size: cli.piece_cache_size,
                         },
                         segment_publish_concurrency: cli.segment_publish_concurrency,
                         sync_from_dsn: cli.sync_from_dsn,

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.58"
+bytesize = "1.2"
 derive_more = "0.99.17"
 domain-block-preprocessor = { version = "0.1.0", path = "../../domains/client/block-preprocessor" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -169,7 +169,7 @@ pub enum SubspaceNetworking {
     Create {
         /// Configuration to use for DSN instantiation
         config: DsnConfig,
-        /// Piece cache size in bytes
+        /// Piece cache size
         piece_cache_size: ByteSize,
     },
 }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -28,6 +28,7 @@ use crate::dsn::{create_dsn_instance, DsnConfigurationError};
 use crate::piece_cache::PieceCache;
 use crate::segment_headers::{start_segment_header_archiver, SegmentHeaderCache};
 use crate::tx_pre_validator::PrimaryChainTxPreValidator;
+use bytesize::ByteSize;
 use derive_more::{Deref, DerefMut, Into};
 use domain_runtime_primitives::Hash as DomainHash;
 use dsn::start_dsn_archiver;
@@ -169,7 +170,7 @@ pub enum SubspaceNetworking {
         /// Configuration to use for DSN instantiation
         config: DsnConfig,
         /// Piece cache size in bytes
-        piece_cache_size: u64,
+        piece_cache_size: ByteSize,
     },
 }
 

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests;
 
+use bytesize::ByteSize;
 use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use sc_client_api::backend::AuxStore;
@@ -47,9 +48,9 @@ where
 {
     const KEY_PREFIX: &[u8] = b"piece_cache";
 
-    /// Create new instance with specified size (in bytes)
-    pub fn new(aux_store: Arc<AS>, cache_size: u64, local_peer_id: PeerId) -> Self {
-        let max_pieces_in_cache = PieceIndex::from(cache_size / Piece::SIZE as u64);
+    /// Create new instance with specified size
+    pub fn new(aux_store: Arc<AS>, cache_size: ByteSize, local_peer_id: PeerId) -> Self {
+        let max_pieces_in_cache = PieceIndex::from(cache_size.as_u64() / Piece::SIZE as u64);
         let local_provided_keys = Self::get_local_provided_keys(aux_store.clone())
             .expect("DB loading should succeed.")
             .unwrap_or_default();

--- a/crates/subspace-service/src/piece_cache/tests.rs
+++ b/crates/subspace-service/src/piece_cache/tests.rs
@@ -1,4 +1,5 @@
 use crate::piece_cache::PieceCache;
+use bytesize::ByteSize;
 use sc_client_api::AuxStore;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -48,7 +49,7 @@ impl AuxStore for TestAuxStore {
 fn basic() {
     let mut store = PieceCache::new(
         Arc::new(TestAuxStore::default()),
-        ArchivedHistorySegment::SIZE as u64,
+        ByteSize::b(ArchivedHistorySegment::SIZE as u64),
         PeerId::random(),
     );
 
@@ -76,7 +77,11 @@ fn basic() {
 
 #[test]
 fn cache_nothing() {
-    let mut store = PieceCache::new(Arc::new(TestAuxStore::default()), 0, PeerId::random());
+    let mut store = PieceCache::new(
+        Arc::new(TestAuxStore::default()),
+        ByteSize::b(0),
+        PeerId::random(),
+    );
 
     store
         .add_pieces(PieceIndex::default(), &ArchivedHistorySegment::default())
@@ -94,7 +99,7 @@ fn cache_nothing() {
 fn auto_cleanup() {
     let mut store = PieceCache::new(
         Arc::new(TestAuxStore::default()),
-        Piece::SIZE as u64,
+        ByteSize::b(Piece::SIZE as u64),
         PeerId::random(),
     );
 

--- a/domains/client/eth-service/src/service.rs
+++ b/domains/client/eth-service/src/service.rs
@@ -40,11 +40,11 @@ pub struct EthConfiguration {
     #[arg(long, default_value = "10")]
     pub execute_gas_limit_multiplier: u64,
 
-    /// Size in bytes of the LRU cache for block data.
+    /// Size of the LRU cache for block data.
     #[arg(long, default_value = "50")]
     pub eth_log_block_cache: usize,
 
-    /// Size in bytes of the LRU cache for transactions statuses data.
+    /// Size of the LRU cache for transactions statuses data.
     #[arg(long, default_value = "50")]
     pub eth_statuses_cache: usize,
 }

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -224,8 +224,8 @@ where
         .next()
         .expect("First block is always producing one segment; qed");
     let history_size = HistorySize::from(SegmentIndex::ZERO);
-    let mut sector = vec![0u8; sector_size(pieces_in_sector)];
-    let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
+    let mut sector = vec![0u8; sector_size(pieces_in_sector).as_u64() as usize];
+    let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size().as_u64() as usize];
     let sector_index = 0;
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let farmer_protocol_info = FarmerProtocolInfo {


### PR DESCRIPTION
This pr gives up on using numbers for quantity of bytes in favor of type safe `bytesize` crate.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
