### PR TITLE
Domains staking: Withdrawls, Domain switching, and Deregistration

### DIFF
--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -149,7 +149,6 @@ pub(crate) fn do_instantiate_domain<T: Config>(
         StakingSummary {
             current_epoch_index: 0,
             current_total_stake: Zero::zero(),
-            next_total_stake: Zero::zero(),
             current_operators: vec![],
             next_operators: vec![],
         },


### PR DESCRIPTION
This PR brings the following changes to Domain staking
- Domain switching: An operator can chose to switch to another domain
- Deregistration: An operator can chose to deregister and there by stops staking from the next epoch. 
- Withdrawals: Any nominator, including the operator pool owner, can chose to withdraw some or all of their staked amount.

Closes: #1639 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
