### PR TITLE
Introduce multiple instances of connected-peers protocol.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -303,10 +303,9 @@ pub(super) fn configure_dsn(
         max_pending_outgoing_connections: pending_out_connections,
         max_established_incoming_connections: in_connections,
         max_pending_incoming_connections: pending_in_connections,
-        target_connections,
-        // TODO: add permanent connections with different peers types
+        general_target_connections: target_connections,
         // maintain permanent connections between farmers
-        connection_decision_handler: Arc::new(|peer_info| {
+        special_connection_decision_handler: Arc::new(|peer_info| {
             matches!(peer_info, PeerInfo::Farmer { .. })
         }),
         ..default_config

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -308,6 +308,10 @@ pub(super) fn configure_dsn(
         special_connection_decision_handler: Arc::new(|peer_info| {
             matches!(peer_info, PeerInfo::Farmer { .. })
         }),
+        // other (non-farmer) connections
+        general_connection_decision_handler: Arc::new(|peer_info| {
+            !matches!(peer_info, PeerInfo::Farmer { .. })
+        }),
         ..default_config
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -305,13 +305,9 @@ pub(super) fn configure_dsn(
         max_pending_incoming_connections: pending_in_connections,
         general_target_connections: target_connections,
         // maintain permanent connections between farmers
-        special_connection_decision_handler: Arc::new(|peer_info| {
-            matches!(peer_info, PeerInfo::Farmer { .. })
-        }),
+        special_connected_peers_handler: Arc::new(PeerInfo::is_farmer),
         // other (non-farmer) connections
-        general_connection_decision_handler: Arc::new(|peer_info| {
-            !matches!(peer_info, PeerInfo::Farmer { .. })
-        }),
+        general_connected_peers_handler: Arc::new(|peer_info| !PeerInfo::is_farmer(peer_info)),
         ..default_config
     };
 

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -54,9 +54,16 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     pub(crate) peer_info_config: PeerInfoConfig,
     /// Provides peer-info for local peer.
     pub(crate) peer_info_provider: PeerInfoProvider,
-    /// The configuration for the [`ConnectedPeers`] protocol.
-    pub(crate) connected_peers_config: ConnectedPeersConfig,
+    /// The configuration for the [`ConnectedPeers`] protocol (general instance).
+    pub(crate) general_connected_peers_config: ConnectedPeersConfig,
+    /// The configuration for the [`ConnectedPeers`] protocol (special instance).
+    pub(crate) special_connected_peers_config: ConnectedPeersConfig,
 }
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GeneralConnectedPeersInstance;
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SpecialConnectedPeersInstance;
 
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "Event")]
@@ -71,7 +78,8 @@ pub(crate) struct Behavior<RecordStore> {
     pub(crate) block_list: BlockListBehaviour,
     pub(crate) reserved_peers: ReservedPeersBehaviour,
     pub(crate) peer_info: PeerInfoBehaviour,
-    pub(crate) connected_peers: ConnectedPeersBehaviour,
+    pub(crate) general_connected_peers: ConnectedPeersBehaviour<GeneralConnectedPeersInstance>,
+    pub(crate) special_connected_peers: ConnectedPeersBehaviour<SpecialConnectedPeersInstance>,
 }
 
 impl<RecordStore> Behavior<RecordStore>
@@ -111,7 +119,12 @@ where
             block_list: BlockListBehaviour::default(),
             reserved_peers: ReservedPeersBehaviour::new(config.reserved_peers),
             peer_info: PeerInfoBehaviour::new(config.peer_info_config, config.peer_info_provider),
-            connected_peers: ConnectedPeersBehaviour::new(config.connected_peers_config),
+            general_connected_peers: ConnectedPeersBehaviour::new(
+                config.general_connected_peers_config,
+            ),
+            special_connected_peers: ConnectedPeersBehaviour::new(
+                config.special_connected_peers_config,
+            ),
         }
     }
 }
@@ -127,5 +140,6 @@ pub(crate) enum Event {
     VoidEventStub(VoidEvent),
     ReservedPeers(ReservedPeersEvent),
     PeerInfo(PeerInfoEvent),
-    ConnectedPeers(ConnectedPeersEvent),
+    GeneralConnectedPeers(ConnectedPeersEvent<GeneralConnectedPeersInstance>),
+    SpecialConnectedPeers(ConnectedPeersEvent<SpecialConnectedPeersInstance>),
 }

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -180,8 +180,9 @@ async fn main() -> anyhow::Result<()> {
                 max_established_outgoing_connections: out_peers,
                 max_pending_incoming_connections: pending_in_peers,
                 max_pending_outgoing_connections: pending_out_peers,
-                // maintain permanent connections with any peer
-                general_connection_decision_handler: Arc::new(|_| true),
+                // we don't maintain permanent connections with any peer
+                general_connected_peers_handler: Arc::new(|_| false),
+                special_connected_peers_handler: Arc::new(|_| false),
                 ..Config::new(
                     protocol_version.to_string(),
                     keypair,

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -181,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
                 max_pending_incoming_connections: pending_in_peers,
                 max_pending_outgoing_connections: pending_out_peers,
                 // maintain permanent connections with any peer
-                connection_decision_handler: Arc::new(|_| true),
+                general_connection_decision_handler: Arc::new(|_| true),
                 ..Config::new(
                     protocol_version.to_string(),
                     keypair,

--- a/crates/subspace-networking/src/connected_peers.rs
+++ b/crates/subspace-networking/src/connected_peers.rs
@@ -20,8 +20,7 @@
 //!
 //! The protocol strives to maintain a certain target number of peers, handles delay between dialing
 //! attempts, and manages a cache for candidates for permanent connections.
-//! Multiple protocol instances could be instantiated. Note that each protocol instance should have
-//! a unique protocol name.
+//! Multiple protocol instances could be instantiated.
 
 mod handler;
 
@@ -83,8 +82,8 @@ enum ConnectionState {
 /// Connected peers protocol configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Protocol name.
-    pub protocol_name: &'static [u8],
+    /// Defines a target for logging.
+    pub log_target: &'static str,
     /// Interval between new dialing attempts.
     pub dialing_interval: Duration,
     /// Number of connected peers that protocol will maintain.
@@ -96,11 +95,11 @@ pub struct Config {
     pub decision_timeout: Duration,
 }
 
-const DEFAULT_CONNECTED_PEERS_PROTOCOL_NAME: &[u8] = b"/connected-peers/1.0.0";
+const DEFAULT_CONNECTED_PEERS_LOG_TARGET: &str = "connected-peers";
 impl Default for Config {
     fn default() -> Self {
         Self {
-            protocol_name: DEFAULT_CONNECTED_PEERS_PROTOCOL_NAME,
+            log_target: DEFAULT_CONNECTED_PEERS_LOG_TARGET,
             dialing_interval: Duration::from_secs(3),
             target_connected_peers: 30,
             dialing_peer_batch_size: 5,
@@ -188,7 +187,7 @@ impl<Instance> Behaviour<Instance> {
         };
 
         self.wake();
-        Handler::new(self.config.protocol_name, keep_alive)
+        Handler::new(keep_alive)
     }
 
     /// Specifies the whether we should keep connections to the peer alive. The decision could
@@ -371,7 +370,7 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
             trace!(
                 %peer_id,
                 ?decision,
-                protocol=%std::str::from_utf8(self.config.protocol_name).expect("Manual protocol setting."),
+                target=%self.config.log_target,
                 "Peer decisions for connected peers protocol."
             );
             match state.connection_state.clone() {

--- a/crates/subspace-networking/src/connected_peers.rs
+++ b/crates/subspace-networking/src/connected_peers.rs
@@ -369,7 +369,7 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
         for (peer_id, state) in self.known_peers.iter_mut() {
             trace!(
                 %peer_id,
-                ?decision,
+                ?state,
                 target=%self.config.log_target,
                 "Peer decisions for connected peers protocol."
             );

--- a/crates/subspace-networking/src/connected_peers/handler.rs
+++ b/crates/subspace-networking/src/connected_peers/handler.rs
@@ -1,4 +1,4 @@
-use libp2p::core::upgrade::ReadyUpgrade;
+use libp2p::core::upgrade::DeniedUpgrade;
 use libp2p::swarm::handler::ConnectionEvent;
 use libp2p::swarm::{ConnectionHandler, ConnectionHandlerEvent, KeepAlive, SubstreamProtocol};
 use std::error::Error;
@@ -18,19 +18,14 @@ use tracing::trace;
 /// peer with positive keep-alive decision (we are interested in this connection), it maintains the
 /// connection alive (`KeepAlive::Yes`). If not, it allows the connection to close (`KeepAlive::No`).
 pub struct Handler {
-    /// Protocol name.
-    protocol_name: &'static [u8],
     /// Specifies whether we should keep the connection alive.
     keep_alive: KeepAlive,
 }
 
 impl Handler {
     /// Builds a new [`Handler`].
-    pub fn new(protocol_name: &'static [u8], keep_alive: KeepAlive) -> Self {
-        Handler {
-            protocol_name,
-            keep_alive,
-        }
+    pub fn new(keep_alive: KeepAlive) -> Self {
+        Handler { keep_alive }
     }
 }
 
@@ -49,13 +44,13 @@ impl ConnectionHandler for Handler {
     type InEvent = KeepAlive;
     type OutEvent = ();
     type Error = ConnectedPeersError;
-    type InboundProtocol = ReadyUpgrade<&'static [u8]>;
-    type OutboundProtocol = ReadyUpgrade<&'static [u8]>;
+    type InboundProtocol = DeniedUpgrade;
+    type OutboundProtocol = DeniedUpgrade;
     type OutboundOpenInfo = ();
     type InboundOpenInfo = ();
 
-    fn listen_protocol(&self) -> SubstreamProtocol<ReadyUpgrade<&'static [u8]>, ()> {
-        SubstreamProtocol::new(ReadyUpgrade::new(self.protocol_name), ())
+    fn listen_protocol(&self) -> SubstreamProtocol<DeniedUpgrade, ()> {
+        SubstreamProtocol::new(DeniedUpgrade, ())
     }
 
     fn on_behaviour_event(&mut self, keep_alive: KeepAlive) {
@@ -71,7 +66,7 @@ impl ConnectionHandler for Handler {
     fn poll(
         &mut self,
         _: &mut Context<'_>,
-    ) -> Poll<ConnectionHandlerEvent<ReadyUpgrade<&'static [u8]>, (), (), Self::Error>> {
+    ) -> Poll<ConnectionHandlerEvent<DeniedUpgrade, (), (), Self::Error>> {
         Poll::Pending
     }
 

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -48,7 +48,7 @@ use thiserror::Error;
 use tracing::{debug, error, info};
 
 /// Defines whether connection should be maintained permanently.
-pub type ConnectionDecisionHandler = Arc<dyn Fn(&PeerInfo) -> bool + Send + Sync + 'static>;
+pub type ConnectedPeersHandler = Arc<dyn Fn(&PeerInfo) -> bool + Send + Sync + 'static>;
 
 const DEFAULT_NETWORK_PROTOCOL_VERSION: &str = "dev";
 const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
@@ -218,9 +218,9 @@ pub struct Config<ProviderStorage> {
     /// Specifies a source for peer information.
     pub peer_info_provider: PeerInfoProvider,
     /// Defines whether we maintain a persistent connection for common peers.
-    pub general_connection_decision_handler: ConnectionDecisionHandler,
+    pub general_connected_peers_handler: ConnectedPeersHandler,
     /// Defines whether we maintain a persistent connection for special peers.
-    pub special_connection_decision_handler: ConnectionDecisionHandler,
+    pub special_connected_peers_handler: ConnectedPeersHandler,
     /// Defines target total (in and out) connection number that should be maintained for general peers.
     pub general_target_connections: u32,
     /// Defines target total (in and out) connection number that should be maintained for special peers.
@@ -332,9 +332,9 @@ where
             protocol_version,
             peer_info_provider,
             // maintain permanent connections with any peer
-            general_connection_decision_handler: Arc::new(|_| true),
+            general_connected_peers_handler: Arc::new(|_| true),
             // we don't need to keep additional connections by default
-            special_connection_decision_handler: Arc::new(|_| false),
+            special_connected_peers_handler: Arc::new(|_| false),
             general_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
         }
@@ -395,8 +395,8 @@ where
         metrics,
         protocol_version,
         peer_info_provider,
-        general_connection_decision_handler,
-        special_connection_decision_handler,
+        general_connected_peers_handler: general_connection_decision_handler,
+        special_connected_peers_handler: special_connection_decision_handler,
         general_target_connections,
         special_target_connections,
     } = config;

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -55,21 +55,22 @@ const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
 const RESERVED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/reserved-peers/1.0.0";
 const PEER_INFO_PROTOCOL_NAME: &[u8] = b"/subspace/peer-info/1.0.0";
-const CONNECTED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/connected-peers/1.0.0";
+const GENERAL_CONNECTED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/general-connected-peers/1.0.0";
+const SPECIAL_CONNECTED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/special-connected-peers/1.0.0";
 
 // Defines max_negotiating_inbound_streams constant for the swarm.
 // It must be set for large plots.
 const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 /// The default maximum established incoming connection number for the swarm.
-const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 50;
+const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 80;
 /// The default maximum established incoming connection number for the swarm.
-const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 50;
+const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 80;
 /// The default maximum pending incoming connection number for the swarm.
-const SWARM_MAX_PENDING_INCOMING_CONNECTIONS: u32 = 50;
+const SWARM_MAX_PENDING_INCOMING_CONNECTIONS: u32 = 80;
 /// The default maximum pending incoming connection number for the swarm.
-const SWARM_MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 50;
+const SWARM_MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 80;
 // The default maximum connection number to be maintained for the swarm.
-const SWARM_TARGET_CONNECTION_NUMBER: u32 = 50;
+const SWARM_TARGET_CONNECTION_NUMBER: u32 = 30;
 // Defines an expiration interval for item providers in Kademlia network.
 const KADEMLIA_PROVIDER_TTL_IN_SECS: Option<Duration> = Some(Duration::from_secs(86400)); /* 1 day */
 // Defines a republication interval for item providers in Kademlia network.
@@ -206,8 +207,6 @@ pub struct Config<ProviderStorage> {
     pub max_pending_incoming_connections: u32,
     /// Pending outgoing swarm connection limit.
     pub max_pending_outgoing_connections: u32,
-    /// Defines target total (in and out) connection number that should be maintained.
-    pub target_connections: u32,
     /// How many temporarily banned unreachable peers to keep in memory.
     pub temporary_bans_cache_size: NonZeroUsize,
     /// Backoff policy for temporary banning of unreachable peers.
@@ -218,8 +217,14 @@ pub struct Config<ProviderStorage> {
     pub protocol_version: String,
     /// Specifies a source for peer information.
     pub peer_info_provider: PeerInfoProvider,
-    /// Defines whether we maintain a persistent connection.
-    pub connection_decision_handler: ConnectionDecisionHandler,
+    /// Defines whether we maintain a persistent connection for common peers.
+    pub general_connection_decision_handler: ConnectionDecisionHandler,
+    /// Defines whether we maintain a persistent connection for special peers.
+    pub special_connection_decision_handler: ConnectionDecisionHandler,
+    /// Defines target total (in and out) connection number that should be maintained for general peers.
+    pub general_target_connections: u32,
+    /// Defines target total (in and out) connection number that should be maintained for special peers.
+    pub special_target_connections: u32,
 }
 
 impl<ProviderStorage> fmt::Debug for Config<ProviderStorage> {
@@ -321,13 +326,17 @@ where
             max_established_outgoing_connections: SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS,
             max_pending_incoming_connections: SWARM_MAX_PENDING_INCOMING_CONNECTIONS,
             max_pending_outgoing_connections: SWARM_MAX_PENDING_OUTGOING_CONNECTIONS,
-            target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             temporary_bans_cache_size: TEMPORARY_BANS_CACHE_SIZE,
             temporary_ban_backoff,
             metrics: None,
             protocol_version,
             peer_info_provider,
-            connection_decision_handler: Arc::new(|_| false),
+            // maintain permanent connections with any peer
+            general_connection_decision_handler: Arc::new(|_| true),
+            // we don't need to keep additional connections by default
+            special_connection_decision_handler: Arc::new(|_| false),
+            general_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
+            special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
         }
     }
 }
@@ -381,13 +390,15 @@ where
         max_established_outgoing_connections,
         max_pending_incoming_connections,
         max_pending_outgoing_connections,
-        target_connections,
         temporary_bans_cache_size,
         temporary_ban_backoff,
         metrics,
         protocol_version,
         peer_info_provider,
-        connection_decision_handler,
+        general_connection_decision_handler,
+        special_connection_decision_handler,
+        general_target_connections,
+        special_target_connections,
     } = config;
     let local_peer_id = peer_id(&keypair);
 
@@ -433,9 +444,14 @@ where
         },
         peer_info_config: PeerInfoConfig::new(PEER_INFO_PROTOCOL_NAME),
         peer_info_provider,
-        connected_peers_config: ConnectedPeersConfig {
-            protocol_name: CONNECTED_PEERS_PROTOCOL_NAME,
-            target_connected_peers: target_connections,
+        general_connected_peers_config: ConnectedPeersConfig {
+            protocol_name: GENERAL_CONNECTED_PEERS_PROTOCOL_NAME,
+            target_connected_peers: general_target_connections,
+            ..ConnectedPeersConfig::default()
+        },
+        special_connected_peers_config: ConnectedPeersConfig {
+            protocol_name: SPECIAL_CONNECTED_PEERS_PROTOCOL_NAME,
+            target_connected_peers: special_target_connections,
             ..ConnectedPeersConfig::default()
         },
     });
@@ -487,7 +503,8 @@ where
         temporary_bans,
         metrics,
         protocol_version,
-        connection_decision_handler,
+        general_connection_decision_handler,
+        special_connection_decision_handler,
     });
 
     Ok((node, node_runner))

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -55,8 +55,8 @@ const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
 const RESERVED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/reserved-peers/1.0.0";
 const PEER_INFO_PROTOCOL_NAME: &[u8] = b"/subspace/peer-info/1.0.0";
-const GENERAL_CONNECTED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/general-connected-peers/1.0.0";
-const SPECIAL_CONNECTED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/special-connected-peers/1.0.0";
+const GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "general-connected-peers";
+const SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "special-connected-peers";
 
 // Defines max_negotiating_inbound_streams constant for the swarm.
 // It must be set for large plots.
@@ -445,12 +445,12 @@ where
         peer_info_config: PeerInfoConfig::new(PEER_INFO_PROTOCOL_NAME),
         peer_info_provider,
         general_connected_peers_config: ConnectedPeersConfig {
-            protocol_name: GENERAL_CONNECTED_PEERS_PROTOCOL_NAME,
+            log_target: GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
             target_connected_peers: general_target_connections,
             ..ConnectedPeersConfig::default()
         },
         special_connected_peers_config: ConnectedPeersConfig {
-            protocol_name: SPECIAL_CONNECTED_PEERS_PROTOCOL_NAME,
+            log_target: SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
             target_connected_peers: special_target_connections,
             ..ConnectedPeersConfig::default()
         },

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -817,12 +817,12 @@ where
                 .general_connected_peers
                 .update_keep_alive_status(event.peer_id, keep_alive);
 
-            let farmer_keep_alive = (self.special_connection_decision_handler)(&peer_info);
+            let special_keep_alive = (self.special_connection_decision_handler)(&peer_info);
 
             self.swarm
                 .behaviour_mut()
                 .special_connected_peers
-                .update_keep_alive_status(event.peer_id, farmer_keep_alive);
+                .update_keep_alive_status(event.peer_id, special_keep_alive);
         }
     }
 

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1,7 +1,7 @@
-use crate::behavior::persistent_parameters::{
-    NetworkingParametersRegistry, PEERS_ADDRESSES_BATCH_SIZE,
-};
-use crate::behavior::{provider_storage, Behavior, Event};
+use crate::behavior::persistent_parameters::NetworkingParametersRegistry;
+use crate::behavior::{
+    provider_storage, Behavior, Event, GeneralConnectedPeersInstance, SpecialConnectedPeersInstance,
+PEERS_ADDRESSES_BATCH_SIZE};
 use crate::connected_peers::Event as ConnectedPeersEvent;
 use crate::create::temporary_bans::TemporaryBans;
 use crate::create::{
@@ -13,6 +13,7 @@ use crate::request_responses::{Event as RequestResponseEvent, IfDisconnected};
 use crate::shared::{Command, CreatedSubscription, Shared};
 use crate::utils::{is_global_address_or_dns, PeerAddress, ResizableSemaphorePermit};
 use bytes::Bytes;
+use either::{Either, Left, Right};
 use futures::channel::mpsc;
 use futures::future::Fuse;
 use futures::{FutureExt, StreamExt};
@@ -113,8 +114,10 @@ where
     established_connections: HashMap<(PeerId, ConnectedPoint), usize>,
     /// Defines protocol version for the network peers. Affects network partition.
     protocol_version: String,
-    /// Defines whether we maintain a persistent connection.
-    connection_decision_handler: ConnectionDecisionHandler,
+    /// Defines whether we maintain a persistent connection for common peers.
+    general_connection_decision_handler: ConnectionDecisionHandler,
+    /// Defines whether we maintain a persistent connection for special peers.
+    special_connection_decision_handler: ConnectionDecisionHandler,
     /// Randomness generator used for choosing Kademlia addresses.
     rng: StdRng,
 }
@@ -134,7 +137,8 @@ where
     pub(crate) temporary_bans: Arc<Mutex<TemporaryBans>>,
     pub(crate) metrics: Option<Metrics>,
     pub(crate) protocol_version: String,
-    pub(crate) connection_decision_handler: ConnectionDecisionHandler,
+    pub(crate) general_connection_decision_handler: ConnectionDecisionHandler,
+    pub(crate) special_connection_decision_handler: ConnectionDecisionHandler,
 }
 
 impl<ProviderStorage> NodeRunner<ProviderStorage>
@@ -153,7 +157,8 @@ where
             temporary_bans,
             metrics,
             protocol_version,
-            connection_decision_handler,
+            general_connection_decision_handler,
+            special_connection_decision_handler,
         }: NodeRunnerConfig<ProviderStorage>,
     ) -> Self {
         Self {
@@ -175,7 +180,8 @@ where
             metrics,
             established_connections: HashMap::new(),
             protocol_version,
-            connection_decision_handler,
+            general_connection_decision_handler,
+            special_connection_decision_handler,
             rng: StdRng::seed_from_u64(KADEMLIA_PEERS_ADDRESSES_BATCH_SIZE as u64), // any seed
         }
     }
@@ -272,8 +278,11 @@ where
             SwarmEvent::Behaviour(Event::PeerInfo(event)) => {
                 self.handle_peer_info_event(event).await;
             }
-            SwarmEvent::Behaviour(Event::ConnectedPeers(event)) => {
-                self.handle_connected_peers_event(event).await;
+            SwarmEvent::Behaviour(Event::GeneralConnectedPeers(event)) => {
+                self.handle_connected_peers_event(Left(event)).await;
+            }
+            SwarmEvent::Behaviour(Event::SpecialConnectedPeers(event)) => {
+                self.handle_connected_peers_event(Right(event)).await;
             }
             SwarmEvent::NewListenAddr { address, .. } => {
                 let shared = match self.shared_weak.upgrade() {
@@ -801,25 +810,44 @@ where
         trace!(?event, "Peer info event.");
 
         if let Ok(PeerInfoSuccess::Received(peer_info)) = event.result {
-            let keep_alive = (self.connection_decision_handler)(&peer_info);
+            let keep_alive = (self.general_connection_decision_handler)(&peer_info);
 
             self.swarm
                 .behaviour_mut()
-                .connected_peers
+                .general_connected_peers
                 .update_keep_alive_status(event.peer_id, keep_alive);
+
+            let farmer_keep_alive = (self.special_connection_decision_handler)(&peer_info);
+
+            self.swarm
+                .behaviour_mut()
+                .special_connected_peers
+                .update_keep_alive_status(event.peer_id, farmer_keep_alive);
         }
     }
 
-    async fn handle_connected_peers_event(&mut self, event: ConnectedPeersEvent) {
+    async fn handle_connected_peers_event(
+        &mut self,
+        event: Either<
+            ConnectedPeersEvent<GeneralConnectedPeersInstance>,
+            ConnectedPeersEvent<SpecialConnectedPeersInstance>,
+        >,
+    ) {
         trace!(?event, "Connected peers event.");
 
-        match event {
-            ConnectedPeersEvent::NewDialingCandidatesRequested => {
-                let peers = self.get_peers_to_dial().await;
+        let peers = self.get_peers_to_dial().await;
 
+        match event {
+            Left(ConnectedPeersEvent::NewDialingCandidatesRequested(..)) => {
                 self.swarm
                     .behaviour_mut()
-                    .connected_peers
+                    .general_connected_peers
+                    .add_peers_to_dial(peers);
+            }
+            Right(ConnectedPeersEvent::NewDialingCandidatesRequested(..)) => {
+                self.swarm
+                    .behaviour_mut()
+                    .special_connected_peers
                     .add_peers_to_dial(&peers);
             }
         }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1,7 +1,9 @@
-use crate::behavior::persistent_parameters::NetworkingParametersRegistry;
+use crate::behavior::persistent_parameters::{
+    NetworkingParametersRegistry, PEERS_ADDRESSES_BATCH_SIZE,
+};
 use crate::behavior::{
     provider_storage, Behavior, Event, GeneralConnectedPeersInstance, SpecialConnectedPeersInstance,
-PEERS_ADDRESSES_BATCH_SIZE};
+};
 use crate::connected_peers::Event as ConnectedPeersEvent;
 use crate::create::temporary_bans::TemporaryBans;
 use crate::create::{
@@ -842,7 +844,7 @@ where
                 self.swarm
                     .behaviour_mut()
                     .general_connected_peers
-                    .add_peers_to_dial(peers);
+                    .add_peers_to_dial(&peers);
             }
             Right(ConnectedPeersEvent::NewDialingCandidatesRequested(..)) => {
                 self.swarm

--- a/crates/subspace-networking/src/peer_info.rs
+++ b/crates/subspace-networking/src/peer_info.rs
@@ -63,6 +63,13 @@ pub enum PeerInfo {
     Client,
 }
 
+impl PeerInfo {
+    /// Returns whether [`PeerInfo`] is a Farmer.
+    pub fn is_farmer(peer_info: &PeerInfo) -> bool {
+        matches!(peer_info, Self::Farmer { .. })
+    }
+}
+
 /// A [`NetworkBehaviour`] that handles inbound peer info requests and
 /// sends outbound peer info requests on the first established connection.
 pub struct Behaviour {

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -240,7 +240,7 @@ where
         special_target_connections: 0,
         reserved_peers: dsn_config.reserved_peers,
         // maintain permanent connections with any peer
-        general_connection_decision_handler: Arc::new(|_| true),
+        general_connected_peers_handler: Arc::new(|_| true),
 
         ..default_networking_config
     };

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -240,7 +240,7 @@ where
         special_target_connections: 0,
         reserved_peers: dsn_config.reserved_peers,
         // maintain permanent connections with any peer
-        connection_decision_handler: Arc::new(|_| true),
+        general_connection_decision_handler: Arc::new(|_| true),
 
         ..default_networking_config
     };

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -236,7 +236,8 @@ where
         max_established_outgoing_connections: dsn_config.max_out_connections,
         max_pending_incoming_connections: dsn_config.max_pending_in_connections,
         max_pending_outgoing_connections: dsn_config.max_pending_out_connections,
-        target_connections: dsn_config.target_connections,
+        general_target_connections: dsn_config.target_connections,
+        special_target_connections: 0,
         reserved_peers: dsn_config.reserved_peers,
         // maintain permanent connections with any peer
         connection_decision_handler: Arc::new(|_| true),


### PR DESCRIPTION
This PR follows https://github.com/subspace/subspace/pull/1654 introducing the connected-peers protocol and adding multiple instances of the same protocol to provide additional connectivity for farmers: maintaining connections not only with other farmers but with other peer types as well.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
