### PR TITLE
Update connected-peers protocol for DSN.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -269,9 +269,11 @@ pub(super) fn configure_dsn(
         max_pending_incoming_connections: pending_in_connections,
         general_target_connections: target_connections,
         // maintain permanent connections between farmers
-        special_connected_peers_handler: Arc::new(PeerInfo::is_farmer),
+        special_connected_peers_handler: Some(Arc::new(PeerInfo::is_farmer)),
         // other (non-farmer) connections
-        general_connected_peers_handler: Arc::new(|peer_info| !PeerInfo::is_farmer(peer_info)),
+        general_connected_peers_handler: Some(Arc::new(|peer_info| {
+            !PeerInfo::is_farmer(peer_info)
+        })),
         bootstrap_addresses: bootstrap_nodes,
         ..default_config
     };

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -55,9 +55,9 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     /// Provides peer-info for local peer.
     pub(crate) peer_info_provider: Option<PeerInfoProvider>,
     /// The configuration for the [`ConnectedPeers`] protocol (general instance).
-    pub(crate) general_connected_peers_config: ConnectedPeersConfig,
+    pub(crate) general_connected_peers_config: Option<ConnectedPeersConfig>,
     /// The configuration for the [`ConnectedPeers`] protocol (special instance).
-    pub(crate) special_connected_peers_config: ConnectedPeersConfig,
+    pub(crate) special_connected_peers_config: Option<ConnectedPeersConfig>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -78,8 +78,10 @@ pub(crate) struct Behavior<RecordStore> {
     pub(crate) block_list: BlockListBehaviour,
     pub(crate) reserved_peers: ReservedPeersBehaviour,
     pub(crate) peer_info: Toggle<PeerInfoBehaviour>,
-    pub(crate) general_connected_peers: ConnectedPeersBehaviour<GeneralConnectedPeersInstance>,
-    pub(crate) special_connected_peers: ConnectedPeersBehaviour<SpecialConnectedPeersInstance>,
+    pub(crate) general_connected_peers:
+        Toggle<ConnectedPeersBehaviour<GeneralConnectedPeersInstance>>,
+    pub(crate) special_connected_peers:
+        Toggle<ConnectedPeersBehaviour<SpecialConnectedPeersInstance>>,
 }
 
 impl<RecordStore> Behavior<RecordStore>
@@ -121,12 +123,14 @@ where
             block_list: BlockListBehaviour::default(),
             reserved_peers: ReservedPeersBehaviour::new(config.reserved_peers),
             peer_info: peer_info.into(),
-            general_connected_peers: ConnectedPeersBehaviour::new(
-                config.general_connected_peers_config,
-            ),
-            special_connected_peers: ConnectedPeersBehaviour::new(
-                config.special_connected_peers_config,
-            ),
+            general_connected_peers: config
+                .general_connected_peers_config
+                .map(ConnectedPeersBehaviour::new)
+                .into(),
+            special_connected_peers: config
+                .special_connected_peers_config
+                .map(ConnectedPeersBehaviour::new)
+                .into(),
         }
     }
 }

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -175,8 +175,8 @@ async fn main() -> anyhow::Result<()> {
                 max_pending_incoming_connections: pending_in_peers,
                 max_pending_outgoing_connections: pending_out_peers,
                 // we don't maintain permanent connections with any peer
-                general_connected_peers_handler: Arc::new(|_| false),
-                special_connected_peers_handler: Arc::new(|_| false),
+                general_connected_peers_handler: None,
+                special_connected_peers_handler: None,
                 bootstrap_addresses: bootstrap_nodes,
 
                 ..Config::new(

--- a/crates/subspace-networking/src/connected_peers.rs
+++ b/crates/subspace-networking/src/connected_peers.rs
@@ -93,6 +93,8 @@ pub struct Config {
     /// Time interval reserved for a decision about connections.
     /// It also affects keep-alive interval.
     pub decision_timeout: Duration,
+    /// Specifies whether we use this protocol fow connection management or not.
+    pub enabled: bool,
 }
 
 const DEFAULT_CONNECTED_PEERS_LOG_TARGET: &str = "connected-peers";
@@ -104,6 +106,7 @@ impl Default for Config {
             target_connected_peers: 30,
             dialing_peer_batch_size: 5,
             decision_timeout: Duration::from_secs(10),
+            enabled: true,
         }
     }
 }
@@ -166,7 +169,7 @@ impl<Instance> Behaviour<Instance> {
     fn new_connection_handler(&mut self, peer_id: &PeerId) -> Handler {
         let default_until = Instant::now().add(self.config.decision_timeout);
         let default_keep_alive_until = KeepAlive::Until(default_until);
-        let keep_alive = if let Some(state) = self.known_peers.get_mut(peer_id) {
+        let mut keep_alive = if let Some(state) = self.known_peers.get_mut(peer_id) {
             match state.connection_state {
                 ConnectionState::Connecting { .. } => {
                     // Connection attempt was successful.
@@ -185,6 +188,11 @@ impl<Instance> Behaviour<Instance> {
 
             default_keep_alive_until
         };
+
+        // Disable connection handler.
+        if !self.config.enabled {
+            keep_alive = KeepAlive::No;
+        }
 
         self.wake();
         Handler::new(keep_alive)
@@ -402,33 +410,35 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
         }
 
         // Schedule new peer dialing.
-        match self.dialing_delay.poll_unpin(cx) {
-            Poll::Pending => {}
-            Poll::Ready(()) => {
-                self.dialing_delay.reset(self.config.dialing_interval);
+        if self.config.enabled {
+            match self.dialing_delay.poll_unpin(cx) {
+                Poll::Pending => {}
+                Poll::Ready(()) => {
+                    self.dialing_delay.reset(self.config.dialing_interval);
 
-                // Request new peer addresses.
-                if self.peer_cache.is_empty() {
-                    trace!("Requesting new peers for connected-peers protocol....");
+                    // Request new peer addresses.
+                    if self.peer_cache.is_empty() {
+                        trace!("Requesting new peers for connected-peers protocol....");
 
-                    return Poll::Ready(ToSwarm::GenerateEvent(
-                        Event::NewDialingCandidatesRequested(PhantomData),
-                    ));
-                }
+                        return Poll::Ready(ToSwarm::GenerateEvent(
+                            Event::NewDialingCandidatesRequested(PhantomData),
+                        ));
+                    }
 
-                // New dial candidates.
-                if self.active_peers() < self.config.target_connected_peers {
-                    let range = 0..(self.config.dialing_peer_batch_size as usize)
-                        .min(self.peer_cache.len());
+                    // New dial candidates.
+                    if self.active_peers() < self.config.target_connected_peers {
+                        let range = 0..(self.config.dialing_peer_batch_size as usize)
+                            .min(self.peer_cache.len());
 
-                    let peer_addresses = self.peer_cache.drain(range);
+                        let peer_addresses = self.peer_cache.drain(range);
 
-                    for (peer_id, address) in peer_addresses {
-                        self.known_peers.entry(peer_id).or_insert_with(|| {
-                            PeerState::new(ConnectionState::Connecting {
-                                peer_address: address,
-                            })
-                        });
+                        for (peer_id, address) in peer_addresses {
+                            self.known_peers.entry(peer_id).or_insert_with(|| {
+                                PeerState::new(ConnectionState::Connecting {
+                                    peer_address: address,
+                                })
+                            });
+                        }
                     }
                 }
             }

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -213,9 +213,11 @@ pub struct Config<ProviderStorage> {
     /// Specifies a source for peer information. None disables the protocol.
     pub peer_info_provider: Option<PeerInfoProvider>,
     /// Defines whether we maintain a persistent connection for common peers.
-    pub general_connected_peers_handler: ConnectedPeersHandler,
+    /// None disables the protocol.
+    pub general_connected_peers_handler: Option<ConnectedPeersHandler>,
     /// Defines whether we maintain a persistent connection for special peers.
-    pub special_connected_peers_handler: ConnectedPeersHandler,
+    /// None disables the protocol.
+    pub special_connected_peers_handler: Option<ConnectedPeersHandler>,
     /// Defines target total (in and out) connection number that should be maintained for general peers.
     pub general_target_connections: u32,
     /// Defines target total (in and out) connection number that should be maintained for special peers.
@@ -326,10 +328,9 @@ where
             metrics: None,
             protocol_version,
             peer_info_provider,
-            // maintain permanent connections with any peer
-            general_connected_peers_handler: Arc::new(|_| true),
             // we don't need to keep additional connections by default
-            special_connected_peers_handler: Arc::new(|_| false),
+            general_connected_peers_handler: None,
+            special_connected_peers_handler: None,
             general_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             bootstrap_addresses: Vec::new(),
@@ -444,11 +445,13 @@ where
         general_connected_peers_config: ConnectedPeersConfig {
             log_target: GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
             target_connected_peers: general_target_connections,
+            enabled: general_connection_decision_handler.is_some(),
             ..ConnectedPeersConfig::default()
         },
         special_connected_peers_config: ConnectedPeersConfig {
             log_target: SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
             target_connected_peers: special_target_connections,
+            enabled: special_connection_decision_handler.is_some(),
             ..ConnectedPeersConfig::default()
         },
     });

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -442,18 +442,20 @@ where
         },
         peer_info_config: PeerInfoConfig::new(PEER_INFO_PROTOCOL_NAME),
         peer_info_provider,
-        general_connected_peers_config: ConnectedPeersConfig {
-            log_target: GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
-            target_connected_peers: general_target_connections,
-            enabled: general_connection_decision_handler.is_some(),
-            ..ConnectedPeersConfig::default()
-        },
-        special_connected_peers_config: ConnectedPeersConfig {
-            log_target: SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
-            target_connected_peers: special_target_connections,
-            enabled: special_connection_decision_handler.is_some(),
-            ..ConnectedPeersConfig::default()
-        },
+        general_connected_peers_config: general_connection_decision_handler.as_ref().map(|_| {
+            ConnectedPeersConfig {
+                log_target: GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
+                target_connected_peers: general_target_connections,
+                ..ConnectedPeersConfig::default()
+            }
+        }),
+        special_connected_peers_config: special_connection_decision_handler.as_ref().map(|_| {
+            ConnectedPeersConfig {
+                log_target: SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
+                target_connected_peers: special_target_connections,
+                ..ConnectedPeersConfig::default()
+            }
+        }),
     });
 
     let mut swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, local_peer_id)

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -952,27 +952,29 @@ where
                 });
             }
 
-            let keep_alive = self
-                .general_connection_decision_handler
-                .as_ref()
-                .map(|handler| handler(&peer_info))
-                .unwrap_or(false);
+            if let Some(general_connected_peers) =
+                self.swarm.behaviour_mut().general_connected_peers.as_mut()
+            {
+                let keep_alive = self
+                    .general_connection_decision_handler
+                    .as_ref()
+                    .map(|handler| handler(&peer_info))
+                    .unwrap_or(false);
 
-            self.swarm
-                .behaviour_mut()
-                .general_connected_peers
-                .update_keep_alive_status(event.peer_id, keep_alive);
+                general_connected_peers.update_keep_alive_status(event.peer_id, keep_alive);
+            }
 
-            let special_keep_alive = self
-                .special_connection_decision_handler
-                .as_ref()
-                .map(|handler| handler(&peer_info))
-                .unwrap_or(false);
+            if let Some(special_connected_peers) =
+                self.swarm.behaviour_mut().special_connected_peers.as_mut()
+            {
+                let special_keep_alive = self
+                    .special_connection_decision_handler
+                    .as_ref()
+                    .map(|handler| handler(&peer_info))
+                    .unwrap_or(false);
 
-            self.swarm
-                .behaviour_mut()
-                .special_connected_peers
-                .update_keep_alive_status(event.peer_id, special_keep_alive);
+                special_connected_peers.update_keep_alive_status(event.peer_id, special_keep_alive);
+            }
         }
     }
 
@@ -984,10 +986,11 @@ where
 
         let peers = self.get_peers_to_dial().await;
 
-        self.swarm
-            .behaviour_mut()
-            .general_connected_peers
-            .add_peers_to_dial(&peers);
+        if let Some(general_connected_peers) =
+            self.swarm.behaviour_mut().general_connected_peers.as_mut()
+        {
+            general_connected_peers.add_peers_to_dial(&peers);
+        }
     }
 
     async fn handle_special_connected_peers_event(
@@ -998,10 +1001,11 @@ where
 
         let peers = self.get_peers_to_dial().await;
 
-        self.swarm
-            .behaviour_mut()
-            .special_connected_peers
-            .add_peers_to_dial(&peers);
+        if let Some(special_connected_peers) =
+            self.swarm.behaviour_mut().special_connected_peers.as_mut()
+        {
+            special_connected_peers.add_peers_to_dial(&peers);
+        }
     }
 
     fn handle_command(&mut self, command: Command) {

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -173,7 +173,7 @@ where
         special_target_connections: 0,
         reserved_peers: dsn_config.reserved_peers,
         // maintain permanent connections with any peer
-        general_connected_peers_handler: Arc::new(|_| true),
+        general_connected_peers_handler: Some(Arc::new(|_| true)),
         bootstrap_addresses: dsn_config.bootstrap_nodes,
 
         ..default_networking_config


### PR DESCRIPTION
This PR follows https://github.com/subspace/subspace/pull/1698 and adds `enabled` property to the `connected-peers` protocol. When the protocol is disabled it doesn't connect to other peers. Also, the PR adds a filter to not redial bootstrap-node to maintain connections. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
