### PR TITLE
Fix sector expiration

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -228,7 +228,7 @@ pub enum Error<Header: HeaderT> {
     /// Stored segment header extrinsic was not found
     #[error("Stored segment header extrinsic was not found: {0:?}")]
     SegmentHeadersExtrinsicNotFound(Vec<SegmentHeader>),
-    /// Duplicated segment commitment
+    /// Different segment commitment found
     #[error(
         "Different segment commitment for segment index {0} was found in storage, likely fork \
         below archiving point"
@@ -1161,6 +1161,14 @@ where
                 .segment_commitment();
 
             if &found_segment_commitment != segment_commitment {
+                warn!(
+                    target: "subspace",
+                    "Different segment commitment for segment index {} was found in storage, \
+                    likely fork below archiving point. expected {:?}, found {:?}",
+                    segment_index,
+                    segment_commitment,
+                    found_segment_commitment
+                );
                 return Err(ConsensusError::ClientImport(
                     Error::<Block::Header>::DifferentSegmentCommitment(segment_index).to_string(),
                 ));

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -460,7 +460,11 @@ where
             .collect_into(&mut sectors_to_check);
         for (sector_index, history_size) in sectors_to_check.drain(..) {
             if let Some(sector_expire_at) = sectors_expire_at.get(&sector_index) {
-                if *sector_expire_at >= archived_segment_header.segment_index() {
+                // +1 means we will start replotting a bit before it actually expires to avoid
+                // storing expired sectors
+                if *sector_expire_at
+                    <= (archived_segment_header.segment_index() + SegmentIndex::ONE)
+                {
                     // Time to replot
                     sector_indices_to_replot.push(sector_index);
                 }
@@ -508,8 +512,10 @@ where
                                 metadata; qed",
                         );
 
+                    // +1 means we will start replotting a bit before it actually expires to avoid
+                    // storing expired sectors
                     if expiration_history_size.segment_index()
-                        >= archived_segment_header.segment_index()
+                        <= (archived_segment_header.segment_index() + SegmentIndex::ONE)
                     {
                         // Time to replot
                         sector_indices_to_replot.push(sector_index);

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -449,6 +449,10 @@ where
 
     while let Some(()) = archived_segments_receiver.next().await {
         let archived_segment_header = last_archived_segment.load(Ordering::SeqCst);
+        trace!(
+            segment_index = %archived_segment_header.segment_index(),
+            "New archived segment received",
+        );
 
         // It is fine to take a synchronous read lock here because the only time
         // write lock is taken is during plotting, which we know doesn't happen
@@ -460,11 +464,23 @@ where
             .collect_into(&mut sectors_to_check);
         for (sector_index, history_size) in sectors_to_check.drain(..) {
             if let Some(sector_expire_at) = sectors_expire_at.get(&sector_index) {
+                trace!(
+                    %sector_index,
+                    %history_size,
+                    %sector_expire_at,
+                    "Checking sector for expiration"
+                );
                 // +1 means we will start replotting a bit before it actually expires to avoid
                 // storing expired sectors
                 if *sector_expire_at
                     <= (archived_segment_header.segment_index() + SegmentIndex::ONE)
                 {
+                    debug!(
+                        %sector_index,
+                        %history_size,
+                        %sector_expire_at,
+                        "Sector expires soon #1, scheduling replotting"
+                    );
                     // Time to replot
                     sector_indices_to_replot.push(sector_index);
                 }
@@ -475,6 +491,12 @@ where
                 .sector_expiration_check(min_sector_lifetime)
                 .map(|expiration_check_history_size| expiration_check_history_size.segment_index())
             {
+                trace!(
+                    %sector_index,
+                    %history_size,
+                    %expiration_check_segment_index,
+                    "Determined sector expiration check segment index"
+                );
                 let maybe_sector_expiration_check_segment_commitment =
                     if let Some(segment_commitment) =
                         archived_segment_commitments_cache.get(&expiration_check_segment_index)
@@ -512,14 +534,32 @@ where
                                 metadata; qed",
                         );
 
+                    trace!(
+                        %sector_index,
+                        %history_size,
+                        sector_expire_at = %expiration_history_size.segment_index(),
+                        "Determined sector expiration segment index"
+                    );
                     // +1 means we will start replotting a bit before it actually expires to avoid
                     // storing expired sectors
                     if expiration_history_size.segment_index()
                         <= (archived_segment_header.segment_index() + SegmentIndex::ONE)
                     {
+                        debug!(
+                            %sector_index,
+                            %history_size,
+                            sector_expire_at = %expiration_history_size.segment_index(),
+                            "Sector expires soon #2, scheduling replotting"
+                        );
                         // Time to replot
                         sector_indices_to_replot.push(sector_index);
                     } else {
+                        trace!(
+                            %sector_index,
+                            %history_size,
+                            sector_expire_at = %expiration_history_size.segment_index(),
+                            "Sector expires later, remembering sector expiration"
+                        );
                         // Store expiration so we don't have to recalculate it later
                         sectors_expire_at
                             .insert(sector_index, expiration_history_size.segment_index());

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -283,7 +283,7 @@ where
                 }
             };
 
-            if expiration_history_size >= *current_history_size {
+            if expiration_history_size <= *current_history_size {
                 return Err(Error::SectorExpired {
                     expiration_history_size,
                     current_history_size: *current_history_size,


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/1647 implemented expiration check incorrectly, because of that as soon as sector expiration is known, consensus was rejecting it as expired :man_facepalming:. While fixing this I also made farmer start replotting one segment ahead of time such that farmer is much less likely to store already expired sectors.

It worked fine though, sector was successfully replotted up until https://github.com/subspace/subspace/pull/1692, where due to ordering of operations it was not possible to retrieve segment header of the segment header that the rest of the system was just notified about.

Last commit is just some helpful extra logging.

We really need to write decent number of tests around all this though :disappointed: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
