### PR TITLE
Parallel chiapos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11522,6 +11522,7 @@ dependencies = [
  "chacha20 0.9.1",
  "criterion",
  "rand 0.8.5",
+ "rayon",
  "sha2 0.10.6",
  "subspace-chiapos",
  "subspace-core-primitives",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -26,7 +26,7 @@ kzg = { git = "https://github.com/subspace/rust-kzg", rev = "1058cc8c8af8461b490
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.4.0", default-features = false, features = ["derive", "max-encoded-len"] }
 parking_lot = { version = "0.12.1", optional = true }
-rayon = { version = "1.6.1", optional = true }
+rayon = { version = "1.7.0", optional = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.159", optional = true, features = ["alloc", "derive"] }
 serde_arrays = { version = "0.1.0", optional = true }

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -26,14 +26,14 @@ lru = "0.10.0"
 parity-scale-codec = "3.4.0"
 parking_lot = "0.12.1"
 rand = "0.8.5"
-rayon = "1.6.1"
+rayon = "1.7.0"
 schnorrkel = "0.9.1"
 serde = { version = "1.0.159", features = ["derive"] }
 static_assertions = "1.1.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding" }
-subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
+subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["parallel"] }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.38"
 tokio = { version = "1.27.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync"] }

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -199,10 +199,8 @@ where
                 }
             }
 
-            // TODO: Can potentially happen in parallel with other work below, saving a bit of
-            //  end-to-end latency
             // Derive PoSpace table
-            let pos_table = PosTable::generate(
+            let pos_table = PosTable::generate_parallel(
                 &self
                     .sector_id
                     .evaluation_seed(piece_offset, self.sector_metadata.history_size),

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -61,4 +61,4 @@ zeroize = "1.6.0"
 jemallocator = "0.5.0"
 
 [dev-dependencies]
-rayon = "1.6.1"
+rayon = "1.7.0"

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -19,6 +19,7 @@ bench = false
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc", "atomic"], optional = true }
 blake3 = { version = "1.3.3", default-features = false, optional = true }
 chacha20 = { version = "0.9.1", default-features = false, optional = true }
+rayon = { version = "1.7.0", optional = true }
 subspace-chiapos = { git = "https://github.com/subspace/chiapos", rev = "3b1ab3ca24764d25da30e0c8243e0bf304b776a5", optional = true }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
@@ -51,6 +52,9 @@ std = [
     "blake3?/std",
     "chacha20?/std",
     "subspace-core-primitives/std",
+]
+parallel = [
+    "dep:rayon",
 ]
 # Enable Chia proof of space support (legacy implementation uses C++ chiapos), only works in `std` environment for now
 chia-legacy = [

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -25,11 +25,14 @@ fn pos_bench<PosTable>(
 ) where
     PosTable: Table,
 {
-    ThreadPoolBuilder::new()
-        // Change number of threads if necessary
-        .num_threads(4)
-        .build_global()
-        .unwrap();
+    #[cfg(feature = "parallel")]
+    {
+        // Repeated initialization is not supported, we just ignore errors here because of it
+        let _ = ThreadPoolBuilder::new()
+            // Change number of threads if necessary
+            .num_threads(4)
+            .build_global();
+    }
 
     let mut group = c.benchmark_group(name);
 

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -3,6 +3,8 @@
 #[cfg(any(feature = "chia-legacy", feature = "chia", feature = "shim"))]
 use criterion::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(feature = "parallel")]
+use rayon::ThreadPoolBuilder;
 #[cfg(any(feature = "chia-legacy", feature = "chia", feature = "shim"))]
 use subspace_core_primitives::PosSeed;
 #[cfg(any(feature = "chia-legacy", feature = "chia", feature = "shim"))]
@@ -23,13 +25,28 @@ fn pos_bench<PosTable>(
 ) where
     PosTable: Table,
 {
+    ThreadPoolBuilder::new()
+        // Change number of threads if necessary
+        .num_threads(4)
+        .build_global()
+        .unwrap();
+
     let mut group = c.benchmark_group(name);
 
-    group.bench_function("table", |b| {
+    group.bench_function("table/single", |b| {
         b.iter(|| {
             PosTable::generate(black_box(&SEED));
         });
     });
+
+    #[cfg(feature = "parallel")]
+    {
+        group.bench_function("table/parallel", |b| {
+            b.iter(|| {
+                PosTable::generate_parallel(black_box(&SEED));
+            });
+        });
+    }
 
     let table = PosTable::generate(&SEED);
 

--- a/crates/subspace-proof-of-space/src/chiapos.rs
+++ b/crates/subspace-proof-of-space/src/chiapos.rs
@@ -37,11 +37,22 @@ macro_rules! impl_any {
     ($($k: expr$(,)? )*) => {
         $(
 impl Tables<$k> {
-    /// Create Chia proof of space tables.
+    /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
+    /// CPU efficiency and memory usage for lower latency.
     ///
     /// Advanced version of [`Self::create_simple`] that allows to reuse cache.
     pub fn create(seed: Seed, cache: &mut TablesCache<$k>) -> Self {
         Self(TablesGeneric::<$k>::create(
+            seed, cache,
+        ))
+    }
+
+    /// Almost the same as [`Self::create()`], but uses parallelism internally for better
+    /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
+    /// in parallel, prefer [`Self::create()`] for better overall performance.
+    #[cfg(any(feature = "parallel", test))]
+    pub fn create_parallel(seed: Seed, cache: &mut TablesCache<$k>) -> Self {
+        Self(TablesGeneric::<$k>::create_parallel(
             seed, cache,
         ))
     }

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -661,7 +661,8 @@ where
         for (y, metadata, [left_position, right_position]) in t_n {
             ys.push(y);
             positions.push([left_position, right_position]);
-            if TABLE_NUMBER != 7 {
+            // Last table doesn't have metadata
+            if metadata_size_bits(K, TABLE_NUMBER) > 0 {
                 metadatas.push(metadata);
             }
         }
@@ -765,7 +766,8 @@ where
         for (y, metadata, [left_position, right_position]) in t_n {
             ys.push(y);
             positions.push([left_position, right_position]);
-            if TABLE_NUMBER != 7 {
+            // Last table doesn't have metadata
+            if metadata_size_bits(K, TABLE_NUMBER) > 0 {
                 metadatas.push(metadata);
             }
         }

--- a/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables/tests.rs
@@ -1,4 +1,4 @@
-use crate::chiapos::Tables;
+use crate::chiapos::{Tables, TablesCache};
 use std::mem;
 
 const K: u8 = 17;
@@ -7,12 +7,21 @@ const K: u8 = 17;
 fn self_verification() {
     let seed = [1; 32];
     let tables = Tables::<K>::create_simple(seed);
+    let tables_parallel = Tables::<K>::create_parallel(seed, &mut TablesCache::default());
 
     for challenge_index in 0..1000_u32 {
         let mut challenge = [0; 32];
         challenge[..mem::size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
         let qualities = tables.find_quality(&challenge).collect::<Vec<_>>();
+        assert_eq!(
+            qualities,
+            tables_parallel.find_quality(&challenge).collect::<Vec<_>>()
+        );
         let proofs = tables.find_proof(&challenge).collect::<Vec<_>>();
+        assert_eq!(
+            proofs,
+            tables_parallel.find_proof(&challenge).collect::<Vec<_>>()
+        );
 
         assert_eq!(qualities.len(), proofs.len());
 


### PR DESCRIPTION
This PR introduces parallelism in chiapos that further massively reduces table construction time.

```
chia/table/parallel     time:   [25.994 ms 26.368 ms 27.029 ms]
```

Proving before:
```
proving/memory          time:   [344.57 ms 361.17 ms 379.25 ms]
```
Proving after:
```
proving/memory          time:   [150.26 ms 154.47 ms 158.15 ms]
                        thrpt:  [6.3231  elem/s 6.4737  elem/s 6.6550  elem/s]
```

Note that this is less efficient than single-threaded version in terms of CPU utilization and memory usage, we only use it for proving where latency is critical.

This has a breaking change for the farmer since order of qualities/proofs wasn't canonical before, now it is and can be different from what was expected in the past (and no migration code was written for this). As far as consensus verification is concerned, nothing has changed.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
