### PR TITLE
Proof of time (initial changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -292,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead 0.5.2",
- "aes 0.8.2",
+ "aes 0.8.3",
  "cipher 0.4.4",
  "ctr 0.9.2",
  "ghash 0.5.0",
@@ -10709,6 +10709,18 @@ dependencies = [
  "sha2 0.10.7",
  "subspace-chiapos",
  "subspace-core-primitives",
+]
+
+[[package]]
+name = "subspace-proof-of-time"
+version = "0.1.0"
+dependencies = [
+ "aes 0.8.3",
+ "rayon",
+ "sc-client-api",
+ "sp-core",
+ "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/subspace-proof-of-time/Cargo.toml
+++ b/crates/subspace-proof-of-time/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "subspace-proof-of-time"
+description = "Subspace proof of time implementation"
+license = "Apache-2.0"
+version = "0.1.0"
+authors = ["Rahul Subramaniyam <rahulksnv@gmail.com>"]
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+aes = "0.8.3"
+rayon = "1.7.0"
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "28e33f78a3aa8ac4c6753108bc0471273ff6bf6f" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "28e33f78a3aa8ac4c6753108bc0471273ff6bf6f" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "28e33f78a3aa8ac4c6753108bc0471273ff6bf6f" }
+thiserror = "1.0.38"

--- a/crates/subspace-proof-of-time/src/aes.rs
+++ b/crates/subspace-proof-of-time/src/aes.rs
@@ -1,0 +1,96 @@
+//! AES related functionality.
+
+use crate::pot::{AesCipherText, AesKey, AesSeed, ProofOfTime, ProofOfTimeError};
+use aes::cipher::generic_array::GenericArray;
+use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::Aes128;
+use rayon::prelude::*;
+use sp_core::H256;
+
+/// AES wrapper.
+pub struct AESWrapper {
+    /// Number of checkpoints per PoT.
+    pub num_checkpoints: u32,
+
+    /// Number of chained AES operations per checkpoint.
+    pub checkpoint_iterations: u32,
+}
+
+impl AESWrapper {
+    /// Creates the AES wrapper.
+    pub fn new(num_checkpoints: u32, checkpoint_iterations: u32) -> Self {
+        Self {
+            num_checkpoints,
+            checkpoint_iterations,
+        }
+    }
+
+    /// Builds the proof.
+    pub fn create_proof(
+        &self,
+        seed: AesSeed,
+        key: AesKey,
+        slot_number: u32,
+        injected_block_hash: H256,
+    ) -> ProofOfTime {
+        let key = GenericArray::from(key.0);
+        let cipher = Aes128::new(&key);
+        let num_iter = self.num_checkpoints * self.checkpoint_iterations;
+
+        let mut checkpoints = Vec::new();
+        let mut block = GenericArray::from(seed.0);
+        for i in 1..(num_iter + 1) {
+            // Encrypt previous block in place to produce the next block.
+            cipher.encrypt_block(&mut block);
+            if i % self.checkpoint_iterations == 0 {
+                // End of the checkpoint, collect the result.
+                checkpoints.push(AesCipherText(block.into()));
+            }
+        }
+
+        ProofOfTime {
+            slot_number,
+            seed,
+            checkpoints,
+            injected_block_hash,
+        }
+    }
+
+    /// Verifies the proof.
+    pub fn verify_proof(&self, key: AesKey, proof: &ProofOfTime) -> Result<bool, ProofOfTimeError> {
+        if proof.checkpoints.len() as u32 != self.num_checkpoints {
+            return Err(ProofOfTimeError::CheckpointMismatch {
+                actual: proof.checkpoints.len() as u32,
+                expected: self.num_checkpoints,
+            });
+        }
+
+        let key = GenericArray::from(key.0);
+        let cipher = Aes128::new(&key);
+
+        // Create the cipher pairs to be evaluated
+        let mut pairs = Vec::new();
+        let mut prev = GenericArray::from(proof.seed.0);
+        for checkpoint in &proof.checkpoints {
+            let cur = GenericArray::from(checkpoint.0);
+            pairs.push((prev, cur));
+            prev = cur;
+        }
+
+        // Evaluate the pairs in parallel.
+        let checkpoint_iterations = self.checkpoint_iterations;
+        let results: Vec<bool> = pairs
+            .par_iter_mut()
+            .map(|(input, expected)| {
+                // Encrypt in place checkpoint_iterations times
+                // and compare with the expected output.
+                for _ in 0..checkpoint_iterations {
+                    cipher.encrypt_block(input);
+                }
+                *input == *expected
+            })
+            .collect();
+
+        Ok(results.iter().all(|result| *result))
+    }
+}

--- a/crates/subspace-proof-of-time/src/clock_maker.rs
+++ b/crates/subspace-proof-of-time/src/clock_maker.rs
@@ -1,0 +1,108 @@
+//! Clock maker related functionality.
+
+use crate::aes::AESWrapper;
+use crate::pot::{AesKey, AesSeed, PotConfig, ProofOfTime};
+use sc_client_api::BlockImportNotification;
+use sp_core::{Blake2Hasher, Hasher, H256};
+use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
+
+pub const INITIAL_KEY: [u8; 16] = [
+    0x9a, 0x84, 0x94, 0x0f, 0xfe, 0xf5, 0xb0, 0xd7, 0x01, 0x99, 0xfc, 0x67, 0xf4, 0x6e, 0xa2, 0x7a,
+];
+
+pub struct ClockMakerImpl<Block> {
+    /// Proof of time config.
+    config: PotConfig,
+
+    /// AES helper.
+    aes: AESWrapper,
+
+    /// Last proof produced by us.
+    last_proof: ProofOfTime,
+
+    /// Pending entropy update from consensus chain.
+    /// (future slot number at which to update, block hash to inject).
+    pending_update: Option<(u32, H256)>,
+
+    _p: std::marker::PhantomData<Block>,
+}
+
+impl<Block> ClockMakerImpl<Block>
+where
+    Block: BlockT,
+    Block::Hash: Into<H256>,
+{
+    /// Creates the clock maker.
+    pub fn new(config: PotConfig, genesis_block_hash: Block::Hash) -> Self {
+        let aes = AESWrapper::new(config.num_checkpoints, config.checkpoint_iterations);
+
+        // Build the initial proof.
+        // seed = hash(genesis block hash), key = INITIAL_KEY.
+        let genesis_block_hash: H256 = genesis_block_hash.into();
+        let proof = aes.create_proof(
+            genesis_block_hash.into(),
+            AesKey(INITIAL_KEY),
+            0,
+            genesis_block_hash,
+        );
+
+        Self {
+            config,
+            aes,
+            last_proof: proof,
+            pending_update: None,
+            _p: Default::default(),
+        }
+    }
+
+    /// Processing per time slot.
+    fn on_slot(&mut self) {
+        let next_slot_number = self.last_proof.slot_number + 1;
+        let mut seed = AesSeed(self.last_proof.output().0);
+        let mut injected_block_hash = self.last_proof.injected_block_hash;
+
+        // Update the (seed, injected_block_hash) if we reached the update slot.
+        let mut updated = false;
+        if let Some((slot_number, block_hash)) = self.pending_update {
+            if slot_number == next_slot_number {
+                seed = Self::update_seed(&seed, block_hash);
+                injected_block_hash = block_hash;
+                updated = true;
+            }
+        }
+        if updated {
+            self.pending_update = None;
+        }
+
+        // Compute the next proof
+        let key = AesKey::from(&seed);
+        self.last_proof = self
+            .aes
+            .create_proof(seed, key, next_slot_number, injected_block_hash);
+
+        // TODO: send message to farmers.
+    }
+
+    /// Processes the block import notification.
+    fn on_block_import(&mut self, notification: BlockImportNotification<Block>) {
+        let block_number = notification.header.number();
+        let injection_depth: NumberFor<Block> = self.config.injection_depth_blocks.into();
+        let update_interval = self.config.randomness_update_interval_blocks.into();
+        if self.pending_update.is_some()
+            || *block_number < injection_depth
+            || (*block_number - injection_depth) % update_interval != 0_u32.into()
+        {
+            return;
+        }
+
+        let slot_number = 0; // TODO: get slot number for block.
+        self.pending_update = Some((slot_number, notification.hash.into()));
+    }
+
+    /// Builds the seed from previous seed and the injected_block_hash_update.
+    fn update_seed(seed: &AesSeed, block_hash: H256) -> AesSeed {
+        let mut bytes = seed.0.to_vec();
+        bytes.append(&mut block_hash.as_bytes().to_vec());
+        Blake2Hasher::hash(&bytes).into()
+    }
+}

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -1,0 +1,7 @@
+//! Proof of time implementation.
+
+#![allow(dead_code)]
+
+pub mod aes;
+pub mod clock_maker;
+pub mod pot;

--- a/crates/subspace-proof-of-time/src/pot.rs
+++ b/crates/subspace-proof-of-time/src/pot.rs
@@ -1,0 +1,101 @@
+//! Common defines.
+
+use sp_core::{Blake2Hasher, Hasher, H256};
+use std::ops::BitXor;
+
+/// The 128 bit key for the AES encryption.
+#[derive(Clone, Debug)]
+pub struct AesKey(pub [u8; 16]);
+
+impl From<&AesSeed> for AesKey {
+    fn from(seed: &AesSeed) -> AesKey {
+        Self(h256_to_arr(Blake2Hasher::hash(&seed.0)))
+    }
+}
+
+/// Input to AES.
+#[derive(Clone, Debug)]
+pub struct AesSeed(pub [u8; 16]);
+
+impl From<H256> for AesSeed {
+    fn from(hash: H256) -> Self {
+        Self(h256_to_arr(hash))
+    }
+}
+
+/// Output from AES.
+#[derive(Clone, Debug)]
+pub struct AesCipherText(pub [u8; 16]);
+
+/// Config params for PoT.
+#[derive(Debug)]
+pub struct PotConfig {
+    /// Frequency of entropy injection from consensus.
+    pub randomness_update_interval_blocks: u32,
+
+    /// Starting point for entropy injection from consensus.
+    pub injection_depth_blocks: u32,
+
+    /// Number of slots it takes for updated global randomness to
+    /// take effect.
+    pub global_randomness_reveal_lag_slots: u32,
+
+    /// Number of slots it takes for injected randomness to
+    /// take effect.
+    pub pot_injection_lag_slots: u32,
+
+    /// Number of checkpoints per proof.
+    pub num_checkpoints: u32,
+
+    /// Number of EAS iterations per checkpoints.
+    /// Total iterations per proof = num_checkpoints * checkpoint_iterations.
+    pub checkpoint_iterations: u32,
+}
+
+/// Proof of time.
+/// TODO: versioning.
+#[derive(Debug)]
+pub struct ProofOfTime {
+    /// Slot the proof was evaluated for.
+    pub slot_number: u32,
+
+    /// The seed used for evaluation.
+    pub seed: AesSeed,
+
+    /// The actual cipher output from each stage.
+    pub checkpoints: Vec<AesCipherText>,
+
+    /// Hash of last block at injection point.
+    pub injected_block_hash: H256,
+}
+
+impl ProofOfTime {
+    pub fn output(&self) -> AesCipherText {
+        self.checkpoints
+            .last()
+            .cloned()
+            .expect("Invalid proof of time")
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProofOfTimeError {
+    #[error("Unexpected number of checkpoints: {expected}, {actual}")]
+    CheckpointMismatch { expected: u32, actual: u32 },
+}
+
+/// Converts H256 -> [u8; 16]
+pub fn h256_to_arr(hash: H256) -> [u8; 16] {
+    let hash = hash.to_fixed_bytes();
+
+    let mut h: [u8; 16] = Default::default();
+    h.copy_from_slice(&hash[0..16]);
+    let h = u128::from_be_bytes(h);
+
+    let mut l: [u8; 16] = Default::default();
+    l.copy_from_slice(&hash[16..32]);
+    let l = u128::from_be_bytes(l);
+
+    let r = h.bitxor(&l);
+    r.to_be_bytes()
+}


### PR DESCRIPTION
Creates the PoT crate. The initial changes include:
1. AES functionality for proof creation/verification. The verification is currently parallel(rayon based)
2. Basic Clock maker changes (generate next proof on every slot, inject entropy on new block)

Next: interfacing/gossip with other components/peers, validate incoming proofs, possibly create storage pool for proofs, more validation/error handling, tests.

Relevant issues: https://github.com/subspace/subspace/issues/1557, https://github.com/subspace/subspace/issues/1572

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
