### PR TITLE
Finalize domain block only when the new finalized block is higher than last finalized

### DIFF
--- a/domains/client/domain-executor/src/domain_block_processor.rs
+++ b/domains/client/domain-executor/src/domain_block_processor.rs
@@ -236,17 +236,17 @@ where
         if let Some(to_finalize_block_number) =
             header_number.checked_sub(&self.domain_confirmation_depth)
         {
-            let to_finalize_block_hash =
-                self.client.hash(to_finalize_block_number)?.ok_or_else(|| {
-                    sp_blockchain::Error::Backend(format!(
-                        "Header for #{to_finalize_block_number} not found"
-                    ))
-                })?;
-            self.client
-                .finalize_block(to_finalize_block_hash, None, true)?;
-            tracing::debug!(
-                "Successfully finalized block: #{to_finalize_block_number},{to_finalize_block_hash}"
-            );
+            if to_finalize_block_number > self.client.info().finalized_number {
+                let to_finalize_block_hash =
+                    self.client.hash(to_finalize_block_number)?.ok_or_else(|| {
+                        sp_blockchain::Error::Backend(format!(
+                            "Header for #{to_finalize_block_number} not found"
+                        ))
+                    })?;
+                self.client
+                    .finalize_block(to_finalize_block_hash, None, true)?;
+                tracing::debug!("Successfully finalized block: #{to_finalize_block_number},{to_finalize_block_hash}");
+            }
         }
 
         let mut roots = self.client.runtime_api().intermediate_roots(header_hash)?;


### PR DESCRIPTION
This PR fixes an issue about the domain block finalization, by only attempting to finalize the block when the new finalized block is newer than the last finalized one.  Ref https://github.com/paritytech/substrate/issues/14347

Unsure whether this patch should be backported to the gemini-3d branch and make a new release regarding the gemini-3e around the corner.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
