### PR TITLE
Rename node RPC methods.

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -97,19 +97,19 @@ pub trait SubspaceRpcApi {
     )]
     fn subscribe_archived_segment_header(&self);
 
-    #[method(name = "subspace_recordsRoots")]
+    #[method(name = "subspace_segmentCommitments")]
     async fn segment_commitments(
         &self,
         segment_indexes: Vec<SegmentIndex>,
     ) -> RpcResult<Vec<Option<SegmentCommitment>>>;
 
-    #[method(name = "subspace_SegmentHeaders")]
+    #[method(name = "subspace_segmentHeaders")]
     async fn segment_headers(
         &self,
         segment_indexes: Vec<SegmentIndex>,
     ) -> RpcResult<Vec<Option<SegmentHeader>>>;
 
-    #[method(name = "subspace_Piece", blocking)]
+    #[method(name = "subspace_piece", blocking)]
     fn piece(&self, piece_index: PieceIndex) -> RpcResult<Option<Vec<u8>>>;
 
     #[method(name = "subspace_acknowledgeArchivedSegmentHeader")]

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -129,7 +129,7 @@ impl NodeClient for NodeRpcClient {
     ) -> Result<Vec<Option<SegmentCommitment>>, RpcError> {
         Ok(self
             .client
-            .request("subspace_recordsRoots", rpc_params![&segment_indexes])
+            .request("subspace_segmentCommitments", rpc_params![&segment_indexes])
             .await?)
     }
 
@@ -139,14 +139,14 @@ impl NodeClient for NodeRpcClient {
     ) -> Result<Vec<Option<SegmentHeader>>, RpcError> {
         Ok(self
             .client
-            .request("subspace_SegmentHeaders", rpc_params![&segment_indexes])
+            .request("subspace_segmentHeaders", rpc_params![&segment_indexes])
             .await?)
     }
 
     async fn piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, RpcError> {
         let result: Option<Vec<u8>> = self
             .client
-            .request("subspace_Piece", rpc_params![&piece_index])
+            .request("subspace_piece", rpc_params![&piece_index])
             .await?;
 
         if let Some(bytes) = result {


### PR DESCRIPTION
This PR changes RPC for nodes and farmers:
- subspace_recordsRoots -> subspace_segmentCommitments 
- subspace_SegmentHeaders -> subspace_segmentHeaders
- subspace_Piece -> subspace_piece

Fixes https://github.com/subspace/subspace/issues/1545

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
