### PR TITLE
Domains staking: Operator rewards, auto staking operator's nomination tax, and connecting block tree

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -1,7 +1,8 @@
 //! Domain block tree
 
 use crate::{
-    BlockTree, Config, DomainBlocks, ExecutionInbox, ExecutionReceiptOf, HeadReceiptNumber,
+    BalanceOf, BlockTree, Config, DomainBlocks, ExecutionInbox, ExecutionReceiptOf,
+    HeadReceiptNumber,
 };
 use codec::{Decode, Encode};
 use frame_support::{ensure, PalletError};
@@ -24,6 +25,8 @@ pub enum Error {
     BadGenesisReceipt,
     UnexpectedReceiptType,
     MaxHeadDomainNumber,
+    MultipleERsAfterChallengePeriod,
+    MissingDomainBlock,
 }
 
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -172,6 +175,16 @@ pub(crate) fn verify_execution_receipt<T: Config>(
     }
 }
 
+/// Details of the pruned domain block such as operators, rewards they would receive.
+pub(crate) struct PrunedDomainBlockInfo<DomainNumber, Balance> {
+    pub domain_block_number: DomainNumber,
+    pub operator_ids: Vec<OperatorId>,
+    pub rewards: Balance,
+}
+
+pub(crate) type ProcessExecutionReceiptResult<T> =
+    Result<Option<PrunedDomainBlockInfo<<T as Config>::DomainNumber, BalanceOf<T>>>, Error>;
+
 /// Process the execution receipt to add it to the block tree
 /// Returns the domain block number that was pruned, if any
 pub(crate) fn process_execution_receipt<T: Config>(
@@ -179,8 +192,8 @@ pub(crate) fn process_execution_receipt<T: Config>(
     submitter: OperatorId,
     execution_receipt: ExecutionReceiptOf<T>,
     receipt_type: AcceptedReceiptType,
-) -> Result<Option<T::DomainNumber>, Error> {
-    let mut pruned_domain_block_number = None;
+) -> ProcessExecutionReceiptResult<T> {
+    let mut pruned_domain_block_info = None;
     match receipt_type {
         AcceptedReceiptType::NewBranch => {
             add_new_receipt_to_block_tree::<T>(domain_id, submitter, execution_receipt);
@@ -197,13 +210,28 @@ pub(crate) fn process_execution_receipt<T: Config>(
             if let Some(to_prune) =
                 domain_block_number.checked_sub(&T::BlockTreePruningDepth::get())
             {
-                for block in BlockTree::<T>::take(domain_id, to_prune) {
-                    DomainBlocks::<T>::remove(block);
+                let receipts_at_number = BlockTree::<T>::take(domain_id, to_prune);
+                if receipts_at_number.len() != 1 {
+                    return Err(Error::MultipleERsAfterChallengePeriod);
                 }
+
+                let receipt = receipts_at_number
+                    .first()
+                    .cloned()
+                    .expect("should always have a value due to check above");
+
+                let domain_block =
+                    DomainBlocks::<T>::take(receipt).ok_or(Error::MissingDomainBlock)?;
+
                 // Remove the block's `ExecutionInbox` as the block is pruned and does not need
                 // to verify its receipt's `extrinsics_root` anymore
                 let _ = ExecutionInbox::<T>::clear_prefix((domain_id, to_prune), u32::MAX, None);
-                pruned_domain_block_number = Some(to_prune)
+
+                pruned_domain_block_info = Some(PrunedDomainBlockInfo {
+                    domain_block_number: to_prune,
+                    operator_ids: domain_block.operator_ids,
+                    rewards: domain_block.execution_receipt.total_rewards,
+                })
             }
         }
         AcceptedReceiptType::CurrentHead => {
@@ -217,7 +245,7 @@ pub(crate) fn process_execution_receipt<T: Config>(
             });
         }
     }
-    Ok(pruned_domain_block_number)
+    Ok(pruned_domain_block_info)
 }
 
 fn add_new_receipt_to_block_tree<T: Config>(
@@ -260,6 +288,8 @@ pub(crate) fn import_genesis_receipt<T: Config>(
 mod tests {
     use super::*;
     use crate::domain_registry::DomainConfig;
+    use crate::pallet::Operators;
+    use crate::staking::Operator;
     use crate::tests::{
         create_dummy_bundle_with_receipts, create_dummy_receipt, GenesisStateRootGenerater,
         ReadRuntimeVersion, Test,
@@ -270,11 +300,12 @@ mod tests {
     use frame_support::weights::Weight;
     use frame_support::{assert_err, assert_ok};
     use frame_system::Pallet as System;
-    use sp_core::H256;
-    use sp_domains::{GenesisReceiptExtension, RuntimeType};
+    use sp_core::{Pair, H256, U256};
+    use sp_domains::{GenesisReceiptExtension, OperatorPair, RuntimeType};
     use sp_runtime::traits::BlockNumberProvider;
     use sp_version::RuntimeVersion;
     use std::sync::Arc;
+    use subspace_runtime_primitives::SSC;
 
     fn run_to_block<T: Config>(block_number: T::BlockNumber, parent_hash: T::Hash) {
         System::<T>::set_block_number(block_number);
@@ -283,7 +314,7 @@ mod tests {
         System::<T>::finalize();
     }
 
-    fn register_genesis_domain(creator: u64) -> DomainId {
+    fn register_genesis_domain(creator: u64, operator_ids: Vec<OperatorId>) -> DomainId {
         assert_ok!(crate::Pallet::<Test>::register_domain_runtime(
             RawOrigin::Root.into(),
             b"evm".to_vec(),
@@ -309,6 +340,24 @@ mod tests {
             },
         )
         .unwrap();
+
+        let pair = OperatorPair::from_seed(&U256::from(0u32).into());
+        for operator_id in operator_ids {
+            Operators::<Test>::insert(
+                operator_id,
+                Operator {
+                    signing_key: pair.public(),
+                    current_domain_id: domain_id,
+                    next_domain_id: domain_id,
+                    minimum_nominator_stake: SSC,
+                    nomination_tax: Default::default(),
+                    current_total_stake: Zero::zero(),
+                    current_epoch_rewards: Zero::zero(),
+                    total_shares: Zero::zero(),
+                    is_frozen: false,
+                },
+            );
+        }
 
         domain_id
     }
@@ -392,7 +441,7 @@ mod tests {
     fn test_genesis_receipt() {
         let mut ext = new_test_ext();
         ext.execute_with(|| {
-            let domain_id = register_genesis_domain(0u64);
+            let domain_id = register_genesis_domain(0u64, vec![0u64]);
 
             // The genesis receipt should be added to the block tree
             let block_tree_node_at_0 = BlockTree::<Test>::get(domain_id, 0);
@@ -429,7 +478,7 @@ mod tests {
 
         let mut ext = new_test_ext();
         ext.execute_with(|| {
-            let domain_id = register_genesis_domain(creator);
+            let domain_id = register_genesis_domain(creator, vec![operator_id]);
 
             // The genesis node of the block tree
             let genesis_node = get_block_tree_node_at::<Test>(domain_id, 0).unwrap();
@@ -519,7 +568,7 @@ mod tests {
         let operator_id2 = 2u64;
         let mut ext = new_test_ext();
         ext.execute_with(|| {
-            let domain_id = register_genesis_domain(creator);
+            let domain_id = register_genesis_domain(creator, vec![operator_id1, operator_id2]);
             extend_block_tree(domain_id, operator_id1, 3);
 
             let head_receipt_number = HeadReceiptNumber::<Test>::get(domain_id);
@@ -564,7 +613,7 @@ mod tests {
         let operator_id2 = 2u64;
         let mut ext = new_test_ext();
         ext.execute_with(|| {
-            let domain_id = register_genesis_domain(creator);
+            let domain_id = register_genesis_domain(creator, vec![operator_id1, operator_id2]);
             extend_block_tree(domain_id, operator_id1, 3);
 
             // Receipt that comfirm a non-head receipt is stale receipt
@@ -610,7 +659,7 @@ mod tests {
         let operator_id2 = 2u64;
         let mut ext = new_test_ext();
         ext.execute_with(|| {
-            let domain_id = register_genesis_domain(creator);
+            let domain_id = register_genesis_domain(creator, vec![operator_id1, operator_id2]);
             extend_block_tree(domain_id, operator_id1, 3);
 
             let head_receipt_number = HeadReceiptNumber::<Test>::get(domain_id);
@@ -673,7 +722,7 @@ mod tests {
         let operator_id = 1u64;
         let mut ext = new_test_ext();
         ext.execute_with(|| {
-            let domain_id = register_genesis_domain(creator);
+            let domain_id = register_genesis_domain(creator, vec![operator_id]);
             extend_block_tree(domain_id, operator_id, 3);
 
             let head_receipt_number = HeadReceiptNumber::<Test>::get(domain_id);

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -162,6 +162,7 @@ pub(crate) fn do_instantiate_domain<T: Config>(
             current_total_stake: Zero::zero(),
             current_operators: BTreeMap::new(),
             next_operators: BTreeSet::new(),
+            current_epoch_rewards: BTreeMap::new(),
         },
     );
 

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -371,7 +371,6 @@ pub(crate) fn do_withdraw_stake<T: Config>(
     })
 }
 
-#[allow(dead_code)]
 /// Distribute the reward to the operators equally and drop any dust to treasury.
 pub(crate) fn do_reward_operators<T: Config>(
     domain_id: DomainId,

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -30,7 +30,7 @@ pub struct Operator<Balance, Share> {
     pub current_total_stake: Balance,
     /// Total rewards this operator received this current epoch.
     pub current_epoch_rewards: Balance,
-    /// Total shares of all the nominators unde this operator.
+    /// Total shares of all the nominators under this operator.
     pub total_shares: Share,
     pub is_frozen: bool,
 }
@@ -84,6 +84,8 @@ pub enum Error {
     OperatorFrozen,
     UnknownNominator,
     ExistingFullWithdraw,
+    MissingOperatorOwner,
+    MintBalance,
 }
 
 pub(crate) fn do_register_operator<T: Config>(
@@ -168,14 +170,14 @@ pub(crate) fn do_nominate_operator<T: Config>(
     Ok(())
 }
 
-fn freeze_account_balance_to_operator<T: Config>(
+pub(crate) fn freeze_account_balance_to_operator<T: Config>(
     who: &T::AccountId,
     operator_id: OperatorId,
     amount: BalanceOf<T>,
 ) -> Result<(), Error> {
     // ensure there is enough free balance to lock
     ensure!(
-        T::Currency::reducible_balance(who, Preservation::Protect, Fortitude::Polite) >= amount,
+        T::Currency::reducible_balance(who, Preservation::Preserve, Fortitude::Polite) >= amount,
         Error::InsufficientBalance
     );
 

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -86,6 +86,12 @@ pub enum Error {
     ExistingFullWithdraw,
     MissingOperatorOwner,
     MintBalance,
+    BlockNumberOverflow,
+    RemoveLock,
+    UpdateLock,
+    EpochOverflow,
+    ShareUnderflow,
+    ShareOverflow,
 }
 
 pub(crate) fn do_register_operator<T: Config>(

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -1,7 +1,7 @@
 //! Staking epoch transition for domain
 
 use crate::pallet::{
-    DomainStakingSummary, Nominators, OngoingEpochTransition, OperatorIdOwner, Operators,
+    DomainStakingSummary, LastEpochStakingDistribution, Nominators, OperatorIdOwner, Operators,
     PendingDeposits, PendingNominatorUnlocks, PendingOperatorDeregistrations,
     PendingOperatorSwitches, PendingOperatorUnlocks, PendingUnlocks, PendingWithdrawals,
 };
@@ -329,7 +329,7 @@ fn do_finalize_domain_pending_transfers<T: Config>(
             total_domain_stake: stake_summary.current_total_stake,
         };
 
-        OngoingEpochTransition::<T>::insert(domain_id, election_verification_params);
+        LastEpochStakingDistribution::<T>::insert(domain_id, election_verification_params);
 
         stake_summary.current_epoch_index = next_epoch;
         stake_summary.current_total_stake = total_domain_stake;
@@ -550,7 +550,7 @@ fn finalize_nominator_deposit<T: Config>(
 #[cfg(test)]
 mod tests {
     use crate::pallet::{
-        DomainStakingSummary, Nominators, OngoingEpochTransition, OperatorIdOwner, Operators,
+        DomainStakingSummary, LastEpochStakingDistribution, Nominators, OperatorIdOwner, Operators,
         PendingDeposits, PendingOperatorDeregistrations, PendingOperatorSwitches,
         PendingOperatorUnlocks, PendingUnlocks, PendingWithdrawals,
     };
@@ -926,7 +926,7 @@ mod tests {
             assert_eq!(domain_stake_summary.current_epoch_index, 1);
 
             // should also store the previous epoch details in-block
-            let election_params = OngoingEpochTransition::<Test>::get(domain_id).unwrap();
+            let election_params = LastEpochStakingDistribution::<Test>::get(domain_id).unwrap();
             assert_eq!(
                 election_params.operators,
                 BTreeMap::from_iter(vec![(operator_id, operator_stake)])

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -29,8 +29,6 @@ pub enum Error {
 
 /// Finalizes the domain's current epoch and begins the next epoch.
 /// Returns true of the epoch indeed was finished.
-// TODO: remove once connected with block tree
-#[allow(dead_code)]
 pub(crate) fn do_finalize_domain_current_epoch<T: Config>(
     domain_id: DomainId,
     domain_block_number: T::DomainNumber,

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -547,6 +547,7 @@ mod tests {
                 current_total_stake: total_domain_stake,
                 current_operators: BTreeMap::from_iter(current_operators),
                 next_operators: BTreeSet::from_iter(next_operators),
+                current_epoch_rewards: BTreeMap::new(),
             },
         );
 


### PR DESCRIPTION
This PR brings the following changes.
- Move the epoch forward when a domain block is pruned.
- Distribute the rewards from ER that was pruned
- Collect all the operator rewards under domain stake summary when the operators are rewarded.
	- Once epoch is complete, operators take the `NominationTax` portion of rewards and restake them by adding a `PendingDeposit`. This deposit is counted in for next epoch.
- Adjust POE verification such that remaining bundles which came after a bundle that triggered epoch transition also use the previous epoch details to verify

Closes: #1663
Closes: #1674 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
