### PR TITLE
Update rust-libp2p version to crates v0.51.3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4289,7 +4289,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4621,7 +4621,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-util",
  "tracing",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4829,71 +4829,28 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.10",
  "instant",
- "libp2p-allow-block-list 0.1.1",
- "libp2p-connection-limits 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.39.2",
- "libp2p-dns 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-identify 0.42.2",
- "libp2p-identity 0.1.2",
- "libp2p-kad 0.43.3",
- "libp2p-mdns 0.43.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-metrics 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-noise 0.42.2",
- "libp2p-ping 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-quic 0.7.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-request-response 0.24.1",
- "libp2p-swarm 0.42.2",
- "libp2p-tcp 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-wasm-ext",
- "libp2p-webrtc 0.4.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-websocket 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-yamux 0.43.1",
- "multiaddr",
- "pin-project",
-]
-
-[[package]]
-name = "libp2p"
-version = "0.51.3"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "getrandom 0.2.10",
- "instant",
- "libp2p-allow-block-list 0.1.0",
- "libp2p-connection-limits 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-core 0.39.1",
- "libp2p-dns 0.39.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
  "libp2p-gossipsub",
- "libp2p-identify 0.42.1",
- "libp2p-identity 0.1.1",
- "libp2p-kad 0.43.2",
- "libp2p-mdns 0.43.1 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-metrics 0.12.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-noise 0.42.1",
- "libp2p-ping 0.42.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-quic 0.7.0-alpha.3 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-request-response 0.24.0",
- "libp2p-swarm 0.42.1",
- "libp2p-tcp 0.39.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-webrtc 0.4.0-alpha.4 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-websocket 0.41.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-yamux 0.43.0",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-wasm-ext",
+ "libp2p-webrtc",
+ "libp2p-websocket",
+ "libp2p-yamux",
  "multiaddr",
  "pin-project",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
- "void",
 ]
 
 [[package]]
@@ -4902,9 +4859,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
 dependencies = [
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm 0.42.2",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "void",
 ]
 
@@ -4914,48 +4871,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
 dependencies = [
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm 0.42.2",
- "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
- "void",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.39.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-identity 0.1.1",
- "log",
- "multiaddr",
- "multihash 0.17.0",
- "multistream-select 0.12.1 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "once_cell",
- "parking_lot 0.12.1",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "serde",
- "smallvec",
- "thiserror",
- "unsigned-varint",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "void",
 ]
 
@@ -4970,17 +4888,18 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-identity 0.1.2",
+ "libp2p-identity",
  "log",
  "multiaddr",
  "multihash 0.17.0",
- "multistream-select 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
- "rw-stream-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rw-stream-sink",
+ "serde",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -4994,21 +4913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
 dependencies = [
  "futures",
- "libp2p-core 0.39.2",
- "log",
- "parking_lot 0.12.1",
- "smallvec",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.39.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "futures",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "smallvec",
@@ -5017,24 +4922,26 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.44.3"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
+version = "0.44.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b34b6da8165c0bde35c82db8efda39b824776537e73973549e76cadb3a77c5"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.2",
  "byteorder",
  "bytes",
+ "either",
  "fnv",
  "futures",
  "hex_fmt",
  "instant",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "log",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -5042,28 +4949,8 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unsigned-varint",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.42.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "asynchronous-codec",
- "either",
- "futures",
- "futures-timer",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
- "log",
- "lru 0.10.0",
- "quick-protobuf",
- "quick-protobuf-codec 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "smallvec",
- "thiserror",
  "void",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -5076,34 +4963,16 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm 0.42.2",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "log",
  "lru 0.10.0",
  "quick-protobuf",
- "quick-protobuf-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-protobuf-codec",
  "smallvec",
  "thiserror",
  "void",
-]
-
-[[package]]
-name = "libp2p-identity"
-version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "bs58",
- "ed25519-dalek",
- "log",
- "multiaddr",
- "multihash 0.17.0",
- "quick-protobuf",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.7",
- "thiserror",
- "zeroize",
 ]
 
 [[package]]
@@ -5119,37 +4988,10 @@ dependencies = [
  "multihash 0.17.0",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.7",
  "thiserror",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.43.2"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "arrayvec 0.7.3",
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
- "log",
- "quick-protobuf",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.7",
- "smallvec",
- "thiserror",
- "uint",
- "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -5166,12 +5008,13 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm 0.42.2",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.7",
  "smallvec",
  "thiserror",
@@ -5189,29 +5032,9 @@ dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm 0.42.2",
- "log",
- "rand 0.8.5",
- "smallvec",
- "socket2 0.4.9",
- "tokio",
- "trust-dns-proto",
- "void",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.43.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "data-encoding",
- "futures",
- "if-watch",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5227,49 +5050,13 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
- "libp2p-core 0.39.2",
- "libp2p-identify 0.42.2",
- "libp2p-kad 0.43.3",
- "libp2p-ping 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.42.2",
- "prometheus-client",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.12.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "libp2p-core 0.39.1",
+ "libp2p-core",
  "libp2p-gossipsub",
- "libp2p-identify 0.42.1",
- "libp2p-identity 0.1.1",
- "libp2p-kad 0.43.2",
- "libp2p-ping 0.42.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "libp2p-swarm 0.42.1",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-ping",
+ "libp2p-swarm",
  "prometheus-client",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.42.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "bytes",
- "curve25519-dalek 3.2.0",
- "futures",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "log",
- "once_cell",
- "quick-protobuf",
- "rand 0.8.5",
- "sha2 0.10.7",
- "snow",
- "static_assertions",
- "thiserror",
- "x25519-dalek 1.1.1",
- "zeroize",
 ]
 
 [[package]]
@@ -5281,8 +5068,8 @@ dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
+ "libp2p-core",
+ "libp2p-identity",
  "log",
  "once_cell",
  "quick-protobuf",
@@ -5305,25 +5092,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
- "libp2p-swarm 0.42.2",
- "log",
- "rand 0.8.5",
- "void",
-]
-
-[[package]]
-name = "libp2p-ping"
-version = "0.42.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "either",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
  "rand 0.8.5",
  "void",
@@ -5339,9 +5109,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
  "quinn-proto",
@@ -5349,42 +5119,6 @@ dependencies = [
  "rustls 0.20.8",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.7.0-alpha.3"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-tls 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "log",
- "parking_lot 0.12.1",
- "quinn-proto",
- "rand 0.8.5",
- "rustls 0.20.8",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "libp2p-request-response"
-version = "0.24.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "async-trait",
- "futures",
- "instant",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm 0.42.1",
- "rand 0.8.5",
- "smallvec",
 ]
 
 [[package]]
@@ -5396,31 +5130,11 @@ dependencies = [
  "async-trait",
  "futures",
  "instant",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm 0.42.2",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.42.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-swarm-derive 0.32.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "log",
- "rand 0.8.5",
- "smallvec",
- "tokio",
- "void",
 ]
 
 [[package]]
@@ -5434,9 +5148,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-swarm-derive 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm-derive",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5456,16 +5170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-swarm-derive"
-version = "0.32.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "heck",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
 name = "libp2p-tcp"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5475,23 +5179,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.39.2",
- "log",
- "socket2 0.4.9",
- "tokio",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.39.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
+ "libp2p-core",
  "log",
  "socket2 0.4.9",
  "tokio",
@@ -5505,32 +5193,14 @@ checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
+ "libp2p-core",
+ "libp2p-identity",
  "rcgen 0.10.0",
  "ring",
  "rustls 0.20.8",
  "thiserror",
  "webpki 0.22.0",
  "x509-parser 0.14.0",
- "yasna",
-]
-
-[[package]]
-name = "libp2p-tls"
-version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "futures",
- "futures-rustls",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "rcgen 0.10.0",
- "ring",
- "rustls 0.20.8",
- "thiserror",
- "webpki 0.22.0",
- "x509-parser 0.15.0",
  "yasna",
 ]
 
@@ -5542,7 +5212,7 @@ checksum = "77dff9d32353a5887adb86c8afc1de1a94d9e8c3bc6df8b2201d7cdf5c848f43"
 dependencies = [
  "futures",
  "js-sys",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5561,47 +5231,16 @@ dependencies = [
  "futures-timer",
  "hex",
  "if-watch",
- "libp2p-core 0.39.2",
- "libp2p-identity 0.1.2",
- "libp2p-noise 0.42.2",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-noise",
  "log",
  "multihash 0.17.0",
  "quick-protobuf",
- "quick-protobuf-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "rcgen 0.9.3",
  "serde",
- "stun",
- "thiserror",
- "tinytemplate",
- "tokio",
- "tokio-util",
- "webrtc",
-]
-
-[[package]]
-name = "libp2p-webrtc"
-version = "0.4.0-alpha.4"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "async-trait",
- "asynchronous-codec",
- "bytes",
- "futures",
- "futures-timer",
- "hex",
- "if-watch",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "libp2p-noise 0.42.1",
- "log",
- "multihash 0.17.0",
- "quick-protobuf",
- "quick-protobuf-codec 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "rand 0.8.5",
- "rcgen 0.9.3",
- "serde",
- "sha2 0.10.7",
  "stun",
  "thiserror",
  "tinytemplate",
@@ -5619,45 +5258,14 @@ dependencies = [
  "either",
  "futures",
  "futures-rustls",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "log",
  "parking_lot 0.12.1",
  "quicksink",
- "rw-stream-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "libp2p-websocket"
-version = "0.41.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "either",
- "futures",
- "futures-rustls",
- "libp2p-core 0.39.1",
- "libp2p-identity 0.1.1",
- "log",
- "parking_lot 0.12.1",
- "quicksink",
- "rw-stream-sink 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
- "soketto",
- "url",
- "webpki-roots 0.23.1",
-]
-
-[[package]]
-name = "libp2p-yamux"
-version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "futures",
- "libp2p-core 0.39.1",
- "log",
- "thiserror",
- "yamux",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5667,7 +5275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
 dependencies = [
  "futures",
- "libp2p-core 0.39.2",
+ "libp2p-core",
  "log",
  "thiserror",
  "yamux",
@@ -6211,19 +5819,6 @@ name = "multistream-select"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.12.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
 dependencies = [
  "bytes",
  "futures",
@@ -7893,18 +7488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-protobuf-codec"
-version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
 name = "quicksink"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8471,16 +8054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rw-stream-sink"
-version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d#3c5940aeadb9ed8527b6f7aa158797359085293d"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8593,7 +8166,7 @@ dependencies = [
  "clap",
  "fdlimit",
  "futures",
- "libp2p-identity 0.1.2",
+ "libp2p-identity",
  "log",
  "names",
  "parity-scale-codec",
@@ -8683,7 +8256,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-identity 0.1.2",
+ "libp2p-identity",
  "log",
  "mockall",
  "parking_lot 0.12.1",
@@ -8904,7 +8477,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "ip_network",
- "libp2p 0.51.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p",
  "linked_hash_set",
  "log",
  "lru 0.10.0",
@@ -8943,7 +8516,7 @@ dependencies = [
  "async-channel",
  "cid",
  "futures",
- "libp2p-identity 0.1.2",
+ "libp2p-identity",
  "log",
  "prost",
  "prost-build",
@@ -8967,7 +8540,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "libp2p-identity 0.1.2",
+ "libp2p-identity",
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
@@ -8991,7 +8564,7 @@ dependencies = [
  "ahash 0.8.3",
  "futures",
  "futures-timer",
- "libp2p 0.51.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p",
  "log",
  "lru 0.10.0",
  "sc-network",
@@ -9009,7 +8582,7 @@ dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
  "futures",
- "libp2p-identity 0.1.2",
+ "libp2p-identity",
  "log",
  "parity-scale-codec",
  "prost",
@@ -9034,7 +8607,7 @@ dependencies = [
  "fork-tree",
  "futures",
  "futures-timer",
- "libp2p 0.51.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p",
  "log",
  "lru 0.10.0",
  "mockall",
@@ -9064,7 +8637,7 @@ source = "git+https://github.com/subspace/substrate?rev=28e33f78a3aa8ac4c6753108
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
- "libp2p 0.51.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p",
  "log",
  "parity-scale-codec",
  "sc-network",
@@ -9087,7 +8660,7 @@ dependencies = [
  "futures-timer",
  "hyper",
  "hyper-rustls 0.24.0",
- "libp2p 0.51.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
@@ -9357,7 +8930,7 @@ source = "git+https://github.com/subspace/substrate?rev=28e33f78a3aa8ac4c6753108
 dependencies = [
  "chrono",
  "futures",
- "libp2p 0.51.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p",
  "log",
  "parking_lot 0.12.1",
  "pin-project",
@@ -11253,7 +10826,7 @@ dependencies = [
  "event-listener-primitives",
  "futures",
  "hex",
- "libp2p 0.51.3 (git+https://github.com/libp2p/rust-libp2p?rev=3c5940aeadb9ed8527b6f7aa158797359085293d)",
+ "libp2p",
  "lru 0.10.0",
  "nohash-hasher",
  "parity-db",
@@ -13188,15 +12761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki",
-]
-
-[[package]]
 name = "webrtc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13739,23 +13303,6 @@ checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs 0.5.2",
  "base64 0.13.1",
- "data-encoding",
- "der-parser 8.2.0",
- "lazy_static",
- "nom",
- "oid-registry 0.6.1",
- "rusticata-macros",
- "thiserror",
- "time 0.3.22",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
-dependencies = [
- "asn1-rs 0.5.2",
  "data-encoding",
  "der-parser 8.2.0",
  "lazy_static",

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -425,7 +425,7 @@ fn derive_libp2p_keypair(schnorrkel_sk: &schnorrkel::SecretKey) -> Keypair {
     let mut secret_bytes = Zeroizing::new(schnorrkel_sk.to_ed25519_bytes());
 
     let keypair = ed25519::Keypair::from(
-        ed25519::SecretKey::from_bytes(&mut secret_bytes.as_mut()[..32])
+        ed25519::SecretKey::try_from_bytes(&mut secret_bytes.as_mut()[..32])
             .expect("Secret key is exactly 32 bytes in size; qed"),
     );
 

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -48,8 +48,7 @@ unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_code
 void = "1.0.2"
 
 [dependencies.libp2p]
-git = "https://github.com/libp2p/rust-libp2p"
-rev = "3c5940aeadb9ed8527b6f7aa158797359085293d"
+version = "0.51.3"
 default-features = false
 features = [
     "dns",

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -31,7 +31,7 @@ async fn main() {
             allow_non_global_addresses_in_dht: true,
             ..Config::default()
         };
-        let keypair = config.keypair.clone().into_ed25519().unwrap();
+        let keypair = config.keypair.clone().try_into_ed25519().unwrap();
 
         let (node, mut node_runner) = subspace_networking::create(config).unwrap();
 
@@ -104,7 +104,7 @@ async fn main() {
     node.wait_for_connected_peers().await.unwrap();
 
     // Prepare multihash to look for in Kademlia
-    let key = Code::Identity.digest(&expected_kaypair.public().encode());
+    let key = Code::Identity.digest(&expected_kaypair.public().to_bytes());
 
     let peers = node
         .get_closest_peers(key)

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -90,7 +90,7 @@ impl Display for KeypairOutput {
 impl KeypairOutput {
     fn new(keypair: Keypair) -> Self {
         Self {
-            keypair: hex::encode(keypair.encode()),
+            keypair: hex::encode(keypair.to_bytes()),
             peer_id: peer_id_from_keypair(keypair).to_base58(),
         }
     }
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<()> {
             let converted_cache_size =
                 NonZeroUsize::new(recs as usize).ok_or_else(|| anyhow!("Incorrect cache size."))?;
 
-            let decoded_keypair = Keypair::decode(hex::decode(keypair)?.as_mut_slice())?;
+            let decoded_keypair = Keypair::try_from_bytes(hex::decode(keypair)?.as_mut_slice())?;
             let local_peer_id = peer_id_from_keypair(decoded_keypair.clone());
             let keypair = identity::Keypair::from(decoded_keypair);
 

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -30,7 +30,7 @@ use libp2p::kad::{
 use libp2p::metrics::Metrics;
 use libp2p::multiaddr::Protocol;
 use libp2p::swarm::SwarmBuilder;
-use libp2p::yamux::YamuxConfig;
+use libp2p::yamux::Config as YamuxConfig;
 use libp2p::{identity, Multiaddr, PeerId, TransportError};
 use parking_lot::Mutex;
 use std::borrow::Cow;

--- a/crates/subspace-networking/src/request_responses/tests.rs
+++ b/crates/subspace-networking/src/request_responses/tests.rs
@@ -40,14 +40,10 @@ fn build_swarm(
 ) -> (Swarm<RequestResponsesBehaviour>, Multiaddr) {
     let keypair = Keypair::generate_ed25519();
 
-    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
-        .into_authentic(&keypair)
-        .unwrap();
-
-    let transport = MemoryTransport::default()
+    let transport = MemoryTransport::new()
         .upgrade(upgrade::Version::V1)
-        .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(libp2p::yamux::YamuxConfig::default())
+        .authenticate(noise::Config::new(&keypair).unwrap())
+        .multiplex(libp2p::yamux::Config::default())
         .boxed();
 
     let configs = list


### PR DESCRIPTION
This PR changes libp2p version to the crates.io version v0.51.3 similar to substrate version of libp2p.

While the commit version is the same the PR changes some obsolete code parts to get rid of `deprecated` warnings.

Fixes https://github.com/subspace/subspace/issues/1553

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
