### PR TITLE
Farmer checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11153,6 +11153,7 @@ dependencies = [
  "criterion",
  "fs2",
  "futures",
+ "hex",
  "libc",
  "lru 0.10.0",
  "memmap2 0.7.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq 0.3.0",
  "digest 0.10.7",
+ "rayon",
 ]
 
 [[package]]

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -50,7 +50,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
-use subspace_farmer_components::sector::{sector_size, SectorMetadata};
+use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::Table;
@@ -421,7 +421,7 @@ pub fn create_signed_vote(
 
     for sector_index in iter::from_fn(|| Some(rand::random())) {
         let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadataChecksummed::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -31,7 +31,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
-use subspace_farmer_components::sector::{sector_size, SectorMetadata};
+use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::Table;
 use subspace_solving::REWARD_SIGNING_CONTEXT;
@@ -159,7 +159,7 @@ fn valid_header(
 
     for sector_index in iter::from_fn(|| Some(rand::random())) {
         let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadataChecksummed::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -66,7 +66,7 @@ impl Encode for Segment {
         RecordedHistorySegment::SIZE
     }
 
-    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+    fn encode_to<O: Output + ?Sized>(&self, dest: &mut O) {
         match self {
             Segment::V0 { items } => {
                 dest.push_byte(0);

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -54,6 +54,7 @@ default = [
 embedded-kzg-settings = []
 # Enables some APIs and internal parallelism for KZG
 parallel = [
+    "blake3/rayon",
     "blst_rust/parallel",
     "dep:rayon",
 ]

--- a/crates/subspace-core-primitives/src/checksum.rs
+++ b/crates/subspace-core-primitives/src/checksum.rs
@@ -1,0 +1,144 @@
+//! Module containing wrapper for SCALE encoding/decoding with checksum
+
+#[cfg(test)]
+mod tests;
+
+use crate::Blake3Hash;
+use core::mem;
+use parity_scale_codec::{Decode, Encode, EncodeLike, Error, Input, Output};
+
+/// Output wrapper for SCALE codec that will write Blake3 checksum at the end of the encoding
+struct Blake3ChecksumOutput<'a, O>
+where
+    O: Output + ?Sized,
+{
+    output: &'a mut O,
+    hasher: blake3::Hasher,
+}
+
+impl<'a, O> Drop for Blake3ChecksumOutput<'a, O>
+where
+    O: Output + ?Sized,
+{
+    #[inline]
+    fn drop(&mut self) {
+        // Write checksum at the very end of encoding
+        let hash = *self.hasher.finalize().as_bytes();
+        hash.encode_to(self.output);
+    }
+}
+
+impl<'a, O> Output for Blake3ChecksumOutput<'a, O>
+where
+    O: Output + ?Sized,
+{
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.hasher.update(bytes);
+        self.output.write(bytes);
+    }
+}
+
+impl<'a, O> Blake3ChecksumOutput<'a, O>
+where
+    O: Output + ?Sized,
+{
+    fn new(output: &'a mut O) -> Self {
+        Self {
+            output,
+            hasher: blake3::Hasher::new(),
+        }
+    }
+}
+
+/// Input wrapper for SCALE codec that will write Blake3 checksum at the end of the encoding
+struct Blake3ChecksumInput<'a, I>
+where
+    I: Input,
+{
+    input: &'a mut I,
+    hasher: blake3::Hasher,
+}
+
+impl<'a, I> Input for Blake3ChecksumInput<'a, I>
+where
+    I: Input,
+{
+    #[inline]
+    fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
+        self.input.remaining_len()
+    }
+
+    #[inline]
+    fn read(&mut self, into: &mut [u8]) -> Result<(), Error> {
+        self.input.read(into)?;
+        self.hasher.update(into);
+        Ok(())
+    }
+}
+
+impl<'a, I> Blake3ChecksumInput<'a, I>
+where
+    I: Input,
+{
+    fn new(output: &'a mut I) -> Self {
+        Self {
+            input: output,
+            hasher: blake3::Hasher::new(),
+        }
+    }
+
+    fn finish(self) -> (Blake3Hash, &'a mut I) {
+        // Compute checksum at the very end of decoding
+        let hash = *self.hasher.finalize().as_bytes();
+        (hash, self.input)
+    }
+}
+
+/// Wrapper data structure that when encoded/decoded will create/check Blake3 checksum
+#[derive(Debug, Clone)]
+pub struct Blake3Checksummed<T>(pub T);
+
+impl<T> Encode for Blake3Checksummed<T>
+where
+    T: Encode,
+{
+    #[inline]
+    fn size_hint(&self) -> usize {
+        self.0.size_hint() + mem::size_of::<Blake3Hash>()
+    }
+
+    #[inline]
+    fn encode_to<O>(&self, dest: &mut O)
+    where
+        O: Output + ?Sized,
+    {
+        self.0.encode_to(&mut Blake3ChecksumOutput::new(dest));
+    }
+
+    #[inline]
+    fn encoded_size(&self) -> usize {
+        self.0.encoded_size() + mem::size_of::<Blake3Hash>()
+    }
+}
+
+impl<T> EncodeLike for Blake3Checksummed<T> where T: EncodeLike {}
+
+impl<T> Decode for Blake3Checksummed<T>
+where
+    T: Decode,
+{
+    #[inline]
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        let mut input = Blake3ChecksumInput::new(input);
+        let data = T::decode(&mut input)?;
+        let (actual_hash, input) = input.finish();
+        let expected_hash = Blake3Hash::decode(input)?;
+
+        if actual_hash == expected_hash {
+            Ok(Self(data))
+        } else {
+            Err(Error::from("Checksum mismatch"))
+        }
+    }
+}

--- a/crates/subspace-core-primitives/src/checksum/tests.rs
+++ b/crates/subspace-core-primitives/src/checksum/tests.rs
@@ -1,0 +1,30 @@
+use super::Blake3Checksummed;
+use crate::Blake3Hash;
+use parity_scale_codec::{Decode, Encode};
+use rand::prelude::*;
+use std::mem;
+
+#[test]
+fn basic() {
+    let random_bytes = random::<[u8; 64]>();
+
+    let plain_encoding = random_bytes.encode();
+    let checksummed_encoding = Blake3Checksummed(random_bytes).encode();
+
+    // Encoding is extended with checksum
+    assert_eq!(
+        plain_encoding.len() + mem::size_of::<Blake3Hash>(),
+        checksummed_encoding.len()
+    );
+
+    // Decoding succeeds
+    let Blake3Checksummed(decoded_random_bytes) =
+        Blake3Checksummed::<[u8; 64]>::decode(&mut checksummed_encoding.as_slice()).unwrap();
+    // Decodes to original data
+    assert_eq!(random_bytes, decoded_random_bytes);
+
+    // Non-checksummed encoding fails to decode
+    assert!(Blake3Checksummed::<[u8; 64]>::decode(&mut plain_encoding.as_slice()).is_err());
+    // Incorrectly checksummed data fails to decode
+    assert!(Blake3Checksummed::<[u8; 32]>::decode(&mut random::<[u8; 64]>().as_ref()).is_err());
+}

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -89,6 +89,14 @@ pub fn blake3_hash(data: &[u8]) -> Blake3Hash {
     *blake3::hash(data).as_bytes()
 }
 
+/// BLAKE3 hashing of a single value in parallel (only useful for large values well above 128kiB).
+#[cfg(feature = "parallel")]
+pub fn blake3_hash_parallel(data: &[u8]) -> Blake3Hash {
+    let mut state = blake3::Hasher::new();
+    state.update_rayon(data);
+    *state.finalize().as_bytes()
+}
+
 /// BLAKE3 hashing of a list of values.
 pub fn blake3_hash_list(data: &[&[u8]]) -> Blake3Hash {
     let mut state = blake3::Hasher::new();

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -29,6 +29,7 @@
     step_trait
 )]
 
+pub mod checksum;
 pub mod crypto;
 pub mod objects;
 mod pieces;
@@ -122,7 +123,7 @@ impl Randomness {
     /// Derive global slot challenge from global randomness.
     // TODO: Separate type for global challenge
     pub fn derive_global_challenge(&self, slot: SlotNumber) -> Blake2b256Hash {
-        crypto::blake2b_256_hash_list(&[&self.0, &slot.to_le_bytes()])
+        blake2b_256_hash_list(&[&self.0, &slot.to_le_bytes()])
     }
 }
 

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -21,6 +21,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bitvec = "1.0.1"
 fs2 = "0.4.3"
 futures = "0.3.28"
+hex = "0.4.3"
 libc = "0.2.146"
 lru = "0.10.0"
 parity-scale-codec = "3.6.3"

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -18,7 +18,9 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
-use subspace_farmer_components::sector::{sector_size, SectorContentsMap, SectorMetadata};
+use subspace_farmer_components::sector::{
+    sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
+};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
@@ -93,12 +95,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
         )
         .unwrap();
-        let sector_metadata = SectorMetadata {
+        let sector_metadata = SectorMetadataChecksummed::from(SectorMetadata {
             sector_index,
             pieces_in_sector,
             s_bucket_sizes: sector_contents_map.s_bucket_sizes(),
             history_size: farmer_protocol_info.history_size,
-        };
+        });
 
         (
             PlottedSector {
@@ -113,7 +115,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         println!("Plotting one sector...");
 
         let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadataChecksummed::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -9,7 +9,7 @@ use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{HistorySize, PublicKey, Record, RecordedHistorySegment};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
-use subspace_farmer_components::sector::{sector_size, SectorMetadata};
+use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
@@ -59,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let sector_size = sector_size(pieces_in_sector);
     let mut sector_bytes = vec![0; sector_size];
-    let mut sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+    let mut sector_metadata_bytes = vec![0; SectorMetadataChecksummed::encoded_size()];
 
     let mut group = c.benchmark_group("plotting");
     group.throughput(Throughput::Bytes(sector_size as u64));

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -18,7 +18,9 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
-use subspace_farmer_components::sector::{sector_size, SectorContentsMap, SectorMetadata};
+use subspace_farmer_components::sector::{
+    sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
+};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
@@ -95,12 +97,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
         )
         .unwrap();
-        let sector_metadata = SectorMetadata {
+        let sector_metadata = SectorMetadataChecksummed::from(SectorMetadata {
             sector_index,
             pieces_in_sector,
             s_bucket_sizes: sector_contents_map.s_bucket_sizes(),
             history_size: farmer_protocol_info.history_size,
-        };
+        });
 
         (
             PlottedSector {
@@ -115,7 +117,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         println!("Plotting one sector...");
 
         let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadataChecksummed::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -17,7 +17,9 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
 use subspace_farmer_components::reading::read_piece;
-use subspace_farmer_components::sector::{sector_size, SectorContentsMap, SectorMetadata};
+use subspace_farmer_components::sector::{
+    sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
+};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
@@ -90,12 +92,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
         )
         .unwrap();
-        let sector_metadata = SectorMetadata {
+        let sector_metadata = SectorMetadataChecksummed::from(SectorMetadata {
             sector_index,
             pieces_in_sector,
             s_bucket_sizes: sector_contents_map.s_bucket_sizes(),
             history_size: farmer_protocol_info.history_size,
-        };
+        });
 
         (
             PlottedSector {
@@ -110,7 +112,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         println!("Plotting one sector...");
 
         let mut plotted_sector_bytes = vec![0; sector_size];
-        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadata::encoded_size()];
+        let mut plotted_sector_metadata_bytes = vec![0; SectorMetadataChecksummed::encoded_size()];
 
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,

--- a/crates/subspace-farmer-components/src/auditing.rs
+++ b/crates/subspace-farmer-components/src/auditing.rs
@@ -1,5 +1,5 @@
 use crate::proving::SolutionCandidates;
-use crate::sector::{SectorContentsMap, SectorMetadata};
+use crate::sector::{SectorContentsMap, SectorMetadataChecksummed};
 use std::collections::VecDeque;
 use std::mem;
 use subspace_core_primitives::crypto::Scalar;
@@ -23,7 +23,7 @@ pub fn audit_sector<'a>(
     global_challenge: &Blake2b256Hash,
     solution_range: SolutionRange,
     sector: &'a [u8],
-    sector_metadata: &'a SectorMetadata,
+    sector_metadata: &'a SectorMetadataChecksummed,
 ) -> Option<SolutionCandidates<'a>> {
     let sector_id = SectorId::new(public_key.hash(), sector_index);
 

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -1,6 +1,6 @@
 use crate::sector::{
     sector_record_chunks_size, sector_size, RawSector, RecordMetadata, SectorContentsMap,
-    SectorMetadata,
+    SectorMetadata, SectorMetadataChecksummed,
 };
 use crate::segment_reconstruction::recover_missing_piece;
 use crate::FarmerProtocolInfo;
@@ -101,7 +101,7 @@ pub struct PlottedSector {
     /// Sector index
     pub sector_index: SectorIndex,
     /// Sector metadata
-    pub sector_metadata: SectorMetadata,
+    pub sector_metadata: SectorMetadataChecksummed,
     /// Indexes of pieces that were plotted
     pub piece_indexes: Vec<PieceIndex>,
 }
@@ -185,10 +185,10 @@ where
         });
     }
 
-    if sector_metadata_output.len() < SectorMetadata::encoded_size() {
+    if sector_metadata_output.len() < SectorMetadataChecksummed::encoded_size() {
         return Err(PlottingError::BadSectorMetadataOutputSize {
             provided: sector_metadata_output.len(),
-            expected: SectorMetadata::encoded_size(),
+            expected: SectorMetadataChecksummed::encoded_size(),
         });
     }
 
@@ -392,13 +392,12 @@ where
         }
     }
 
-    // TODO: Write commitments and witnesses
-    let sector_metadata = SectorMetadata {
+    let sector_metadata = SectorMetadataChecksummed::from(SectorMetadata {
         sector_index,
         pieces_in_sector,
         s_bucket_sizes: sector_contents_map.s_bucket_sizes(),
         history_size: farmer_protocol_info.history_size,
-    };
+    });
 
     sector_metadata_output.copy_from_slice(&sector_metadata.encode());
 

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -350,7 +350,9 @@ where
             remaining_bytes.split_at_mut(sector_record_chunks_size(pieces_in_sector));
 
         // Write sector contents map so we can decode it later
-        sector_contents_map_region.copy_from_slice(sector_contents_map.as_ref());
+        sector_contents_map
+            .encode_into(sector_contents_map_region)
+            .expect("Chunked into correct size above; qed");
 
         let num_encoded_record_chunks = sector_contents_map.num_encoded_record_chunks();
         let mut next_encoded_record_chunks_offset = vec![0_usize; pieces_in_sector.into()];

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -16,7 +16,7 @@ use std::simd::Simd;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::crypto::kzg::Kzg;
-use subspace_core_primitives::crypto::Scalar;
+use subspace_core_primitives::crypto::{blake3_hash, Scalar};
 use subspace_core_primitives::{
     ArchivedHistorySegment, Piece, PieceIndex, PieceOffset, PublicKey, Record, SBucket, SectorId,
     SectorIndex,
@@ -467,6 +467,7 @@ async fn download_sector<PG: PieceGetter>(
             *metadata = RecordMetadata {
                 commitment: *piece.commitment(),
                 witness: *piece.witness(),
+                piece_checksum: blake3_hash(piece.as_ref()),
             };
 
             // We have processed this piece index, clear it

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -237,6 +237,8 @@ where
                         })?;
                     drop(sector_record_chunks);
 
+                    // NOTE: We do not check plot consistency using checksum because it is more
+                    // expensive and consensus will verify validity of the proof anyway
                     let record_metadata = read_record_metadata(
                         piece_offset,
                         self.sector_metadata.pieces_in_sector,

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -1,6 +1,8 @@
 use crate::auditing::ChunkCandidate;
 use crate::reading::{read_record_metadata, read_sector_record_chunks, ReadingError};
-use crate::sector::{SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadata};
+use crate::sector::{
+    SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadataChecksummed,
+};
 use std::collections::VecDeque;
 use subspace_core_primitives::crypto::kzg::{Commitment, Kzg, Witness};
 use subspace_core_primitives::crypto::Scalar;
@@ -72,7 +74,7 @@ pub struct SolutionCandidates<'a> {
     sector_id: SectorId,
     s_bucket: SBucket,
     sector: &'a [u8],
-    sector_metadata: &'a SectorMetadata,
+    sector_metadata: &'a SectorMetadataChecksummed,
     chunk_candidates: VecDeque<ChunkCandidate>,
 }
 
@@ -83,7 +85,7 @@ impl<'a> SolutionCandidates<'a> {
         sector_id: SectorId,
         s_bucket: SBucket,
         sector: &'a [u8],
-        sector_metadata: &'a SectorMetadata,
+        sector_metadata: &'a SectorMetadataChecksummed,
         chunk_candidates: VecDeque<ChunkCandidate>,
     ) -> Self {
         Self {
@@ -158,7 +160,7 @@ where
     sector_index: SectorIndex,
     sector_id: SectorId,
     s_bucket: SBucket,
-    sector_metadata: &'a SectorMetadata,
+    sector_metadata: &'a SectorMetadataChecksummed,
     s_bucket_offsets: Box<[u32; Record::NUM_S_BUCKETS]>,
     kzg: &'a Kzg,
     erasure_coding: &'a ErasureCoding,
@@ -349,7 +351,7 @@ where
         sector_id: SectorId,
         s_bucket: SBucket,
         sector: &'a [u8],
-        sector_metadata: &'a SectorMetadata,
+        sector_metadata: &'a SectorMetadataChecksummed,
         kzg: &'a Kzg,
         erasure_coding: &'a ErasureCoding,
         chunk_candidates: VecDeque<ChunkCandidate>,

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -1,6 +1,6 @@
 use crate::sector::{
     sector_record_chunks_size, sector_size, RecordMetadata, SectorContentsMap,
-    SectorContentsMapFromBytesError, SectorMetadata,
+    SectorContentsMapFromBytesError, SectorMetadataChecksummed,
 };
 use parity_scale_codec::Decode;
 use rayon::prelude::*;
@@ -249,7 +249,7 @@ pub(crate) fn read_record_metadata(
 pub fn read_piece<PosTable>(
     piece_offset: PieceOffset,
     sector_id: &SectorId,
-    sector_metadata: &SectorMetadata,
+    sector_metadata: &SectorMetadataChecksummed,
     sector: &[u8],
     erasure_coding: &ErasureCoding,
     table_generator: &mut PosTable::Generator,

--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -37,6 +37,7 @@ pub const fn sector_size(pieces_in_sector: u16) -> usize {
     sector_record_chunks_size(pieces_in_sector)
         + sector_record_metadata_size(pieces_in_sector)
         + SectorContentsMap::encoded_size(pieces_in_sector)
+        + mem::size_of::<Blake3Hash>()
 }
 
 /// Metadata of the plotted sector

--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -129,11 +129,13 @@ pub(crate) struct RecordMetadata {
     pub(crate) commitment: RecordCommitment,
     /// Record witness
     pub(crate) witness: RecordWitness,
+    /// Checksum (hash) of the whole piece
+    pub(crate) piece_checksum: Blake3Hash,
 }
 
 impl RecordMetadata {
     pub(crate) const fn encoded_size() -> usize {
-        RecordWitness::SIZE + RecordCommitment::SIZE
+        RecordWitness::SIZE + RecordCommitment::SIZE + mem::size_of::<Blake3Hash>()
     }
 }
 

--- a/crates/subspace-farmer/src/single_disk_plot/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/farming.rs
@@ -12,7 +12,7 @@ use subspace_core_primitives::{PublicKey, SectorIndex, Solution};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::proving;
-use subspace_farmer_components::sector::SectorMetadata;
+use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_proof_of_space::Table;
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
@@ -72,7 +72,7 @@ pub(super) async fn farming<NC, PosTable>(
     node_client: NC,
     sector_size: usize,
     plot_mmap: Mmap,
-    sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+    sectors_metadata: Arc<RwLock<Vec<SectorMetadataChecksummed>>>,
     kzg: Kzg,
     erasure_coding: ErasureCoding,
     handlers: Arc<Handlers>,

--- a/crates/subspace-farmer/src/single_disk_plot/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_cache.rs
@@ -5,10 +5,11 @@ use std::io::{Seek, SeekFrom};
 use std::path::Path;
 use std::sync::Arc;
 use std::{fs, io, mem};
-use subspace_core_primitives::{Piece, PieceIndex};
+use subspace_core_primitives::crypto::blake3_hash_list;
+use subspace_core_primitives::{Blake3Hash, Piece, PieceIndex};
 use subspace_farmer_components::file_ext::FileExt;
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Disk piece cache open error
 #[derive(Debug, Error)]
@@ -30,6 +31,9 @@ pub enum DiskPieceCacheError {
     /// Cache size has zero capacity, this is not supported
     #[error("Cache size has zero capacity, this is not supported")]
     ZeroCapacity,
+    /// Checksum mismatch
+    #[error("Checksum mismatch")]
+    ChecksumMismatch,
 }
 
 /// Offset wrapper for pieces in [`DiskPieceCache`]
@@ -95,7 +99,7 @@ impl DiskPieceCache {
     }
 
     pub(super) const fn element_size() -> usize {
-        mem::size_of::<PieceIndex>() + Piece::SIZE
+        PieceIndex::SIZE + Piece::SIZE + mem::size_of::<Blake3Hash>()
     }
 
     /// Contents of this disk cache
@@ -154,9 +158,11 @@ impl DiskPieceCache {
                 .map_mut(&self.inner.file)?
         };
 
-        let piece_index_bytes = piece_index.to_bytes();
-        write_mmap[..piece_index_bytes.len()].copy_from_slice(&piece_index_bytes);
-        write_mmap[piece_index_bytes.len()..].copy_from_slice(piece.as_ref());
+        let (piece_index_bytes, remaining_bytes) = write_mmap.split_at_mut(PieceIndex::SIZE);
+        piece_index_bytes.copy_from_slice(&piece_index.to_bytes());
+        let (piece_bytes, checksum) = remaining_bytes.split_at_mut(Piece::SIZE);
+        piece_bytes.copy_from_slice(piece.as_ref());
+        checksum.copy_from_slice(&blake3_hash_list(&[piece_index_bytes, piece.as_ref()]));
 
         write_mmap.flush()?;
 
@@ -196,13 +202,25 @@ impl DiskPieceCache {
             return Ok(None);
         }
 
+        let piece_element_memory =
+            &self.inner.read_mmap[offset * Self::element_size()..][..Self::element_size()];
+        let (piece_index_bytes, remaining_bytes) = piece_element_memory.split_at(PieceIndex::SIZE);
+        let (piece_bytes, expected_checksum) = remaining_bytes.split_at(Piece::SIZE);
         let mut piece = Piece::default();
-        piece.copy_from_slice(
-            &self.inner.read_mmap[offset * Self::element_size() + PieceIndex::SIZE..]
-                [..Piece::SIZE],
-        );
+        piece.copy_from_slice(piece_bytes);
 
-        // TODO: Verify checksum (when we have them) and return `None` in case it doesn't match
+        // Verify checksum
+        let actual_checksum = blake3_hash_list(&[piece_index_bytes, piece.as_ref()]);
+        if actual_checksum != expected_checksum {
+            debug!(
+                actual_checksum = %hex::encode(actual_checksum),
+                expected_checksum = %hex::encode(expected_checksum),
+                "Hash doesn't match, corrupted piece in cache"
+            );
+
+            return Err(DiskPieceCacheError::ChecksumMismatch);
+        }
+
         Ok(Some(piece))
     }
 

--- a/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/piece_reader.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use subspace_core_primitives::{Piece, PieceOffset, PublicKey, SectorId, SectorIndex};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::reading;
-use subspace_farmer_components::sector::{sector_size, SectorMetadata};
+use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_proof_of_space::Table;
 use tracing::{error, warn};
 
@@ -33,7 +33,7 @@ impl PieceReader {
         public_key: PublicKey,
         pieces_in_sector: u16,
         global_plot_mmap: Mmap,
-        sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+        sectors_metadata: Arc<RwLock<Vec<SectorMetadataChecksummed>>>,
         erasure_coding: ErasureCoding,
         modifying_sector_index: Arc<RwLock<Option<SectorIndex>>>,
     ) -> (Self, impl Future<Output = ()>)
@@ -84,7 +84,7 @@ async fn read_pieces<PosTable>(
     public_key: PublicKey,
     pieces_in_sector: u16,
     global_plot_mmap: Mmap,
-    sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+    sectors_metadata: Arc<RwLock<Vec<SectorMetadataChecksummed>>>,
     erasure_coding: ErasureCoding,
     modifying_sector_index: Arc<RwLock<Option<SectorIndex>>>,
     mut read_piece_receiver: mpsc::Receiver<ReadPieceRequest>,
@@ -161,7 +161,7 @@ fn read_piece<PosTable>(
     piece_offset: PieceOffset,
     pieces_in_sector: u16,
     sector_count: SectorIndex,
-    sector_metadata: &SectorMetadata,
+    sector_metadata: &SectorMetadataChecksummed,
     global_plot: &[u8],
     erasure_coding: &ErasureCoding,
     table_generator: &mut PosTable::Generator,

--- a/crates/subspace-farmer/src/single_disk_plot/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_plot/plotting.rs
@@ -27,7 +27,7 @@ use subspace_farmer_components::plotting;
 use subspace_farmer_components::plotting::{
     plot_sector, PieceGetter, PieceGetterRetryPolicy, PlottedSector,
 };
-use subspace_farmer_components::sector::SectorMetadata;
+use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_proof_of_space::Table;
 use thiserror::Error;
 use tracing::{debug, info, trace, warn};
@@ -88,7 +88,7 @@ pub(super) async fn plotting<NC, PG, PosTable>(
     mut metadata_header_mmap: MmapMut,
     plot_file: Arc<File>,
     metadata_file: File,
-    sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+    sectors_metadata: Arc<RwLock<Vec<SectorMetadataChecksummed>>>,
     piece_getter: PG,
     kzg: Kzg,
     erasure_coding: ErasureCoding,
@@ -244,7 +244,7 @@ pub(super) async fn plotting_scheduler<NC>(
     last_archived_segment_index: SegmentIndex,
     min_sector_lifetime: HistorySize,
     node_client: NC,
-    sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+    sectors_metadata: Arc<RwLock<Vec<SectorMetadataChecksummed>>>,
     sectors_to_plot_sender: mpsc::Sender<(SectorIndex, oneshot::Sender<()>)>,
 ) -> Result<(), BackgroundTaskError>
 where
@@ -424,7 +424,7 @@ async fn send_plotting_notifications<NC>(
     target_sector_count: SectorIndex,
     min_sector_lifetime: HistorySize,
     node_client: &NC,
-    sectors_metadata: Arc<RwLock<Vec<SectorMetadata>>>,
+    sectors_metadata: Arc<RwLock<Vec<SectorMetadataChecksummed>>>,
     last_archived_segment: &Atomic<SegmentHeader>,
     mut archived_segments_receiver: mpsc::Receiver<()>,
     mut sectors_to_plot_sender: mpsc::Sender<(SectorIndex, oneshot::Sender<()>)>,

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -329,13 +329,13 @@ impl NetworkingParametersManager {
                     }
 
                     // Verify checksum
-                    let actual_hash = blake3_hash(encoded_bytes);
-                    let expected_hash = &remaining_bytes[..mem::size_of::<Blake3Hash>()];
-                    if actual_hash != expected_hash {
+                    let actual_checksum = blake3_hash(encoded_bytes);
+                    let expected_checksum = &remaining_bytes[..mem::size_of::<Blake3Hash>()];
+                    if actual_checksum != expected_checksum {
                         debug!(
                             encoded_bytes_len = %encoded_bytes.len(),
-                            ?actual_hash,
-                            ?expected_hash,
+                            actual_checksum = %hex::encode(actual_checksum),
+                            expected_checksum = %hex::encode(expected_checksum),
                             "Hash doesn't match, possible disk corruption or file was just \
                             created, ignoring"
                         );

--- a/crates/subspace-networking/src/request_handlers/piece_announcement.rs
+++ b/crates/subspace-networking/src/request_handlers/piece_announcement.rs
@@ -27,7 +27,7 @@ impl Encode for PieceAnnouncementRequest {
                 .fold(0usize, |sum, item| sum + item.len())
     }
 
-    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+    fn encode_to<O: Output + ?Sized>(&self, dest: &mut O) {
         self.piece_index_hash.to_bytes().encode_to(dest);
         for addr in &self.addresses {
             addr.to_vec().encode_to(dest);

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -37,7 +37,7 @@ use subspace_core_primitives::{HistorySize, PublicKey, Record, SegmentIndex, Sol
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
-use subspace_farmer_components::sector::{sector_size, SectorMetadata};
+use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::Table;
 use subspace_runtime_primitives::opaque::Block;
@@ -234,7 +234,7 @@ where
         .expect("First block is always producing one segment; qed");
     let history_size = HistorySize::from(SegmentIndex::ZERO);
     let mut sector = vec![0u8; sector_size(pieces_in_sector)];
-    let mut sector_metadata = vec![0u8; SectorMetadata::encoded_size()];
+    let mut sector_metadata = vec![0u8; SectorMetadataChecksummed::encoded_size()];
     let sector_index = 0;
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let farmer_protocol_info = FarmerProtocolInfo {


### PR DESCRIPTION
This implements first two items of https://github.com/subspace/subspace/issues/1723 step by step and fully unlocks https://github.com/subspace/subspace/issues/1725.

Essentially we look at every major thing farmer writes to disk and ensure we have a checksum there. For sectors we have two-level checksums: for pieces and whole sector. Piece checksum is checked during retrieval (but not proving since it takes time and will be checked by consensus anyway in case corruption happened), while whole sector is not really checked, but will be useful for `subspace-farmer scrub` command to quickly check the whole sector without trying to interpret it in any way.

Checksumming wrapper in `subspace-core-primitives` is useful, but in some cases more domain specific handling was chosen for efficiency purposes.

This is certainly a big breaking change to many on-disk farmer data structures.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
