### PR TITLE
Staking: Use Hold fungible instead of Freeze and add treasury account

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -298,7 +298,7 @@ pub(crate) fn import_genesis_receipt<T: Config>(
         execution_receipt: genesis_receipt,
         operator_ids: sp_std::vec![],
     };
-    // NOTE: no need to upate the head receipt number as we are using `ValueQuery`
+    // NOTE: no need to update the head receipt number as we are using `ValueQuery`
     BlockTree::<T>::mutate(domain_id, domain_block_number, |er_hashes| {
         er_hashes.insert(er_hash);
     });
@@ -310,7 +310,7 @@ mod tests {
     use super::*;
     use crate::domain_registry::DomainConfig;
     use crate::pallet::Operators;
-    use crate::staking::Operator;
+    use crate::staking::{Operator, OperatorStatus};
     use crate::tests::{
         create_dummy_bundle_with_receipts, create_dummy_receipt, GenesisStateRootGenerater,
         ReadRuntimeVersion, Test,
@@ -375,7 +375,7 @@ mod tests {
                     current_total_stake: Zero::zero(),
                     current_epoch_rewards: Zero::zero(),
                     total_shares: Zero::zero(),
-                    is_frozen: false,
+                    status: OperatorStatus::Registered,
                 },
             );
         }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -258,6 +258,9 @@ mod pallet {
 
         /// Domain epoch transition interval
         type StakeEpochDuration: Get<Self::DomainNumber>;
+
+        /// Treasury account.
+        type TreasuryAccount: Get<Self::AccountId>;
     }
 
     #[pallet::pallet]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -184,9 +184,11 @@ mod pallet {
             + From<H256>;
 
         /// Same with `pallet_subspace::Config::ConfirmationDepthK`.
+        #[pallet::constant]
         type ConfirmationDepthK: Get<Self::BlockNumber>;
 
         /// Delay before a domain runtime is upgraded.
+        #[pallet::constant]
         type DomainRuntimeUpgradeDelay: Get<Self::BlockNumber>;
 
         /// Currency type used by the domains for staking and other currency related stuff.
@@ -245,21 +247,27 @@ mod pallet {
         type WeightInfo: WeightInfo;
 
         /// Initial domain tx range value.
+        #[pallet::constant]
         type InitialDomainTxRange: Get<u64>;
 
         /// Domain tx range is adjusted after every DomainTxRangeAdjustmentInterval blocks.
+        #[pallet::constant]
         type DomainTxRangeAdjustmentInterval: Get<u64>;
 
         /// Minimum operator stake required to become operator of a domain.
+        #[pallet::constant]
         type MinOperatorStake: Get<BalanceOf<Self>>;
 
         /// Minimum number of blocks after which any finalized withdrawals are released to nominators.
+        #[pallet::constant]
         type StakeWithdrawalLockingPeriod: Get<Self::DomainNumber>;
 
         /// Domain epoch transition interval
+        #[pallet::constant]
         type StakeEpochDuration: Get<Self::DomainNumber>;
 
         /// Treasury account.
+        #[pallet::constant]
         type TreasuryAccount: Get<Self::AccountId>;
     }
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -63,7 +63,9 @@ pub(crate) type FungibleFreezeId<T> =
 pub(crate) type NominatorId<T> = <T as frame_system::Config>::AccountId;
 
 pub trait FreezeIdentifier<T: Config> {
-    fn staking_freeze_id(operator_id: OperatorId) -> FungibleFreezeId<T>;
+    fn staking_pending_deposit(operator_id: OperatorId) -> FungibleFreezeId<T>;
+    fn staking_staked(operator_id: OperatorId) -> FungibleFreezeId<T>;
+    fn staking_pending_unlock(operator_id: OperatorId) -> FungibleFreezeId<T>;
     fn domain_instantiation_id(domain_id: DomainId) -> FungibleFreezeId<T>;
 }
 

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -510,7 +510,7 @@ mod tests {
     };
     use crate::tests::{new_test_ext, ExistentialDeposit, RuntimeOrigin, Test};
     use crate::{BalanceOf, Config, Error, FreezeIdentifier, NominatorId};
-    use frame_support::traits::fungible::{InspectFreeze, Mutate, MutateFreeze};
+    use frame_support::traits::fungible::{Mutate, MutateFreeze};
     use frame_support::traits::Currency;
     use frame_support::{assert_err, assert_ok};
     use sp_core::{Pair, U256};

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -591,6 +591,7 @@ fn finalize_nominator_deposit<T: Config>(
 ) -> Result<(), TransitionError> {
     // calculate the shares to be added to nominator
     let share_per_ssc = if total_shares.is_zero() {
+        // share price is 1 for first nominator
         Perbill::one()
     } else {
         Perbill::from_rational(*total_shares, T::Share::from(*total_stake))

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -20,7 +20,6 @@ use sp_domains::{DomainId, OperatorId};
 use sp_runtime::traits::{CheckedAdd, CheckedSub, One, Zero};
 use sp_runtime::Perbill;
 use sp_std::collections::btree_map::BTreeMap;
-use sp_std::collections::btree_set::BTreeSet;
 use sp_std::vec::Vec;
 
 #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
@@ -684,8 +683,7 @@ pub(crate) fn do_finalize_slashed_operators<T: Config>(
             let unlocking_nominators = slash_info
                 .unlocking_nominators
                 .into_iter()
-                .map(|pending_unlock| pending_unlock.nominator_id)
-                .collect::<BTreeSet<NominatorId<T>>>();
+                .map(|pending_unlock| pending_unlock.nominator_id);
 
             let pending_withdrawal_freeze_id =
                 T::HoldIdentifier::staking_pending_unlock(operator_id);

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -6,7 +6,7 @@ use crate::pallet::{
     PendingOperatorSwitches, PendingOperatorUnlocks, PendingSlashes, PendingUnlocks,
     PendingWithdrawals,
 };
-use crate::staking::{Error as TransitionError, Nominator, Withdraw};
+use crate::staking::{Error as TransitionError, Nominator, OperatorStatus, Withdraw};
 use crate::{
     BalanceOf, Config, ElectionVerificationParams, FungibleHoldId, HoldIdentifier, NominatorId,
 };
@@ -163,8 +163,8 @@ fn switch_operator<T: Config>(operator_id: OperatorId) -> Result<(), TransitionE
             .as_mut()
             .ok_or(TransitionError::UnknownOperator)?;
 
-        // operator is frozen, just no-op
-        if operator.is_frozen {
+        // operator is not registered, just no-op
+        if operator.status != OperatorStatus::Registered {
             return Ok(());
         }
 
@@ -381,8 +381,8 @@ fn finalize_operator_pending_transfers<T: Config>(
             .as_mut()
             .ok_or(TransitionError::UnknownOperator)?;
 
-        if operator.is_frozen {
-            return Err(TransitionError::OperatorFrozen);
+        if operator.status != OperatorStatus::Registered {
+            return Err(TransitionError::OperatorNotRegistered);
         }
 
         let mut total_stake = operator

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -3,7 +3,7 @@ use crate::{self as pallet_domains, BundleError, DomainRegistry, FungibleFreezeI
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Hooks};
 use frame_support::weights::Weight;
-use frame_support::{assert_err, assert_ok, parameter_types};
+use frame_support::{assert_err, assert_ok, parameter_types, PalletId};
 use scale_info::TypeInfo;
 use sp_core::crypto::Pair;
 use sp_core::{Get, H256, U256};
@@ -14,7 +14,7 @@ use sp_domains::{
     SealedBundleHeader, StakingFreezeIdentifier,
 };
 use sp_runtime::testing::Header;
-use sp_runtime::traits::{BlakeTwo256, Hash as HashT, IdentityLookup};
+use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, Hash as HashT, IdentityLookup};
 use sp_runtime::OpaqueExtrinsic;
 use std::sync::atomic::{AtomicU64, Ordering};
 use subspace_core_primitives::U256 as P256;
@@ -162,6 +162,7 @@ parameter_types! {
     pub const MinOperatorStake: Balance = 100 * SSC;
     pub const StakeWithdrawalLockingPeriod: BlockNumber = 5;
     pub const StakeEpochDuration: BlockNumber = 5;
+    pub TreasuryAccount: u64 = PalletId(*b"treasury").into_account_truncating();
 }
 
 impl pallet_domains::Config for Test {
@@ -185,6 +186,7 @@ impl pallet_domains::Config for Test {
     type BlockTreePruningDepth = BlockTreePruningDepth;
     type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
+    type TreasuryAccount = TreasuryAccount;
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -11,7 +11,7 @@ use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
     BundleHeader, DomainId, DomainInstanceData, DomainsFreezeIdentifier, ExecutionReceipt,
     GenerateGenesisStateRoot, OpaqueBundle, OperatorId, OperatorPair, ProofOfElection,
-    SealedBundleHeader,
+    SealedBundleHeader, StakingFreezeIdentifier,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, IdentityLookup};
@@ -114,8 +114,22 @@ pub enum FreezeIdentifier {
 }
 
 impl pallet_domains::FreezeIdentifier<Test> for FreezeIdentifier {
-    fn staking_freeze_id(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(operator_id))
+    fn staking_pending_deposit(operator_id: OperatorId) -> FungibleFreezeId<Test> {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::PendingDeposit(operator_id),
+        ))
+    }
+
+    fn staking_staked(operator_id: OperatorId) -> FungibleFreezeId<Test> {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::Staked(operator_id),
+        ))
+    }
+
+    fn staking_pending_unlock(operator_id: OperatorId) -> FungibleFreezeId<Test> {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::PendingUnlock(operator_id),
+        ))
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> FungibleFreezeId<Test> {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::domain_registry::{DomainConfig, DomainObject};
-use crate::{self as pallet_domains, BundleError, DomainRegistry, FungibleFreezeId};
+use crate::{self as pallet_domains, BundleError, DomainRegistry, FungibleHoldId};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Hooks};
 use frame_support::weights::Weight;
@@ -9,9 +9,9 @@ use sp_core::crypto::Pair;
 use sp_core::{Get, H256, U256};
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
-    BundleHeader, DomainId, DomainInstanceData, DomainsFreezeIdentifier, ExecutionReceipt,
+    BundleHeader, DomainId, DomainInstanceData, DomainsHoldIdentifier, ExecutionReceipt,
     GenerateGenesisStateRoot, OpaqueBundle, OperatorId, OperatorPair, ProofOfElection,
-    SealedBundleHeader, StakingFreezeIdentifier,
+    SealedBundleHeader, StakingHoldIdentifier,
 };
 use sp_runtime::testing::Header;
 use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, Hash as HashT, IdentityLookup};
@@ -109,36 +109,36 @@ impl Get<BlockNumber> for ConfirmationDepthK {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum FreezeIdentifier {
-    Domains(DomainsFreezeIdentifier),
+pub enum HoldIdentifier {
+    Domains(DomainsHoldIdentifier),
 }
 
-impl pallet_domains::FreezeIdentifier<Test> for FreezeIdentifier {
-    fn staking_pending_deposit(operator_id: OperatorId) -> FungibleFreezeId<Test> {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::PendingDeposit(operator_id),
+impl pallet_domains::HoldIdentifier<Test> for HoldIdentifier {
+    fn staking_pending_deposit(operator_id: OperatorId) -> FungibleHoldId<Test> {
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::PendingDeposit(operator_id),
         ))
     }
 
-    fn staking_staked(operator_id: OperatorId) -> FungibleFreezeId<Test> {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::Staked(operator_id),
+    fn staking_staked(operator_id: OperatorId) -> FungibleHoldId<Test> {
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::Staked(operator_id),
         ))
     }
 
-    fn staking_pending_unlock(operator_id: OperatorId) -> FungibleFreezeId<Test> {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::PendingUnlock(operator_id),
+    fn staking_pending_unlock(operator_id: OperatorId) -> FungibleHoldId<Test> {
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::PendingUnlock(operator_id),
         ))
     }
 
-    fn domain_instantiation_id(domain_id: DomainId) -> FungibleFreezeId<Test> {
-        Self::Domains(DomainsFreezeIdentifier::DomainInstantiation(domain_id))
+    fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<Test> {
+        Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
     }
 }
 
 parameter_types! {
-    pub const MaxFreezes: u32 = 10;
+    pub const MaxHolds: u32 = 10;
     pub const ExistentialDeposit: Balance = 1;
 }
 
@@ -152,10 +152,10 @@ impl pallet_balances::Config for Test {
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type WeightInfo = ();
-    type FreezeIdentifier = FreezeIdentifier;
-    type MaxFreezes = MaxFreezes;
-    type RuntimeHoldReason = ();
-    type MaxHolds = ();
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
+    type RuntimeHoldReason = HoldIdentifier;
+    type MaxHolds = MaxHolds;
 }
 
 parameter_types! {
@@ -172,7 +172,7 @@ impl pallet_domains::Config for Test {
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
-    type FreezeIdentifier = FreezeIdentifier;
+    type HoldIdentifier = HoldIdentifier;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Test>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -462,11 +462,11 @@ pub type EpochIndex = u32;
 /// Type representing operator ID
 pub type OperatorId = u64;
 
-/// Staking specific freeze identifier
+/// Staking specific hold identifier
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum StakingFreezeIdentifier {
+pub enum StakingHoldIdentifier {
     /// Holds all the pending deposits to an Operator.
     PendingDeposit(OperatorId),
     /// Holds all the currently staked funds to an Operator.
@@ -475,12 +475,12 @@ pub enum StakingFreezeIdentifier {
     PendingUnlock(OperatorId),
 }
 
-/// Domains specific Identifier for Balances freeze.
+/// Domains specific Identifier for Balances holds.
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum DomainsFreezeIdentifier {
-    Staking(StakingFreezeIdentifier),
+pub enum DomainsHoldIdentifier {
+    Staking(StakingHoldIdentifier),
     DomainInstantiation(DomainId),
 }
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -462,12 +462,25 @@ pub type EpochIndex = u32;
 /// Type representing operator ID
 pub type OperatorId = u64;
 
+/// Staking specific freeze identifier
+#[derive(
+    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
+)]
+pub enum StakingFreezeIdentifier {
+    /// Holds all the pending deposits to an Operator.
+    PendingDeposit(OperatorId),
+    /// Holds all the currently staked funds to an Operator.
+    Staked(OperatorId),
+    /// Holds all the currently unlocking funds.
+    PendingUnlock(OperatorId),
+}
+
 /// Domains specific Identifier for Balances freeze.
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
 pub enum DomainsFreezeIdentifier {
-    Staking(OperatorId),
+    Staking(StakingFreezeIdentifier),
     DomainInstantiation(DomainId),
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -61,8 +61,8 @@ use sp_core::crypto::{ByteArray, KeyTypeId};
 use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
-    DomainId, DomainInstanceData, DomainsFreezeIdentifier, OperatorId, OperatorPublicKey,
-    StakingFreezeIdentifier,
+    DomainId, DomainInstanceData, DomainsHoldIdentifier, OperatorId, OperatorPublicKey,
+    StakingHoldIdentifier,
 };
 use sp_runtime::traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
@@ -325,37 +325,37 @@ parameter_types! {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum FreezeIdentifier {
-    Domains(DomainsFreezeIdentifier),
+pub enum HoldIdentifier {
+    Domains(DomainsHoldIdentifier),
 }
 
-impl pallet_domains::FreezeIdentifier<Runtime> for FreezeIdentifier {
+impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
     fn staking_pending_deposit(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::PendingDeposit(operator_id),
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::PendingDeposit(operator_id),
         ))
     }
 
     fn staking_staked(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::Staked(operator_id),
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::Staked(operator_id),
         ))
     }
 
     fn staking_pending_unlock(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::PendingUnlock(operator_id),
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::PendingUnlock(operator_id),
         ))
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::DomainInstantiation(domain_id))
+        Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
     }
 }
 
 parameter_types! {
     // TODO: revisit this
-    pub const MaxFreezes: u32 = 100;
+    pub const MaxHolds: u32 = 100;
 }
 
 impl pallet_balances::Config for Runtime {
@@ -370,10 +370,10 @@ impl pallet_balances::Config for Runtime {
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
-    type FreezeIdentifier = FreezeIdentifier;
-    type MaxFreezes = MaxFreezes;
-    type RuntimeHoldReason = ();
-    type MaxHolds = ();
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
+    type RuntimeHoldReason = HoldIdentifier;
+    type MaxHolds = MaxHolds;
 }
 
 parameter_types! {
@@ -499,7 +499,7 @@ impl pallet_domains::Config for Runtime {
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
-    type FreezeIdentifier = FreezeIdentifier;
+    type HoldIdentifier = HoldIdentifier;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -45,7 +45,7 @@ use domain_runtime_primitives::{BlockNumber as DomainNumber, Hash as DomainHash}
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Everything, Get};
 use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
-use frame_support::{construct_runtime, parameter_types};
+use frame_support::{construct_runtime, parameter_types, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
 use frame_system::EnsureNever;
 use pallet_feeds::feed_processor::FeedProcessor;
@@ -64,7 +64,7 @@ use sp_domains::{
     DomainId, DomainInstanceData, DomainsFreezeIdentifier, OperatorId, OperatorPublicKey,
     StakingFreezeIdentifier,
 };
-use sp_runtime::traits::{AccountIdLookup, BlakeTwo256, NumberFor};
+use sp_runtime::traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{
     create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, Perbill, SaturatedConversion,
@@ -485,6 +485,7 @@ parameter_types! {
     // TODO: revisit these
     pub const StakeWithdrawalLockingPeriod: BlockNumber = 100;
     pub const StakeEpochDuration: DomainNumber = 5;
+    pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
 }
 
 // `BlockTreePruningDepth` should <= `BlockHashCount` because we need the consensus block hash to verify
@@ -512,6 +513,7 @@ impl pallet_domains::Config for Runtime {
     type BlockTreePruningDepth = BlockTreePruningDepth;
     type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
+    type TreasuryAccount = TreasuryAccount;
 }
 
 parameter_types! {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -62,6 +62,7 @@ use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainId, DomainInstanceData, DomainsFreezeIdentifier, OperatorId, OperatorPublicKey,
+    StakingFreezeIdentifier,
 };
 use sp_runtime::traits::{AccountIdLookup, BlakeTwo256, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
@@ -329,8 +330,22 @@ pub enum FreezeIdentifier {
 }
 
 impl pallet_domains::FreezeIdentifier<Runtime> for FreezeIdentifier {
-    fn staking_freeze_id(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(operator_id))
+    fn staking_pending_deposit(operator_id: OperatorId) -> Self {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::PendingDeposit(operator_id),
+        ))
+    }
+
+    fn staking_staked(operator_id: OperatorId) -> Self {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::Staked(operator_id),
+        ))
+    }
+
+    fn staking_pending_unlock(operator_id: OperatorId) -> Self {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::PendingUnlock(operator_id),
+        ))
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> Self {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -53,8 +53,8 @@ use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::transaction::PreValidationObject;
 use sp_domains::{
-    DomainId, DomainInstanceData, DomainsFreezeIdentifier, ExecutionReceipt, OpaqueBundle,
-    OpaqueBundles, OperatorId, OperatorPublicKey, StakingFreezeIdentifier,
+    DomainId, DomainInstanceData, DomainsHoldIdentifier, ExecutionReceipt, OpaqueBundle,
+    OpaqueBundles, OperatorId, OperatorPublicKey, StakingHoldIdentifier,
 };
 use sp_runtime::traits::{
     AccountIdConversion, AccountIdLookup, BlakeTwo256, DispatchInfoOf, NumberFor,
@@ -290,36 +290,36 @@ impl pallet_timestamp::Config for Runtime {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum FreezeIdentifier {
-    Domains(DomainsFreezeIdentifier),
+pub enum HoldIdentifier {
+    Domains(DomainsHoldIdentifier),
 }
 
-impl pallet_domains::FreezeIdentifier<Runtime> for FreezeIdentifier {
+impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
     fn staking_pending_deposit(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::PendingDeposit(operator_id),
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::PendingDeposit(operator_id),
         ))
     }
 
     fn staking_staked(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::Staked(operator_id),
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::Staked(operator_id),
         ))
     }
 
     fn staking_pending_unlock(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(
-            StakingFreezeIdentifier::PendingUnlock(operator_id),
+        Self::Domains(DomainsHoldIdentifier::Staking(
+            StakingHoldIdentifier::PendingUnlock(operator_id),
         ))
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::DomainInstantiation(domain_id))
+        Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
     }
 }
 
 parameter_types! {
-    pub const MaxFreezes: u32 = 10;
+    pub const MaxHolds: u32 = 10;
 }
 
 impl pallet_balances::Config for Runtime {
@@ -335,10 +335,10 @@ impl pallet_balances::Config for Runtime {
     type ExistentialDeposit = ConstU128<{ 500 * SHANNON }>;
     type AccountStore = System;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
-    type FreezeIdentifier = FreezeIdentifier;
-    type MaxFreezes = MaxFreezes;
-    type RuntimeHoldReason = ();
-    type MaxHolds = ();
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
+    type RuntimeHoldReason = HoldIdentifier;
+    type MaxHolds = MaxHolds;
 }
 
 parameter_types! {
@@ -551,7 +551,7 @@ impl pallet_domains::Config for Runtime {
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
-    type FreezeIdentifier = FreezeIdentifier;
+    type HoldIdentifier = HoldIdentifier;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -32,7 +32,7 @@ use frame_support::traits::{
 };
 use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
-use frame_support::{construct_runtime, parameter_types};
+use frame_support::{construct_runtime, parameter_types, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
 use frame_system::EnsureNever;
 use pallet_balances::NegativeImbalance;
@@ -57,7 +57,8 @@ use sp_domains::{
     OpaqueBundles, OperatorId, OperatorPublicKey, StakingFreezeIdentifier,
 };
 use sp_runtime::traits::{
-    AccountIdLookup, BlakeTwo256, DispatchInfoOf, NumberFor, PostDispatchInfoOf, Zero,
+    AccountIdConversion, AccountIdLookup, BlakeTwo256, DispatchInfoOf, NumberFor,
+    PostDispatchInfoOf, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -540,6 +541,7 @@ parameter_types! {
     pub const BlockTreePruningDepth: u32 = 256;
     pub const StakeWithdrawalLockingPeriod: BlockNumber = 20;
     pub const StakeEpochDuration: DomainNumber = 5;
+    pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
 }
 
 impl pallet_domains::Config for Runtime {
@@ -563,6 +565,7 @@ impl pallet_domains::Config for Runtime {
     type BlockTreePruningDepth = BlockTreePruningDepth;
     type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
+    type TreasuryAccount = TreasuryAccount;
 }
 
 parameter_types! {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -54,7 +54,7 @@ use sp_domains::fraud_proof::FraudProof;
 use sp_domains::transaction::PreValidationObject;
 use sp_domains::{
     DomainId, DomainInstanceData, DomainsFreezeIdentifier, ExecutionReceipt, OpaqueBundle,
-    OpaqueBundles, OperatorId, OperatorPublicKey,
+    OpaqueBundles, OperatorId, OperatorPublicKey, StakingFreezeIdentifier,
 };
 use sp_runtime::traits::{
     AccountIdLookup, BlakeTwo256, DispatchInfoOf, NumberFor, PostDispatchInfoOf, Zero,
@@ -294,8 +294,22 @@ pub enum FreezeIdentifier {
 }
 
 impl pallet_domains::FreezeIdentifier<Runtime> for FreezeIdentifier {
-    fn staking_freeze_id(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsFreezeIdentifier::Staking(operator_id))
+    fn staking_pending_deposit(operator_id: OperatorId) -> Self {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::PendingDeposit(operator_id),
+        ))
+    }
+
+    fn staking_staked(operator_id: OperatorId) -> Self {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::Staked(operator_id),
+        ))
+    }
+
+    fn staking_pending_unlock(operator_id: OperatorId) -> Self {
+        Self::Domains(DomainsFreezeIdentifier::Staking(
+            StakingFreezeIdentifier::PendingUnlock(operator_id),
+        ))
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> Self {


### PR DESCRIPTION
This PR has following changes for each commit respectively:
- Introduce multiple lock ID states for frozen balance instead just one lock id for staking.
- Introduces Treasury account. We do not add Treasury pallet yet.
- Move from Freeze fungible to Hold due to limitations when multiple lock states are introduced.
- Introduce OperatorStatus and ensure slashed operator cannot produce bundle
- Merge commit includes some updates to tests that were recently introduced

I suggest going commit by commit while reading commit messages for more details.

Closes: #1711

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
