### PR TITLE
Piece cache preparation

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -744,8 +744,11 @@ async fn send_archived_segment_notification(
     let segment_index = archived_segment.segment_header.segment_index();
     let (acknowledgement_sender, mut acknowledgement_receiver) =
         tracing_unbounded::<()>("subspace_acknowledgement", 100);
+    // Keep `archived_segment` around until all acknowledgements are received since some receivers
+    // might use weak references
+    let archived_segment = Arc::new(archived_segment);
     let archived_segment_notification = ArchivedSegmentNotification {
-        archived_segment: Arc::new(archived_segment),
+        archived_segment: Arc::clone(&archived_segment),
         acknowledgement_sender,
     };
 

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -71,16 +71,40 @@ impl SegmentIndex {
         PieceIndex::from(self.0 * ArchivedHistorySegment::NUM_PIECES as u64)
     }
 
-    /// Iterator over piece indexes that belong to this segment.
-    pub fn segment_piece_indexes(&self) -> impl Iterator<Item = PieceIndex> {
-        (self.first_piece_index()..).take(ArchivedHistorySegment::NUM_PIECES)
+    /// Get the last piece index in this segment.
+    pub fn last_piece_index(&self) -> PieceIndex {
+        PieceIndex::from((self.0 + 1) * ArchivedHistorySegment::NUM_PIECES as u64 - 1)
     }
 
-    /// Iterator over piece indexes that belong to this segment with source pieces first.
-    pub fn segment_piece_indexes_source_first(&self) -> impl Iterator<Item = PieceIndex> {
-        self.segment_piece_indexes()
+    /// List of piece indexes that belong to this segment.
+    pub fn segment_piece_indexes(&self) -> [PieceIndex; ArchivedHistorySegment::NUM_PIECES] {
+        let mut piece_indices = [PieceIndex::ZERO; ArchivedHistorySegment::NUM_PIECES];
+        (self.first_piece_index()..=self.last_piece_index())
+            .zip(&mut piece_indices)
+            .for_each(|(input, output)| {
+                *output = input;
+            });
+
+        piece_indices
+    }
+
+    /// List of piece indexes that belong to this segment with source pieces first.
+    pub fn segment_piece_indexes_source_first(
+        &self,
+    ) -> [PieceIndex; ArchivedHistorySegment::NUM_PIECES] {
+        let mut source_first_piece_indices = [PieceIndex::ZERO; ArchivedHistorySegment::NUM_PIECES];
+
+        let piece_indices = self.segment_piece_indexes();
+        piece_indices
+            .into_iter()
             .step_by(2)
-            .chain(self.segment_piece_indexes().skip(1).step_by(2))
+            .chain(piece_indices.into_iter().skip(1).step_by(2))
+            .zip(&mut source_first_piece_indices)
+            .for_each(|(input, output)| {
+                *output = input;
+            });
+
+        source_first_piece_indices
     }
 }
 

--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -81,6 +81,7 @@ pub(crate) async fn recover_missing_piece<PG: PieceGetter>(
                 }
             }
         })
+        .into_iter()
         .collect::<FuturesOrdered<_>>();
 
     let mut segment_pieces = vec![None::<Piece>; ArchivedHistorySegment::NUM_PIECES];

--- a/crates/subspace-farmer/src/utils/farmer_piece_cache.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_cache.rs
@@ -55,8 +55,6 @@ impl FarmerPieceCache {
 }
 
 impl PieceCache for FarmerPieceCache {
-    type KeysIterator = impl IntoIterator<Item = Key>;
-
     fn should_cache(&self, key: &Key) -> bool {
         self.heap.lock().should_include_key(key)
     }
@@ -75,12 +73,6 @@ impl PieceCache for FarmerPieceCache {
 
     fn get_piece(&self, key: &Key) -> Option<Piece> {
         self.store.get(key)
-    }
-
-    fn keys(&self) -> Self::KeysIterator {
-        // It is not great that we're cloning it, but at the same time dealing with self-referential
-        // lifetimes originating from the fact that mutex is used here proven to be challenging
-        self.heap.lock().keys().cloned().collect::<Vec<_>>()
     }
 
     fn contains_key(&self, key: &Key) -> bool {

--- a/crates/subspace-farmer/src/utils/farmer_piece_cache.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_cache.rs
@@ -56,7 +56,7 @@ impl FarmerPieceCache {
 
 impl PieceCache for FarmerPieceCache {
     fn should_cache(&self, key: &Key) -> bool {
-        self.heap.lock().should_include_key(key)
+        self.heap.lock().should_include_key(key.clone())
     }
 
     fn add_piece(&mut self, key: Key, piece: Piece) {
@@ -76,6 +76,6 @@ impl PieceCache for FarmerPieceCache {
     }
 
     fn contains_key(&self, key: &Key) -> bool {
-        self.heap.lock().contains_key(key)
+        self.heap.lock().contains_key(key.clone())
     }
 }

--- a/crates/subspace-farmer/src/utils/piece_cache.rs
+++ b/crates/subspace-farmer/src/utils/piece_cache.rs
@@ -4,8 +4,6 @@ use subspace_networking::libp2p::kad::record::Key;
 /// Defines persistent piece cache interface.
 // TODO: This should be elsewhere, like in `subspace-dsn`
 pub trait PieceCache: Sync + Send + 'static {
-    type KeysIterator: IntoIterator<Item = Key>;
-
     /// Check whether key should be cached based on current cache size and key-to-peer-id distance.
     fn should_cache(&self, key: &Key) -> bool;
 
@@ -14,9 +12,6 @@ pub trait PieceCache: Sync + Send + 'static {
 
     /// Get piece from the cache.
     fn get_piece(&self, key: &Key) -> Option<Piece>;
-
-    /// Iterator over pieces in cache.
-    fn keys(&self) -> Self::KeysIterator;
 
     /// Checks whether the key exists in the cache.
     fn contains_key(&self, key: &Key) -> bool;

--- a/crates/subspace-networking/src/behavior/provider_storage/providers.rs
+++ b/crates/subspace-networking/src/behavior/provider_storage/providers.rs
@@ -442,7 +442,7 @@ impl ProviderStorage for ParityDbProviderStorage {
 
         self.remove_provider_from_db(key, provider.to_bytes());
 
-        self.heap.lock().remove(key);
+        self.heap.lock().remove(key.clone());
     }
 
     fn provided(&self) -> Self::ProvidedIter<'_> {

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -65,4 +65,4 @@ pub use request_handlers::segment_header::{
 pub use shared::NewPeerInfo;
 pub use utils::multihash::Multihash;
 pub use utils::prometheus::start_prometheus_metrics_server;
-pub use utils::unique_record_binary_heap::UniqueRecordBinaryHeap;
+pub use utils::unique_record_binary_heap::{KeyWrapper, UniqueRecordBinaryHeap};

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
@@ -1,49 +1,83 @@
 #[cfg(test)]
 mod tests;
 
+use crate::utils::multihash::ToMultihash;
 pub use libp2p::kad::record::Key;
 use libp2p::kad::KBucketDistance;
 pub use libp2p::PeerId;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
+use subspace_core_primitives::PieceIndex;
 
 type KademliaBucketKey<T> = libp2p::kad::KBucketKey<T>;
 
 // Helper structure. It wraps Kademlia distance to a given peer for heap-metrics.
 #[derive(Debug, Clone)]
-struct RecordHeapKey {
+struct RecordHeapKey<K> {
     peer_distance: KBucketDistance,
-    key: KademliaBucketKey<Key>,
+    key: K,
 }
 
-impl RecordHeapKey {
+impl<K> RecordHeapKey<K>
+where
+    Key: From<K>,
+    K: Clone,
+{
     fn peer_distance(&self) -> KBucketDistance {
         self.peer_distance
     }
 
-    fn new(peer_key: &KademliaBucketKey<PeerId>, key: KademliaBucketKey<Key>) -> Self {
-        let peer_distance = key.distance(peer_key);
+    fn new(peer_key: &KademliaBucketKey<PeerId>, key: K) -> Self {
+        let peer_distance = KademliaBucketKey::new(Key::from(key.clone())).distance(peer_key);
         Self { peer_distance, key }
     }
 }
 
-impl Eq for RecordHeapKey {}
+impl<K> Eq for RecordHeapKey<K>
+where
+    Key: From<K>,
+    K: Clone,
+{
+}
 
-impl PartialEq<Self> for RecordHeapKey {
+impl<K> PartialEq<Self> for RecordHeapKey<K>
+where
+    Key: From<K>,
+    K: Clone,
+{
     fn eq(&self, other: &Self) -> bool {
         self.peer_distance().eq(&other.peer_distance())
     }
 }
 
-impl PartialOrd<Self> for RecordHeapKey {
+impl<K> PartialOrd<Self> for RecordHeapKey<K>
+where
+    Key: From<K>,
+    K: Clone,
+{
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for RecordHeapKey {
+impl<K> Ord for RecordHeapKey<K>
+where
+    Key: From<K>,
+    K: Clone,
+{
     fn cmp(&self, other: &Self) -> Ordering {
         self.peer_distance().cmp(&other.peer_distance())
+    }
+}
+
+/// Wrapper data structure that allows to work with keys as Kademlia keys, while not storing 32
+/// bytes if the key itself is smaller, while potentially trading a bit of runtime performance.
+#[derive(Debug, Copy, Clone)]
+pub struct KeyWrapper<T>(pub T);
+
+impl From<KeyWrapper<PieceIndex>> for Key {
+    fn from(value: KeyWrapper<PieceIndex>) -> Self {
+        value.0.hash().to_multihash().into()
     }
 }
 
@@ -53,13 +87,17 @@ impl Ord for RecordHeapKey {
 /// It maintains limited size and evicts (pops) items when this limited is exceeded.
 /// Unique keys are only inserted once.
 #[derive(Clone, Debug)]
-pub struct UniqueRecordBinaryHeap {
+pub struct UniqueRecordBinaryHeap<K = Key> {
     peer_key: KademliaBucketKey<PeerId>,
-    set: BTreeSet<RecordHeapKey>,
+    set: BTreeSet<RecordHeapKey<K>>,
     limit: usize,
 }
 
-impl UniqueRecordBinaryHeap {
+impl<K> UniqueRecordBinaryHeap<K>
+where
+    Key: From<K>,
+    K: Clone,
+{
     /// Constructs a heap with given PeerId and size limit.
     pub fn new(peer_id: PeerId, limit: usize) -> Self {
         Self {
@@ -78,15 +116,15 @@ impl UniqueRecordBinaryHeap {
     ///
     /// If key doesn't pass [`UniqueRecordBinaryHeap::should_include_key`] check, it will be
     /// silently ignored.
-    pub fn insert(&mut self, key: Key) -> Option<Key> {
-        let key = RecordHeapKey::new(&self.peer_key, KademliaBucketKey::new(key));
+    pub fn insert(&mut self, key: K) -> Option<K> {
+        let key = RecordHeapKey::new(&self.peer_key, key);
 
         if !self.should_include_key_internal(&key) {
             return None;
         }
 
         let evicted = if self.is_limit_reached() {
-            self.set.pop_last().map(|key| key.key.into_preimage())
+            self.set.pop_last().map(|key| key.key)
         } else {
             None
         };
@@ -97,26 +135,24 @@ impl UniqueRecordBinaryHeap {
     }
 
     /// Removes a key from the heap.
-    pub fn remove(&mut self, key: &Key) {
-        let key = RecordHeapKey::new(&self.peer_key, KademliaBucketKey::new(key.clone()));
+    pub fn remove(&mut self, key: K) {
+        let key = RecordHeapKey::new(&self.peer_key, key);
         self.set.remove(&key);
     }
 
     /// Checks whether we include the key.
-    pub fn should_include_key(&self, key: &Key) -> bool {
-        let new_key = RecordHeapKey::new(&self.peer_key, KademliaBucketKey::new(key.clone()));
-
-        self.should_include_key_internal(&new_key)
+    pub fn should_include_key(&self, key: K) -> bool {
+        let key = RecordHeapKey::new(&self.peer_key, key);
+        self.should_include_key_internal(&key)
     }
 
     /// Checks whether the heap contains the given key.
-    pub fn contains_key(&self, key: &Key) -> bool {
-        let key = RecordHeapKey::new(&self.peer_key, KademliaBucketKey::new(key.clone()));
-
+    pub fn contains_key(&self, key: K) -> bool {
+        let key = RecordHeapKey::new(&self.peer_key, key);
         self.set.contains(&key)
     }
 
-    fn should_include_key_internal(&self, new_key: &RecordHeapKey) -> bool {
+    fn should_include_key_internal(&self, new_key: &RecordHeapKey<K>) -> bool {
         if self.set.contains(new_key) {
             return false;
         }
@@ -135,8 +171,8 @@ impl UniqueRecordBinaryHeap {
     }
 
     /// Iterator over all keys in arbitrary order
-    pub fn keys(&self) -> impl Iterator<Item = &'_ Key> {
-        self.set.iter().map(|key| key.key.preimage())
+    pub fn keys(&self) -> impl ExactSizeIterator<Item = &'_ K> + '_ {
+        self.set.iter().map(|key| &key.key)
     }
 
     fn is_limit_reached(&self) -> bool {

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap/tests.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap/tests.rs
@@ -35,10 +35,10 @@ fn binary_heap_remove_works() {
     heap.insert(key1.clone());
     assert_eq!(heap.size(), 1);
 
-    heap.remove(&key2);
+    heap.remove(key2);
     assert_eq!(heap.size(), 1);
 
-    heap.remove(&key1);
+    heap.remove(key1);
     assert_eq!(heap.size(), 0);
 }
 
@@ -70,7 +70,7 @@ fn binary_heap_eviction_works() {
     let key2 = Key::from(vec![2]);
 
     heap.insert(key1.clone());
-    let should_be_evicted = heap.should_include_key(&key2);
+    let should_be_evicted = heap.should_include_key(key2.clone());
     let evicted = heap.insert(key2.clone());
     assert!(evicted.is_some());
 
@@ -96,13 +96,13 @@ fn binary_heap_should_include_key_works() {
 
     // Limit not reached
     let key1 = Key::from(vec![1]);
-    assert!(heap.should_include_key(&key1));
+    assert!(heap.should_include_key(key1.clone()));
 
     // Limit reached and key is not "less" than top key
     heap.insert(key1.clone());
-    assert!(!heap.should_include_key(&key1));
+    assert!(!heap.should_include_key(key1));
 
     // Limit reached and key is "less" than top key
     let key2 = Key::from(vec![2]);
-    assert!(heap.should_include_key(&key2));
+    assert!(heap.should_include_key(key2));
 }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -566,12 +566,12 @@ where
             (block_import, subspace_link, segment_headers_store, mut telemetry, mut bundle_validator),
     } = partial_components;
 
-    let (node, bootstrap_nodes, piece_cache) = match config.subspace_networking.clone() {
+    let (node, bootstrap_nodes) = match config.subspace_networking.clone() {
         SubspaceNetworking::Reuse {
             node,
             bootstrap_nodes,
             // TODO: Revisit piece cache creation when we get SDK requirements.
-        } => (node, bootstrap_nodes, None),
+        } => (node, bootstrap_nodes),
         SubspaceNetworking::Create {
             config: dsn_config,
             piece_cache_size,
@@ -624,7 +624,7 @@ where
             let (node, mut node_runner) = create_dsn_instance(
                 dsn_protocol_version,
                 dsn_config.clone(),
-                piece_cache.clone(),
+                piece_cache,
                 segment_headers_store.clone(),
             )?;
 
@@ -655,7 +655,7 @@ where
                     ),
                 );
 
-            (node, dsn_config.bootstrap_nodes, Some(piece_cache))
+            (node, dsn_config.bootstrap_nodes)
         }
     };
 
@@ -969,7 +969,6 @@ where
                         .clone(),
                     dsn_bootstrap_nodes: dsn_bootstrap_nodes.clone(),
                     segment_headers_store: segment_headers_store.clone(),
-                    piece_provider: piece_cache.clone(),
                     sync_oracle: subspace_sync_oracle.clone(),
                 };
 

--- a/crates/subspace-service/src/piece_cache.rs
+++ b/crates/subspace-service/src/piece_cache.rs
@@ -4,7 +4,6 @@ mod tests;
 use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use sc_client_api::backend::AuxStore;
-use sc_consensus_subspace_rpc::PieceProvider;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::error::Error;
@@ -273,14 +272,5 @@ where
             %peer_id,
             "Attempted to remove a provider record from the aux piece record store."
         );
-    }
-}
-
-impl<AS: AuxStore> PieceProvider for PieceCache<AS> {
-    fn get_piece_by_index(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
-        self.get_piece(piece_index.hash())
     }
 }

--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -29,7 +29,7 @@ use sc_consensus_subspace::{
     ArchivedSegmentNotification, NewSlotNotification, RewardSigningNotification,
     SegmentHeadersStore, SubspaceSyncOracle,
 };
-use sc_consensus_subspace_rpc::{PieceProvider, SubspaceRpc, SubspaceRpcApiServer};
+use sc_consensus_subspace_rpc::{SubspaceRpc, SubspaceRpcApiServer};
 use sc_rpc::SubscriptionTaskExecutor;
 use sc_rpc_api::DenyUnsafe;
 use sc_rpc_spec_v2::chain_spec::{ChainSpec, ChainSpecApiServer};
@@ -46,7 +46,7 @@ use subspace_runtime_primitives::{AccountId, Balance, Index};
 use substrate_frame_rpc_system::{System, SystemApiServer};
 
 /// Full client dependencies.
-pub struct FullDeps<C, P, PP, SO, AS>
+pub struct FullDeps<C, P, SO, AS>
 where
     SO: SyncOracle + Send + Sync + Clone,
 {
@@ -72,15 +72,13 @@ where
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
     /// Segment header provider.
     pub segment_headers_store: SegmentHeadersStore<AS>,
-    /// Provides pieces from piece cache.
-    pub piece_provider: Option<PP>,
     /// Subspace sync oracle
     pub sync_oracle: SubspaceSyncOracle<SO>,
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<C, P, PP, SO, AS>(
-    deps: FullDeps<C, P, PP, SO, AS>,
+pub fn create_full<C, P, SO, AS>(
+    deps: FullDeps<C, P, SO, AS>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
     C: ProvideRuntimeApi<Block>
@@ -95,7 +93,6 @@ where
         + BlockBuilder<Block>
         + sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey>,
     P: TransactionPool + 'static,
-    PP: PieceProvider + Send + Sync + 'static,
     SO: SyncOracle + Send + Sync + Clone + 'static,
     AS: AuxStore + Send + Sync + 'static,
 {
@@ -111,7 +108,6 @@ where
         archived_segment_notification_stream,
         dsn_bootstrap_nodes,
         segment_headers_store,
-        piece_provider,
         sync_oracle,
     } = deps;
 
@@ -132,7 +128,6 @@ where
             archived_segment_notification_stream,
             dsn_bootstrap_nodes,
             segment_headers_store,
-            piece_provider,
             sync_oracle,
         )
         .into_rpc(),


### PR DESCRIPTION
Some preparation I was doing locally.

`UniqueRecordBinaryHeapWrapper` will allow us to wrap `PieceIndex` and use that to save some memory by storing 8 bytes instead of 32 for every entry. It also allows to get the original key rather than `Key`, which will also be helpful in the future when we evict pieces from cache and need to translate evicted piece to offset in a specific single disk plot.

RPC refactoring fixes some edge cases that piece cache on the farmer had to deal with related to race condition between new segment notification being set and actually written to auxiliary storage. We'll be removing node cache and the only user of that on-disk cache now is in `subspace-service`, which makes removal quite easy.

This PR will be followed up by another PR for https://github.com/subspace/subspace/issues/1534

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
