### PR TITLE
Change cuckoo-filter errors handling for farmers.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -365,15 +365,7 @@ where
                             return;
                         }
 
-                        if let Err(err) = archival_storage_pieces.add_pieces(&new_pieces) {
-                            error!(
-                                %err,
-                                %disk_farm_index,
-                                %sector_index,
-                                %sector_offset,
-                                "Couldn't add new pieces to archival storage cuckoo filter.",
-                            );
-                        }
+                        archival_storage_pieces.add_pieces(&new_pieces);
 
                         // TODO: Skip those that were already announced (because they cached)
                         let publish_fut = async move {


### PR DESCRIPTION
This PR changes cuckoo-filter error handling from immediate error to logging only the last error. Cuckoo filters add items, remove other items, and return errors when the cuckoo-filter size is insufficient.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
