### PR TITLE
Add `--operator` boolean flag to run domain node as authority and update documentation.

### DIFF
--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -19,7 +19,8 @@ use clap::Parser;
 use domain_service::DomainConfiguration;
 use sc_cli::{
     ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
-    NetworkParams, Result, RunCmd as SubstrateRunCmd, RuntimeVersion, SharedParams, SubstrateCli,
+    NetworkParams, Result, Role, RunCmd as SubstrateRunCmd, RuntimeVersion, SharedParams,
+    SubstrateCli,
 };
 use sc_service::config::PrometheusConfig;
 use sc_service::BasePath;
@@ -62,6 +63,10 @@ pub struct DomainCli {
     /// Optional relayer address to relay messages on behalf.
     #[clap(long)]
     pub relayer_id: Option<String>,
+
+    /// Run the node as an Operator
+    #[arg(long, conflicts_with = "validator")]
+    pub operator: bool,
 
     /// Additional args for domain.
     #[clap(raw = true)]
@@ -250,7 +255,14 @@ impl CliConfiguration<Self> for DomainCli {
     }
 
     fn role(&self, is_dev: bool) -> Result<sc_service::Role> {
-        self.run.role(is_dev)
+        // is authority when operator is enabled or in dev mode
+        let is_authority = self.operator || is_dev;
+
+        Ok(if is_authority {
+            Role::Authority
+        } else {
+            Role::Full
+        })
     }
 
     fn transaction_pool(&self, is_dev: bool) -> Result<sc_service::config::TransactionPoolOptions> {

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -256,7 +256,7 @@ impl CliConfiguration<Self> for DomainCli {
 
     fn role(&self, is_dev: bool) -> Result<sc_service::Role> {
         // is authority when operator is enabled or in dev mode
-        let is_authority = self.operator || is_dev;
+        let is_authority = self.operator || self.run.validator || is_dev;
 
         Ok(if is_authority {
             Role::Authority

--- a/domains/README.md
+++ b/domains/README.md
@@ -16,6 +16,29 @@ NOTE: currently, the domain chain does not support to syncing from other operato
 
 The domain operator node is embeded within the `subspace-node` binary, please refer to [Subspace node](../crates/subspace-node/README.md) for how to build from source.
 
+#### Create Operator key:
+Operator needs key pair to participate in Bundle production.
+You can create a key using following command:
+```bash
+target/production/subspace-node key generate --scheme sr25519
+```
+
+Backup the key. Take `Public key (hex)` of the Keypair. The public key is part of the Operator config.
+
+#### Insert key to Keystore:
+The above generated key is added to the Keystore so that Operator node can use to participate in Bundle production.
+The key is inserted using the following command:
+```bash
+target/production/subspace-node key insert \
+      --suri "<Secret phrase>" --key-type <key1> --scheme sr25519 --keystore-path /tmp/keystore
+```
+The above command assumes `/tmp/keystore` as the keystore location. `key-type` should a 4-letter word.
+`suri` is the secret phrase of the Operator key.
+
+#### Register Operator:
+Operator needs to register to a domain they want to operate on using `register_operator`. Registration extrinsic requires Operator Config.
+Once the domain epoch is finished, Operator can produce bundles from the new epoch.
+
 ### Start the domain operator node
 
 The domain operator node is running with an embededded consensus node, thus you need to specify the args for both the consensus node and the domain operator node:
@@ -25,8 +48,21 @@ subspace-node [consensus-chain-args] -- [domain-args]
 ```
 
 Example:
+Start a node as Operator on `local` chain:
+```bash
+target/production/subspace-node \
+    --chain local \
+    --rpc-external \
+    --node-key 0000000000000000000000000000000000000000000000000000000000000001 \
+    -- \
+    --domain-id 0 \
+    --chain local \
+    --operator \
+    --keystore-path /tmp/keystore \
+    --rpc-external
+```
 
-Start a single node development chain:
+For `dev` chain, you can use `--dev` flag that combines `--chain dev` and `--operator`.
 ```bash
 target/production/subspace-node \
     --dev \
@@ -46,12 +82,12 @@ target/production/subspace-node \
     --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
     -- \
     --domain-id 0 \
-    --dev \
+    --chain dev \
     --rpc-external
 ```
+Since there is no `operator` flag, this node will not participate in Bundle production.
 
 By default, node data is written to `subspace-node/domain-{domain-id}` subdirectory of the OS-specific user's local data directory.
-
 ```
 Linux
 $XDG_DATA_HOME or                   /home/alice/.local/share

--- a/domains/README.md
+++ b/domains/README.md
@@ -30,9 +30,9 @@ The above generated key is added to the Keystore so that Operator node can use t
 The key is inserted using the following command:
 ```bash
 target/production/subspace-node key insert \
-      --suri "<Secret phrase>" --key-type <key1> --scheme sr25519 --keystore-path /tmp/keystore
+      --suri "<Secret phrase>" --key-type oper --scheme sr25519 --keystore-path /tmp/keystore
 ```
-The above command assumes `/tmp/keystore` as the keystore location. `key-type` should a 4-letter word.
+The above command assumes `/tmp/keystore` as the keystore location.
 `suri` is the secret phrase of the Operator key.
 
 #### Register Operator:


### PR DESCRIPTION
This PR adds a new domain cli `operator` that replaces `validator` when running a domain node.

If the arguments contain `validator` along with `operator`, then we fail due to conflict. ~Just `validator` on Domain node will not have any effect.~

Closes: #1781 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
