### PR TITLE
Make the domain client instantiation-aware

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -658,11 +658,15 @@ mod pallet {
                         )
                         .map_err(Error::<T>::from)?;
 
-                        do_finalize_domain_current_epoch::<T>(
-                            domain_id,
-                            pruned_block_info.domain_block_number,
-                        )
-                        .map_err(Error::<T>::from)?;
+                        if pruned_block_info.domain_block_number % T::StakeEpochDuration::get()
+                            == Zero::zero()
+                        {
+                            do_finalize_domain_current_epoch::<T>(
+                                domain_id,
+                                pruned_block_info.domain_block_number,
+                            )
+                            .map_err(Error::<T>::from)?;
+                        }
                     }
                 }
             }
@@ -923,19 +927,16 @@ mod pallet {
                         genesis_domain.runtime_type.clone(),
                         genesis_domain.runtime_version.clone(),
                         genesis_domain.code.clone(),
-                        Zero::zero(),
+                        One::one(),
                     )
                     .expect("Genesis runtime registration must always succeed");
 
                     // Instantiate the genesis domain
                     let domain_config = DomainConfig::from_genesis::<T>(genesis_domain, runtime_id);
                     let domain_owner = genesis_domain.owner_account_id.clone();
-                    let domain_id = do_instantiate_domain::<T>(
-                        domain_config,
-                        domain_owner.clone(),
-                        Zero::zero(),
-                    )
-                    .expect("Genesis domain instantiation must always succeed");
+                    let domain_id =
+                        do_instantiate_domain::<T>(domain_config, domain_owner.clone(), One::one())
+                            .expect("Genesis domain instantiation must always succeed");
 
                     // Register domain_owner as the genesis operator.
                     let operator_config = OperatorConfig {
@@ -954,7 +955,7 @@ mod pallet {
                     )
                     .expect("Genesis operator registration must succeed");
 
-                    do_finalize_domain_current_epoch::<T>(domain_id, Zero::zero())
+                    do_finalize_domain_current_epoch::<T>(domain_id, One::one())
                         .expect("Genesis epoch must succeed");
                 }
             }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1056,16 +1056,20 @@ impl<T: Config> Pallet<T> {
             .map(|domain_object| domain_object.domain_config.runtime_id)
     }
 
-    pub fn domain_instance_data(domain_id: DomainId) -> Option<DomainInstanceData> {
-        let runtime_id = DomainRegistry::<T>::get(domain_id)?
-            .domain_config
-            .runtime_id;
-        let (runtime_type, runtime_code) = RuntimeRegistry::<T>::get(runtime_id)
-            .map(|runtime_object| (runtime_object.runtime_type, runtime_object.code))?;
-        Some(DomainInstanceData {
-            runtime_type,
-            runtime_code,
-        })
+    pub fn domain_instance_data(
+        domain_id: DomainId,
+    ) -> Option<(DomainInstanceData, T::BlockNumber)> {
+        let domain_obj = DomainRegistry::<T>::get(domain_id)?;
+        let (runtime_type, runtime_code) =
+            RuntimeRegistry::<T>::get(domain_obj.domain_config.runtime_id)
+                .map(|runtime_object| (runtime_object.runtime_type, runtime_object.code))?;
+        Some((
+            DomainInstanceData {
+                runtime_type,
+                runtime_code,
+            },
+            domain_obj.created_at,
+        ))
     }
 
     pub fn genesis_state_root(domain_id: DomainId) -> Option<H256> {

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -38,11 +38,7 @@ pub enum Error {
 pub(crate) fn do_finalize_domain_current_epoch<T: Config>(
     domain_id: DomainId,
     domain_block_number: T::DomainNumber,
-) -> Result<bool, Error> {
-    if domain_block_number % T::StakeEpochDuration::get() != Zero::zero() {
-        return Ok(false);
-    }
-
+) -> Result<(), Error> {
     // slash the operators
     do_finalize_slashed_operators::<T>(domain_id).map_err(Error::SlashOperator)?;
 
@@ -57,7 +53,7 @@ pub(crate) fn do_finalize_domain_current_epoch<T: Config>(
 
     // finalize any withdrawals and then deposits
     do_finalize_domain_pending_transfers::<T>(domain_id, domain_block_number)?;
-    Ok(true)
+    Ok(())
 }
 
 /// Unlocks any operators who are de-registering or nominators who are withdrawing staked funds.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -602,7 +602,7 @@ sp_api::decl_runtime_apis! {
         fn runtime_id(domain_id: DomainId) -> Option<RuntimeId>;
 
         /// Returns the domain instance data for given `domain_id`.
-        fn domain_instance_data(domain_id: DomainId) -> Option<DomainInstanceData>;
+        fn domain_instance_data(domain_id: DomainId) -> Option<(DomainInstanceData, NumberFor<Block>)>;
 
         /// Returns the current timestamp at given height.
         fn timestamp() -> Moment;

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -43,6 +43,7 @@ impl DomainInstanceStarter {
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let BootstrapResult {
             domain_instance_data,
+            domain_created_at,
             imported_block_notification_stream,
         } = bootstrap_result;
 
@@ -142,6 +143,7 @@ impl DomainInstanceStarter {
                 let domain_params = domain_service::DomainParams {
                     domain_id,
                     domain_config,
+                    domain_created_at,
                     consensus_client,
                     consensus_network_sync_oracle: consensus_sync_service.clone(),
                     select_chain,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -854,7 +854,7 @@ impl_runtime_apis! {
             Domains::runtime_id(domain_id)
         }
 
-        fn domain_instance_data(domain_id: DomainId) -> Option<DomainInstanceData> {
+        fn domain_instance_data(domain_id: DomainId) -> Option<(DomainInstanceData, NumberFor<Block>)> {
             Domains::domain_instance_data(domain_id)
         }
 

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -37,6 +37,7 @@ where
     CBlock: BlockT,
 {
     pub(crate) domain_id: DomainId,
+    pub(crate) domain_created_at: NumberFor<CBlock>,
     pub(crate) client: Arc<Client>,
     pub(crate) consensus_client: Arc<CClient>,
     pub(crate) backend: Arc<Backend>,
@@ -54,6 +55,7 @@ where
     fn clone(&self) -> Self {
         Self {
             domain_id: self.domain_id,
+            domain_created_at: self.domain_created_at,
             client: self.client.clone(),
             consensus_client: self.consensus_client.clone(),
             backend: self.backend.clone(),

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -164,6 +164,7 @@ pub struct OperatorParams<
     NSNS: Stream<Item = NewSlotNotification> + Send + 'static,
 {
     pub domain_id: DomainId,
+    pub domain_created_at: NumberFor<CBlock>,
     pub consensus_client: Arc<CClient>,
     pub consensus_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
     pub client: Arc<Client>,

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -153,6 +153,7 @@ where
 
         let domain_block_processor = DomainBlockProcessor {
             domain_id: params.domain_id,
+            domain_created_at: params.domain_created_at,
             client: params.client.clone(),
             consensus_client: params.consensus_client.clone(),
             backend: params.backend.clone(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -528,8 +528,12 @@ async fn test_executor_full_node_catching_up() {
         Ferdie,
         BasePath::new(directory.path().join("ferdie")),
     );
-    // Produce 1 consensus block to initialize genesis domain
-    ferdie.produce_block_with_slot(1.into()).await.unwrap();
+    // Produce 5 consensus block to initialize genesis domain
+    //
+    // This also make the first consensus block being processed by the alice's domain
+    // block processor be block #5, to ensure it can correctly handle the consensus
+    // block even it is out of order.
+    ferdie.produce_blocks(5).await.unwrap();
 
     // Run Alice (a evm domain authority node)
     let alice = domain_test_service::DomainNodeBuilder::new(

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -244,6 +244,7 @@ where
 {
     pub domain_id: DomainId,
     pub domain_config: DomainConfiguration<AccountId>,
+    pub domain_created_at: NumberFor<CBlock>,
     pub consensus_client: Arc<CClient>,
     pub consensus_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
     pub select_chain: SC,
@@ -341,6 +342,7 @@ where
     let DomainParams {
         domain_id,
         domain_config,
+        domain_created_at,
         consensus_client,
         consensus_network_sync_oracle,
         select_chain,
@@ -440,6 +442,7 @@ where
         &select_chain,
         OperatorParams {
             domain_id,
+            domain_created_at,
             consensus_client: consensus_client.clone(),
             consensus_network_sync_oracle,
             client: client.clone(),

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -3,7 +3,7 @@
 
 use crate::chain_spec::{domain_instance_genesis_config, load_chain_spec_with};
 use crate::{construct_extrinsic_generic, node_config, EcdsaKeyring, UncheckedExtrinsicFor};
-use domain_client_operator::{Bootstrapper, OperatorStreams};
+use domain_client_operator::{BootstrapResult, Bootstrapper, OperatorStreams};
 use domain_runtime_primitives::opaque::Block;
 use domain_runtime_primitives::{Balance, DomainCoreApi, InherentExtrinsicApi};
 use domain_service::providers::DefaultProvider;
@@ -14,12 +14,12 @@ use evm_domain_test_runtime::AccountId as AccountId20;
 use fp_rpc::EthereumRuntimeRPCApi;
 use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};
 use pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi;
-use sc_client_api::{BlockchainEvents, HeaderBackend, StateBackendFor};
+use sc_client_api::{HeaderBackend, StateBackendFor};
 use sc_executor::NativeExecutionDispatch;
 use sc_network::{NetworkService, NetworkStateInfo};
 use sc_network_sync::SyncingService;
 use sc_service::config::MultiaddrWithPeerId;
-use sc_service::{BasePath, ChainSpec, Role, RpcHandlers, TFullBackend, TaskManager};
+use sc_service::{BasePath, Role, RpcHandlers, TFullBackend, TaskManager};
 use sc_utils::mpsc::TracingUnboundedSender;
 use serde::de::DeserializeOwned;
 use sp_api::{ApiExt, ConstructRuntimeApi, Metadata, NumberFor, ProvideRuntimeApi};
@@ -169,10 +169,25 @@ where
         domain_nodes: Vec<MultiaddrWithPeerId>,
         domain_nodes_exclusive: bool,
         run_relayer: bool,
-        chain_spec: Box<dyn ChainSpec>,
         role: Role,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> Self {
+        let BootstrapResult {
+            domain_instance_data,
+            domain_created_at,
+            imported_block_notification_stream,
+        } = {
+            let bootstrapper = Bootstrapper::<Block, _, _>::new(mock_consensus_node.client.clone());
+            bootstrapper
+                .fetch_domain_bootstrap_info(domain_id)
+                .await
+                .expect("Failed to get domain instance data")
+        };
+        let chain_spec = {
+            let genesis_config =
+                domain_instance_genesis_config(domain_id, domain_instance_data.runtime_code);
+            load_chain_spec_with(genesis_config)
+        };
         let service_config = node_config(
             domain_id,
             tokio_handle.clone(),
@@ -208,9 +223,7 @@ where
             consensus_block_import_throttling_buffer_size: 0,
             block_importing_notification_stream: mock_consensus_node
                 .block_importing_notification_stream(),
-            imported_block_notification_stream: mock_consensus_node
-                .client
-                .every_import_notification_stream(),
+            imported_block_notification_stream,
             new_slot_notification_stream: mock_consensus_node.new_slot_notification_stream(),
             _phantom: Default::default(),
         };
@@ -221,6 +234,7 @@ where
         let domain_params = domain_service::DomainParams {
             domain_id,
             domain_config,
+            domain_created_at,
             consensus_client: mock_consensus_node.client.clone(),
             consensus_network_sync_oracle: mock_consensus_node.sync_service.clone(),
             select_chain: mock_consensus_node.select_chain.clone(),
@@ -408,28 +422,14 @@ impl DomainNodeBuilder {
         domain_id: DomainId,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> EvmDomainNode {
-        let domain_instance_data = {
-            let bootstrapper = Bootstrapper::<Block, _, _>::new(mock_consensus_node.client.clone());
-            bootstrapper
-                .fetch_domain_bootstrap_info(domain_id)
-                .await
-                .expect("Failed to get domain instance data")
-                .domain_instance_data
-        };
-        let chain_spec = {
-            let genesis_config =
-                domain_instance_genesis_config(domain_id, domain_instance_data.runtime_code);
-            load_chain_spec_with(genesis_config)
-        };
         DomainNode::build(
-            DomainId::new(0u32),
+            domain_id,
             self.tokio_handle,
             self.key,
             self.base_path,
             self.domain_nodes,
             self.domain_nodes_exclusive,
             self.run_relayer,
-            chain_spec,
             role,
             mock_consensus_node,
         )

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1210,7 +1210,7 @@ impl_runtime_apis! {
             Domains::runtime_id(domain_id)
         }
 
-        fn domain_instance_data(domain_id: DomainId) -> Option<DomainInstanceData> {
+        fn domain_instance_data(domain_id: DomainId) -> Option<(DomainInstanceData, NumberFor<Block>)> {
             Domains::domain_instance_data(domain_id)
         }
 


### PR DESCRIPTION
In the main branch, the domain client assumes that the domain chain will start at the genesis block of the consensus chain. This is not true in domain v2, where the domain chain is started after the domain is instantiated at the consensus chain, for the genesis domain it starts at consensus block `#1` due to our workaround of the extension issue. This PR recorrects this assumption in the domain client and handles various edge cases properly.

The error we meet in the devnet:
```
2023-07-28 14:27:03 [Domain] Failed to process consensus block on startup error=Backend("Consensus hash for domain hash #0,0x8a3a…f13a not found")
```
is because the domain block processor handles the consensus block out of order (i.e. the first consensus block being processed is not block `#1`), this can happen if the consensus chain import block when the domain chain is still initializing:
https://github.com/subspace/subspace/blob/d2b394445acb5c8f1be3b62501f47e805a73ca9a/domains/client/domain-operator/src/domain_worker.rs#L97-L109

this PR's last commit (although very tiny) adds a test case to simulate this error (pick this commit to the main branch and run the test, which will result in the same error) and ensure it is fixed.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
