### PR TITLE
Introduce and use stateful proof of space generator API

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -53,6 +53,7 @@ use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
 use subspace_farmer_components::sector::{sector_size, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::shim::ShimTable;
+use subspace_proof_of_space::Table;
 use subspace_solving::REWARD_SIGNING_CONTEXT;
 
 type PosTable = ShimTable;
@@ -412,6 +413,8 @@ pub fn create_signed_vote(
     let pieces_in_sector = farmer_protocol_info.max_pieces_in_sector;
     let sector_size = sector_size(pieces_in_sector);
 
+    let mut table_generator = PosTable::generator();
+
     for sector_index in iter::from_fn(|| Some(rand::random())) {
         let mut plotted_sector_bytes = vec![0; sector_size];
         let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
@@ -427,6 +430,7 @@ pub fn create_signed_vote(
             pieces_in_sector,
             &mut plotted_sector_bytes,
             &mut plotted_sector_metadata_bytes,
+            &mut table_generator,
         ))
         .unwrap();
 
@@ -445,7 +449,7 @@ pub fn create_signed_vote(
         };
 
         let solution = solution_candidates
-            .into_iter::<_, PosTable>(&reward_address, kzg, erasure_coding)
+            .into_iter::<_, PosTable>(&reward_address, kzg, erasure_coding, &mut table_generator)
             .unwrap()
             .next()
             .unwrap()

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -33,6 +33,7 @@ use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
 use subspace_farmer_components::sector::{sector_size, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_proof_of_space::Table;
 use subspace_solving::REWARD_SIGNING_CONTEXT;
 use subspace_verification::{
     calculate_block_weight, derive_randomness, verify_solution, VerifySolutionParams,
@@ -154,6 +155,8 @@ fn valid_header(
     let pieces_in_sector = farmer_parameters.farmer_protocol_info.max_pieces_in_sector;
     let sector_size = sector_size(pieces_in_sector);
 
+    let mut table_generator = PosTable::generator();
+
     for sector_index in iter::from_fn(|| Some(rand::random())) {
         let mut plotted_sector_bytes = vec![0; sector_size];
         let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
@@ -169,6 +172,7 @@ fn valid_header(
             pieces_in_sector,
             &mut plotted_sector_bytes,
             &mut plotted_sector_metadata_bytes,
+            &mut table_generator,
         ))
         .unwrap();
 
@@ -193,6 +197,7 @@ fn valid_header(
                 &public_key,
                 &farmer_parameters.kzg,
                 &farmer_parameters.erasure_coding,
+                &mut table_generator,
             )
             .unwrap()
             .next()

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -21,6 +21,7 @@ use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, 
 use subspace_farmer_components::sector::{sector_size, SectorContentsMap, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::Table;
 
 type PosTable = ChiaTable;
 
@@ -51,6 +52,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
     )
     .unwrap();
+    let mut table_generator = PosTable::generator();
     let archived_history_segment = archiver
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
@@ -123,6 +125,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
             &mut plotted_sector_bytes,
             &mut plotted_sector_metadata_bytes,
+            &mut table_generator,
         ))
         .unwrap();
 

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -12,6 +12,7 @@ use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
 use subspace_farmer_components::sector::{sector_size, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::Table;
 
 type PosTable = ChiaTable;
 
@@ -33,6 +34,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
     )
     .unwrap();
+    let mut table_generator = PosTable::generator();
     let archived_history_segment = archiver
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
@@ -73,6 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(pieces_in_sector),
                 black_box(&mut sector_bytes),
                 black_box(&mut sector_metadata_bytes),
+                black_box(&mut table_generator),
             ))
             .unwrap();
         })

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -21,6 +21,7 @@ use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, 
 use subspace_farmer_components::sector::{sector_size, SectorContentsMap, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::Table;
 
 type PosTable = ChiaTable;
 
@@ -53,6 +54,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
     )
     .unwrap();
+    let mut table_generator = PosTable::generator();
     let archived_history_segment = archiver
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
@@ -125,6 +127,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
             &mut plotted_sector_bytes,
             &mut plotted_sector_metadata_bytes,
+            &mut table_generator,
         ))
         .unwrap();
 
@@ -164,7 +167,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let num_actual_solutions = solution_candidates
             .clone()
-            .into_iter::<_, PosTable>(&reward_address, &kzg, &erasure_coding)
+            .into_iter::<_, PosTable>(&reward_address, &kzg, &erasure_coding, &mut table_generator)
             .unwrap()
             .len();
 
@@ -194,6 +197,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&reward_address),
                         black_box(&kzg),
                         black_box(&erasure_coding),
+                        black_box(&mut table_generator),
                     )
                     .unwrap()
                     // Process just one solution
@@ -260,6 +264,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                                 black_box(&reward_address),
                                 black_box(&kzg),
                                 black_box(&erasure_coding),
+                                black_box(&mut table_generator),
                             )
                             .unwrap()
                             // Process just one solution

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -20,6 +20,7 @@ use subspace_farmer_components::reading::read_piece;
 use subspace_farmer_components::sector::{sector_size, SectorContentsMap, SectorMetadata};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
+use subspace_proof_of_space::Table;
 
 type PosTable = ChiaTable;
 
@@ -50,6 +51,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
     )
     .unwrap();
+    let mut table_generator = PosTable::generator();
     let archived_history_segment = archiver
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
@@ -120,6 +122,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
             &mut plotted_sector_bytes,
             &mut plotted_sector_metadata_bytes,
+            &mut table_generator,
         ))
         .unwrap();
 
@@ -148,6 +151,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&plotted_sector.sector_metadata),
                 black_box(&plotted_sector_bytes),
                 black_box(&erasure_coding),
+                black_box(&mut table_generator),
             )
             .unwrap();
         })
@@ -195,6 +199,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             black_box(&plotted_sector.sector_metadata),
                             black_box(sector),
                             black_box(&erasure_coding),
+                            black_box(&mut table_generator),
                         )
                         .unwrap();
                     }

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -10,7 +10,7 @@ use subspace_core_primitives::{
     Piece, PieceOffset, Record, RecordCommitment, RecordWitness, SBucket, SectorId,
 };
 use subspace_erasure_coding::ErasureCoding;
-use subspace_proof_of_space::{Quality, Table};
+use subspace_proof_of_space::{Quality, Table, TableGenerator};
 use thiserror::Error;
 
 /// Errors that happen during reading
@@ -257,6 +257,7 @@ pub fn read_piece<PosTable>(
     sector_metadata: &SectorMetadata,
     sector: &[u8],
     erasure_coding: &ErasureCoding,
+    table_generator: &mut PosTable::Generator,
 ) -> Result<Piece, ReadingError>
 where
     PosTable: Table,
@@ -284,7 +285,7 @@ where
             pieces_in_sector,
             &sector_metadata.s_bucket_offsets(),
             &sector_contents_map,
-            &PosTable::generate(
+            &table_generator.generate(
                 &sector_id.derive_evaluation_seed(piece_offset, sector_metadata.history_size),
             ),
             sector,

--- a/crates/subspace-farmer/src/single_disk_plot/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/farming.rs
@@ -83,6 +83,8 @@ where
     NC: NodeClient,
     PosTable: Table,
 {
+    let mut table_generator = PosTable::generator();
+
     while let Some(slot_info) = slot_info_notifications.next().await {
         let slot = slot_info.slot_number;
         let sectors_metadata = sectors_metadata.read();
@@ -120,6 +122,7 @@ where
                 &reward_address,
                 &kzg,
                 &erasure_coding,
+                &mut table_generator,
             )? {
                 let solution = match maybe_solution {
                     Ok(solution) => solution,

--- a/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
@@ -98,6 +98,8 @@ async fn read_pieces<PosTable>(
         }
     }
 
+    let mut table_generator = PosTable::generator();
+
     while let Some(read_piece_request) = read_piece_receiver.next().await {
         let ReadPieceRequest {
             sector_index,
@@ -145,6 +147,7 @@ async fn read_pieces<PosTable>(
             &sector_metadata,
             &global_plot_mmap,
             &erasure_coding,
+            &mut table_generator,
         );
 
         // Doesn't matter if receiver still cares about it
@@ -161,6 +164,7 @@ fn read_piece<PosTable>(
     sector_metadata: &SectorMetadata,
     global_plot: &[u8],
     erasure_coding: &ErasureCoding,
+    table_generator: &mut PosTable::Generator,
 ) -> Option<Piece>
 where
     PosTable: Table,
@@ -198,6 +202,7 @@ where
         sector_metadata,
         sector,
         erasure_coding,
+        table_generator,
     ) {
         Ok(piece) => piece,
         Err(error) => {

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -103,6 +103,7 @@ where
     PG: PieceGetter + Send + 'static,
     PosTable: Table,
 {
+    let mut table_generator = PosTable::generator();
     // TODO: Concurrency
     while let Some((sector_index, _acknowledgement_sender)) = sectors_to_plot.next().await {
         trace!(%sector_index, "Preparing to plot sector");
@@ -174,6 +175,7 @@ where
             pieces_in_sector,
             &mut sector,
             &mut sector_metadata,
+            &mut table_generator,
         );
 
         // Inform others that this sector is being modified

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -8,7 +8,7 @@ use rayon::ThreadPoolBuilder;
 #[cfg(any(feature = "chia", feature = "shim"))]
 use subspace_core_primitives::PosSeed;
 #[cfg(any(feature = "chia", feature = "shim"))]
-use subspace_proof_of_space::{Quality, Table};
+use subspace_proof_of_space::{Quality, Table, TableGenerator};
 
 #[cfg(any(feature = "chia", feature = "shim"))]
 fn pos_bench<PosTable>(
@@ -35,22 +35,24 @@ fn pos_bench<PosTable>(
 
     let mut group = c.benchmark_group(name);
 
+    let mut generator_instance = PosTable::generator();
     group.bench_function("table/single", |b| {
         b.iter(|| {
-            PosTable::generate(black_box(&seed));
+            generator_instance.generate(black_box(&seed));
         });
     });
 
     #[cfg(feature = "parallel")]
     {
+        let mut generator_instance = PosTable::generator();
         group.bench_function("table/parallel", |b| {
             b.iter(|| {
-                PosTable::generate_parallel(black_box(&seed));
+                generator_instance.generate_parallel(black_box(&seed));
             });
         });
     }
 
-    let table = PosTable::generate(&seed);
+    let table = generator_instance.generate(&seed);
 
     group.bench_function("quality/no-solution", |b| {
         b.iter(|| {

--- a/crates/subspace-proof-of-space/src/chia.rs
+++ b/crates/subspace-proof-of-space/src/chia.rs
@@ -2,7 +2,7 @@
 use crate::chiapos::Tables;
 #[cfg(any(feature = "parallel", test))]
 use crate::chiapos::TablesCache;
-use crate::{PosTableType, Quality, Table};
+use crate::{PosTableType, Quality, Table, TableGenerator};
 use core::mem;
 use subspace_core_primitives::{PosProof, PosQualityBytes, PosSeed};
 
@@ -33,7 +33,29 @@ impl<'a> Quality for ChiaQuality<'a> {
     }
 }
 
-/// Subspace proof of space table
+/// Subspace proof of space table generator.
+///
+/// Chia implementation.
+#[derive(Debug, Default, Clone)]
+pub struct ChiaTableGenerator {
+    tables_cache: TablesCache<K>,
+}
+
+impl TableGenerator<ChiaTable> for ChiaTableGenerator {
+    fn generate(&mut self, seed: &PosSeed) -> ChiaTable {
+        ChiaTable {
+            tables: Tables::<K>::create((*seed).into(), &mut self.tables_cache),
+        }
+    }
+
+    fn generate_parallel(&mut self, seed: &PosSeed) -> ChiaTable {
+        ChiaTable {
+            tables: Tables::<K>::create_parallel((*seed).into(), &mut self.tables_cache),
+        }
+    }
+}
+
+/// Subspace proof of space table.
 ///
 /// Chia implementation.
 #[derive(Debug)]
@@ -43,6 +65,7 @@ pub struct ChiaTable {
 
 impl Table for ChiaTable {
     const TABLE_TYPE: PosTableType = PosTableType::Chia;
+    type Generator = ChiaTableGenerator;
 
     type Quality<'a> = ChiaQuality<'a>;
 

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -120,7 +120,7 @@ fn calculate_left_target_on_demand(parity: usize, r: usize, m: usize) -> usize {
 }
 
 /// Caches that can be used to optimize creation of multiple [`Tables`](super::Tables).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TablesCache<const K: u8> {
     buckets: Vec<Bucket>,
     rmap_scratch: Vec<RmapItem>,
@@ -713,6 +713,7 @@ where
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
     /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
     /// in parallel, prefer [`Self::create()`] for better overall performance.
+    // TODO: Cache more allocations in this function to improve performance further
     #[cfg(any(feature = "parallel", test))]
     pub(super) fn create_parallel<const PARENT_TABLE_NUMBER: u8>(
         last_table: &Table<K, PARENT_TABLE_NUMBER>,

--- a/crates/subspace-proof-of-space/src/shim.rs
+++ b/crates/subspace-proof-of-space/src/shim.rs
@@ -1,6 +1,6 @@
 //! Shim proof of space implementation
 
-use crate::{PosTableType, Quality, Table};
+use crate::{PosTableType, Quality, Table, TableGenerator};
 use core::iter;
 use subspace_core_primitives::crypto::blake2b_256_hash;
 use subspace_core_primitives::{Blake2b256Hash, PosProof, PosQualityBytes, PosSeed, U256};
@@ -36,6 +36,18 @@ impl<'a> Quality for ShimQuality<'a> {
     }
 }
 
+/// Subspace proof of space table generator.
+///
+/// Shim implementation.
+#[derive(Debug, Default, Clone)]
+pub struct ShimTableGenerator;
+
+impl TableGenerator<ShimTable> for ShimTableGenerator {
+    fn generate(&mut self, seed: &PosSeed) -> ShimTable {
+        ShimTable::generate(seed)
+    }
+}
+
 /// Subspace proof of space table.
 ///
 /// Shim implementation.
@@ -46,6 +58,7 @@ pub struct ShimTable {
 
 impl Table for ShimTable {
     const TABLE_TYPE: PosTableType = PosTableType::Shim;
+    type Generator = ShimTableGenerator;
 
     type Quality<'a> = ShimQuality<'a>;
 


### PR DESCRIPTION
Follow-up for https://github.com/subspace/subspace/pull/1685 and last PR for https://github.com/subspace/subspace/issues/1502 for now (I don't think further improvements are on the critical path even though I already know how to improve things even more).

The net result of this PR is minimal, but it does introduce API that will become helpful in the future.

Basically caches were only used between low-level Chia tables, with stateful API cache is reused between creation of different tables on high level.

One hard to notice change here is in plotting where parallelized `generate` call was replaced with sequential `generate_parallel` call. The reason for this is that upcoming increase from k17 to k22 will massively increase memory requirements for table generation and it will become too expensive and non-performant to generate multiple tables concurrently. With large k it makes more sense to generate a single table at a time in parallel instead.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
