### PR TITLE
enable subspace-primitives serde in archiving

### DIFF
--- a/crates/subspace-archiving/Cargo.toml
+++ b/crates/subspace-archiving/Cargo.toml
@@ -35,6 +35,10 @@ parallel = [
     "dep:rayon",
     "subspace-core-primitives/parallel",
 ]
+serde = [
+    "dep:serde",
+    "subspace-core-primitives/serde",
+]
 std = [
     "parity-scale-codec/std",
     "parallel",


### PR DESCRIPTION
This is a companion PR with cherry picked commits that are in gemini-3d maintenance branch #1461

Turns out `primitives serde` was not included in the std and hence some types had missing serde derivations.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
