### PR TITLE
PoT benches and tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10782,6 +10782,8 @@ name = "subspace-proof-of-time"
 version = "0.1.0"
 dependencies = [
  "aes 0.8.3",
+ "criterion",
+ "rand 0.8.5",
  "rayon",
  "subspace-core-primitives",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10784,7 +10784,6 @@ dependencies = [
  "aes 0.8.3",
  "criterion",
  "rand 0.8.5",
- "rayon",
  "subspace-core-primitives",
  "thiserror",
 ]

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -49,7 +49,7 @@ use core::convert::AsRef;
 use core::fmt;
 use core::num::NonZeroU64;
 use core::simd::Simd;
-use derive_more::{Add, Deref, DerefMut, Display, Div, From, Into, Mul, Rem, Sub};
+use derive_more::{Add, AsMut, AsRef, Deref, DerefMut, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 pub use pieces::{
@@ -229,15 +229,21 @@ impl PosProof {
 }
 
 /// Proof of time key(input to the encryption).
-#[derive(Debug, Copy, Clone, From, Into, Encode, Decode)]
+#[derive(
+    Debug, Default, Copy, Clone, From, Into, AsRef, AsMut, Encode, Decode, TypeInfo, MaxEncodedLen,
+)]
 pub struct PotKey(PotBytes);
 
 /// Proof of time seed (input to the encryption).
-#[derive(Debug, Copy, Clone, From, Into, Encode, Decode)]
+#[derive(
+    Debug, Default, Copy, Clone, From, Into, AsRef, AsMut, Encode, Decode, TypeInfo, MaxEncodedLen,
+)]
 pub struct PotSeed(PotBytes);
 
 /// Proof of time ciphertext (output from the encryption).
-#[derive(Debug, Copy, Clone, From, Into, Encode, Decode)]
+#[derive(
+    Debug, Default, Copy, Clone, From, Into, AsRef, AsMut, Encode, Decode, TypeInfo, MaxEncodedLen,
+)]
 pub struct PotCheckpoint(PotBytes);
 
 /// Proof of time.

--- a/crates/subspace-proof-of-time/Cargo.toml
+++ b/crates/subspace-proof-of-time/Cargo.toml
@@ -10,6 +10,10 @@ include = [
     "/Cargo.toml",
 ]
 
+[lib]
+# Necessary for CLI options to work on benches
+bench = false
+
 [dependencies]
 aes = "0.8.3"
 rayon = { version = "1.7.0", optional = true }
@@ -17,7 +21,13 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 thiserror = { version = "1.0.38", optional = true }
 
 [dev-dependencies]
+criterion = "0.5.1"
+rand = "0.8.5"
 rayon = "1.7.0"
+
+[[bench]]
+name = "pot"
+harness = false
 
 [features]
 default = ["std", "parallel"]

--- a/crates/subspace-proof-of-time/Cargo.toml
+++ b/crates/subspace-proof-of-time/Cargo.toml
@@ -16,25 +16,20 @@ bench = false
 
 [dependencies]
 aes = "0.8.3"
-rayon = { version = "1.7.0", optional = true }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 thiserror = { version = "1.0.38", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
-rayon = "1.7.0"
 
 [[bench]]
 name = "pot"
 harness = false
 
 [features]
-default = ["std", "parallel"]
+default = ["std"]
 std = [
     "subspace-core-primitives/std",
     "thiserror",
-]
-parallel = [
-    "dep:rayon",
 ]

--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -1,0 +1,52 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{thread_rng, Rng};
+use subspace_core_primitives::{BlockHash, PotKey, PotSeed};
+use subspace_proof_of_time::ProofOfTime;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut seed = PotSeed::default();
+    thread_rng().fill(seed.as_mut());
+    let mut key = PotKey::default();
+    thread_rng().fill(key.as_mut());
+    let slot_number = 1;
+    let mut injected_block_hash = BlockHash::default();
+    thread_rng().fill(injected_block_hash.as_mut());
+    let checkpoints = 16;
+    // About 1s on 5.5 GHz Raptor Lake CPU
+    let iterations = 166_000_000;
+    let proof_of_time_sequential = ProofOfTime::new(1, iterations);
+    let proof_of_time = ProofOfTime::new(checkpoints, iterations / u32::from(checkpoints));
+
+    c.bench_function("prove/sequential", |b| {
+        b.iter(|| {
+            proof_of_time_sequential.create(
+                black_box(seed),
+                black_box(key),
+                black_box(slot_number),
+                black_box(injected_block_hash),
+            );
+        })
+    });
+
+    c.bench_function("prove/checkpoints", |b| {
+        b.iter(|| {
+            proof_of_time.create(
+                black_box(seed),
+                black_box(key),
+                black_box(slot_number),
+                black_box(injected_block_hash),
+            );
+        })
+    });
+
+    let proof = proof_of_time.create(seed, key, slot_number, injected_block_hash);
+
+    c.bench_function("verify", |b| {
+        b.iter(|| {
+            proof_of_time.verify(black_box(&proof)).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -68,23 +68,12 @@ impl ProofOfTime {
             });
         }
 
-        #[cfg(feature = "parallel")]
-        let result = pot_aes::verify_parallel(
+        if pot_aes::verify_sequential(
             &proof.seed,
             &proof.key,
             &proof.checkpoints,
             self.checkpoint_iterations,
-        );
-
-        #[cfg(not(feature = "parallel"))]
-        let result = pot_aes::verify_sequential(
-            &proof.seed,
-            &proof.key,
-            &proof.checkpoints,
-            self.checkpoint_iterations,
-        );
-
-        if result {
+        ) {
             Ok(())
         } else {
             Err(PotVerificationError::VerificationFailed)

--- a/crates/subspace-proof-of-time/src/pot_aes.rs
+++ b/crates/subspace-proof-of-time/src/pot_aes.rs
@@ -6,8 +6,6 @@ use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockEncrypt, KeyInit};
 use aes::Aes128;
 use alloc::vec::Vec;
-#[cfg(any(feature = "parallel", test))]
-use rayon::prelude::*;
 use subspace_core_primitives::{PotBytes, PotCheckpoint, PotKey, PotSeed};
 
 /// Creates the AES based proof.
@@ -33,7 +31,6 @@ pub(crate) fn create(
 }
 
 /// Verifies the AES based proof sequentially.
-#[cfg(any(not(feature = "parallel"), test))]
 pub(crate) fn verify_sequential(
     seed: &PotSeed,
     key: &PotKey,
@@ -57,43 +54,6 @@ pub(crate) fn verify_sequential(
         .iter()
         .zip(checkpoints)
         .all(|(a, b)| a.as_slice() == b.as_ref())
-}
-
-/// Verifies the AES based proof in parallel.
-#[cfg(any(feature = "parallel", test))]
-pub(crate) fn verify_parallel(
-    seed: &PotSeed,
-    key: &PotKey,
-    checkpoints: &[PotCheckpoint],
-    checkpoint_iterations: u32,
-) -> bool {
-    let key = GenericArray::from(PotBytes::from(*key));
-    let cipher = Aes128::new(&key);
-
-    // Create the cipher pairs to be evaluated
-    let mut pairs = Vec::new();
-    let mut cur_block = GenericArray::from(PotBytes::from(*seed));
-    for checkpoint in checkpoints {
-        let checkpoint_block = GenericArray::from(PotBytes::from(*checkpoint));
-        pairs.push((cur_block, checkpoint_block));
-        cur_block = checkpoint_block;
-    }
-
-    // Evaluate the pairs in parallel.
-    let results: Vec<bool> = pairs
-        .par_iter_mut()
-        .map(|(input, expected)| {
-            let mut input = *input;
-            // Encrypt in place checkpoint_iterations times
-            // and compare with the expected output.
-            for _ in 0..checkpoint_iterations {
-                cipher.encrypt_block(&mut input);
-            }
-            input == *expected
-        })
-        .collect();
-
-    results.iter().all(|result| *result)
 }
 
 #[cfg(test)]
@@ -170,64 +130,6 @@ mod tests {
 
         // Decryption with wrong key fails.
         assert!(!verify_sequential(
-            &seed,
-            &PotKey::from(KEY_1),
-            &checkpoints,
-            checkpoint_iterations
-        ));
-    }
-
-    #[test]
-    fn test_encrypt_decrypt_parallel() {
-        let seed = PotSeed::from(SEED);
-        let key = PotKey::from(KEY);
-        let num_checkpoints = 10;
-        let checkpoint_iterations = 100;
-
-        // Can encrypt/decrypt.
-        let checkpoints = create(&seed, &key, num_checkpoints, checkpoint_iterations);
-        assert_eq!(checkpoints.len(), num_checkpoints as usize);
-        assert!(verify_parallel(
-            &seed,
-            &key,
-            &checkpoints,
-            checkpoint_iterations
-        ));
-
-        // Decryption of invalid cipher text fails.
-        let mut checkpoints_1 = checkpoints.clone();
-        checkpoints_1[0] = PotCheckpoint::from(BAD_CIPHER);
-        assert!(!verify_parallel(
-            &seed,
-            &key,
-            &checkpoints_1,
-            checkpoint_iterations
-        ));
-
-        // Decryption with wrong number of iterations fails.
-        assert!(!verify_parallel(
-            &seed,
-            &key,
-            &checkpoints,
-            checkpoint_iterations + 1
-        ));
-        assert!(!verify_parallel(
-            &seed,
-            &key,
-            &checkpoints,
-            checkpoint_iterations - 1
-        ));
-
-        // Decryption with wrong seed fails.
-        assert!(!verify_parallel(
-            &PotSeed::from(SEED_1),
-            &key,
-            &checkpoints,
-            checkpoint_iterations
-        ));
-
-        // Decryption with wrong key fails.
-        assert!(!verify_parallel(
             &seed,
             &PotKey::from(KEY_1),
             &checkpoints,


### PR DESCRIPTION
This introduces basic PoT benchmarks and initial tuning for single-threaded verification. It is now using instruction-level parallelism and thus is way faster than naive parallelization. In fact it is so fast I don't think it is worth having parallel version at all (which is why I deleted it).

I set benchmarks to the number of iterations that corresponds to ~1s on my machine and verification on a single core takes ~152ms or ~6.5x less time.

I have other ideas for improvements, but will submit those separately if they turn out to be fruitful.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
