### PR TITLE
Enable sync from DSN by default

### DIFF
--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -224,7 +224,7 @@ pub struct Cli {
     pub dsn_disable_private_ips: bool,
 
     /// Enables DSN-sync on startup.
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub sync_from_dsn: bool,
 
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).


### PR DESCRIPTION
I did some tests and it appears that pruned nodes are not crashing on restart anymore, hence enabling sync from DSN by default to resolve https://github.com/subspace/subspace/issues/1514.

The only thing technically separating us from https://github.com/subspace/subspace/issues/1515 is documentation updates, we'll need to verify this on devnet and then update docs.

`action = clap::ArgAction::Set` allows us to use `--sync-from-dsn false` if desired, otherwise turning default of `true` back to `false` just with CLI is not possible.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
