### PR TITLE
Disable incremental archiving during major sync

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -378,7 +378,7 @@ pub fn create_archived_segment(kzg: Kzg) -> NewArchivedSegment {
     let mut block = vec![0u8; RecordedHistorySegment::SIZE];
     rand::thread_rng().fill(block.as_mut_slice());
     archiver
-        .add_block(block, Default::default())
+        .add_block(block, Default::default(), true)
         .into_iter()
         .next()
         .unwrap()

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -74,7 +74,7 @@ fn archived_segment(kzg: Kzg) -> NewArchivedSegment {
     let mut archiver = Archiver::new(kzg).unwrap();
 
     archiver
-        .add_block(block, Default::default())
+        .add_block(block, Default::default(), true)
         .into_iter()
         .next()
         .unwrap()

--- a/crates/subspace-archiving/benches/archiving.rs
+++ b/crates/subspace-archiving/benches/archiving.rs
@@ -1,10 +1,10 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 
-const AMOUNT_OF_DATA: usize = 1024 * 1024;
+const AMOUNT_OF_DATA: usize = 5 * 1024 * 1024;
 const SMALL_BLOCK_SIZE: usize = 500;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -15,17 +15,36 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("segment-archiving-large-block", |b| {
         b.iter(|| {
-            archiver
-                .clone()
-                .add_block(input.clone(), Default::default());
+            archiver.clone().add_block(
+                black_box(input.clone()),
+                black_box(Default::default()),
+                black_box(true),
+            );
         })
     });
 
-    c.bench_function("segment-archiving-small-blocks", |b| {
+    c.bench_function("segment-archiving-small-blocks/incremental", |b| {
         b.iter(|| {
             let mut archiver = archiver.clone();
             for chunk in input.chunks(SMALL_BLOCK_SIZE) {
-                archiver.add_block(chunk.to_vec(), Default::default());
+                archiver.add_block(
+                    black_box(chunk.to_vec()),
+                    black_box(Default::default()),
+                    black_box(true),
+                );
+            }
+        })
+    });
+
+    c.bench_function("segment-archiving-small-blocks/non-incremental", |b| {
+        b.iter(|| {
+            let mut archiver = archiver.clone();
+            for chunk in input.chunks(SMALL_BLOCK_SIZE) {
+                archiver.add_block(
+                    black_box(chunk.to_vec()),
+                    black_box(Default::default()),
+                    black_box(false),
+                );
             }
         })
     });

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -95,7 +95,7 @@ fn archiver() {
     };
     // There is not enough data to produce archived segment yet
     assert!(archiver
-        .add_block(block_0.clone(), block_0_object_mapping.clone())
+        .add_block(block_0.clone(), block_0_object_mapping.clone(), true)
         .is_empty());
 
     let (block_1, block_1_object_mapping) = {
@@ -133,7 +133,8 @@ fn archiver() {
         (block, object_mapping)
     };
     // This should produce 1 archived segment
-    let archived_segments = archiver.add_block(block_1.clone(), block_1_object_mapping.clone());
+    let archived_segments =
+        archiver.add_block(block_1.clone(), block_1_object_mapping.clone(), true);
     assert_eq!(archived_segments.len(), 1);
 
     let first_archived_segment = archived_segments.into_iter().next().unwrap();
@@ -210,7 +211,8 @@ fn archiver() {
         block
     };
     // This should be big enough to produce two archived segments in one go
-    let archived_segments = archiver.add_block(block_2.clone(), BlockObjectMapping::default());
+    let archived_segments =
+        archiver.add_block(block_2.clone(), BlockObjectMapping::default(), true);
     assert_eq!(archived_segments.len(), 2);
 
     // Check that initializing archiver with initial state before last block results in the same
@@ -225,7 +227,11 @@ fn archiver() {
         .unwrap();
 
         assert_eq!(
-            archiver_with_initial_state.add_block(block_2.clone(), BlockObjectMapping::default()),
+            archiver_with_initial_state.add_block(
+                block_2.clone(),
+                BlockObjectMapping::default(),
+                true
+            ),
             archived_segments,
         );
     }
@@ -331,7 +337,8 @@ fn archiver() {
         thread_rng().fill(block.as_mut_slice());
         block
     };
-    let archived_segments = archiver.add_block(block_3.clone(), BlockObjectMapping::default());
+    let archived_segments =
+        archiver.add_block(block_3.clone(), BlockObjectMapping::default(), true);
     assert_eq!(archived_segments.len(), 1);
 
     // Check that initializing archiver with initial state before last block results in the same
@@ -346,7 +353,7 @@ fn archiver() {
         .unwrap();
 
         assert_eq!(
-            archiver_with_initial_state.add_block(block_3, BlockObjectMapping::default()),
+            archiver_with_initial_state.add_block(block_3, BlockObjectMapping::default(), true),
             archived_segments,
         );
     }
@@ -466,7 +473,7 @@ fn one_byte_smaller_segment() {
     assert_eq!(
         Archiver::new(kzg.clone())
             .unwrap()
-            .add_block(vec![0u8; block_size], BlockObjectMapping::default())
+            .add_block(vec![0u8; block_size], BlockObjectMapping::default(), true)
             .len(),
         1
     );
@@ -474,7 +481,11 @@ fn one_byte_smaller_segment() {
     // against code regressions
     assert!(Archiver::new(kzg)
         .unwrap()
-        .add_block(vec![0u8; block_size - 1], BlockObjectMapping::default())
+        .add_block(
+            vec![0u8; block_size - 1],
+            BlockObjectMapping::default(),
+            true
+        )
         .is_empty());
 }
 
@@ -498,7 +509,7 @@ fn spill_over_edge_case() {
         // We leave three bytes at the end intentionally
         - 3;
     assert!(archiver
-        .add_block(vec![0u8; block_size], BlockObjectMapping::default())
+        .add_block(vec![0u8; block_size], BlockObjectMapping::default(), true)
         .is_empty());
 
     // Here we add one more block with internal length that takes 4 bytes in compact length
@@ -513,6 +524,7 @@ fn spill_over_edge_case() {
                 offset: 0,
             }],
         },
+        true,
     );
     assert_eq!(archived_segments.len(), 2);
     // If spill over actually happened, we'll not find object mapping in the first segment
@@ -539,7 +551,8 @@ fn object_on_the_edge_of_segment() {
     let kzg = Kzg::new(embedded_kzg_settings());
     let mut archiver = Archiver::new(kzg).unwrap();
     let first_block = vec![0u8; RecordedHistorySegment::SIZE];
-    let archived_segments = archiver.add_block(first_block.clone(), BlockObjectMapping::default());
+    let archived_segments =
+        archiver.add_block(first_block.clone(), BlockObjectMapping::default(), true);
     assert_eq!(archived_segments.len(), 1);
     let archived_segment = archived_segments.into_iter().next().unwrap();
     let left_unarchived_from_first_block = first_block.len() as u32
@@ -600,6 +613,7 @@ fn object_on_the_edge_of_segment() {
                     offset: object_mapping.offset() - 1,
                 }],
             },
+            true,
         );
 
         assert_eq!(archived_segments.len(), 2);
@@ -618,6 +632,7 @@ fn object_on_the_edge_of_segment() {
         BlockObjectMapping {
             objects: vec![object_mapping],
         },
+        true,
     );
 
     assert_eq!(archived_segments.len(), 2);

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -25,7 +25,7 @@ fn segment_reconstruction_works() {
 
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default());
+    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
 
     assert_eq!(archived_segments.len(), 1);
 
@@ -66,7 +66,7 @@ fn piece_reconstruction_works() {
     // Block that fits into the segment fully
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default());
+    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
 
     assert_eq!(archived_segments.len(), 1);
 
@@ -126,7 +126,7 @@ fn segment_reconstruction_fails() {
     // Block that fits into the segment fully
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default());
+    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
 
     assert_eq!(archived_segments.len(), 1);
 
@@ -163,7 +163,7 @@ fn piece_reconstruction_fails() {
     // Block that fits into the segment fully
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default());
+    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
 
     assert_eq!(archived_segments.len(), 1);
 

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -49,12 +49,12 @@ fn basic() {
         block
     };
     let archived_segments = archiver
-        .add_block(block_0.clone(), BlockObjectMapping::default())
+        .add_block(block_0.clone(), BlockObjectMapping::default(), true)
         .into_iter()
-        .chain(archiver.add_block(block_1.clone(), BlockObjectMapping::default()))
-        .chain(archiver.add_block(block_2.clone(), BlockObjectMapping::default()))
-        .chain(archiver.add_block(block_3.clone(), BlockObjectMapping::default()))
-        .chain(archiver.add_block(block_4, BlockObjectMapping::default()))
+        .chain(archiver.add_block(block_1.clone(), BlockObjectMapping::default(), true))
+        .chain(archiver.add_block(block_2.clone(), BlockObjectMapping::default(), true))
+        .chain(archiver.add_block(block_3.clone(), BlockObjectMapping::default(), true))
+        .chain(archiver.add_block(block_4, BlockObjectMapping::default(), true))
         .collect::<Vec<_>>();
 
     assert_eq!(archived_segments.len(), 5);
@@ -257,9 +257,9 @@ fn partial_data() {
         block
     };
     let archived_segments = archiver
-        .add_block(block_0.clone(), BlockObjectMapping::default())
+        .add_block(block_0.clone(), BlockObjectMapping::default(), true)
         .into_iter()
-        .chain(archiver.add_block(block_1, BlockObjectMapping::default()))
+        .chain(archiver.add_block(block_1, BlockObjectMapping::default(), true))
         .collect::<Vec<_>>();
 
     assert_eq!(archived_segments.len(), 1);
@@ -332,7 +332,7 @@ fn invalid_usage() {
         block
     };
 
-    let archived_segments = archiver.add_block(block_0, BlockObjectMapping::default());
+    let archived_segments = archiver.add_block(block_0, BlockObjectMapping::default(), true);
 
     assert_eq!(archived_segments.len(), 4);
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -57,6 +57,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
+            true,
         )
         .into_iter()
         .next()

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -39,6 +39,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
+            true,
         )
         .into_iter()
         .next()

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -59,6 +59,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
+            true,
         )
         .into_iter()
         .next()

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -56,6 +56,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
+            true,
         )
         .into_iter()
         .next()

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -228,7 +228,7 @@ where
 
     let genesis_block = client.block(client.info().genesis_hash).unwrap().unwrap();
     let archived_segment = archiver
-        .add_block(genesis_block.encode(), BlockObjectMapping::default())
+        .add_block(genesis_block.encode(), BlockObjectMapping::default(), true)
         .into_iter()
         .next()
         .expect("First block is always producing one segment; qed");


### PR DESCRIPTION
Should help significantly when syncing large number of small blocks. The only reason we have incremental archiving support is to amortize the cost of archiving over period of time, but during sync we'd rather use all cores since we have a lot of blocks to process.

Fixes https://github.com/subspace/subspace/issues/1726

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
