### PR TITLE
Overhaul the extraction of bundles and receipts

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -26,7 +26,7 @@ use frame_support::traits::Get;
 use frame_system::offchain::SubmitTransaction;
 pub use pallet::*;
 use sp_core::H256;
-use sp_domains::bundle_election::{verify_system_bundle_solution, verify_vrf_proof};
+use sp_domains::bundle_election::verify_system_bundle_solution;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::merkle_tree::Witness;
 use sp_domains::transaction::InvalidTransactionCode;
@@ -539,13 +539,9 @@ impl<T: Config> Pallet<T> {
             return Err(BundleError::BadSignature);
         }
 
-        verify_vrf_proof(
-            &proof_of_election.executor_public_key,
-            &proof_of_election.vrf_output,
-            &proof_of_election.vrf_proof,
-            &proof_of_election.global_challenge,
-        )
-        .map_err(|_| BundleError::BadVrfProof)?;
+        proof_of_election
+            .verify_vrf_proof()
+            .map_err(|_| BundleError::BadVrfProof)?;
 
         Self::validate_execution_receipts(&bundle.receipts).map_err(BundleError::Receipt)?;
 

--- a/crates/sp-domains/src/bundle_election.rs
+++ b/crates/sp-domains/src/bundle_election.rs
@@ -168,7 +168,7 @@ pub enum VrfProofError {
 }
 
 /// Verify the vrf proof generated in the bundle election.
-pub fn verify_vrf_proof(
+pub(crate) fn verify_vrf_proof(
     public_key: &ExecutorPublicKey,
     vrf_output: &[u8],
     vrf_proof: &[u8],

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -201,6 +201,16 @@ impl<Number, Hash> FraudProof<Number, Hash> {
     }
 }
 
+impl<Number, Hash> FraudProof<Number, Hash>
+where
+    Number: Encode,
+    Hash: Encode,
+{
+    pub fn hash(&self) -> H256 {
+        BlakeTwo256::hash(&self.encode())
+    }
+}
+
 /// Proves an invalid state transition by challenging the trace at specific index in a bad receipt.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct InvalidStateTransitionProof {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -23,6 +23,7 @@ pub mod merkle_tree;
 pub mod transaction;
 
 use crate::fraud_proof::FraudProof;
+use bundle_election::VrfProofError;
 use merkle_tree::Witness;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -215,6 +216,17 @@ pub struct ProofOfElection<DomainHash> {
     pub system_block_number: BlockNumber,
     /// Block hash corresponding to the `block_number` above.
     pub system_block_hash: DomainHash,
+}
+
+impl<DomainHash> ProofOfElection<DomainHash> {
+    pub fn verify_vrf_proof(&self) -> Result<(), VrfProofError> {
+        bundle_election::verify_vrf_proof(
+            &self.executor_public_key,
+            &self.vrf_output,
+            &self.vrf_proof,
+            &self.global_challenge,
+        )
+    }
 }
 
 impl<DomainHash: Default> ProofOfElection<DomainHash> {
@@ -440,8 +452,8 @@ sp_api::decl_runtime_apis! {
             domain_id: DomainId,
         ) -> OpaqueBundles<Block, DomainHash>;
 
-        /// Extract the hashes of bundles stored in the block
-        fn extract_stored_bundle_hashes() -> Vec<H256>;
+        /// Returns the hash of successfully submitted bundles.
+        fn successful_bundle_hashes() -> Vec<H256>;
 
         /// Extract the receipts from the given extrinsics.
         fn extract_receipts(

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -1,9 +1,6 @@
-use crate::{
-    Block, BlockNumber, Hash, Receipts, RuntimeCall, RuntimeEvent, System, UncheckedExtrinsic,
-};
+use crate::{Block, BlockNumber, Domains, Hash, Receipts, RuntimeCall, UncheckedExtrinsic};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::FarmerPublicKey;
-use sp_core::H256;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::transaction::PreValidationObject;
 use sp_domains::{DomainId, ExecutionReceipt};
@@ -18,21 +15,20 @@ pub(crate) fn extract_system_bundles(
     sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash>,
     sp_domains::SignedOpaqueBundles<Block, domain_runtime_primitives::Hash>,
 ) {
+    let successful_bundles = Domains::successful_bundles();
     let (system_bundles, core_bundles): (Vec<_>, Vec<_>) = extrinsics
         .into_iter()
-        .filter_map(|uxt| {
-            if let RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
+        .filter_map(|uxt| match uxt.function {
+            RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
                 signed_opaque_bundle,
-            }) = uxt.function
-            {
+            }) if successful_bundles.contains(&signed_opaque_bundle.hash()) => {
                 if signed_opaque_bundle.domain_id().is_system() {
                     Some((Some(signed_opaque_bundle.bundle), None))
                 } else {
                     Some((None, Some(signed_opaque_bundle)))
                 }
-            } else {
-                None
             }
+            _ => None,
         })
         .unzip();
     (
@@ -45,12 +41,15 @@ pub(crate) fn extract_core_bundles(
     extrinsics: Vec<UncheckedExtrinsic>,
     domain_id: DomainId,
 ) -> sp_domains::OpaqueBundles<Block, domain_runtime_primitives::Hash> {
+    let successful_bundles = Domains::successful_bundles();
     extrinsics
         .into_iter()
         .filter_map(|uxt| match uxt.function {
             RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
                 signed_opaque_bundle,
-            }) if signed_opaque_bundle.domain_id() == domain_id => {
+            }) if signed_opaque_bundle.domain_id() == domain_id
+                && successful_bundles.contains(&signed_opaque_bundle.hash()) =>
+            {
                 Some(signed_opaque_bundle.bundle)
             }
             _ => None,
@@ -58,27 +57,19 @@ pub(crate) fn extract_core_bundles(
         .collect()
 }
 
-pub(crate) fn extract_stored_bundle_hashes() -> Vec<H256> {
-    System::read_events_no_consensus()
-        .filter_map(|e| match e.event {
-            RuntimeEvent::Domains(pallet_domains::Event::BundleStored { bundle_hash, .. }) => {
-                Some(bundle_hash)
-            }
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-}
-
 pub(crate) fn extract_receipts(
     extrinsics: Vec<UncheckedExtrinsic>,
     domain_id: DomainId,
 ) -> Vec<ExecutionReceipt<BlockNumber, Hash, domain_runtime_primitives::Hash>> {
+    let successful_bundles = Domains::successful_bundles();
     extrinsics
         .into_iter()
         .filter_map(|uxt| match uxt.function {
             RuntimeCall::Domains(pallet_domains::Call::submit_bundle {
                 signed_opaque_bundle,
-            }) if signed_opaque_bundle.domain_id() == domain_id => {
+            }) if signed_opaque_bundle.domain_id() == domain_id
+                && successful_bundles.contains(&signed_opaque_bundle.hash()) =>
+            {
                 Some(signed_opaque_bundle.bundle.receipts)
             }
             _ => None,

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -1,4 +1,6 @@
-use crate::{Block, BlockNumber, Hash, RuntimeCall, RuntimeEvent, System, UncheckedExtrinsic};
+use crate::{
+    Block, BlockNumber, Hash, Receipts, RuntimeCall, RuntimeEvent, System, UncheckedExtrinsic,
+};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::FarmerPublicKey;
 use sp_core::H256;
@@ -89,11 +91,13 @@ pub(crate) fn extract_fraud_proofs(
     extrinsics: Vec<UncheckedExtrinsic>,
     domain_id: DomainId,
 ) -> Vec<FraudProof<BlockNumber, Hash>> {
+    let successful_fraud_proofs = Receipts::successful_fraud_proofs();
     extrinsics
         .into_iter()
         .filter_map(|uxt| match uxt.function {
             RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof })
-                if fraud_proof.domain_id() == domain_id =>
+                if fraud_proof.domain_id() == domain_id
+                    && successful_fraud_proofs.contains(&fraud_proof.hash()) =>
             {
                 Some(fraud_proof)
             }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -787,7 +787,7 @@ impl_runtime_apis! {
             crate::domains::extract_core_bundles(extrinsics, domain_id)
         }
 
-        fn extract_stored_bundle_hashes() -> Vec<H256> {
+        fn successful_bundle_hashes() -> Vec<H256> {
             Domains::successful_bundles()
         }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -788,7 +788,7 @@ impl_runtime_apis! {
         }
 
         fn extract_stored_bundle_hashes() -> Vec<H256> {
-            crate::domains::extract_stored_bundle_hashes()
+            Domains::successful_bundles()
         }
 
         fn extract_receipts(

--- a/crates/subspace-transaction-pool/src/bundle_validator.rs
+++ b/crates/subspace-transaction-pool/src/bundle_validator.rs
@@ -52,14 +52,14 @@ where
         }
     }
 
-    fn extract_stored_bundles_at(
+    fn successfully_submitted_bundles_at(
         &self,
         block_hash: Block::Hash,
     ) -> sp_blockchain::Result<HashSet<Hash>> {
         let bundle_hashes: HashSet<_> = self
             .client
             .runtime_api()
-            .extract_stored_bundle_hashes(block_hash)?
+            .successful_bundle_hashes(block_hash)?
             .into_iter()
             .collect();
         Ok(bundle_hashes)
@@ -96,7 +96,7 @@ where
             }
         }
         for (hash, number) in blocks {
-            let bundles = self.extract_stored_bundles_at(hash)?;
+            let bundles = self.successfully_submitted_bundles_at(hash)?;
             bundle_stored_in_last_k.push_front(BlockBundle::new(hash, number, bundles));
         }
         Ok(())
@@ -142,7 +142,7 @@ where
 
         // Add bundles from the new block of the best fork
         for enacted_block in enacted {
-            let bundles = self.extract_stored_bundles_at(enacted_block.hash)?;
+            let bundles = self.successfully_submitted_bundles_at(enacted_block.hash)?;
             bundle_stored_in_last_k.push_front(BlockBundle::new(
                 enacted_block.hash,
                 enacted_block.number,

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -190,16 +190,18 @@ where
         if bundle_exists {
             Ok(Action::Empty)
         } else {
-            let executor_public_key = &bundle_solution.proof_of_election().executor_public_key;
+            let proof_of_election = bundle_solution.proof_of_election();
 
-            if !executor_public_key.verify(&bundle.hash(), signature) {
+            if !proof_of_election
+                .executor_public_key
+                .verify(&bundle.hash(), signature)
+            {
                 return Err(Self::Error::BadBundleSignature);
             }
 
             // TODO: validate the bundle election.
 
-            // TODO: Validate the receipts correctly when the bundle gossip is re-enabled.
-            let domain_id = bundle_solution.proof_of_election().domain_id;
+            let domain_id = proof_of_election.domain_id;
 
             self.gossip_message_validator
                 .validate_bundle_receipts(&bundle.receipts, domain_id)?;

--- a/domains/client/domain-executor/src/system_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/system_gossip_message_validator.rs
@@ -137,16 +137,18 @@ where
         if bundle_exists {
             Ok(Action::Empty)
         } else {
-            let executor_public_key = &bundle_solution.proof_of_election().executor_public_key;
+            let proof_of_election = bundle_solution.proof_of_election();
 
-            if !executor_public_key.verify(&bundle.hash(), signature) {
+            if !proof_of_election
+                .executor_public_key
+                .verify(&bundle.hash(), signature)
+            {
                 return Err(GossipMessageError::BadBundleSignature);
             }
 
             // TODO: validate the bundle election.
 
-            // TODO: Validate the receipts correctly when the bundle gossip is re-enabled.
-            let domain_id = bundle_solution.proof_of_election().domain_id;
+            let domain_id = proof_of_election.domain_id;
 
             self.gossip_message_validator
                 .validate_bundle_receipts(&bundle.receipts, domain_id)?;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -917,11 +917,13 @@ fn extract_fraud_proofs(
     extrinsics: Vec<UncheckedExtrinsic>,
     domain_id: DomainId,
 ) -> Vec<FraudProof<NumberFor<Block>, Hash>> {
+    let successful_fraud_proofs = Receipts::successful_fraud_proofs();
     extrinsics
         .into_iter()
         .filter_map(|uxt| match uxt.function {
             RuntimeCall::Domains(pallet_domains::Call::submit_fraud_proof { fraud_proof })
-                if fraud_proof.domain_id() == domain_id =>
+                if fraud_proof.domain_id() == domain_id
+                    && successful_fraud_proofs.contains(&fraud_proof.hash()) =>
             {
                 Some(fraud_proof)
             }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1198,7 +1198,7 @@ impl_runtime_apis! {
             extract_core_bundles(extrinsics, domain_id)
         }
 
-        fn extract_stored_bundle_hashes() -> Vec<H256> {
+        fn successful_bundle_hashes() -> Vec<H256> {
             Domains::successful_bundles()
         }
 


### PR DESCRIPTION
This PR primarily ensures the extracted bundles/receipts/fraud proofs from the original primary block are finally accepted by the primary chain, i.e., the `submit_bundle`/`submit_fraud_proof` calls are successful in the end. Temporary runtime storage will be cleared on block initialize is used to store the hashes of successful bundles and fraud proofs. Runtime API `extract_stored_bundle_hashes` is also changed to make use of this storage (This is mainly for consistency favor as I was reluctant to spend time thinking about the fraud proof events at present).

Close https://github.com/subspace/subspace/issues/1446

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
