### PR TITLE
Fix node healthcheck

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -59,7 +59,7 @@ RUN \
 HEALTHCHECK CMD curl \
                   -H "Content-Type: application/json" \
                   -d '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }' \
-                  -f "http://localhost:9933"
+                  -f "http://localhost:9944"
 
 COPY --from=0 /code/subspace-node /subspace-node
 

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -68,7 +68,7 @@ RUN \
 HEALTHCHECK CMD curl \
                   -H "Content-Type: application/json" \
                   -d '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }' \
-                  -f "http://localhost:9933"
+                  -f "http://localhost:9944"
 
 COPY --from=0 /code/subspace-node /subspace-node
 


### PR DESCRIPTION
Port 9933 is gone, but 9944 now supports both HTTP and WS RPC.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
