### PR TITLE
Domains: Scheduled runtime upgrades

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -390,15 +390,14 @@ mod pallet {
     }
 
     #[pallet::hooks]
+    // TODO: proper benchmark
     impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
         fn on_initialize(block_number: T::BlockNumber) -> Weight {
             SuccessfulBundles::<T>::kill();
-            let upgrade_runtimes_result = do_upgrade_runtimes::<T>(block_number);
 
-            T::DbWeight::get().reads_writes(
-                upgrade_runtimes_result.reads,
-                upgrade_runtimes_result.writes + 1,
-            )
+            do_upgrade_runtimes::<T>(block_number);
+
+            Weight::zero()
         }
 
         fn on_finalize(_: T::BlockNumber) {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -67,6 +67,7 @@ parameter_types! {
     pub const InitialDomainTxRange: u64 = 10;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
     pub const ExpectedBundlesPerInterval: u64 = 600;
+    pub const DomainRuntimeUpgradeDelay: BlockNumber = 100;
 }
 
 static CONFIRMATION_DEPTH_K: AtomicU64 = AtomicU64::new(10);
@@ -92,6 +93,7 @@ impl Get<BlockNumber> for ConfirmationDepthK {
 impl pallet_domains::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type ConfirmationDepthK = ConfirmationDepthK;
+    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Test>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -426,11 +426,14 @@ parameter_types! {
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
     pub const DomainTxRangeAdjustmentInterval: u64 = TX_RANGE_ADJUSTMENT_INTERVAL_BLOCKS;
     pub const ExpectedBundlesPerInterval: u64 = EXPECTED_BUNDLES_PER_INTERVAL;
+    /// Runtime upgrade is delayed for 1 day at 6 sec block time.
+    pub const DomainRuntimeUpgradeDelay: BlockNumber = 14_400;
 }
 
 impl pallet_domains::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ConfirmationDepthK = ConfirmationDepthK;
+    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -483,11 +483,13 @@ parameter_types! {
     pub const InitialDomainTxRange: u64 = 10;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
     pub const ExpectedBundlesPerInterval: u64 = 600;
+    pub const DomainRuntimeUpgradeDelay: BlockNumber = 10;
 }
 
 impl pallet_domains::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type ConfirmationDepthK = ConfirmationDepthK;
+    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;


### PR DESCRIPTION
This PR handles the domain runtime upgrades as described in the V2 spec and as follows
- Upgrade is submitted and then scheduled after a delay number of blocks
- Once the delay is finished, the runtime upgrade is finished and respective digests and events are deposited for all types of clients

Commit by commit makes more sense

Closes: #1592 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
