### PR TITLE
Fix fork choice rule to prefer the heaviest chain

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -69,7 +69,6 @@ use sp_consensus_subspace::{
 use sp_core::H256;
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
 use sp_runtime::traits::One;
-use std::cmp::Ordering;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
@@ -1121,8 +1120,6 @@ where
         .await
         .map_err(|error| ConsensusError::ClientImport(error.to_string()))?;
 
-        let pre_digest = subspace_digest_items.pre_digest;
-
         let parent_weight = if block_number.is_one() {
             0
         } else {
@@ -1136,12 +1133,7 @@ where
                 })?
         };
 
-        let added_weight = calculate_block_weight::<PosTable, _, _>(
-            &pre_digest.solution,
-            pre_digest.slot.into(),
-            &subspace_digest_items.global_randomness,
-        )
-        .map_err(|error| ConsensusError::ClientImport(error.to_string()))?;
+        let added_weight = calculate_block_weight(subspace_digest_items.solution_range);
         let total_weight = parent_weight + added_weight;
 
         let info = self.client.info();
@@ -1175,14 +1167,12 @@ where
         // The fork choice rule is that we pick the heaviest chain (i.e. smallest solution
         // range), if there's a tie we go with the longest chain.
         let fork_choice = {
-            let (last_best, last_best_number) = (info.best_hash, info.best_number);
-
-            let last_best_weight = if &last_best == block.header.parent_hash() {
+            let last_best_weight = if &info.best_hash == block.header.parent_hash() {
                 // the parent=genesis case is already covered for loading parent weight,
                 // so we don't need to cover again here.
                 parent_weight
             } else {
-                aux_schema::load_block_weight(&*self.client, last_best)
+                aux_schema::load_block_weight(&*self.client, info.best_hash)
                     .map_err(|e| ConsensusError::ChainLookup(e.to_string()))?
                     .ok_or_else(|| {
                         ConsensusError::ChainLookup(
@@ -1191,11 +1181,7 @@ where
                     })?
             };
 
-            ForkChoiceStrategy::Custom(match total_weight.cmp(&last_best_weight) {
-                Ordering::Greater => true,
-                Ordering::Equal => block_number > last_best_number,
-                Ordering::Less => false,
-            })
+            ForkChoiceStrategy::Custom(total_weight > last_best_weight)
         };
         block.fork_choice = Some(fork_choice);
 

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -431,14 +431,13 @@ impl PosExtension {
 /// Consensus-related runtime interface
 #[runtime_interface]
 pub trait Consensus {
-    /// Verify whether solution is valid, returns solution distance that is `<= solution_range/2` on
-    /// success.
+    /// Verify whether solution is valid.
     fn verify_solution(
         &mut self,
         solution: WrappedSolution,
         slot: u64,
         params: WrappedVerifySolutionParams<'_>,
-    ) -> Result<SolutionRange, String> {
+    ) -> Result<(), String> {
         use sp_externalities::ExternalitiesExt;
         use subspace_proof_of_space::PosTableType;
 
@@ -453,21 +452,27 @@ pub trait Consensus {
             .0;
 
         match pos_table_type {
-            PosTableType::Chia => subspace_verification::verify_solution::<ChiaTable, _, _>(
-                &solution.0,
-                slot,
-                &params.0,
-                kzg,
-            )
-            .map_err(|error| error.to_string()),
-            PosTableType::Shim => subspace_verification::verify_solution::<ShimTable, _, _>(
-                &solution.0,
-                slot,
-                &params.0,
-                kzg,
-            )
-            .map_err(|error| error.to_string()),
+            PosTableType::Chia => {
+                subspace_verification::verify_solution::<ChiaTable, _, _>(
+                    &solution.0,
+                    slot,
+                    &params.0,
+                    kzg,
+                )
+                .map_err(|error| error.to_string())?;
+            }
+            PosTableType::Shim => {
+                subspace_verification::verify_solution::<ShimTable, _, _>(
+                    &solution.0,
+                    slot,
+                    &params.0,
+                    kzg,
+                )
+                .map_err(|error| error.to_string())?;
+            }
         }
+
+        Ok(())
     }
 }
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -216,8 +216,7 @@ fn valid_header(
         )
         .unwrap();
         let solution_range = solution_distance * 2;
-        let block_weight =
-            calculate_block_weight::<PosTable, _, _>(&solution, slot, &global_randomness).unwrap();
+        let block_weight = calculate_block_weight(solution_range);
 
         let pre_digest = PreDigest {
             slot: slot.into(),
@@ -618,8 +617,9 @@ fn test_header_import_non_canonical_with_equal_block_weight() {
     });
 }
 
+// TODO: This test doesn't actually reorg, but probably should
 #[test]
-fn test_chain_reorg_to_longer_chain() {
+fn test_chain_reorg_to_heavier_chain() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
         let farmer = FarmerParameters::new();


### PR DESCRIPTION
Previously we were deriving block weight from solution quality, which was actually wrong, it should have been derived from corresponding solution range instead.

Also in case node is presented with two forks that have the same weight, it'll now prefer the first block seen, rather the higher block number.


Resolves https://github.com/subspace/subspace/issues/1505

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
