### PR TITLE
Push all container images

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -62,6 +62,8 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
             type=ref,event=tag
+            type=ref,event=branch
+            type=sha,format=long
           flavor: |
             latest=false
             suffix=${{ matrix.platform.image-suffix }}
@@ -71,8 +73,7 @@ jobs:
         with:
           file: Dockerfile-${{ matrix.image }}${{ matrix.platform.dockerfile-suffix }}
           platforms: ${{ matrix.platform.arch }}
-          # Only push for releases
-          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
This allows us to build things from test branches and such.
There will be two tags added to each container image now: branch and commit hash, looks [like this](https://github.com/subspace/subspace/actions/runs/5715239649/job/15484131314#step:5:45):
```
ghcr.io/subspace/bootstrap-node:push-all-container-images
ghcr.io/subspace/bootstrap-node:sha-dd55323a3be41255c8686a832974c44c21260a16
```

Releases will have a third tag corresponding to release as usual.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
