### PR TITLE
Fix genesis block encoding on restart

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -366,10 +366,17 @@ where
                 *last_archived_block.block.header().number(),
             ));
 
+            let last_archived_block_encoded =
+                if last_archived_block.block.header().number().is_zero() {
+                    encode_genesis_block(&last_archived_block)
+                } else {
+                    last_archived_block.encode()
+                };
+
             Archiver::with_initial_state(
                 kzg,
                 last_segment_header,
-                &last_archived_block.encode(),
+                &last_archived_block_encoded,
                 block_object_mappings,
             )
             .expect("Incorrect parameters for archiver")


### PR DESCRIPTION
Without this on restart I was (naturally) getting this:
> Thread 'main' panicked at 'Incorrect parameters for archiver: InvalidBlockSmallSize { block_bytes: 100, archived_block_bytes: 130023418 }', /home/runner/work/subspace/subspace/crates/sc-consensus-subspace/src/archiver.rs:346

Missed it in https://github.com/subspace/subspace/pull/1671 :man_facepalming: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
