### PR TITLE
Downgrade debug networking messages

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -551,10 +551,12 @@ where
                     };
                 }
 
+                debug!(?peer_id, "SwarmEvent::OutgoingConnectionError for peer.");
+
                 match error {
                     DialError::Transport(ref addresses) => {
                         for (addr, _) in addresses {
-                            debug!(?error, ?peer_id, %addr, "SwarmEvent::OutgoingConnectionError (DialError::Transport) for peer.");
+                            trace!(?error, ?peer_id, %addr, "SwarmEvent::OutgoingConnectionError (DialError::Transport) for peer.");
                             if let Some(peer_id) = peer_id {
                                 self.networking_parameters_registry
                                     .remove_known_peer_addresses(peer_id, vec![addr.clone()])
@@ -563,7 +565,7 @@ where
                         }
                     }
                     DialError::WrongPeerId { obtained, .. } => {
-                        debug!(?error, ?peer_id, obtained_peer_id=?obtained, "SwarmEvent::WrongPeerId (DialError::WrongPeerId) for peer.");
+                        trace!(?error, ?peer_id, obtained_peer_id=?obtained, "SwarmEvent::WrongPeerId (DialError::WrongPeerId) for peer.");
 
                         if let Some(ref peer_id) = peer_id {
                             let kademlia = &mut self.swarm.behaviour_mut().kademlia;
@@ -571,7 +573,7 @@ where
                         }
                     }
                     _ => {
-                        debug!(?error, ?peer_id, "SwarmEvent::OutgoingConnectionError");
+                        trace!(?error, ?peer_id, "SwarmEvent::OutgoingConnectionError");
                     }
                 }
             }


### PR DESCRIPTION
The size of those messages is very large and makes CLI output unreadable. I think they should be trace messages instead. Feel free to suggest an alternative that prints more details, but certainly not the whole error stack and complete list of addresses.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
