### PR TITLE
Allow customizing cache size for farmers with CLI argument

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -62,6 +62,7 @@ where
         disable_farming,
         mut dsn,
         max_concurrent_plots,
+        cache_percentage,
         no_info: _,
     } = farming_args;
 
@@ -180,6 +181,7 @@ where
                 kzg: kzg.clone(),
                 erasure_coding: erasure_coding.clone(),
                 piece_getter: piece_getter.clone(),
+                cache_percentage,
             },
             disk_farm_index,
         );

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -5,12 +5,11 @@ mod ss58;
 mod utils;
 
 use crate::utils::get_usable_plot_space;
-use anyhow::Result;
 use bytesize::ByteSize;
 use clap::{Parser, ValueEnum, ValueHint};
 use ss58::parse_ss58_reward_address;
 use std::fs;
-use std::num::{NonZeroU16, NonZeroUsize};
+use std::num::{NonZeroU16, NonZeroU8, NonZeroUsize};
 use std::path::PathBuf;
 use std::str::FromStr;
 use subspace_core_primitives::PublicKey;
@@ -61,9 +60,22 @@ struct FarmingArgs {
     /// Number of plots that can be plotted concurrently, impacts RAM usage.
     #[arg(long, default_value = "10")]
     max_concurrent_plots: NonZeroUsize,
+    /// Percentage of plot dedicated for caching purposes, 99% max.
+    #[arg(long, default_value = "1", value_parser = cache_percentage_parser)]
+    cache_percentage: NonZeroU8,
     /// Do not print info about configured farms on startup.
     #[arg(long)]
     no_info: bool,
+}
+
+fn cache_percentage_parser(s: &str) -> anyhow::Result<NonZeroU8> {
+    let cache_percentage = NonZeroU8::from_str(s)?;
+
+    if cache_percentage.get() > 99 {
+        return Err(anyhow::anyhow!("Cache percentage can't exceed 100"));
+    }
+
+    Ok(cache_percentage)
 }
 
 /// Arguments for DSN
@@ -140,7 +152,7 @@ struct DiskFarm {
 impl FromStr for DiskFarm {
     type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> anyhow::Result<Self, Self::Err> {
         let parts = s.split(',').collect::<Vec<_>>();
         if parts.len() != 2 {
             return Err("Must contain 2 coma-separated components".to_string());
@@ -227,7 +239,7 @@ struct Command {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
             fmt::layer().with_filter(


### PR DESCRIPTION
This removes hardcoded constant and allows to customize cache size from 1% (default) to 99%.

Resolves first half of https://github.com/subspace/subspace/issues/1755, we'll remove node cache later.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
