### PR TITLE
Modify parity_db storage provider for DSN.

### DIFF
--- a/crates/subspace-networking/src/behavior/provider_storage/providers.rs
+++ b/crates/subspace-networking/src/behavior/provider_storage/providers.rs
@@ -133,6 +133,10 @@ impl ParityDbProviderCollection {
     fn providers(&self) -> impl Iterator<Item = ParityDbProviderRecord> + '_ {
         self.map.values().cloned()
     }
+
+    fn len(&self) -> usize {
+        self.map.len()
+    }
 }
 
 #[derive(Clone, Debug, Decode, Encode)]
@@ -329,12 +333,13 @@ impl ParityDbProviderStorage {
 
     fn save_providers(&self, key: &Key, providers: ParityDbProviderCollection) -> bool {
         let key: &[u8] = key.borrow();
+        let data = if providers.len() > 0 {
+            Some(providers.to_vec())
+        } else {
+            None
+        };
 
-        let tx = [(
-            PARITY_DB_ALL_PROVIDERS_COLUMN_NAME,
-            key,
-            Some(providers.to_vec()),
-        )];
+        let tx = [(PARITY_DB_ALL_PROVIDERS_COLUMN_NAME, key, data)];
 
         let result = self.db.commit(tx);
         if let Err(err) = &result {


### PR DESCRIPTION
This PR changes the saving of the empty provider collection. It passes None to the Parity DB transaction and thus removes the empty collection from DB. It likely relates to https://github.com/subspace/subspace/issues/1388 and should also ease https://github.com/subspace/subspace/issues/1311

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
