### PR TITLE
Prepare for sector replotting

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -254,6 +254,10 @@ where
         .iter()
         .enumerate()
         .flat_map(|(disk_farm_index, single_disk_plot)| {
+            let disk_farm_index = disk_farm_index
+                .try_into()
+                .expect("More than 256 plots are not supported, what are you even doing?!");
+
             (0 as SectorIndex..)
                 .zip(single_disk_plot.plotted_sectors())
                 .filter_map(
@@ -298,6 +302,9 @@ where
         .into_iter()
         .enumerate()
         .map(|(disk_farm_index, single_disk_plot)| {
+            let disk_farm_index = disk_farm_index
+                .try_into()
+                .expect("More than 256 plots are not supported, what are you even doing?!");
             let readers_and_pieces = Arc::clone(&readers_and_pieces);
             let node = node.clone();
             let span = info_span!("farm", %disk_farm_index);

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -381,7 +381,11 @@ type Handler<A> = Bag<HandlerFn<A>, A>;
 
 #[derive(Default, Debug)]
 struct Handlers {
-    sector_plotted: Handler<(PlottedSector, Arc<OwnedSemaphorePermit>)>,
+    sector_plotted: Handler<(
+        PlottedSector,
+        Option<PlottedSector>,
+        Arc<OwnedSemaphorePermit>,
+    )>,
     solution: Handler<SolutionResponse>,
 }
 
@@ -895,9 +899,9 @@ impl SingleDiskPlot {
             move |(sector_index, sector_metadata)| {
                 let sector_id = SectorId::new(public_key.hash(), sector_index);
 
-                let mut piece_indexes = Vec::with_capacity(self.pieces_in_sector.into());
+                let mut piece_indexes = Vec::with_capacity(usize::from(self.pieces_in_sector));
                 (PieceOffset::ZERO..)
-                    .take(self.pieces_in_sector.into())
+                    .take(usize::from(self.pieces_in_sector))
                     .map(|piece_offset| {
                         sector_id.derive_piece_index(
                             piece_offset,
@@ -930,7 +934,11 @@ impl SingleDiskPlot {
     /// throttling of the plotting process is desired.
     pub fn on_sector_plotted(
         &self,
-        callback: HandlerFn<(PlottedSector, Arc<OwnedSemaphorePermit>)>,
+        callback: HandlerFn<(
+            PlottedSector,
+            Option<PlottedSector>,
+            Arc<OwnedSemaphorePermit>,
+        )>,
     ) -> HandlerId {
         self.handlers.sector_plotted.add(callback)
     }

--- a/crates/subspace-farmer/src/utils/archival_storage_pieces.rs
+++ b/crates/subspace-farmer/src/utils/archival_storage_pieces.rs
@@ -56,6 +56,17 @@ impl ArchivalStoragePieces {
             );
         }
     }
+
+    pub fn delete_pieces(&self, piece_indexes: &[PieceIndex]) {
+        let mut cuckoo_filter = self.cuckoo_filter.lock();
+
+        for piece_index in piece_indexes {
+            cuckoo_filter.delete(piece_index);
+        }
+        drop(cuckoo_filter);
+
+        self.listeners.call_simple(&Notification);
+    }
 }
 
 impl CuckooFilterProvider for ArchivalStoragePieces {

--- a/crates/subspace-farmer/src/utils/readers_and_pieces.rs
+++ b/crates/subspace-farmer/src/utils/readers_and_pieces.rs
@@ -6,7 +6,7 @@ use tracing::{trace, warn};
 
 #[derive(Debug, Copy, Clone)]
 pub struct PieceDetails {
-    pub disk_farm_index: usize,
+    pub disk_farm_index: u8,
     pub sector_index: SectorIndex,
     pub piece_offset: PieceOffset,
 }
@@ -47,8 +47,8 @@ impl ReadersAndPieces {
                 return None;
             }
         };
-        let mut reader = match self.readers.get(piece_details.disk_farm_index).cloned() {
-            Some(reader) => reader,
+        let mut reader = match self.readers.get(usize::from(piece_details.disk_farm_index)) {
+            Some(reader) => reader.clone(),
             None => {
                 warn!(?piece_index_hash, ?piece_details, "Plot offset is invalid");
                 return None;

--- a/crates/subspace-farmer/src/utils/readers_and_pieces.rs
+++ b/crates/subspace-farmer/src/utils/readers_and_pieces.rs
@@ -14,7 +14,8 @@ struct PieceDetails {
     piece_offset: PieceOffset,
 }
 
-/// Wrapper data structure for pieces plotted under multiple plots and corresponding piece readers.
+/// Wrapper data structure for pieces plotted under multiple plots and corresponding piece readers,
+/// it also maintains filter in given [`ArchivalStoragePieces`].
 #[derive(Debug)]
 pub struct ReadersAndPieces {
     readers: Vec<PieceReader>,


### PR DESCRIPTION
Builds on top of https://github.com/subspace/subspace/pull/1642 for https://github.com/subspace/subspace/issues/1503 and prepares farmer to sectors that are being replotted.

As of this PR replotting doesn't actually happen yet, but farmer should be fully ready with both internal data structures for pieces retrieval and cuckoo filter being updated when pieces are removed from the plot too.

The first commit changes `disk_farm_index` such that we use less RAM for keeping track of all pieces across different plots (https://github.com/subspace/subspace/pull/1642 decreased size of other types). This limits total capacity a single farmer can handle to ~65*256 TiB, which should be still plenty practically speaking. Otherwise user can always start multiple farmers.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
