### PR TITLE
Fix segment headers limit

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -209,14 +209,15 @@ pub(super) fn configure_dsn(
                             segment_indexes.clone()
                         }
                         SegmentHeaderRequest::LastSegmentHeaders {
-                            segment_header_number,
+                            mut segment_header_number,
                         } => {
                             if segment_header_number > SEGMENT_HEADER_NUMBER_LIMIT {
                                 debug!(
                                     %segment_header_number,
                                     "Segment header number exceeded the limit."
                                 );
-                                return None;
+
+                                segment_header_number = SEGMENT_HEADER_NUMBER_LIMIT;
                             }
 
                             let last_segment_index = SegmentIndex::from(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -21,9 +21,13 @@ use subspace_networking::{
     PieceByHashRequestHandler, PieceByHashResponse, SegmentHeaderBySegmentIndexesRequestHandler,
     SegmentHeaderRequest, SegmentHeaderResponse,
 };
+use subspace_rpc_primitives::MAX_SEGMENT_HEADERS_PER_REQUEST;
 use tracing::{debug, error, info, Instrument};
 
-const SEGMENT_HEADER_NUMBER_LIMIT: u64 = 1000;
+/// How many segment headers can be requested at a time.
+///
+/// Must be the same as RPC limit since all requests go to the node anyway.
+const SEGMENT_HEADER_NUMBER_LIMIT: u64 = MAX_SEGMENT_HEADERS_PER_REQUEST as u64;
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub(super) fn configure_dsn(

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -23,7 +23,7 @@ use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_networking::libp2p::Multiaddr;
 
 /// Defines a limit for number of segments that can be requested over RPC
-pub const MAX_SEGMENT_HEADERS_PER_REQUEST: usize = 300;
+pub const MAX_SEGMENT_HEADERS_PER_REQUEST: usize = 1000;
 
 /// Information necessary for farmer application
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -16,7 +16,7 @@ use subspace_networking::{
 use thiserror::Error;
 use tracing::{debug, error, trace};
 
-const SEGMENT_HEADERS_NUMBER_LIMIT: u64 = 100;
+const SEGMENT_HEADERS_NUMBER_LIMIT: u64 = 1000;
 
 /// Errors that might happen during DSN configuration.
 #[derive(Debug, Error)]


### PR DESCRIPTION
We somehow made it impossible to request segment headers due to node limit for responses being 100, limit for RPC being 300 and limit specified in request being 1000. While farmer was able to clamp the requested range to static limit, node was not.

No idea how this happened, but this was wrong and fixed here.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
