### PR TITLE
Improve plotting performance

### DIFF
--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -91,7 +91,7 @@ impl SectorMetadata {
 }
 
 /// Commitment and witness corresponding to the same record
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Default, Clone, Encode, Decode)]
 pub struct RecordMetadata {
     /// Record commitment
     pub commitment: RecordCommitment,
@@ -109,12 +109,11 @@ pub struct RawSector {
 }
 
 impl RawSector {
-    /// Create new raw sector with internal vectors being allocated (but not filled) to be able to
-    /// store data for specified number of pieces in sector
+    /// Create new raw sector with internal vectors being allocated and filled with default values
     pub fn new(pieces_in_sector: u16) -> Self {
         Self {
-            records: Vec::with_capacity(usize::from(pieces_in_sector)),
-            metadata: Vec::with_capacity(usize::from(pieces_in_sector)),
+            records: Record::new_zero_vec(usize::from(pieces_in_sector)),
+            metadata: vec![RecordMetadata::default(); usize::from(pieces_in_sector)],
         }
     }
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -106,7 +106,7 @@ where
             base_path,
             keypair,
             dsn,
-            &readers_and_pieces,
+            Arc::downgrade(&readers_and_pieces),
             node_client.clone(),
             archival_storage_pieces.clone(),
             archival_storage_info.clone(),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -137,6 +137,7 @@ where
         piece_provider,
         piece_cache.clone(),
         archival_storage_info,
+        Arc::clone(&readers_and_pieces),
     ));
 
     let _piece_cache_worker = run_future_in_dedicated_thread(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use parking_lot::Mutex;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use subspace_core_primitives::SegmentIndex;
 use subspace_farmer::piece_cache::PieceCache;
 use subspace_farmer::utils::archival_storage_info::ArchivalStorageInfo;
@@ -47,7 +47,7 @@ pub(super) fn configure_dsn(
         target_connections,
         external_addresses,
     }: DsnArgs,
-    readers_and_pieces: &Arc<Mutex<Option<ReadersAndPieces>>>,
+    weak_readers_and_pieces: Weak<Mutex<Option<ReadersAndPieces>>>,
     node_client: NodeRpcClient,
     archival_storage_pieces: ArchivalStoragePieces,
     archival_storage_info: ArchivalStorageInfo,
@@ -60,8 +60,6 @@ pub(super) fn configure_dsn(
 
         NetworkingParametersManager::new(&known_addresses_db_path).map(|manager| manager.boxed())?
     };
-
-    let weak_readers_and_pieces = Arc::downgrade(readers_and_pieces);
 
     let provider_db_path = base_path.join("providers_db");
 

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -143,6 +143,12 @@ where
 
             if let Some(old_sector_metadata) = &maybe_old_sector_metadata {
                 if farmer_app_info.protocol_info.history_size <= old_sector_metadata.history_size {
+                    debug!(
+                        current_history_size = %farmer_app_info.protocol_info.history_size,
+                        old_sector_history_size = %old_sector_metadata.history_size,
+                        "Latest protocol history size is not yet newer than old sector history \
+                        size, wait for a bit and try again"
+                    );
                     tokio::time::sleep(FARMER_APP_INFO_RETRY_INTERVAL).await;
                     continue;
                 }


### PR DESCRIPTION
Here I have a few somewhat obvious small improvements for plotting process that should significantly improve experience on devnet.

Piece retrieval from DSN was optimized to retrieve pieces out of order (better performance overall) and incrementally build sector without throwing away previously downloaded pieces in case some pieces failed to download. In other words if some pieces are unavailable, retry will only be done to those pieces, saving requests and time.

Another improvement is primarily for small network/large plot, where pieces that are neither in local cache nor in L2 are first searched in local plots before reaching out to external archival storage, which should also help with small networks where farmer that is trying to plot might end up being the only source of the pieces they are trying to get.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
