### PR TITLE
EVM changes and backports to Gemini-3d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,6 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-base-fee",
- "pallet-dynamic-fee",
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
@@ -3425,16 +3424,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "fp-dynamic-fee"
-version = "1.0.0"
-source = "git+https://github.com/subspace/frontier/?rev=e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b#e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b"
-dependencies = [
- "async-trait",
- "sp-core",
- "sp-inherents",
 ]
 
 [[package]]
@@ -6713,22 +6702,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-trie",
-]
-
-[[package]]
-name = "pallet-dynamic-fee"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/frontier/?rev=e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b#e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b"
-dependencies = [
- "fp-dynamic-fee",
- "fp-evm",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-inherents",
- "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11040,6 +11040,7 @@ dependencies = [
  "domain-eth-service",
  "domain-runtime-primitives",
  "domain-service",
+ "fp-evm",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ name = "domain-runtime-primitives"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -6852,6 +6853,7 @@ dependencies = [
 name = "pallet-messenger"
 version = "0.1.0"
 dependencies = [
+ "domain-runtime-primitives",
  "frame-support",
  "frame-system",
  "log",
@@ -7061,6 +7063,7 @@ dependencies = [
 name = "pallet-transporter"
 version = "0.1.0"
 dependencies = [
+ "domain-runtime-primitives",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "subspace-core-primitives",
+ "subspace-runtime-primitives",
  "subspace-wasm-tools",
  "system-runtime-primitives",
  "tracing",
@@ -2601,6 +2602,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]
@@ -2668,8 +2670,8 @@ dependencies = [
 name = "domain-test-primitives"
 version = "0.1.0"
 dependencies = [
- "domain-runtime-primitives",
  "sp-api",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "pallet-feeds",
  "pallet-messenger",
  "pallet-sudo",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -1534,6 +1535,7 @@ dependencies = [
  "pallet-evm-precompile-simple",
  "pallet-messenger",
  "pallet-sudo",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -1620,6 +1622,7 @@ version = "0.1.0"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
+ "domain-test-primitives",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -1632,6 +1635,7 @@ dependencies = [
  "pallet-executor-registry",
  "pallet-messenger",
  "pallet-sudo",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -2448,6 +2452,7 @@ dependencies = [
  "domain-client-consensus-relay-chain",
  "domain-client-executor-gossip",
  "domain-runtime-primitives",
+ "domain-test-primitives",
  "domain-test-service",
  "futures",
  "futures-timer",
@@ -2657,6 +2662,14 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "system-runtime-primitives",
  "tracing",
+]
+
+[[package]]
+name = "domain-test-primitives"
+version = "0.1.0"
+dependencies = [
+ "domain-runtime-primitives",
+ "sp-api",
 ]
 
 [[package]]

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -35,6 +35,7 @@ use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
 use sp_trie::StorageProof;
 use subspace_core_primitives::{Blake2b256Hash, BlockNumber, Randomness};
+use subspace_runtime_primitives::Moment;
 
 /// Key type for Executor.
 const KEY_TYPE: KeyTypeId = KeyTypeId(*b"exec");
@@ -457,5 +458,8 @@ sp_api::decl_runtime_apis! {
 
         // Returns the state root of the system domain at specific number and hash.
         fn system_domain_state_root_at(number: NumberFor<Block>, domain_hash: DomainHash) -> Option<Block::Hash>;
+
+        // Returns the current timestamp at given height
+        fn timestamp() -> Moment;
     }
 }

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -31,6 +31,7 @@ domain-client-executor = { version = "0.1.0", path = "../../domains/client/domai
 domain-eth-service = { version = "0.1.0", path = "../../domains/client/eth-service" }
 domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }

--- a/crates/subspace-node/src/core_domain/core_evm_chain_spec.rs
+++ b/crates/subspace-node/src/core_domain/core_evm_chain_spec.rs
@@ -249,7 +249,6 @@ fn testnet_genesis(
         evm_chain_id: EVMChainIdConfig { chain_id },
         evm: Default::default(),
         ethereum: Default::default(),
-        dynamic_fee: Default::default(),
         base_fee: Default::default(),
     }
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -804,6 +804,10 @@ impl_runtime_apis! {
         ) -> Option<domain_runtime_primitives::Hash>{
             Receipts::domain_state_root_at(DomainId::SYSTEM, number, domain_hash)
         }
+
+        fn timestamp() -> Moment{
+            Timestamp::now()
+        }
     }
 
     impl sp_session::SessionKeys<Block> for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,

--- a/domains/client/block-preprocessor/Cargo.toml
+++ b/domains/client/block-preprocessor/Cargo.toml
@@ -27,6 +27,7 @@ sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }
+subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
 subspace-wasm-tools = { version = "0.1.0", path = "../../../crates/subspace-wasm-tools" }
 system-runtime-primitives = { version = "0.1.0", path = "../../primitives/system-runtime" }
 tracing = "0.1.37"

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -1,0 +1,50 @@
+//! Provides functionality of adding inherent extrinsics to the Domain.
+//! Unlike Primary chain where inherent data is first derived the block author
+//! and the data is verified by the on primary runtime, domains inherents
+//! short circuit the derivation and verification of inherent data
+//! as the inherent data is directly taken from the primary block from which
+//! domain block is being built.
+//!
+//! One of the first use case for this is passing Timestamp data. Before building a
+//! domain block using a primary block, we take the current time from the primary runtime
+//! and then create an unsigned extrinsic that is put on top the bundle extrinsics.
+//!
+//! Deriving these extrinsics during fraud proof verification should be possible since
+//! verification environment will have access to primary chain.
+
+use crate::runtime_api::InherentExtrinsicConstructor;
+use sp_api::ProvideRuntimeApi;
+use sp_core::traits::ReadRuntimeVersion;
+use sp_domains::ExecutorApi;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+
+/// Returns required inherent extrinsics for the domain block based on the primary block.
+/// Note: primary block hash must be used to construct domain block.
+// TODO: connect once runtimes have implemented the necessary api.
+#[allow(dead_code)]
+pub fn construct_inherent_extrinsics<Block, DomainRuntimeApi, PBlock, PClient>(
+    primary_client: &Arc<PClient>,
+    domain_runtime_api: &DomainRuntimeApi,
+    primary_block_hash: PBlock::Hash,
+    domain_parent_hash: Block::Hash,
+) -> Result<Vec<Block::Extrinsic>, sp_blockchain::Error>
+where
+    Block: BlockT,
+    PBlock: BlockT,
+    PClient: ProvideRuntimeApi<PBlock>,
+    PClient::Api: ExecutorApi<PBlock, Block::Hash> + ReadRuntimeVersion,
+    DomainRuntimeApi: InherentExtrinsicConstructor<Block>,
+{
+    let primary_api = primary_client.runtime_api();
+    let moment = primary_api.timestamp(primary_block_hash)?;
+
+    let mut inherent_exts = vec![];
+    if let Some(inherent_timestamp) =
+        domain_runtime_api.construct_timestamp_inherent_extrinsic(domain_parent_hash, moment)?
+    {
+        inherent_exts.push(inherent_timestamp)
+    }
+
+    Ok(inherent_exts)
+}

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -14,15 +14,12 @@
 
 use crate::runtime_api::InherentExtrinsicConstructor;
 use sp_api::ProvideRuntimeApi;
-use sp_core::traits::ReadRuntimeVersion;
 use sp_domains::ExecutorApi;
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
 /// Returns required inherent extrinsics for the domain block based on the primary block.
 /// Note: primary block hash must be used to construct domain block.
-// TODO: connect once runtimes have implemented the necessary api.
-#[allow(dead_code)]
 pub fn construct_inherent_extrinsics<Block, DomainRuntimeApi, PBlock, PClient>(
     primary_client: &Arc<PClient>,
     domain_runtime_api: &DomainRuntimeApi,
@@ -33,7 +30,7 @@ where
     Block: BlockT,
     PBlock: BlockT,
     PClient: ProvideRuntimeApi<PBlock>,
-    PClient::Api: ExecutorApi<PBlock, Block::Hash> + ReadRuntimeVersion,
+    PClient::Api: ExecutorApi<PBlock, Block::Hash>,
     DomainRuntimeApi: InherentExtrinsicConstructor<Block>,
 {
     let primary_api = primary_client.runtime_api();

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -13,7 +13,6 @@
 //! 5. Push back the potential new domain runtime extrisnic.
 
 #![warn(rust_2018_idioms)]
-#![deny(unused_crate_dependencies)]
 
 mod inherents;
 pub mod runtime_api;

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -22,8 +22,10 @@ pub mod runtime_api_light;
 mod utils;
 pub mod xdm_verifier;
 
+use crate::inherents::construct_inherent_extrinsics;
 use crate::runtime_api::{
-    CoreBundleConstructor, SetCodeConstructor, SignerExtractor, StateRootExtractor,
+    CoreBundleConstructor, InherentExtrinsicConstructor, SetCodeConstructor, SignerExtractor,
+    StateRootExtractor,
 };
 use crate::xdm_verifier::{
     verify_xdm_with_primary_chain_client, verify_xdm_with_system_domain_client,
@@ -399,7 +401,10 @@ where
     SBlock: BlockT,
     SBlock::Hash: From<Block::Hash>,
     NumberFor<SBlock>: From<NumberFor<Block>>,
-    RuntimeApi: SignerExtractor<Block> + SetCodeConstructor<Block> + StateRootExtractor<Block>,
+    RuntimeApi: SignerExtractor<Block>
+        + SetCodeConstructor<Block>
+        + StateRootExtractor<Block>
+        + InherentExtrinsicConstructor<Block>,
     PClient: HeaderBackend<PBlock> + BlockBackend<PBlock> + ProvideRuntimeApi<PBlock> + Send + Sync,
     PClient::Api: ExecutorApi<PBlock, Block::Hash>,
     SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock> + 'static,
@@ -453,13 +458,26 @@ where
 
         let extrinsics = compile_own_domain_bundles::<Block, PBlock>(core_bundles);
 
-        let mut extrinsics = deduplicate_and_shuffle_extrinsics(
+        let extrinsics = deduplicate_and_shuffle_extrinsics(
             domain_hash,
             &self.runtime_api,
             extrinsics,
             shuffling_seed,
         )
         .map(|extrinsics| self.filter_invalid_xdm_extrinsics(domain_hash, extrinsics))?;
+
+        // fetch inherent extrinsics
+        let inherent_extrinsics = construct_inherent_extrinsics(
+            &self.primary_chain_client,
+            &self.runtime_api,
+            primary_hash,
+            domain_hash,
+        )?;
+
+        let mut extrinsics: Vec<Block::Extrinsic> = inherent_extrinsics
+            .into_iter()
+            .chain(extrinsics.into_iter())
+            .collect();
 
         if let Some(new_runtime) = maybe_new_runtime {
             let encoded_set_code = self

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -13,7 +13,9 @@
 //! 5. Push back the potential new domain runtime extrisnic.
 
 #![warn(rust_2018_idioms)]
+#![deny(unused_crate_dependencies)]
 
+mod inherents;
 pub mod runtime_api;
 pub mod runtime_api_full;
 pub mod runtime_api_light;

--- a/domains/client/block-preprocessor/src/runtime_api.rs
+++ b/domains/client/block-preprocessor/src/runtime_api.rs
@@ -37,7 +37,7 @@ pub trait InherentExtrinsicConstructor<Block: BlockT> {
     fn construct_timestamp_inherent_extrinsic(
         &self,
         at: Block::Hash,
-        moment: domain_runtime_primitives::Moment,
+        moment: subspace_runtime_primitives::Moment,
     ) -> Result<Option<Block::Extrinsic>, ApiError>;
 }
 

--- a/domains/client/block-preprocessor/src/runtime_api.rs
+++ b/domains/client/block-preprocessor/src/runtime_api.rs
@@ -31,6 +31,16 @@ pub trait CoreBundleConstructor<PBlock: BlockT, Block: BlockT> {
     ) -> Result<Vec<Vec<u8>>, ApiError>;
 }
 
+/// Trait to construct inherent extrinsics
+pub trait InherentExtrinsicConstructor<Block: BlockT> {
+    /// Returns Inherent timestamp extrinsic if the Runtime implements the API.
+    fn construct_timestamp_inherent_extrinsic(
+        &self,
+        at: Block::Hash,
+        moment: domain_runtime_primitives::Moment,
+    ) -> Result<Option<Block::Extrinsic>, ApiError>;
+}
+
 /// Trait to wrap the new domain runtime as an extrinsic of
 /// `domain_pallet_executive::Call::sudo_unchecked_weight_unsigned`.
 pub trait SetCodeConstructor<Block: BlockT> {

--- a/domains/client/block-preprocessor/src/runtime_api_full.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_full.rs
@@ -3,12 +3,13 @@ use crate::runtime_api::{
     SetCodeConstructor, SignerExtractor, StateRootExtractor,
 };
 use crate::utils::extract_xdm_proof_state_roots_with_client;
-use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi, Moment};
+use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use sp_api::{ApiError, ApiExt, BlockT, ProvideRuntimeApi};
 use sp_domains::SignedOpaqueBundle;
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
 use std::sync::Arc;
+use subspace_runtime_primitives::Moment;
 use system_runtime_primitives::SystemDomainApi;
 
 /// A runtime api with full backend.

--- a/domains/client/block-preprocessor/src/runtime_api_full.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_full.rs
@@ -1,9 +1,9 @@
 use crate::runtime_api::{
-    CoreBundleConstructor, ExtractSignerResult, ExtractedStateRoots, SetCodeConstructor,
-    SignerExtractor, StateRootExtractor,
+    CoreBundleConstructor, ExtractSignerResult, ExtractedStateRoots, InherentExtrinsicConstructor,
+    SetCodeConstructor, SignerExtractor, StateRootExtractor,
 };
 use crate::utils::extract_xdm_proof_state_roots_with_client;
-use domain_runtime_primitives::DomainCoreApi;
+use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi, Moment};
 use sp_api::{ApiError, BlockT, ProvideRuntimeApi};
 use sp_domains::SignedOpaqueBundle;
 use sp_messenger::MessengerApi;
@@ -64,6 +64,22 @@ where
     ) -> Result<Vec<Vec<u8>>, ApiError> {
         let api = self.client.runtime_api();
         api.construct_submit_core_bundle_extrinsics(at, signed_opaque_bundles)
+    }
+}
+
+impl<Block, Client> InherentExtrinsicConstructor<Block> for RuntimeApiFull<Client>
+where
+    Block: BlockT,
+    Client: ProvideRuntimeApi<Block>,
+    Client::Api: InherentExtrinsicApi<Block>,
+{
+    fn construct_timestamp_inherent_extrinsic(
+        &self,
+        at: Block::Hash,
+        moment: Moment,
+    ) -> Result<Option<Block::Extrinsic>, ApiError> {
+        let api = self.client.runtime_api();
+        api.construct_inherent_timestamp_extrinsic(at, moment)
     }
 }
 

--- a/domains/client/block-preprocessor/src/runtime_api_full.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_full.rs
@@ -4,7 +4,7 @@ use crate::runtime_api::{
 };
 use crate::utils::extract_xdm_proof_state_roots_with_client;
 use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi, Moment};
-use sp_api::{ApiError, BlockT, ProvideRuntimeApi};
+use sp_api::{ApiError, ApiExt, BlockT, ProvideRuntimeApi};
 use sp_domains::SignedOpaqueBundle;
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
@@ -79,7 +79,11 @@ where
         moment: Moment,
     ) -> Result<Option<Block::Extrinsic>, ApiError> {
         let api = self.client.runtime_api();
-        api.construct_inherent_timestamp_extrinsic(at, moment)
+        if api.has_api::<dyn InherentExtrinsicApi<Block>>(at)? {
+            api.construct_inherent_timestamp_extrinsic(at, moment)
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/domains/client/block-preprocessor/src/runtime_api_light.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_light.rs
@@ -1,10 +1,11 @@
 use crate::runtime_api::{
-    CoreBundleConstructor, ExtractSignerResult, ExtractedStateRoots, SetCodeConstructor,
-    SignerExtractor, StateRootExtractor,
+    CoreBundleConstructor, ExtractSignerResult, ExtractedStateRoots, InherentExtrinsicConstructor,
+    SetCodeConstructor, SignerExtractor, StateRootExtractor,
 };
 use crate::utils::extract_xdm_proof_state_roots_with_runtime;
 use codec::{Codec, Encode};
-use domain_runtime_primitives::DomainCoreApi;
+use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi, Moment};
+use sc_executor::RuntimeVersionOf;
 use sc_executor_common::runtime_blob::RuntimeBlob;
 use sp_api::{ApiError, BlockT, Core, Hasher, RuntimeVersion};
 use sp_core::traits::{CallContext, CodeExecutor, FetchRuntimeCode, RuntimeCode};
@@ -176,6 +177,22 @@ where
     }
 }
 
+impl<Executor, Block> InherentExtrinsicApi<Block> for RuntimeApiLight<Executor>
+where
+    Block: BlockT,
+    Executor: CodeExecutor,
+{
+    fn __runtime_api_internal_call_api_at(
+        &self,
+        _at: <Block as BlockT>::Hash,
+        _context: ExecutionContext,
+        params: Vec<u8>,
+        fn_name: &dyn Fn(RuntimeVersion) -> &'static str,
+    ) -> Result<Vec<u8>, ApiError> {
+        self.dispatch_call(fn_name, params)
+    }
+}
+
 impl<PBlock, Executor, Block> CoreBundleConstructor<PBlock, Block> for RuntimeApiLight<Executor>
 where
     PBlock: BlockT,
@@ -220,5 +237,21 @@ where
         runtime_code: Vec<u8>,
     ) -> Result<Vec<u8>, ApiError> {
         <Self as DomainCoreApi<Block>>::construct_set_code_extrinsic(self, at, runtime_code)
+    }
+}
+
+impl<Executor, Block> InherentExtrinsicConstructor<Block> for RuntimeApiLight<Executor>
+where
+    Block: BlockT,
+    Executor: CodeExecutor + RuntimeVersionOf,
+{
+    fn construct_timestamp_inherent_extrinsic(
+        &self,
+        at: Block::Hash,
+        moment: Moment,
+    ) -> Result<Option<Block::Extrinsic>, ApiError> {
+        <Self as InherentExtrinsicApi<Block>>::construct_inherent_timestamp_extrinsic(
+            self, at, moment,
+        )
     }
 }

--- a/domains/client/block-preprocessor/src/runtime_api_light.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_light.rs
@@ -5,7 +5,7 @@ use crate::runtime_api::{
 use crate::utils::extract_xdm_proof_state_roots_with_runtime;
 use codec::{Codec, Encode};
 use domain_runtime_primitives::{
-    runtime_decl_for_inherent_extrinsic_api, DomainCoreApi, InherentExtrinsicApi, Moment,
+    runtime_decl_for_inherent_extrinsic_api, DomainCoreApi, InherentExtrinsicApi,
 };
 use sc_executor_common::runtime_blob::RuntimeBlob;
 use sp_api::{ApiError, BlockT, Core, Hasher, RuntimeVersion};
@@ -17,6 +17,7 @@ use sp_runtime::traits::NumberFor;
 use sp_state_machine::BasicExternalities;
 use std::borrow::Cow;
 use std::sync::Arc;
+use subspace_runtime_primitives::Moment;
 use system_runtime_primitives::SystemDomainApi;
 
 /// This is a stateless wrapper around the runtime api.

--- a/domains/client/block-preprocessor/src/runtime_api_light.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_light.rs
@@ -4,7 +4,9 @@ use crate::runtime_api::{
 };
 use crate::utils::extract_xdm_proof_state_roots_with_runtime;
 use codec::{Codec, Encode};
-use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi, Moment};
+use domain_runtime_primitives::{
+    runtime_decl_for_inherent_extrinsic_api, DomainCoreApi, InherentExtrinsicApi, Moment,
+};
 use sc_executor::RuntimeVersionOf;
 use sc_executor_common::runtime_blob::RuntimeBlob;
 use sp_api::{ApiError, BlockT, Core, Hasher, RuntimeVersion};
@@ -250,8 +252,15 @@ where
         at: Block::Hash,
         moment: Moment,
     ) -> Result<Option<Block::Extrinsic>, ApiError> {
-        <Self as InherentExtrinsicApi<Block>>::construct_inherent_timestamp_extrinsic(
-            self, at, moment,
-        )
+        let runtime_version = self.runtime_version()?;
+        if runtime_version.has_api_with(&runtime_decl_for_inherent_extrinsic_api::ID, |v| {
+            v == runtime_decl_for_inherent_extrinsic_api::VERSION
+        }) {
+            <Self as InherentExtrinsicApi<Block>>::construct_inherent_timestamp_extrinsic(
+                self, at, moment,
+            )
+        } else {
+            Ok(None)
+        }
     }
 }

--- a/domains/client/block-preprocessor/src/runtime_api_light.rs
+++ b/domains/client/block-preprocessor/src/runtime_api_light.rs
@@ -7,7 +7,6 @@ use codec::{Codec, Encode};
 use domain_runtime_primitives::{
     runtime_decl_for_inherent_extrinsic_api, DomainCoreApi, InherentExtrinsicApi, Moment,
 };
-use sc_executor::RuntimeVersionOf;
 use sc_executor_common::runtime_blob::RuntimeBlob;
 use sp_api::{ApiError, BlockT, Core, Hasher, RuntimeVersion};
 use sp_core::traits::{CallContext, CodeExecutor, FetchRuntimeCode, RuntimeCode};
@@ -245,7 +244,7 @@ where
 impl<Executor, Block> InherentExtrinsicConstructor<Block> for RuntimeApiLight<Executor>
 where
     Block: BlockT,
-    Executor: CodeExecutor + RuntimeVersionOf,
+    Executor: CodeExecutor,
 {
     fn construct_timestamp_inherent_extrinsic(
         &self,

--- a/domains/client/domain-executor/Cargo.toml
+++ b/domains/client/domain-executor/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1.27.0", features = ["macros"] }
 
 [dev-dependencies]
 core-payments-domain-runtime = { version = "0.1.0", path = "../../runtime/core-payments" }
+domain-test-primitives = { version = "0.1.0", path = "../../test/primitives" }
 domain-test-service = { version = "0.1.0", path = "../../test/service" }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-domains = { version = "0.1.0", path = "../../../crates/pallet-domains" }

--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -4,7 +4,7 @@ use crate::utils::translate_number_type;
 use crate::TransactionFor;
 use domain_block_preprocessor::runtime_api_full::RuntimeApiFull;
 use domain_block_preprocessor::CoreDomainBlockPreprocessor;
-use domain_runtime_primitives::DomainCoreApi;
+use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use sc_client_api::{AuxStore, BlockBackend, Finalizer, StateBackendFor};
 use sc_consensus::BlockImport;
 use sp_api::{NumberFor, ProvideRuntimeApi};
@@ -85,6 +85,7 @@ where
     Client::Api: DomainCoreApi<Block>
         + MessengerApi<Block, NumberFor<Block>>
         + sp_block_builder::BlockBuilder<Block>
+        + InherentExtrinsicApi<Block>
         + sp_api::ApiExt<Block, StateBackend = StateBackendFor<Backend, Block>>,
     for<'b> &'b BI: BlockImport<
         Block,

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -20,7 +20,7 @@ use crate::domain_worker::{handle_block_import_notifications, handle_slot_notifi
 use crate::parent_chain::CoreDomainParentChain;
 use crate::utils::{BlockInfo, ExecutorSlotInfo};
 use crate::{ExecutorStreams, TransactionFor};
-use domain_runtime_primitives::DomainCoreApi;
+use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use futures::channel::mpsc;
 use futures::{future, FutureExt, Stream, StreamExt, TryFutureExt};
 use sc_client_api::{
@@ -101,6 +101,7 @@ pub(super) async fn start_worker<
     Client::Api: DomainCoreApi<Block>
         + BlockBuilder<Block>
         + MessengerApi<Block, NumberFor<Block>>
+        + InherentExtrinsicApi<Block>
         + sp_api::ApiExt<Block, StateBackend = StateBackendFor<Backend, Block>>,
     for<'b> &'b BI: BlockImport<
         Block,

--- a/domains/client/domain-executor/src/core_executor.rs
+++ b/domains/client/domain-executor/src/core_executor.rs
@@ -5,7 +5,7 @@ use crate::domain_bundle_proposer::DomainBundleProposer;
 use crate::fraud_proof::FraudProofGenerator;
 use crate::parent_chain::CoreDomainParentChain;
 use crate::{active_leaves, EssentialExecutorParams, TransactionFor};
-use domain_runtime_primitives::DomainCoreApi;
+use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use futures::channel::mpsc;
 use futures::{FutureExt, Stream};
 use sc_client_api::{
@@ -81,6 +81,7 @@ where
     Client::Api: DomainCoreApi<Block>
         + sp_block_builder::BlockBuilder<Block>
         + MessengerApi<Block, NumberFor<Block>>
+        + InherentExtrinsicApi<Block>
         + sp_api::ApiExt<Block, StateBackend = StateBackendFor<Backend, Block>>,
     for<'b> &'b BI: sc_consensus::BlockImport<
         Block,

--- a/domains/client/eth-service/Cargo.toml
+++ b/domains/client/eth-service/Cargo.toml
@@ -18,7 +18,7 @@ domain-service = { version = "0.1.0", path = "../../service" }
 fc-consensus = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fc-db = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fc-mapping-sync = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
-fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
+fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b", features = ['rpc-binary-search-estimate'] }
 fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fc-storage = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b", features = ['default'] }

--- a/domains/client/eth-service/src/lib.rs
+++ b/domains/client/eth-service/src/lib.rs
@@ -1,5 +1,4 @@
-#![allow(dead_code)]
-#![deny(unused_crate_dependencies)]
+#![warn(rust_2018_idioms)]
 
 pub mod provider;
 pub(crate) mod rpc;

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -525,6 +525,11 @@ where
             .unwrap_or_default()
     }
 
+    // TODO: at the moment the aux storage grows as the chain grows
+    // We can prune the the storage by doing another round of check for any undelivered messages
+    // and then prune the storage.
+    // We can use Finalize event but its not triggered yet as we dont finalize.
+    // Other option would be to use fraud proof period.
     pub(crate) fn store_relayed_block(
         client: &Arc<Client>,
         domain_id: DomainId,

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -27,6 +27,7 @@ sp-std = { version = "5.0.0", default-features = false, git = "https://github.co
 sp-trie = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 
 [dev-dependencies]
+domain-runtime-primitives = { path = "../../primitives/runtime" }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transporter = { version = "0.1.0", path = "../transporter" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -23,7 +23,7 @@ use sp_messenger::messages::{
     ProtocolMessageRequest, RequestResponse, VersionedPayload,
 };
 use sp_messenger::verification::{StorageProofVerifier, VerificationError};
-use sp_runtime::traits::ValidateUnsigned;
+use sp_runtime::traits::{Convert, ValidateUnsigned};
 
 fn create_channel(domain_id: DomainId, channel_id: ChannelId, fee_model: FeeModel<Balance>) {
     let params = InitiateChannelParams {
@@ -680,7 +680,7 @@ fn initiate_transfer_on_domain(domain_a_ext: &mut TestExternalities) {
             domain_a::RuntimeOrigin::signed(account_id),
             Location {
                 domain_id: domain_b::SelfDomainId::get(),
-                account_id,
+                account_id: domain_b::MockAccountIdConverter::convert(account_id),
             },
             500,
         );
@@ -852,7 +852,7 @@ fn test_transport_funds_between_domains_failed_low_balance() {
             domain_a::RuntimeOrigin::signed(account_id),
             Location {
                 domain_id: domain_b::SelfDomainId::get(),
-                account_id,
+                account_id: domain_b::MockAccountIdConverter::convert(account_id),
             },
             500,
         );
@@ -874,7 +874,7 @@ fn test_transport_funds_between_domains_failed_no_open_channel() {
             domain_a::RuntimeOrigin::signed(account_id),
             Location {
                 domain_id: domain_b::SelfDomainId::get(),
-                account_id,
+                account_id: domain_b::MockAccountIdConverter::convert(account_id),
             },
             500,
         );

--- a/domains/pallets/transporter/Cargo.toml
+++ b/domains/pallets/transporter/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
+domain-runtime-primitives = { path = "../../primitives/runtime" , default-features = false }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
@@ -32,6 +33,7 @@ sp-io = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev 
 default = ["std"]
 std = [
   "codec/std",
+  "domain-runtime-primitives/std",
   "frame-support/std",
   "frame-system/std",
   "scale-info/std",

--- a/domains/pallets/transporter/src/tests.rs
+++ b/domains/pallets/transporter/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::mock::{
-    new_test_ext, AccountId, Balance, Balances, MockRuntime, RuntimeEvent, RuntimeOrigin,
-    SelfDomainId, SelfEndpointId, System, Transporter, USER_ACCOUNT,
+    new_test_ext, AccountId, Balance, Balances, MockAccountIdConverter, MockRuntime, RuntimeEvent,
+    RuntimeOrigin, SelfDomainId, SelfEndpointId, System, Transporter, USER_ACCOUNT,
 };
 use crate::{EndpointHandler, Error, Location, Transfer};
 use codec::Encode;
@@ -10,6 +10,7 @@ use sp_domains::DomainId;
 use sp_messenger::endpoint::{
     Endpoint, EndpointHandler as EndpointHandlerT, EndpointRequest, EndpointResponse,
 };
+use sp_runtime::traits::Convert;
 use std::marker::PhantomData;
 
 #[test]
@@ -23,7 +24,7 @@ fn test_initiate_transfer_failed() {
         let dst_domain_id = 1.into();
         let dst_location = Location {
             domain_id: dst_domain_id,
-            account_id: account,
+            account_id: MockAccountIdConverter::convert(account),
         };
         let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, 500);
         assert_err!(res, Error::<MockRuntime>::LowBalance);
@@ -43,7 +44,7 @@ fn test_initiate_transfer() {
         let dst_domain_id = 1.into();
         let dst_location = Location {
             domain_id: dst_domain_id,
-            account_id: account,
+            account_id: MockAccountIdConverter::convert(account),
         };
         let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, 500);
         assert_ok!(res);
@@ -63,12 +64,12 @@ fn test_initiate_transfer() {
                 amount: 500,
                 sender: Location {
                     domain_id: SelfDomainId::get(),
-                    account_id: account
+                    account_id: MockAccountIdConverter::convert(account),
                 },
                 receiver: Location {
                     domain_id: dst_domain_id,
-                    account_id: account
-                }
+                    account_id: MockAccountIdConverter::convert(account),
+                },
             }
         )
     })
@@ -84,11 +85,11 @@ fn test_transfer_response_missing_request() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
         }
         .encode();
@@ -100,7 +101,7 @@ fn test_transfer_response_missing_request() {
 fn initiate_transfer(dst_domain_id: DomainId, account: AccountId, amount: Balance) {
     let dst_location = Location {
         domain_id: dst_domain_id,
-        account_id: account,
+        account_id: MockAccountIdConverter::convert(account),
     };
 
     let res = Transporter::transfer(RuntimeOrigin::signed(account), dst_location, amount);
@@ -156,12 +157,12 @@ fn test_transfer_response_invalid_request() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
                 // change receiver id
-                account_id: 100,
+                account_id: MockAccountIdConverter::convert(100),
             },
         }
         .encode();
@@ -198,11 +199,11 @@ fn test_transfer_response_revert() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
         }
         .encode();
@@ -256,11 +257,11 @@ fn test_transfer_response_successful() {
             amount,
             sender: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
             receiver: Location {
                 domain_id: dst_domain_id,
-                account_id: account,
+                account_id: MockAccountIdConverter::convert(account),
             },
         }
         .encode();
@@ -302,11 +303,11 @@ fn test_receive_incoming_transfer() {
                 amount,
                 sender: Location {
                     domain_id: src_domain_id,
-                    account_id: 0,
+                    account_id: MockAccountIdConverter::convert(0),
                 },
                 receiver: Location {
                     domain_id: dst_domain_id,
-                    account_id: receiver,
+                    account_id: MockAccountIdConverter::convert(receiver),
                 },
             }
             .encode(),

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -17,6 +17,7 @@ sp-api = { version = "4.0.0-dev", default-features = false, git = "https://githu
 sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 
 [features]
 default = ["std"]
@@ -26,4 +27,5 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"subspace-runtime-primitives/std",
 ]

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
@@ -23,6 +24,7 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subsp
 default = ["std"]
 std = [
 	"parity-scale-codec/std",
+	"scale-info/std",
 	"sp-api/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -47,6 +47,9 @@ pub type Address = MultiAddress<AccountId, ()>;
 /// Type used for expressing timestamp.
 pub type Moment = u64;
 
+/// Slot duration that is same as primary runtime.
+pub const SLOT_DURATION: u64 = 1000;
+
 /// Extracts the signer from an unchecked extrinsic.
 ///
 /// Used by executor to extract the optional signer when shuffling the extrinsics.

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -44,6 +44,9 @@ pub type BlockNumber = u32;
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;
 
+/// Type used for expressing timestamp.
+pub type Moment = u64;
+
 /// Extracts the signer from an unchecked extrinsic.
 ///
 /// Used by executor to extract the optional signer when shuffling the extrinsics.
@@ -106,5 +109,11 @@ sp_api::decl_runtime_apis! {
 
         /// Returns an encoded extrinsic aiming to upgrade the runtime using given code.
         fn construct_set_code_extrinsic(code: Vec<u8>) -> Vec<u8>;
+    }
+
+    /// Api that construct inherent extrinsics.
+    pub trait InherentExtrinsicApi {
+        /// Api to construct inherent timestamp extrinsic from given time
+        fn construct_inherent_timestamp_extrinsic(moment: Moment) -> Option<Block::Extrinsic>;
     }
 }

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -17,8 +17,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::generic::UncheckedExtrinsic;
-use sp_runtime::traits::{Block as BlockT, IdentifyAccount, Verify};
+use sp_runtime::scale_info::TypeInfo;
+use sp_runtime::traits::{Block as BlockT, Convert, IdentifyAccount, Verify};
 use sp_runtime::{MultiAddress, MultiSignature};
 use sp_std::vec::Vec;
 use subspace_runtime_primitives::Moment;
@@ -67,6 +69,41 @@ where
         self.signature
             .as_ref()
             .and_then(|(signed, _, _)| lookup.lookup(signed.clone()).ok())
+    }
+}
+
+/// MultiAccountId used by all the domains to describe their account type.
+#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
+pub enum MultiAccountId {
+    /// 32 byte account Id.
+    AccountId32([u8; 32]),
+    /// 20 byte account Id. Ex: Ethereum
+    AccountId20([u8; 20]),
+    /// Some raw bytes
+    Raw(Vec<u8>),
+}
+
+/// Extensible conversion trait. Generic over both source and destination types.
+pub trait TryConvertBack<A, B>: Convert<A, B> {
+    /// Make conversion back.
+    fn try_convert_back(b: B) -> Option<A>;
+}
+
+/// An AccountId32 to MultiAccount converter.
+pub struct AccountIdConverter;
+
+impl Convert<AccountId, MultiAccountId> for AccountIdConverter {
+    fn convert(account_id: AccountId) -> MultiAccountId {
+        MultiAccountId::AccountId32(account_id.into())
+    }
+}
+
+impl TryConvertBack<AccountId, MultiAccountId> for AccountIdConverter {
+    fn try_convert_back(multi_account_id: MultiAccountId) -> Option<AccountId> {
+        match multi_account_id {
+            MultiAccountId::AccountId32(acc) => Some(AccountId::new(acc)),
+            _ => None,
+        }
     }
 }
 

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -21,6 +21,7 @@ use sp_runtime::generic::UncheckedExtrinsic;
 use sp_runtime::traits::{Block as BlockT, IdentifyAccount, Verify};
 use sp_runtime::{MultiAddress, MultiSignature};
 use sp_std::vec::Vec;
+use subspace_runtime_primitives::Moment;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
@@ -43,9 +44,6 @@ pub type BlockNumber = u32;
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;
-
-/// Type used for expressing timestamp.
-pub type Moment = u64;
 
 /// Slot duration that is same as primary runtime.
 pub const SLOT_DURATION: u64 = 1000;

--- a/domains/runtime/core-eth-relay/Cargo.toml
+++ b/domains/runtime/core-eth-relay/Cargo.toml
@@ -28,6 +28,7 @@ pallet-executor-registry = { version = "0.1.0", path = "../../pallets/executor-r
 pallet-feeds = { version = "0.1.0", path = "../../../crates/pallet-feeds", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "../../pallets/messenger", default-features = false }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transporter = { version = "0.1.0", path = "../../pallets/transporter", default-features = false }
@@ -72,6 +73,7 @@ std = [
 	"pallet-feeds/std",
 	"pallet-messenger/std",
 	"pallet-sudo/std",
+	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
 	"pallet-transporter/std",

--- a/domains/runtime/core-eth-relay/src/runtime.rs
+++ b/domains/runtime/core-eth-relay/src/runtime.rs
@@ -1,12 +1,11 @@
 use crate::feed_processor::{feed_processor, FeedProcessorId, FeedProcessorKind};
 use codec::{Decode, Encode};
-use core::time::Duration;
 use domain_runtime_primitives::{opaque, SLOT_DURATION};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
 use frame_support::dispatch::DispatchClass;
-use frame_support::traits::{ConstU16, ConstU32, ConstU64, Everything, UnixTime};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, Everything};
 use frame_support::weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types};
@@ -307,15 +306,6 @@ impl pallet_sudo::Config for Runtime {
     type RuntimeCall = RuntimeCall;
 }
 
-/// Dummy time provider that always returns zero.
-pub struct DummyTimeProvider;
-
-impl UnixTime for DummyTimeProvider {
-    fn now() -> Duration {
-        Duration::ZERO
-    }
-}
-
 // Ethereum mainnet configuration
 parameter_types! {
     pub const MaxSyncCommitteeSize: u32 = 512;
@@ -350,8 +340,7 @@ parameter_types! {
 
 impl pallet_ethereum_beacon_client::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    // TODO: Replace this with proper implementation once we can retrieve timestamp in domain runtime
-    type TimeProvider = DummyTimeProvider;
+    type TimeProvider = Timestamp;
     type MaxSyncCommitteeSize = MaxSyncCommitteeSize;
     type MaxProofBranchSize = MaxProofBranchSize;
     type MaxExtraDataSize = MaxExtraDataSize;

--- a/domains/runtime/core-eth-relay/src/runtime.rs
+++ b/domains/runtime/core-eth-relay/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::feed_processor::{feed_processor, FeedProcessorId, FeedProcessorKind};
 use codec::{Decode, Encode};
-use domain_runtime_primitives::{opaque, SLOT_DURATION};
+use domain_runtime_primitives::{opaque, AccountIdConverter, SLOT_DURATION};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -299,6 +299,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/runtime/core-evm/Cargo.toml
+++ b/domains/runtime/core-evm/Cargo.toml
@@ -42,6 +42,7 @@ pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = fal
 pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-messenger = { version = "0.1.0", path = "../../pallets/messenger", default-features = false }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transporter = { version = "0.1.0", path = "../../pallets/transporter", default-features = false }
@@ -92,6 +93,7 @@ std = [
 	"pallet-evm-precompile-simple/std",
 	"pallet-messenger/std",
 	"pallet-sudo/std",
+	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
 	"pallet-transporter/std",

--- a/domains/runtime/core-evm/Cargo.toml
+++ b/domains/runtime/core-evm/Cargo.toml
@@ -33,7 +33,6 @@ hex-literal = { version = '0.4.0', optional = true }
 log = { version = "0.4.17", default-features = false }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
-pallet-dynamic-fee = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-ethereum = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
 pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier/", rev = "e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b" }
@@ -84,7 +83,6 @@ std = [
 	"log/std",
 	"pallet-balances/std",
 	"pallet-base-fee/std",
-	"pallet-dynamic-fee/std",
 	"pallet-ethereum/std",
 	"pallet-evm/std",
 	"pallet-evm-chain-id/std",

--- a/domains/runtime/core-evm/src/precompiles.rs
+++ b/domains/runtime/core-evm/src/precompiles.rs
@@ -6,9 +6,9 @@ use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
 
-pub struct FrontierPrecompiles<R>(PhantomData<R>);
+pub struct Precompiles<R>(PhantomData<R>);
 
-impl<R> FrontierPrecompiles<R>
+impl<R> Precompiles<R>
 where
     R: pallet_evm::Config,
 {
@@ -25,13 +25,14 @@ where
     }
 }
 
-impl<R> Default for FrontierPrecompiles<R> {
+impl<R> Default for Precompiles<R> {
+    #[inline]
     fn default() -> Self {
         Self(PhantomData::default())
     }
 }
 
-impl<R> PrecompileSet for FrontierPrecompiles<R>
+impl<R> PrecompileSet for Precompiles<R>
 where
     R: pallet_evm::Config,
 {

--- a/domains/runtime/core-evm/src/runtime.rs
+++ b/domains/runtime/core-evm/src/runtime.rs
@@ -6,7 +6,7 @@ pub use domain_runtime_primitives::{opaque, Balance, BlockNumber, Hash, Index};
 use fp_account::EthereumSignature;
 use fp_evm::weight_per_gas;
 use frame_support::dispatch::DispatchClass;
-use frame_support::traits::{ConstU16, ConstU32, ConstU64, Everything, FindAuthor, UnixTime};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, Everything, FindAuthor};
 use frame_support::weights::constants::{
     BlockExecutionWeight, ExtrinsicBaseWeight, ParityDbWeight, WEIGHT_REF_TIME_PER_MILLIS,
 };
@@ -40,7 +40,6 @@ use sp_runtime::{
 pub use sp_runtime::{MultiAddress, Perbill, Permill};
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
-use sp_std::time::Duration;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -409,14 +408,6 @@ parameter_types! {
     pub WeightPerGas: Weight = Weight::from_parts(weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK), 0);
 }
 
-pub struct ZeroTimeProvider;
-
-impl UnixTime for ZeroTimeProvider {
-    fn now() -> Duration {
-        Duration::ZERO
-    }
-}
-
 impl pallet_evm::Config for Runtime {
     type FeeCalculator = BaseFee;
     type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -435,10 +426,7 @@ impl pallet_evm::Config for Runtime {
     type OnChargeTransaction = ();
     type OnCreate = ();
     type FindAuthor = FindAuthorTruncated;
-    // TODO: Right now, block time is always zero.
-    //       We should take from the primary inherents and push it here
-    //       Else any contract using block time will give invalid behavior
-    type UnixTime = ZeroTimeProvider;
+    type UnixTime = Timestamp;
 }
 
 parameter_types! {

--- a/domains/runtime/core-evm/src/runtime.rs
+++ b/domains/runtime/core-evm/src/runtime.rs
@@ -1,11 +1,12 @@
 use crate::precompiles::FrontierPrecompiles;
 use codec::{Decode, Encode};
 use domain_runtime_primitives::opaque::Header;
+use domain_runtime_primitives::SLOT_DURATION;
 pub use domain_runtime_primitives::{opaque, Balance, BlockNumber, Hash, Index};
 use fp_account::EthereumSignature;
 use fp_evm::weight_per_gas;
 use frame_support::dispatch::DispatchClass;
-use frame_support::traits::{ConstU16, ConstU32, Everything, FindAuthor, UnixTime};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, Everything, FindAuthor, UnixTime};
 use frame_support::weights::constants::{
     BlockExecutionWeight, ExtrinsicBaseWeight, ParityDbWeight, WEIGHT_REF_TIME_PER_MILLIS,
 };
@@ -43,7 +44,7 @@ use sp_std::time::Duration;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use subspace_runtime_primitives::{SHANNON, SSC};
+use subspace_runtime_primitives::{Moment, SHANNON, SSC};
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = EthereumSignature;
@@ -278,6 +279,14 @@ impl frame_system::Config for Runtime {
     type MaxConsumers = ConstU32<16>;
 }
 
+impl pallet_timestamp::Config for Runtime {
+    /// A timestamp: milliseconds since the unix epoch.
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
+    type WeightInfo = ();
+}
+
 parameter_types! {
     pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
     pub const MaxLocks: u32 = 50;
@@ -488,23 +497,24 @@ construct_runtime!(
     {
         // System support stuff.
         System: frame_system = 0,
-        ExecutivePallet: domain_pallet_executive = 1,
+        Timestamp: pallet_timestamp = 1,
+        ExecutivePallet: domain_pallet_executive = 2,
 
         // monetary stuff
-        Balances: pallet_balances = 2,
-        TransactionPayment: pallet_transaction_payment = 3,
+        Balances: pallet_balances = 20,
+        TransactionPayment: pallet_transaction_payment = 21,
 
         // messenger stuff
         // Note: Indexes should match the indexes of the System domain runtime
-        Messenger: pallet_messenger = 6,
-        Transporter: pallet_transporter = 7,
+        Messenger: pallet_messenger = 60,
+        Transporter: pallet_transporter = 61,
 
         // evm stuff
-        Ethereum: pallet_ethereum = 50,
-        EVM: pallet_evm = 51,
-        EVMChainId: pallet_evm_chain_id = 52,
-        DynamicFee: pallet_dynamic_fee = 53,
-        BaseFee: pallet_base_fee = 54,
+        Ethereum: pallet_ethereum = 80,
+        EVM: pallet_evm = 81,
+        EVMChainId: pallet_evm_chain_id = 82,
+        DynamicFee: pallet_dynamic_fee = 83,
+        BaseFee: pallet_base_fee = 84,
 
         // Sudo account
         Sudo: pallet_sudo = 100,
@@ -674,6 +684,16 @@ impl_runtime_apis! {
                     weight: Weight::from_parts(0, 0),
                 }.into()
             ).encode()
+        }
+    }
+
+    impl domain_runtime_primitives::InherentExtrinsicApi<Block> for Runtime {
+        fn construct_inherent_timestamp_extrinsic(moment: Moment) -> Option<<Block as BlockT>::Extrinsic> {
+             Some(
+                UncheckedExtrinsic::new_unsigned(
+                    pallet_timestamp::Call::set{ now: moment }.into()
+                )
+             )
         }
     }
 

--- a/domains/runtime/core-payments/src/runtime.rs
+++ b/domains/runtime/core-payments/src/runtime.rs
@@ -27,7 +27,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use subspace_runtime_primitives::{SHANNON, SSC};
+use subspace_runtime_primitives::{Moment, SHANNON, SSC};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
@@ -311,13 +311,13 @@ construct_runtime!(
         ExecutivePallet: domain_pallet_executive = 1,
 
         // Monetary stuff.
-        Balances: pallet_balances = 2,
-        TransactionPayment: pallet_transaction_payment = 3,
+        Balances: pallet_balances = 20,
+        TransactionPayment: pallet_transaction_payment = 21,
 
         // messenger stuff
         // Note: Indexes should match the indexes of the System domain runtime
-        Messenger: pallet_messenger = 6,
-        Transporter: pallet_transporter = 7,
+        Messenger: pallet_messenger = 60,
+        Transporter: pallet_transporter = 61,
 
         // Sudo account
         Sudo: pallet_sudo = 100,
@@ -461,6 +461,12 @@ impl_runtime_apis! {
                     weight: Weight::from_parts(0, 0),
                 }.into()
             ).encode()
+        }
+    }
+
+    impl domain_runtime_primitives::InherentExtrinsicApi<Block> for Runtime {
+        fn construct_inherent_timestamp_extrinsic(_moment: Moment) -> Option<<Block as BlockT>::Extrinsic> {
+             None
         }
     }
 

--- a/domains/runtime/core-payments/src/runtime.rs
+++ b/domains/runtime/core-payments/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, AccountIdConverter};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -290,6 +290,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/runtime/core-payments/src/runtime.rs
+++ b/domains/runtime/core-payments/src/runtime.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace-core-payments-domain"),
     impl_name: create_runtime_str!("subspace-core-payments-domain"),
     authoring_version: 0,
-    spec_version: 0,
+    spec_version: 1,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -382,19 +382,20 @@ construct_runtime!(
         ExecutivePallet: domain_pallet_executive = 1,
 
         // Monetary stuff.
-        Balances: pallet_balances = 2,
-        TransactionPayment: pallet_transaction_payment = 3,
+        Balances: pallet_balances = 20,
+        TransactionPayment: pallet_transaction_payment = 21,
 
         // System domain.
         //
         // Must be after Balances pallet so that its genesis is built after the Balances genesis is
         // built.
-        ExecutorRegistry: pallet_executor_registry = 4,
-        Receipts: pallet_receipts = 9,
-        DomainRegistry: pallet_domain_registry = 5,
+        ExecutorRegistry: pallet_executor_registry = 40,
+        Receipts: pallet_receipts = 41,
+        DomainRegistry: pallet_domain_registry = 42,
+
         // Note: Indexes should be used by all other core domain for proper xdm decode.
-        Messenger: pallet_messenger = 6,
-        Transporter: pallet_transporter = 7,
+        Messenger: pallet_messenger = 60,
+        Transporter: pallet_transporter = 61,
 
         // Sudo account
         Sudo: pallet_sudo = 100,

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, AccountIdConverter};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -361,6 +361,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -92,7 +92,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace-system-domain"),
     impl_name: create_runtime_str!("subspace-system-domain"),
     authoring_version: 0,
-    spec_version: 2,
+    spec_version: 3,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -9,7 +9,7 @@ use domain_client_executor::{
 };
 use domain_client_executor_gossip::ExecutorGossipParams;
 use domain_client_message_relayer::GossipMessageSink;
-use domain_runtime_primitives::{Balance, DomainCoreApi};
+use domain_runtime_primitives::{Balance, DomainCoreApi, InherentExtrinsicApi};
 use frame_benchmarking::frame_support::codec::FullCodec;
 use frame_benchmarking::frame_support::dispatch::TypeInfo;
 use futures::channel::mpsc;
@@ -390,6 +390,7 @@ where
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
         + MessengerApi<Block, NumberFor<Block>>
+        + InherentExtrinsicApi<Block>
         + RelayerApi<Block, AccountId, NumberFor<Block>>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
     AccountId: DeserializeOwned

--- a/domains/test/primitives/Cargo.toml
+++ b/domains/test/primitives/Cargo.toml
@@ -12,12 +12,12 @@ include = [
 ]
 
 [dependencies]
-domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
+subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 
 [features]
 default = ["std"]
 std = [
-    "domain-runtime-primitives/std",
     "sp-api/std",
+    "subspace-runtime-primitives/std",
 ]

--- a/domains/test/primitives/Cargo.toml
+++ b/domains/test/primitives/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "domain-test-primitives"
+version = "0.1.0"
+authors = ["Subspace Labs <https://subspace.network>"]
+edition = "2021"
+license = "GPL-3.0-or-later"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "domain-runtime-primitives/std",
+    "sp-api/std",
+]

--- a/domains/test/primitives/src/lib.rs
+++ b/domains/test/primitives/src/lib.rs
@@ -1,0 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+//! Test primitive crates that expose necessary extensions that are used in tests.
+
+use domain_runtime_primitives::Moment;
+
+sp_api::decl_runtime_apis! {
+    /// Api that returns the timestamp
+    pub trait TimestampApi {
+        /// Api to construct inherent timestamp extrinsic from given time
+        fn timestamp() -> Moment;
+    }
+}

--- a/domains/test/primitives/src/lib.rs
+++ b/domains/test/primitives/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! Test primitive crates that expose necessary extensions that are used in tests.
 
-use domain_runtime_primitives::Moment;
+use subspace_runtime_primitives::Moment;
 
 sp_api::decl_runtime_apis! {
     /// Api that returns the timestamp

--- a/domains/test/runtime/core-payments/Cargo.toml
+++ b/domains/test/runtime/core-payments/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"]}
 domain-pallet-executive = { version = "0.1.0", path = "../../../pallets/executive", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../../primitives/runtime", default-features = false }
+domain-test-primitives = { version = "0.1.0", path = "../../primitives", default-features = false }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
@@ -27,6 +28,7 @@ pallet-domain-registry = { version = "0.1.0", path = "../../../pallets/domain-re
 pallet-executor-registry = { version = "0.1.0", path = "../../../pallets/executor-registry", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "../../../pallets/messenger", default-features = false }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/substrate", rev = "fdb68194ab6995447610b3dbdee70559711dbd63" }
 pallet-transporter = { version = "0.1.0", path = "../../../pallets/transporter", default-features = false }
@@ -58,6 +60,7 @@ std = [
 	"codec/std",
 	"domain-pallet-executive/std",
 	"domain-runtime-primitives/std",
+	"domain-test-primitives/std",
 	"frame-support/std",
 	"frame-system/std",
 	"frame-system-rpc-runtime-api/std",
@@ -67,6 +70,7 @@ std = [
 	"pallet-executor-registry/std",
 	"pallet-messenger/std",
 	"pallet-sudo/std",
+	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
 	"pallet-transporter/std",

--- a/domains/test/runtime/core-payments/src/runtime.rs
+++ b/domains/test/runtime/core-payments/src/runtime.rs
@@ -1,10 +1,10 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, Moment};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
 use frame_support::dispatch::DispatchClass;
-use frame_support::traits::{ConstU16, ConstU32, Everything};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, Everything};
 use frame_support::weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types};
@@ -199,6 +199,13 @@ impl frame_system::Config for Runtime {
     type MaxConsumers = ConstU32<16>;
 }
 
+impl pallet_timestamp::Config for Runtime {
+    type Moment = subspace_runtime_primitives::Moment;
+    type OnTimestampSet = ();
+    type MinimumPeriod = ConstU64<0>;
+    type WeightInfo = ();
+}
+
 parameter_types! {
     pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
     pub const MaxLocks: u32 = 50;
@@ -310,16 +317,17 @@ construct_runtime!(
     {
         // System support stuff.
         System: frame_system = 0,
-        ExecutivePallet: domain_pallet_executive = 1,
+        Timestamp: pallet_timestamp = 1,
+        ExecutivePallet: domain_pallet_executive = 2,
 
         // Monetary stuff.
-        Balances: pallet_balances = 2,
-        TransactionPayment: pallet_transaction_payment = 3,
+        Balances: pallet_balances = 20,
+        TransactionPayment: pallet_transaction_payment = 21,
 
         // messenger stuff
         // Note: Indexes should match the indexes of the System domain runtime
-        Messenger: pallet_messenger = 6,
-        Transporter: pallet_transporter = 7,
+        Messenger: pallet_messenger = 60,
+        Transporter: pallet_transporter = 61,
 
         // Sudo account
         Sudo: pallet_sudo = 100,
@@ -514,6 +522,22 @@ impl_runtime_apis! {
 
         fn should_relay_inbox_message_response(dst_domain_id: DomainId, msg_id: MessageId) -> bool {
             Messenger::should_relay_inbox_message_response(dst_domain_id, msg_id)
+        }
+    }
+
+    impl domain_runtime_primitives::InherentExtrinsicApi<Block> for Runtime {
+        fn construct_inherent_timestamp_extrinsic(moment: Moment) -> Option<<Block as BlockT>::Extrinsic> {
+             Some(
+                UncheckedExtrinsic::new_unsigned(
+                    pallet_timestamp::Call::set{ now: moment }.into()
+                )
+             )
+        }
+    }
+
+    impl domain_test_primitives::TimestampApi<Block> for Runtime {
+        fn timestamp() -> Moment {
+             Timestamp::now()
         }
     }
 

--- a/domains/test/runtime/core-payments/src/runtime.rs
+++ b/domains/test/runtime/core-payments/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::opaque;
+use domain_runtime_primitives::{opaque, AccountIdConverter};
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -299,6 +299,7 @@ impl pallet_transporter::Config for Runtime {
     type SelfEndpointId = TransporterEndpointId;
     type Currency = Balances;
     type Sender = Messenger;
+    type AccountIdConverter = AccountIdConverter;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/test/runtime/core-payments/src/runtime.rs
+++ b/domains/test/runtime/core-payments/src/runtime.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode};
-use domain_runtime_primitives::{opaque, Moment};
+use domain_runtime_primitives::opaque;
 pub use domain_runtime_primitives::{
     AccountId, Address, Balance, BlockNumber, Hash, Index, Signature,
 };
@@ -27,7 +27,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use subspace_runtime_primitives::{SHANNON, SSC};
+use subspace_runtime_primitives::{Moment, SHANNON, SSC};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;

--- a/domains/test/service/src/core_domain.rs
+++ b/domains/test/service/src/core_domain.rs
@@ -1,12 +1,13 @@
 //! Utilities used for testing with the system domain.
 #![warn(missing_docs)]
+
 use crate::system_domain::SClient;
 use crate::{
     construct_extrinsic_generic, node_config, Backend, SystemDomainNode, UncheckedExtrinsicFor,
 };
 use domain_client_executor::ExecutorStreams;
 use domain_runtime_primitives::opaque::Block;
-use domain_runtime_primitives::{AccountId, Balance, DomainCoreApi};
+use domain_runtime_primitives::{AccountId, Balance, DomainCoreApi, InherentExtrinsicApi};
 use domain_service::providers::DefaultProvider;
 use domain_service::FullClient;
 use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};
@@ -107,6 +108,7 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
+        + InherentExtrinsicApi<Block>
         + MessengerApi<Block, NumberFor<Block>>
         + RelayerApi<Block, AccountId, NumberFor<Block>>,
     Executor: NativeExecutionDispatch + Send + Sync + 'static,

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -44,6 +44,7 @@ use sp_runtime::codec::Encode;
 use sp_runtime::generic;
 use sp_runtime::traits::Dispatchable;
 
+pub use core_domain::*;
 pub use sp_keyring::Sr25519Keyring as Keyring;
 pub use system_domain::*;
 pub use system_domain_test_runtime;
@@ -229,4 +230,21 @@ where
         Signature::Sr25519(signature),
         extra,
     )
+}
+
+/// Construct an unsigned extrinsic that can be applied to the test runtime.
+pub fn construct_unsigned_extrinsic<Runtime>(
+    function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
+) -> UncheckedExtrinsicFor<Runtime>
+where
+    Runtime: frame_system::Config<Hash = H256, BlockNumber = u32>
+        + pallet_transaction_payment::Config
+        + Send
+        + Sync,
+    Runtime::RuntimeCall:
+        Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo> + Send + Sync,
+    BalanceOf<Runtime>: Send + Sync + From<u64> + sp_runtime::FixedPointOperand,
+{
+    let function = function.into();
+    UncheckedExtrinsicFor::<Runtime>::new_unsigned(function)
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1242,6 +1242,10 @@ impl_runtime_apis! {
         ) -> Option<domain_runtime_primitives::Hash>{
             Receipts::domain_state_root_at(DomainId::SYSTEM, number, domain_hash)
         }
+
+        fn timestamp() -> Moment{
+            Timestamp::now()
+        }
     }
 
     impl sp_session::SessionKeys<Block> for Runtime {


### PR DESCRIPTION
This PR introduces cherry-picked commits from `main` and commits, prefixed with `backport: `,  introducing compatibility changes specifically for Gemini-3d.

The upgrade flow would be as follows:
- Make Node release
- Do a runtime upgrade of Primary chain.
- Enable domains
- Optionally, do System and Payments upgrades to enable XDM
- Register Core EVM

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
