### PR TITLE
Rename BundleHeader to SealedBundleHeader

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -537,11 +537,17 @@ impl<T: Config> Pallet<T> {
 
     fn validate_bundle(
         OpaqueBundle {
-            header,
+            sealed_header,
             receipts,
             extrinsics: _,
         }: &OpaqueBundle<T::BlockNumber, T::Hash, T::DomainHash>,
     ) -> Result<(), BundleError> {
+        if !sealed_header.verify_signature() {
+            return Err(BundleError::BadSignature);
+        }
+
+        let header = &sealed_header.header;
+
         let current_block_number = frame_system::Pallet::<T>::current_block_number();
 
         // Reject the stale bundles so that they can't be used by attacker to occupy the block space without cost.
@@ -570,10 +576,6 @@ impl<T: Config> Pallet<T> {
                     return Err(BundleError::StaleBundle);
                 }
             }
-        }
-
-        if !header.verify_signature() {
-            return Err(BundleError::BadSignature);
         }
 
         let proof_of_election = header.bundle_solution.proof_of_election();
@@ -688,7 +690,7 @@ where
     pub fn submit_bundle_unsigned(
         opaque_bundle: OpaqueBundle<T::BlockNumber, T::Hash, T::DomainHash>,
     ) {
-        let slot = opaque_bundle.header.slot_number;
+        let slot = opaque_bundle.sealed_header.header.slot_number;
         let receipts_count = opaque_bundle.receipts.len();
         let extrincis_count = opaque_bundle.extrinsics.len();
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -7,8 +7,8 @@ use sp_core::{Get, H256, U256};
 use sp_domains::fraud_proof::{ExecutionPhase, FraudProof, InvalidStateTransitionProof};
 use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{
-    create_dummy_bundle_with_receipts_generic, BundleSolution, DomainId, ExecutionReceipt,
-    ExecutorPair, OpaqueBundle, PreliminaryBundleHeader,
+    create_dummy_bundle_with_receipts_generic, BundleHeader, BundleSolution, DomainId,
+    ExecutionReceipt, ExecutorPair, OpaqueBundle,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup, ValidateUnsigned};
@@ -134,7 +134,7 @@ fn create_dummy_bundle(
 
     let execution_receipt = create_dummy_receipt(primary_number, primary_hash);
 
-    let preliminary_bundle_header = PreliminaryBundleHeader {
+    let bundle_header = BundleHeader {
         primary_number,
         primary_hash,
         slot_number: 0u64,
@@ -142,10 +142,10 @@ fn create_dummy_bundle(
         bundle_solution: BundleSolution::dummy(domain_id, pair.public()),
     };
 
-    let signature = pair.sign(preliminary_bundle_header.hash().as_ref());
+    let signature = pair.sign(bundle_header.hash().as_ref());
 
     OpaqueBundle {
-        header: preliminary_bundle_header.into_bundle_header(signature),
+        header: bundle_header.into_sealed_bundle_header(signature),
         receipts: vec![execution_receipt],
         extrinsics: Vec::new(),
     }

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -8,7 +8,7 @@ use sp_domains::fraud_proof::{ExecutionPhase, FraudProof, InvalidStateTransition
 use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{
     create_dummy_bundle_with_receipts_generic, BundleHeader, BundleSolution, DomainId,
-    ExecutionReceipt, ExecutorPair, OpaqueBundle,
+    ExecutionReceipt, ExecutorPair, OpaqueBundle, SealedBundleHeader,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup, ValidateUnsigned};
@@ -134,7 +134,7 @@ fn create_dummy_bundle(
 
     let execution_receipt = create_dummy_receipt(primary_number, primary_hash);
 
-    let bundle_header = BundleHeader {
+    let header = BundleHeader {
         primary_number,
         primary_hash,
         slot_number: 0u64,
@@ -142,10 +142,10 @@ fn create_dummy_bundle(
         bundle_solution: BundleSolution::dummy(domain_id, pair.public()),
     };
 
-    let signature = pair.sign(bundle_header.hash().as_ref());
+    let signature = pair.sign(header.hash().as_ref());
 
     OpaqueBundle {
-        header: bundle_header.into_sealed_bundle_header(signature),
+        sealed_header: SealedBundleHeader::new(header, signature),
         receipts: vec![execution_receipt],
         extrinsics: Vec::new(),
     }

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -1,4 +1,4 @@
-use crate::{BundleHeader, DomainId};
+use crate::{DomainId, SealedBundleHeader};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
@@ -265,9 +265,9 @@ pub struct BundleEquivocationProof<Number, Hash> {
     pub slot: Slot,
     // TODO: Make H256 a generic when bundle equivocation is implemented properly.
     /// The first header involved in the equivocation.
-    pub first_header: BundleHeader<Number, Hash, H256>,
+    pub first_header: SealedBundleHeader<Number, Hash, H256>,
     /// The second header involved in the equivocation.
-    pub second_header: BundleHeader<Number, Hash, H256>,
+    pub second_header: SealedBundleHeader<Number, Hash, H256>,
 }
 
 impl<Number: Clone + From<u32> + Encode, Hash: Clone + Default + Encode>
@@ -284,7 +284,7 @@ impl<Number: Clone + From<u32> + Encode, Hash: Clone + Default + Encode>
     pub fn dummy_at(slot_number: u64) -> Self {
         use sp_application_crypto::UncheckedFrom;
 
-        let dummy_header = BundleHeader {
+        let dummy_header = SealedBundleHeader {
             primary_number: Number::from(0u32),
             primary_hash: Hash::default(),
             slot_number,

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -1,4 +1,4 @@
-use crate::{DomainId, SealedBundleHeader};
+use crate::{BundleHeader, DomainId, SealedBundleHeader};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
@@ -285,14 +285,16 @@ impl<Number: Clone + From<u32> + Encode, Hash: Clone + Default + Encode>
         use sp_application_crypto::UncheckedFrom;
 
         let dummy_header = SealedBundleHeader {
-            primary_number: Number::from(0u32),
-            primary_hash: Hash::default(),
-            slot_number,
-            extrinsics_root: H256::default(),
-            bundle_solution: crate::BundleSolution::dummy(
-                DomainId::SYSTEM,
-                crate::ExecutorPublicKey::unchecked_from([0u8; 32]),
-            ),
+            header: BundleHeader {
+                primary_number: Number::from(0u32),
+                primary_hash: Hash::default(),
+                slot_number,
+                extrinsics_root: H256::default(),
+                bundle_solution: crate::BundleSolution::dummy(
+                    DomainId::SYSTEM,
+                    crate::ExecutorPublicKey::unchecked_from([0u8; 32]),
+                ),
+            },
             signature: crate::ExecutorSignature::unchecked_from([0u8; 64]),
         };
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -177,9 +177,9 @@ pub struct DomainConfig<Hash, Balance, Weight> {
 
 /// Preliminary header of bundle.
 ///
-/// [`PreliminaryBundleHeader`] contains everything of [`BundleHeader`] except for the signature,
+/// [`PreliminaryBundleHeader`] contains everything of [`SealedBundleHeader`] except for the signature,
 /// domain operator needs to sign the hash of [`PreliminaryBundleHeader`] and uses the signature to
-/// assemble the final [`BundleHeader`].
+/// assemble the final [`SealedBundleHeader`].
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct PreliminaryBundleHeader<Number, Hash, DomainHash> {
     /// The block number of primary block at which the bundle was created.
@@ -204,12 +204,12 @@ impl<Number: Encode, Hash: Encode, DomainHash: Encode>
 }
 
 impl<Number, Hash, DomainHash> PreliminaryBundleHeader<Number, Hash, DomainHash> {
-    /// Converts [`PreliminaryBundleHeader`] into [`BundleHeader`].
+    /// Converts [`PreliminaryBundleHeader`] into [`SealedBundleHeader`].
     pub fn into_bundle_header(
         self,
         signature: ExecutorSignature,
-    ) -> BundleHeader<Number, Hash, DomainHash> {
-        BundleHeader {
+    ) -> SealedBundleHeader<Number, Hash, DomainHash> {
+        SealedBundleHeader {
             primary_number: self.primary_number,
             primary_hash: self.primary_hash,
             slot_number: self.slot_number,
@@ -231,7 +231,7 @@ struct PreliminaryBundleHeaderRef<'a, Number, Hash, DomainHash> {
 
 /// Header of bundle.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
-pub struct BundleHeader<Number, Hash, DomainHash> {
+pub struct SealedBundleHeader<Number, Hash, DomainHash> {
     /// The block number of primary block at which the bundle was created.
     pub primary_number: Number,
     /// The hash of primary block at which the bundle was created.
@@ -246,7 +246,9 @@ pub struct BundleHeader<Number, Hash, DomainHash> {
     pub signature: ExecutorSignature,
 }
 
-impl<Number: Encode, Hash: Encode, DomainHash: Encode> BundleHeader<Number, Hash, DomainHash> {
+impl<Number: Encode, Hash: Encode, DomainHash: Encode>
+    SealedBundleHeader<Number, Hash, DomainHash>
+{
     /// Returns the hash of the corresponding preliminary header.
     pub fn pre_hash(&self) -> H256 {
         let preliminary_bundle_header_ref = PreliminaryBundleHeaderRef {
@@ -402,7 +404,7 @@ impl<DomainHash: Default> BundleSolution<DomainHash> {
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct Bundle<Extrinsic, Number, Hash, DomainHash> {
     /// The bundle header.
-    pub header: BundleHeader<Number, Hash, DomainHash>,
+    pub header: SealedBundleHeader<Number, Hash, DomainHash>,
     /// Expected receipts by the primay chain when the bundle was created.
     ///
     /// NOTE: It's fine to `Vec` instead of `BoundedVec` as each bundle is
@@ -526,7 +528,7 @@ where
 {
     use sp_core::crypto::UncheckedFrom;
 
-    let header = BundleHeader {
+    let header = SealedBundleHeader {
         primary_number,
         primary_hash,
         slot_number: 0u64,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -175,13 +175,13 @@ pub struct DomainConfig<Hash, Balance, Weight> {
     pub min_operator_stake: Balance,
 }
 
-/// Preliminary header of bundle.
+/// Unsealed header of bundle.
 ///
-/// [`PreliminaryBundleHeader`] contains everything of [`SealedBundleHeader`] except for the signature,
-/// domain operator needs to sign the hash of [`PreliminaryBundleHeader`] and uses the signature to
+/// [`BundleHeader`] contains everything of [`SealedBundleHeader`] except for the signature,
+/// domain operator needs to sign the hash of [`BundleHeader`] and uses the signature to
 /// assemble the final [`SealedBundleHeader`].
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
-pub struct PreliminaryBundleHeader<Number, Hash, DomainHash> {
+pub struct BundleHeader<Number, Hash, DomainHash> {
     /// The block number of primary block at which the bundle was created.
     pub primary_number: Number,
     /// The hash of primary block at which the bundle was created.
@@ -194,18 +194,16 @@ pub struct PreliminaryBundleHeader<Number, Hash, DomainHash> {
     pub bundle_solution: BundleSolution<DomainHash>,
 }
 
-impl<Number: Encode, Hash: Encode, DomainHash: Encode>
-    PreliminaryBundleHeader<Number, Hash, DomainHash>
-{
-    /// Returns the hash of this preliminary header.
+impl<Number: Encode, Hash: Encode, DomainHash: Encode> BundleHeader<Number, Hash, DomainHash> {
+    /// Returns the hash of this header.
     pub fn hash(&self) -> H256 {
         BlakeTwo256::hash_of(self)
     }
 }
 
-impl<Number, Hash, DomainHash> PreliminaryBundleHeader<Number, Hash, DomainHash> {
-    /// Converts [`PreliminaryBundleHeader`] into [`SealedBundleHeader`].
-    pub fn into_bundle_header(
+impl<Number, Hash, DomainHash> BundleHeader<Number, Hash, DomainHash> {
+    /// Converts [`BundleHeader`] into [`SealedBundleHeader`].
+    pub fn into_sealed_bundle_header(
         self,
         signature: ExecutorSignature,
     ) -> SealedBundleHeader<Number, Hash, DomainHash> {
@@ -221,7 +219,7 @@ impl<Number, Hash, DomainHash> PreliminaryBundleHeader<Number, Hash, DomainHash>
 }
 
 #[derive(Encode)]
-struct PreliminaryBundleHeaderRef<'a, Number, Hash, DomainHash> {
+struct BundleHeaderRef<'a, Number, Hash, DomainHash> {
     primary_number: &'a Number,
     primary_hash: &'a Hash,
     slot_number: u64,
@@ -249,9 +247,9 @@ pub struct SealedBundleHeader<Number, Hash, DomainHash> {
 impl<Number: Encode, Hash: Encode, DomainHash: Encode>
     SealedBundleHeader<Number, Hash, DomainHash>
 {
-    /// Returns the hash of the corresponding preliminary header.
+    /// Returns the hash of the corresponding unsealed header.
     pub fn pre_hash(&self) -> H256 {
-        let preliminary_bundle_header_ref = PreliminaryBundleHeaderRef {
+        let bundle_header_ref = BundleHeaderRef {
             primary_number: &self.primary_number,
             primary_hash: &self.primary_hash,
             slot_number: self.slot_number,
@@ -259,7 +257,7 @@ impl<Number: Encode, Hash: Encode, DomainHash: Encode>
             bundle_solution: &self.bundle_solution,
         };
 
-        BlakeTwo256::hash_of(&preliminary_bundle_header_ref)
+        BlakeTwo256::hash_of(&bundle_header_ref)
     }
 
     /// Returns the hash of this header.

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -697,10 +697,10 @@ async fn test_invalid_transaction_proof_creation_and_verification() {
     let mut bundle_with_bad_extrinsics = maybe_bundle.unwrap();
     bundle_with_bad_extrinsics.extrinsics =
         vec![OpaqueExtrinsic::from_bytes(&transfer_from_one_to_bob.encode()).unwrap()];
-    bundle_with_bad_extrinsics.header.signature = alice
+    bundle_with_bad_extrinsics.sealed_header.signature = alice
         .key
         .pair()
-        .sign(bundle_with_bad_extrinsics.header.pre_hash().as_ref())
+        .sign(bundle_with_bad_extrinsics.sealed_header.pre_hash().as_ref())
         .into();
 
     alice

--- a/domains/client/domain-executor/src/core_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/core_gossip_message_validator.rs
@@ -178,7 +178,7 @@ where
         if bundle_exists {
             Ok(Action::Empty)
         } else {
-            if !bundle.header.verify_signature() {
+            if !bundle.sealed_header.verify_signature() {
                 return Err(Self::Error::BadBundleSignature);
             }
 
@@ -189,7 +189,11 @@ where
             self.gossip_message_validator
                 .validate_bundle_receipts(&bundle.receipts, domain_id)?;
 
-            let at = bundle.header.bundle_solution.creation_block_hash();
+            let at = bundle
+                .sealed_header
+                .header
+                .bundle_solution
+                .creation_block_hash();
 
             self.gossip_message_validator.validate_bundle_transactions(
                 &bundle.extrinsics,

--- a/domains/client/domain-executor/src/domain_bundle_producer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_producer.rs
@@ -237,7 +237,7 @@ where
                 .executor_public_key
                 .clone();
 
-            let (preliminary_bundle_header, receipts, extrinsics) = self
+            let (bundle_header, receipts, extrinsics) = self
                 .domain_bundle_proposer
                 .propose_bundle_at(
                     bundle_solution,
@@ -247,7 +247,7 @@ where
                 )
                 .await?;
 
-            let to_sign = preliminary_bundle_header.hash();
+            let to_sign = bundle_header.hash();
 
             let signature = self
                 .keystore
@@ -274,7 +274,7 @@ where
             })?;
 
             let bundle = Bundle {
-                header: preliminary_bundle_header.into_bundle_header(signature),
+                header: bundle_header.into_sealed_bundle_header(signature),
                 receipts,
                 extrinsics,
             };

--- a/domains/client/domain-executor/src/domain_bundle_producer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_producer.rs
@@ -9,7 +9,9 @@ use sc_client_api::{AuxStore, BlockBackend, ProofProvider};
 use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
-use sp_domains::{Bundle, BundleSolution, DomainId, ExecutorPublicKey, ExecutorSignature};
+use sp_domains::{
+    Bundle, BundleSolution, DomainId, ExecutorPublicKey, ExecutorSignature, SealedBundleHeader,
+};
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, One, Saturating, Zero};
 use sp_runtime::RuntimeAppPublic;
@@ -274,7 +276,7 @@ where
             })?;
 
             let bundle = Bundle {
-                header: bundle_header.into_sealed_bundle_header(signature),
+                sealed_header: SealedBundleHeader::new(bundle_header, signature),
                 receipts,
                 extrinsics,
             };

--- a/domains/client/domain-executor/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-executor/src/domain_bundle_proposer.rs
@@ -8,7 +8,7 @@ use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
 use sp_consensus_slots::Slot;
-use sp_domains::{BundleSolution, PreliminaryBundleHeader};
+use sp_domains::{BundleHeader, BundleSolution};
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, One, Saturating, Zero};
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -35,7 +35,7 @@ impl<Block, Client, PBlock, PClient, TransactionPool> Clone
 }
 
 pub(super) type ProposeBundleOutput<Block, PBlock> = (
-    PreliminaryBundleHeader<NumberFor<PBlock>, <PBlock as BlockT>::Hash, <Block as BlockT>::Hash>,
+    BundleHeader<NumberFor<PBlock>, <PBlock as BlockT>::Hash, <Block as BlockT>::Hash>,
     Vec<ExecutionReceiptFor<PBlock, <Block as BlockT>::Hash>>,
     Vec<<Block as BlockT>::Extrinsic>,
 );
@@ -127,7 +127,7 @@ where
 
         receipts_sanity_check::<Block, PBlock>(&receipts)?;
 
-        let header = PreliminaryBundleHeader {
+        let header = BundleHeader {
             primary_number,
             primary_hash,
             slot_number: slot.into(),

--- a/domains/client/domain-executor/src/gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/gossip_message_validator.rs
@@ -179,7 +179,8 @@ where
         let bundle_is_an_equivocation = false;
 
         if bundle_is_an_equivocation {
-            let equivocation_proof = BundleEquivocationProof::dummy_at(bundle.header.slot_number);
+            let equivocation_proof =
+                BundleEquivocationProof::dummy_at(bundle.sealed_header.header.slot_number);
             let fraud_proof =
                 FraudProof::<ParentChainBlock>::BundleEquivocation(equivocation_proof);
             self.parent_chain.submit_fraud_proof_unsigned(fraud_proof)?;

--- a/domains/client/domain-executor/src/system_gossip_message_validator.rs
+++ b/domains/client/domain-executor/src/system_gossip_message_validator.rs
@@ -125,7 +125,7 @@ where
         if bundle_exists {
             Ok(Action::Empty)
         } else {
-            if !bundle.header.verify_signature() {
+            if !bundle.sealed_header.verify_signature() {
                 return Err(GossipMessageError::BadBundleSignature);
             }
 
@@ -136,7 +136,11 @@ where
             self.gossip_message_validator
                 .validate_bundle_receipts(&bundle.receipts, domain_id)?;
 
-            let at = bundle.header.bundle_solution.creation_block_hash();
+            let at = bundle
+                .sealed_header
+                .header
+                .bundle_solution
+                .creation_block_hash();
 
             self.gossip_message_validator.validate_bundle_transactions(
                 &bundle.extrinsics,

--- a/domains/client/domain-executor/src/tests.rs
+++ b/domains/client/domain-executor/src/tests.rs
@@ -409,15 +409,15 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     let bad_submit_bundle_tx = {
         let mut opaque_bundle = bundle.unwrap();
         for receipt in opaque_bundle.receipts.iter_mut() {
-            if receipt.primary_number == target_bundle.header.primary_number + 1 {
+            if receipt.primary_number == target_bundle.sealed_header.header.primary_number + 1 {
                 assert_eq!(receipt.trace.len(), 3);
                 receipt.trace[mismatch_trace_index] = Default::default();
             }
         }
-        opaque_bundle.header.signature = alice
+        opaque_bundle.sealed_header.signature = alice
             .key
             .pair()
-            .sign(opaque_bundle.header.pre_hash().as_ref())
+            .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
             .into();
         bundle_to_tx(opaque_bundle)
     };
@@ -823,11 +823,11 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
                 });
 
         let mut opaque_bundle = bundle_template.clone();
-        opaque_bundle.header.primary_number = primary_number;
-        opaque_bundle.header.primary_hash = primary_hash;
-        opaque_bundle.header.signature = alice_key
+        opaque_bundle.sealed_header.header.primary_number = primary_number;
+        opaque_bundle.sealed_header.header.primary_hash = primary_hash;
+        opaque_bundle.sealed_header.signature = alice_key
             .pair()
-            .sign(opaque_bundle.header.pre_hash().as_ref())
+            .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
             .into();
         opaque_bundle.receipts = vec![execution_receipt];
 

--- a/domains/pallets/domain-registry/src/lib.rs
+++ b/domains/pallets/domain-registry/src/lib.rs
@@ -724,12 +724,14 @@ impl<T: Config> Pallet<T> {
     fn pre_dispatch_submit_core_bundle(
         opaque_bundle: &OpaqueBundle<T::BlockNumber, T::Hash, T::DomainHash>,
     ) -> Result<(), Error<T>> {
+        let header = &opaque_bundle.sealed_header.header;
+
         let BundleSolution::Core {
             proof_of_election,
             core_block_number,
             core_block_hash,
             core_state_root
-        } = &opaque_bundle.header.bundle_solution else {
+        } = &header.bundle_solution else {
             return Err(Error::<T>::NotCoreDomainBundle);
         };
 
@@ -739,20 +741,18 @@ impl<T: Config> Pallet<T> {
             return Err(Error::<T>::NotCoreDomainBundle);
         }
 
-        let bundle = opaque_bundle;
-
         let bundle_created_on_valid_primary_block =
-            pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, bundle.header.primary_number)
-                .map(|block_hash| block_hash == bundle.header.primary_hash)
+            pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, header.primary_number)
+                .map(|block_hash| block_hash == header.primary_hash)
                 .unwrap_or(false);
 
         if !bundle_created_on_valid_primary_block {
             log::debug!(
                 target: "runtime::domain-registry",
                 "Bundle of {domain_id:?} is probably created on a primary fork #{:?}, expected: {:?}, got: {:?}",
-                bundle.header.primary_number,
-                pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, bundle.header.primary_number),
-                bundle.header.primary_hash,
+                header.primary_number,
+                pallet_settlement::PrimaryBlockHash::<T>::get(domain_id, header.primary_number),
+                header.primary_hash,
             );
             return Err(Error::BundleCreatedOnUnknownBlock);
         }
@@ -762,7 +762,7 @@ impl<T: Config> Pallet<T> {
         let max_allowed = head_receipt_number + T::MaximumReceiptDrift::get();
 
         let mut new_best_number = head_receipt_number;
-        let receipts = &bundle.receipts;
+        let receipts = &opaque_bundle.receipts;
         for receipt in receipts {
             // Non-best receipt
             if receipt.primary_number <= new_best_number {
@@ -840,7 +840,7 @@ impl<T: Config> Pallet<T> {
         let state_root_verifiable = core_block_number <= new_best_number;
 
         if !core_block_number.is_zero() && state_root_verifiable {
-            let maybe_state_root = bundle.receipts.iter().find_map(|receipt| {
+            let maybe_state_root = opaque_bundle.receipts.iter().find_map(|receipt| {
                 receipt.trace.last().and_then(|state_root| {
                     if (receipt.primary_number, receipt.domain_hash)
                         == (core_block_number, *core_block_hash)

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -513,7 +513,7 @@ impl MockPrimaryNode {
             if let RuntimeCall::Domains(pallet_domains::Call::submit_bundle { opaque_bundle }) =
                 ext.function
             {
-                if opaque_bundle.header.slot_number == slot {
+                if opaque_bundle.sealed_header.header.slot_number == slot {
                     return Some(opaque_bundle);
                 }
             }


### PR DESCRIPTION
Applied suggestion from https://github.com/subspace/subspace/pull/1496#discussion_r1220141119, pure renamings. I'm not super happy with the nested `sealed_header.header` honestly, but I don't have a better idea and do agree the maintainability is more important.

- `PreliminaryBundleHeader` => `BundleHeader`
- `BundleHeader` => `SealedBundleHeader`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
