### PR TITLE
Larger sector size

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -397,12 +397,13 @@ pub fn create_signed_vote(
     let pieces_in_sector = farmer_protocol_info.max_pieces_in_sector;
     let sector_size = sector_size(pieces_in_sector);
 
-    for sector_index in iter::from_fn(|| Some(rand::random())) {
+    for (sector_offset, sector_index) in iter::from_fn(|| Some(rand::random())).enumerate() {
         let mut plotted_sector_bytes = vec![0; sector_size];
         let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
+            sector_offset,
             sector_index,
             archived_history_segment,
             PieceGetterRetryPolicy::default(),

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -143,12 +143,13 @@ fn valid_header(
     let pieces_in_sector = farmer_parameters.farmer_protocol_info.max_pieces_in_sector;
     let sector_size = sector_size(pieces_in_sector);
 
-    for sector_index in iter::from_fn(|| Some(rand::random())) {
+    for (sector_offset, sector_index) in iter::from_fn(|| Some(rand::random())).enumerate() {
         let mut plotted_sector_bytes = vec![0; sector_size];
         let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
+            sector_offset,
             sector_index,
             &farmer_parameters.archived_segment.pieces,
             PieceGetterRetryPolicy::default(),

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -24,7 +24,7 @@ use subspace_proof_of_space::chia::ChiaTable;
 
 type PosTable = ChiaTable;
 
-const MAX_PIECES_IN_SECTOR: u16 = 1300;
+const MAX_PIECES_IN_SECTOR: u16 = 1000;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     println!("Initializing...");

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -42,6 +42,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .unwrap_or(10);
 
     let public_key = PublicKey::default();
+    let sector_offset = 0;
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
     StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
@@ -110,6 +111,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
+            sector_offset,
             sector_index,
             &archived_history_segment,
             PieceGetterRetryPolicy::default(),

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -26,6 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .unwrap_or_else(|_error| MAX_PIECES_IN_SECTOR);
 
     let public_key = PublicKey::default();
+    let sector_offset = 0;
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
     StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
@@ -61,6 +62,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             block_on(plot_sector::<_, PosTable>(
                 black_box(&public_key),
+                black_box(sector_offset),
                 black_box(sector_index),
                 black_box(&archived_history_segment),
                 black_box(PieceGetterRetryPolicy::default()),

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -17,7 +17,7 @@ use subspace_proof_of_space::chia::ChiaTable;
 
 type PosTable = ChiaTable;
 
-const MAX_PIECES_IN_SECTOR: u16 = 1300;
+const MAX_PIECES_IN_SECTOR: u16 = 1000;
 
 fn criterion_benchmark(c: &mut Criterion) {
     println!("Initializing...");

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -44,6 +44,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let keypair = Keypair::from_bytes(&[0; 96]).unwrap();
     let public_key = PublicKey::from(keypair.public.to_bytes());
+    let sector_offset = 0;
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
     let mut rng = StdRng::seed_from_u64(42);
@@ -113,6 +114,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
+            sector_offset,
             sector_index,
             &archived_history_segment,
             PieceGetterRetryPolicy::default(),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -25,7 +25,7 @@ use subspace_proof_of_space::chia::ChiaTable;
 
 type PosTable = ChiaTable;
 
-const MAX_PIECES_IN_SECTOR: u16 = 1300;
+const MAX_PIECES_IN_SECTOR: u16 = 1000;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     println!("Initializing...");

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -23,7 +23,7 @@ use subspace_proof_of_space::chia::ChiaTable;
 
 type PosTable = ChiaTable;
 
-const MAX_PIECES_IN_SECTOR: u16 = 1300;
+const MAX_PIECES_IN_SECTOR: u16 = 1000;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     println!("Initializing...");

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -41,6 +41,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .unwrap_or(10);
 
     let public_key = PublicKey::default();
+    let sector_offset = 0;
     let sector_index = 0;
     let mut input = RecordedHistorySegment::new_boxed();
     StdRng::seed_from_u64(42).fill(AsMut::<[u8]>::as_mut(input.as_mut()));
@@ -107,6 +108,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
+            sector_offset,
             sector_index,
             &archived_history_segment,
             PieceGetterRetryPolicy::default(),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -32,7 +32,7 @@ use subspace_networking::utils::piece_announcement::announce_single_piece_index_
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
 use tokio::sync::broadcast;
-use tracing::{debug, error, info, info_span, warn, Instrument, Span};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 use zeroize::Zeroizing;
 
 const RECORDS_ROOTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000_000).expect("Not zero; qed");
@@ -350,7 +350,7 @@ where
                             // Release only after publishing is finished
                             drop(plotting_permit);
                         }
-                        .instrument(Span::current());
+                        .in_current_span();
 
                         tokio::spawn(async move {
                             let result =

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -32,7 +32,7 @@ use subspace_networking::utils::piece_announcement::announce_single_piece_index_
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
 use tokio::sync::broadcast;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, info_span, warn, Instrument, Span};
 use zeroize::Zeroizing;
 
 const RECORDS_ROOTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000_000).expect("Not zero; qed");
@@ -221,7 +221,7 @@ where
     let plotted_pieces: HashMap<PieceIndexHash, PieceDetails> = single_disk_plots
         .iter()
         .enumerate()
-        .flat_map(|(plot_offset, single_disk_plot)| {
+        .flat_map(|(disk_farm_index, single_disk_plot)| {
             single_disk_plot
                 .plotted_sectors()
                 .enumerate()
@@ -231,7 +231,7 @@ where
                         Err(error) => {
                             error!(
                                 %error,
-                                %plot_offset,
+                                %disk_farm_index,
                                 %sector_offset,
                                 "Failed reading plotted sector on startup, skipping"
                             );
@@ -245,7 +245,7 @@ where
                             (
                                 piece_index.hash(),
                                 PieceDetails {
-                                    plot_offset,
+                                    disk_farm_index,
                                     sector_index: plotted_sector.sector_index,
                                     piece_offset,
                                 },
@@ -266,9 +266,10 @@ where
     let mut single_disk_plots_stream = single_disk_plots
         .into_iter()
         .enumerate()
-        .map(|(plot_offset, single_disk_plot)| {
+        .map(|(disk_farm_index, single_disk_plot)| {
             let readers_and_pieces = Arc::clone(&readers_and_pieces);
             let node = node.clone();
+            let span = info_span!("farm", %disk_farm_index);
 
             // We are not going to send anything here, but dropping of sender on dropping of
             // corresponding `SingleDiskPlot` will allow us to stop background tasks.
@@ -279,6 +280,7 @@ where
             single_disk_plot
                 .on_sector_plotted(Arc::new(
                     move |(sector_offset, plotted_sector, plotting_permit)| {
+                        let _span_guard = span.enter();
                         let plotting_permit = Arc::clone(plotting_permit);
                         let node = node.clone();
                         let sector_offset = *sector_offset;
@@ -310,7 +312,7 @@ where
                                         (
                                             piece_index.hash(),
                                             PieceDetails {
-                                                plot_offset,
+                                                disk_farm_index,
                                                 sector_index,
                                                 piece_offset,
                                             },
@@ -347,7 +349,8 @@ where
 
                             // Release only after publishing is finished
                             drop(plotting_permit);
-                        };
+                        }
+                        .instrument(Span::current());
 
                         tokio::spawn(async move {
                             let result =

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -208,7 +208,7 @@ pub(super) fn configure_dsn(
 
                             readers_and_pieces
                                 .read_piece(&piece_index_hash)?
-                                .instrument(Span::current())
+                                .in_current_span()
                         };
 
                         let piece = read_piece_fut.await;
@@ -216,7 +216,7 @@ pub(super) fn configure_dsn(
                         Some(PieceByHashResponse { piece })
                     }
                 }
-                .instrument(Span::current())
+                .in_current_span()
             }),
             SegmentHeaderBySegmentIndexesRequestHandler::create(move |req| {
                 debug!(?req, "Segment headers request received.");
@@ -278,7 +278,7 @@ pub(super) fn configure_dsn(
                         }
                     }
                 }
-                .instrument(Span::current())
+                .in_current_span()
             }),
         ],
         max_established_outgoing_connections: out_connections,

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -772,6 +772,7 @@ impl SingleDiskPlot {
                                     Ok(plotting_permit) => plotting_permit,
                                     Err(error) => {
                                         warn!(
+                                            %sector_offset,
                                             %sector_index,
                                             %error,
                                             "Semaphore was closed, interrupting plotting"
@@ -789,6 +790,7 @@ impl SingleDiskPlot {
 
                             let plot_sector_fut = plot_sector::<_, PosTable>(
                                 &public_key,
+                                sector_offset,
                                 sector_index,
                                 &piece_getter,
                                 PieceGetterRetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
@@ -810,6 +812,8 @@ impl SingleDiskPlot {
                             sectors_metadata
                                 .write()
                                 .push(plotted_sector.sector_metadata.clone());
+
+                            info!(%sector_offset, %sector_index, "Sector plotted successfully");
 
                             handlers.sector_plotted.call_simple(&(
                                 sector_offset,

--- a/crates/subspace-farmer/src/utils/readers_and_pieces.rs
+++ b/crates/subspace-farmer/src/utils/readers_and_pieces.rs
@@ -6,7 +6,7 @@ use tracing::{trace, warn};
 
 #[derive(Debug, Copy, Clone)]
 pub struct PieceDetails {
-    pub plot_offset: usize,
+    pub disk_farm_index: usize,
     pub sector_index: SectorIndex,
     pub piece_offset: PieceOffset,
 }
@@ -47,7 +47,7 @@ impl ReadersAndPieces {
                 return None;
             }
         };
-        let mut reader = match self.readers.get(piece_details.plot_offset).cloned() {
+        let mut reader = match self.readers.get(piece_details.disk_farm_index).cloned() {
             Some(reader) => reader,
             None => {
                 warn!(?piece_index_hash, ?piece_details, "Plot offset is invalid");

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -87,7 +87,7 @@ sp_runtime::impl_opaque_keys! {
 }
 
 /// How many pieces one sector is supposed to contain (max)
-const MAX_PIECES_IN_SECTOR: u16 = 32;
+const MAX_PIECES_IN_SECTOR: u16 = 1000;
 
 // To learn more about runtime versioning and what each of the following value means:
 //   https://substrate.dev/docs/en/knowledgebase/runtime/upgrades#runtime-versioning

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -226,6 +226,7 @@ where
     let history_size = HistorySize::from(SegmentIndex::ZERO);
     let mut sector = vec![0u8; sector_size(pieces_in_sector)];
     let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
+    let sector_offset = 0;
     let sector_index = 0;
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let farmer_protocol_info = FarmerProtocolInfo {
@@ -236,6 +237,7 @@ where
 
     let plotted_sector = plot_sector::<_, PosTable>(
         &public_key,
+        sector_offset,
         sector_index,
         &archived_segment.pieces,
         PieceGetterRetryPolicy::default(),


### PR DESCRIPTION
This increases number of pieces in sector to 1000 (spec says 1300, but we'll likely go with 1000 instead).

The first commit just improves logging, so it is easier to see what farmer is doing and which plot+sector it corresponds to.

This is a backwards compatible change since plot sector size is specified as max value in the protocol, older value of 32 is still perfectly valid.

NOTE: It is possible to override max plot size in the farmer with CLI to plot arbitrarily small sectors, down to 1 piece, so this change doesn't mean you have to plot at least 1G sector now.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
