### PR TITLE
Allow Substrate sync to resume after sync from DSN

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -793,6 +793,7 @@ where
             node.clone(),
             Arc::clone(&client),
             import_queue_service,
+            sync_service.clone(),
         );
         task_manager
             .spawn_handle()


### PR DESCRIPTION
This fixes node's ability to finish sync with Substrate after DSN has done its job.

Block import notifications will not be fired though as described in https://github.com/paritytech/substrate/issues/14448, but that can be fixed separately if domains implementation is not ready for such behavior.

Fixed https://github.com/subspace/subspace/issues/1510

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
