### PR TITLE
Improve sync effectiveness by checking last 2 segment headers only

### DIFF
--- a/crates/subspace-service/src/dsn/import_blocks/segment_headers.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/segment_headers.rs
@@ -113,7 +113,9 @@ impl SegmentHeaderHandler {
                         .send_generic_request(
                             peer_id,
                             SegmentHeaderRequest::LastSegmentHeaders {
-                                segment_header_number: SEGMENT_HEADER_NUMBER_PER_REQUEST,
+                                // Request 2 top segment headers, accounting for situations when new
+                                // segment header was just produced and not all nodes have it
+                                segment_header_number: 2,
                             },
                         )
                         .await;


### PR DESCRIPTION
Here is a spec discussion: https://www.notion.so/Subspace-Dilithium-Consensus-Specification-v2-3-274a730b53eb4c93a8d879b90de532ce?d=aa3f2a4ad43c47aa8a4b2964d154876f&pvs=4#a7546828b97a4a87b33e67399a37a97c

But basically right now when node sees tips 6,6,0,6, it picks 0 as the segment header present on most nodes (it compares up to 1000 last segment headers and unless there are forks effectively always prefers one that is the least synced). By comparing just last two we improve effectiveness of DSN sync by syncing onto much newer segment header.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
