### PR TITLE
EVM Runtime final TODOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10899,6 +10899,7 @@ dependencies = [
  "domain-eth-service",
  "domain-runtime-primitives",
  "domain-service",
+ "fp-evm",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,6 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-base-fee",
- "pallet-dynamic-fee",
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
@@ -3307,16 +3306,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "fp-dynamic-fee"
-version = "1.0.0"
-source = "git+https://github.com/subspace/frontier/?rev=e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b#e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b"
-dependencies = [
- "async-trait",
- "sp-core",
- "sp-inherents",
 ]
 
 [[package]]
@@ -6590,22 +6579,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-trie",
-]
-
-[[package]]
-name = "pallet-dynamic-fee"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/frontier/?rev=e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b#e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b"
-dependencies = [
- "fp-dynamic-fee",
- "fp-evm",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-std",
 ]
 
 [[package]]

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -31,6 +31,7 @@ domain-client-executor = { version = "0.1.0", path = "../../domains/client/domai
 domain-eth-service = { version = "0.1.0", path = "../../domains/client/eth-service" }
 domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false }
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }

--- a/crates/subspace-node/src/core_domain/core_evm_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_evm_chain_spec.rs
@@ -249,7 +249,6 @@ fn testnet_genesis(
         evm_chain_id: EVMChainIdConfig { chain_id },
         evm: Default::default(),
         ethereum: Default::default(),
-        dynamic_fee: Default::default(),
         base_fee: Default::default(),
     }
 }

--- a/domains/client/eth-service/Cargo.toml
+++ b/domains/client/eth-service/Cargo.toml
@@ -18,7 +18,7 @@ domain-service = { version = "0.1.0", path = "../../service" }
 fc-consensus = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fc-db = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fc-mapping-sync = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
-fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
+fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b", features = ['rpc-binary-search-estimate'] }
 fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fc-storage = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b", features = ['default'] }

--- a/domains/runtime/core-evm/Cargo.toml
+++ b/domains/runtime/core-evm/Cargo.toml
@@ -33,7 +33,6 @@ hex-literal = { version = '0.4.0', optional = true }
 log = { version = "0.4.17", default-features = false }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
-pallet-dynamic-fee = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-ethereum = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
@@ -84,7 +83,6 @@ std = [
 	"log/std",
 	"pallet-balances/std",
 	"pallet-base-fee/std",
-	"pallet-dynamic-fee/std",
 	"pallet-ethereum/std",
 	"pallet-evm/std",
 	"pallet-evm-chain-id/std",

--- a/domains/runtime/core-evm/src/precompiles.rs
+++ b/domains/runtime/core-evm/src/precompiles.rs
@@ -6,9 +6,9 @@ use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
 
-pub struct FrontierPrecompiles<R>(PhantomData<R>);
+pub struct Precompiles<R>(PhantomData<R>);
 
-impl<R> FrontierPrecompiles<R>
+impl<R> Precompiles<R>
 where
     R: pallet_evm::Config,
 {
@@ -25,14 +25,14 @@ where
     }
 }
 
-impl<R> Default for FrontierPrecompiles<R> {
+impl<R> Default for Precompiles<R> {
     #[inline]
     fn default() -> Self {
         Self(PhantomData::default())
     }
 }
 
-impl<R> PrecompileSet for FrontierPrecompiles<R>
+impl<R> PrecompileSet for Precompiles<R>
 where
     R: pallet_evm::Config,
 {


### PR DESCRIPTION
This PR fixes the last set of TODOs in EVM domain
- Return the correct transaction signer
- Update Runtime parameters. Used Moonbeam and Aster as reference and took some of their code
- Add simple revert to precompiles so that they are callable from the solidity contracts.
- Update EVM Chainspec with correct EVM dev accounts 

Polkadot apps natively recognize `Ethereum` type chains. ~This was not detected for our chain because there is a preconfigured ethereum chains list in polkadot apps. We have a PR for upstream to add our domain in that list - https://github.com/polkadot-js/apps/pull/9399. Until then spec_name will be `fronteir-template` instead of `subspace-evm-domain`.~
Apps PR is merged but not deployed yet. But our testing went fine we this is good to get in. Looks like Apps do weekly deployments and should expect our domain to work out of the box when they deploy. Until then we can locally update the spec_name for it to work with current deployment of Apss

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
