### PR TITLE
Fix finalization for dev chain

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -45,7 +45,7 @@ use subspace_core_primitives::{BlockNumber, SegmentHeader};
 /// Ideally, we'd decouple pruning from finalization, but it may require invasive changes in
 /// Substrate and is not worth it right now.
 /// https://github.com/paritytech/substrate/discussions/14359
-const FINALIZATION_DEPTH_IN_SEGMENTS: usize = 5;
+pub(crate) const FINALIZATION_DEPTH_IN_SEGMENTS: usize = 5;
 
 fn find_last_archived_block<Block, Client>(
     client: &Client,
@@ -546,7 +546,7 @@ where
                     segment_headers
                         .iter()
                         .flat_map(|(_k, v)| v.iter().rev())
-                        .nth(FINALIZATION_DEPTH_IN_SEGMENTS + 1)
+                        .nth(FINALIZATION_DEPTH_IN_SEGMENTS)
                         .map(|segment_header| segment_header.last_archived_block().number)
                 };
 

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -27,6 +27,7 @@ mod slot_worker;
 #[cfg(test)]
 mod tests;
 
+use crate::archiver::FINALIZATION_DEPTH_IN_SEGMENTS;
 use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream};
 use crate::slot_worker::{SlotWorkerSyncOracle, SubspaceSlotWorker};
 pub use archiver::create_subspace_archiver;
@@ -1276,8 +1277,10 @@ where
         block_importing_notification_stream,
         // TODO: Consider making `confirmation_depth_k` non-zero
         segment_headers: Arc::new(Mutex::new(LruCache::new(
-            NonZeroUsize::new(confirmation_depth_k as usize)
-                .expect("Confirmation depth of zero is not supported"),
+            NonZeroUsize::new(
+                (FINALIZATION_DEPTH_IN_SEGMENTS + 1).max(confirmation_depth_k as usize),
+            )
+            .expect("Confirmation depth of zero is not supported"),
         ))),
         kzg,
     };


### PR DESCRIPTION
Follow-up to https://github.com/subspace/subspace/pull/1541

Turns out in some cases (dev chain) we did not store enough blocks in `segments_header` cache, which resulted in no blocks being finalized.

Also `+ 1` was unnecessary in `.nth()` call because it is 0-indexed already.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
