### PR TITLE
Rename pallet-receipts to pallet-settlement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,9 +2596,9 @@ dependencies = [
  "sp-keystore",
  "sp-messenger",
  "sp-offchain",
- "sp-receipts",
  "sp-runtime",
  "sp-session",
+ "sp-settlement",
  "sp-transaction-pool",
  "subspace-core-primitives",
  "subspace-fraud-proof",
@@ -10381,18 +10381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-receipts"
-version = "0.1.0"
-dependencies = [
- "parity-scale-codec",
- "sp-api",
- "sp-core",
- "sp-domains",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "sp-rpc"
 version = "6.0.0"
 source = "git+https://github.com/subspace/substrate?rev=9cf78129a2638d3f370868863d16f4fe32b4ad30#9cf78129a2638d3f370868863d16f4fe32b4ad30"
@@ -10465,6 +10453,18 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-settlement"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-core",
+ "sp-domains",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -10981,8 +10981,8 @@ dependencies = [
  "sp-domains",
  "sp-keyring",
  "sp-messenger",
- "sp-receipts",
  "sp-runtime",
+ "sp-settlement",
  "sp-state-machine",
  "sp-trie",
  "subspace-runtime-primitives",
@@ -11157,9 +11157,9 @@ dependencies = [
  "sp-inherents",
  "sp-objects",
  "sp-offchain",
- "sp-receipts",
  "sp-runtime",
  "sp-session",
+ "sp-settlement",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
@@ -11232,9 +11232,9 @@ dependencies = [
  "sp-externalities",
  "sp-objects",
  "sp-offchain",
- "sp-receipts",
  "sp-runtime",
  "sp-session",
+ "sp-settlement",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
@@ -11320,9 +11320,9 @@ dependencies = [
  "sp-inherents",
  "sp-objects",
  "sp-offchain",
- "sp-receipts",
  "sp-runtime",
  "sp-session",
+ "sp-settlement",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
@@ -11727,9 +11727,9 @@ dependencies = [
  "sp-io",
  "sp-messenger",
  "sp-offchain",
- "sp-receipts",
  "sp-runtime",
  "sp-session",
+ "sp-settlement",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
@@ -11773,9 +11773,9 @@ dependencies = [
  "sp-io",
  "sp-messenger",
  "sp-offchain",
- "sp-receipts",
  "sp-runtime",
  "sp-session",
+ "sp-settlement",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6650,7 +6650,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-executor-registry",
- "pallet-receipts",
+ "pallet-settlement",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -6672,7 +6672,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "pallet-receipts",
+ "pallet-settlement",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -6885,21 +6885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-receipts"
-version = "0.1.0"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-domains",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-rewards"
 version = "0.1.0"
 dependencies = [
@@ -6920,6 +6905,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
+]
+
+[[package]]
+name = "pallet-settlement"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-domains",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -11136,9 +11136,9 @@ dependencies = [
  "pallet-grandpa-finality-verifier",
  "pallet-object-store",
  "pallet-offences-subspace",
- "pallet-receipts",
  "pallet-rewards",
  "pallet-runtime-configs",
+ "pallet-settlement",
  "pallet-subspace",
  "pallet-sudo",
  "pallet-timestamp",
@@ -11301,8 +11301,8 @@ dependencies = [
  "pallet-grandpa-finality-verifier",
  "pallet-object-store",
  "pallet-offences-subspace",
- "pallet-receipts",
  "pallet-rewards",
+ "pallet-settlement",
  "pallet-subspace",
  "pallet-sudo",
  "pallet-timestamp",
@@ -11712,7 +11712,7 @@ dependencies = [
  "pallet-domain-registry",
  "pallet-executor-registry",
  "pallet-messenger",
- "pallet-receipts",
+ "pallet-settlement",
  "pallet-sudo",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11758,7 +11758,7 @@ dependencies = [
  "pallet-domain-registry",
  "pallet-executor-registry",
  "pallet-messenger",
- "pallet-receipts",
+ "pallet-settlement",
  "pallet-sudo",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -17,7 +17,7 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "h
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 log = { version = "0.4.17", default-features = false }
-pallet-receipts = { version = "0.1.0", default-features = false, path = "../pallet-receipts" }
+pallet-settlement = { version = "0.1.0", default-features = false, path = "../pallet-settlement" }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../sp-domains" }
@@ -39,7 +39,7 @@ std = [
   "scale-info/std",
   "sp-core/std",
   "sp-domains/std",
-  "pallet-receipts/std",
+  "pallet-settlement/std",
   "sp-runtime/std",
   "sp-std/std",
 ]

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{self as pallet_domains};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Hooks};
 use frame_support::{assert_noop, assert_ok, parameter_types};
-use pallet_receipts::{PrimaryBlockHash, ReceiptVotes};
+use pallet_settlement::{PrimaryBlockHash, ReceiptVotes};
 use sp_core::crypto::Pair;
 use sp_core::{Get, H256, U256};
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof, InvalidStateTransitionProof};
@@ -27,7 +27,7 @@ frame_support::construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         System: frame_system,
-        Receipts: pallet_receipts,
+        Settlement: pallet_settlement,
         Domains: pallet_domains,
     }
 );
@@ -93,7 +93,7 @@ impl pallet_domains::Config for Test {
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Test>;
 }
 
-impl pallet_receipts::Config for Test {
+impl pallet_settlement::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = H256;
     type MaximumReceiptDrift = MaximumReceiptDrift;
@@ -210,7 +210,7 @@ fn submit_execution_receipt_incrementally_should_work() {
     new_test_ext().execute_with(|| {
         let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
         PrimaryBlockHash::<Test>::insert(DomainId::SYSTEM, 0, genesis_hash);
-        Receipts::initialize_genesis_receipt(DomainId::SYSTEM, genesis_hash);
+        Settlement::initialize_genesis_receipt(DomainId::SYSTEM, genesis_hash);
 
         (0..256).for_each(|index| {
             let block_hash = block_hashes[index];
@@ -226,21 +226,21 @@ fn submit_execution_receipt_incrementally_should_work() {
                 dummy_bundles[index].clone(),
             ));
 
-            assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 0);
+            assert_eq!(Settlement::finalized_receipt_number(DomainId::SYSTEM), 0);
         });
 
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(257)).is_none());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(257)).is_none());
         assert_ok!(Domains::submit_bundle(
             RuntimeOrigin::none(),
             dummy_bundles[256].clone(),
         ));
         // The oldest ER should be deleted.
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(1)).is_none());
-        assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 1);
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(257)).is_some());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(1)).is_none());
+        assert_eq!(Settlement::finalized_receipt_number(DomainId::SYSTEM), 1);
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(257)).is_some());
 
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(2)).is_some());
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(258)).is_none());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(2)).is_some());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(258)).is_none());
 
         assert_noop!(
             pallet_domains::Pallet::<Test>::pre_dispatch(&pallet_domains::Call::submit_bundle {
@@ -253,9 +253,9 @@ fn submit_execution_receipt_incrementally_should_work() {
             RuntimeOrigin::none(),
             dummy_bundles[257].clone(),
         ));
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(2)).is_none());
-        assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 2);
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash(258)).is_some());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(2)).is_none());
+        assert_eq!(Settlement::finalized_receipt_number(DomainId::SYSTEM), 2);
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash(258)).is_some());
     });
 }
 
@@ -319,7 +319,7 @@ fn submit_execution_receipt_with_huge_gap_should_work() {
             dummy_bundles[257].clone(),
         ));
         assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
-        assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 2);
+        assert_eq!(Settlement::finalized_receipt_number(DomainId::SYSTEM), 2);
     });
 }
 
@@ -369,25 +369,25 @@ fn submit_bundle_with_many_reeipts_should_work() {
         assert!(!frame_system::BlockHash::<Test>::contains_key(1));
         assert!(!frame_system::BlockHash::<Test>::contains_key(255));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle1));
-        assert_eq!(Receipts::head_receipt_number(DomainId::SYSTEM), 255);
+        assert_eq!(Settlement::head_receipt_number(DomainId::SYSTEM), 255);
 
         // Reaching the receipts pruning depth, block hash mapping will be pruned as well.
         assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle2));
         assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 0));
-        assert_eq!(Receipts::oldest_receipt_number(DomainId::SYSTEM), 1);
+        assert_eq!(Settlement::oldest_receipt_number(DomainId::SYSTEM), 1);
 
         assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle3));
         assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 1));
-        assert_eq!(Receipts::oldest_receipt_number(DomainId::SYSTEM), 2);
+        assert_eq!(Settlement::oldest_receipt_number(DomainId::SYSTEM), 2);
 
         assert!(PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), bundle4));
         assert!(!PrimaryBlockHash::<Test>::contains_key(DomainId::SYSTEM, 2));
-        assert_eq!(Receipts::oldest_receipt_number(DomainId::SYSTEM), 3);
-        assert_eq!(Receipts::finalized_receipt_number(DomainId::SYSTEM), 2);
-        assert_eq!(Receipts::head_receipt_number(DomainId::SYSTEM), 258);
+        assert_eq!(Settlement::oldest_receipt_number(DomainId::SYSTEM), 3);
+        assert_eq!(Settlement::finalized_receipt_number(DomainId::SYSTEM), 2);
+        assert_eq!(Settlement::head_receipt_number(DomainId::SYSTEM), 258);
     });
 }
 
@@ -414,8 +414,8 @@ fn only_system_domain_receipts_are_maintained_on_primary_chain() {
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), system_bundle));
         assert_ok!(Domains::submit_bundle(RuntimeOrigin::none(), core_bundle));
         // Only system domain receipt is tracked, core domain receipt is ignored.
-        assert!(Receipts::receipts(DomainId::SYSTEM, system_receipt.hash()).is_some());
-        assert!(Receipts::receipts(DomainId::SYSTEM, core_receipt.hash()).is_none());
+        assert!(Settlement::receipts(DomainId::SYSTEM, system_receipt.hash()).is_some());
+        assert!(Settlement::receipts(DomainId::SYSTEM, core_receipt.hash()).is_none());
     });
 }
 
@@ -457,7 +457,7 @@ fn submit_fraud_proof_should_work() {
             ));
 
             let receipt_hash = dummy_bundles[index].clone().bundle.receipts[0].hash();
-            assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash).is_some());
+            assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash).is_some());
             let mut votes = ReceiptVotes::<Test>::iter_prefix((DomainId::SYSTEM, block_hash));
             assert_eq!(votes.next(), Some((receipt_hash, 1)));
             assert_eq!(votes.next(), None);
@@ -470,15 +470,15 @@ fn submit_fraud_proof_should_work() {
         ));
         assert_eq!(Domains::head_receipt_number(), 256);
         let receipt_hash = dummy_bundles[255].clone().bundle.receipts[0].hash();
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash).is_some());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash).is_some());
 
         assert_ok!(Domains::submit_fraud_proof(
             RuntimeOrigin::none(),
             dummy_proof(DomainId::SYSTEM)
         ));
-        assert_eq!(Receipts::head_receipt_number(DomainId::SYSTEM), 99);
+        assert_eq!(Settlement::head_receipt_number(DomainId::SYSTEM), 99);
         let receipt_hash = dummy_bundles[98].clone().bundle.receipts[0].hash();
-        assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash).is_some());
+        assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash).is_some());
         // Receipts for block [100, 256] should be removed as being invalid.
         (100..=256).for_each(|block_number| {
             let receipt_hash = dummy_bundles[block_number as usize - 1]
@@ -486,7 +486,7 @@ fn submit_fraud_proof_should_work() {
                 .bundle
                 .receipts[0]
                 .hash();
-            assert!(Receipts::receipts(DomainId::SYSTEM, receipt_hash).is_none());
+            assert!(Settlement::receipts(DomainId::SYSTEM, receipt_hash).is_none());
             let block_hash = block_hashes[block_number as usize - 1];
             assert!(
                 ReceiptVotes::<Test>::iter_prefix((DomainId::SYSTEM, block_hash))

--- a/crates/pallet-settlement/Cargo.toml
+++ b/crates/pallet-settlement/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pallet-receipts"
+name = "pallet-settlement"
 version = "0.1.0"
 authors = ["Subspace Labs <https://subspace.network>"]
 edition = "2021"

--- a/crates/pallet-settlement/src/lib.rs
+++ b/crates/pallet-settlement/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Receipts Pallet
+//! # Settlement Pallet
 //!
 //! This pallet provides the general common settlement functions needed by the consensus chain
 //! and system domain, which mainly includes tracking the receipts and handling the fraud proofs

--- a/crates/sp-settlement/Cargo.toml
+++ b/crates/sp-settlement/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sp-receipts"
+name = "sp-settlement"
 version = "0.1.0"
 authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
 edition = "2021"

--- a/crates/sp-settlement/src/lib.rs
+++ b/crates/sp-settlement/src/lib.rs
@@ -24,7 +24,7 @@ use sp_runtime::traits::NumberFor;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
-    pub trait ReceiptsApi<DomainHash: Encode + Decode> {
+    pub trait SettlementApi<DomainHash: Encode + Decode> {
         /// Returns the trace of given domain receipt hash.
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<DomainHash>;
 

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -25,8 +25,8 @@ sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", re
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
 sp-domain-digests = { version = "0.1.0", path = "../../domains/primitives/digests" }
 sp-messenger = { version = "0.1.0", path = "../../domains/primitives/messenger" }
-sp-receipts = { version = "0.1.0", path = "../sp-receipts" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", path = "../sp-settlement" }
 sp-state-machine = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 subspace-wasm-tools = { version = "0.1.0", path = "../subspace-wasm-tools" }

--- a/crates/subspace-fraud-proof/src/verifier_api.rs
+++ b/crates/subspace-fraud-proof/src/verifier_api.rs
@@ -1,4 +1,4 @@
-//! This module derives an trait [`VerifierApi`] from the runtime api `ReceiptsApi`
+//! This module derives an trait [`VerifierApi`] from the runtime api `SettlementApi`
 //! as well as the implementation to provide convenient interfaces used in the fraud
 //! proof verification.
 
@@ -9,8 +9,8 @@ use sp_api::ProvideRuntimeApi;
 use sp_core::H256;
 use sp_domains::fraud_proof::{ExecutionPhase, InvalidStateTransitionProof, VerificationError};
 use sp_domains::DomainId;
-use sp_receipts::ReceiptsApi;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_settlement::SettlementApi;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -46,7 +46,7 @@ pub trait VerifierApi {
 
 /// A wrapper of primary chain client/system domain client in common.
 ///
-/// Both primary chain client and system domain client maintains the state of receipts, i.e., implements `ReceiptsApi`.
+/// Both primary chain client and system domain client maintains the state of receipts, i.e., implements `SettlementApi`.
 pub struct VerifierClient<Client, Block> {
     client: Arc<Client>,
     _phantom: PhantomData<Block>,
@@ -75,7 +75,7 @@ impl<Client, Block> VerifierApi for VerifierClient<Client, Block>
 where
     Block: BlockT,
     Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-    Client::Api: ReceiptsApi<Block, domain_runtime_primitives::Hash>,
+    Client::Api: SettlementApi<Block, domain_runtime_primitives::Hash>,
 {
     // TODO: It's not necessary to require `pre_state_root` in the proof and then verify, it can
     // be just retrieved by the verifier itself according the execution phase, which requires some

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -51,9 +51,9 @@ sp-domains = { version = "0.1.0", default-features = false, path = "../sp-domain
 sp-inherents = { git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false, version = "4.0.0-dev"}
 sp-objects = { version = "0.1.0", default-features = false, path = "../sp-objects" }
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-sp-receipts = { version = "0.1.0", default-features = false, path = "../sp-receipts" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", default-features = false, path = "../sp-settlement" }
 sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-version = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -107,9 +107,9 @@ std = [
 	"sp-inherents/std",
 	"sp-objects/std",
 	"sp-offchain/std",
-	"sp-receipts/std",
 	"sp-runtime/std",
 	"sp-session/std",
+	"sp-settlement/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -31,7 +31,7 @@ pallet-feeds = { version = "0.1.0", default-features = false, path = "../pallet-
 pallet-grandpa-finality-verifier = { version = "0.1.0", default-features = false, path = "../pallet-grandpa-finality-verifier" }
 pallet-object-store = { version = "0.1.0", default-features = false, path = "../pallet-object-store" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../pallet-offences-subspace" }
-pallet-receipts = { version = "0.1.0", default-features = false, path = "../pallet-receipts" }
+pallet-settlement = { version = "0.1.0", default-features = false, path = "../pallet-settlement" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../pallet-rewards" }
 pallet-runtime-configs = { version = "0.1.0", default-features = false, path = "../pallet-runtime-configs" }
 pallet-subspace = { version = "0.1.0", default-features = false, path = "../pallet-subspace" }
@@ -87,7 +87,7 @@ std = [
 	"pallet-grandpa-finality-verifier/std",
 	"pallet-object-store/std",
 	"pallet-offences-subspace/std",
-	"pallet-receipts/std",
+	"pallet-settlement/std",
 	"pallet-rewards/std",
 	"pallet-runtime-configs/std",
 	"pallet-subspace/std",

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -1,4 +1,4 @@
-use crate::{Block, BlockNumber, Domains, Hash, Receipts, RuntimeCall, UncheckedExtrinsic};
+use crate::{Block, BlockNumber, Domains, Hash, RuntimeCall, Settlement, UncheckedExtrinsic};
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 use sp_consensus_subspace::FarmerPublicKey;
 use sp_domains::fraud_proof::FraudProof;
@@ -82,7 +82,7 @@ pub(crate) fn extract_fraud_proofs(
     extrinsics: Vec<UncheckedExtrinsic>,
     domain_id: DomainId,
 ) -> Vec<FraudProof<BlockNumber, Hash>> {
-    let successful_fraud_proofs = Receipts::successful_fraud_proofs();
+    let successful_fraud_proofs = Settlement::successful_fraud_proofs();
     extrinsics
         .into_iter()
         .filter_map(|uxt| match uxt.function {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -407,7 +407,7 @@ impl pallet_domains::Config for Runtime {
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
 }
 
-impl pallet_receipts::Config for Runtime {
+impl pallet_settlement::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = domain_runtime_primitives::Hash;
     type MaximumReceiptDrift = MaximumReceiptDrift;
@@ -495,7 +495,7 @@ construct_runtime!(
         Feeds: pallet_feeds = 9,
         GrandpaFinalityVerifier: pallet_grandpa_finality_verifier = 10,
         ObjectStore: pallet_object_store = 11,
-        Receipts: pallet_receipts = 15,
+        Settlement: pallet_settlement = 15,
         Domains: pallet_domains = 12,
         RuntimeConfigs: pallet_runtime_configs = 14,
 
@@ -734,7 +734,7 @@ impl_runtime_apis! {
 
     impl sp_receipts::ReceiptsApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<domain_runtime_primitives::Hash> {
-            Receipts::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
+            Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }
 
         fn state_root(
@@ -742,11 +742,11 @@ impl_runtime_apis! {
             domain_block_number: NumberFor<Block>,
             domain_block_hash: Hash,
         ) -> Option<domain_runtime_primitives::Hash> {
-            Receipts::state_root((domain_id, domain_block_number, domain_block_hash))
+            Settlement::state_root((domain_id, domain_block_number, domain_block_hash))
         }
 
         fn primary_hash(domain_id: DomainId, domain_block_number: BlockNumber) -> Option<Hash> {
-            Receipts::primary_hash(domain_id, domain_block_number)
+            Settlement::primary_hash(domain_id, domain_block_number)
         }
 
         fn receipts_pruning_depth() -> BlockNumber {
@@ -831,7 +831,7 @@ impl_runtime_apis! {
             number: NumberFor<Block>,
             domain_hash: domain_runtime_primitives::Hash
         ) -> Option<domain_runtime_primitives::Hash>{
-            Receipts::domain_state_root_at(DomainId::SYSTEM, number, domain_hash)
+            Settlement::domain_state_root_at(DomainId::SYSTEM, number, domain_hash)
         }
 
         fn timestamp() -> Moment{

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -732,7 +732,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_receipts::ReceiptsApi<Block, domain_runtime_primitives::Hash> for Runtime {
+    impl sp_settlement::SettlementApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<domain_runtime_primitives::Hash> {
             Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -59,8 +59,8 @@ sp-domains = { version = "0.1.0", path = "../sp-domains" }
 sp-externalities = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-objects = { version = "0.1.0", path = "../sp-objects" }
 sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-sp-receipts = { version = "0.1.0", path = "../sp-receipts" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", path = "../sp-settlement" }
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-trie = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -70,9 +70,9 @@ use sp_domains::ExecutorApi;
 use sp_externalities::Extensions;
 use sp_objects::ObjectsApi;
 use sp_offchain::OffchainWorkerApi;
-use sp_receipts::ReceiptsApi;
 use sp_runtime::traits::{Block as BlockT, BlockIdTo, NumberFor};
 use sp_session::SessionKeys;
+use sp_settlement::SettlementApi;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
@@ -280,7 +280,7 @@ where
         + TaggedTransactionQueue<Block>
         + ExecutorApi<Block, DomainHash>
         + ObjectsApi<Block>
-        + ReceiptsApi<Block, domain_runtime_primitives::Hash>
+        + SettlementApi<Block, domain_runtime_primitives::Hash>
         + PreValidationObjectApi<Block, domain_runtime_primitives::Hash>
         + SubspaceApi<Block, FarmerPublicKey>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
@@ -534,7 +534,7 @@ where
         + TransactionPaymentApi<Block, Balance>
         + ExecutorApi<Block, DomainHash>
         + ObjectsApi<Block>
-        + ReceiptsApi<Block, domain_runtime_primitives::Hash>
+        + SettlementApi<Block, domain_runtime_primitives::Hash>
         + PreValidationObjectApi<Block, domain_runtime_primitives::Hash>
         + SubspaceApi<Block, FarmerPublicKey>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,

--- a/domains/pallets/domain-registry/Cargo.toml
+++ b/domains/pallets/domain-registry/Cargo.toml
@@ -17,7 +17,7 @@ frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "h
 frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false }
 frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false }
 log = { version = "0.4.17", default-features = false }
-pallet-receipts = { version = "0.1.0", default-features = false, path = "../../../crates/pallet-receipts" }
+pallet-settlement = { version = "0.1.0", default-features = false, path = "../../../crates/pallet-settlement" }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.159", optional = true }
 sp-core = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false }
@@ -41,7 +41,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"log/std",
-	"pallet-receipts/std",
+	"pallet-settlement/std",
 	"scale-info/std",
 	"serde/std",
 	"sp-core/std",

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -62,7 +62,7 @@ mod pallet {
     use frame_support::traits::LockableCurrency;
     use frame_support::PalletError;
     use frame_system::pallet_prelude::*;
-    use pallet_receipts::{Error as PalletReceiptError, FraudProofError};
+    use pallet_settlement::{Error as PalletSettlementError, FraudProofError};
     use sp_core::H256;
     use sp_domain_digests::AsPredigest;
     use sp_domains::bundle_election::ReadBundleElectionParamsError;
@@ -76,7 +76,7 @@ mod pallet {
     use sp_std::vec::Vec;
 
     #[pallet::config]
-    pub trait Config: frame_system::Config + pallet_receipts::Config {
+    pub trait Config: frame_system::Config + pallet_settlement::Config {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
@@ -315,7 +315,7 @@ mod pallet {
         ) -> DispatchResult {
             ensure_none(origin)?;
 
-            pallet_receipts::Pallet::<T>::track_receipts(
+            pallet_settlement::Pallet::<T>::track_receipts(
                 signed_opaque_bundle.domain_id(),
                 signed_opaque_bundle.bundle.receipts.as_slice(),
             )
@@ -339,7 +339,7 @@ mod pallet {
             log::trace!(target: "runtime::domain-registry", "Processing fraud proof: {fraud_proof:?}");
 
             if fraud_proof.domain_id().is_core() {
-                pallet_receipts::Pallet::<T>::process_fraud_proof(fraud_proof)
+                pallet_settlement::Pallet::<T>::process_fraud_proof(fraud_proof)
                     .map_err(Error::<T>::from)?;
             }
 
@@ -361,7 +361,7 @@ mod pallet {
             let mut consumed_weight = Weight::zero();
             for domain_id in Domains::<T>::iter_keys() {
                 for (primary_number, primary_hash) in &primary_block_info {
-                    pallet_receipts::PrimaryBlockHash::<T>::insert(
+                    pallet_settlement::PrimaryBlockHash::<T>::insert(
                         domain_id,
                         primary_number,
                         primary_hash,
@@ -453,13 +453,13 @@ mod pallet {
         BeforeDomainCreation,
     }
 
-    impl<T> From<PalletReceiptError> for Error<T> {
+    impl<T> From<PalletSettlementError> for Error<T> {
         #[inline]
-        fn from(error: PalletReceiptError) -> Self {
+        fn from(error: PalletSettlementError) -> Self {
             match error {
-                PalletReceiptError::MissingParent => Self::Receipt(ReceiptError::MissingParent),
-                PalletReceiptError::FraudProof(err) => Self::FraudProof(err),
-                PalletReceiptError::UnavailablePrimaryBlockHash => {
+                PalletSettlementError::MissingParent => Self::Receipt(ReceiptError::MissingParent),
+                PalletSettlementError::FraudProof(err) => Self::FraudProof(err),
+                PalletSettlementError::UnavailablePrimaryBlockHash => {
                     Self::UnavailablePrimaryBlockHash
                 }
             }
@@ -612,7 +612,8 @@ mod pallet {
                         );
                         return InvalidTransactionCode::FraudProof.into();
                     }
-                    if let Err(e) = pallet_receipts::Pallet::<T>::validate_fraud_proof(fraud_proof)
+                    if let Err(e) =
+                        pallet_settlement::Pallet::<T>::validate_fraud_proof(fraud_proof)
                     {
                         log::debug!(
                             target: "runtime::domain-registry",
@@ -684,12 +685,12 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn head_receipt_number(domain_id: DomainId) -> T::BlockNumber {
-        pallet_receipts::Pallet::<T>::head_receipt_number(domain_id)
+        pallet_settlement::Pallet::<T>::head_receipt_number(domain_id)
     }
 
     /// Returns the block number of the oldest receipt still being tracked in the state.
     pub fn oldest_receipt_number(domain_id: DomainId) -> T::BlockNumber {
-        pallet_receipts::Pallet::<T>::oldest_receipt_number(domain_id)
+        pallet_settlement::Pallet::<T>::oldest_receipt_number(domain_id)
     }
 
     pub fn domain_authorities(domain_id: DomainId) -> Vec<(ExecutorPublicKey, T::StakeWeight)> {
@@ -741,7 +742,7 @@ impl<T: Config> Pallet<T> {
         let bundle = &signed_opaque_bundle.bundle;
 
         let bundle_created_on_valid_primary_block =
-            pallet_receipts::PrimaryBlockHash::<T>::get(domain_id, bundle.header.primary_number)
+            pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, bundle.header.primary_number)
                 .map(|block_hash| block_hash == bundle.header.primary_hash)
                 .unwrap_or(false);
 
@@ -750,7 +751,7 @@ impl<T: Config> Pallet<T> {
                 target: "runtime::domain-registry",
                 "Bundle of {domain_id:?} is probably created on a primary fork #{:?}, expected: {:?}, got: {:?}",
                 bundle.header.primary_number,
-                pallet_receipts::PrimaryBlockHash::<T>::get(domain_id, bundle.header.primary_number),
+                pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, bundle.header.primary_number),
                 bundle.header.primary_hash,
             );
             return Err(Error::BundleCreatedOnUnknownBlock);
@@ -791,13 +792,13 @@ impl<T: Config> Pallet<T> {
                 return Err(Error::<T>::Receipt(ReceiptError::BeforeDomainCreation));
             }
 
-            if !pallet_receipts::Pallet::<T>::point_to_valid_primary_block(domain_id, receipt) {
+            if !pallet_settlement::Pallet::<T>::point_to_valid_primary_block(domain_id, receipt) {
                 log::debug!(
                     target: "runtime::domain-registry",
                     "Receipt of {domain_id:?} #{primary_number:?},{:?} points to an unknown primary block, \
                     expected: #{primary_number:?},{:?}",
                     receipt.primary_hash,
-                    pallet_receipts::PrimaryBlockHash::<T>::get(domain_id, primary_number),
+                    pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, primary_number),
                 );
                 return Err(Error::<T>::Receipt(ReceiptError::UnknownBlock));
             }
@@ -853,7 +854,7 @@ impl<T: Config> Pallet<T> {
 
             let expected_state_root = match maybe_state_root {
                 Some(v) => v,
-                None => pallet_receipts::Pallet::<T>::state_root((
+                None => pallet_settlement::Pallet::<T>::state_root((
                     domain_id,
                     core_block_number,
                     core_block_hash,
@@ -864,7 +865,7 @@ impl<T: Config> Pallet<T> {
                             target: "runtime::domain-registry",
                             "State root for {domain_id:?} #{core_block_number:?},{core_block_hash:?} not found, \
                             current head receipt: {:?}",
-                            pallet_receipts::Pallet::<T>::receipt_head(domain_id),
+                            pallet_settlement::Pallet::<T>::receipt_head(domain_id),
                         );
                         err
                     })?,
@@ -968,7 +969,7 @@ impl<T: Config> Pallet<T> {
 
         let current_block_number = frame_system::Pallet::<T>::block_number();
         CreatedAt::<T>::insert(domain_id, current_block_number);
-        pallet_receipts::Pallet::<T>::initialize_head_receipt_number(
+        pallet_settlement::Pallet::<T>::initialize_head_receipt_number(
             domain_id,
             current_block_number,
         );

--- a/domains/pallets/domain-registry/src/tests.rs
+++ b/domains/pallets/domain-registry/src/tests.rs
@@ -28,7 +28,7 @@ frame_support::construct_runtime!(
         System: frame_system,
         Balances: pallet_balances,
         ExecutorRegistry: pallet_executor_registry,
-        Receipts: pallet_receipts,
+        Settlement: pallet_settlement,
         DomainRegistry: pallet_domain_registry,
     }
 );
@@ -134,7 +134,7 @@ impl pallet_domain_registry::Config for Test {
     type WeightInfo = ();
 }
 
-impl pallet_receipts::Config for Test {
+impl pallet_settlement::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = Hash;
     type MaximumReceiptDrift = MaximumReceiptDrift;

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -17,7 +17,7 @@ pub type TestExternalities = sp_state_machine::TestExternalities<BlakeTwo256>;
 macro_rules! impl_runtime {
     ($runtime:ty, $domain_id:literal) => {
         use crate::mock::{
-            mock_pallet_receipts, AccountId, Balance, MessageId, MockEndpoint, TestExternalities,
+            mock_pallet_settlement, AccountId, Balance, MessageId, MockEndpoint, TestExternalities,
         };
         use crate::relayer::RelayerId;
         use codec::{Encode, Decode};
@@ -42,7 +42,7 @@ macro_rules! impl_runtime {
                 UncheckedExtrinsic = UncheckedExtrinsic,
             {
                 System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-                Receipts: mock_pallet_receipts::{Pallet, Storage},
+                Settlement: mock_pallet_settlement::{Pallet, Storage},
                 Messenger: crate::{Pallet, Call, Event<T>},
                 Balances: pallet_balances::{Pallet, Call, Config<T>, Storage, Event<T>},
                 Transporter: pallet_transporter::{Pallet, Call, Storage, Event<T>},
@@ -86,7 +86,7 @@ macro_rules! impl_runtime {
             pub const RelayerConfirmationDepth: u64 = 2;
         }
 
-        impl mock_pallet_receipts::Config for $runtime {}
+        impl mock_pallet_settlement::Config for $runtime {}
 
         parameter_types! {
             pub const SelfDomainId: DomainId = DomainId::new($domain_id);
@@ -227,7 +227,7 @@ impl EndpointHandler<MessageId> for MockEndpoint {
 
 #[frame_support::pallet]
 #[allow(dead_code)]
-pub(crate) mod mock_pallet_receipts {
+pub(crate) mod mock_pallet_settlement {
     use crate::mock::DomainId;
     use frame_support::pallet_prelude::*;
 

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -510,7 +510,7 @@ fn channel_relay_request_and_response(
     };
     domain_b_test_ext.execute_with(|| {
         // set state root
-        domain_b::Receipts::set_state_root(
+        domain_b::Settlement::set_state_root(
             xdm.src_domain_id,
             xdm.proof.system_domain_block_info.block_number,
             xdm.proof.system_domain_block_info.block_hash,
@@ -579,7 +579,7 @@ fn channel_relay_request_and_response(
         },
     };
     domain_a_test_ext.execute_with(|| {
-        domain_a::Receipts::set_state_root(
+        domain_a::Settlement::set_state_root(
             xdm.src_domain_id,
             xdm.proof.system_domain_block_info.block_number,
             xdm.proof.system_domain_block_info.block_hash,

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -295,7 +295,7 @@ where
     type Query = Option<StateRoot>;
 
     fn module_prefix() -> &'static [u8] {
-        "Receipts".as_ref()
+        "Settlement".as_ref()
     }
 
     fn storage_prefix() -> &'static [u8] {

--- a/domains/runtime/system/Cargo.toml
+++ b/domains/runtime/system/Cargo.toml
@@ -25,7 +25,7 @@ frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 pallet-domain-registry = { version = "0.1.0", path = "../../pallets/domain-registry", default-features = false }
 pallet-executor-registry = { version = "0.1.0", path = "../../pallets/executor-registry", default-features = false }
-pallet-receipts = { version = "0.1.0", path = "../../../crates/pallet-receipts", default-features = false }
+pallet-settlement = { version = "0.1.0", path = "../../../crates/pallet-settlement", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "../../pallets/messenger", default-features = false }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -71,7 +71,7 @@ std = [
 	"pallet-balances/std",
 	"pallet-domain-registry/std",
 	"pallet-executor-registry/std",
-	"pallet-receipts/std",
+	"pallet-settlement/std",
 	"pallet-messenger/std",
 	"pallet-sudo/std",
 	"pallet-transaction-payment/std",

--- a/domains/runtime/system/Cargo.toml
+++ b/domains/runtime/system/Cargo.toml
@@ -40,9 +40,9 @@ sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https:/
 sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger", default-features = false }
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-sp-receipts = { version = "0.1.0", path = "../../../crates/sp-receipts", default-features = false }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", path = "../../../crates/sp-settlement", default-features = false }
 sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-version = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -86,9 +86,9 @@ std = [
 	"sp-io/std",
 	"sp-messenger/std",
 	"sp-offchain/std",
-	"sp-receipts/std",
 	"sp-runtime/std",
 	"sp-session/std",
+	"sp-settlement/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -595,7 +595,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_receipts::ReceiptsApi<Block, domain_runtime_primitives::Hash> for Runtime {
+    impl sp_settlement::SettlementApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<domain_runtime_primitives::Hash> {
             Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }

--- a/domains/runtime/system/src/runtime.rs
+++ b/domains/runtime/system/src/runtime.rs
@@ -294,7 +294,7 @@ impl pallet_domain_registry::Config for Runtime {
     type WeightInfo = pallet_domain_registry::weights::SubstrateWeight<Runtime>;
 }
 
-impl pallet_receipts::Config for Runtime {
+impl pallet_settlement::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = domain_runtime_primitives::Hash;
     type MaximumReceiptDrift = MaximumReceiptDrift;
@@ -310,11 +310,11 @@ pub struct DomainInfo;
 
 impl sp_messenger::endpoint::DomainInfo<BlockNumber, Hash, Hash> for DomainInfo {
     fn domain_best_number(domain_id: DomainId) -> Option<BlockNumber> {
-        Some(Receipts::head_receipt_number(domain_id))
+        Some(Settlement::head_receipt_number(domain_id))
     }
 
     fn domain_state_root(domain_id: DomainId, number: BlockNumber, hash: Hash) -> Option<Hash> {
-        Receipts::domain_state_root_at(domain_id, number, hash)
+        Settlement::domain_state_root_at(domain_id, number, hash)
     }
 }
 
@@ -393,7 +393,7 @@ construct_runtime!(
         // Must be after Balances pallet so that its genesis is built after the Balances genesis is
         // built.
         ExecutorRegistry: pallet_executor_registry = 40,
-        Receipts: pallet_receipts = 41,
+        Settlement: pallet_settlement = 41,
         DomainRegistry: pallet_domain_registry = 42,
 
         // Note: Indexes should be used by all other core domain for proper xdm decode.
@@ -597,7 +597,7 @@ impl_runtime_apis! {
 
     impl sp_receipts::ReceiptsApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<domain_runtime_primitives::Hash> {
-            Receipts::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
+            Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }
 
         fn state_root(
@@ -605,11 +605,11 @@ impl_runtime_apis! {
             domain_block_number: BlockNumber,
             domain_block_hash: Hash,
         ) -> Option<Hash> {
-            Receipts::state_root((domain_id, domain_block_number, domain_block_hash))
+            Settlement::state_root((domain_id, domain_block_number, domain_block_hash))
         }
 
         fn primary_hash(domain_id: DomainId, domain_block_number: BlockNumber) -> Option<Hash> {
-            Receipts::primary_hash(domain_id, domain_block_number)
+            Settlement::primary_hash(domain_id, domain_block_number)
         }
 
         fn receipts_pruning_depth() -> BlockNumber {
@@ -706,7 +706,7 @@ impl_runtime_apis! {
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
             domain_id: DomainId,
         ) -> Vec<FraudProof<NumberFor<Block>, Hash>> {
-            let successful_fraud_proofs = Receipts::successful_fraud_proofs();
+            let successful_fraud_proofs = Settlement::successful_fraud_proofs();
             extrinsics
                 .into_iter()
                 .filter_map(|uxt| match uxt.function {
@@ -726,7 +726,7 @@ impl_runtime_apis! {
         }
 
         fn core_domain_state_root_at(domain_id: DomainId, number: BlockNumber, domain_hash: Hash) -> Option<Hash> {
-            Receipts::domain_state_root_at(domain_id, number, domain_hash)
+            Settlement::domain_state_root_at(domain_id, number, domain_hash)
         }
     }
 
@@ -740,11 +740,11 @@ impl_runtime_apis! {
         }
 
         fn domain_best_number(domain_id: DomainId) -> Option<BlockNumber> {
-            Some(Receipts::head_receipt_number(domain_id))
+            Some(Settlement::head_receipt_number(domain_id))
         }
 
         fn domain_state_root(domain_id: DomainId, number: BlockNumber, hash: Hash) -> Option<Hash>{
-            Receipts::domain_state_root_at(domain_id, number, hash)
+            Settlement::domain_state_root_at(domain_id, number, hash)
         }
 
         fn relayer_assigned_messages(relayer_id: AccountId) -> RelayerMessagesWithStorageKey {

--- a/domains/service/Cargo.toml
+++ b/domains/service/Cargo.toml
@@ -55,9 +55,9 @@ sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/subst
 sp-keystore = { version = "0.13.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-messenger = { version = "0.1.0", path = "../../domains/primitives/messenger" }
 sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-sp-receipts = { version = "0.1.0", path = "../../crates/sp-receipts" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", path = "../../crates/sp-settlement" }
 sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 system-runtime-primitives = { version = "0.1.0", path = "../primitives/system-runtime" }
 subspace-core-primitives = { version = "0.1.0", path = "../../crates/subspace-core-primitives" }

--- a/domains/service/src/core_domain.rs
+++ b/domains/service/src/core_domain.rs
@@ -41,8 +41,8 @@ use sp_core::{Encode, H256};
 use sp_domains::{DomainId, ExecutorApi};
 use sp_messenger::{MessengerApi, RelayerApi};
 use sp_offchain::OffchainWorkerApi;
-use sp_receipts::ReceiptsApi;
 use sp_session::SessionKeys;
+use sp_settlement::SettlementApi;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -367,7 +367,7 @@ where
         + SystemDomainApi<SBlock, NumberFor<PBlock>, PBlock::Hash, Block::Hash>
         + MessengerApi<SBlock, NumberFor<SBlock>>
         + RelayerApi<SBlock, domain_runtime_primitives::AccountId, NumberFor<SBlock>>
-        + ReceiptsApi<SBlock, <Block as BlockT>::Hash>,
+        + SettlementApi<SBlock, <Block as BlockT>::Hash>,
     PClient: HeaderBackend<PBlock>
         + HeaderMetadata<PBlock, Error = sp_blockchain::Error>
         + BlockBackend<PBlock>

--- a/domains/service/src/system_domain.rs
+++ b/domains/service/src/system_domain.rs
@@ -34,8 +34,8 @@ use sp_domains::transaction::PreValidationObjectApi;
 use sp_domains::{DomainId, ExecutorApi};
 use sp_messenger::{MessengerApi, RelayerApi};
 use sp_offchain::OffchainWorkerApi;
-use sp_receipts::ReceiptsApi;
 use sp_session::SessionKeys;
+use sp_settlement::SettlementApi;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
 use subspace_core_primitives::Blake2b256Hash;
@@ -98,7 +98,7 @@ where
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
         + RelayerApi<Block, AccountId, NumberFor<Block>>
-        + ReceiptsApi<Block, Hash>
+        + SettlementApi<Block, Hash>
         + PreValidationObjectApi<Block, Hash>,
 {
     /// Task manager.
@@ -218,7 +218,7 @@ where
         + SystemDomainApi<Block, NumberFor<PBlock>, PBlock::Hash, <Block as BlockT>::Hash>
         + MessengerApi<Block, NumberFor<Block>>
         + ApiExt<Block, StateBackend = StateBackendFor<TFullBackend<Block>, Block>>
-        + ReceiptsApi<Block, Hash>
+        + SettlementApi<Block, Hash>
         + PreValidationObjectApi<Block, Hash>,
     ExecutionDispatch: NativeExecutionDispatch + 'static,
 {
@@ -352,7 +352,7 @@ where
         + Send
         + Sync
         + 'static,
-    PClient::Api: ExecutorApi<PBlock, Hash> + ReceiptsApi<PBlock, Hash>,
+    PClient::Api: ExecutorApi<PBlock, Hash> + SettlementApi<PBlock, Hash>,
     SC: SelectChain<PBlock>,
     IBNS: Stream<Item = (NumberFor<PBlock>, mpsc::Sender<()>)> + Send + 'static,
     CIBNS: Stream<Item = BlockImportNotification<PBlock>> + Send + 'static,
@@ -373,7 +373,7 @@ where
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
         + RelayerApi<Block, AccountId, NumberFor<Block>>
-        + ReceiptsApi<Block, Hash>
+        + SettlementApi<Block, Hash>
         + PreValidationObjectApi<Block, Hash>,
     ExecutorDispatch: NativeExecutionDispatch + 'static,
 {

--- a/domains/test/runtime/system/Cargo.toml
+++ b/domains/test/runtime/system/Cargo.toml
@@ -48,9 +48,9 @@ sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https:/
 sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-messenger = { version = "0.1.0", path = "../../../primitives/messenger", default-features = false }
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-sp-receipts = { version = "0.1.0", path = "../../../../crates/sp-receipts", default-features = false }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", path = "../../../../crates/sp-settlement", default-features = false }
 sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-version = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -86,9 +86,9 @@ std = [
 	"sp-io/std",
 	"sp-messenger/std",
 	"sp-offchain/std",
-	"sp-receipts/std",
 	"sp-runtime/std",
 	"sp-session/std",
+	"sp-settlement/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",

--- a/domains/test/runtime/system/Cargo.toml
+++ b/domains/test/runtime/system/Cargo.toml
@@ -35,7 +35,7 @@ pallet-domain-registry = { version = "0.1.0", path = "../../../pallets/domain-re
 pallet-executor-registry = { version = "0.1.0", path = "../../../pallets/executor-registry", default-features = false }
 pallet-messenger = { version = "0.1.0", path = "../../../pallets/messenger", default-features = false }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-pallet-receipts = { version = "0.1.0", path = "../../../../crates/pallet-receipts", default-features = false }
+pallet-settlement = { version = "0.1.0", path = "../../../../crates/pallet-settlement", default-features = false }
 pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 pallet-transporter = { version = "0.1.0", path = "../../../pallets/transporter", default-features = false }
@@ -74,7 +74,7 @@ std = [
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
 	"pallet-domain-registry/std",
-	"pallet-receipts/std",
+	"pallet-settlement/std",
 	"pallet-messenger/std",
 	"pallet-executor-registry/std",
 	"scale-info/std",

--- a/domains/test/runtime/system/src/runtime.rs
+++ b/domains/test/runtime/system/src/runtime.rs
@@ -317,7 +317,7 @@ impl pallet_domain_registry::Config for Runtime {
     type WeightInfo = pallet_domain_registry::weights::SubstrateWeight<Runtime>;
 }
 
-impl pallet_receipts::Config for Runtime {
+impl pallet_settlement::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = domain_runtime_primitives::Hash;
     type MaximumReceiptDrift = MaximumReceiptDrift;
@@ -352,11 +352,11 @@ pub struct DomainInfo;
 
 impl sp_messenger::endpoint::DomainInfo<BlockNumber, Hash, Hash> for DomainInfo {
     fn domain_best_number(domain_id: DomainId) -> Option<BlockNumber> {
-        Some(Receipts::head_receipt_number(domain_id))
+        Some(Settlement::head_receipt_number(domain_id))
     }
 
     fn domain_state_root(domain_id: DomainId, number: BlockNumber, hash: Hash) -> Option<Hash> {
-        Receipts::domain_state_root_at(domain_id, number, hash)
+        Settlement::domain_state_root_at(domain_id, number, hash)
     }
 }
 
@@ -415,7 +415,7 @@ construct_runtime!(
         // Must be after Balances pallet so that its genesis is built after the Balances genesis is
         // built.
         ExecutorRegistry: pallet_executor_registry,
-        Receipts: pallet_receipts,
+        Settlement: pallet_settlement,
         DomainRegistry: pallet_domain_registry,
 
         // messenger stuff
@@ -611,7 +611,7 @@ impl_runtime_apis! {
 
     impl sp_receipts::ReceiptsApi<Block, Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<Hash> {
-            Receipts::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
+            Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }
 
         fn state_root(
@@ -619,11 +619,11 @@ impl_runtime_apis! {
             domain_block_number: BlockNumber,
             domain_block_hash: Hash,
         ) -> Option<Hash> {
-            Receipts::state_root((domain_id, domain_block_number, domain_block_hash))
+            Settlement::state_root((domain_id, domain_block_number, domain_block_hash))
         }
 
         fn primary_hash(domain_id: DomainId, domain_block_number: BlockNumber) -> Option<Hash> {
-            Receipts::primary_hash(domain_id, domain_block_number)
+            Settlement::primary_hash(domain_id, domain_block_number)
         }
 
         fn receipts_pruning_depth() -> BlockNumber {
@@ -720,7 +720,7 @@ impl_runtime_apis! {
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
             domain_id: DomainId,
         ) -> Vec<FraudProof<NumberFor<Block>, Hash>> {
-            let successful_fraud_proofs = Receipts::successful_fraud_proofs();
+            let successful_fraud_proofs = Settlement::successful_fraud_proofs();
             extrinsics
                 .into_iter()
                 .filter_map(|uxt| match uxt.function {
@@ -740,7 +740,7 @@ impl_runtime_apis! {
         }
 
         fn core_domain_state_root_at(domain_id: DomainId, number: BlockNumber, domain_hash: Hash) -> Option<Hash> {
-            Receipts::domain_state_root_at(domain_id, number, domain_hash)
+            Settlement::domain_state_root_at(domain_id, number, domain_hash)
         }
     }
 
@@ -754,11 +754,11 @@ impl_runtime_apis! {
         }
 
         fn domain_best_number(domain_id: DomainId) -> Option<BlockNumber> {
-            Some(Receipts::head_receipt_number(domain_id))
+            Some(Settlement::head_receipt_number(domain_id))
         }
 
         fn domain_state_root(domain_id: DomainId, number: BlockNumber, hash: Hash) -> Option<Hash>{
-            Receipts::domain_state_root_at(domain_id, number, hash)
+            Settlement::domain_state_root_at(domain_id, number, hash)
         }
 
         fn relayer_assigned_messages(relayer_id: AccountId) -> RelayerMessagesWithStorageKey {

--- a/domains/test/runtime/system/src/runtime.rs
+++ b/domains/test/runtime/system/src/runtime.rs
@@ -609,7 +609,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_receipts::ReceiptsApi<Block, Hash> for Runtime {
+    impl sp_settlement::SettlementApi<Block, Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<Hash> {
             Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -29,7 +29,7 @@ pallet-feeds = { version = "0.1.0", default-features = false, path = "../../crat
 pallet-grandpa-finality-verifier = { version = "0.1.0", default-features = false, path = "../../crates/pallet-grandpa-finality-verifier" }
 pallet-object-store = { version = "0.1.0", default-features = false, path = "../../crates/pallet-object-store" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../../crates/pallet-offences-subspace" }
-pallet-receipts = { version = "0.1.0", default-features = false, path = "../../crates/pallet-receipts" }
+pallet-settlement = { version = "0.1.0", default-features = false, path = "../../crates/pallet-settlement" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../../crates/pallet-rewards" }
 pallet-subspace = { version = "0.1.0", default-features = false, path = "../../crates/pallet-subspace" }
 pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -82,7 +82,7 @@ std = [
 	"pallet-grandpa-finality-verifier/std",
 	"pallet-object-store/std",
 	"pallet-offences-subspace/std",
-	"pallet-receipts/std",
+	"pallet-settlement/std",
 	"pallet-rewards/std",
 	"pallet-subspace/std",
 	"pallet-sudo/std",

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -46,9 +46,9 @@ sp-domains = { version = "0.1.0", default-features = false, path = "../../crates
 sp-inherents = { git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30", default-features = false, version = "4.0.0-dev"}
 sp-objects = { version = "0.1.0", default-features = false, path = "../../crates/sp-objects" }
 sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
-sp-receipts = { version = "0.1.0", default-features = false, path = "../../crates/sp-receipts" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
+sp-settlement = { version = "0.1.0", default-features = false, path = "../../crates/sp-settlement" }
 sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
 sp-version = { version = "5.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "9cf78129a2638d3f370868863d16f4fe32b4ad30" }
@@ -101,8 +101,8 @@ std = [
 	"sp-objects/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
-	"sp-receipts/std",
 	"sp-session/std",
+	"sp-settlement/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -485,7 +485,7 @@ impl pallet_domains::Config for Runtime {
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
 }
 
-impl pallet_receipts::Config for Runtime {
+impl pallet_settlement::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = domain_runtime_primitives::Hash;
     type MaximumReceiptDrift = MaximumReceiptDrift;
@@ -613,7 +613,7 @@ construct_runtime!(
         Feeds: pallet_feeds = 6,
         GrandpaFinalityVerifier: pallet_grandpa_finality_verifier = 13,
         ObjectStore: pallet_object_store = 10,
-        Receipts: pallet_receipts = 14,
+        Settlement: pallet_settlement = 14,
         Domains: pallet_domains = 11,
 
         Vesting: orml_vesting = 7,
@@ -912,7 +912,7 @@ fn extract_fraud_proofs(
     extrinsics: Vec<UncheckedExtrinsic>,
     domain_id: DomainId,
 ) -> Vec<FraudProof<NumberFor<Block>, Hash>> {
-    let successful_fraud_proofs = Receipts::successful_fraud_proofs();
+    let successful_fraud_proofs = Settlement::successful_fraud_proofs();
     extrinsics
         .into_iter()
         .filter_map(|uxt| match uxt.function {
@@ -1144,7 +1144,7 @@ impl_runtime_apis! {
 
     impl sp_receipts::ReceiptsApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<domain_runtime_primitives::Hash> {
-            Receipts::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
+            Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }
 
         fn state_root(
@@ -1152,11 +1152,11 @@ impl_runtime_apis! {
             domain_block_number: NumberFor<Block>,
             domain_block_hash: Hash,
         ) -> Option<domain_runtime_primitives::Hash> {
-            Receipts::state_root((domain_id, domain_block_number, domain_block_hash))
+            Settlement::state_root((domain_id, domain_block_number, domain_block_hash))
         }
 
         fn primary_hash(domain_id: DomainId, domain_block_number: BlockNumber) -> Option<Hash> {
-            Receipts::primary_hash(domain_id, domain_block_number)
+            Settlement::primary_hash(domain_id, domain_block_number)
         }
 
         fn receipts_pruning_depth() -> BlockNumber {
@@ -1241,7 +1241,7 @@ impl_runtime_apis! {
             number: NumberFor<Block>,
             domain_hash: domain_runtime_primitives::Hash
         ) -> Option<domain_runtime_primitives::Hash>{
-            Receipts::domain_state_root_at(DomainId::SYSTEM, number, domain_hash)
+            Settlement::domain_state_root_at(DomainId::SYSTEM, number, domain_hash)
         }
 
         fn timestamp() -> Moment{

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1142,7 +1142,7 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_receipts::ReceiptsApi<Block, domain_runtime_primitives::Hash> for Runtime {
+    impl sp_settlement::SettlementApi<Block, domain_runtime_primitives::Hash> for Runtime {
         fn execution_trace(domain_id: DomainId, receipt_hash: H256) -> Vec<domain_runtime_primitives::Hash> {
             Settlement::receipts(domain_id, receipt_hash).map(|receipt| receipt.trace).unwrap_or_default()
         }


### PR DESCRIPTION
This PR is a pure refactoring by renaming `pallet-receipts` to `pallet-settlement` and `sp-receipts` to `sp-settlement`, which is something I have been thinking about and confirmed during the offsite.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
