### PR TITLE
Enable primitives `serde` feature in archiving

### DIFF
--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -35,6 +35,10 @@ rayon = [
     "dep:rayon",
     "subspace-core-primitives/rayon",
 ]
+serde = [
+    "dep:serde",
+    "subspace-core-primitives/serde",
+]
 std = [
     "parity-scale-codec/std",
     "rayon",


### PR DESCRIPTION
This PR enables serde feature in archiving that was missing and therefore causing the build to fail. More here - https://github.com/subspace/subspace/actions/runs/4991087910/jobs/8937321575#step:3:2292


I'll create a companion PR to main once this PR lands


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
