### PR TITLE
Fix polynomial normalization

### DIFF
--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -107,7 +107,7 @@ impl Polynomial {
             .count();
         self.0
             .coeffs
-            .truncate(self.0.coeffs.len() - trailing_zeroes);
+            .truncate((self.0.coeffs.len() - trailing_zeroes).max(1));
     }
 }
 


### PR DESCRIPTION
Some polynomials containing just zeroes were reduced to nothing, causing issues when trying to create witness for corresponding records. I think we should leave at least one element in there.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
