### PR TITLE
Domains: Farmer rewards auto staking

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -109,9 +109,9 @@ mod pallet {
         ScheduledRuntimeUpgrade,
     };
     use crate::staking::{
-        do_deregister_operator, do_nominate_operator, do_register_operator, do_reward_operators,
-        do_switch_operator_domain, do_withdraw_stake, Error as StakingError, Nominator, Operator,
-        OperatorConfig, StakingSummary, Withdraw,
+        do_auto_stake_block_rewards, do_deregister_operator, do_nominate_operator,
+        do_register_operator, do_reward_operators, do_switch_operator_domain, do_withdraw_stake,
+        Error as StakingError, Nominator, Operator, OperatorConfig, StakingSummary, Withdraw,
     };
     use crate::staking_epoch::{
         do_finalize_domain_current_epoch, do_unlock_pending_withdrawals,
@@ -478,6 +478,12 @@ mod pallet {
     pub(super) type LastEpochStakingDistribution<T: Config> =
         StorageMap<_, Identity, DomainId, ElectionVerificationParams<BalanceOf<T>>, OptionQuery>;
 
+    /// A preferred Operator for a given Nominator. Nominator's rewards are auto staked to their
+    /// preferred Operator.
+    #[pallet::storage]
+    pub(super) type PreferredOperator<T: Config> =
+        StorageMap<_, Identity, NominatorId<T>, OperatorId, OptionQuery>;
+
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
         /// Can not find the operator for given operator id.
@@ -587,6 +593,10 @@ mod pallet {
             operator_id: OperatorId,
         },
         WithdrewStake {
+            operator_id: OperatorId,
+            nominator_id: NominatorId<T>,
+        },
+        PreferredOperator {
             operator_id: OperatorId,
             nominator_id: NominatorId<T>,
         },
@@ -895,6 +905,25 @@ mod pallet {
             do_withdraw_stake::<T>(operator_id, who.clone(), withdraw).map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::WithdrewStake {
+                operator_id,
+                nominator_id: who,
+            });
+
+            Ok(())
+        }
+
+        #[pallet::call_index(10)]
+        #[pallet::weight((Weight::from_all(10_000), Pays::Yes))]
+        // TODO: proper benchmark
+        pub fn auto_stake_block_rewards(
+            origin: OriginFor<T>,
+            operator_id: OperatorId,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            do_auto_stake_block_rewards::<T>(who.clone(), operator_id).map_err(Error::<T>::from)?;
+
+            Self::deposit_event(Event::PreferredOperator {
                 operator_id,
                 nominator_id: who,
             });

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -131,7 +131,8 @@ mod pallet {
     use sp_domains::fraud_proof::FraudProof;
     use sp_domains::transaction::InvalidTransactionCode;
     use sp_domains::{
-        DomainId, ExtrinsicsRoot, GenesisDomain, OperatorId, ReceiptHash, RuntimeId, RuntimeType,
+        DomainId, EpochIndex, ExtrinsicsRoot, GenesisDomain, OperatorId, ReceiptHash, RuntimeId,
+        RuntimeType,
     };
     use sp_runtime::traits::{
         AtLeast32BitUnsigned, BlockNumberProvider, Bounded, CheckEqual, CheckedAdd, MaybeDisplay,
@@ -478,8 +479,8 @@ mod pallet {
     pub(super) type LastEpochStakingDistribution<T: Config> =
         StorageMap<_, Identity, DomainId, ElectionVerificationParams<BalanceOf<T>>, OptionQuery>;
 
-    /// A preferred Operator for a given Nominator. Nominator's rewards are auto staked to their
-    /// preferred Operator.
+    /// A preferred Operator for a given Farmer, enabling automatic staking of block rewards.
+    /// For the auto-staking to succeed, the Farmer must also be a Nominator of the preferred Operator.
     #[pallet::storage]
     pub(super) type PreferredOperator<T: Config> =
         StorageMap<_, Identity, NominatorId<T>, OperatorId, OptionQuery>;
@@ -600,6 +601,14 @@ mod pallet {
             operator_id: OperatorId,
             nominator_id: NominatorId<T>,
         },
+        OperatorRewarded {
+            operator_id: OperatorId,
+            reward: BalanceOf<T>,
+        },
+        DomainEpochCompleted {
+            domain_id: DomainId,
+            completed_epoch_index: EpochIndex,
+        },
     }
 
     /// Per-domain state for tx range calculation.
@@ -678,11 +687,16 @@ mod pallet {
                         if pruned_block_info.domain_block_number % T::StakeEpochDuration::get()
                             == Zero::zero()
                         {
-                            do_finalize_domain_current_epoch::<T>(
+                            let completed_epoch_index = do_finalize_domain_current_epoch::<T>(
                                 domain_id,
                                 pruned_block_info.domain_block_number,
                             )
                             .map_err(Error::<T>::from)?;
+
+                            Self::deposit_event(Event::DomainEpochCompleted {
+                                domain_id,
+                                completed_epoch_index,
+                            });
                         }
 
                         do_unlock_pending_withdrawals::<T>(

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -3,7 +3,7 @@
 use crate::pallet::{
     DomainStakingSummary, NextOperatorId, Nominators, OperatorIdOwner, Operators, PendingDeposits,
     PendingNominatorUnlocks, PendingOperatorDeregistrations, PendingOperatorSwitches,
-    PendingOperatorUnlocks, PendingSlashes, PendingWithdrawals,
+    PendingOperatorUnlocks, PendingSlashes, PendingWithdrawals, PreferredOperator,
 };
 use crate::staking_epoch::{mint_funds, PendingNominatorUnlock, PendingOperatorSlashInfo};
 use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
@@ -445,6 +445,28 @@ pub(crate) fn do_reward_operators<T: Config>(
     })
 }
 
+/// Sets Operator as the preferred one to auto stake the block rewards.
+/// Caller must be nominator of the Operator.
+pub(crate) fn do_auto_stake_block_rewards<T: Config>(
+    nominator_id: NominatorId<T>,
+    operator_id: OperatorId,
+) -> Result<(), Error> {
+    // must be a nominator of this operator
+    ensure!(
+        Nominators::<T>::contains_key(operator_id, nominator_id.clone()),
+        Error::UnknownNominator
+    );
+
+    let operator = Operators::<T>::get(operator_id).ok_or(Error::UnknownOperator)?;
+    ensure!(
+        operator.status == OperatorStatus::Registered,
+        Error::OperatorNotRegistered
+    );
+
+    PreferredOperator::<T>::insert(nominator_id, operator_id);
+    Ok(())
+}
+
 #[allow(dead_code)]
 // TODO: remove once fraud proof is done
 /// Freezes the slashed operators and moves the operator to be removed once the domain they are
@@ -529,7 +551,7 @@ pub(crate) mod tests {
     use crate::pallet::{
         DomainStakingSummary, NextOperatorId, OperatorIdOwner, Operators, PendingDeposits,
         PendingNominatorUnlocks, PendingOperatorDeregistrations, PendingOperatorSwitches,
-        PendingSlashes, PendingUnlocks, PendingWithdrawals,
+        PendingSlashes, PendingUnlocks, PendingWithdrawals, PreferredOperator,
     };
     use crate::staking::{
         do_nominate_operator, do_reward_operators, do_slash_operators, do_withdraw_stake,
@@ -1392,6 +1414,51 @@ pub(crate) mod tests {
                 res,
                 Error::<Test>::Staking(crate::staking::Error::TryDepositWithPendingWithdraw)
             )
+        });
+    }
+
+    #[test]
+    fn auto_stake_block_rewards() {
+        let domain_id = DomainId::new(0);
+        let operator_account = 1;
+        let operator_free_balance = 1500 * SSC;
+        let operator_stake = 1000 * SSC;
+        let pair = OperatorPair::from_seed(&U256::from(0u32).into());
+
+        let nominator_account = 2;
+        let nominator_free_balance = 150 * SSC;
+        let nominator_stake = 100 * SSC;
+        let nominators = BTreeMap::from_iter(vec![(
+            nominator_account,
+            (nominator_free_balance, nominator_stake),
+        )]);
+
+        let mut ext = new_test_ext();
+        ext.execute_with(|| {
+            let (operator_id, _) = register_operator(
+                domain_id,
+                operator_account,
+                operator_free_balance,
+                operator_stake,
+                10 * SSC,
+                pair.public(),
+                nominators,
+            );
+
+            // Finalize pending deposit
+            do_finalize_domain_current_epoch::<Test>(domain_id, 0).unwrap();
+            assert!(!PreferredOperator::<Test>::contains_key(nominator_account));
+
+            let res = Domains::auto_stake_block_rewards(
+                RuntimeOrigin::signed(nominator_account),
+                operator_id,
+            );
+            assert_ok!(res);
+
+            assert_eq!(
+                operator_id,
+                PreferredOperator::<Test>::get(nominator_account).unwrap()
+            );
         });
     }
 }

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -6,7 +6,7 @@ use crate::pallet::{
     PendingOperatorUnlocks, PendingSlashes, PendingWithdrawals, PreferredOperator,
 };
 use crate::staking_epoch::{mint_funds, PendingNominatorUnlock, PendingOperatorSlashInfo};
-use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
+use crate::{BalanceOf, Config, Event, HoldIdentifier, NominatorId, Pallet};
 use codec::{Decode, Encode};
 use frame_support::traits::fungible::{Inspect, MutateHold};
 use frame_support::traits::tokens::{Fortitude, Preservation};
@@ -435,6 +435,11 @@ pub(crate) fn do_reward_operators<T: Config>(
             stake_summary
                 .current_epoch_rewards
                 .insert(operator_id, total_reward);
+
+            Pallet::<T>::deposit_event(Event::OperatorRewarded {
+                operator_id,
+                reward: reward_per_operator,
+            });
 
             rewards = rewards
                 .checked_sub(&reward_per_operator)

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -516,6 +516,14 @@ impl pallet_domains::Config for Runtime {
     type TreasuryAccount = TreasuryAccount;
 }
 
+pub struct StakingOnReward;
+
+impl pallet_rewards::OnReward<AccountId, Balance> for StakingOnReward {
+    fn on_reward(account: AccountId, reward: Balance) {
+        Domains::on_block_reward(account, reward);
+    }
+}
+
 parameter_types! {
     pub const BlockReward: Balance = SSC / (ExpectedVotesPerBlock::get() as Balance + 1);
     pub const VoteReward: Balance = SSC / (ExpectedVotesPerBlock::get() as Balance + 1);
@@ -529,7 +537,7 @@ impl pallet_rewards::Config for Runtime {
     type FindBlockRewardAddress = Subspace;
     type FindVotingRewardAddresses = Subspace;
     type WeightInfo = ();
-    type OnReward = ();
+    type OnReward = StakingOnReward;
 }
 
 pub type FeedId = u64;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -529,6 +529,7 @@ impl pallet_rewards::Config for Runtime {
     type FindBlockRewardAddress = Subspace;
     type FindVotingRewardAddresses = Subspace;
     type WeightInfo = ();
+    type OnReward = ();
 }
 
 pub type FeedId = u64;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -581,6 +581,7 @@ impl pallet_rewards::Config for Runtime {
     type FindBlockRewardAddress = Subspace;
     type FindVotingRewardAddresses = Subspace;
     type WeightInfo = ();
+    type OnReward = ();
 }
 
 /// Polkadot-like chain.


### PR DESCRIPTION
This PR brings the farmer rewards auto staking in the following commits
- Introduces OnReward hooks from the reward pallet
- Define Nominator's preferred Operator to auto stake rewards.
- Auto stake farmer rewards to their preferred Operator.

Closes: #1734 
Closes: #1568

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
