### PR TITLE
Proof of time components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8675,11 +8675,19 @@ dependencies = [
 name = "sc-proof-of-time"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-network",
+ "sc-network-gossip",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-subspace",
+ "sp-runtime",
  "subspace-core-primitives",
  "subspace-proof-of-time",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8672,6 +8672,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-proof-of-time"
+version = "0.1.0"
+dependencies = [
+ "parking_lot 0.12.1",
+ "sc-network",
+ "subspace-core-primitives",
+ "subspace-proof-of-time",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
 source = "git+https://github.com/subspace/substrate?rev=55c157cff49b638a59d81a9f971f0f9a66829c71#55c157cff49b638a59d81a9f971f0f9a66829c71"

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sc-proof-of-time"
+description = "Subspace proof of time implementation"
+license = "MIT OR Apache-2.0"
+version = "0.1.0"
+authors = ["Rahul Subramaniyam <rahulksnv@gmail.com>"]
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
+subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time" }
+parking_lot = "0.12.1"
+thiserror = "1.0.38"
+tracing = "0.1.37"

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -11,9 +11,17 @@ include = [
 ]
 
 [dependencies]
+futures = "0.3.28"
+parity-scale-codec = { version = "3.6.1", features = ["derive"] }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time" }
 parking_lot = "0.12.1"
 thiserror = "1.0.38"
+tokio = { version = "1.28.2", features = ["time"] }
 tracing = "0.1.37"

--- a/crates/sc-proof-of-time/src/clock_master.rs
+++ b/crates/sc-proof-of-time/src/clock_master.rs
@@ -1,0 +1,232 @@
+//! Clock master implementation.
+
+use crate::gossip::PotGossip;
+use crate::state_manager::PotProtocolState;
+use crate::utils::get_consensus_tip_proofs;
+use crate::PotComponents;
+use futures::{FutureExt, StreamExt};
+use parity_scale_codec::{Decode, Encode};
+use sc_network::PeerId;
+use sp_blockchain::{HeaderBackend, Info};
+use sp_consensus::SyncOracle;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+use subspace_core_primitives::{BlockHash, NonEmptyVec, PotKey, PotProof, PotSeed, SlotNumber};
+use subspace_proof_of_time::ProofOfTime;
+use tokio::sync::mpsc::{channel, Sender};
+use tracing::{error, trace, warn};
+
+/// Channel size to send the produced proofs.
+/// The proof producer thread will block if the receiver is behind and
+/// the channel fills up.
+const PROOFS_CHANNEL_SIZE: usize = 12; // 2 * reveal lag.
+
+/// Inputs for bootstrapping.
+#[derive(Debug, Clone)]
+pub struct BootstrapParams {
+    /// Genesis block hash.
+    pub genesis_hash: BlockHash,
+
+    /// The initial key to be used.
+    pub key: PotKey,
+
+    /// Initial slot number.
+    pub slot: SlotNumber,
+}
+
+impl BootstrapParams {
+    pub fn new(genesis_hash: BlockHash, key: PotKey, slot: SlotNumber) -> Self {
+        Self {
+            genesis_hash,
+            key,
+            slot,
+        }
+    }
+}
+
+/// The clock master manages the protocol: periodic proof generation/verification, gossip.
+pub struct ClockMaster<Block: BlockT, Client, SO> {
+    proof_of_time: ProofOfTime,
+    gossip: PotGossip<Block>,
+    client: Arc<Client>,
+    sync_oracle: Arc<SO>,
+    pot_state: Arc<dyn PotProtocolState>,
+    chain_info_fn: Arc<dyn Fn() -> Info<Block> + Send + Sync>,
+}
+
+impl<Block, Client, SO> ClockMaster<Block, Client, SO>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block>,
+    SO: SyncOracle + Send + Sync + Clone + 'static,
+{
+    /// Creates the clock master instance.
+    /// TODO: chain_info() is not a trait method, but part of the
+    /// client::Client struct itself. Passing it in brings in lot
+    /// of unnecessary generics/dependencies. chain_info_fn() tries
+    /// to avoid that by using a Fn instead. Follow up with upstream
+    /// to include this in the trait.
+    pub fn new(
+        components: PotComponents,
+        gossip: PotGossip<Block>,
+        client: Arc<Client>,
+        sync_oracle: Arc<SO>,
+        chain_info_fn: Arc<dyn Fn() -> Info<Block> + Send + Sync>,
+    ) -> Self {
+        let PotComponents {
+            proof_of_time,
+            protocol_state: pot_state,
+            ..
+        } = components;
+
+        Self {
+            proof_of_time,
+            pot_state,
+            gossip,
+            client,
+            sync_oracle,
+            chain_info_fn,
+        }
+    }
+
+    /// Starts the workers.
+    pub async fn run(self, bootstrap_params: Option<BootstrapParams>) {
+        if let Some(params) = bootstrap_params.as_ref() {
+            // The clock master is responsible for bootstrapping, build/add the
+            // initial proof to the state and start the proof producer.
+            self.add_bootstrap_proof(params);
+        } else {
+            // Wait for sync to complete, get the proof from the tip.
+            let proofs = match get_consensus_tip_proofs(
+                self.client.clone(),
+                self.sync_oracle.clone(),
+                self.chain_info_fn.clone(),
+            )
+            .await
+            {
+                Ok(proofs) => proofs,
+                Err(err) => {
+                    error!("clock master: Failed to get initial proofs: {err:?}");
+                    return;
+                }
+            };
+            self.pot_state.reset(proofs);
+        }
+
+        let (local_proof_sender, mut local_proof_receiver) = channel(PROOFS_CHANNEL_SIZE);
+
+        // Filter out incoming messages without sender_id or that fail to decode.
+        let mut incoming_messages = Box::pin(self.gossip.incoming_messages().filter_map(
+            |notification| async move {
+                let mut ret = None;
+                if let Some(sender) = notification.sender {
+                    if let Ok(msg) = PotProof::decode(&mut &notification.message[..]) {
+                        ret = Some((sender, msg))
+                    }
+                }
+                ret
+            },
+        ));
+
+        let proof_of_time = self.proof_of_time.clone();
+        let pot_state = self.pot_state.clone();
+        thread::Builder::new()
+            .name("pot-proof-producer".to_string())
+            .spawn(move || {
+                Self::produce_proofs(proof_of_time, pot_state, local_proof_sender);
+            })
+            .expect("Failed to spawn PoT proof producer thread");
+
+        loop {
+            //let engine = self.gossip.engine.clone();
+            //let gossip_engine = futures::future::poll_fn(|cx| engine.lock().poll_unpin(cx));
+
+            futures::select! {
+                local_proof = local_proof_receiver.recv().fuse() => {
+                    if let Some(proof) = local_proof {
+                        trace!("clock_master: got local proof: {proof}");
+                        self.handle_local_proof(proof);
+                    }
+                },
+                gossiped = incoming_messages.next().fuse() => {
+                    if let Some((sender, proof)) = gossiped {
+                        trace!("clock_master: got gossiped proof: {sender} => {proof}");
+                        self.handle_gossip_message(self.pot_state.as_ref(), sender, proof);
+                    }
+                },
+                _ = self.gossip.is_terminated().fuse() => {
+                    error!("clock_master: gossip engine has terminated.");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Long running loop to produce the proofs.
+    fn produce_proofs(
+        proof_of_time: ProofOfTime,
+        state: Arc<dyn PotProtocolState>,
+        proof_sender: Sender<PotProof>,
+    ) {
+        loop {
+            // Build the next proof on top of the latest tip.
+            let last_proof = state.tip().expect("Clock master chain cannot be empty");
+
+            // TODO: injected block hash from consensus
+            let start_ts = Instant::now();
+            let next_slot_number = last_proof.slot_number + 1;
+            let next_seed = last_proof.next_seed(None);
+            let next_key = last_proof.next_key();
+            let next_proof = proof_of_time.create(
+                next_seed,
+                next_key,
+                next_slot_number,
+                last_proof.injected_block_hash,
+            );
+            let elapsed = start_ts.elapsed();
+            trace!("clock_master::produce proofs: {next_proof}, time=[{elapsed:?}]");
+
+            // Store the new proof back into the chain and gossip to other clock masters.
+            if let Err(e) = state.on_proof(&next_proof) {
+                trace!("clock_master::produce proofs: failed to extend chain: {e:?}");
+                continue;
+            } else if let Err(e) = proof_sender.blocking_send(next_proof.clone()) {
+                warn!("clock_master::produce proofs: send failed: {e:?}");
+                return;
+            }
+        }
+    }
+
+    /// Gossips the locally generated proof.
+    fn handle_local_proof(&self, proof: PotProof) {
+        self.gossip.gossip_message(proof.encode());
+    }
+
+    /// Handles the incoming gossip message.
+    fn handle_gossip_message(&self, state: &dyn PotProtocolState, sender: PeerId, proof: PotProof) {
+        let start_ts = Instant::now();
+        let ret = state.on_proof_from_peer(sender, &proof);
+        let elapsed = start_ts.elapsed();
+
+        if let Err(err) = ret {
+            trace!("clock_master::on gossip: {err:?}, {sender}");
+        } else {
+            trace!("clock_master::on gossip: {proof}, time=[{elapsed:?}], {sender}");
+            self.gossip.gossip_message(proof.encode());
+        }
+    }
+
+    /// Builds/adds the bootstrap proof to the state.
+    fn add_bootstrap_proof(&self, params: &BootstrapParams) {
+        let proof = self.proof_of_time.create(
+            PotSeed::from_block_hash(params.genesis_hash),
+            params.key,
+            params.slot,
+            params.genesis_hash,
+        );
+        let proofs = NonEmptyVec::new(vec![proof]).expect("Vec is non empty");
+        self.pot_state.reset(proofs);
+    }
+}

--- a/crates/sc-proof-of-time/src/clock_master.rs
+++ b/crates/sc-proof-of-time/src/clock_master.rs
@@ -69,7 +69,7 @@ where
     /// to avoid that by using a Fn instead. Follow up with upstream
     /// to include this in the trait.
     pub fn new(
-        components: PotComponents,
+        components: PotComponents<Block>,
         gossip: PotGossip<Block>,
         client: Arc<Client>,
         sync_oracle: Arc<SO>,

--- a/crates/sc-proof-of-time/src/clock_master.rs
+++ b/crates/sc-proof-of-time/src/clock_master.rs
@@ -137,6 +137,7 @@ where
             .spawn(move || {
                 Self::produce_proofs(proof_of_time, pot_state, local_proof_sender);
             })
+            // TODO: Proper error handling or proof
             .expect("Failed to spawn PoT proof producer thread");
 
         loop {
@@ -172,6 +173,7 @@ where
     ) {
         loop {
             // Build the next proof on top of the latest tip.
+            // TODO: Proper error handling or proof
             let last_proof = state.tip().expect("Clock master chain cannot be empty");
 
             // TODO: injected block hash from consensus
@@ -226,7 +228,7 @@ where
             params.slot,
             params.genesis_hash,
         );
-        let proofs = NonEmptyVec::new(vec![proof]).expect("Vec is non empty");
+        let proofs = NonEmptyVec::new(vec![proof]).expect("Vec is non empty; qed");
         self.pot_state.reset(proofs);
     }
 }

--- a/crates/sc-proof-of-time/src/gossip.rs
+++ b/crates/sc-proof-of-time/src/gossip.rs
@@ -1,0 +1,137 @@
+//! PoT gossip functionality.
+
+use futures::channel::mpsc::Receiver;
+use futures::FutureExt;
+use parity_scale_codec::Decode;
+use parking_lot::{Mutex, RwLock};
+use sc_network::config::NonDefaultSetConfig;
+use sc_network::PeerId;
+use sc_network_gossip::{
+    GossipEngine, MessageIntent, Syncing as GossipSyncing, TopicNotification, ValidationResult,
+    Validator, ValidatorContext,
+};
+use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
+use std::collections::HashSet;
+use std::sync::Arc;
+use subspace_core_primitives::crypto::blake2b_256_hash;
+use subspace_core_primitives::PotProof;
+
+pub(crate) const GOSSIP_PROTOCOL: &str = "/subspace/subspace-proof-of-time";
+
+type MessageHash = [u8; 32];
+
+/// PoT gossip components.
+#[derive(Clone)]
+pub struct PotGossip<Block: BlockT> {
+    engine: Arc<Mutex<GossipEngine<Block>>>,
+    validator: Arc<PotGossipValidator>,
+}
+
+impl<Block: BlockT> PotGossip<Block> {
+    /// Creates the gossip components.
+    pub fn new<Network, GossipSync>(network: Network, sync: Arc<GossipSync>) -> Self
+    where
+        Network: sc_network_gossip::Network<Block> + Send + Sync + Clone + 'static,
+        GossipSync: GossipSyncing<Block> + 'static,
+    {
+        let validator = Arc::new(PotGossipValidator::new());
+        let engine = Arc::new(Mutex::new(GossipEngine::new(
+            network,
+            sync,
+            GOSSIP_PROTOCOL,
+            validator.clone(),
+            None,
+        )));
+        Self { engine, validator }
+    }
+
+    /// Gossips the message to the network.
+    pub fn gossip_message(&self, message: Vec<u8>) {
+        self.validator.on_broadcast(&message);
+        self.engine
+            .lock()
+            .gossip_message(topic::<Block>(), message, false);
+    }
+
+    /// Returns the receiver for the messages.
+    pub fn incoming_messages(&self) -> Receiver<TopicNotification> {
+        self.engine.lock().messages_for(topic::<Block>())
+    }
+
+    /// Waits for gossip engine to terminate.
+    pub async fn is_terminated(&self) {
+        let poll_fn = futures::future::poll_fn(|cx| self.engine.lock().poll_unpin(cx));
+        poll_fn.await;
+    }
+}
+
+/// Validator for gossiped messages
+#[derive(Debug)]
+struct PotGossipValidator {
+    pending: RwLock<HashSet<MessageHash>>,
+}
+
+impl PotGossipValidator {
+    /// Creates the validator.
+    fn new() -> Self {
+        Self {
+            pending: RwLock::new(HashSet::new()),
+        }
+    }
+
+    /// Called when the message is broadcast.
+    fn on_broadcast(&self, msg: &[u8]) {
+        let hash = blake2b_256_hash(msg);
+        let mut pending = self.pending.write();
+        pending.insert(hash);
+    }
+}
+
+impl<Block: BlockT> Validator<Block> for PotGossipValidator {
+    fn validate(
+        &self,
+        _context: &mut dyn ValidatorContext<Block>,
+        _sender: &PeerId,
+        mut data: &[u8],
+    ) -> ValidationResult<Block::Hash> {
+        match PotProof::decode(&mut data) {
+            Ok(_) => ValidationResult::ProcessAndKeep(topic::<Block>()),
+            Err(_) => ValidationResult::Discard,
+        }
+    }
+
+    fn message_expired<'a>(&'a self) -> Box<dyn FnMut(Block::Hash, &[u8]) -> bool + 'a> {
+        Box::new(move |_topic, data| {
+            let hash = blake2b_256_hash(data);
+            let pending = self.pending.read();
+            !pending.contains(&hash)
+        })
+    }
+
+    fn message_allowed<'a>(
+        &'a self,
+    ) -> Box<dyn FnMut(&PeerId, MessageIntent, &Block::Hash, &[u8]) -> bool + 'a> {
+        Box::new(move |_who, _intent, _topic, data| {
+            let hash = blake2b_256_hash(data);
+            let mut pending = self.pending.write();
+            if pending.contains(&hash) {
+                pending.remove(&hash);
+                true
+            } else {
+                false
+            }
+        })
+    }
+}
+
+/// PoT message topic.
+fn topic<Block: BlockT>() -> Block::Hash {
+    <<Block::Header as HeaderT>::Hashing as HashT>::hash(b"subspace-proof-of-time-gossip")
+}
+
+/// Returns the network configuration for PoT gossip.
+pub fn pot_gossip_peers_set_config() -> NonDefaultSetConfig {
+    let mut cfg = NonDefaultSetConfig::new(GOSSIP_PROTOCOL.into(), 5 * 1024 * 1024);
+    cfg.allow_non_reserved(25, 25);
+    cfg
+}

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -1,0 +1,49 @@
+//! Subspace proof of time implementation.
+
+mod state_manager;
+
+use core::num::{NonZeroU32, NonZeroU8};
+use subspace_core_primitives::{BlockNumber, SlotNumber};
+
+// TODO: change the fields that can't be zero to NonZero types.
+#[derive(Debug, Clone)]
+pub struct PotConfig {
+    /// Frequency of entropy injection from consensus.
+    pub randomness_update_interval_blocks: BlockNumber,
+
+    /// Starting point for entropy injection from consensus.
+    pub injection_depth_blocks: BlockNumber,
+
+    /// Number of slots it takes for updated global randomness to
+    /// take effect.
+    pub global_randomness_reveal_lag_slots: SlotNumber,
+
+    /// Number of slots it takes for injected randomness to
+    /// take effect.
+    pub pot_injection_lag_slots: SlotNumber,
+
+    /// If the received proof is more than max_future_slots into the
+    /// future from the current tip's slot, reject it.
+    pub max_future_slots: SlotNumber,
+
+    /// Total iterations per proof.
+    pub pot_iterations: NonZeroU32,
+
+    /// Number of checkpoints per proof.
+    pub num_checkpoints: NonZeroU8,
+}
+
+impl Default for PotConfig {
+    fn default() -> Self {
+        // TODO: fill proper values
+        Self {
+            randomness_update_interval_blocks: 18,
+            injection_depth_blocks: 90,
+            global_randomness_reveal_lag_slots: 6,
+            pot_injection_lag_slots: 6,
+            max_future_slots: 10,
+            pot_iterations: NonZeroU32::new(16 * 200_000).expect("pot_iterations cannot be zero"),
+            num_checkpoints: NonZeroU8::new(16).expect("num_checkpoints cannot be zero"),
+        }
+    }
+}

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -1,9 +1,18 @@
 //! Subspace proof of time implementation.
 
+mod clock_master;
+mod gossip;
 mod state_manager;
+mod utils;
 
+use crate::state_manager::PotProtocolState;
 use core::num::{NonZeroU32, NonZeroU8};
+use std::sync::Arc;
 use subspace_core_primitives::{BlockNumber, SlotNumber};
+use subspace_proof_of_time::ProofOfTime;
+
+pub use clock_master::{BootstrapParams, ClockMaster};
+pub use gossip::{pot_gossip_peers_set_config, PotGossip};
 
 // TODO: change the fields that can't be zero to NonZero types.
 #[derive(Debug, Clone)]
@@ -35,7 +44,8 @@ pub struct PotConfig {
 
 impl Default for PotConfig {
     fn default() -> Self {
-        // TODO: fill proper values
+        // TODO: fill proper values. These are set to produce
+        // approximately 1 proof/sec during testing.
         Self {
             randomness_update_interval_blocks: 18,
             injection_depth_blocks: 90,
@@ -46,4 +56,13 @@ impl Default for PotConfig {
             num_checkpoints: NonZeroU8::new(16).expect("num_checkpoints cannot be zero"),
         }
     }
+}
+
+/// Components initialized during the new_partial() phase of set up.
+pub struct PotComponents {
+    /// Proof of time implementation.
+    proof_of_time: ProofOfTime,
+
+    /// Protocol state.
+    protocol_state: Arc<dyn PotProtocolState>,
 }

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod clock_master;
 mod gossip;
+mod node_client;
 mod state_manager;
 mod utils;
 
@@ -13,6 +14,7 @@ use subspace_proof_of_time::ProofOfTime;
 
 pub use clock_master::{BootstrapParams, ClockMaster};
 pub use gossip::{pot_gossip_peers_set_config, PotGossip};
+pub use node_client::PotClient;
 
 // TODO: change the fields that can't be zero to NonZero types.
 #[derive(Debug, Clone)]

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -56,8 +56,8 @@ impl Default for PotConfig {
             global_randomness_reveal_lag_slots: 6,
             pot_injection_lag_slots: 6,
             max_future_slots: 10,
-            pot_iterations: NonZeroU32::new(16 * 200_000).expect("pot_iterations cannot be zero"),
-            num_checkpoints: NonZeroU8::new(16).expect("num_checkpoints cannot be zero"),
+            pot_iterations: NonZeroU32::new(16 * 200_000).expect("Not zero; qed"),
+            num_checkpoints: NonZeroU8::new(16).expect("Not zero; qed"),
         }
     }
 }
@@ -79,6 +79,7 @@ impl<Block: BlockT> PotComponents<Block> {
     pub fn new() -> Self {
         let config = PotConfig::default();
         let proof_of_time = ProofOfTime::new(config.pot_iterations, config.num_checkpoints)
+            // TODO: Proper error handling or proof
             .expect("Failed to initialize proof of time");
         let (protocol_state, consensus_state) = init_pot_state(config, proof_of_time.clone());
 

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -80,8 +80,7 @@ impl<Block: BlockT> PotComponents<Block> {
         let config = PotConfig::default();
         let proof_of_time = ProofOfTime::new(config.pot_iterations, config.num_checkpoints)
             .expect("Failed to initialize proof of time");
-        let (protocol_state, consensus_state) =
-            init_pot_state(config, proof_of_time.clone(), vec![]);
+        let (protocol_state, consensus_state) = init_pot_state(config, proof_of_time.clone());
 
         Self {
             proof_of_time,

--- a/crates/sc-proof-of-time/src/node_client.rs
+++ b/crates/sc-proof-of-time/src/node_client.rs
@@ -32,7 +32,7 @@ where
 {
     /// Creates the PoT client instance.
     pub fn new(
-        components: PotComponents,
+        components: PotComponents<Block>,
         gossip: PotGossip<Block>,
         client: Arc<Client>,
         sync_oracle: Arc<SO>,

--- a/crates/sc-proof-of-time/src/node_client.rs
+++ b/crates/sc-proof-of-time/src/node_client.rs
@@ -1,0 +1,109 @@
+//! Consensus node interface to the clock master network.
+
+use crate::gossip::PotGossip;
+use crate::state_manager::PotProtocolState;
+use crate::utils::get_consensus_tip_proofs;
+use crate::PotComponents;
+use futures::{FutureExt, StreamExt};
+use parity_scale_codec::Decode;
+use sc_network::PeerId;
+use sp_blockchain::{HeaderBackend, Info};
+use sp_consensus::SyncOracle;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+use std::time::Instant;
+use subspace_core_primitives::PotProof;
+use tracing::{error, trace};
+
+/// The PoT client implementation
+pub struct PotClient<Block: BlockT, Client, SO> {
+    gossip: PotGossip<Block>,
+    pot_state: Arc<dyn PotProtocolState>,
+    client: Arc<Client>,
+    sync_oracle: Arc<SO>,
+    chain_info_fn: Arc<dyn Fn() -> Info<Block> + Send + Sync>,
+}
+
+impl<Block, Client, SO> PotClient<Block, Client, SO>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block>,
+    SO: SyncOracle + Send + Sync + Clone + 'static,
+{
+    /// Creates the PoT client instance.
+    pub fn new(
+        components: PotComponents,
+        gossip: PotGossip<Block>,
+        client: Arc<Client>,
+        sync_oracle: Arc<SO>,
+        chain_info_fn: Arc<dyn Fn() -> Info<Block> + Send + Sync>,
+    ) -> Self {
+        Self {
+            gossip,
+            pot_state: components.protocol_state,
+            client,
+            sync_oracle,
+            chain_info_fn,
+        }
+    }
+
+    /// Starts the workers.
+    pub async fn run(self) {
+        // Wait for sync to complete, get the proof from the tip.
+        let proofs = match get_consensus_tip_proofs(
+            self.client.clone(),
+            self.sync_oracle.clone(),
+            self.chain_info_fn.clone(),
+        )
+        .await
+        {
+            Ok(proofs) => proofs,
+            Err(err) => {
+                error!("PoT client: Failed to get initial proofs: {err:?}");
+                return;
+            }
+        };
+        self.pot_state.reset(proofs);
+
+        // Filter out incoming messages without sender_id or that fail to decode.
+        let mut incoming_messages = Box::pin(self.gossip.incoming_messages().filter_map(
+            |notification| async move {
+                let mut ret = None;
+                if let Some(sender) = notification.sender {
+                    if let Ok(msg) = PotProof::decode(&mut &notification.message[..]) {
+                        ret = Some((sender, msg))
+                    }
+                }
+                ret
+            },
+        ));
+
+        loop {
+            futures::select! {
+                gossiped = incoming_messages.next().fuse() => {
+                    if let Some((sender, proof)) = gossiped {
+                        trace!("pot_client: got gossiped proof: {sender} => {proof}");
+                        self.handle_gossip_message(self.pot_state.as_ref(), sender, proof);
+                    }
+                },
+                _ = self.gossip.is_terminated().fuse() => {
+                    error!("pot_client: gossip engine has terminated.");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Handles the incoming gossip message.
+    fn handle_gossip_message(&self, state: &dyn PotProtocolState, sender: PeerId, proof: PotProof) {
+        let start_ts = Instant::now();
+        let ret = state.on_proof_from_peer(sender, &proof);
+        let elapsed = start_ts.elapsed();
+
+        if let Err(err) = ret {
+            trace!("pot_client::on gossip: {err:?}, {sender}");
+        } else {
+            trace!("pot_client::on gossip: {proof}, time=[{elapsed:?}], {sender}");
+        }
+    }
+}

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -1,0 +1,291 @@
+//! PoT state management.
+
+use crate::PotConfig;
+use parking_lot::Mutex;
+use sc_network::PeerId;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use subspace_core_primitives::{NonEmptyVec, PotKey, PotProof, PotSeed, SlotNumber};
+use subspace_proof_of_time::{PotVerificationError, ProofOfTime};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PotProtocolStateError {
+    #[error("Failed to extend chain: {expected}/{actual}")]
+    TipMismatch {
+        expected: SlotNumber,
+        actual: SlotNumber,
+    },
+
+    #[error("Proof for an older slot number: {tip_slot}/{proof_slot}")]
+    StaleProof {
+        tip_slot: SlotNumber,
+        proof_slot: SlotNumber,
+    },
+
+    #[error("Proof had an unexpected seed: {expected:?}/{actual:?}")]
+    InvalidSeed { expected: PotSeed, actual: PotSeed },
+
+    #[error("Proof had an unexpected key: {expected:?}/{actual:?}")]
+    InvalidKey { expected: PotKey, actual: PotKey },
+
+    #[error("Proof verification failed: {0:?}")]
+    InvalidProof(PotVerificationError),
+
+    #[error("Proof is too much into future: {tip_slot}/{proof_slot}")]
+    TooFuturistic {
+        tip_slot: SlotNumber,
+        proof_slot: SlotNumber,
+    },
+
+    #[error("Duplicate proof from peer: {0:?}")]
+    DuplicateProofFromPeer(PeerId),
+}
+
+/// The shared PoT state.
+struct InternalState {
+    /// Last N entries of the PotChain, sorted by height.
+    /// TODO: purging to be implemented.
+    chain: Vec<PotProof>,
+
+    /// Proofs for future slot numbers, indexed by slot number.
+    /// Each entry holds the proofs indexed by sender. The proofs
+    /// are already verified before being added to the future list.
+    /// TODO: limit the number of proofs per future slot.
+    future_proofs: BTreeMap<SlotNumber, BTreeMap<PeerId, PotProof>>,
+}
+
+/// Wrapper to manage the state.
+struct StateManager {
+    /// Pot config
+    config: PotConfig,
+
+    /// PoT wrapper for verification.
+    proof_of_time: Arc<ProofOfTime>,
+
+    /// The PoT state
+    state: Mutex<InternalState>,
+}
+
+impl StateManager {
+    /// Creates the state.
+    pub fn new(config: PotConfig, proof_of_time: Arc<ProofOfTime>, chain: Vec<PotProof>) -> Self {
+        Self {
+            config,
+            proof_of_time,
+            state: Mutex::new(InternalState {
+                chain,
+                future_proofs: BTreeMap::new(),
+            }),
+        }
+    }
+
+    /// Extends the chain with the given proof, without verifying it
+    /// (e.g) called when clock maker locally produces a proof.
+    pub fn extend_chain(&self, proof: &PotProof) -> Result<(), PotProtocolStateError> {
+        let mut state = self.state.lock();
+        let tip = match state.chain.last() {
+            Some(tip) => tip,
+            None => {
+                self.add_to_tip(&mut state, proof);
+                return Ok(());
+            }
+        };
+
+        if (tip.slot_number + 1) == proof.slot_number {
+            self.add_to_tip(&mut state, proof);
+            Ok(())
+        } else {
+            // The tip moved by the time the proof was computed.
+            Err(PotProtocolStateError::TipMismatch {
+                expected: tip.slot_number + 1,
+                actual: proof.slot_number,
+            })
+        }
+    }
+
+    /// Extends the chain with the given proof, after verifying it
+    /// (e.g) called when the proof is received from a peer via gossip.
+    pub fn verify_and_extend_chain(
+        &self,
+        sender: PeerId,
+        proof: &PotProof,
+    ) -> Result<(), PotProtocolStateError> {
+        // Verify the proof outside the lock.
+        // TODO: penalize peers that send too many bad proofs.
+        self.proof_of_time
+            .verify(proof)
+            .map_err(PotProtocolStateError::InvalidProof)?;
+
+        let mut state = self.state.lock();
+        let tip = match state.chain.last() {
+            Some(tip) => tip.clone(),
+            None => {
+                self.add_to_tip(&mut state, proof);
+                return Ok(());
+            }
+        };
+
+        // Case 1: the proof is for an older slot
+        if proof.slot_number <= tip.slot_number {
+            return Err(PotProtocolStateError::StaleProof {
+                tip_slot: tip.slot_number,
+                proof_slot: proof.slot_number,
+            });
+        }
+
+        // Case 2: the proof extends the tip
+        if (tip.slot_number + 1) == proof.slot_number {
+            let expected_seed = tip.next_seed(None);
+            if proof.seed != expected_seed {
+                return Err(PotProtocolStateError::InvalidSeed {
+                    expected: expected_seed,
+                    actual: proof.seed,
+                });
+            }
+
+            let expected_key = tip.next_key();
+            if proof.key != expected_key {
+                return Err(PotProtocolStateError::InvalidKey {
+                    expected: expected_key,
+                    actual: proof.key,
+                });
+            }
+
+            // All checks passed, advance the tip with the new proof
+            self.add_to_tip(&mut state, proof);
+            return Ok(());
+        }
+
+        // Case 3: proof for a future slot
+        self.handle_future_proof(&mut state, &tip, sender, proof)
+    }
+
+    /// Handles the received proof for a future slot.
+    fn handle_future_proof(
+        &self,
+        state: &mut InternalState,
+        tip: &PotProof,
+        sender: PeerId,
+        proof: &PotProof,
+    ) -> Result<(), PotProtocolStateError> {
+        // Reject if too much into future
+        if (proof.slot_number - tip.slot_number) > self.config.max_future_slots {
+            return Err(PotProtocolStateError::TooFuturistic {
+                tip_slot: tip.slot_number,
+                proof_slot: proof.slot_number,
+            });
+        }
+
+        match state.future_proofs.entry(proof.slot_number) {
+            Entry::Vacant(entry) => {
+                let mut proofs = BTreeMap::new();
+                proofs.insert(sender, proof.clone());
+                entry.insert(proofs);
+                Ok(())
+            }
+            Entry::Occupied(mut entry) => {
+                let proofs_for_slot = entry.get_mut();
+                // Reject if the sender already sent a proof for same slot number.
+                if proofs_for_slot.contains_key(&sender) {
+                    return Err(PotProtocolStateError::DuplicateProofFromPeer(sender));
+                }
+
+                // TODO: put a max limit on future proofs per slot number.
+                proofs_for_slot.insert(sender, proof.clone());
+                Ok(())
+            }
+        }
+    }
+
+    /// Called when the chain is extended with a new proof.
+    /// Tries to advance the tip as much as possible, by merging with
+    /// the pending future proofs.
+    fn merge_future_proofs(&self, state: &mut InternalState) {
+        let mut cur_tip = state.chain.last().cloned();
+        while let Some(tip) = cur_tip.as_ref() {
+            // At this point, we know the expected seed/key for the next proof
+            // in the sequence. If there is at least an entry with the expected
+            // key/seed(there could be several from different peers), extend the
+            // chain.
+            let next_slot = tip.slot_number + 1;
+            let proofs_for_slot = match state.future_proofs.remove(&next_slot) {
+                Some(proofs) => proofs,
+                None => return,
+            };
+
+            let next_seed = tip.next_seed(None);
+            let next_key = tip.next_key();
+            match proofs_for_slot
+                .values()
+                .find(|proof| proof.seed == next_seed && proof.key == next_key)
+                .cloned()
+            {
+                Some(next_proof) => {
+                    // Extend the tip with the next proof, continue merging.
+                    state.chain.push(next_proof.clone());
+                    cur_tip = Some(next_proof);
+                }
+                None => {
+                    // TODO: penalize peers that sent invalid key/seed
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Adds the proof to the current tip
+    fn add_to_tip(&self, state: &mut InternalState, proof: &PotProof) {
+        state.chain.push(proof.clone());
+        state.future_proofs.remove(&proof.slot_number);
+        self.merge_future_proofs(state);
+    }
+}
+
+/// Interface to the internal protocol components (clock master, PoT client).
+pub(crate) trait PotProtocolState: Send + Sync {
+    /// Re(initializes) the chain with the given set of proofs.
+    /// TODO: the proofs are assumed to have been validated, validate
+    /// if needed.
+    fn reset(&self, proofs: NonEmptyVec<PotProof>);
+
+    /// Returns the current tip.
+    fn tip(&self) -> Option<PotProof>;
+
+    /// Called when a proof is produced locally. It tries to extend the
+    /// chain without verifying the proof.
+    fn on_proof(&self, proof: &PotProof) -> Result<(), PotProtocolStateError>;
+
+    /// Called when a proof is received via gossip from a peer. The proof
+    /// is first verified before trying to extend the chain.
+    fn on_proof_from_peer(
+        &self,
+        sender: PeerId,
+        proof: &PotProof,
+    ) -> Result<(), PotProtocolStateError>;
+}
+
+impl PotProtocolState for StateManager {
+    fn reset(&self, proofs: NonEmptyVec<PotProof>) {
+        let mut proofs = proofs.to_vec();
+        let mut state = self.state.lock();
+        state.chain.clear();
+        state.chain.append(&mut proofs);
+        state.future_proofs.clear();
+    }
+    fn tip(&self) -> Option<PotProof> {
+        self.state.lock().chain.last().cloned()
+    }
+
+    fn on_proof(&self, proof: &PotProof) -> Result<(), PotProtocolStateError> {
+        self.extend_chain(proof)
+    }
+
+    fn on_proof_from_peer(
+        &self,
+        sender: PeerId,
+        proof: &PotProof,
+    ) -> Result<(), PotProtocolStateError> {
+        self.verify_and_extend_chain(sender, proof)
+    }
+}

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -3,12 +3,14 @@
 use crate::PotConfig;
 use parking_lot::Mutex;
 use sc_network::PeerId;
+use sp_runtime::traits::{Block as BlockT, NumberFor, One};
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use subspace_core_primitives::{NonEmptyVec, PotKey, PotProof, PotSeed, SlotNumber};
 use subspace_proof_of_time::{PotVerificationError, ProofOfTime};
 
+/// Error codes for PotProtocolState APIs.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PotProtocolStateError {
     #[error("Failed to extend chain: {expected}/{actual}")]
@@ -42,6 +44,85 @@ pub(crate) enum PotProtocolStateError {
     DuplicateProofFromPeer(PeerId),
 }
 
+/// Error codes for PotConsensusState APIs.
+#[derive(Debug, thiserror::Error)]
+pub enum PotConsensusStateError {
+    #[error("Parent block proofs empty: {summary:?}/{slot_number}/{block_number}")]
+    ParentProofsEmpty {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+    },
+
+    #[error("Invalid slot range: {summary:?}/{slot_number}/{block_number}/{start_slot}")]
+    InvalidRange {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+        start_slot: SlotNumber,
+    },
+
+    #[error("Proof unavailable to send: {summary:?}/{slot_number}/{block_number}")]
+    ProofUnavailable {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+    },
+
+    #[error(
+        "Unexpected proof count: {summary:?}/{slot_number}/{block_number}/{expected}/{actual}"
+    )]
+    UnexpectedProofCount {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+        expected: usize,
+        actual: usize,
+    },
+
+    #[error("Received proof locally missing: {summary:?}/{slot_number}/{block_number}")]
+    ReceivedSlotMissing {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+    },
+
+    #[error("Received proof did not match local proof: {summary:?}/{slot_number}/{block_number}")]
+    ReceivedProofMismatch {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+    },
+
+    #[error("Received block with no proofs: {summary:?}/{slot_number}/{block_number}")]
+    ReceivedProofsEmpty {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+    },
+
+    #[error(
+    "Received proofs with unexpected slot number: {summary:?}/{slot_number}/{block_number}/{expected}/{actual}"
+    )]
+    ReceivedUnexpectedSlotNumber {
+        summary: PotStateSummary,
+        slot_number: SlotNumber,
+        block_number: String,
+        expected: SlotNumber,
+        actual: SlotNumber,
+    },
+}
+
+/// Summary of the current state.
+#[derive(Debug, Clone)]
+pub struct PotStateSummary {
+    /// Current tip.
+    pub tip: Option<SlotNumber>,
+
+    /// Length of chain.
+    pub chain_length: usize,
+}
+
 /// The shared PoT state.
 struct InternalState {
     /// Last N entries of the PotChain, sorted by height.
@@ -55,13 +136,22 @@ struct InternalState {
     future_proofs: BTreeMap<SlotNumber, BTreeMap<PeerId, PotProof>>,
 }
 
+impl InternalState {
+    fn summary(&self) -> PotStateSummary {
+        PotStateSummary {
+            tip: self.chain.iter().last().map(|proof| proof.slot_number),
+            chain_length: self.chain.len(),
+        }
+    }
+}
+
 /// Wrapper to manage the state.
 struct StateManager {
     /// Pot config
     config: PotConfig,
 
     /// PoT wrapper for verification.
-    proof_of_time: Arc<ProofOfTime>,
+    proof_of_time: ProofOfTime,
 
     /// The PoT state
     state: Mutex<InternalState>,
@@ -69,7 +159,7 @@ struct StateManager {
 
 impl StateManager {
     /// Creates the state.
-    pub fn new(config: PotConfig, proof_of_time: Arc<ProofOfTime>, chain: Vec<PotProof>) -> Self {
+    pub fn new(config: PotConfig, proof_of_time: ProofOfTime, chain: Vec<PotProof>) -> Self {
         Self {
             config,
             proof_of_time,
@@ -288,4 +378,216 @@ impl PotProtocolState for StateManager {
     ) -> Result<(), PotProtocolStateError> {
         self.verify_and_extend_chain(sender, proof)
     }
+}
+
+/// Interface to consensus.
+pub trait PotConsensusState<Block: BlockT>: Send + Sync {
+    /// Called by consensus when trying to claim the slot.
+    /// Returns the proofs in the slot range
+    /// [parent.last_proof.slot + 1, slot_number - global_randomness_reveal_lag_slots].
+    fn get_block_proofs(
+        &self,
+        slot_number: SlotNumber,
+        block_number: NumberFor<Block>,
+        parent_block_proofs: &[PotProof],
+    ) -> Result<Vec<PotProof>, PotConsensusStateError>;
+
+    /// Called during block import validation.
+    /// Verifies the sequence of proofs in the block being validated.
+    fn verify_block_proofs(
+        &self,
+        slot_number: SlotNumber,
+        block_number: NumberFor<Block>,
+        block_proofs: &[PotProof],
+        parent_block_proofs: &[PotProof],
+    ) -> Result<(), PotConsensusStateError>;
+}
+
+impl<Block: BlockT> PotConsensusState<Block> for StateManager {
+    fn get_block_proofs(
+        &self,
+        slot_number: SlotNumber,
+        block_number: NumberFor<Block>,
+        parent_block_proofs: &[PotProof],
+    ) -> Result<Vec<PotProof>, PotConsensusStateError> {
+        let state = self.state.lock();
+        let summary = state.summary();
+        let proof_slot = slot_number - self.config.global_randomness_reveal_lag_slots;
+
+        // For block 1, just return one proof at the target slot,
+        // as the parent(genesis) does not have any proofs.
+        if block_number.is_one() {
+            let proof = state
+                .chain
+                .iter()
+                .find(|proof| proof.slot_number == proof_slot)
+                .ok_or(PotConsensusStateError::ProofUnavailable {
+                    summary,
+                    slot_number,
+                    block_number: format!("{block_number}"),
+                })?;
+            return Ok(vec![proof.clone()]);
+        }
+
+        let start_slot = parent_block_proofs
+            .iter()
+            .last()
+            .ok_or(PotConsensusStateError::ParentProofsEmpty {
+                summary: summary.clone(),
+                slot_number,
+                block_number: format!("{block_number}"),
+            })?
+            .slot_number
+            + 1;
+
+        if start_slot > proof_slot {
+            return Err(PotConsensusStateError::InvalidRange {
+                summary: summary.clone(),
+                slot_number,
+                block_number: format!("{block_number}"),
+                start_slot,
+            });
+        }
+
+        // Collect the proofs in the requested range.
+        let mut proofs = Vec::with_capacity((proof_slot - start_slot + 1) as usize);
+        for slot in start_slot..=proof_slot {
+            // TODO: avoid repeated search by copying the range.
+            let proof = state
+                .chain
+                .iter()
+                .find(|proof| proof.slot_number == slot)
+                .ok_or(PotConsensusStateError::ProofUnavailable {
+                    summary: summary.clone(),
+                    slot_number: slot,
+                    block_number: format!("{block_number}"),
+                })?;
+            proofs.push(proof.clone());
+        }
+
+        Ok(proofs)
+    }
+
+    fn verify_block_proofs(
+        &self,
+        slot_number: SlotNumber,
+        block_number: NumberFor<Block>,
+        block_proofs: &[PotProof],
+        parent_block_proofs: &[PotProof],
+    ) -> Result<(), PotConsensusStateError> {
+        let state = self.state.lock();
+        let summary = state.summary();
+
+        if block_number.is_one() {
+            // If block 1, check it has one proof.
+            // TODO: we currently don't have a way to check the slot number at the
+            // sender, to be resolved.
+            if block_proofs.len() != 1 {
+                return Err(PotConsensusStateError::UnexpectedProofCount {
+                    summary,
+                    slot_number,
+                    block_number: format!("{block_number}"),
+                    expected: 1,
+                    actual: block_proofs.len(),
+                });
+            }
+
+            let received = &block_proofs[0]; // Safe to index.
+            let proof = state
+                .chain
+                .iter()
+                .find(|proof| proof.slot_number == received.slot_number)
+                .ok_or(PotConsensusStateError::ReceivedSlotMissing {
+                    summary: summary.clone(),
+                    slot_number: received.slot_number,
+                    block_number: format!("{block_number}"),
+                })?;
+            // Safe to index.
+            if *proof != *received {
+                return Err(PotConsensusStateError::ReceivedProofMismatch {
+                    summary: summary.clone(),
+                    slot_number: received.slot_number,
+                    block_number: format!("{block_number}"),
+                });
+            }
+
+            return Ok(());
+        }
+
+        // Check that the parent last proof and the block first proof
+        // form a chain.
+        let last_parent_proof =
+            parent_block_proofs
+                .iter()
+                .last()
+                .ok_or(PotConsensusStateError::ParentProofsEmpty {
+                    summary: summary.clone(),
+                    slot_number,
+                    block_number: format!("{block_number}"),
+                })?;
+        let first_block_proof =
+            block_proofs
+                .get(0)
+                .ok_or(PotConsensusStateError::ReceivedProofsEmpty {
+                    summary: summary.clone(),
+                    slot_number,
+                    block_number: format!("{block_number}"),
+                })?;
+        if first_block_proof.slot_number != (last_parent_proof.slot_number + 1) {
+            return Err(PotConsensusStateError::ReceivedUnexpectedSlotNumber {
+                summary: summary.clone(),
+                slot_number,
+                block_number: format!("{block_number}"),
+                expected: last_parent_proof.slot_number + 1,
+                actual: first_block_proof.slot_number,
+            });
+        }
+
+        // Compare the received proofs against the local chain. Since the
+        // local chain is already validated, not doing the AES check on the
+        // received proofs.
+        let mut expected_slot = first_block_proof.slot_number;
+        for received in block_proofs {
+            if received.slot_number != expected_slot {
+                return Err(PotConsensusStateError::ReceivedUnexpectedSlotNumber {
+                    summary: summary.clone(),
+                    slot_number,
+                    block_number: format!("{block_number}"),
+                    expected: expected_slot,
+                    actual: received.slot_number,
+                });
+            }
+            expected_slot += 1;
+
+            // TODO: avoid repeated lookups, locate start of range
+            let local_proof = state
+                .chain
+                .iter()
+                .find(|local_proof| local_proof.slot_number == received.slot_number)
+                .ok_or(PotConsensusStateError::ReceivedSlotMissing {
+                    summary: summary.clone(),
+                    slot_number: received.slot_number,
+                    block_number: format!("{block_number}"),
+                })?;
+
+            if *local_proof != *received {
+                return Err(PotConsensusStateError::ReceivedProofMismatch {
+                    summary: summary.clone(),
+                    slot_number: received.slot_number,
+                    block_number: format!("{block_number}"),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) fn init_pot_state<Block: BlockT>(
+    config: PotConfig,
+    proof_of_time: ProofOfTime,
+    chain: Vec<PotProof>,
+) -> (Arc<dyn PotProtocolState>, Arc<dyn PotConsensusState<Block>>) {
+    let state = Arc::new(StateManager::new(config, proof_of_time, chain));
+    (state.clone(), state)
 }

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -158,9 +158,9 @@ impl InternalState {
     }
 
     /// Adds the proof to the current tip.
-    fn add_to_tip(&mut self, proof: &PotProof) {
-        self.chain.push(proof.clone());
+    fn add_to_tip(&mut self, proof: PotProof) {
         self.future_proofs.remove(&proof.slot_number);
+        self.chain.push(proof);
         self.merge_future_proofs();
     }
 
@@ -169,13 +169,13 @@ impl InternalState {
         let tip = match self.chain.last() {
             Some(tip) => tip,
             None => {
-                self.add_to_tip(proof);
+                self.add_to_tip(proof.clone());
                 return Ok(());
             }
         };
 
         if (tip.slot_number + 1) == proof.slot_number {
-            self.add_to_tip(proof);
+            self.add_to_tip(proof.clone());
             Ok(())
         } else {
             // The tip moved by the time the proof was computed.
@@ -196,7 +196,7 @@ impl InternalState {
         let tip = match self.chain.last() {
             Some(tip) => tip.clone(),
             None => {
-                self.add_to_tip(proof);
+                self.add_to_tip(proof.clone());
                 return Ok(());
             }
         };
@@ -228,7 +228,7 @@ impl InternalState {
             }
 
             // All checks passed, advance the tip with the new proof
-            self.add_to_tip(proof);
+            self.add_to_tip(proof.clone());
             return Ok(());
         }
 

--- a/crates/sc-proof-of-time/src/utils.rs
+++ b/crates/sc-proof-of-time/src/utils.rs
@@ -1,0 +1,59 @@
+//! Common utils.
+
+use sp_blockchain::{HeaderBackend, Info};
+use sp_consensus::SyncOracle;
+use sp_consensus_subspace::digests::extract_pre_digest;
+use sp_runtime::traits::{Block as BlockT, Zero};
+use std::sync::Arc;
+use subspace_core_primitives::{NonEmptyVec, PotProof};
+use tracing::info;
+
+/// Helper to retrieve the PoT state from latest tip.
+pub(crate) async fn get_consensus_tip_proofs<Block, Client, SO>(
+    client: Arc<Client>,
+    sync_oracle: Arc<SO>,
+    chain_info_fn: Arc<dyn Fn() -> Info<Block> + Send + Sync>,
+) -> Result<NonEmptyVec<PotProof>, String>
+where
+    Block: BlockT,
+    Client: HeaderBackend<Block>,
+    SO: SyncOracle + Send + Sync + Clone + 'static,
+{
+    // Wait for sync to complete
+    let delay = tokio::time::Duration::from_secs(1);
+    info!("get_consensus_tip_proofs(): waiting for sync to complete ...");
+    let info = loop {
+        while sync_oracle.is_major_syncing() {
+            tokio::time::sleep(delay).await;
+        }
+
+        // Get the hdr of the best block hash
+        let info = (chain_info_fn)();
+        if !info.best_number.is_zero() {
+            break info;
+        }
+        info!("get_consensus_tip_proofs(): chain_info: {info:?}, to retry ...");
+        tokio::time::sleep(delay).await;
+    };
+
+    let header = client
+        .header(info.best_hash)
+        .map_err(|err| format!("get_consensus_tip_proofs(): failed to get hdr: {err:?}, {info:?}"))?
+        .ok_or(format!("get_consensus_tip_proofs(): missing hdr: {info:?}"))?;
+
+    // Get the pre-digest from the block hdr
+    let _pre_digest = extract_pre_digest(&header).map_err(|err| {
+        format!("get_consensus_tip_proofs(): failed to get pre digest: {err:?}, {info:?}")
+    })?;
+
+    // TODO: enable this after adding the proofs to pre-digest.
+    /*
+    info!(
+        "get_consensus_tip_proofs(): {info:?}, pre_digest: slot = {}, num_proofs = {}",
+        pre_digest.slot,
+        pre_digest.proof_of_time.len()
+    );
+    NonEmptyVec::new(pre_digest.proof_of_time).map_err(|err| format!("{err:?}"))
+     */
+    Err("TODO".to_string())
+}

--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -1,3 +1,4 @@
+use core::num::{NonZeroU32, NonZeroU8};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 use subspace_core_primitives::{BlockHash, PotKey, PotSeed};
@@ -11,41 +12,38 @@ fn criterion_benchmark(c: &mut Criterion) {
     let slot_number = 1;
     let mut injected_block_hash = BlockHash::default();
     thread_rng().fill(injected_block_hash.as_mut());
-    let checkpoints = 8;
+    let checkpoints_1 = NonZeroU8::new(1).expect("Creating checkpoints cannot fail");
+    let checkpoints_8 = NonZeroU8::new(8).expect("Creating checkpoints cannot fail");
     // About 1s on 5.5 GHz Raptor Lake CPU
-    let iterations = 166_000_000;
-    let proof_of_time_sequential = ProofOfTime::new(1, iterations);
-    let proof_of_time = ProofOfTime::new(checkpoints, iterations / u32::from(checkpoints));
+    let pot_iterations = NonZeroU32::new(166_000_000).expect("Creating pot_iterations cannot fail");
+    let proof_of_time_sequential = ProofOfTime::new(pot_iterations, checkpoints_1)
+        .expect("Failed to create proof_of_time_sequential");
+    let proof_of_time =
+        ProofOfTime::new(pot_iterations, checkpoints_8).expect("Failed to create proof_of_time");
 
     c.bench_function("prove/sequential", |b| {
         b.iter(|| {
-            proof_of_time_sequential
-                .create(
-                    black_box(seed),
-                    black_box(key),
-                    black_box(slot_number),
-                    black_box(injected_block_hash),
-                )
-                .unwrap();
+            proof_of_time_sequential.create(
+                black_box(seed),
+                black_box(key),
+                black_box(slot_number),
+                black_box(injected_block_hash),
+            );
         })
     });
 
     c.bench_function("prove/checkpoints", |b| {
         b.iter(|| {
-            proof_of_time
-                .create(
-                    black_box(seed),
-                    black_box(key),
-                    black_box(slot_number),
-                    black_box(injected_block_hash),
-                )
-                .unwrap();
+            proof_of_time.create(
+                black_box(seed),
+                black_box(key),
+                black_box(slot_number),
+                black_box(injected_block_hash),
+            );
         })
     });
 
-    let proof = proof_of_time
-        .create(seed, key, slot_number, injected_block_hash)
-        .unwrap();
+    let proof = proof_of_time.create(seed, key, slot_number, injected_block_hash);
 
     c.bench_function("verify", |b| {
         b.iter(|| {

--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -12,14 +12,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     let slot_number = 1;
     let mut injected_block_hash = BlockHash::default();
     thread_rng().fill(injected_block_hash.as_mut());
-    let checkpoints_1 = NonZeroU8::new(1).expect("Creating checkpoints cannot fail");
-    let checkpoints_8 = NonZeroU8::new(8).expect("Creating checkpoints cannot fail");
+    let checkpoints_1 = NonZeroU8::new(1).expect("Not zero; qed");
+    let checkpoints_8 = NonZeroU8::new(8).expect("Not zero; qed");
     // About 1s on 5.5 GHz Raptor Lake CPU
-    let pot_iterations = NonZeroU32::new(166_000_000).expect("Creating pot_iterations cannot fail");
-    let proof_of_time_sequential = ProofOfTime::new(pot_iterations, checkpoints_1)
-        .expect("Failed to create proof_of_time_sequential");
-    let proof_of_time =
-        ProofOfTime::new(pot_iterations, checkpoints_8).expect("Failed to create proof_of_time");
+    let pot_iterations = NonZeroU32::new(166_000_000).expect("Not zero; qed");
+    let proof_of_time_sequential = ProofOfTime::new(pot_iterations, checkpoints_1).unwrap();
+    let proof_of_time = ProofOfTime::new(pot_iterations, checkpoints_8).unwrap();
 
     c.bench_function("prove/sequential", |b| {
         b.iter(|| {

--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -19,27 +19,33 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("prove/sequential", |b| {
         b.iter(|| {
-            proof_of_time_sequential.create(
-                black_box(seed),
-                black_box(key),
-                black_box(slot_number),
-                black_box(injected_block_hash),
-            );
+            proof_of_time_sequential
+                .create(
+                    black_box(seed),
+                    black_box(key),
+                    black_box(slot_number),
+                    black_box(injected_block_hash),
+                )
+                .unwrap();
         })
     });
 
     c.bench_function("prove/checkpoints", |b| {
         b.iter(|| {
-            proof_of_time.create(
-                black_box(seed),
-                black_box(key),
-                black_box(slot_number),
-                black_box(injected_block_hash),
-            );
+            proof_of_time
+                .create(
+                    black_box(seed),
+                    black_box(key),
+                    black_box(slot_number),
+                    black_box(injected_block_hash),
+                )
+                .unwrap();
         })
     });
 
-    let proof = proof_of_time.create(seed, key, slot_number, injected_block_hash);
+    let proof = proof_of_time
+        .create(seed, key, slot_number, injected_block_hash)
+        .unwrap();
 
     c.bench_function("verify", |b| {
         b.iter(|| {

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -35,6 +35,7 @@ pub enum PotVerificationError {
 }
 
 /// Wrapper for the low level AES primitives
+#[derive(Clone)]
 pub struct ProofOfTime {
     /// Number of checkpoints per PoT.
     num_checkpoints: u8,

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -3,7 +3,16 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 mod pot_aes;
 
-use subspace_core_primitives::{BlockHash, PotKey, PotProof, PotSeed, SlotNumber};
+use subspace_core_primitives::{
+    BlockHash, NonEmptyVec, NonEmptyVecErr, PotKey, PotProof, PotSeed, SlotNumber,
+};
+
+#[derive(Debug)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
+pub enum PotCreationError {
+    #[cfg_attr(feature = "thiserror", error("Failed to initialize checkpoints"))]
+    CheckpointInitFailed(NonEmptyVecErr),
+}
 
 #[derive(Debug)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
@@ -43,19 +52,21 @@ impl ProofOfTime {
         key: PotKey,
         slot_number: SlotNumber,
         injected_block_hash: BlockHash,
-    ) -> PotProof {
-        PotProof::new(
+    ) -> Result<PotProof, PotCreationError> {
+        let checkpoints = NonEmptyVec::new(pot_aes::create(
+            &seed,
+            &key,
+            self.num_checkpoints,
+            self.checkpoint_iterations,
+        ))
+        .map_err(PotCreationError::CheckpointInitFailed)?;
+        Ok(PotProof::new(
             slot_number,
             seed,
             key,
-            pot_aes::create(
-                &seed,
-                &key,
-                self.num_checkpoints,
-                self.checkpoint_iterations,
-            ),
+            checkpoints,
             injected_block_hash,
-        )
+        ))
     }
 
     /// Verifies the proof.
@@ -71,7 +82,7 @@ impl ProofOfTime {
         if pot_aes::verify_sequential(
             &proof.seed,
             &proof.key,
-            &proof.checkpoints,
+            proof.checkpoints.as_slice(),
             self.checkpoint_iterations,
         ) {
             Ok(())

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -79,7 +79,7 @@ impl ProofOfTime {
             self.num_checkpoints,
             self.checkpoint_iterations,
         ))
-        .expect("Failed to create proof of time");
+        .expect("List of checkpoints is never empty; qed");
         PotProof::new(slot_number, seed, key, checkpoints, injected_block_hash)
     }
 


### PR DESCRIPTION
The changes:
1. Adds the PoT clock master, consensus client functionality.
2. Adds PoT gossip, validation
3. The proofs are stored in the block pre digest during block making, the proofs are validated by peers as part of block import checks. The PoT is not yet used as source of randomness

Tested with this set up:
- One clock master instance boot straps the PoT chain
- Another clock master instance initializes off the chain created by the bootstrap instance
- Verified that the two nodes converge eventually

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
