### PR TITLE
Update Transporter to support MultiAccountId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ name = "domain-runtime-primitives"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -6729,6 +6730,7 @@ dependencies = [
 name = "pallet-messenger"
 version = "0.1.0"
 dependencies = [
+ "domain-runtime-primitives",
  "frame-support",
  "frame-system",
  "log",
@@ -6942,6 +6944,7 @@ dependencies = [
 name = "pallet-transporter"
 version = "0.1.0"
 dependencies = [
+ "domain-runtime-primitives",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -528,6 +528,11 @@ where
             .unwrap_or_default()
     }
 
+    // TODO: at the moment the aux storage grows as the chain grows
+    // We can prune the the storage by doing another round of check for any undelivered messages
+    // and then prune the storage.
+    // We can use Finalize event but its not triggered yet as we dont finalize.
+    // Other option would be to use fraud proof period.
     pub(crate) fn store_relayed_block(
         client: &Arc<Client>,
         domain_id: DomainId,

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -27,6 +27,7 @@ sp-std = { version = "5.0.0", default-features = false, git = "https://github.co
 sp-trie = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 
 [dev-dependencies]
+domain-runtime-primitives = { path = "../../primitives/runtime" }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 pallet-transporter = { version = "0.1.0", path = "../transporter" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -23,7 +23,7 @@ use sp_messenger::messages::{
     ProtocolMessageRequest, RequestResponse, VersionedPayload,
 };
 use sp_messenger::verification::{StorageProofVerifier, VerificationError};
-use sp_runtime::traits::ValidateUnsigned;
+use sp_runtime::traits::{Convert, ValidateUnsigned};
 
 fn create_channel(domain_id: DomainId, channel_id: ChannelId, fee_model: FeeModel<Balance>) {
     let params = InitiateChannelParams {
@@ -680,7 +680,7 @@ fn initiate_transfer_on_domain(domain_a_ext: &mut TestExternalities) {
             domain_a::RuntimeOrigin::signed(account_id),
             Location {
                 domain_id: domain_b::SelfDomainId::get(),
-                account_id,
+                account_id: domain_b::MockAccountIdConverter::convert(account_id),
             },
             500,
         );
@@ -852,7 +852,7 @@ fn test_transport_funds_between_domains_failed_low_balance() {
             domain_a::RuntimeOrigin::signed(account_id),
             Location {
                 domain_id: domain_b::SelfDomainId::get(),
-                account_id,
+                account_id: domain_b::MockAccountIdConverter::convert(account_id),
             },
             500,
         );
@@ -874,7 +874,7 @@ fn test_transport_funds_between_domains_failed_no_open_channel() {
             domain_a::RuntimeOrigin::signed(account_id),
             Location {
                 domain_id: domain_b::SelfDomainId::get(),
-                account_id,
+                account_id: domain_b::MockAccountIdConverter::convert(account_id),
             },
             500,
         );

--- a/domains/pallets/transporter/Cargo.toml
+++ b/domains/pallets/transporter/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+domain-runtime-primitives = { path = "../../primitives/runtime" , default-features = false }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
@@ -32,6 +33,7 @@ sp-io = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev 
 default = ["std"]
 std = [
   "codec/std",
+  "domain-runtime-primitives/std",
   "frame-support/std",
   "frame-system/std",
   "scale-info/std",

--- a/domains/pallets/transporter/src/tests.rs
+++ b/domains/pallets/transporter/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::mock::{
-    new_test_ext, AccountId, Balance, Balances, MockRuntime, RuntimeEvent, RuntimeOrigin,
-    SelfDomainId, SelfEndpointId, System, Transporter, USER_ACCOUNT,
+    new_test_ext, AccountId, Balance, Balances, MockAccountIdConverter, MockRuntime, RuntimeEvent,
+    RuntimeOrigin, SelfDomainId, SelfEndpointId, System, Transporter, USER_ACCOUNT,
 };
 use crate::{EndpointHandler, Error, Location, Transfer};
 use codec::Encode;
@@ -10,6 +10,7 @@ use sp_domains::DomainId;
 use sp_messenger::endpoint::{
     Endpoint, EndpointHandler as EndpointHandlerT, EndpointRequest, EndpointResponse,
 };
+use sp_runtime::traits::Convert;
 use std::marker::PhantomData;
 
 #[test]
@@ -23,7 +24,7 @@ fn test_initiate_transfer_failed() {
         let dst_domain_id = 1.into();
         let dst_location = Location {
             domain_id: dst_domain_id,
-            account_id: account,
+            account_id: MockAccountIdConverter::convert(account),
         };
         let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, 500);
         assert_err!(res, Error::<MockRuntime>::LowBalance);
@@ -43,7 +44,7 @@ fn test_initiate_transfer() {
         let dst_domain_id = 1.into();
         let dst_location = Location {
             domain_id: dst_domain_id,
-            account_id: account,
+            account_id: MockAccountIdConverter::convert(account),
         };
         let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, 500);
         assert_ok!(res);
@@ -63,12 +64,12 @@ fn test_initiate_transfer() {
                 amount: 500,
                 sender: Location {
                     domain_id: SelfDomainId::get(),
-                    account_id: account
+                    account_id: MockAccountIdConverter::convert(account),
                 },
                 receiver: Location {
                     domain_id: dst_domain_id,
-                    account_id: account
-                }
+                    account_id: MockAccountIdConverter::convert(account),
+                },
             }
         )
     })
@@ -84,11 +85,11 @@ fn test_transfer_response_missing_request() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
         }
         .encode();
@@ -100,7 +101,7 @@ fn test_transfer_response_missing_request() {
 fn initiate_transfer(dst_domain_id: DomainId, account: AccountId, amount: Balance) {
     let dst_location = Location {
         domain_id: dst_domain_id,
-        account_id: account,
+        account_id: MockAccountIdConverter::convert(account),
     };
 
     let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, amount);
@@ -156,12 +157,12 @@ fn test_transfer_response_invalid_request() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
                 // change receiver id
-                account_id: 100,
+                account_id: MockAccountIdConverter::convert(100),
             },
         }
         .encode();
@@ -198,11 +199,11 @@ fn test_transfer_response_revert() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
         }
         .encode();
@@ -256,11 +257,11 @@ fn test_transfer_response_successful() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
         }
         .encode();
@@ -302,11 +303,11 @@ fn test_receive_incoming_transfer() {
                 amount,
                 sender: Location {
                     domain_id: src_domain_id,
-                    account_id: 0,
+                    account_id: MockAccountIdConverter::convert(0),
                 },
                 receiver: Location {
                     domain_id: dst_domain_id,
-                    account_id: receiver,
+                    account_id: MockAccountIdConverter::convert(receiver),
                 },
             }
             .encode(),

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -23,6 +24,7 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subsp
 default = ["std"]
 std = [
 	"parity-scale-codec/std",
+	"scale-info/std",
 	"sp-api/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -17,8 +17,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::generic::UncheckedExtrinsic;
-use sp_runtime::traits::{Block as BlockT, IdentifyAccount, Verify};
+use sp_runtime::scale_info::TypeInfo;
+use sp_runtime::traits::{Block as BlockT, Convert, IdentifyAccount, Verify};
 use sp_runtime::{MultiAddress, MultiSignature};
 use sp_std::vec::Vec;
 use subspace_runtime_primitives::Moment;
@@ -67,6 +69,41 @@ where
         self.signature
             .as_ref()
             .and_then(|(signed, _, _)| lookup.lookup(signed.clone()).ok())
+    }
+}
+
+/// MultiAccountId used by all the domains to describe their account type.
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub enum MultiAccountId {
+    /// 32 byte account Id.
+    AccountId32([u8; 32]),
+    /// 20 byte account Id. Ex: Ethereum
+    AccountId20([u8; 20]),
+    /// Some raw bytes
+    Raw(Vec<u8>),
+}
+
+/// Extensible conversion trait. Generic over both source and destination types.
+pub trait TryConvertBack<A, B>: Convert<A, B> {
+    /// Make conversion back.
+    fn try_convert_back(b: B) -> Option<A>;
+}
+
+/// An AccountId32 to MultiAccount converter.
+pub struct AccountIdConverter;
+
+impl Convert<AccountId, MultiAccountId> for AccountIdConverter {
+    fn convert(account_id: AccountId) -> MultiAccountId {
+        MultiAccountId::AccountId32(account_id.into())
+    }
+}
+
+impl TryConvertBack<AccountId, MultiAccountId> for AccountIdConverter {
+    fn try_convert_back(multi_account_id: MultiAccountId) -> Option<AccountId> {
+        match multi_account_id {
+            MultiAccountId::AccountId32(acc) => Some(AccountId::new(acc)),
+            _ => None,
+        }
     }
 }
 

--- a/domains/runtime/core-eth-relay/src/runtime.rs
+++ b/domains/runtime/core-eth-relay/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::feed_processor::{feed_processor, FeedProcessorId, FeedProcessorKind};
 use codec::{Decode, Encode};
-use domain_runtime_primitives::{opaque, SLOT_DURATION};
+use domain_runtime_primitives::{opaque, AccountIdConverter, SLOT_DURATION};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -299,6 +299,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/runtime/core-payments/src/runtime.rs
+++ b/domains/runtime/core-payments/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, AccountIdConverter};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -290,6 +290,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, AccountIdConverter};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -361,6 +361,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/test/runtime/core-payments/src/runtime.rs
+++ b/domains/test/runtime/core-payments/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, AccountIdConverter};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -299,6 +299,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {


### PR DESCRIPTION
This PR adds MultiAccountId to support 32, 20 and raw account bytes. With this change, one can move funds between different domains with different account types. Ex: System <> EVM.

Closes: #1435

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
