### PR TITLE
Mark some consensus RPCs as unsafe

### DIFF
--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -129,6 +129,7 @@ where
             dsn_bootstrap_nodes,
             segment_headers_store,
             sync_oracle,
+            deny_unsafe,
         )
         .into_rpc(),
     )?;


### PR DESCRIPTION
This will make it not required to acknowledge archived segments when unsafe RPCs are not enabled. Otherwise it is possible to make public RPC node "stuck" by simply subscribing to archived segments without acknowledging them.

Ignore whitespace changes, diff is pretty small.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
