### PR TITLE
DSN external addresses.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -42,6 +42,7 @@ pub(super) fn configure_dsn(
         pending_in_connections,
         pending_out_connections,
         target_connections,
+        external_addresses,
     }: DsnArgs,
     readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
     node_client: NodeRpcClient,
@@ -271,6 +272,7 @@ pub(super) fn configure_dsn(
             !PeerInfo::is_farmer(peer_info)
         })),
         bootstrap_addresses: bootstrap_nodes,
+        external_addresses,
         ..default_config
     };
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -103,6 +103,9 @@ struct DsnArgs {
     /// Defines target total (in and out) connection number that should be maintained.
     #[arg(long, default_value_t = 50)]
     target_connections: u32,
+    /// Known external addresses
+    #[arg(long, alias = "external-address")]
+    external_addresses: Vec<Multiaddr>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -118,6 +121,7 @@ impl Default for WriteToDisk {
     }
 }
 
+#[allow(clippy::large_enum_variant)] // we allow large function parameter list and enums
 #[derive(Debug, clap::Subcommand)]
 enum Subcommand {
     /// Wipes plot and identity

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -63,6 +63,9 @@ enum Command {
         /// production use.
         #[arg(long)]
         protocol_version: String,
+        /// Known external addresses
+        #[arg(long, alias = "external-address")]
+        external_addresses: Vec<Multiaddr>,
     },
     /// Generate a new keypair
     GenerateKeypair {
@@ -126,6 +129,7 @@ async fn main() -> anyhow::Result<()> {
             db_path,
             piece_providers_cache_size,
             protocol_version,
+            external_addresses,
         } => {
             debug!(
                 "Libp2p protocol stack instantiated with version: {} ",
@@ -178,6 +182,7 @@ async fn main() -> anyhow::Result<()> {
                 general_connected_peers_handler: None,
                 special_connected_peers_handler: None,
                 bootstrap_addresses: bootstrap_nodes,
+                external_addresses,
 
                 ..Config::new(
                     protocol_version.to_string(),

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -493,7 +493,7 @@ where
     }
 
     // Setup external addresses
-    for addr in external_addresses {
+    for addr in external_addresses.iter().cloned() {
         info!("DSN external address added: {addr}");
         swarm.add_external_address(addr);
     }
@@ -529,6 +529,7 @@ where
         special_connection_decision_handler,
         bootstrap_addresses,
         kademlia_mode,
+        external_addresses,
     });
 
     Ok((node, node_runner))

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -227,6 +227,9 @@ pub struct Config<ProviderStorage> {
     pub bootstrap_addresses: Vec<Multiaddr>,
     /// Kademlia mode. None means "automatic mode".
     pub kademlia_mode: Option<Mode>,
+    /// Known external addresses to the local peer. The addresses will be added on the swarm start
+    /// and enable peer to notify others about its reachable address.
+    pub external_addresses: Vec<Multiaddr>,
 }
 
 impl<ProviderStorage> fmt::Debug for Config<ProviderStorage> {
@@ -341,6 +344,7 @@ where
             special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             bootstrap_addresses: Vec::new(),
             kademlia_mode: Some(Mode::Server),
+            external_addresses: Vec::new(),
         }
     }
 }
@@ -405,6 +409,7 @@ where
         special_target_connections,
         bootstrap_addresses,
         kademlia_mode,
+        external_addresses,
     } = config;
     let local_peer_id = peer_id(&keypair);
 
@@ -485,6 +490,12 @@ where
                 swarm.listen_on(addr)?;
             }
         }
+    }
+
+    // Setup external addresses
+    for addr in external_addresses {
+        info!("DSN external address added: {addr}");
+        swarm.add_external_address(addr);
     }
 
     // Create final structs

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -411,6 +411,7 @@ fn main() -> Result<(), Error> {
                             max_pending_in_connections: cli.dsn_pending_in_connections,
                             max_pending_out_connections: cli.dsn_pending_out_connections,
                             target_connections: cli.dsn_target_connections,
+                            external_addresses: cli.dsn_external_addresses,
                         }
                     };
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -222,6 +222,10 @@ pub struct Cli {
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub sync_from_dsn: bool,
 
+    /// Known external addresses
+    #[arg(long, alias = "dsn-external-address")]
+    pub dsn_external_addresses: Vec<Multiaddr>,
+
     /// Piece cache size in human readable format (e.g. 10GB, 2TiB) or just bytes (e.g. 4096).
     #[arg(long, default_value = "1GiB")]
     pub piece_cache_size: ByteSize,

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -67,6 +67,9 @@ pub struct DsnConfig {
 
     /// Defines target total (in and out) connection number for DSN that should be maintained.
     pub target_connections: u32,
+
+    /// Known external addresses
+    pub external_addresses: Vec<Multiaddr>,
 }
 
 pub(crate) fn create_dsn_instance<AS>(
@@ -175,6 +178,7 @@ where
         // maintain permanent connections with any peer
         general_connected_peers_handler: Some(Arc::new(|_| true)),
         bootstrap_addresses: dsn_config.bootstrap_nodes,
+        external_addresses: dsn_config.external_addresses,
 
         ..default_networking_config
     };


### PR DESCRIPTION
This PR adds two features to DSN apps (node, farmer, and bootstrap-node):
- CLI arguments for specifying external addresses (`--external-address` or `--dsn-external-address` for node)
- adding observed external address to swarm - the last libp2p upgrade removed auto adding such addresses that led to having `ProviderRecord` without external addresses and decreased chances to get pieces

The current fix for observed addresses support only `tcp` protocol and should be modified to support `quic` and the proper solution is to add autonat as recommended by libp2p docs. Another limitation is that the external address port should be equal to one of the listeners' ports.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
