### PR TITLE
Increase number of Docker healthcheck retries from 5 to 60

### DIFF
--- a/docs/farming.md
+++ b/docs/farming.md
@@ -234,7 +234,7 @@ services:
       timeout: 5s
 # If node setup takes longer than expected, you want to increase `interval` and `retries` number.
       interval: 30s
-      retries: 5
+      retries: 60
 
   farmer:
     depends_on:


### PR DESCRIPTION
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)

This change increases the number of Docker healthcheck retries from 5 to 60 to prevent errors when running `compose up` against an existing plot.

The archiver currently takes a while to run through an existing plot (in the order of ~10 minutes per 100k blocks on my modest test hardware). The node container will not report `healthy` until this process has completed and the farmer container will not start until that condition is met. With the existing ~3 minute timeout limit on the healthcheck, the farmer will report an error instead of starting when the node eventually does go `healthy`.

Note that this is intended to be a temporary fix until the archiving process has been optimised for speed.

Related issue: [Delay when starting node impacts Docker healthcheck](https://github.com/subspace/subspace/issues/1628).