### PR TITLE
Refactor sync from DSN

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -357,6 +357,10 @@ fn finalize_block<Block, Backend, Client>(
     Backend: BackendT<Block>,
     Client: LockImportRun<Block, Backend> + Finalizer<Block, Backend>,
 {
+    if number.is_zero() {
+        // Block zero is finalized already and generates unnecessary warning if called again
+        return;
+    }
     // We don't have anything useful to do with this result yet, the only source of errors was
     // logged already inside
     let _result: Result<_, sp_blockchain::Error> = client.lock_import_and_run(|import_op| {

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -23,7 +23,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::{BootstrappedNetworkingParameters, Config, PieceByHashRequestHandler};
-use subspace_service::dsn::import_blocks::import_blocks;
+use subspace_service::dsn::import_blocks::initial_block_import_from_dsn;
 
 /// The `import-blocks-from-network` command used to import blocks from Subspace Network DSN.
 #[derive(Debug, Parser)]
@@ -86,7 +86,8 @@ impl ImportBlocksFromDsnCmd {
         // Repeat until no new blocks are imported
         loop {
             let new_imported_blocks =
-                import_blocks(&node, Arc::clone(&client), &mut import_queue, false).await?;
+                initial_block_import_from_dsn(&node, Arc::clone(&client), &mut import_queue, false)
+                    .await?;
 
             if new_imported_blocks == 0 {
                 break;

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -19,8 +19,10 @@ mod segment_headers;
 
 use crate::dsn::import_blocks::piece_validator::SegmentCommitmentPieceValidator;
 use crate::dsn::import_blocks::segment_headers::SegmentHeaderHandler;
+use futures::FutureExt;
 use parity_scale_codec::Encode;
 use sc_client_api::{BlockBackend, HeaderBackend};
+use sc_consensus::import_queue::ImportQueueService;
 use sc_consensus::{BlockImportError, BlockImportStatus, IncomingBlock, Link};
 use sc_service::ImportQueue;
 use sc_tracing::tracing::{debug, info, trace};
@@ -81,23 +83,99 @@ impl<B: BlockT> Link<B> for WaitLink<B> {
 /// requires [`ImportQueue`] as a dependency.
 ///
 /// Returns number of imported blocks.
-pub async fn initial_block_import_from_dsn<B, IQ, C>(
+pub async fn initial_block_import_from_dsn<Block, IQ, Client>(
     node: &Node,
-    client: Arc<C>,
+    client: Arc<Client>,
     import_queue: &mut IQ,
     force: bool,
 ) -> Result<u64, sc_service::Error>
 where
-    C: HeaderBackend<B> + BlockBackend<B> + Send + Sync + 'static,
-    B: BlockT,
-    IQ: ImportQueue<B> + 'static,
+    Block: BlockT,
+    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+    IQ: ImportQueue<Block> + 'static,
+{
+    let mut link = WaitLink::new();
+    let mut import_queue_service = import_queue.service();
+
+    let import_blocks_fut =
+        import_blocks_from_dsn(node, client.as_ref(), import_queue_service.as_mut(), force);
+    let drive_import_queue_fut = async {
+        let mut last_imported_blocks = link.imported_blocks;
+        loop {
+            futures::future::poll_fn(|ctx| {
+                import_queue.poll_actions(ctx, &mut link);
+
+                if last_imported_blocks == link.imported_blocks && link.error.is_none() {
+                    // Nothing changed yet, wait for waker to be called
+                    Poll::Pending
+                } else {
+                    last_imported_blocks = link.imported_blocks;
+                    Poll::Ready(())
+                }
+            })
+            .await;
+
+            if let Some(WaitLinkError { error, hash }) = &link.error {
+                return Err::<(), sc_service::Error>(sc_service::Error::Other(format!(
+                    "Stopping block import after #{} blocks on {} because of an error: {}",
+                    link.imported_blocks, hash, error
+                )));
+            }
+        }
+    };
+
+    let downloaded_blocks = futures::select! {
+        maybe_downloaded_blocks = import_blocks_fut.fuse() => {
+            maybe_downloaded_blocks?
+        }
+        result = drive_import_queue_fut.fuse() => {
+            if let Err(error) = result {
+                return Err(error);
+            } else {
+                unreachable!();
+            }
+        }
+    };
+
+    while link.imported_blocks < downloaded_blocks {
+        futures::future::poll_fn(|ctx| {
+            import_queue.poll_actions(ctx, &mut link);
+
+            Poll::Ready(())
+        })
+        .await;
+
+        if let Some(WaitLinkError { error, hash }) = &link.error {
+            return Err(sc_service::Error::Other(format!(
+                "Stopping block import after #{} blocks on {} because of an error: {}",
+                link.imported_blocks, hash, error
+            )));
+        }
+    }
+
+    Ok(downloaded_blocks)
+}
+
+/// Starts the process of importing blocks.
+///
+/// Returns number of downloaded blocks.
+pub async fn import_blocks_from_dsn<Block, IQS, Client>(
+    node: &Node,
+    client: &Client,
+    import_queue_service: &mut IQS,
+    force: bool,
+) -> Result<u64, sc_service::Error>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+    IQS: ImportQueueService<Block> + ?Sized,
 {
     // TODO: Consider introducing and using global in-memory segment header cache (this comment is
     //  in multiple files)
     let segment_commitments = SegmentHeaderHandler::new(node.clone())
         .get_segment_headers()
         .await
-        .map_err(|error| sc_service::Error::Other(error.to_string()))?
+        .map_err(|error| error.to_string())?
         .iter()
         .map(SegmentHeader::segment_commitment)
         .collect::<Vec<_>>();
@@ -116,10 +194,8 @@ where
     debug!("Connected to peers.");
 
     let best_block_number = client.info().best_number;
-    let mut link = WaitLink::new();
-    let mut imported_blocks = 0;
-    let mut reconstructor =
-        Reconstructor::new().map_err(|error| sc_service::Error::Other(error.to_string()))?;
+    let mut downloaded_blocks = 0;
+    let mut reconstructor = Reconstructor::new().map_err(|error| error.to_string())?;
 
     // Skip the first segment, everyone has it locally
     for segment_index in (SegmentIndex::ZERO..).take(segments_found).skip(1) {
@@ -131,8 +207,7 @@ where
         for piece_index in pieces_indices {
             let maybe_piece = piece_provider
                 .get_piece(piece_index, RetryPolicy::Limited(0))
-                .await
-                .map_err(|error| sc_service::Error::Other(error.to_string()))?;
+                .await?;
 
             trace!(
                 ?piece_index,
@@ -157,7 +232,7 @@ where
 
         let reconstructed_contents = reconstructor
             .add_segment(segment_pieces.as_ref())
-            .map_err(|error| sc_service::Error::Other(error.to_string()))?;
+            .map_err(|error| error.to_string())?;
 
         for (block_number, block_bytes) in reconstructed_contents.blocks {
             {
@@ -181,16 +256,16 @@ where
                 }
             }
 
-            let block = B::decode(&mut block_bytes.as_slice())
-                .map_err(|error| sc_service::Error::Other(error.to_string()))?;
+            let block =
+                Block::decode(&mut block_bytes.as_slice()).map_err(|error| error.to_string())?;
 
             let (header, extrinsics) = block.deconstruct();
             let hash = header.hash();
 
             // import queue handles verification and importing it into the client.
-            import_queue.service_ref().import_blocks(
+            import_queue_service.import_blocks(
                 BlockOrigin::NetworkInitialSync,
-                vec![IncomingBlock::<B> {
+                vec![IncomingBlock::<Block> {
                     hash,
                     header: Some(header),
                     body: Some(extrinsics),
@@ -204,43 +279,13 @@ where
                 }],
             );
 
-            imported_blocks += 1;
+            downloaded_blocks += 1;
 
-            if imported_blocks % 1000 == 0 {
+            if downloaded_blocks % 1000 == 0 {
                 info!("Imported block {}", block_number);
             }
         }
-
-        futures::future::poll_fn(|ctx| {
-            import_queue.poll_actions(ctx, &mut link);
-
-            Poll::Ready(())
-        })
-        .await;
-
-        if let Some(WaitLinkError { error, hash }) = &link.error {
-            return Err(sc_service::Error::Other(format!(
-                "Stopping block import after #{} blocks on {} because of an error: {}",
-                link.imported_blocks, hash, error
-            )));
-        }
     }
 
-    while link.imported_blocks < imported_blocks {
-        futures::future::poll_fn(|ctx| {
-            import_queue.poll_actions(ctx, &mut link);
-
-            Poll::Ready(())
-        })
-        .await;
-
-        if let Some(WaitLinkError { error, hash }) = &link.error {
-            return Err(sc_service::Error::Other(format!(
-                "Stopping block import after #{} blocks on {} because of an error: {}",
-                link.imported_blocks, hash, error
-            )));
-        }
-    }
-
-    Ok(imported_blocks)
+    Ok(downloaded_blocks)
 }

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -77,10 +77,11 @@ impl<B: BlockT> Link<B> for WaitLink<B> {
     }
 }
 
-/// Starts the process of importing blocks.
+/// Starts the process of importing blocks, used for for initial sync on node startup because it
+/// requires [`ImportQueue`] as a dependency.
 ///
 /// Returns number of imported blocks.
-pub async fn import_blocks<B, IQ, C>(
+pub async fn initial_block_import_from_dsn<B, IQ, C>(
     node: &Node,
     client: Arc<C>,
     import_queue: &mut IQ,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -624,16 +624,18 @@ where
             }))
             .detach();
 
-            task_manager.spawn_essential_handle().spawn_essential(
-                "node-runner",
-                Some("subspace-networking"),
-                Box::pin(
-                    async move {
-                        node_runner.run().await;
-                    }
-                    .in_current_span(),
-                ),
-            );
+            task_manager
+                .spawn_essential_handle()
+                .spawn_essential_blocking(
+                    "node-runner",
+                    Some("subspace-networking"),
+                    Box::pin(
+                        async move {
+                            node_runner.run().await;
+                        }
+                        .in_current_span(),
+                    ),
+                );
 
             (node, dsn_config.bootstrap_nodes, Some(piece_cache))
         }
@@ -646,11 +648,13 @@ where
             .subscribe(),
     );
 
-    task_manager.spawn_essential_handle().spawn_essential(
-        "segment-header-archiver",
-        Some("subspace-networking"),
-        Box::pin(segment_header_archiving_fut.in_current_span()),
-    );
+    task_manager
+        .spawn_essential_handle()
+        .spawn_essential_blocking(
+            "segment-header-archiver",
+            Some("subspace-networking"),
+            Box::pin(segment_header_archiving_fut.in_current_span()),
+        );
 
     let dsn_bootstrap_nodes = {
         // Fall back to node itself as bootstrap node for DSN so farmer always has someone to

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -24,7 +24,7 @@ pub mod rpc;
 pub mod segment_headers;
 pub mod tx_pre_validator;
 
-use crate::dsn::import_blocks::import_blocks as import_blocks_from_dsn;
+use crate::dsn::import_blocks::initial_block_import_from_dsn;
 use crate::dsn::{create_dsn_instance, DsnConfigurationError};
 use crate::metrics::NodeMetrics;
 use crate::piece_cache::PieceCache;
@@ -715,7 +715,7 @@ where
         // Repeat until no new blocks are imported
         loop {
             let new_imported_blocks =
-                import_blocks_from_dsn(&node, client.clone(), &mut import_queue, false)
+                initial_block_import_from_dsn(&node, client.clone(), &mut import_queue, false)
                     .await
                     .map_err(|error| {
                         sc_service::Error::Other(format!(


### PR DESCRIPTION
A few tweaks I did working towards https://github.com/subspace/subspace/issues/1508

First commit removes annoying warning when node tries to finalize genesis block, the other two commits result in reusable `import_blocks_from_dsn` function that works with sharable `ImportQueueService` rather than `ImportQueue` (which is consumed by Substrate's networking and can't be shared).

`import_blocks_from_dsn` will later be called from more places.

Last commit fixed subspace networking disconnection from peers while heavy block importing is happening by letting it run in dedicated thread.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
