### PR TITLE
Ensure correct runtime spec version to call Timestamp API 

### DIFF
--- a/crates/subspace-fraud-proof/src/domain_extrinsics_builder.rs
+++ b/crates/subspace-fraud-proof/src/domain_extrinsics_builder.rs
@@ -5,7 +5,7 @@ use domain_block_preprocessor::runtime_api_light::RuntimeApiLight;
 use domain_block_preprocessor::{CoreDomainBlockPreprocessor, SystemDomainBlockPreprocessor};
 use domain_runtime_primitives::opaque::Block;
 use sc_client_api::{BlockBackend, HeaderBackend};
-use sp_api::ProvideRuntimeApi;
+use sp_api::{CallApiAt, ProvideRuntimeApi};
 use sp_core::traits::CodeExecutor;
 use sp_core::H256;
 use sp_domains::{DomainId, ExecutorApi};
@@ -114,6 +114,7 @@ where
     PClient: HeaderBackend<PBlock>
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
+        + CallApiAt<PBlock>
         + Send
         + Sync
         + 'static,
@@ -167,6 +168,7 @@ where
     PClient: HeaderBackend<PBlock>
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
+        + CallApiAt<PBlock>
         + Send
         + Sync
         + 'static,

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -35,7 +35,7 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use sc_client_api::BlockBackend;
-use sp_api::ProvideRuntimeApi;
+use sp_api::{CallApiAt, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_domains::{DomainId, ExecutorApi, OpaqueBundles};
 use sp_messenger::MessengerApi;
@@ -404,7 +404,12 @@ where
         + SetCodeConstructor<Block>
         + StateRootExtractor<Block>
         + InherentExtrinsicConstructor<Block>,
-    PClient: HeaderBackend<PBlock> + BlockBackend<PBlock> + ProvideRuntimeApi<PBlock> + Send + Sync,
+    PClient: HeaderBackend<PBlock>
+        + BlockBackend<PBlock>
+        + ProvideRuntimeApi<PBlock>
+        + CallApiAt<PBlock>
+        + Send
+        + Sync,
     PClient::Api: ExecutorApi<PBlock, Block::Hash>,
     SClient: HeaderBackend<SBlock> + ProvideRuntimeApi<SBlock> + 'static,
     SClient::Api: SystemDomainApi<SBlock, NumberFor<PBlock>, PBlock::Hash>

--- a/domains/client/domain-executor/src/core_bundle_processor.rs
+++ b/domains/client/domain-executor/src/core_bundle_processor.rs
@@ -7,7 +7,7 @@ use domain_block_preprocessor::CoreDomainBlockPreprocessor;
 use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use sc_client_api::{AuxStore, BlockBackend, Finalizer, StateBackendFor};
 use sc_consensus::BlockImport;
-use sp_api::{NumberFor, ProvideRuntimeApi};
+use sp_api::{CallApiAt, NumberFor, ProvideRuntimeApi};
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_core::traits::CodeExecutor;
 use sp_domains::{DomainId, ExecutorApi};
@@ -99,6 +99,7 @@ where
     PClient: HeaderBackend<PBlock>
         + HeaderMetadata<PBlock, Error = sp_blockchain::Error>
         + BlockBackend<PBlock>
+        + CallApiAt<PBlock>
         + ProvideRuntimeApi<PBlock>
         + 'static,
     PClient::Api: ExecutorApi<PBlock, Block::Hash> + 'static,

--- a/domains/client/domain-executor/src/core_domain_worker.rs
+++ b/domains/client/domain-executor/src/core_domain_worker.rs
@@ -28,7 +28,7 @@ use sc_client_api::{
     StateBackendFor,
 };
 use sc_consensus::BlockImport;
-use sp_api::{BlockT, ProvideRuntimeApi};
+use sp_api::{BlockT, CallApiAt, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus_slots::Slot;
@@ -116,6 +116,7 @@ pub(super) async fn start_worker<
     PClient: HeaderBackend<PBlock>
         + HeaderMetadata<PBlock, Error = sp_blockchain::Error>
         + BlockBackend<PBlock>
+        + CallApiAt<PBlock>
         + ProvideRuntimeApi<PBlock>
         + BlockchainEvents<PBlock>
         + 'static,

--- a/domains/client/domain-executor/src/core_executor.rs
+++ b/domains/client/domain-executor/src/core_executor.rs
@@ -12,7 +12,7 @@ use sc_client_api::{
     AuxStore, BlockBackend, BlockImportNotification, BlockchainEvents, Finalizer, ProofProvider,
     StateBackendFor,
 };
-use sp_api::ProvideRuntimeApi;
+use sp_api::{CallApiAt, ProvideRuntimeApi};
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::SelectChain;
 use sp_consensus_slots::Slot;
@@ -98,6 +98,7 @@ where
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
         + BlockchainEvents<PBlock>
+        + CallApiAt<PBlock>
         + Send
         + Sync
         + 'static,

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -31,7 +31,9 @@ use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
 use sc_transaction_pool_api::{InPoolTransaction, TransactionPool};
 use sc_utils::mpsc::tracing_unbounded;
 use serde::de::DeserializeOwned;
-use sp_api::{ApiExt, BlockT, ConstructRuntimeApi, Decode, Metadata, NumberFor, ProvideRuntimeApi};
+use sp_api::{
+    ApiExt, BlockT, CallApiAt, ConstructRuntimeApi, Decode, Metadata, NumberFor, ProvideRuntimeApi,
+};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::{SelectChain, SyncOracle};
@@ -367,6 +369,7 @@ where
         + HeaderMetadata<PBlock, Error = sp_blockchain::Error>
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
+        + CallApiAt<PBlock>
         + BlockchainEvents<PBlock>
         + Send
         + Sync

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -24,7 +24,9 @@ use sc_service::{
 use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
 use sc_transaction_pool_api::{InPoolTransaction, TransactionPool};
 use sc_utils::mpsc::tracing_unbounded;
-use sp_api::{ApiExt, BlockT, ConstructRuntimeApi, Metadata, NumberFor, ProvideRuntimeApi};
+use sp_api::{
+    ApiExt, BlockT, CallApiAt, ConstructRuntimeApi, Metadata, NumberFor, ProvideRuntimeApi,
+};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::{SelectChain, SyncOracle};
@@ -67,6 +69,7 @@ where
     PClient: HeaderBackend<PBlock>
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
+        + CallApiAt<PBlock>
         + Send
         + Sync
         + 'static,
@@ -176,6 +179,7 @@ where
     PClient: HeaderBackend<PBlock>
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
+        + CallApiAt<PBlock>
         + Send
         + Sync
         + 'static,
@@ -305,6 +309,7 @@ where
         + BlockBackend<PBlock>
         + ProvideRuntimeApi<PBlock>
         + BlockchainEvents<PBlock>
+        + CallApiAt<PBlock>
         + Send
         + Sync
         + 'static,


### PR DESCRIPTION
I have missed the backward compatibility while calling the Timestamp API on primary chain in the last PR. Since there was no API versioning and doing that also require another runtime upgrade on Gemini-3d, I chose to use spec version to call the timestamp API since it is introduced at spec_version 2 else we provide Zero time for spec version below 2

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
