### PR TITLE
Update README.md

### DIFF
--- a/domains/README.md
+++ b/domains/README.md
@@ -55,7 +55,7 @@ target/production/subspace-node \
     --rpc-external \
     --node-key 0000000000000000000000000000000000000000000000000000000000000001 \
     -- \
-    --domain-id 0 \
+    -- --domain-id 0 \
     --chain local \
     --operator \
     --keystore-path /tmp/keystore \
@@ -69,7 +69,7 @@ target/production/subspace-node \
     --rpc-external \
     --node-key 0000000000000000000000000000000000000000000000000000000000000001 \
     -- \
-    --domain-id 0 \
+    -- --domain-id 0 \
     --dev \
     --rpc-external
 ```


### PR DESCRIPTION
Upon trying to run a domain operator node, CLI was complaining about incorrectly set value for the domain-id. 

Adding -- before the domain ID seems to do the trick and allow setting domain-id as a value. 

Tested on Windows 10, not sure if it works the same way for Linux / MacOS.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
