### PR TITLE
Do not read the runtime version from code using extension at genesis

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -40,7 +40,8 @@ use sp_std::vec::Vec;
 #[frame_support::pallet]
 mod pallet {
     use crate::runtime_registry::{
-        do_register_runtime, do_upgrade_runtime, Error as RuntimeRegistryError, RuntimeObject,
+        do_register_runtime, do_upgrade_runtime, register_runtime_at_genesis,
+        Error as RuntimeRegistryError, RuntimeObject,
     };
     use crate::weights::WeightInfo;
     use frame_support::pallet_prelude::{StorageMap, *};
@@ -293,9 +294,10 @@ mod pallet {
         fn build(&self) {
             if let Some(genesis_domain_runtime) = &self.genesis_domain_runtime {
                 // Register the genesis domain runtime
-                do_register_runtime::<T>(
+                register_runtime_at_genesis::<T>(
                     genesis_domain_runtime.name.clone(),
                     genesis_domain_runtime.runtime_type.clone(),
+                    genesis_domain_runtime.runtime_version.clone(),
                     genesis_domain_runtime.code.clone(),
                     Zero::zero(),
                 )

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -29,6 +29,7 @@ use parity_scale_codec::MaxEncodedLen;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
+use sp_api::RuntimeVersion;
 use sp_core::crypto::KeyTypeId;
 use sp_core::sr25519::vrf::{VrfOutput, VrfProof, VrfSignature};
 use sp_core::H256;
@@ -470,6 +471,7 @@ where
 pub struct GenesisDomainRuntime {
     pub name: Vec<u8>,
     pub runtime_type: RuntimeType,
+    pub runtime_version: RuntimeVersion,
     pub code: Vec<u8>,
 }
 

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -400,6 +400,7 @@ fn subspace_genesis_config(
             genesis_domain_runtime: Some(sp_domains::GenesisDomainRuntime {
                 name: b"evm".to_vec(),
                 runtime_type: RuntimeType::Evm,
+                runtime_version: evm_domain_runtime::VERSION,
                 code: evm_domain_runtime::WASM_BINARY
                     .unwrap_or_else(|| panic!("EVM domain runtime not available"))
                     .to_owned(),


### PR DESCRIPTION
The genesis storage is built using the BasicExternality that has no extensions, so `do_register_runtime` does not work as it requires the ReadRuntimeVersionExt, this workaround passes the runtime version directly into the GenesisConfig. cc @vedhavyas 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
