### PR TITLE
Limit reconstruction concurrency on farmer to avoid excessive memory usage

### DIFF
--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, trace, warn};
 
+// TODO: Probably should be made configurable
 const PARALLELISM_LEVEL: usize = 20;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Fixes https://github.com/subspace/subspace/issues/1606 by simply not allowing reconstructing more than one piece at a time due to significant memory usage required for this.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
