### PR TITLE
Faster chiapos (part 3)

### DIFF
--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -43,6 +43,8 @@ std = [
 ]
 parallel = [
     "dep:rayon",
+    # Parallel implementation requires std due to usage of channels to achieve highest performance
+    "std",
 ]
 # Enable Chia proof of space support
 chia = [

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -120,6 +120,7 @@ fn calculate_left_target_on_demand(parity: usize, r: usize, m: usize) -> usize {
 /// Caches that can be used to optimize creation of multiple [`Tables`](super::Tables).
 #[derive(Debug)]
 pub struct TablesCache<const K: u8> {
+    buckets: Vec<Bucket>,
     rmap_scratch: Vec<RmapItem>,
     left_targets: Vec<Vec<Vec<Position>>>,
 }
@@ -128,6 +129,7 @@ impl<const K: u8> Default for TablesCache<K> {
     /// Create new instance
     fn default() -> Self {
         Self {
+            buckets: Vec::new(),
             rmap_scratch: Vec::new(),
             left_targets: calculate_left_targets(),
         }
@@ -630,6 +632,7 @@ where
     where
         EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     {
+        let buckets = &mut cache.buckets;
         let rmap_scratch = &mut cache.rmap_scratch;
         let left_targets = &cache.left_targets;
 
@@ -648,7 +651,8 @@ where
             .ys()
             .last()
             .expect("List of y values is never empty; qed");
-        let mut buckets = Vec::with_capacity(1 + usize::from(last_y) / usize::from(PARAM_BC));
+        buckets.clear();
+        buckets.reserve(1 + usize::from(last_y) / usize::from(PARAM_BC));
         for (&y, position) in last_table.ys().iter().zip(Position::ZERO..) {
             let bucket_index = u32::from(y) / u32::from(PARAM_BC);
 
@@ -738,6 +742,7 @@ where
     where
         EvaluatableUsize<{ metadata_size_bytes(K, PARENT_TABLE_NUMBER) }>: Sized,
     {
+        let buckets = &mut cache.buckets;
         let left_targets = &cache.left_targets;
 
         let mut left_bucket = Bucket {
@@ -755,7 +760,8 @@ where
             .ys()
             .last()
             .expect("List of y values is never empty; qed");
-        let mut buckets = Vec::with_capacity(1 + usize::from(last_y) / usize::from(PARAM_BC));
+        buckets.clear();
+        buckets.reserve(1 + usize::from(last_y) / usize::from(PARAM_BC));
         for (&y, position) in last_table.ys().iter().zip(Position::ZERO..) {
             let bucket_index = u32::from(y) / u32::from(PARAM_BC);
 

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -636,13 +636,8 @@ where
         let rmap_scratch = &mut cache.rmap_scratch;
         let left_targets = &cache.left_targets;
 
-        let mut left_bucket = Bucket {
+        let mut bucket = Bucket {
             bucket_index: 0,
-            start_position: Position::ZERO,
-            size: Position::ZERO,
-        };
-        let mut right_bucket = Bucket {
-            bucket_index: 1,
             start_position: Position::ZERO,
             size: Position::ZERO,
         };
@@ -653,46 +648,28 @@ where
             .expect("List of y values is never empty; qed");
         buckets.clear();
         buckets.reserve(1 + usize::from(last_y) / usize::from(PARAM_BC));
-        for (&y, position) in last_table.ys().iter().zip(Position::ZERO..) {
-            let bucket_index = u32::from(y) / u32::from(PARAM_BC);
+        last_table
+            .ys()
+            .iter()
+            .zip(Position::ZERO..)
+            .for_each(|(&y, position)| {
+                let bucket_index = u32::from(y) / u32::from(PARAM_BC);
 
-            if bucket_index == left_bucket.bucket_index {
-                left_bucket.size += Position::ONE;
-                continue;
-            } else if bucket_index == right_bucket.bucket_index {
-                if right_bucket.size == Position::ZERO {
-                    right_bucket.start_position = position;
+                if bucket_index == bucket.bucket_index {
+                    bucket.size += Position::ONE;
+                    return;
                 }
-                right_bucket.size += Position::ONE;
-                continue;
-            }
 
-            buckets.push(left_bucket);
+                buckets.push(bucket);
 
-            if bucket_index == right_bucket.bucket_index + 1 {
-                // Move right bucket into left bucket while reusing existing allocations
-                left_bucket = right_bucket;
-
-                right_bucket = Bucket {
+                bucket = Bucket {
                     bucket_index,
                     start_position: position,
                     size: Position::ONE,
                 };
-            } else {
-                // We have skipped some buckets, clean up both left and right buckets
-                left_bucket = Bucket {
-                    bucket_index,
-                    start_position: position,
-                    size: Position::ONE,
-                };
-
-                right_bucket.bucket_index = bucket_index + 1;
-                right_bucket.size = Position::ZERO;
-            }
-        }
-        // Iteration stopped, but we did not store the last two buckets yet
-        buckets.push(left_bucket);
-        buckets.push(right_bucket);
+            });
+        // Iteration stopped, but we did not store the last bucket yet
+        buckets.push(bucket);
 
         let num_values = 1 << K;
         let mut t_n = Vec::with_capacity(num_values);
@@ -745,13 +722,8 @@ where
         let buckets = &mut cache.buckets;
         let left_targets = &cache.left_targets;
 
-        let mut left_bucket = Bucket {
+        let mut bucket = Bucket {
             bucket_index: 0,
-            start_position: Position::ZERO,
-            size: Position::ZERO,
-        };
-        let mut right_bucket = Bucket {
-            bucket_index: 1,
             start_position: Position::ZERO,
             size: Position::ZERO,
         };
@@ -762,46 +734,28 @@ where
             .expect("List of y values is never empty; qed");
         buckets.clear();
         buckets.reserve(1 + usize::from(last_y) / usize::from(PARAM_BC));
-        for (&y, position) in last_table.ys().iter().zip(Position::ZERO..) {
-            let bucket_index = u32::from(y) / u32::from(PARAM_BC);
+        last_table
+            .ys()
+            .iter()
+            .zip(Position::ZERO..)
+            .for_each(|(&y, position)| {
+                let bucket_index = u32::from(y) / u32::from(PARAM_BC);
 
-            if bucket_index == left_bucket.bucket_index {
-                left_bucket.size += Position::ONE;
-                continue;
-            } else if bucket_index == right_bucket.bucket_index {
-                if right_bucket.size == Position::ZERO {
-                    right_bucket.start_position = position;
+                if bucket_index == bucket.bucket_index {
+                    bucket.size += Position::ONE;
+                    return;
                 }
-                right_bucket.size += Position::ONE;
-                continue;
-            }
 
-            buckets.push(left_bucket);
+                buckets.push(bucket);
 
-            if bucket_index == right_bucket.bucket_index + 1 {
-                // Move right bucket into left bucket while reusing existing allocations
-                left_bucket = right_bucket;
-
-                right_bucket = Bucket {
+                bucket = Bucket {
                     bucket_index,
                     start_position: position,
                     size: Position::ONE,
                 };
-            } else {
-                // We have skipped some buckets, clean up both left and right buckets
-                left_bucket = Bucket {
-                    bucket_index,
-                    start_position: position,
-                    size: Position::ONE,
-                };
-
-                right_bucket.bucket_index = bucket_index + 1;
-                right_bucket.size = Position::ZERO;
-            }
-        }
-        // Iteration stopped, but we did not store the last two buckets yet
-        buckets.push(left_bucket);
-        buckets.push(right_bucket);
+            });
+        // Iteration stopped, but we did not store the last bucket yet
+        buckets.push(bucket);
 
         let num_values = 1 << K;
         let mut t_n = Vec::with_capacity(num_values);

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -749,8 +749,11 @@ where
         right_bucket.ys.clear();
         right_bucket.start_position = Position::ZERO;
 
-        // Experimentally found that this value seems reasonable
-        let mut buckets = Vec::with_capacity(usize::from(PARAM_BC) / (1 << PARAM_EXT) * 3);
+        let last_y = *last_table
+            .ys()
+            .last()
+            .expect("List of y values is never empty; qed");
+        let mut buckets = Vec::with_capacity(1 + usize::from(last_y) / usize::from(PARAM_BC));
         for (&y, position) in last_table.ys().iter().zip(Position::ZERO..) {
             let bucket_index = usize::from(y) / usize::from(PARAM_BC);
 

--- a/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
@@ -5,7 +5,7 @@ use crate::chiapos::constants::{PARAM_B, PARAM_BC, PARAM_C, PARAM_EXT};
 use crate::chiapos::table::types::{Metadata, Position, X, Y};
 use crate::chiapos::table::{
     calculate_left_targets, compute_f1, compute_f1_simd, compute_fn, find_matches,
-    metadata_size_bytes, partial_y, Bucket, COMPUTE_F1_SIMD_FACTOR,
+    metadata_size_bytes, partial_y, COMPUTE_F1_SIMD_FACTOR,
 };
 use crate::chiapos::utils::EvaluatableUsize;
 use crate::chiapos::Seed;
@@ -139,26 +139,17 @@ fn test_matches() {
         right_bucket_ys.sort_unstable();
         right_bucket_ys.reverse();
 
-        let left_bucket = Bucket {
-            bucket_index: 0,
-            ys: left_bucket_ys,
-            start_position: Position::ZERO,
-        };
-        let right_bucket = Bucket {
-            bucket_index: 0,
-            ys: right_bucket_ys,
-            start_position: Position::ZERO,
-        };
-
         let matches = find_matches(
-            &left_bucket,
-            &right_bucket,
+            &left_bucket_ys,
+            Position::ZERO,
+            &right_bucket_ys,
+            Position::ZERO,
             &mut rmap_scratch,
             &left_targets,
         );
         for m in matches.unwrap() {
-            let yl = usize::from(*left_bucket.ys.get(usize::from(m.left_position)).unwrap());
-            let yr = usize::from(*right_bucket.ys.get(usize::from(m.right_position)).unwrap());
+            let yl = usize::from(*left_bucket_ys.get(usize::from(m.left_position)).unwrap());
+            let yr = usize::from(*right_bucket_ys.get(usize::from(m.right_position)).unwrap());
 
             assert!(check_match(yl, yr));
             total_matches += 1;


### PR DESCRIPTION
This is yet another iteration on top of https://github.com/subspace/subspace/pull/1683 that primarily benefits larger k, on k22 I've got these results (~100ms less than https://github.com/subspace/subspace/pull/1683 when using all cores, single-core didn't change meaningfully):
```
chia/table/parallel     time:   [605.64 ms 619.75 ms 633.06 ms]
```

Yeah, I'd be able to farm with k22 on my machine now :sunglasses: 

On 4 performance cores we're looking at this:
```
chia/table/parallel     time:   [1.4368 s 1.4439 s 1.4510 s]
```

So even with slower processor it should still be well within 6 seconds window.

---

I have tried various additional SIMD and parallelization technics, but looks like I'm hitting hardware limitations. Things either stay the same (meaning compiler/CPU is doing as well of a job with simpler code) or worse. This is as far as I can get it without resorting to lower-level architecture-specific intrinsics, which is something I'm not good at.

In particular `perf` says application is 30%+ memory bound and has 50%+ cache misses on my CPU, branch misprediction and bad speculation are also at ~10% level:
```
cpu_core/topdown-retiring/u      # 35,1% Retiring           (46,90%)
cpu_core/topdown-bad-spec/u      #  8,6% Bad Speculation    (46,90%)
cpu_core/topdown-fe-bound/u      #  9,8% Frontend Bound     (46,90%)
cpu_core/topdown-be-bound/u      # 46,5% Backend Bound      (46,90%)
cpu_core/topdown-heavy-ops/u     #  1,4% Heavy Operations  #     33,7% Light Operations (46,90%)
cpu_core/topdown-br-mispredict/u #  8,2% Branch Mispredict #      0,4% Machine Clears   (46,90%)
cpu_core/topdown-fetch-lat/u     #  7,1% Fetch Latency     #      2,7% Fetch Bandwidth  (46,90%)
cpu_core/topdown-mem-bound/u     # 34,3% Memory Bound      #     12,2% Core Bound       (46,90%)
cpu_core/cache-misses:u/                                    (48,04%)
cpu_atom/cache-misses:u/                                    (52,11%)
```

I have one more thing to do that is not algorithm improvement, but rather API change for better cache reuse, but that will be a separate PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
