### PR TITLE
Prune the transaction from pool instead of removing it as invalid

### DIFF
--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -536,10 +536,12 @@ impl MockPrimaryNode {
             .await
     }
 
-    /// Remove tx from tx pool
-    pub fn remove_tx_from_tx_pool(&self, tx: &OpaqueExtrinsic) -> Result<(), Box<dyn Error>> {
-        self.transaction_pool
-            .remove_invalid(&[self.transaction_pool.hash_of(tx)]);
+    /// Remove a ready transaction from transaction pool.
+    pub fn prune_tx_from_pool(&self, tx: &OpaqueExtrinsic) -> Result<(), Box<dyn Error>> {
+        self.transaction_pool.pool().prune_known(
+            &BlockId::Hash(self.client.info().best_hash),
+            &[self.transaction_pool.hash_of(tx)],
+        )?;
         self.transaction_pool
             .pool()
             .validated_pool()


### PR DESCRIPTION
All the existing usages of `remove_tx_from_tx_pool` are to remove a ready transaction from the pool if I'm not wrong, this PR refactors it into `prune_tx_from_pool`, removing such transactions using `prune_known` instead of marking them as invalid and causing the same transaction banned.

Close #1399

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
