### PR TITLE
Use global_randomness instead of global_challenge in ProofOfElection

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -352,10 +352,16 @@ where
                         .boxed(),
                     );
 
+                    let slot_number = new_slot_info.slot.into();
+
+                    let global_challenge = new_slot_info
+                        .global_randomness
+                        .derive_global_challenge(slot_number);
+
                     // This will be sent to the farmer
                     SlotInfo {
-                        slot_number: new_slot_info.slot.into(),
-                        global_challenge: new_slot_info.global_challenge,
+                        slot_number,
+                        global_challenge,
                         solution_range: new_slot_info.solution_range,
                         voting_solution_range: new_slot_info.voting_solution_range,
                     }

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -79,8 +79,8 @@ use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    Blake2b256Hash, HistorySize, PublicKey, SectorId, SegmentCommitment, SegmentHeader,
-    SegmentIndex, Solution, SolutionRange,
+    HistorySize, PublicKey, Randomness, SectorId, SegmentCommitment, SegmentHeader, SegmentIndex,
+    Solution, SolutionRange,
 };
 use subspace_proof_of_space::Table;
 use subspace_solving::REWARD_SIGNING_CONTEXT;
@@ -94,8 +94,8 @@ use subspace_verification::{
 pub struct NewSlotInfo {
     /// Slot
     pub slot: Slot,
-    /// Global slot challenge
-    pub global_challenge: Blake2b256Hash,
+    /// Global randomness
+    pub global_randomness: Randomness,
     /// Acceptable solution range for block authoring
     pub solution_range: SolutionRange,
     /// Acceptable solution range for voting

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -180,7 +180,6 @@ where
             extract_global_randomness_for_block(self.client.as_ref(), parent_hash).ok()?;
         let (solution_range, voting_solution_range) =
             extract_solution_ranges_for_block(self.client.as_ref(), parent_hash).ok()?;
-        let global_challenge = global_randomness.derive_global_challenge(slot.into());
 
         let maybe_root_plot_public_key = self
             .client
@@ -190,7 +189,7 @@ where
 
         let new_slot_info = NewSlotInfo {
             slot,
-            global_challenge,
+            global_randomness,
             solution_range,
             voting_solution_range,
         };

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -208,9 +208,8 @@ pub struct ProofOfElection<DomainHash> {
     pub domain_id: DomainId,
     /// The slot number.
     pub slot_number: u64,
-    // TODO: Use global_randomness instead.
-    /// Global challenge.
-    pub global_challenge: Blake2b256Hash,
+    /// Global randomness.
+    pub global_randomness: Randomness,
     /// VRF signature.
     pub vrf_signature: VrfSignature,
     /// Operator index in the OperatorRegistry.
@@ -224,11 +223,14 @@ impl<DomainHash> ProofOfElection<DomainHash> {
         &self,
         operator_signing_key: &OperatorPublicKey,
     ) -> Result<(), VrfProofError> {
+        let global_challenge = self
+            .global_randomness
+            .derive_global_challenge(self.slot_number);
         bundle_producer_election::verify_vrf_proof(
             self.domain_id,
             operator_signing_key,
             &self.vrf_signature,
-            &self.global_challenge,
+            &global_challenge,
         )
     }
 
@@ -252,7 +254,7 @@ impl<DomainHash: Default> ProofOfElection<DomainHash> {
         Self {
             domain_id,
             slot_number: 0u64,
-            global_challenge: Blake2b256Hash::default(),
+            global_randomness: Randomness::default(),
             vrf_signature,
             operator_id,
             _phantom: Default::default(),

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -554,7 +554,7 @@ fn main() -> Result<(), Error> {
                             .then(|slot_notification| async move {
                                 (
                                     slot_notification.new_slot_info.slot,
-                                    slot_notification.new_slot_info.global_challenge,
+                                    slot_notification.new_slot_info.global_randomness,
                                     None,
                                 )
                             })

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -145,7 +145,7 @@ where
     ) -> sp_blockchain::Result<Option<OpaqueBundle<Block, CBlock>>> {
         let OperatorSlotInfo {
             slot,
-            global_challenge,
+            global_randomness,
         } = slot_info;
 
         let best_receipt_is_written = crate::aux_schema::consensus_block_hash_for::<
@@ -195,7 +195,7 @@ where
                 slot,
                 consensus_block_info.hash,
                 self.domain_id,
-                global_challenge,
+                global_randomness,
             )?
         {
             tracing::info!("📦 Claimed bundle at slot {slot}");

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -96,7 +96,7 @@ use sp_runtime::traits::{
 };
 use std::marker::PhantomData;
 use std::sync::Arc;
-use subspace_core_primitives::Blake2b256Hash;
+use subspace_core_primitives::Randomness;
 
 type ExecutionReceiptFor<Block, CBlock> = ExecutionReceipt<
     NumberFor<CBlock>,
@@ -138,6 +138,8 @@ pub struct OperatorStreams<CBlock, IBNS, CIBNS, NSNS> {
     pub _phantom: PhantomData<CBlock>,
 }
 
+type NewSlotNotification = (Slot, Randomness, Option<mpsc::Sender<()>>);
+
 pub struct OperatorParams<
     Block,
     CBlock,
@@ -155,7 +157,7 @@ pub struct OperatorParams<
     CBlock: BlockT,
     IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
     CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
-    NSNS: Stream<Item = (Slot, Blake2b256Hash, Option<mpsc::Sender<()>>)> + Send + 'static,
+    NSNS: Stream<Item = NewSlotNotification> + Send + 'static,
 {
     pub domain_id: DomainId,
     pub consensus_client: Arc<CClient>,

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -4,7 +4,9 @@ use crate::domain_bundle_producer::DomainBundleProducer;
 use crate::domain_bundle_proposer::DomainBundleProposer;
 use crate::fraud_proof::FraudProofGenerator;
 use crate::parent_chain::DomainParentChain;
-use crate::{active_leaves, DomainImportNotifications, OperatorParams, TransactionFor};
+use crate::{
+    active_leaves, DomainImportNotifications, NewSlotNotification, OperatorParams, TransactionFor,
+};
 use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use futures::channel::mpsc;
 use futures::{FutureExt, Stream};
@@ -16,13 +18,11 @@ use sc_utils::mpsc::tracing_unbounded;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::SelectChain;
-use sp_consensus_slots::Slot;
 use sp_core::traits::{CodeExecutor, SpawnEssentialNamed};
 use sp_domains::{BundleProducerElectionApi, DomainsApi};
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::{Block as BlockT, HashFor, NumberFor};
 use std::sync::Arc;
-use subspace_core_primitives::Blake2b256Hash;
 use subspace_runtime_primitives::Balance;
 
 /// Domain operator.
@@ -121,7 +121,7 @@ where
         SC: SelectChain<CBlock>,
         IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
         CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
-        NSNS: Stream<Item = (Slot, Blake2b256Hash, Option<mpsc::Sender<()>>)> + Send + 'static,
+        NSNS: Stream<Item = NewSlotNotification> + Send + 'static,
     {
         let active_leaves = active_leaves(params.consensus_client.as_ref(), select_chain).await?;
 

--- a/domains/client/domain-operator/src/utils.rs
+++ b/domains/client/domain-operator/src/utils.rs
@@ -4,15 +4,15 @@ use sp_consensus_slots::Slot;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use std::convert::TryInto;
 use std::sync::Arc;
-use subspace_core_primitives::{Blake2b256Hash, BlockNumber};
+use subspace_core_primitives::{BlockNumber, Randomness};
 
 /// Data required to produce bundles on executor node.
 #[derive(PartialEq, Clone, Debug)]
 pub(super) struct OperatorSlotInfo {
     /// Slot
     pub(super) slot: Slot,
-    /// Global challenge
-    pub(super) global_challenge: Blake2b256Hash,
+    /// Global randomness
+    pub(super) global_randomness: Randomness,
 }
 
 #[derive(Debug, Clone)]

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -37,7 +37,7 @@ use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
-use subspace_core_primitives::Blake2b256Hash;
+use subspace_core_primitives::Randomness;
 use subspace_runtime_primitives::Index as Nonce;
 use subspace_transaction_pool::FullChainApiWrapper;
 use substrate_frame_rpc_system::AccountNonceApi;
@@ -296,7 +296,7 @@ where
     SC: SelectChain<CBlock>,
     IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
     CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
-    NSNS: Stream<Item = (Slot, Blake2b256Hash, Option<mpsc::Sender<()>>)> + Send + 'static,
+    NSNS: Stream<Item = (Slot, Randomness, Option<mpsc::Sender<()>>)> + Send + 'static,
     RuntimeApi: ConstructRuntimeApi<Block, FullClient<Block, RuntimeApi, ExecutorDispatch>>
         + Send
         + Sync

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -177,10 +177,13 @@ async fn start_farming<PosTable, Client>(
     }) = new_slot_notification_stream.next().await
     {
         if u64::from(new_slot_info.slot) % 2 == 0 {
+            let global_challenge = new_slot_info
+                .global_randomness
+                .derive_global_challenge(new_slot_info.slot.into());
             let solution_candidates = audit_sector(
                 &public_key,
                 sector_index,
-                &new_slot_info.global_challenge,
+                &global_challenge,
                 new_slot_info.solution_range,
                 &sector,
                 &plotted_sector.sector_metadata,

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -67,7 +67,7 @@ use std::error::Error;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time;
-use subspace_core_primitives::{Blake2b256Hash, Solution};
+use subspace_core_primitives::{Randomness, Solution};
 use subspace_fraud_proof::domain_extrinsics_builder::DomainExtrinsicsBuilder;
 use subspace_fraud_proof::invalid_state_transition_proof::InvalidStateTransitionProofVerifier;
 use subspace_fraud_proof::invalid_transaction_proof::InvalidTransactionProofVerifier;
@@ -209,7 +209,7 @@ pub struct MockConsensusNode {
     /// The slot notification subscribers
     #[allow(clippy::type_complexity)]
     new_slot_notification_subscribers:
-        Vec<TracingUnboundedSender<(Slot, Blake2b256Hash, Option<mpsc::Sender<()>>)>>,
+        Vec<TracingUnboundedSender<(Slot, Randomness, Option<mpsc::Sender<()>>)>>,
     /// Block import pipeline
     #[allow(clippy::type_complexity)]
     block_import: MockBlockImport<
@@ -448,7 +448,7 @@ impl MockConsensusNode {
         {
             let value = (
                 slot,
-                Hash::random().into(),
+                Randomness::from(Hash::random().to_fixed_bytes()),
                 Some(slot_acknowledgement_sender),
             );
             self.new_slot_notification_subscribers
@@ -488,7 +488,7 @@ impl MockConsensusNode {
     /// Subscribe the new slot notification
     pub fn new_slot_notification_stream(
         &mut self,
-    ) -> TracingUnboundedReceiver<(Slot, Blake2b256Hash, Option<mpsc::Sender<()>>)> {
+    ) -> TracingUnboundedReceiver<(Slot, Randomness, Option<mpsc::Sender<()>>)> {
         let (tx, rx) = tracing_unbounded("subspace_new_slot_notification_stream", 100);
         self.new_slot_notification_subscribers.push(tx);
         rx


### PR DESCRIPTION
This PR changes the `global_challenge` to `global_randomness` in ProofOfElection as requested [here](https://www.notion.so/Domains-v2-Specification-WIP-3fb0ec6e4d204c4881a7df50ef58da8f?d=a4acface83e3417bbcdcff36802e6861&pvs=4#8898da8048954b8d873c6638c7e2ed9b), by modifying the initial NewSlotInfo from `global_challenge` to `global_randomness` in sc-consensus-subspace.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
