### PR TITLE
Upgrade libp2p to v.0.52.1 for DSN.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,9 +501,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asn1-rs"
@@ -836,7 +836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "constant_time_eq",
 ]
 
@@ -847,7 +847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "constant_time_eq",
 ]
 
@@ -858,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -993,6 +993,15 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -2594,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -3799,6 +3808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
+dependencies = [
+ "futures-io",
+ "rustls 0.21.2",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +3828,17 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-ticker"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "instant",
+]
 
 [[package]]
 name = "futures-timer"
@@ -4288,7 +4318,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4620,7 +4650,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4630,7 +4660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "async-lock",
  "async-trait",
  "beef",
@@ -4828,27 +4858,58 @@ dependencies = [
  "futures-timer",
  "getrandom 0.2.10",
  "instant",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
- "libp2p-dns",
- "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-identity",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-metrics",
- "libp2p-noise",
- "libp2p-ping",
- "libp2p-quic",
- "libp2p-request-response",
- "libp2p-swarm",
- "libp2p-tcp",
+ "libp2p-allow-block-list 0.1.1",
+ "libp2p-connection-limits 0.1.0",
+ "libp2p-core 0.39.2",
+ "libp2p-dns 0.39.0",
+ "libp2p-identify 0.42.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-kad 0.43.3",
+ "libp2p-mdns 0.43.1",
+ "libp2p-metrics 0.12.0",
+ "libp2p-noise 0.42.2",
+ "libp2p-ping 0.42.0",
+ "libp2p-quic 0.7.0-alpha.3",
+ "libp2p-request-response 0.24.1",
+ "libp2p-swarm 0.42.2",
+ "libp2p-tcp 0.39.0",
  "libp2p-wasm-ext",
  "libp2p-webrtc",
- "libp2p-websocket",
- "libp2p-yamux",
- "multiaddr",
+ "libp2p-websocket 0.41.0",
+ "libp2p-yamux 0.43.1",
+ "multiaddr 0.17.1",
+ "pin-project",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38039ba2df4f3255842050845daef4a004cc1f26da03dbc645535088b51910ef"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.10",
+ "instant",
+ "libp2p-allow-block-list 0.2.0",
+ "libp2p-connection-limits 0.2.1",
+ "libp2p-core 0.40.0",
+ "libp2p-dns 0.40.0",
+ "libp2p-gossipsub",
+ "libp2p-identify 0.43.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-kad 0.44.3",
+ "libp2p-mdns 0.44.0",
+ "libp2p-metrics 0.13.0",
+ "libp2p-noise 0.43.0",
+ "libp2p-ping 0.43.0",
+ "libp2p-request-response 0.25.0",
+ "libp2p-swarm 0.43.2",
+ "libp2p-tcp 0.40.0",
+ "libp2p-websocket 0.42.0",
+ "libp2p-yamux 0.44.0",
+ "multiaddr 0.18.0",
  "pin-project",
 ]
 
@@ -4858,9 +4919,21 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
 dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm 0.42.2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
+dependencies = [
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
  "void",
 ]
 
@@ -4870,9 +4943,21 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
 dependencies = [
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm 0.42.2",
+ "void",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
+dependencies = [
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
  "void",
 ]
 
@@ -4887,17 +4972,45 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-identity",
+ "libp2p-identity 0.1.2",
  "log",
- "multiaddr",
+ "multiaddr 0.17.1",
  "multihash 0.17.0",
- "multistream-select",
+ "multistream-select 0.12.1",
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
- "rw-stream-sink",
+ "rw-stream-sink 0.3.0",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef7dd7b09e71aac9271c60031d0e558966cdb3253ba0308ab369bb2de80630d0"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-identity 0.2.2",
+ "log",
+ "multiaddr 0.18.0",
+ "multihash 0.19.0",
+ "multistream-select 0.13.0",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "rw-stream-sink 0.4.0",
  "serde",
  "smallvec",
  "thiserror",
@@ -4912,7 +5025,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
 dependencies = [
  "futures",
- "libp2p-core",
+ "libp2p-core 0.39.2",
+ "log",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4394c81c0c06d7b4a60f3face7e8e8a9b246840f98d2c80508d0721b032147"
+dependencies = [
+ "futures",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
  "log",
  "parking_lot 0.12.1",
  "smallvec",
@@ -4921,9 +5049,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.44.4"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b34b6da8165c0bde35c82db8efda39b824776537e73973549e76cadb3a77c5"
+checksum = "8e378da62e8c9251f6e885ed173a561663f29b251e745586cf6ae6150b295c37"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.2",
@@ -4932,24 +5060,24 @@ dependencies = [
  "either",
  "fnv",
  "futures",
+ "futures-ticker",
+ "getrandom 0.2.10",
  "hex_fmt",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
  "log",
- "prometheus-client",
+ "prometheus-client 0.21.2",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.2.0",
  "rand 0.8.5",
  "regex",
  "serde",
  "sha2 0.10.7",
  "smallvec",
- "thiserror",
  "unsigned-varint",
  "void",
- "wasm-timer",
 ]
 
 [[package]]
@@ -4962,13 +5090,35 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm 0.42.2",
  "log",
  "lru 0.10.0",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.1.0",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a29675a32dbcc87790db6cf599709e64308f1ae9d5ecea2d259155889982db8"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-timer",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
+ "log",
+ "lru 0.10.0",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
  "smallvec",
  "thiserror",
  "void",
@@ -4980,11 +5130,28 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e2d584751cecb2aabaa56106be6be91338a60a0f4e420cf2af639204f596fc1"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "ed25519-dalek",
  "log",
- "multiaddr",
+ "multiaddr 0.17.1",
  "multihash 0.17.0",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38d6012784fe4cc14e6d443eb415b11fc7c456dc15d9f0d90d9b70bc7ac3ec1"
+dependencies = [
+ "bs58 0.5.0",
+ "ed25519-dalek",
+ "log",
+ "multihash 0.19.0",
  "quick-protobuf",
  "rand 0.8.5",
  "serde",
@@ -4999,7 +5166,7 @@ version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39d5ef876a2b2323d63c258e63c2f8e36f205fe5a11f0b3095d59635650790ff"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -5007,9 +5174,37 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm 0.42.2",
+ "log",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "smallvec",
+ "thiserror",
+ "uint",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2584b0c27f879a1cca4b753fd96874109e5a2f46bd6e30924096456c2ba9b2"
+dependencies = [
+ "arrayvec 0.7.4",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5031,13 +5226,34 @@ dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm 0.42.2",
  "log",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.4.9",
+ "tokio",
+ "trust-dns-proto",
+ "void",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
+dependencies = [
+ "data-encoding",
+ "futures",
+ "if-watch",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "socket2 0.5.3",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -5049,13 +5265,30 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
- "libp2p-core",
+ "libp2p-core 0.39.2",
+ "libp2p-identify 0.42.2",
+ "libp2p-kad 0.43.3",
+ "libp2p-ping 0.42.0",
+ "libp2p-swarm 0.42.2",
+ "prometheus-client 0.19.0",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3787ea81798dcc5bf1d8b40a8e8245cf894b168d04dd70aa48cb3ff2fff141d2"
+dependencies = [
+ "instant",
+ "libp2p-core 0.40.0",
  "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-ping",
- "libp2p-swarm",
- "prometheus-client",
+ "libp2p-identify 0.43.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-kad 0.44.3",
+ "libp2p-ping 0.43.0",
+ "libp2p-swarm 0.43.2",
+ "once_cell",
+ "prometheus-client 0.21.2",
 ]
 
 [[package]]
@@ -5067,9 +5300,34 @@ dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures",
- "libp2p-core",
- "libp2p-identity",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
  "log",
+ "once_cell",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "snow",
+ "static_assertions",
+ "thiserror",
+ "x25519-dalek 1.1.1",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87945db2b3f977af09b62b9aa0a5f3e4870995a577ecd845cdeba94cdf6bbca7"
+dependencies = [
+ "bytes",
+ "curve25519-dalek 3.2.0",
+ "futures",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "log",
+ "multiaddr 0.18.0",
+ "multihash 0.19.0",
  "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5091,8 +5349,26 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-swarm 0.42.2",
+ "log",
+ "rand 0.8.5",
+ "void",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd5ee3270229443a2b34b27ed0cb7470ef6b4a6e45e54e89a8771fa683bab48"
+dependencies = [
+ "either",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
  "log",
  "rand 0.8.5",
  "void",
@@ -5108,14 +5384,36 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-tls",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-tls 0.1.0",
  "log",
  "parking_lot 0.12.1",
- "quinn-proto",
+ "quinn-proto 0.9.3",
  "rand 0.8.5",
  "rustls 0.20.8",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.8.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f1b4fb39b4136b29458735d8c82907d4851e611dbacbe919dd4ab2f02a69a8"
+dependencies = [
+ "bytes",
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-tls 0.2.0",
+ "log",
+ "parking_lot 0.12.1",
+ "quinn-proto 0.10.1",
+ "rand 0.8.5",
+ "rustls 0.21.2",
  "thiserror",
  "tokio",
 ]
@@ -5129,11 +5427,29 @@ dependencies = [
  "async-trait",
  "futures",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm 0.42.2",
  "rand 0.8.5",
  "smallvec",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20bd837798cdcce4283d2675f08bcd3756a650d56eab4d4367e1b3f27eed6887"
+dependencies = [
+ "async-trait",
+ "futures",
+ "instant",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm 0.43.2",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "void",
 ]
 
 [[package]]
@@ -5147,10 +5463,33 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm-derive",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-swarm-derive 0.32.0",
  "log",
+ "rand 0.8.5",
+ "smallvec",
+ "tokio",
+ "void",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43106820057e0f65c77b01a3873593f66e676da4e40c70c3a809b239109f1d30"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-swarm-derive 0.33.0",
+ "log",
+ "multistream-select 0.13.0",
+ "once_cell",
  "rand 0.8.5",
  "smallvec",
  "tokio",
@@ -5169,6 +5508,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-swarm-derive"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
+dependencies = [
+ "heck",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
 name = "libp2p-tcp"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5178,9 +5530,26 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core",
+ "libp2p-core 0.39.2",
  "log",
  "socket2 0.4.9",
+ "tokio",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09bfdfb6f945c5c014b87872a0bdb6e0aef90e92f380ef57cd9013f118f9289d"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "log",
+ "socket2 0.5.3",
  "tokio",
 ]
 
@@ -5191,15 +5560,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
 dependencies = [
  "futures",
- "futures-rustls",
- "libp2p-core",
- "libp2p-identity",
+ "futures-rustls 0.22.2",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
  "rcgen 0.10.0",
  "ring",
  "rustls 0.20.8",
  "thiserror",
  "webpki 0.22.0",
  "x509-parser 0.14.0",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec63209ec17ffb354a5fdfde7c36f14d168367c5f115fdb5a177a342414d5a55"
+dependencies = [
+ "futures",
+ "futures-rustls 0.24.0",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "rcgen 0.10.0",
+ "ring",
+ "rustls 0.21.2",
+ "thiserror",
+ "webpki 0.22.0",
+ "x509-parser 0.15.0",
  "yasna",
 ]
 
@@ -5211,7 +5599,7 @@ checksum = "77dff9d32353a5887adb86c8afc1de1a94d9e8c3bc6df8b2201d7cdf5c848f43"
 dependencies = [
  "futures",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.39.2",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5230,13 +5618,13 @@ dependencies = [
  "futures-timer",
  "hex",
  "if-watch",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-noise",
+ "libp2p-core 0.39.2",
+ "libp2p-identity 0.1.2",
+ "libp2p-noise 0.42.2",
  "log",
  "multihash 0.17.0",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.1.0",
  "rand 0.8.5",
  "rcgen 0.9.3",
  "serde",
@@ -5256,15 +5644,35 @@ checksum = "111273f7b3d3510524c752e8b7a5314b7f7a1fee7e68161c01a7d72cbb06db9f"
 dependencies = [
  "either",
  "futures",
- "futures-rustls",
- "libp2p-core",
+ "futures-rustls 0.22.2",
+ "libp2p-core 0.39.2",
  "log",
  "parking_lot 0.12.1",
  "quicksink",
- "rw-stream-sink",
+ "rw-stream-sink 0.3.0",
  "soketto",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956d981ebc84abc3377e5875483c06d94ff57bc6b25f725047f9fd52592f72d4"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls 0.22.2",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "log",
+ "parking_lot 0.12.1",
+ "quicksink",
+ "rw-stream-sink 0.4.0",
+ "soketto",
+ "url",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -5274,7 +5682,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
 dependencies = [
  "futures",
- "libp2p-core",
+ "libp2p-core 0.39.2",
+ "log",
+ "thiserror",
+ "yamux",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a9b42ab6de15c6f076d8fb11dc5f48d899a10b55a2e16b12be9012a05287b0"
+dependencies = [
+ "futures",
+ "libp2p-core 0.40.0",
  "log",
  "thiserror",
  "yamux",
@@ -5740,6 +6161,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a651988b3ed3ad1bc8c87d016bb92f6f395b84ed1db9b926b32b1fc5a2c8b5"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity 0.2.2",
+ "multibase",
+ "multihash 0.19.0",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url",
+]
+
+[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5776,9 +6216,18 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "serde",
- "serde-big-array",
  "sha2 0.10.7",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd59dcc2bbe70baabeac52cd22ae52c55eefe6c38ff11a9439f16a350a939f2"
+dependencies = [
+ "core2",
+ "serde",
  "unsigned-varint",
 ]
 
@@ -5807,6 +6256,20 @@ name = "multistream-select"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
  "futures",
@@ -6002,7 +6465,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "itoa",
 ]
 
@@ -6890,7 +7353,7 @@ version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "bytes",
@@ -7375,6 +7838,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.1",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
 name = "prometheus-client-derive-encode"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7477,6 +7952,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-protobuf-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "quicksink"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7503,6 +7991,23 @@ dependencies = [
  "tinyvec",
  "tracing",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85af4ed6ee5a89f26a26086e9089a6643650544c025158449a3626ebf72884b3"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.21.2",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
 ]
 
 [[package]]
@@ -8043,6 +8548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8156,7 +8672,7 @@ dependencies = [
  "clap",
  "fdlimit",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.2",
  "log",
  "names",
  "parity-scale-codec",
@@ -8246,7 +8762,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-identity",
+ "libp2p-identity 0.1.2",
  "log",
  "mockall",
  "parking_lot 0.12.1",
@@ -8469,7 +8985,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "ip_network",
- "libp2p",
+ "libp2p 0.51.3",
  "linked_hash_set",
  "log",
  "lru 0.10.0",
@@ -8508,7 +9024,7 @@ dependencies = [
  "async-channel",
  "cid",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.2",
  "log",
  "prost",
  "prost-build",
@@ -8532,7 +9048,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "libp2p-identity",
+ "libp2p-identity 0.1.2",
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
@@ -8556,7 +9072,7 @@ dependencies = [
  "ahash 0.8.3",
  "futures",
  "futures-timer",
- "libp2p",
+ "libp2p 0.51.3",
  "log",
  "lru 0.10.0",
  "sc-network",
@@ -8574,7 +9090,7 @@ dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.2",
  "log",
  "parity-scale-codec",
  "prost",
@@ -8600,7 +9116,7 @@ dependencies = [
  "fork-tree",
  "futures",
  "futures-timer",
- "libp2p",
+ "libp2p 0.51.3",
  "log",
  "lru 0.10.0",
  "mockall",
@@ -8630,7 +9146,7 @@ source = "git+https://github.com/subspace/substrate?rev=55c157cff49b638a59d81a9f
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
- "libp2p",
+ "libp2p 0.51.3",
  "log",
  "parity-scale-codec",
  "sc-network",
@@ -8653,7 +9169,7 @@ dependencies = [
  "futures-timer",
  "hyper",
  "hyper-rustls 0.24.0",
- "libp2p",
+ "libp2p 0.51.3",
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
@@ -8923,7 +9439,7 @@ source = "git+https://github.com/subspace/substrate?rev=55c157cff49b638a59d81a9f
 dependencies = [
  "chrono",
  "futures",
- "libp2p",
+ "libp2p 0.51.3",
  "log",
  "parking_lot 0.12.1",
  "pin-project",
@@ -9266,15 +9782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_arrays"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9479,9 +9986,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "snap"
@@ -9774,7 +10281,7 @@ dependencies = [
  "bitflags",
  "blake2",
  "bounded-collections",
- "bs58",
+ "bs58 0.4.0",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
@@ -10696,14 +11203,17 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex",
- "libp2p",
+ "libp2p 0.52.1",
+ "libp2p-connection-limits 0.2.1",
+ "libp2p-kad 0.44.3",
+ "libp2p-quic 0.8.0-alpha",
  "lru 0.10.0",
  "nohash-hasher",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "prometheus-client",
+ "prometheus-client 0.19.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -11556,11 +12066,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -12525,6 +13036,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
 name = "webrtc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13067,6 +13587,23 @@ checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs 0.5.2",
  "base64 0.13.1",
+ "data-encoding",
+ "der-parser 8.2.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.6.1",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
+dependencies = [
+ "asn1-rs 0.5.2",
  "data-encoding",
  "der-parser 8.2.0",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,5 @@ sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/subst
 sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 substrate-prometheus-endpoint = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,5 +117,3 @@ sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/subst
 sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 substrate-prometheus-endpoint = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-
-

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -286,7 +286,7 @@ pub(super) fn configure_dsn(
                 move |address| {
                     info!(
                         "DSN listening on {}",
-                        address.clone().with(Protocol::P2p(node.id().into()))
+                        address.clone().with(Protocol::P2p(node.id()))
                     );
                 }
             }))

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -51,7 +51,7 @@ unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_code
 void = "1.0.2"
 
 [dependencies.libp2p]
-version = "0.51.3"
+version = "0.52.1"
 default-features = false
 features = [
     "dns",
@@ -62,7 +62,6 @@ features = [
     "metrics",
     "noise",
     "ping",
-    "quic",
     "request-response",
     "serde",
     "tcp",
@@ -70,6 +69,18 @@ features = [
     "websocket",
     "yamux",
 ]
+[dependencies.libp2p-quic]
+version = "0.8.0-alpha"
+features = ["tokio"]
+
+# Remove after this patch goes to the release branch
+[dependencies.libp2p-kad]
+version = "0.44.3"
+
+# Remove after this patch goes to the release branch
+[dependencies.libp2p-connection-limits]
+version = "0.2.1"
 
 [dev-dependencies]
 rand = "0.8.5"
+

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -83,4 +83,3 @@ version = "0.2.1"
 
 [dev-dependencies]
 rand = "0.8.5"
-

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -99,7 +99,7 @@ async fn main() {
         .unwrap();
 
     // Prepare multihash to look for in Kademlia
-    let key: Multihash = node.id().into();
+    let key = Multihash::from(node.id());
 
     let peers = node
         .get_closest_peers(key)

--- a/crates/subspace-networking/examples/networking.rs
+++ b/crates/subspace-networking/examples/networking.rs
@@ -47,7 +47,7 @@ async fn main() {
 
     let mut subscription = node_1.subscribe(Sha256Topic::new(TOPIC)).await.unwrap();
 
-    let bootstrap_addresses = vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))];
+    let bootstrap_addresses = vec![node_1_addr.with(Protocol::P2p(node_1.id()))];
     let config_2 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_global_addresses_in_dht: true,

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -66,7 +66,7 @@ pub(crate) struct GeneralConnectedPeersInstance;
 pub(crate) struct SpecialConnectedPeersInstance;
 
 #[derive(NetworkBehaviour)]
-#[behaviour(out_event = "Event")]
+#[behaviour(to_swarm = "Event")]
 #[behaviour(event_process = false)]
 pub(crate) struct Behavior<RecordStore> {
     pub(crate) identify: Identify,

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -160,7 +160,7 @@ async fn test_async_handler_works_with_pending_internal_future() {
     let node_1_addr = node_1_address_receiver.await.unwrap();
     drop(on_new_listener_handler);
 
-    let bootstrap_addresses = vec![node_1_addr.with(Protocol::P2p(node_1.id().into()))];
+    let bootstrap_addresses = vec![node_1_addr.with(Protocol::P2p(node_1.id()))];
     let config_2 = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         allow_non_global_addresses_in_dht: true,

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -195,7 +195,7 @@ async fn main() -> anyhow::Result<()> {
                 move |multiaddr| {
                     info!(
                         "Listening on {}",
-                        multiaddr.clone().with(Protocol::P2p(node_id.into()))
+                        multiaddr.clone().with(Protocol::P2p(node_id))
                     );
                 }
             }))

--- a/crates/subspace-networking/src/connected_peers.rs
+++ b/crates/subspace-networking/src/connected_peers.rs
@@ -255,7 +255,7 @@ impl<Instance> Behaviour<Instance> {
 
 impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
     type ConnectionHandler = Handler;
-    type OutEvent = Event<Instance>;
+    type ToSwarm = Event<Instance>;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -342,8 +342,9 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
             | FromSwarm::ExpiredListenAddr(_)
             | FromSwarm::ListenerError(_)
             | FromSwarm::ListenerClosed(_)
-            | FromSwarm::NewExternalAddr(_)
-            | FromSwarm::ExpiredExternalAddr(_) => {}
+            | FromSwarm::NewExternalAddrCandidate(_)
+            | FromSwarm::ExternalAddrConfirmed(_)
+            | FromSwarm::ExternalAddrExpired(_) => {}
         }
     }
 
@@ -359,7 +360,7 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
         &mut self,
         cx: &mut Context<'_>,
         _: &mut impl PollParameters,
-    ) -> Poll<ToSwarm<Self::OutEvent, THandlerInEvent<Self>>> {
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         // Notify handlers about received connection decision.
         if let Some(change) = self.peer_decision_changes.pop() {
             return Poll::Ready(ToSwarm::NotifyHandler {

--- a/crates/subspace-networking/src/connected_peers/handler.rs
+++ b/crates/subspace-networking/src/connected_peers/handler.rs
@@ -41,8 +41,8 @@ impl fmt::Display for ConnectedPeersError {
 impl Error for ConnectedPeersError {}
 
 impl ConnectionHandler for Handler {
-    type InEvent = KeepAlive;
-    type OutEvent = ();
+    type FromBehaviour = KeepAlive;
+    type ToBehaviour = ();
     type Error = ConnectedPeersError;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = DeniedUpgrade;

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -34,7 +34,7 @@ use libp2p::metrics::Metrics;
 use libp2p::multiaddr::Protocol;
 use libp2p::swarm::SwarmBuilder;
 use libp2p::yamux::Config as YamuxConfig;
-use libp2p::{identity, Multiaddr, PeerId, TransportError};
+use libp2p::{identity, Multiaddr, PeerId, StreamProtocol, TransportError};
 use parking_lot::Mutex;
 use std::borrow::Cow;
 use std::iter::Empty;
@@ -51,10 +51,10 @@ use tracing::{debug, error, info};
 pub type ConnectedPeersHandler = Arc<dyn Fn(&PeerInfo) -> bool + Send + Sync + 'static>;
 
 const DEFAULT_NETWORK_PROTOCOL_VERSION: &str = "dev";
-const KADEMLIA_PROTOCOL: &[u8] = b"/subspace/kad/0.1.0";
+const KADEMLIA_PROTOCOL: &str = "/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
-const RESERVED_PEERS_PROTOCOL_NAME: &[u8] = b"/subspace/reserved-peers/1.0.0";
-const PEER_INFO_PROTOCOL_NAME: &[u8] = b"/subspace/peer-info/1.0.0";
+const RESERVED_PEERS_PROTOCOL_NAME: &str = "/subspace/reserved-peers/1.0.0";
+const PEER_INFO_PROTOCOL_NAME: &str = "/subspace/peer-info/1.0.0";
 const GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "general-connected-peers";
 const SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "special-connected-peers";
 
@@ -262,7 +262,10 @@ where
         let mut kademlia = KademliaConfig::default();
         kademlia
             .set_query_timeout(KADEMLIA_QUERY_TIMEOUT)
-            .set_protocol_names(vec![Cow::Owned(KADEMLIA_PROTOCOL.into())])
+            .set_protocol_names(vec![StreamProtocol::try_from_owned(
+                KADEMLIA_PROTOCOL.to_owned(),
+            )
+            .expect("Manual protocol name creation.")])
             .disjoint_query_paths(true)
             .set_max_packet_size(2 * Piece::SIZE)
             .set_kbucket_inserts(KademliaBucketInserts::Manual)

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -63,5 +63,6 @@ pub use request_handlers::segment_header::{
     SegmentHeaderBySegmentIndexesRequestHandler, SegmentHeaderRequest, SegmentHeaderResponse,
 };
 pub use shared::NewPeerInfo;
+pub use utils::multihash::Multihash;
 pub use utils::prometheus::start_prometheus_metrics_server;
 pub use utils::unique_record_binary_heap::UniqueRecordBinaryHeap;

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -1,5 +1,6 @@
 use crate::request_handlers::generic_request_handler::GenericRequest;
 use crate::shared::{Command, CreatedSubscription, HandlerFn, Shared};
+use crate::utils::multihash::Multihash;
 use crate::utils::ResizableSemaphorePermit;
 use crate::{request_responses, NewPeerInfo};
 use bytes::Bytes;
@@ -7,7 +8,6 @@ use event_listener_primitives::HandlerId;
 use futures::channel::mpsc::SendError;
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, Stream, StreamExt};
-use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::{Sha256Topic, SubscriptionError};
 use libp2p::kad::record::Key;
 use libp2p::kad::PeerRecord;

--- a/crates/subspace-networking/src/peer_info.rs
+++ b/crates/subspace-networking/src/peer_info.rs
@@ -206,7 +206,7 @@ impl Behaviour {
 
 impl NetworkBehaviour for Behaviour {
     type ConnectionHandler = Handler;
-    type OutEvent = Event;
+    type ToSwarm = Event;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -245,7 +245,7 @@ impl NetworkBehaviour for Behaviour {
         &mut self,
         cx: &mut Context<'_>,
         _: &mut impl PollParameters,
-    ) -> Poll<ToSwarm<Self::OutEvent, THandlerInEvent<Self>>> {
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if self.should_notify_handlers.swap(false, Ordering::SeqCst) {
             debug!("Notify peer-info handlers.");
 
@@ -323,8 +323,9 @@ impl NetworkBehaviour for Behaviour {
             | FromSwarm::ExpiredListenAddr(_)
             | FromSwarm::ListenerError(_)
             | FromSwarm::ListenerClosed(_)
-            | FromSwarm::NewExternalAddr(_)
-            | FromSwarm::ExpiredExternalAddr(_) => {}
+            | FromSwarm::NewExternalAddrCandidate(_)
+            | FromSwarm::ExternalAddrConfirmed(_)
+            | FromSwarm::ExternalAddrExpired(_) => {}
         }
     }
 }

--- a/crates/subspace-networking/src/request_handlers/piece_announcement.rs
+++ b/crates/subspace-networking/src/request_handlers/piece_announcement.rs
@@ -4,7 +4,7 @@
 //! `RequestResponsesBehaviour` with generic [`GenericRequestHandler`].
 
 use crate::request_handlers::generic_request_handler::{GenericRequest, GenericRequestHandler};
-use libp2p::multihash::Multihash;
+use crate::utils::multihash::Multihash;
 use libp2p::Multiaddr;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 

--- a/crates/subspace-networking/src/request_responses.rs
+++ b/crates/subspace-networking/src/request_responses.rs
@@ -51,9 +51,10 @@ pub use libp2p::request_response::{InboundFailure, OutboundFailure, RequestId};
 use libp2p::swarm::behaviour::{ConnectionClosed, DialFailure, FromSwarm, ListenFailure};
 use libp2p::swarm::handler::multi::MultiHandler;
 use libp2p::swarm::{
-    ConnectionDenied, ConnectionHandler, ConnectionId, NetworkBehaviour, PollParameters,
-    THandlerInEvent, ToSwarm,
+    ConnectionDenied, ConnectionId, NetworkBehaviour, PollParameters, THandlerInEvent,
+    THandlerOutEvent, ToSwarm,
 };
+use libp2p::StreamProtocol;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -334,12 +335,12 @@ impl RequestResponsesBehaviour {
                 ProtocolSupport::Outbound
             };
 
-            let rq_rp = RequestResponse::new(
+            let rq_rp = RequestResponse::with_codec(
                 GenericCodec {
                     max_request_size: config.max_request_size,
                     max_response_size: config.max_response_size,
                 },
-                iter::once((config.name.as_bytes().to_vec(), protocol_support)),
+                iter::once(StreamProtocol::new(config.name)).zip(iter::repeat(protocol_support)),
                 cfg,
             );
 
@@ -417,7 +418,7 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
         String,
         <RequestResponse<GenericCodec> as NetworkBehaviour>::ConnectionHandler,
     >;
-    type OutEvent = Event;
+    type ToSwarm = Event;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -555,31 +556,33 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
                     protocol.on_swarm_event(FromSwarm::ListenerClosed(inner));
                 }
             }
-            FromSwarm::NewExternalAddr(inner) => {
+            FromSwarm::NewExternalAddrCandidate(inner) => {
                 for (protocol, _) in self.protocols.values_mut() {
-                    protocol.on_swarm_event(FromSwarm::NewExternalAddr(inner));
+                    protocol.on_swarm_event(FromSwarm::NewExternalAddrCandidate(inner));
                 }
             }
-            FromSwarm::ExpiredExternalAddr(inner) => {
+            FromSwarm::ExternalAddrConfirmed(inner) => {
                 for (protocol, _) in self.protocols.values_mut() {
-                    protocol.on_swarm_event(FromSwarm::ExpiredExternalAddr(inner));
+                    protocol.on_swarm_event(FromSwarm::ExternalAddrConfirmed(inner));
+                }
+            }
+            FromSwarm::ExternalAddrExpired(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::ExternalAddrExpired(inner));
                 }
             }
         };
-    }
-
-    fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
-        Vec::new()
     }
 
     fn on_connection_handler_event(
         &mut self,
         peer_id: PeerId,
         connection: ConnectionId,
-        (p_name, event): <Self::ConnectionHandler as ConnectionHandler>::OutEvent,
+        event: THandlerOutEvent<Self>,
     ) {
+        let p_name = event.0;
         if let Some((proto, _)) = self.protocols.get_mut(&*p_name) {
-            return proto.on_connection_handler_event(peer_id, connection, event);
+            return proto.on_connection_handler_event(peer_id, connection, event.1);
         }
 
         warn!(
@@ -592,7 +595,7 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
         &mut self,
         cx: &mut Context,
         params: &mut impl PollParameters,
-    ) -> Poll<ToSwarm<Self::OutEvent, THandlerInEvent<Self>>> {
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         'poll_all: loop {
             if let Some(message_request) = self.message_request.take() {
                 let MessageRequest {
@@ -707,9 +710,6 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
                                 event: ((*protocol).to_string(), event),
                             })
                         }
-                        ToSwarm::ReportObservedAddr { address, score } => {
-                            return Poll::Ready(ToSwarm::ReportObservedAddr { address, score })
-                        }
                         ToSwarm::CloseConnection {
                             peer_id,
                             connection,
@@ -718,6 +718,21 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
                                 peer_id,
                                 connection,
                             })
+                        }
+                        ToSwarm::NewExternalAddrCandidate(observed) => {
+                            return Poll::Ready(ToSwarm::NewExternalAddrCandidate(observed))
+                        }
+                        ToSwarm::ExternalAddrConfirmed(addr) => {
+                            return Poll::Ready(ToSwarm::ExternalAddrConfirmed(addr))
+                        }
+                        ToSwarm::ExternalAddrExpired(addr) => {
+                            return Poll::Ready(ToSwarm::ExternalAddrExpired(addr))
+                        }
+                        ToSwarm::ListenOn { opts } => {
+                            return Poll::Ready(ToSwarm::ListenOn { opts })
+                        }
+                        ToSwarm::RemoveListener { id } => {
+                            return Poll::Ready(ToSwarm::RemoveListener { id })
                         }
                     };
 
@@ -909,7 +924,7 @@ pub struct GenericCodec {
 
 #[async_trait::async_trait]
 impl RequestResponseCodec for GenericCodec {
-    type Protocol = Vec<u8>;
+    type Protocol = StreamProtocol;
     type Request = Vec<u8>;
     type Response = Result<Vec<u8>, ()>;
 

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -3,11 +3,11 @@
 
 use crate::peer_info::PeerInfo;
 use crate::request_responses::RequestFailure;
+use crate::utils::multihash::Multihash;
 use crate::utils::{ResizableSemaphore, ResizableSemaphorePermit};
 use bytes::Bytes;
 use event_listener_primitives::Bag;
 use futures::channel::{mpsc, oneshot};
-use libp2p::core::multihash::Multihash;
 use libp2p::gossipsub::{PublishError, Sha256Topic, SubscriptionError};
 use libp2p::kad::record::Key;
 use libp2p::kad::PeerRecord;

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -93,7 +93,7 @@ pub(crate) fn convert_multiaddresses(addresses: Vec<Multiaddr>) -> Vec<PeerAddre
 
             let peer_id: Option<PeerId> = modified_multiaddr.pop().and_then(|protocol| {
                 if let Protocol::P2p(peer_id) = protocol {
-                    peer_id.try_into().ok()
+                    Some(peer_id)
                 } else {
                     None
                 }

--- a/crates/subspace-networking/src/utils/multihash.rs
+++ b/crates/subspace-networking/src/utils/multihash.rs
@@ -1,8 +1,10 @@
 //! Defines multihash codes for Subspace DSN.
 
-use libp2p::multihash::Multihash;
 use std::error::Error;
 use subspace_core_primitives::PieceIndexHash;
+
+/// Type alias for libp2p Multihash. Constant 64 was copied from libp2p protocols.
+pub type Multihash = libp2p::multihash::Multihash<64>;
 
 /// Start of Subspace Network multicodec namespace (+1000 to distinguish from future stable values):
 /// https://github.com/multiformats/multicodec/blob/master/table.csv

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
@@ -1,23 +1,23 @@
 #[cfg(test)]
 mod tests;
 
-use libp2p::kad::kbucket::Distance;
 pub use libp2p::kad::record::Key;
+use libp2p::kad::KBucketDistance;
 pub use libp2p::PeerId;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
-type KademliaBucketKey<T> = libp2p::kad::kbucket::Key<T>;
+type KademliaBucketKey<T> = libp2p::kad::KBucketKey<T>;
 
 // Helper structure. It wraps Kademlia distance to a given peer for heap-metrics.
 #[derive(Debug, Clone)]
 struct RecordHeapKey {
-    peer_distance: Distance,
+    peer_distance: KBucketDistance,
     key: KademliaBucketKey<Key>,
 }
 
 impl RecordHeapKey {
-    fn peer_distance(&self) -> Distance {
+    fn peer_distance(&self) -> KBucketDistance {
         self.peer_distance
     }
 

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap/tests.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap/tests.rs
@@ -1,13 +1,10 @@
 use crate::utils::unique_record_binary_heap::UniqueRecordBinaryHeap;
 use libp2p::kad::record::Key;
-use libp2p::multihash::{Code, Multihash};
 use libp2p::PeerId;
 
 #[test]
 fn binary_heap_insert_works() {
-    let peer_id =
-        PeerId::from_multihash(Multihash::wrap(Code::Identity.into(), [0u8].as_slice()).unwrap())
-            .unwrap();
+    let peer_id = PeerId::random();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 10);
 
     assert_eq!(heap.size(), 0);
@@ -28,9 +25,7 @@ fn binary_heap_insert_works() {
 
 #[test]
 fn binary_heap_remove_works() {
-    let peer_id =
-        PeerId::from_multihash(Multihash::wrap(Code::Identity.into(), [0u8].as_slice()).unwrap())
-            .unwrap();
+    let peer_id = PeerId::random();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 10);
 
     let key1 = Key::from(vec![1]);
@@ -48,9 +43,7 @@ fn binary_heap_remove_works() {
 
 #[test]
 fn binary_heap_limit_works() {
-    let peer_id =
-        PeerId::from_multihash(Multihash::wrap(Code::Identity.into(), [0u8].as_slice()).unwrap())
-            .unwrap();
+    let peer_id = PeerId::random();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 1);
 
     let key1 = Key::from(vec![1]);
@@ -67,11 +60,9 @@ fn binary_heap_limit_works() {
 
 #[test]
 fn binary_heap_eviction_works() {
-    type KademliaBucketKey<T> = libp2p::kad::kbucket::Key<T>;
+    type KademliaBucketKey<T> = libp2p::kad::KBucketKey<T>;
 
-    let peer_id =
-        PeerId::from_multihash(Multihash::wrap(Code::Identity.into(), [0u8].as_slice()).unwrap())
-            .unwrap();
+    let peer_id = PeerId::random();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 1);
 
     let key1 = Key::from(vec![1]);
@@ -99,9 +90,7 @@ fn binary_heap_eviction_works() {
 
 #[test]
 fn binary_heap_should_include_key_works() {
-    let peer_id =
-        PeerId::from_multihash(Multihash::wrap(Code::Identity.into(), [2u8].as_slice()).unwrap())
-            .unwrap();
+    let peer_id = PeerId::random();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 1);
 
     // Limit not reached

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap/tests.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap/tests.rs
@@ -1,3 +1,4 @@
+use crate::utils::multihash::Multihash;
 use crate::utils::unique_record_binary_heap::UniqueRecordBinaryHeap;
 use libp2p::kad::record::Key;
 use libp2p::PeerId;
@@ -43,7 +44,7 @@ fn binary_heap_remove_works() {
 
 #[test]
 fn binary_heap_limit_works() {
-    let peer_id = PeerId::random();
+    let peer_id = PeerId::from_multihash(Multihash::wrap(0, [0u8].as_slice()).unwrap()).unwrap();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 1);
 
     let key1 = Key::from(vec![1]);
@@ -62,7 +63,7 @@ fn binary_heap_limit_works() {
 fn binary_heap_eviction_works() {
     type KademliaBucketKey<T> = libp2p::kad::KBucketKey<T>;
 
-    let peer_id = PeerId::random();
+    let peer_id = PeerId::from_multihash(Multihash::wrap(0, [0u8].as_slice()).unwrap()).unwrap();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 1);
 
     let key1 = Key::from(vec![1]);
@@ -90,7 +91,7 @@ fn binary_heap_eviction_works() {
 
 #[test]
 fn binary_heap_should_include_key_works() {
-    let peer_id = PeerId::random();
+    let peer_id = PeerId::from_multihash(Multihash::wrap(0, [2u8].as_slice()).unwrap()).unwrap();
     let mut heap = UniqueRecordBinaryHeap::new(peer_id, 1);
 
     // Limit not reached

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -636,7 +636,7 @@ where
                 move |address| {
                     info!(
                         "DSN listening on {}",
-                        address.clone().with(Protocol::P2p(node.id().into()))
+                        address.clone().with(Protocol::P2p(node.id()))
                     );
                 }
             }))
@@ -697,7 +697,7 @@ where
             }
 
             node_listeners.iter_mut().for_each(|multiaddr| {
-                multiaddr.push(Protocol::P2p(node.id().into()));
+                multiaddr.push(Protocol::P2p(node.id()));
             });
 
             node_listeners


### PR DESCRIPTION
This PR updates libp2p to v.0.52.1.

Important changes:
- introduce `Server` Kademlia mode for the apps
- fix for https://github.com/libp2p/rust-libp2p/issues/4249
- quic protocol requires a separate dependency now

External dependencies (patches) for the `Cargo.toml` of `subspace-networking` crate (to remove on the next release):
- libp2p-kad = "0.44.3" (to export required `Distance` type)
- libp2p-connection-limits = "0.2.1" (to fix the connection-limits bug)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
