### PR TITLE
Fix for sync issue

### DIFF
--- a/crates/sc-subspace-block-relay/src/utils.rs
+++ b/crates/sc-subspace-block-relay/src/utils.rs
@@ -125,6 +125,9 @@ pub(crate) enum RelayError {
     #[error("Block body: {0}")]
     BlockBody(String),
 
+    #[error("Block extrinsics not found: {0}")]
+    BlockExtrinsicsNotFound(String),
+
     #[error("Unexpected number of resolved entries: {expected}, {actual}")]
     ResolveMismatch { expected: usize, actual: usize },
 


### PR DESCRIPTION
Issue: Block relay implementation assumes that pruned blocks won't be found by the backend APIs. But some of the APIs (like `client.header()`) return a valid value. While others like`client.block_body()` return success, but with empty list of extrinsics. This leads the server to return empty blocks.

Fix: drop requests for blocks with empty extrinsics. This is consistent with the substrate block handler.

https://github.com/subspace/subspace/issues/1562
### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
