### PR TITLE
Compact blocks refactoring (part 1)

### DIFF
--- a/crates/subspace-block-relay/src/consensus.rs
+++ b/crates/subspace-block-relay/src/consensus.rs
@@ -95,7 +95,7 @@ enum ServerMessage<Block: BlockT, ProtocolReq> {
 struct ConsensusRelayClient<
     Block: BlockT,
     Pool: TransactionPool,
-    ProtoClient: ProtocolClient<Block, BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
+    ProtoClient: ProtocolClient<BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
 > {
     network: Arc<NetworkWrapper<Block>>,
     protocol_name: ProtocolName,
@@ -106,7 +106,7 @@ struct ConsensusRelayClient<
 impl<
         Block: BlockT,
         Pool: TransactionPool,
-        ProtoClient: ProtocolClient<Block, BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
+        ProtoClient: ProtocolClient<BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
     > ConsensusRelayClient<Block, Pool, ProtoClient>
 {
     /// Downloads the requested block from the peer using the relay protocol
@@ -178,7 +178,7 @@ impl<
     async fn resolve_extrinsics(
         &self,
         protocol_response: ProtoClient::ProtocolRsp,
-        req_rsp: Arc<RequestResponseWrapper<Block>>,
+        req_rsp: Arc<RequestResponseWrapper>,
     ) -> Result<(Vec<Extrinsic<Block>>, usize), RelayError> {
         let (block_hash, resolved) = self
             .protocol_client
@@ -210,7 +210,7 @@ impl<
 impl<
         Block: BlockT,
         Pool: TransactionPool,
-        ProtoClient: ProtocolClient<Block, BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
+        ProtoClient: ProtocolClient<BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
     > BlockDownloader<Block> for ConsensusRelayClient<Block, Pool, ProtoClient>
 {
     async fn download_block(

--- a/crates/subspace-block-relay/src/consensus.rs
+++ b/crates/subspace-block-relay/src/consensus.rs
@@ -48,7 +48,7 @@ struct InitialRequest<Block: BlockT, ProtocolRequest> {
     from_block: BlockId<Block>,
 
     /// Requested block components
-    block_attributes: u32,
+    block_attributes: BlockAttributes,
 
     /// The protocol specific part of the request
     protocol_request: ProtocolRequest,
@@ -127,7 +127,7 @@ where
                 FromBlock::Hash(h) => BlockId::<Block>::Hash(h),
                 FromBlock::Number(n) => BlockId::<Block>::Number(n),
             },
-            block_attributes: request.fields.to_be_u32(),
+            block_attributes: request.fields,
             protocol_request: self.protocol_client.build_initial_request(),
         };
         let initial_response = network_peer_handle
@@ -333,8 +333,7 @@ where
         initial_request: InitialRequest<Block, ProtoServer::Request>,
     ) -> Result<Vec<u8>, RelayError> {
         let block_hash = self.block_hash(&initial_request.from_block)?;
-        let block_attributes = BlockAttributes::from_be_u32(initial_request.block_attributes)
-            .map_err(RelayError::InvalidBlockAttributes)?;
+        let block_attributes = initial_request.block_attributes;
 
         // Build the generic and the protocol specific parts of the response
         let partial_block = self.get_partial_block(&block_hash, block_attributes)?;

--- a/crates/subspace-block-relay/src/consensus.rs
+++ b/crates/subspace-block-relay/src/consensus.rs
@@ -97,10 +97,10 @@ struct ConsensusRelayClient<
     Pool: TransactionPool,
     ProtoClient: ProtocolClient<BlockHash<Block>, TxHash<Pool>, Extrinsic<Block>>,
 > {
-    network: Arc<NetworkWrapper<Block>>,
+    network: Arc<NetworkWrapper>,
     protocol_name: ProtocolName,
     protocol_client: Arc<ProtoClient>,
-    _pool: std::marker::PhantomData<Pool>,
+    _phantom_data: std::marker::PhantomData<(Block, Pool)>,
 }
 
 impl<
@@ -569,7 +569,7 @@ where
 }
 
 pub fn build_consensus_relay<Block, Client, Pool>(
-    network: Arc<NetworkWrapper<Block>>,
+    network: Arc<NetworkWrapper>,
     client: Arc<Client>,
     pool: Arc<Pool>,
     spawn_handle: SpawnTaskHandle,
@@ -588,7 +588,7 @@ where
         protocol_client: Arc::new(CompactBlockClient {
             backend: backend.clone(),
         }),
-        _pool: Default::default(),
+        _phantom_data: Default::default(),
     };
 
     let relay_server = ConsensusRelayServer {

--- a/crates/subspace-block-relay/src/lib.rs
+++ b/crates/subspace-block-relay/src/lib.rs
@@ -89,36 +89,36 @@ pub(crate) trait ProtocolClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
 where
     Self: Send + Sync,
 {
-    type ProtocolReq: Send + Sync + Encode + Decode + 'static;
-    type ProtocolRsp: Send + Sync + Encode + Decode + 'static;
+    type Request: Send + Sync + Encode + Decode + 'static;
+    type Response: Send + Sync + Encode + Decode + 'static;
 
     /// Builds the protocol portion of the initial request
-    fn build_initial_request(&self) -> Self::ProtocolReq;
+    fn build_initial_request(&self) -> Self::Request;
 
     /// Resolves the initial response to produce the protocol units.
     /// `encoder_fn` needs to be called to generate the request payload
     /// as part of request/response sequences initiated by the protocol.
     async fn resolve_initial_response(
         &self,
-        response: Self::ProtocolRsp,
+        response: Self::Response,
         network_peer_handle: &NetworkPeerHandle,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>;
 }
 
 /// The server side of the relay protocol
 pub(crate) trait ProtocolServer<DownloadUnitId> {
-    type ProtocolReq: Encode + Decode;
-    type ProtocolRsp: Encode + Decode;
+    type Request: Encode + Decode;
+    type Response: Encode + Decode;
 
     /// Builds the protocol response to the initial request
     fn build_initial_response(
         &self,
         download_unit_id: &DownloadUnitId,
-        initial_request: Self::ProtocolReq,
-    ) -> Result<Self::ProtocolRsp, RelayError>;
+        initial_request: Self::Request,
+    ) -> Result<Self::Response, RelayError>;
 
     /// Handles the additional client messages during the reconcile phase
-    fn on_request(&self, request: Self::ProtocolReq) -> Result<Self::ProtocolRsp, RelayError>;
+    fn on_request(&self, request: Self::Request) -> Result<Self::Response, RelayError>;
 }
 
 /// The relay user specific backend interface

--- a/crates/subspace-block-relay/src/lib.rs
+++ b/crates/subspace-block-relay/src/lib.rs
@@ -40,7 +40,7 @@
 
 #![feature(const_option)]
 
-use crate::utils::{RelayError, RequestResponseWrapper};
+use crate::utils::{NetworkPeerHandle, RelayError};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use std::time::Duration;
@@ -101,7 +101,7 @@ where
     async fn resolve_initial_response(
         &self,
         response: Self::ProtocolRsp,
-        req_rsp: &RequestResponseWrapper,
+        network_peer_handle: &NetworkPeerHandle,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>;
 }
 

--- a/crates/subspace-block-relay/src/lib.rs
+++ b/crates/subspace-block-relay/src/lib.rs
@@ -43,7 +43,6 @@
 use crate::utils::{RelayError, RequestResponseWrapper};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
-use sp_runtime::traits::Block as BlockT;
 use std::time::Duration;
 
 mod consensus;
@@ -86,10 +85,9 @@ pub(crate) struct Resolved<ProtocolUnitId, ProtocolUnit> {
 
 /// The client side of the relay protocol
 #[async_trait]
-pub(crate) trait ProtocolClient<Block, DownloadUnitId, ProtocolUnitId, ProtocolUnit>
+pub(crate) trait ProtocolClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
 where
     Self: Send + Sync,
-    Block: BlockT,
 {
     type ProtocolReq: Send + Sync + Encode + Decode + 'static;
     type ProtocolRsp: Send + Sync + Encode + Decode + 'static;
@@ -103,7 +101,7 @@ where
     async fn resolve_initial_response(
         &self,
         response: Self::ProtocolRsp,
-        req_rsp: &RequestResponseWrapper<Block>,
+        req_rsp: &RequestResponseWrapper,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>;
 }
 

--- a/crates/subspace-block-relay/src/protocol/compact_block.rs
+++ b/crates/subspace-block-relay/src/protocol/compact_block.rs
@@ -4,7 +4,6 @@ use crate::utils::RequestResponseWrapper;
 use crate::{ProtocolBackend, ProtocolClient, ProtocolServer, RelayError, Resolved, LOG_TARGET};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
-use sp_runtime::traits::Block as BlockT;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -147,15 +146,12 @@ where
     }
 
     /// Fetches the missing entries from the server
-    async fn resolve_misses<Block>(
+    async fn resolve_misses(
         &self,
         compact_response: InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
         context: ResolveContext<ProtocolUnitId, ProtocolUnit>,
-        req_rsp: &RequestResponseWrapper<Block>,
-    ) -> Result<Vec<Resolved<ProtocolUnitId, ProtocolUnit>>, RelayError>
-    where
-        Block: BlockT,
-    {
+        req_rsp: &RequestResponseWrapper,
+    ) -> Result<Vec<Resolved<ProtocolUnitId, ProtocolUnit>>, RelayError> {
         let ResolveContext {
             mut resolved,
             local_miss,
@@ -202,11 +198,10 @@ where
 }
 
 #[async_trait]
-impl<Block, DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-    ProtocolClient<Block, DownloadUnitId, ProtocolUnitId, ProtocolUnit>
+impl<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
+    ProtocolClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
     for CompactBlockClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
 where
-    Block: BlockT,
     DownloadUnitId: Send + Sync + Encode + Decode + Clone + std::fmt::Debug + 'static,
     ProtocolUnitId: Send + Sync + Encode + Decode + Clone + 'static,
     ProtocolUnit: Send + Sync + Encode + Decode + Clone + 'static,
@@ -221,7 +216,7 @@ where
     async fn resolve_initial_response(
         &self,
         response: Self::ProtocolRsp,
-        req_rsp: &RequestResponseWrapper<Block>,
+        req_rsp: &RequestResponseWrapper,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError> {
         let compact_response = match response {
             CompactBlockRsp::Initial(compact_response) => compact_response,

--- a/crates/subspace-block-relay/src/protocol/compact_block.rs
+++ b/crates/subspace-block-relay/src/protocol/compact_block.rs
@@ -19,7 +19,7 @@ const PROTOCOL_UNIT_SIZE_THRESHOLD: NonZeroUsize = NonZeroUsize::new(32).expect(
 
 /// Request messages
 #[derive(Encode, Decode)]
-pub(crate) enum CompactBlockReq<DownloadUnitId, ProtocolUnitId> {
+pub(crate) enum CompactBlockRequest<DownloadUnitId, ProtocolUnitId> {
     /// Initial request
     Initial,
 
@@ -29,7 +29,7 @@ pub(crate) enum CompactBlockReq<DownloadUnitId, ProtocolUnitId> {
 
 /// Response messages
 #[derive(Encode, Decode)]
-pub(crate) enum CompactBlockRsp<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
+pub(crate) enum CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
     /// Initial/compact response
     Initial(InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>),
 
@@ -158,17 +158,18 @@ where
         } = context;
         let missing = local_miss.len();
         // Request the missing entries from the server
-        let request = CompactBlockReq::MissingEntries(MissingEntriesRequest {
+        let request = CompactBlockRequest::MissingEntries(MissingEntriesRequest {
             download_unit_id: compact_response.download_unit_id.clone(),
             protocol_unit_ids: local_miss.clone(),
         });
-        let response: CompactBlockRsp<DownloadUnitId, ProtocolUnitId, ProtocolUnit> =
+        let response: CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit> =
             network_peer_handle.request(request).await?;
-        let missing_entries_response = if let CompactBlockRsp::MissingEntries(rsp) = response {
-            rsp
-        } else {
-            return Err(RelayError::UnexpectedProtocolRespone);
-        };
+        let missing_entries_response =
+            if let CompactBlockResponse::MissingEntries(response) = response {
+                response
+            } else {
+                return Err(RelayError::UnexpectedProtocolRespone);
+            };
 
         if missing_entries_response.protocol_units.len() != missing {
             return Err(RelayError::ResolveMismatch {
@@ -206,20 +207,20 @@ where
     ProtocolUnitId: Send + Sync + Encode + Decode + Clone + 'static,
     ProtocolUnit: Send + Sync + Encode + Decode + Clone + 'static,
 {
-    type ProtocolReq = CompactBlockReq<DownloadUnitId, ProtocolUnitId>;
-    type ProtocolRsp = CompactBlockRsp<DownloadUnitId, ProtocolUnitId, ProtocolUnit>;
+    type Request = CompactBlockRequest<DownloadUnitId, ProtocolUnitId>;
+    type Response = CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>;
 
-    fn build_initial_request(&self) -> Self::ProtocolReq {
-        CompactBlockReq::Initial
+    fn build_initial_request(&self) -> Self::Request {
+        CompactBlockRequest::Initial
     }
 
     async fn resolve_initial_response(
         &self,
-        response: Self::ProtocolRsp,
+        response: Self::Response,
         network_peer_handle: &NetworkPeerHandle,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError> {
         let compact_response = match response {
-            CompactBlockRsp::Initial(compact_response) => compact_response,
+            CompactBlockResponse::Initial(compact_response) => compact_response,
             _ => return Err(RelayError::UnexpectedInitialResponse),
         };
 
@@ -269,15 +270,15 @@ where
     ProtocolUnitId: Encode + Decode + Clone,
     ProtocolUnit: Encode + Decode,
 {
-    type ProtocolReq = CompactBlockReq<DownloadUnitId, ProtocolUnitId>;
-    type ProtocolRsp = CompactBlockRsp<DownloadUnitId, ProtocolUnitId, ProtocolUnit>;
+    type Request = CompactBlockRequest<DownloadUnitId, ProtocolUnitId>;
+    type Response = CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>;
 
     fn build_initial_response(
         &self,
         download_unit_id: &DownloadUnitId,
-        initial_request: Self::ProtocolReq,
-    ) -> Result<Self::ProtocolRsp, RelayError> {
-        if !matches!(initial_request, CompactBlockReq::Initial) {
+        initial_request: Self::Request,
+    ) -> Result<Self::Response, RelayError> {
+        if !matches!(initial_request, CompactBlockRequest::Initial) {
             return Err(RelayError::UnexpectedInitialRequest);
         }
 
@@ -297,23 +298,23 @@ where
                 })
                 .collect(),
         };
-        Ok(CompactBlockRsp::Initial(response))
+        Ok(CompactBlockResponse::Initial(response))
     }
 
-    fn on_request(&self, request: Self::ProtocolReq) -> Result<Self::ProtocolRsp, RelayError> {
-        let req = match request {
-            CompactBlockReq::MissingEntries(req) => req,
+    fn on_request(&self, request: Self::Request) -> Result<Self::Response, RelayError> {
+        let request = match request {
+            CompactBlockRequest::MissingEntries(req) => req,
             _ => return Err(RelayError::UnexpectedProtocolRequest),
         };
 
         let mut protocol_units = BTreeMap::new();
-        let total_len = req.protocol_unit_ids.len();
-        for (missing_id, protocol_unit_id) in req.protocol_unit_ids {
-            if let Some(ret) = self
+        let total_len = request.protocol_unit_ids.len();
+        for (missing_id, protocol_unit_id) in request.protocol_unit_ids {
+            if let Some(protocol_unit) = self
                 .backend
-                .protocol_unit(&req.download_unit_id, &protocol_unit_id)?
+                .protocol_unit(&request.download_unit_id, &protocol_unit_id)?
             {
-                protocol_units.insert(missing_id, ret);
+                protocol_units.insert(missing_id, protocol_unit);
             } else {
                 warn!(
                     target: LOG_TARGET,
@@ -328,8 +329,8 @@ where
                 protocol_units.len()
             );
         }
-        Ok(CompactBlockRsp::MissingEntries(MissingEntriesResponse {
-            protocol_units,
-        }))
+        Ok(CompactBlockResponse::MissingEntries(
+            MissingEntriesResponse { protocol_units },
+        ))
     }
 }

--- a/crates/subspace-block-relay/src/utils.rs
+++ b/crates/subspace-block-relay/src/utils.rs
@@ -18,13 +18,15 @@ pub struct NetworkWrapper {
     network: Mutex<Option<NetworkRequestService>>,
 }
 
-impl NetworkWrapper {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+impl Default for NetworkWrapper {
+    fn default() -> Self {
         Self {
             network: Mutex::new(None),
         }
     }
+}
+
+impl NetworkWrapper {
     pub fn set(&self, network: NetworkRequestService) {
         *self.network.lock() = Some(network);
     }

--- a/crates/subspace-block-relay/src/utils.rs
+++ b/crates/subspace-block-relay/src/utils.rs
@@ -109,9 +109,6 @@ pub(crate) enum RequestResponseErr {
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum RelayError {
-    #[error("Invalid block attributes: {0}")]
-    InvalidBlockAttributes(codec::Error),
-
     #[error("Block header: {0}")]
     BlockHeader(String),
 

--- a/crates/subspace-block-relay/src/utils.rs
+++ b/crates/subspace-block-relay/src/utils.rs
@@ -37,17 +37,17 @@ impl<Block: BlockT> NetworkWrapper<Block> {
 
 /// Helper for request response.
 #[derive(Clone)]
-pub(crate) struct RequestResponseWrapper<Block: BlockT> {
+pub(crate) struct RequestResponseWrapper {
     protocol_name: ProtocolName,
     who: PeerId,
-    network: Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+    network: Arc<dyn NetworkRequest + Send + Sync + 'static>,
 }
 
-impl<Block: BlockT> RequestResponseWrapper<Block> {
+impl RequestResponseWrapper {
     pub(crate) fn new(
         protocol_name: ProtocolName,
         who: PeerId,
-        network: Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+        network: Arc<dyn NetworkRequest + Send + Sync + 'static>,
     ) -> Self {
         Self {
             protocol_name,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -755,7 +755,7 @@ where
             })?;
     }
 
-    let network_wrapper = Arc::new(NetworkWrapper::new());
+    let network_wrapper = Arc::new(NetworkWrapper::default());
     let block_relay = if config.enable_subspace_block_relay {
         Some(build_consensus_relay(
             network_wrapper.clone(),


### PR DESCRIPTION
This doesn't change anything functionally, but (subjectively) makes it easier to read and reason about.

I basically removed some abstractions that didn't seem to serve any purpose and removed some generic that were not necessary. I also improved naming of variables and structures, all of these `hdr`, `rr_err`, `req_rsp` are very annoying and make my brain stutter when I read thought the code. With clearer names it is possible to read things faster and code looks a bit cleaner.

And conversions into `Result` like `impl From<RelayError> for Result<Result<Vec<u8>, RequestFailure>, oneshot::Canceled>` really put me off. This nested `Result` API should be fixed in Substrate, it should have one error where cancelled request is just one of the error variants instead.

I'm still reading into request/response mechanism in more detail, there might be another PR later.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
