### PR TITLE
Remove `Node::wait_for_connected_peers()` as no longer necessary

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -34,7 +34,6 @@ use subspace_farmer_components::plotting::{PieceGetter, PieceGetterRetryPolicy, 
 use subspace_networking::libp2p::identity::{ed25519, Keypair};
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
-use subspace_networking::Node;
 use subspace_proof_of_space::Table;
 use tokio::time::sleep;
 use tracing::{debug, error, info, info_span, trace, warn};
@@ -43,7 +42,6 @@ use zeroize::Zeroizing;
 const RECORDS_ROOTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000_000).expect("Not zero; qed");
 const GET_PIECE_MAX_RETRIES_COUNT: u16 = 3;
 const GET_PIECE_DELAY_IN_SECS: u64 = 3;
-const POPULATE_PIECE_DELAY: Duration = Duration::from_secs(10);
 
 /// Start farming by using multiple replica plot in specified path and connecting to WebSocket
 /// server at specified address.
@@ -154,9 +152,8 @@ where
         Box::pin({
             let piece_cache = piece_cache.clone();
             let piece_getter = piece_getter.clone();
-            let node = node.clone();
 
-            populate_pieces_cache(node, last_segment_index, piece_getter, piece_cache)
+            populate_pieces_cache(last_segment_index, piece_getter, piece_cache)
         }),
         "pieces-cache-population".to_string(),
     )?;
@@ -384,7 +381,6 @@ fn derive_libp2p_keypair(schnorrkel_sk: &schnorrkel::SecretKey) -> Keypair {
 /// previous segments to see if they are already in the cache. If they are not, they are added
 /// from DSN.
 async fn populate_pieces_cache<PV, PC>(
-    node: Node,
     segment_index: SegmentIndex,
     piece_getter: Arc<FarmerPieceGetter<PV, PC>>,
     piece_cache: Arc<tokio::sync::Mutex<FarmerPieceCache>>,
@@ -392,9 +388,6 @@ async fn populate_pieces_cache<PV, PC>(
     PV: PieceValidator + Send + Sync + 'static,
     PC: PieceCache + Send + 'static,
 {
-    // Give some time to obtain DSN connection.
-    let _ = node.wait_for_connected_peers(POPULATE_PIECE_DELAY).await;
-
     debug!(%segment_index, "Started syncing piece cache...");
     let final_piece_index =
         u64::from(segment_index.first_piece_index()) + ArchivedHistorySegment::NUM_PIECES as u64;

--- a/crates/subspace-networking/examples/get-peers-complex.rs
+++ b/crates/subspace-networking/examples/get-peers-complex.rs
@@ -94,10 +94,6 @@ async fn main() {
         node_runner.run().await;
     });
 
-    node.wait_for_connected_peers(Duration::from_secs(5))
-        .await
-        .unwrap();
-
     // Prepare multihash to look for in Kademlia
     let key = Multihash::from(node.id());
 

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -191,11 +191,6 @@ async fn test_async_handler_works_with_pending_internal_future() {
         node_runner_2.run().await;
     });
 
-    node_2
-        .wait_for_connected_peers(Duration::from_secs(25))
-        .await
-        .unwrap();
-
     let resp = node_2
         .send_generic_request(node_1.id(), ExampleRequest)
         .await

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1188,17 +1188,6 @@ where
                     IfDisconnected::TryConnect,
                 );
             }
-            Command::CheckConnectedPeers { result_sender } => {
-                let connected_peers_present = self.swarm.connected_peers().next().is_some();
-
-                let kademlia_connection_initiated = if connected_peers_present {
-                    self.swarm.behaviour_mut().kademlia.bootstrap().is_ok()
-                } else {
-                    false
-                };
-
-                let _ = result_sender.send(kademlia_connection_initiated);
-            }
             Command::StartLocalAnnouncing { key, result_sender } => {
                 let local_peer_id = *self.swarm.local_peer_id();
                 let addresses = self.swarm.external_addresses().cloned().collect::<Vec<_>>();

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -61,9 +61,6 @@ pub(crate) enum Command {
         request: Vec<u8>,
         result_sender: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
     },
-    CheckConnectedPeers {
-        result_sender: oneshot::Sender<bool>,
-    },
     StartLocalAnnouncing {
         key: Key,
         result_sender: oneshot::Sender<bool>,

--- a/crates/subspace-service/src/dsn/import_blocks.rs
+++ b/crates/subspace-service/src/dsn/import_blocks.rs
@@ -43,8 +43,6 @@ use subspace_networking::Node;
 // Refuse to compile on non-64-bit platforms, otherwise segment indices will not fit in memory
 const_assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u64>());
 
-/// How long to wait for peers before giving up
-const WAIT_FOR_PEERS_TIMEOUT: Duration = Duration::from_secs(10);
 /// How many blocks to queue before pausing and waiting for blocks to be imported
 const QUEUED_BLOCKS_LIMIT: BlockNumber = 2048;
 /// Time to wait for blocks to import if import is too slow
@@ -190,17 +188,6 @@ where
     Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
     IQS: ImportQueueService<Block> + ?Sized,
 {
-    debug!("Waiting for connected peers...");
-    if node
-        .wait_for_connected_peers(WAIT_FOR_PEERS_TIMEOUT)
-        .await
-        .is_err()
-    {
-        info!("Was not able to find any DSN peers, cancelling sync from DSN");
-        return Ok(0);
-    }
-    debug!("Connected to peers.");
-
     let segment_headers = SegmentHeaderHandler::new(node.clone())
         .get_segment_headers()
         .await


### PR DESCRIPTION
With bootstrapping that happens before any other commands are processed, this is no longer necessary.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
