### PR TITLE
Sector expiration/replotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10522,6 +10522,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "atomic",
  "backoff",
  "base58",
  "blake2",

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -224,6 +224,10 @@ mod pallet {
         #[pallet::constant]
         type RecentHistoryFraction: Get<(HistorySize, HistorySize)>;
 
+        /// Minimum lifetime of a plotted sector, measured in archived segment.
+        #[pallet::constant]
+        type MinSectorLifetime: Get<HistorySize>;
+
         /// Number of votes expected per block.
         ///
         /// This impacts solution range for votes in consensus.
@@ -1059,6 +1063,7 @@ impl<T: Config> Pallet<T> {
                 T::RecentHistoryFraction::get().0,
                 T::RecentHistoryFraction::get().1,
             ),
+            min_sector_lifetime: T::MinSectorLifetime::get(),
         }
     }
 }

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -408,6 +408,7 @@ pub fn create_signed_vote(
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
     let pieces_in_sector = farmer_protocol_info.max_pieces_in_sector;
     let sector_size = sector_size(pieces_in_sector);

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -164,6 +164,7 @@ parameter_types! {
         HistorySize::new(NonZeroU64::new(1).unwrap()),
         HistorySize::new(NonZeroU64::new(10).unwrap()),
     );
+    pub const MinSectorLifetime: HistorySize = HistorySize::new(NonZeroU64::new(4).unwrap());
     pub const RecordSize: u32 = 3840;
     pub const ExpectedVotesPerBlock: u32 = 9;
     pub const ReplicationFactor: u16 = 1;
@@ -181,6 +182,7 @@ impl Config for Test {
     type ConfirmationDepthK = ConfirmationDepthK;
     type RecentSegments = RecentSegments;
     type RecentHistoryFraction = RecentHistoryFraction;
+    type MinSectorLifetime = MinSectorLifetime;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -1482,6 +1482,8 @@ fn vote_equivocation_parent_voters_duplicate() {
     });
 }
 
+// TODO: Test for `CheckVoteError::InvalidHistorySize`
+
 #[test]
 fn enabling_block_rewards_works() {
     fn set_block_rewards() {

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -250,6 +250,7 @@ where
                 sector_expiration: SegmentIndex::from(100),
                 recent_segments: chain_constants.recent_segments(),
                 recent_history_fraction: chain_constants.recent_history_fraction(),
+                min_sector_lifetime: chain_constants.min_sector_lifetime(),
             };
 
             FarmerAppInfo {
@@ -581,6 +582,7 @@ where
         Ok(())
     }
 
+    // TODO: Remove as unnecessary, `segment_headers` can be used instead
     async fn segment_commitments(
         &self,
         segment_indexes: Vec<SegmentIndex>,

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -79,8 +79,8 @@ use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    Blake2b256Hash, PublicKey, SectorId, SegmentCommitment, SegmentHeader, SegmentIndex, Solution,
-    SolutionRange,
+    Blake2b256Hash, HistorySize, PublicKey, SectorId, SegmentCommitment, SegmentHeader,
+    SegmentIndex, Solution, SolutionRange,
 };
 use subspace_proof_of_space::Table;
 use subspace_solving::REWARD_SIGNING_CONTEXT;
@@ -241,6 +241,17 @@ pub enum Error<Header: HeaderT> {
     /// Segment commitment not found
     #[error("Segment commitment for segment index {0} not found")]
     SegmentCommitmentNotFound(SegmentIndex),
+    /// Sector expired
+    #[error("Sector expired")]
+    SectorExpired {
+        /// Expiration history size
+        expiration_history_size: HistorySize,
+        /// Current history size
+        current_history_size: HistorySize,
+    },
+    /// Invalid history size
+    #[error("Invalid history size")]
+    InvalidHistorySize,
     /// Only root plot public key is allowed
     #[error("Only root plot public key is allowed")]
     OnlyRootPlotPublicKeyAllowed,
@@ -297,6 +308,14 @@ where
                     Error::InvalidAuditChunkOffset
                 }
                 VerificationPrimitiveError::InvalidChunkWitness => Error::InvalidChunkWitness,
+                VerificationPrimitiveError::SectorExpired {
+                    expiration_history_size,
+                    current_history_size,
+                } => Error::SectorExpired {
+                    expiration_history_size,
+                    current_history_size,
+                },
+                VerificationPrimitiveError::InvalidHistorySize => Error::InvalidHistorySize,
             },
         }
     }
@@ -982,6 +1001,16 @@ where
 
         let segment_commitment =
             maybe_segment_commitment.ok_or(Error::SegmentCommitmentNotFound(segment_index))?;
+        let sector_expiration_check_segment_commitment = aux_schema::load_segment_commitment(
+            self.client.as_ref(),
+            subspace_digest_items
+                .pre_digest
+                .solution
+                .history_size
+                .sector_expiration_check(chain_constants.min_sector_lifetime())
+                .ok_or(Error::InvalidHistorySize)?
+                .segment_index(),
+        )?;
 
         // Piece is not checked during initial block verification because it requires access to
         // segment header and runtime, check it now.
@@ -997,6 +1026,12 @@ where
                     segment_commitment,
                     recent_segments: chain_constants.recent_segments(),
                     recent_history_fraction: chain_constants.recent_history_fraction(),
+                    min_sector_lifetime: chain_constants.min_sector_lifetime(),
+                    // TODO: Below `skip_runtime_access` has no impact on this, but ideally it
+                    //  should (though we don't support fast sync yet, so doesn't matter in
+                    //  practice)
+                    current_history_size: self.client.runtime_api().history_size(parent_hash)?,
+                    sector_expiration_check_segment_commitment,
                 }),
             },
             &self.subspace_link.kzg,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -321,6 +321,8 @@ pub enum ChainConstants {
         recent_segments: HistorySize,
         /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
         recent_history_fraction: (HistorySize, HistorySize),
+        /// Minimum lifetime of a plotted sector, measured in archived segment.
+        min_sector_lifetime: HistorySize,
     },
 }
 
@@ -372,6 +374,15 @@ impl ChainConstants {
             ..
         } = self;
         *recent_history_fraction
+    }
+
+    /// Minimum lifetime of a plotted sector, measured in archived segment.
+    pub fn min_sector_lifetime(&self) -> HistorySize {
+        let Self::V0 {
+            min_sector_lifetime,
+            ..
+        } = self;
+        *min_sector_lifetime
     }
 }
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -103,6 +103,7 @@ impl FarmerParameters {
                 HistorySize::from(NonZeroU64::new(1).unwrap()),
                 HistorySize::from(NonZeroU64::new(10).unwrap()),
             ),
+            min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
         };
 
         Self {

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -60,6 +60,7 @@ fn default_test_constants() -> ChainConstants<Header> {
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     }
 }
 
@@ -1453,3 +1454,5 @@ fn test_disallow_root_plot_public_key_override() {
         );
     });
 }
+
+// TODO: Test for expired sector

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -47,6 +47,7 @@ use ::serde::{Deserialize, Serialize};
 use alloc::vec::Vec;
 use core::convert::AsRef;
 use core::fmt;
+use core::num::NonZeroU64;
 use core::simd::Simd;
 use derive_more::{Add, Deref, DerefMut, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
@@ -922,7 +923,11 @@ impl SectorId {
     }
 
     /// Derive evaluation seed
-    pub fn evaluation_seed(&self, piece_offset: PieceOffset, history_size: HistorySize) -> PosSeed {
+    pub fn derive_evaluation_seed(
+        &self,
+        piece_offset: PieceOffset,
+        history_size: HistorySize,
+    ) -> PosSeed {
         let evaluation_seed = blake2b_256_hash_list(&[
             &self.0,
             &piece_offset.to_bytes(),
@@ -930,5 +935,39 @@ impl SectorId {
         ]);
 
         PosSeed::from(evaluation_seed)
+    }
+
+    /// Derive history size when sector created at `history_size` expires.
+    ///
+    /// Returns `None` on overflow.
+    pub fn derive_expiration_history_size(
+        &self,
+        history_size: HistorySize,
+        sector_expiration_check_segment_commitment: &SegmentCommitment,
+        min_sector_lifetime: HistorySize,
+    ) -> Option<HistorySize> {
+        let sector_expiration_check_history_size =
+            history_size.sector_expiration_check(min_sector_lifetime)?;
+
+        let input_hash = U256::from_le_bytes(blake2b_256_hash_list(&[
+            &self.0,
+            &sector_expiration_check_segment_commitment.to_bytes(),
+        ]));
+
+        let last_possible_expiration =
+            min_sector_lifetime.checked_add(history_size.get().checked_mul(4u64)?)?;
+        let expires_in = input_hash
+            % U256::from(
+                last_possible_expiration
+                    .get()
+                    .checked_sub(sector_expiration_check_history_size.get())?,
+            );
+        let expires_in = u64::try_from(expires_in).expect("Number modulo u64 fits into u64; qed");
+
+        let expiration_history_size = sector_expiration_check_history_size.get() + expires_in;
+        let expiration_history_size = NonZeroU64::try_from(expiration_history_size).expect(
+            "History size is not zero, so result is not zero even if expires immediately; qed",
+        );
+        Some(HistorySize::from(expiration_history_size))
     }
 }

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -144,6 +144,13 @@ impl HistorySize {
     pub fn segment_index(&self) -> SegmentIndex {
         SegmentIndex::from(self.0.get() - 1)
     }
+
+    /// History size at which expiration check for sector happens.
+    ///
+    /// Returns `None` on overflow.
+    pub fn sector_expiration_check(&self, min_sector_lifetime: Self) -> Option<Self> {
+        self.0.checked_add(min_sector_lifetime.0.get()).map(Self)
+    }
 }
 
 /// Recorded history segment before archiving is applied.

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -70,6 +70,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
     let global_challenge = Blake2b256Hash::default();
     let solution_range = SolutionRange::MAX;

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -54,6 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
 
     let sector_size = sector_size(pieces_in_sector);

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -73,6 +73,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
     let solution_range = SolutionRange::MAX;
     let reward_address = PublicKey::default();

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -69,6 +69,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
 
     let sector_size = sector_size(pieces_in_sector);

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -44,4 +44,6 @@ pub struct FarmerProtocolInfo {
     pub recent_segments: HistorySize,
     /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
     pub recent_history_fraction: (HistorySize, HistorySize),
+    /// Minimum lifetime of a plotted sector, measured in archived segment
+    pub min_sector_lifetime: HistorySize,
 }

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -255,7 +255,7 @@ where
         .for_each(|((piece_offset, record), mut encoded_chunks_used)| {
             // Derive PoSpace table
             let pos_table = PosTable::generate(
-                &sector_id.evaluation_seed(piece_offset, farmer_protocol_info.history_size),
+                &sector_id.derive_evaluation_seed(piece_offset, farmer_protocol_info.history_size),
             );
 
             let source_record_chunks = record

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -203,7 +203,7 @@ where
             let pos_table = PosTable::generate_parallel(
                 &self
                     .sector_id
-                    .evaluation_seed(piece_offset, self.sector_metadata.history_size),
+                    .derive_evaluation_seed(piece_offset, self.sector_metadata.history_size),
             );
 
             let maybe_chunk_cache: Result<_, ProvingError> = try {

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -285,7 +285,7 @@ where
             &sector_metadata.s_bucket_offsets(),
             &sector_contents_map,
             &PosTable::generate(
-                &sector_id.evaluation_seed(piece_offset, sector_metadata.history_size),
+                &sector_id.derive_evaluation_seed(piece_offset, sector_metadata.history_size),
             ),
             sector,
         )?,

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -14,6 +14,7 @@ include = [
 [dependencies]
 anyhow = "1.0.71"
 async-trait = "0.1.68"
+atomic = "0.5.3"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base58 = "0.2.0"
 blake2 = "0.10.6"

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -463,8 +463,8 @@ async fn populate_pieces_cache<PG, PC>(
 
         match result {
             Ok(Some(piece)) => {
-                debug!(%piece_index, "Added piece to cache.");
                 piece_cache.lock().await.add_piece(key, piece);
+                trace!(%piece_index, "Added piece to cache.");
             }
             Ok(None) => {
                 debug!(%piece_index, "Couldn't find piece.");
@@ -526,11 +526,8 @@ async fn fill_piece_cache_from_archived_segments(
 
                         match piece {
                             Ok(Some(piece)) => {
-                                {
-                                    piece_cache.lock().await.add_piece(key, piece);
-                                }
-
-                                trace!(%piece_index, "Got piece for archived segment.");
+                                piece_cache.lock().await.add_piece(key, piece);
+                                trace!(%piece_index, "Added piece to cache.");
 
                                 break 'retry;
                             }

--- a/crates/subspace-farmer/src/single_disk_plot.rs
+++ b/crates/subspace-farmer/src/single_disk_plot.rs
@@ -9,7 +9,7 @@ use crate::single_disk_plot::farming::farming;
 pub use crate::single_disk_plot::farming::FarmingError;
 use crate::single_disk_plot::piece_reader::PieceReader;
 pub use crate::single_disk_plot::plotting::PlottingError;
-use crate::single_disk_plot::plotting::{plotting, replotting};
+use crate::single_disk_plot::plotting::{plotting, plotting_scheduler};
 use crate::utils::JoinOnDrop;
 use bytesize::ByteSize;
 use derive_more::{Display, From};
@@ -724,7 +724,7 @@ impl SingleDiskPlot {
                 }
             })?;
 
-        tasks.push(Box::pin(replotting(
+        tasks.push(Box::pin(plotting_scheduler(
             public_key.hash(),
             sectors_indices_left_to_plot,
             target_sector_count,

--- a/crates/subspace-farmer/src/single_disk_plot/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/farming.rs
@@ -27,7 +27,7 @@ const SOLUTIONS_LIMIT: usize = 1;
 /// Errors that happen during farming
 #[derive(Debug, Error)]
 pub enum FarmingError {
-    /// Failed to substribe to slot info notifications
+    /// Failed to subscribe to slot info notifications
     #[error("Failed to substribe to slot info notifications: {error}")]
     FailedToSubscribeSlotInfo {
         /// Lower-level error

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -1,14 +1,27 @@
-use crate::single_disk_plot::{Handlers, PlotMetadataHeader, RESERVED_PLOT_METADATA};
+use crate::single_disk_plot::{
+    BackgroundTaskError, Handlers, PlotMetadataHeader, RESERVED_PLOT_METADATA,
+};
 use crate::{node_client, NodeClient};
+use atomic::Atomic;
+use futures::channel::{mpsc, oneshot};
+use futures::future::{select, Either};
+use futures::{SinkExt, StreamExt};
+use lru::LruCache;
 use memmap2::{MmapMut, MmapOptions};
 use parity_scale_codec::Encode;
 use parking_lot::RwLock;
+use std::collections::HashMap;
 use std::fs::File;
-use std::num::NonZeroU16;
+use std::io;
+use std::num::{NonZeroU16, NonZeroUsize};
+use std::ops::Range;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::{io, mem};
+use std::time::Duration;
 use subspace_core_primitives::crypto::kzg::Kzg;
-use subspace_core_primitives::{PieceOffset, PublicKey, SectorIndex};
+use subspace_core_primitives::{
+    Blake2b256Hash, HistorySize, PieceOffset, PublicKey, SectorId, SectorIndex, SegmentIndex,
+};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::plotting;
 use subspace_farmer_components::plotting::{
@@ -20,6 +33,7 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 use tracing::{debug, info, trace, warn};
 
+const FARMER_APP_INFO_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 /// Get piece retry attempts number.
 const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");
 
@@ -29,6 +43,24 @@ pub enum PlottingError {
     /// Failed to retrieve farmer info
     #[error("Failed to retrieve farmer info: {error}")]
     FailedToGetFarmerInfo {
+        /// Lower-level error
+        error: node_client::Error,
+    },
+    /// Failed to get segment header
+    #[error("Failed to get segment header: {error}")]
+    FailedToGetSegmentHeader {
+        /// Lower-level error
+        error: node_client::Error,
+    },
+    /// Missing archived segment header
+    #[error("Missing archived segment header: {segment_index}")]
+    MissingArchivedSegmentHeader {
+        /// Segment index that was missing
+        segment_index: SegmentIndex,
+    },
+    /// Failed to subscribe to archived segments
+    #[error("Failed to subscribe to archived segments: {error}")]
+    FailedToSubscribeArchivedSegments {
         /// Lower-level error
         error: node_client::Error,
     },
@@ -51,7 +83,6 @@ pub(super) async fn plotting<NC, PG, PosTable>(
     pieces_in_sector: u16,
     sector_size: usize,
     sector_metadata_size: usize,
-    target_sector_count: SectorIndex,
     mut metadata_header: PlotMetadataHeader,
     mut metadata_header_mmap: MmapMut,
     plot_file: Arc<File>,
@@ -63,17 +94,15 @@ pub(super) async fn plotting<NC, PG, PosTable>(
     handlers: Arc<Handlers>,
     modifying_sector_index: Arc<RwLock<Option<SectorIndex>>>,
     concurrent_plotting_semaphore: Arc<Semaphore>,
+    mut sectors_to_plot: mpsc::Receiver<(SectorIndex, oneshot::Sender<()>)>,
 ) -> Result<(), PlottingError>
 where
     NC: NodeClient,
     PG: PieceGetter + Send + 'static,
     PosTable: Table,
 {
-    // Some sectors may already be plotted, skip them
-    let sectors_indices_left_to_plot = metadata_header.sector_count..target_sector_count;
-
     // TODO: Concurrency
-    for sector_index in sectors_indices_left_to_plot {
+    while let Some((sector_index, _acknowledgement_sender)) = sectors_to_plot.next().await {
         trace!(%sector_index, "Preparing to plot sector");
 
         let mut sector = unsafe {
@@ -103,12 +132,34 @@ where
             }
         };
 
-        debug!(%sector_index, "Plotting sector");
+        let maybe_old_sector_metadata = sectors_metadata.read().get(sector_index as usize).cloned();
 
-        let farmer_app_info = node_client
-            .farmer_app_info()
-            .await
-            .map_err(|error| PlottingError::FailedToGetFarmerInfo { error })?;
+        if maybe_old_sector_metadata.is_some() {
+            debug!(%sector_index, "Replotting sector");
+        } else {
+            debug!(%sector_index, "Plotting sector");
+        }
+
+        // This `loop` is a workaround for edge-case in local setup if expiration is configured to
+        // 1. In that scenario we get replotting notification essentially straight from block import
+        // pipeline of the node, before block is imported. This can result in subsequent request for
+        // farmer app info to return old data, meaning we're replotting exactly the same sector that
+        // just expired.
+        let farmer_app_info = loop {
+            let farmer_app_info = node_client
+                .farmer_app_info()
+                .await
+                .map_err(|error| PlottingError::FailedToGetFarmerInfo { error })?;
+
+            if let Some(old_sector_metadata) = &maybe_old_sector_metadata {
+                if farmer_app_info.protocol_info.history_size <= old_sector_metadata.history_size {
+                    tokio::time::sleep(FARMER_APP_INFO_RETRY_INTERVAL).await;
+                    continue;
+                }
+            }
+
+            break farmer_app_info;
+        };
 
         let plot_sector_fut = plot_sector::<_, PosTable>(
             &public_key,
@@ -130,23 +181,22 @@ where
         sector.flush()?;
         sector_metadata.flush()?;
 
-        metadata_header.sector_count += 1;
-        metadata_header_mmap.copy_from_slice(metadata_header.encode().as_slice());
-        let maybe_old_sector_metadata = {
+        if sector_index + 1 > metadata_header.sector_count {
+            metadata_header.sector_count = sector_index + 1;
+            metadata_header_mmap.copy_from_slice(metadata_header.encode().as_slice());
+        }
+        {
             let mut sectors_metadata = sectors_metadata.write();
             // If exists then we're replotting, otherwise we create sector for the first time
             if let Some(existing_sector_metadata) = sectors_metadata.get_mut(sector_index as usize)
             {
-                let mut sector_metadata_tmp = plotted_sector.sector_metadata.clone();
-                mem::swap(existing_sector_metadata, &mut sector_metadata_tmp);
-                Some(sector_metadata_tmp)
+                *existing_sector_metadata = plotted_sector.sector_metadata.clone();
             } else {
                 sectors_metadata.push(plotted_sector.sector_metadata.clone());
-                None
             }
-        };
+        }
 
-        let old_plotted_sector = maybe_old_sector_metadata.map(|old_sector_metadata| {
+        let maybe_old_plotted_sector = maybe_old_sector_metadata.map(|old_sector_metadata| {
             let old_history_size = old_sector_metadata.history_size;
 
             PlottedSector {
@@ -175,14 +225,214 @@ where
         // Inform others that this sector is no longer being modified
         modifying_sector_index.write().take();
 
-        info!(%sector_index, "Sector plotted successfully");
+        if maybe_old_plotted_sector.is_some() {
+            info!(%sector_index, "Sector replotted successfully");
+        } else {
+            info!(%sector_index, "Sector plotted successfully");
+        }
 
         handlers.sector_plotted.call_simple(&(
             plotted_sector,
-            old_plotted_sector,
+            maybe_old_plotted_sector,
             Arc::new(plotting_permit),
         ));
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn replotting<NC>(
+    public_key_hash: Blake2b256Hash,
+    sectors_indices_left_to_plot: Range<SectorIndex>,
+    target_sector_count: SectorIndex,
+    last_archived_segment_index: SegmentIndex,
+    min_sector_lifetime: HistorySize,
+    node_client: NC,
+    sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+    mut sectors_to_plot_sender: mpsc::Sender<(SectorIndex, oneshot::Sender<()>)>,
+) -> Result<(), BackgroundTaskError>
+where
+    NC: NodeClient,
+{
+    info!("Subscribing to archived segments");
+
+    let mut archived_segments_notifications = node_client
+        .subscribe_archived_segment_headers()
+        .await
+        .map_err(|error| PlottingError::FailedToSubscribeArchivedSegments { error })?;
+
+    // Create a proxy channel with atomically updatable last archived segment that
+    // allows to not buffer messages from RPC subscription, but also access the most
+    // recent value at any time
+    let last_archived_segment = Atomic::new(
+        node_client
+            .segment_headers(vec![last_archived_segment_index])
+            .await
+            .map_err(|error| PlottingError::FailedToGetSegmentHeader { error })?
+            .into_iter()
+            .next()
+            .flatten()
+            .ok_or(PlottingError::MissingArchivedSegmentHeader {
+                segment_index: last_archived_segment_index,
+            })?,
+    );
+    let (mut archived_segments_sender, mut archived_segments_receiver) = mpsc::channel(0);
+    archived_segments_sender
+        .try_send(())
+        .expect("No messages were sent yet, there is capacity for one message; qed");
+
+    let read_archived_segments_notifications_fut = async {
+        while let Some(segment_header) = archived_segments_notifications.next().await {
+            debug!(?segment_header, "New archived segment");
+            if let Err(error) = node_client
+                .acknowledge_archived_segment_header(segment_header.segment_index())
+                .await
+            {
+                debug!(%error, "Failed to acknowledge segment header");
+            }
+
+            last_archived_segment.store(segment_header, Ordering::SeqCst);
+            // Just a notification such that receiving side can read updated
+            // `last_archived_segment` (whatever it happens to be right now)
+            if let Err(error) = archived_segments_sender.try_send(()) {
+                if error.is_disconnected() {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok::<_, BackgroundTaskError>(())
+    };
+
+    let send_plotting_notifications_fut = async {
+        // Finish initial plotting if some sectors were not plotted fully yet
+        for sector_index in sectors_indices_left_to_plot {
+            let (acknowledgement_sender, acknowledgement_receiver) = oneshot::channel();
+            if let Err(error) = sectors_to_plot_sender
+                .send((sector_index, acknowledgement_sender))
+                .await
+            {
+                warn!(%error, "Failed to send sector index for initial plotting");
+                return Ok(());
+            }
+
+            // We do not care if message was sent back or sender was just dropped
+            let _ = acknowledgement_receiver.await;
+        }
+
+        let mut sectors_expire_at = HashMap::with_capacity(usize::from(target_sector_count));
+
+        let mut sector_indices_to_replot = Vec::new();
+        let mut sectors_to_check = Vec::with_capacity(usize::from(target_sector_count));
+        // TODO: Move constant to the top of the file
+        const ARCHIVED_SEGMENTS_CACHE_SIZE: NonZeroUsize =
+            NonZeroUsize::new(1000).expect("Not zero; qed");
+        let mut archived_segment_commitments_cache = LruCache::new(ARCHIVED_SEGMENTS_CACHE_SIZE);
+        while let Some(()) = archived_segments_receiver.next().await {
+            let archived_segment_header = last_archived_segment.load(Ordering::SeqCst);
+
+            // It is fine to take a synchronous read lock here because the only time
+            // write lock is taken is during plotting, which we know doesn't happen
+            // right now. We copy data here because `.read()`'s guard is not `Send`.
+            sectors_metadata
+                .read()
+                .iter()
+                .map(|sector_metadata| (sector_metadata.sector_index, sector_metadata.history_size))
+                .collect_into(&mut sectors_to_check);
+            for (sector_index, history_size) in sectors_to_check.drain(..) {
+                if let Some(sector_expire_at) = sectors_expire_at.get(&sector_index) {
+                    if *sector_expire_at >= archived_segment_header.segment_index() {
+                        // Time to replot
+                        sector_indices_to_replot.push(sector_index);
+                    }
+                    continue;
+                }
+
+                if let Some(expiration_check_segment_index) = history_size
+                    .sector_expiration_check(min_sector_lifetime)
+                    .map(|expiration_check_history_size| {
+                        expiration_check_history_size.segment_index()
+                    })
+                {
+                    let maybe_sector_expiration_check_segment_commitment =
+                        if let Some(segment_commitment) =
+                            archived_segment_commitments_cache.get(&expiration_check_segment_index)
+                        {
+                            Some(*segment_commitment)
+                        } else {
+                            node_client
+                                .segment_headers(vec![expiration_check_segment_index])
+                                .await
+                                .map_err(|error| PlottingError::FailedToGetSegmentHeader { error })?
+                                .into_iter()
+                                .next()
+                                .flatten()
+                                .map(|segment_header| {
+                                    let segment_commitment = segment_header.segment_commitment();
+
+                                    archived_segment_commitments_cache
+                                        .push(expiration_check_segment_index, segment_commitment);
+                                    segment_commitment
+                                })
+                        };
+
+                    if let Some(sector_expiration_check_segment_commitment) =
+                        maybe_sector_expiration_check_segment_commitment
+                    {
+                        let sector_id = SectorId::new(public_key_hash, sector_index);
+                        let expiration_history_size = sector_id
+                            .derive_expiration_history_size(
+                                history_size,
+                                &sector_expiration_check_segment_commitment,
+                                min_sector_lifetime,
+                            )
+                            .expect(
+                                "Farmers internally stores correct history size in sector \
+                                metadata; qed",
+                            );
+
+                        if expiration_history_size.segment_index()
+                            >= archived_segment_header.segment_index()
+                        {
+                            // Time to replot
+                            sector_indices_to_replot.push(sector_index);
+                        } else {
+                            // Store expiration so we don't have to recalculate it later
+                            sectors_expire_at
+                                .insert(sector_index, expiration_history_size.segment_index());
+                        }
+                    }
+                }
+            }
+
+            for sector_index in sector_indices_to_replot.iter() {
+                let (acknowledgement_sender, acknowledgement_receiver) = oneshot::channel();
+                if let Err(error) = sectors_to_plot_sender
+                    .send((*sector_index, acknowledgement_sender))
+                    .await
+                {
+                    warn!(%error, "Failed to send sector index for replotting");
+                    return Ok(());
+                }
+
+                // We do not care if message was sent back or sender was just dropped
+                let _ = acknowledgement_receiver.await;
+
+                sectors_expire_at.remove(sector_index);
+            }
+
+            sector_indices_to_replot.clear();
+        }
+
+        Ok(())
+    };
+
+    let (Either::Left((result, _)) | Either::Right((result, _))) = select(
+        Box::pin(read_archived_segments_notifications_fut),
+        Box::pin(send_plotting_notifications_fut),
+    )
+    .await;
+
+    result
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -180,6 +180,9 @@ const RECENT_HISTORY_FRACTION: (HistorySize, HistorySize) = (
     HistorySize::new(NonZeroU64::new(1).expect("Not zero; qed")),
     HistorySize::new(NonZeroU64::new(10).expect("Not zero; qed")),
 );
+/// Minimum lifetime of a plotted sector, measured in archived segment.
+const MIN_SECTOR_LIFETIME: HistorySize =
+    HistorySize::new(NonZeroU64::new(4).expect("Not zero; qed"));
 
 /// The block weight for 2 seconds of compute
 const BLOCK_WEIGHT_FOR_2_SEC: Weight =
@@ -265,6 +268,7 @@ parameter_types! {
     pub const ExpectedVotesPerBlock: u32 = EXPECTED_VOTES_PER_BLOCK;
     pub const RecentSegments: HistorySize = RECENT_SEGMENTS;
     pub const RecentHistoryFraction: (HistorySize, HistorySize) = RECENT_HISTORY_FRACTION;
+    pub const MinSectorLifetime: HistorySize = MIN_SECTOR_LIFETIME;
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
@@ -288,6 +292,7 @@ impl pallet_subspace::Config for Runtime {
     type ConfirmationDepthK = ConfirmationDepthK;
     type RecentSegments = RecentSegments;
     type RecentHistoryFraction = RecentHistoryFraction;
+    type MinSectorLifetime = MinSectorLifetime;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -42,13 +42,21 @@ use subspace_proof_of_space::Table;
 #[derive(Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error {
-    /// Piece verification failed
+    /// Invalid piece offset
     #[cfg_attr(feature = "thiserror", error("Piece verification failed"))]
     InvalidPieceOffset {
         /// Index of the piece that failed verification
         piece_offset: u16,
         /// How many pieces one sector is supposed to contain (max)
         max_pieces_in_sector: u16,
+    },
+    /// Sector expired
+    #[cfg_attr(feature = "thiserror", error("Sector expired"))]
+    SectorExpired {
+        /// Expiration history size
+        expiration_history_size: HistorySize,
+        /// Current history size
+        current_history_size: HistorySize,
     },
     /// Piece verification failed
     #[cfg_attr(feature = "thiserror", error("Piece verification failed"))]
@@ -76,6 +84,9 @@ pub enum Error {
     /// Invalid chunk witness
     #[cfg_attr(feature = "thiserror", error("Invalid chunk witness"))]
     InvalidChunkWitness,
+    /// Invalid history size
+    #[cfg_attr(feature = "thiserror", error("Invalid history size"))]
+    InvalidHistorySize,
 }
 
 /// Check the reward signature validity.
@@ -136,10 +147,16 @@ pub struct PieceCheckParams {
     pub max_pieces_in_sector: u16,
     /// Segment commitment of segment to which piece belongs
     pub segment_commitment: SegmentCommitment,
-    /// Number of latest archived segments that are considered "recent history".
+    /// Number of latest archived segments that are considered "recent history"
     pub recent_segments: HistorySize,
-    /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
+    /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector
     pub recent_history_fraction: (HistorySize, HistorySize),
+    /// Minimum lifetime of a plotted sector, measured in archived segment
+    pub min_sector_lifetime: HistorySize,
+    /// Current size of the history
+    pub current_history_size: HistorySize,
+    /// Segment commitment at `min_sector_lifetime` from sector creation (if exists)
+    pub sector_expiration_check_segment_commitment: Option<SegmentCommitment>,
 }
 
 /// Parameters for solution verification
@@ -189,7 +206,7 @@ where
 
     // Check that proof of space is valid
     let quality = match PosTable::is_proof_valid(
-        &sector_id.evaluation_seed(solution.piece_offset, solution.history_size),
+        &sector_id.derive_evaluation_seed(solution.piece_offset, solution.history_size),
         s_bucket_audit_index.into(),
         &solution.proof_of_space,
     ) {
@@ -240,6 +257,9 @@ where
         segment_commitment,
         recent_segments,
         recent_history_fraction,
+        min_sector_lifetime,
+        current_history_size,
+        sector_expiration_check_segment_commitment,
     }) = piece_check_params
     {
         if u16::from(solution.piece_offset) >= *max_pieces_in_sector {
@@ -247,6 +267,27 @@ where
                 piece_offset: u16::from(solution.piece_offset),
                 max_pieces_in_sector: *max_pieces_in_sector,
             });
+        }
+        if let Some(sector_expiration_check_segment_commitment) =
+            sector_expiration_check_segment_commitment
+        {
+            let expiration_history_size = match sector_id.derive_expiration_history_size(
+                solution.history_size,
+                sector_expiration_check_segment_commitment,
+                *min_sector_lifetime,
+            ) {
+                Some(expiration_history_size) => expiration_history_size,
+                None => {
+                    return Err(Error::InvalidHistorySize);
+                }
+            };
+
+            if expiration_history_size >= *current_history_size {
+                return Err(Error::SectorExpired {
+                    expiration_history_size,
+                    current_history_size: *current_history_size,
+                });
+            }
         }
 
         let position = sector_id

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -237,6 +237,7 @@ where
             HistorySize::from(NonZeroU64::new(1).unwrap()),
             HistorySize::from(NonZeroU64::new(10).unwrap()),
         ),
+        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
 
     let plotted_sector = plot_sector::<_, PosTable>(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -244,6 +244,7 @@ parameter_types! {
         HistorySize::new(NonZeroU64::new(1).unwrap()),
         HistorySize::new(NonZeroU64::new(10).unwrap()),
     );
+    pub const MinSectorLifetime: HistorySize = HistorySize::new(NonZeroU64::new(4).unwrap());
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -256,6 +257,7 @@ impl pallet_subspace::Config for Runtime {
     type ConfirmationDepthK = ConfirmationDepthK;
     type RecentSegments = RecentSegments;
     type RecentHistoryFraction = RecentHistoryFraction;
+    type MinSectorLifetime = MinSectorLifetime;
     type ExpectedVotesPerBlock = ExpectedVotesPerBlock;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;


### PR DESCRIPTION
This is an implementation of sector expiration as described in the specification, last PR in a series building on top of https://github.com/subspace/subspace/pull/1645.

The way it is implemented on farmer side is a bit tricky. Plotting process is not just receiving a stream of sector indices that need to be plotted/replotted. We listen for archived segment notifications from the node and for each notification we check which new sectors have expired (and keep track of known expiry history sizes for sectors we have checked before). This happens in a separate non-blocking async task.

I have tested that this works properly manually, but I did not write tests for this just yet to get this PR out sooner (there are a few TODOs for this though).

In the end we have yet another function with tons of arguments in farmer code. I don't thing turning it into a struct is a real solution, I need to think how to refactor it so that it is structured in a better way somehow.

Resolves https://github.com/subspace/subspace/issues/1503

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
