### PR TITLE
Sync from DSN

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -546,7 +546,7 @@ where
                     let mut segment_headers = segment_headers.lock();
                     segment_headers.put(block_number + One::one(), new_segment_headers);
 
-                    // Skip last 5 archived segments
+                    // Skip last `FINALIZATION_DEPTH_IN_SEGMENTS` archived segments
                     segment_headers
                         .iter()
                         .flat_map(|(_k, v)| v.iter().rev())

--- a/crates/subspace-networking/examples/announce-piece-complex.rs
+++ b/crates/subspace-networking/examples/announce-piece-complex.rs
@@ -78,7 +78,9 @@ async fn main() {
         node_runner.run().await;
     });
 
-    node.wait_for_connected_peers().await.unwrap();
+    node.wait_for_connected_peers(Duration::from_secs(5))
+        .await
+        .unwrap();
 
     let piece_index = PieceIndex::ONE;
     let piece_index_hash = piece_index.hash();

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -101,7 +101,9 @@ async fn main() {
         node_runner.run().await;
     });
 
-    node.wait_for_connected_peers().await.unwrap();
+    node.wait_for_connected_peers(Duration::from_secs(5))
+        .await
+        .unwrap();
 
     // Prepare multihash to look for in Kademlia
     let key = Code::Identity.digest(&expected_kaypair.public().to_bytes());

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -178,7 +178,10 @@ async fn test_async_handler_works_with_pending_internal_future() {
         node_runner_2.run().await;
     });
 
-    node_2.wait_for_connected_peers().await.unwrap();
+    node_2
+        .wait_for_connected_peers(Duration::from_secs(5))
+        .await
+        .unwrap();
 
     let resp = node_2
         .send_generic_request(node_1.id(), ExampleRequest)

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -539,4 +539,15 @@ impl Node {
     pub fn on_new_listener(&self, callback: HandlerFn<Multiaddr>) -> HandlerId {
         self.shared.handlers.new_listener.add(callback)
     }
+
+    /// Callback is called when number of established peer connections changes.
+    pub fn on_num_established_peer_connections_change(
+        &self,
+        callback: HandlerFn<usize>,
+    ) -> HandlerId {
+        self.shared
+            .handlers
+            .num_established_peer_connections_change
+            .add(callback)
+    }
 }

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -90,6 +90,7 @@ type Handler<A> = Bag<HandlerFn<A>, A>;
 #[derive(Default, Debug)]
 pub(crate) struct Handlers {
     pub(crate) new_listener: Handler<Multiaddr>,
+    pub(crate) num_established_peer_connections_change: Handler<usize>,
 }
 
 #[derive(Debug)]
@@ -99,7 +100,7 @@ pub(crate) struct Shared {
     /// Addresses on which node is listening for incoming requests.
     pub(crate) listeners: Mutex<Vec<Multiaddr>>,
     pub(crate) external_addresses: Mutex<Vec<Multiaddr>>,
-    pub(crate) connected_peers_count: Arc<AtomicUsize>,
+    pub(crate) num_established_peer_connections: Arc<AtomicUsize>,
     /// Sender end of the channel for sending commands to the swarm.
     pub(crate) command_sender: mpsc::Sender<Command>,
     pub(crate) kademlia_tasks_semaphore: ResizableSemaphore,
@@ -118,7 +119,7 @@ impl Shared {
             id,
             listeners: Mutex::default(),
             external_addresses: Mutex::default(),
-            connected_peers_count: Arc::new(AtomicUsize::new(0)),
+            num_established_peer_connections: Arc::new(AtomicUsize::new(0)),
             command_sender,
             kademlia_tasks_semaphore,
             regular_tasks_semaphore,

--- a/crates/subspace-node/src/import_blocks_from_dsn.rs
+++ b/crates/subspace-node/src/import_blocks_from_dsn.rs
@@ -96,7 +96,7 @@ impl ImportBlocksFromDsnCmd {
             imported_blocks += new_imported_blocks;
 
             info!(
-                "🎉 Imported {} blocks, best #{}/#{}",
+                "🎉 Imported {} blocks from DSN, current best #{}/#{}",
                 imported_blocks,
                 client.info().best_number,
                 client.info().best_hash
@@ -104,8 +104,8 @@ impl ImportBlocksFromDsnCmd {
         }
 
         info!(
-            "🎉 Imported {} blocks, best #{}/#{}, check against reliable sources to make sure it is a \
-            block on canonical chain",
+            "🎉 Imported {} blocks from DSN, best #{}/#{}, check against reliable sources to make \
+            sure it is a block on canonical chain",
             imported_blocks,
             client.info().best_number,
             client.info().best_hash

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -179,7 +179,8 @@ where
     IQS: ImportQueueService<Block> + ?Sized,
 {
     debug!("Waiting for connected peers...");
-    if tokio::time::timeout(WAIT_FOR_PEERS_TIMEOUT, node.wait_for_connected_peers())
+    if node
+        .wait_for_connected_peers(WAIT_FOR_PEERS_TIMEOUT)
         .await
         .is_err()
     {

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -30,6 +30,7 @@ use sp_consensus::BlockOrigin;
 use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::Arc;
 use std::task::Poll;
+use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::{
@@ -37,6 +38,9 @@ use subspace_core_primitives::{
 };
 use subspace_networking::utils::piece_provider::{PieceProvider, RetryPolicy};
 use subspace_networking::Node;
+
+/// How long to wait for peers before giving up
+const WAIT_FOR_PEERS_TIMEOUT: Duration = Duration::from_secs(10);
 
 struct WaitLinkError<B: BlockT> {
     error: BlockImportError,
@@ -156,6 +160,10 @@ where
     Ok(downloaded_blocks)
 }
 
+// TODO: Handle situation where block we are about to import is already included in chain and
+//  further sync from DSN is not necessary
+// TODO: Only download segment headers starting with the first segment that node doesn't have rather
+//  than from genesis
 /// Starts the process of importing blocks.
 ///
 /// Returns number of downloaded blocks.
@@ -170,19 +178,33 @@ where
     Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
     IQS: ImportQueueService<Block> + ?Sized,
 {
-    // TODO: Consider introducing and using global in-memory segment header cache (this comment is
-    //  in multiple files)
-    let segment_commitments = SegmentHeaderHandler::new(node.clone())
+    debug!("Waiting for connected peers...");
+    if tokio::time::timeout(WAIT_FOR_PEERS_TIMEOUT, node.wait_for_connected_peers())
+        .await
+        .is_err()
+    {
+        info!("Was not able to find any DSN peers, cancelling sync from DSN");
+        return Ok(0);
+    }
+    debug!("Connected to peers.");
+
+    let segment_headers = SegmentHeaderHandler::new(node.clone())
         .get_segment_headers()
         .await
-        .map_err(|error| error.to_string())?
+        .map_err(|error| error.to_string())?;
+
+    debug!("Found {} segment headers", segment_headers.len());
+
+    if segment_headers.is_empty() {
+        return Ok(0);
+    }
+
+    // TODO: Consider introducing and using global in-memory segment header cache (this comment is
+    //  in multiple files)
+    let segment_commitments = segment_headers
         .iter()
         .map(SegmentHeader::segment_commitment)
         .collect::<Vec<_>>();
-
-    if segment_commitments.is_empty() {
-        return Ok(0);
-    }
 
     let segments_found = segment_commitments.len();
     let piece_provider = PieceProvider::<SegmentCommitmentPieceValidator>::new(
@@ -193,10 +215,6 @@ where
             segment_commitments,
         )),
     );
-
-    debug!("Waiting for connected peers...");
-    let _ = node.wait_for_connected_peers().await;
-    debug!("Connected to peers.");
 
     let best_block_number = client.info().best_number;
     let mut downloaded_blocks = 0;

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -179,6 +179,11 @@ where
         .iter()
         .map(SegmentHeader::segment_commitment)
         .collect::<Vec<_>>();
+
+    if segment_commitments.is_empty() {
+        return Ok(0);
+    }
+
     let segments_found = segment_commitments.len();
     let piece_provider = PieceProvider::<SegmentCommitmentPieceValidator>::new(
         node.clone(),

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -734,7 +734,7 @@ where
             imported_blocks += new_imported_blocks;
 
             info!(
-                "🎉 Imported {} blocks, best #{}/#{}",
+                "🎉 Imported {} blocks from DSN, current best #{}/#{}",
                 imported_blocks,
                 client.info().best_number,
                 client.info().best_hash
@@ -742,8 +742,8 @@ where
         }
 
         info!(
-            "🎉 Imported {} blocks, best #{}/#{}, check against reliable sources to make sure it is a \
-            block on canonical chain",
+            "🎉 Imported {} blocks from DSN, best #{}/#{}, check against reliable sources to make \
+            sure it is a block on canonical chain",
             imported_blocks,
             client.info().best_number,
             client.info().best_hash

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -22,6 +22,7 @@ mod metrics;
 pub mod piece_cache;
 pub mod rpc;
 pub mod segment_headers;
+mod sync_from_dsn;
 pub mod tx_pre_validator;
 
 use crate::dsn::import_blocks::initial_block_import_from_dsn;
@@ -44,7 +45,7 @@ use sc_client_api::execution_extensions::ExtensionsFactory;
 use sc_client_api::{
     BlockBackend, BlockchainEvents, ExecutorProvider, HeaderBackend, StateBackendFor,
 };
-use sc_consensus::{BlockImport, DefaultImportQueue};
+use sc_consensus::{BlockImport, DefaultImportQueue, ImportQueue};
 use sc_consensus_slots::SlotProportion;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::{
@@ -52,6 +53,7 @@ use sc_consensus_subspace::{
     RewardSigningNotification, SubspaceLink, SubspaceParams,
 };
 use sc_executor::{NativeElseWasmExecutor, NativeExecutionDispatch};
+use sc_network::NetworkService;
 use sc_service::error::Error as ServiceError;
 use sc_service::{Configuration, NetworkStarter, PartialComponents, SpawnTasksParams, TaskManager};
 use sc_subspace_block_relay::{build_consensus_relay, NetworkWrapper};
@@ -445,7 +447,7 @@ where
     /// Chain selection rule.
     pub select_chain: FullSelectChain,
     /// Network service.
-    pub network_service: Arc<sc_network::NetworkService<Block, <Block as BlockT>::Hash>>,
+    pub network_service: Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
     /// Sync service.
     pub sync_service: Arc<sc_network_sync::SyncingService<Block>>,
     /// RPC handlers.
@@ -715,6 +717,7 @@ where
         .spawn_essential_handle()
         .spawn_essential_blocking("subspace-archiver", None, Box::pin(subspace_archiver));
 
+    // TODO: This prevents SIGINT from working properly
     if config.sync_from_dsn {
         let mut imported_blocks = 0;
 
@@ -743,15 +746,18 @@ where
             );
         }
 
-        info!(
-            "🎉 Imported {} blocks from DSN, best #{}/#{}, check against reliable sources to make \
-            sure it is a block on canonical chain",
-            imported_blocks,
-            client.info().best_number,
-            client.info().best_hash
-        );
+        if imported_blocks > 0 {
+            info!(
+                "🎉 Imported {} blocks from DSN, best #{}/#{}, check against reliable sources to \
+                make sure it is a block on canonical chain",
+                imported_blocks,
+                client.info().best_number,
+                client.info().best_hash
+            );
+        }
     }
 
+    let import_queue_service = import_queue.service();
     let network_wrapper = Arc::new(NetworkWrapper::default());
     let block_relay = if config.enable_subspace_block_relay {
         Some(build_consensus_relay(
@@ -777,8 +783,31 @@ where
             warp_sync_params: None,
             block_relay,
         })?;
+
     if config.enable_subspace_block_relay {
         network_wrapper.set(network_service.clone());
+    }
+    if config.sync_from_dsn {
+        let (observer, worker) = sync_from_dsn::create_observer_and_worker(
+            Arc::clone(&network_service),
+            node.clone(),
+            Arc::clone(&client),
+            import_queue_service,
+        );
+        task_manager
+            .spawn_handle()
+            .spawn("observer", Some("sync-from-dsn"), observer);
+        task_manager
+            .spawn_essential_handle()
+            .spawn_essential_blocking(
+                "worker",
+                Some("sync-from-dsn"),
+                Box::pin(async move {
+                    if let Err(error) = worker.await {
+                        error!(%error, "Sync from DSN exited with an error");
+                    }
+                }),
+            );
     }
 
     let sync_oracle = sync_service.clone();

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -546,7 +546,9 @@ where
         other: (block_import, subspace_link, mut telemetry, mut bundle_validator),
     } = partial_components;
 
-    let segment_header_cache = SegmentHeaderCache::new(client.clone());
+    let segment_header_cache = SegmentHeaderCache::new(client.clone()).map_err(|error| {
+        Error::Other(format!("Failed to instantiate segment header cache: {error}").into())
+    })?;
 
     let (node, bootstrap_nodes, piece_cache) = match config.subspace_networking.clone() {
         SubspaceNetworking::Reuse {

--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -67,6 +67,7 @@ async fn create_observer<Block, Client>(
     Block: BlockT,
     Client: BlockchainEvents<Block> + Send + Sync + 'static,
 {
+    // Separate reactive observer for Subspace networking that is not a future
     let _handler_id = node.on_num_established_peer_connections_change({
         // Assuming node is online by default
         let was_online = AtomicBool::new(false);

--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -1,0 +1,191 @@
+use crate::dsn::import_blocks::import_blocks_from_dsn;
+use futures::channel::mpsc;
+use futures::{FutureExt, StreamExt};
+use sc_client_api::{BlockBackend, BlockchainEvents};
+use sc_consensus::import_queue::ImportQueueService;
+use sc_network::{NetworkPeers, NetworkService};
+use sp_api::BlockT;
+use sp_blockchain::HeaderBackend;
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use subspace_networking::Node;
+use tracing::{info, trace};
+
+/// How much time to wait for new block to be imported before timing out and starting sync from DSN.
+const NO_IMPORTED_BLOCKS_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+/// Frequency with which to check whether node is online or not
+const CHECK_ONLINE_STATUS_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+enum NotificationReason {
+    NoImportedBlocks,
+    WentOnlineSubspace,
+    WentOnlineSubstrate,
+}
+
+/// Create node observer that will track node state and send notifications to worker to start sync
+/// from DSN.
+pub(super) fn create_observer_and_worker<Block, Client>(
+    network_service: Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
+    node: Node,
+    client: Arc<Client>,
+    mut import_queue_service: Box<dyn ImportQueueService<Block>>,
+) -> (
+    impl Future<Output = ()> + Send + 'static,
+    impl Future<Output = Result<(), sc_service::Error>> + Send + 'static,
+)
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block>
+        + BlockBackend<Block>
+        + BlockchainEvents<Block>
+        + Send
+        + Sync
+        + 'static,
+{
+    let (tx, rx) = mpsc::channel(0);
+    let observer_fut = {
+        let node = node.clone();
+        let client = Arc::clone(&client);
+
+        async move { create_observer(network_service.as_ref(), &node, client.as_ref(), tx).await }
+    };
+    let worker_fut = async move {
+        create_worker(&node, client.as_ref(), import_queue_service.as_mut(), rx).await
+    };
+    (observer_fut, worker_fut)
+}
+
+async fn create_observer<Block, Client>(
+    network_service: &NetworkService<Block, <Block as BlockT>::Hash>,
+    node: &Node,
+    client: &Client,
+    notifications_sender: mpsc::Sender<NotificationReason>,
+) where
+    Block: BlockT,
+    Client: BlockchainEvents<Block> + Send + Sync + 'static,
+{
+    let _handler_id = node.on_num_established_peer_connections_change({
+        // Assuming node is online by default
+        let was_online = AtomicBool::new(false);
+        let notifications_sender = notifications_sender.clone();
+
+        Arc::new(move |&new_connections| {
+            let is_online = new_connections > 0;
+            let was_online = was_online.swap(is_online, Ordering::AcqRel);
+
+            if is_online && !was_online {
+                // Doesn't matter if sending failed here
+                let _ = notifications_sender
+                    .clone()
+                    .try_send(NotificationReason::WentOnlineSubspace);
+            }
+        })
+    });
+    futures::select! {
+        _ = create_imported_blocks_observer(client, notifications_sender.clone()).fuse() => {
+            // Runs indefinitely
+        }
+        _ = create_substrate_network_observer(network_service, notifications_sender).fuse() => {
+            // Runs indefinitely
+        }
+        // TODO: More sources
+    }
+}
+
+async fn create_imported_blocks_observer<Block, Client>(
+    client: &Client,
+    mut notifications_sender: mpsc::Sender<NotificationReason>,
+) where
+    Block: BlockT,
+    Client: BlockchainEvents<Block> + Send + Sync + 'static,
+{
+    let mut import_notification_stream = client.every_import_notification_stream();
+    loop {
+        match tokio::time::timeout(
+            NO_IMPORTED_BLOCKS_TIMEOUT,
+            import_notification_stream.next(),
+        )
+        .await
+        {
+            Ok(Some(_notification)) => {
+                // Do nothing
+            }
+            Ok(None) => {
+                // No more notifications
+                return;
+            }
+            Err(_timeout) => {
+                if let Err(error) =
+                    notifications_sender.try_send(NotificationReason::NoImportedBlocks)
+                {
+                    if error.is_disconnected() {
+                        // Receiving side was closed
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn create_substrate_network_observer<Block>(
+    network_service: &NetworkService<Block, <Block as BlockT>::Hash>,
+    mut notifications_sender: mpsc::Sender<NotificationReason>,
+) where
+    Block: BlockT,
+{
+    // Assuming node is online by default
+    let mut was_online = false;
+
+    loop {
+        tokio::time::sleep(CHECK_ONLINE_STATUS_INTERVAL).await;
+
+        let is_online = network_service.sync_num_connected() > 0;
+
+        if is_online && !was_online {
+            if let Err(error) =
+                notifications_sender.try_send(NotificationReason::WentOnlineSubstrate)
+            {
+                if error.is_disconnected() {
+                    // Receiving side was closed
+                    return;
+                }
+            }
+        }
+
+        was_online = is_online;
+    }
+}
+
+async fn create_worker<Block, IQS, Client>(
+    node: &Node,
+    client: &Client,
+    import_queue_service: &mut IQS,
+    mut notifications: mpsc::Receiver<NotificationReason>,
+) -> Result<(), sc_service::Error>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+    IQS: ImportQueueService<Block> + ?Sized,
+{
+    while let Some(reason) = notifications.next().await {
+        // TODO: Remove this condition once we switch to Subspace networking for everything
+        if matches!(reason, NotificationReason::WentOnlineSubspace) {
+            trace!("Ignoring Subspace networking for DSN sync for now");
+            continue;
+        }
+
+        while notifications.try_next().is_ok() {
+            // Just drain extra messages if there are any
+        }
+
+        info!(?reason, "Received notification to sync from DSN");
+        // TODO: Maybe handle failed block imports, additional helpful logging
+        import_blocks_from_dsn(node, client, import_queue_service, false).await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
First 3 commits fix bugs and prepare for the last one.

This is a partial implementation of https://github.com/subspace/subspace/issues/1508 / https://github.com/subspace/subspace/issues/1510, partial because I have found an interesting bug in https://github.com/paritytech/substrate/issues/14442 that needs to be resolved to make it fully functional. Even then performance is not great and a lot of tuning can be done, but it will work with pruned nodes.

The approach here is based on triggers, more specifically first two from https://github.com/subspace/subspace/issues/1507#issuecomment-1597635616 that trigger DSN sync as an operation completely independent from normal Substrate sync.

There is a trigger for Subspace network online/offline status change, but since we don't have regular communication between peers there yet, node might appear to go online/offline much more often than it is in reality. It is ignored for now, but already implemented and will be taken into account (or will supersede Substrate) in the future.

Also logging will be greatly improved in the future, right now there is nothing printed to the console, just best block suddenly increases out of nowhere as far as user is concerned.

Basically, consider this an MVP that will be improved upon before we can consider https://github.com/subspace/subspace/issues/1508 / https://github.com/subspace/subspace/issues/1510 resolved.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
