### PR TITLE
Fix compact block issue

### DIFF
--- a/crates/sc-subspace-block-relay/src/lib.rs
+++ b/crates/sc-subspace-block-relay/src/lib.rs
@@ -96,11 +96,13 @@ where
     fn build_initial_request(&self) -> Self::Request;
 
     /// Resolves the initial response to produce the protocol units.
-    async fn resolve_initial_response<RequestMsg: From<Self::Request> + Encode + Send + Sync>(
+    async fn resolve_initial_response<Request>(
         &self,
         response: Self::Response,
-        network_peer_handle: &NetworkPeerHandle<RequestMsg>,
-    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>;
+        network_peer_handle: &NetworkPeerHandle,
+    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>
+    where
+        Request: From<Self::Request> + Encode + Send + Sync;
 }
 
 /// The server side of the relay protocol

--- a/crates/sc-subspace-block-relay/src/lib.rs
+++ b/crates/sc-subspace-block-relay/src/lib.rs
@@ -96,12 +96,10 @@ where
     fn build_initial_request(&self) -> Self::Request;
 
     /// Resolves the initial response to produce the protocol units.
-    /// `encoder_fn` needs to be called to generate the request payload
-    /// as part of request/response sequences initiated by the protocol.
-    async fn resolve_initial_response(
+    async fn resolve_initial_response<RequestMsg: From<Self::Request> + Encode + Send + Sync>(
         &self,
         response: Self::Response,
-        network_peer_handle: &NetworkPeerHandle,
+        network_peer_handle: &NetworkPeerHandle<RequestMsg>,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>;
 }
 

--- a/crates/sc-subspace-block-relay/src/protocol/compact_block.rs
+++ b/crates/sc-subspace-block-relay/src/protocol/compact_block.rs
@@ -146,15 +146,14 @@ where
     }
 
     /// Fetches the missing entries from the server
-    async fn resolve_misses<RequestMsg>(
+    async fn resolve_misses<Request>(
         &self,
         compact_response: InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
         context: ResolveContext<ProtocolUnitId, ProtocolUnit>,
-        network_peer_handle: &NetworkPeerHandle<RequestMsg>,
+        network_peer_handle: &NetworkPeerHandle,
     ) -> Result<Vec<Resolved<ProtocolUnitId, ProtocolUnit>>, RelayError>
     where
-        RequestMsg:
-            From<CompactBlockRequest<DownloadUnitId, ProtocolUnitId>> + Encode + Send + Sync,
+        Request: From<CompactBlockRequest<DownloadUnitId, ProtocolUnitId>> + Encode + Send + Sync,
     {
         let ResolveContext {
             mut resolved,
@@ -167,7 +166,7 @@ where
             protocol_unit_ids: local_miss.clone(),
         });
         let response: CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit> =
-            network_peer_handle.request(request).await?;
+            network_peer_handle.request(Request::from(request)).await?;
         let missing_entries_response =
             if let CompactBlockResponse::MissingEntries(response) = response {
                 response
@@ -218,11 +217,14 @@ where
         CompactBlockRequest::Initial
     }
 
-    async fn resolve_initial_response<RequestMsg: From<Self::Request> + Encode + Send + Sync>(
+    async fn resolve_initial_response<Request>(
         &self,
         response: Self::Response,
-        network_peer_handle: &NetworkPeerHandle<RequestMsg>,
-    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError> {
+        network_peer_handle: &NetworkPeerHandle,
+    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>
+    where
+        Request: From<Self::Request> + Encode + Send + Sync,
+    {
         let compact_response = match response {
             CompactBlockResponse::Initial(compact_response) => compact_response,
             _ => return Err(RelayError::UnexpectedInitialResponse),
@@ -247,7 +249,7 @@ where
         let misses = context.local_miss.len();
         let download_unit_id = compact_response.download_unit_id.clone();
         let resolved = self
-            .resolve_misses(compact_response, context, network_peer_handle)
+            .resolve_misses::<Request>(compact_response, context, network_peer_handle)
             .await?;
         trace!(
             target: LOG_TARGET,

--- a/crates/sc-subspace-block-relay/src/protocol/compact_block.rs
+++ b/crates/sc-subspace-block-relay/src/protocol/compact_block.rs
@@ -146,12 +146,16 @@ where
     }
 
     /// Fetches the missing entries from the server
-    async fn resolve_misses(
+    async fn resolve_misses<RequestMsg>(
         &self,
         compact_response: InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
         context: ResolveContext<ProtocolUnitId, ProtocolUnit>,
-        network_peer_handle: &NetworkPeerHandle,
-    ) -> Result<Vec<Resolved<ProtocolUnitId, ProtocolUnit>>, RelayError> {
+        network_peer_handle: &NetworkPeerHandle<RequestMsg>,
+    ) -> Result<Vec<Resolved<ProtocolUnitId, ProtocolUnit>>, RelayError>
+    where
+        RequestMsg:
+            From<CompactBlockRequest<DownloadUnitId, ProtocolUnitId>> + Encode + Send + Sync,
+    {
         let ResolveContext {
             mut resolved,
             local_miss,
@@ -214,10 +218,10 @@ where
         CompactBlockRequest::Initial
     }
 
-    async fn resolve_initial_response(
+    async fn resolve_initial_response<RequestMsg: From<Self::Request> + Encode + Send + Sync>(
         &self,
         response: Self::Response,
-        network_peer_handle: &NetworkPeerHandle,
+        network_peer_handle: &NetworkPeerHandle<RequestMsg>,
     ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError> {
         let compact_response = match response {
             CompactBlockResponse::Initial(compact_response) => compact_response,


### PR DESCRIPTION
Since all the messages hit the same server end point, they need to be wrapped in a common `enum`. The changes from the last PR did not follow this requirement which causes decode failure. This PR fixes the issue

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
