### PR TITLE
Recent weight piece sampling

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -37,6 +37,7 @@ use sp_runtime::testing::{Digest, DigestItem, Header, TestXt};
 use sp_runtime::traits::{Block as BlockT, Header as _, IdentityLookup};
 use sp_runtime::Perbill;
 use std::iter;
+use std::num::NonZeroU64;
 use std::sync::Once;
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
@@ -158,6 +159,11 @@ parameter_types! {
     pub const InitialSolutionRange: SolutionRange = INITIAL_SOLUTION_RANGE;
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
     pub const ConfirmationDepthK: u32 = 10;
+    pub const RecentSegments: HistorySize = HistorySize::new(NonZeroU64::new(5).unwrap());
+    pub const RecentHistoryFraction: (HistorySize, HistorySize) = (
+        HistorySize::new(NonZeroU64::new(1).unwrap()),
+        HistorySize::new(NonZeroU64::new(10).unwrap()),
+    );
     pub const RecordSize: u32 = 3840;
     pub const ExpectedVotesPerBlock: u32 = 9;
     pub const ReplicationFactor: u16 = 1;
@@ -173,6 +179,8 @@ impl Config for Test {
     type SlotProbability = SlotProbability;
     type ExpectedBlockTime = ConstU64<1>;
     type ConfirmationDepthK = ConfirmationDepthK;
+    type RecentSegments = RecentSegments;
+    type RecentHistoryFraction = RecentHistoryFraction;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
@@ -393,6 +401,11 @@ pub fn create_signed_vote(
         history_size: HistorySize::from(SegmentIndex::ZERO),
         max_pieces_in_sector: MAX_PIECES_IN_SECTOR,
         sector_expiration: SegmentIndex::ONE,
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     };
     let pieces_in_sector = farmer_protocol_info.max_pieces_in_sector;
     let sector_size = sector_size(pieces_in_sector);

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -242,11 +242,14 @@ where
             })?;
 
         let farmer_app_info: Result<FarmerAppInfo, ApiError> = try {
+            let chain_constants = runtime_api.chain_constants(best_hash)?;
             let protocol_info = FarmerProtocolInfo {
                 history_size: runtime_api.history_size(best_hash)?,
                 max_pieces_in_sector: runtime_api.max_pieces_in_sector(best_hash)?,
                 // TODO: Fetch this from the runtime
                 sector_expiration: SegmentIndex::from(100),
+                recent_segments: chain_constants.recent_segments(),
+                recent_history_fraction: chain_constants.recent_history_fraction(),
             };
 
             FarmerAppInfo {

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -938,8 +938,6 @@ where
             pre_digest.solution.sector_index,
         );
 
-        // TODO: Derive `pre_digest.solution.piece_offset` from local challenge instead
-
         let piece_index = sector_id.derive_piece_index(
             pre_digest.solution.piece_offset,
             pre_digest.solution.history_size,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -317,6 +317,10 @@ pub enum ChainConstants {
         era_duration: BlockNumber,
         /// Slot probability.
         slot_probability: (u64, u64),
+        /// Number of latest archived segments that are considered "recent history".
+        recent_segments: HistorySize,
+        /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
+        recent_history_fraction: (HistorySize, HistorySize),
     },
 }
 
@@ -351,6 +355,23 @@ impl ChainConstants {
             slot_probability, ..
         } = self;
         *slot_probability
+    }
+
+    /// Number of latest archived segments that are considered "recent history".
+    pub fn recent_segments(&self) -> HistorySize {
+        let Self::V0 {
+            recent_segments, ..
+        } = self;
+        *recent_segments
+    }
+
+    /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
+    pub fn recent_history_fraction(&self) -> (HistorySize, HistorySize) {
+        let Self::V0 {
+            recent_history_fraction,
+            ..
+        } = self;
+        *recent_history_fraction
     }
 }
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -20,7 +20,7 @@ use sp_runtime::testing::H256;
 use sp_runtime::traits::Header as HeaderT;
 use sp_runtime::{Digest, DigestItem};
 use std::iter;
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU64, NonZeroUsize};
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -55,6 +55,11 @@ fn default_test_constants() -> ChainConstants<Header> {
         era_duration: 20,
         slot_probability: (1, 6),
         storage_bound: Default::default(),
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     }
 }
 
@@ -92,6 +97,11 @@ impl FarmerParameters {
             history_size: HistorySize::from(SegmentIndex::ZERO),
             max_pieces_in_sector: 1,
             sector_expiration: SegmentIndex::ONE,
+            recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+            recent_history_fraction: (
+                HistorySize::from(NonZeroU64::new(1).unwrap()),
+                HistorySize::from(NonZeroU64::new(10).unwrap()),
+            ),
         };
 
         Self {

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -266,6 +266,20 @@ impl From<PieceOffset> for u16 {
     }
 }
 
+impl From<PieceOffset> for u32 {
+    #[inline]
+    fn from(original: PieceOffset) -> Self {
+        Self::from(original.0)
+    }
+}
+
+impl From<PieceOffset> for u64 {
+    #[inline]
+    fn from(original: PieceOffset) -> Self {
+        Self::from(original.0)
+    }
+}
+
 impl From<PieceOffset> for usize {
     #[inline]
     fn from(original: PieceOffset) -> Self {

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -104,6 +104,11 @@ impl From<SegmentIndex> for HistorySize {
 }
 
 impl HistorySize {
+    /// Create new instance.
+    pub const fn new(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+
     /// Size of blockchain history in pieces.
     pub const fn in_pieces(&self) -> NonZeroU64 {
         self.0.saturating_mul(

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -66,6 +66,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
         sector_expiration: SegmentIndex::ONE,
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     };
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -50,6 +50,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
         sector_expiration: SegmentIndex::ONE,
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     };
 
     let sector_size = sector_size(pieces_in_sector);

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -69,6 +69,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
         sector_expiration: SegmentIndex::ONE,
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     };
     let solution_range = SolutionRange::MAX;
     let reward_address = PublicKey::default();

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -65,6 +65,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
         sector_expiration: SegmentIndex::ONE,
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     };
 
     let sector_size = sector_size(pieces_in_sector);

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -41,4 +41,8 @@ pub struct FarmerProtocolInfo {
     pub max_pieces_in_sector: u16,
     /// Number of segments after which sector expires
     pub sector_expiration: SegmentIndex,
+    /// Number of latest archived segments that are considered "recent history".
+    pub recent_segments: HistorySize,
+    /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
+    pub recent_history_fraction: (HistorySize, HistorySize),
 }

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -199,7 +199,13 @@ where
     let piece_indexes: Vec<PieceIndex> = (PieceOffset::ZERO..)
         .take(pieces_in_sector.into())
         .map(|piece_offset| {
-            sector_id.derive_piece_index(piece_offset, farmer_protocol_info.history_size)
+            sector_id.derive_piece_index(
+                piece_offset,
+                farmer_protocol_info.history_size,
+                farmer_protocol_info.max_pieces_in_sector,
+                farmer_protocol_info.recent_segments,
+                farmer_protocol_info.recent_history_fraction,
+            )
         })
         .collect();
 

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -28,7 +28,7 @@ use sc_consensus_subspace::{NewSlotNotification, RewardSigningNotification};
 use sp_api::ProvideRuntimeApi;
 use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature, SubspaceApi};
 use sp_core::{Decode, Encode};
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::objects::BlockObjectMapping;
@@ -233,6 +233,11 @@ where
         history_size,
         max_pieces_in_sector: pieces_in_sector,
         sector_expiration: SegmentIndex::from(100),
+        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_history_fraction: (
+            HistorySize::from(NonZeroU64::new(1).unwrap()),
+            HistorySize::from(NonZeroU64::new(10).unwrap()),
+        ),
     };
 
     let plotted_sector = plot_sector::<_, PosTable>(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -30,6 +30,7 @@ include!(concat!(
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Compact, CompactLen, Encode};
+use core::num::NonZeroU64;
 use frame_support::traits::{
     ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Currency, ExistenceRequirement, Get,
     Imbalance, WithdrawReasons,
@@ -240,6 +241,11 @@ parameter_types! {
     pub const ShouldAdjustSolutionRange: bool = false;
     pub const ExpectedVotesPerBlock: u32 = 9;
     pub const ConfirmationDepthK: u32 = 100;
+    pub const RecentSegments: HistorySize = HistorySize::new(NonZeroU64::new(5).unwrap());
+    pub const RecentHistoryFraction: (HistorySize, HistorySize) = (
+        HistorySize::new(NonZeroU64::new(1).unwrap()),
+        HistorySize::new(NonZeroU64::new(10).unwrap()),
+    );
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -250,6 +256,8 @@ impl pallet_subspace::Config for Runtime {
     type SlotProbability = SlotProbability;
     type ExpectedBlockTime = ExpectedBlockTime;
     type ConfirmationDepthK = ConfirmationDepthK;
+    type RecentSegments = RecentSegments;
+    type RecentHistoryFraction = RecentHistoryFraction;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;


### PR DESCRIPTION
All the changes in this PR are infra for `SectorId::derive_piece_index` in `subspace-core-primitives`.

What we are trying to achieve here is to make sure that we treat recent history of the blockchain as such that is having higher weight. At least 10% of the plotted sector will contain pieces from recent history, in case sector size was reduced from max allowed size the fraction will be even higher.

In order to deal with various incentives around avoiding recent history, at least 20% of pieces at the beginning of the sector are pieces from recent and whole history interleaved with each other.

The parameters for these are unlikely to change, hence they are chain constants.

This is a fundamental concept and breaking change to the protocol, thus no attempt to make it backwards compatible was made.

See https://github.com/subspace/subspace/issues/1504 and https://subspacelabs.notion.site/Subspace-Dilithium-Consensus-Specification-v2-3-274a730b53eb4c93a8d879b90de532ce for details.

Resolves https://github.com/subspace/subspace/issues/1504

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
