### PR TITLE
Make peer-info protocol optional.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -147,7 +147,9 @@ pub(super) fn configure_dsn(
         protocol_prefix,
         keypair,
         farmer_provider_storage.clone(),
-        PeerInfoProvider::new_farmer(Box::new(archival_storage_pieces)),
+        Some(PeerInfoProvider::new_farmer(Box::new(
+            archival_storage_pieces,
+        ))),
     );
     let config = Config {
         reserved_peers,

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -53,7 +53,7 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     /// The configuration for the [`PeerInfo`] protocol.
     pub(crate) peer_info_config: PeerInfoConfig,
     /// Provides peer-info for local peer.
-    pub(crate) peer_info_provider: PeerInfoProvider,
+    pub(crate) peer_info_provider: Option<PeerInfoProvider>,
     /// The configuration for the [`ConnectedPeers`] protocol (general instance).
     pub(crate) general_connected_peers_config: ConnectedPeersConfig,
     /// The configuration for the [`ConnectedPeers`] protocol (special instance).
@@ -77,7 +77,7 @@ pub(crate) struct Behavior<RecordStore> {
     pub(crate) connection_limits: ConnectionLimitsBehaviour,
     pub(crate) block_list: BlockListBehaviour,
     pub(crate) reserved_peers: ReservedPeersBehaviour,
-    pub(crate) peer_info: PeerInfoBehaviour,
+    pub(crate) peer_info: Toggle<PeerInfoBehaviour>,
     pub(crate) general_connected_peers: ConnectedPeersBehaviour<GeneralConnectedPeersInstance>,
     pub(crate) special_connected_peers: ConnectedPeersBehaviour<SpecialConnectedPeersInstance>,
 }
@@ -105,6 +105,10 @@ where
             })
             .into();
 
+        let peer_info = config
+            .peer_info_provider
+            .map(|provider| PeerInfoBehaviour::new(config.peer_info_config, provider));
+
         Self {
             identify: Identify::new(config.identify),
             kademlia,
@@ -116,7 +120,7 @@ where
             connection_limits: ConnectionLimitsBehaviour::new(config.connection_limits),
             block_list: BlockListBehaviour::default(),
             reserved_peers: ReservedPeersBehaviour::new(config.reserved_peers),
-            peer_info: PeerInfoBehaviour::new(config.peer_info_config, config.peer_info_provider),
+            peer_info: peer_info.into(),
             general_connected_peers: ConnectedPeersBehaviour::new(
                 config.general_connected_peers_config,
             ),

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::{
     peer_id, BootstrappedNetworkingParameters, Config, NetworkingParametersManager,
-    ParityDbProviderStorage, PeerInfoProvider, VoidProviderStorage,
+    ParityDbProviderStorage, VoidProviderStorage,
 };
 use tracing::{debug, info, Level};
 use tracing_subscriber::fmt::Subscriber;
@@ -187,7 +187,7 @@ async fn main() -> anyhow::Result<()> {
                     protocol_version.to_string(),
                     keypair,
                     provider_storage,
-                    PeerInfoProvider::new_bootstrap_node(),
+                    None,
                 )
             };
             let (node, mut node_runner) =

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -210,8 +210,8 @@ pub struct Config<ProviderStorage> {
     pub metrics: Option<Metrics>,
     /// Defines protocol version for the network peers. Affects network partition.
     pub protocol_version: String,
-    /// Specifies a source for peer information.
-    pub peer_info_provider: PeerInfoProvider,
+    /// Specifies a source for peer information. None disables the protocol.
+    pub peer_info_provider: Option<PeerInfoProvider>,
     /// Defines whether we maintain a persistent connection for common peers.
     pub general_connected_peers_handler: ConnectedPeersHandler,
     /// Defines whether we maintain a persistent connection for special peers.
@@ -239,7 +239,7 @@ impl Default for Config<MemoryProviderStorage> {
             DEFAULT_NETWORK_PROTOCOL_VERSION.to_string(),
             keypair,
             MemoryProviderStorage::new(peer_id),
-            PeerInfoProvider::new_client(),
+            Some(PeerInfoProvider::new_client()),
         )
     }
 }
@@ -253,7 +253,7 @@ where
         protocol_version: String,
         keypair: identity::Keypair,
         provider_storage: ProviderStorage,
-        peer_info_provider: PeerInfoProvider,
+        peer_info_provider: Option<PeerInfoProvider>,
     ) -> Self {
         let mut kademlia = KademliaConfig::default();
         kademlia

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -129,7 +129,7 @@ where
         dsn_protocol_version,
         keypair,
         provider_storage.clone(),
-        PeerInfoProvider::new_node(),
+        Some(PeerInfoProvider::new_node()),
     );
 
     default_networking_config


### PR DESCRIPTION
This PR sets peer-info protocol optional for bootstrap-node. We opted for a simpler design of peer-info protocol and didn't implement requesting cuckoo-filter from farmers. We push cuckoo-filter unconditionally to new connections and it's not suitable for bootstrap nodes. Bootstrap-node will receive thousands of cuckoo-filters from bootstrapping farmers which is unnecessary and could lead to a choke point.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
