### PR TITLE
Reduce number of PoT checkpoints 2x

### DIFF
--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -11,7 +11,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let slot_number = 1;
     let mut injected_block_hash = BlockHash::default();
     thread_rng().fill(injected_block_hash.as_mut());
-    let checkpoints = 16;
+    let checkpoints = 8;
     // About 1s on 5.5 GHz Raptor Lake CPU
     let iterations = 166_000_000;
     let proof_of_time_sequential = ProofOfTime::new(1, iterations);


### PR DESCRIPTION
Since we have unusual use of AES, we don't really care whether we're doing encoding or decoding, we have both inputs and outputs either way.

If that is the case, why don't we cut number of checkpoints in half and for every sub-interval (between two checkpoints) do this instead:
```
[encoding]-> | <-[decoding]
```

Essentially run half of iterations in forward and half of iterations in backward direction, then compare that both resulted in the same middle value.

This way with 8 checkpoints instead of 16 we still get the same instruction-level parallelism and the same verification performance (as I have confirmed with benchmarks).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
