### PR TITLE
Address translation for observed addresses for DSN

### DIFF
--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -78,6 +78,9 @@ const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: Option<u32> = Some(2);
 // TODO: Consider moving this constant to configuration or removing `Toggle` wrapper when we find a
 // use-case for gossipsub protocol.
 const ENABLE_GOSSIP_PROTOCOL: bool = false;
+//TODO: Investigate port reuse for QUIC
+/// Specifies whether we use the same outgoing port for TCP connections.
+const TCP_PORT_REUSE: bool = true;
 
 /// Base limit for number of concurrent tasks initiated towards Kademlia.
 ///
@@ -436,6 +439,7 @@ where
         Arc::clone(&temporary_bans),
         timeout,
         yamux_config,
+        TCP_PORT_REUSE,
     )?;
 
     info!(


### PR DESCRIPTION
This PR adds address translation and prepares TCP port reuse for the future:
- address translation changes observed address from the `Identified` event of the `identify` protocol to the address with the same port as in the first available listener port
- "TCP port reuse" param is added to the configuration but disabled by default. There are no CLI parameters to enable it yet. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
