### PR TITLE
Improve sync from DSN

### DIFF
--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -32,13 +32,9 @@ pub(crate) async fn recover_missing_piece<PG: PieceGetter>(
     let segment_index = missing_piece_index.segment_index();
     let position = missing_piece_index.position();
 
-    let semaphore = Semaphore::new(PARALLELISM_LEVEL);
-    let acquired_pieces_counter = AtomicUsize::default();
+    let semaphore = &Semaphore::new(PARALLELISM_LEVEL);
+    let acquired_pieces_counter = &AtomicUsize::default();
     let required_pieces_number = RecordedHistorySegment::NUM_RAW_RECORDS;
-
-    // This is so we can move references into the future below
-    let semaphore = &semaphore;
-    let acquired_pieces_counter = &acquired_pieces_counter;
 
     let mut received_segment_pieces = segment_index
         .segment_piece_indexes_source_first()

--- a/crates/subspace-service/src/dsn/import_blocks/segment_headers.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/segment_headers.rs
@@ -81,7 +81,7 @@ impl SegmentHeaderHandler {
     async fn get_last_segment_header(
         &self,
     ) -> Result<Option<(SegmentHeader, Vec<PeerId>)>, Box<dyn Error>> {
-        for (required_nodes, retry_attempt) in (1..=SEGMENT_HEADER_CONSENSUS_INITIAL_NODES)
+        for (required_peers, retry_attempt) in (1..=SEGMENT_HEADER_CONSENSUS_INITIAL_NODES)
             .rev()
             .zip(1_usize..)
         {
@@ -147,10 +147,10 @@ impl SegmentHeaderHandler {
 
             let peer_count = peer_blocks.len();
 
-            if peer_count < required_nodes {
+            if peer_count < required_peers {
                 debug!(
                     %peer_count,
-                    %required_nodes,
+                    %required_peers,
                     %retry_attempt,
                     "Segment header consensus requires more peers, will retry"
                 );

--- a/crates/subspace-service/src/dsn/import_blocks/segment_headers.rs
+++ b/crates/subspace-service/src/dsn/import_blocks/segment_headers.rs
@@ -39,7 +39,7 @@ impl SegmentHeaderHandler {
         all_segment_headers.push(last_segment_header);
 
         while last_segment_header.segment_index() > SegmentIndex::ZERO {
-            let segment_indexes: Vec<_> = (SegmentIndex::ZERO..last_segment_header.segment_index())
+            let segment_indexes = (SegmentIndex::ZERO..last_segment_header.segment_index())
                 .rev()
                 .take(SEGMENT_HEADER_NUMBER_PER_REQUEST as usize)
                 .collect();
@@ -81,8 +81,7 @@ impl SegmentHeaderHandler {
     async fn get_last_segment_header(
         &self,
     ) -> Result<Option<(SegmentHeader, Vec<PeerId>)>, Box<dyn Error>> {
-        for (root_block_consensus_nodes, retry_attempt) in (1
-            ..=SEGMENT_HEADER_CONSENSUS_INITIAL_NODES)
+        for (required_nodes, retry_attempt) in (1..=SEGMENT_HEADER_CONSENSUS_INITIAL_NODES)
             .rev()
             .zip(1_usize..)
         {
@@ -148,10 +147,10 @@ impl SegmentHeaderHandler {
 
             let peer_count = peer_blocks.len();
 
-            if peer_count < root_block_consensus_nodes {
+            if peer_count < required_nodes {
                 debug!(
                     %peer_count,
-                    %root_block_consensus_nodes,
+                    %required_nodes,
                     %retry_attempt,
                     "Segment header consensus requires more peers, will retry"
                 );

--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -8,7 +8,6 @@ use sc_network::config::SyncMode;
 use sc_network::{NetworkPeers, NetworkService};
 use sp_api::BlockT;
 use sp_blockchain::HeaderBackend;
-use sp_consensus::BlockOrigin;
 use std::future::Future;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -209,14 +208,7 @@ where
 
         info!(?reason, "Received notification to sync from DSN");
         // TODO: Maybe handle failed block imports, additional helpful logging
-        if let Err(error) = import_blocks_from_dsn(
-            node,
-            client,
-            import_queue_service,
-            BlockOrigin::NetworkInitialSync,
-            false,
-        )
-        .await
+        if let Err(error) = import_blocks_from_dsn(node, client, import_queue_service, false).await
         {
             warn!(%error, "Error when syncing blocks from DSN");
         }


### PR DESCRIPTION
There were several issues with sync from DSN, I'm surprised it worked at all :see_no_evil:

So first I removed initial sync from DSN mode. It doesn't seem to be required anymore since we can discover when node is not synced in runtime just fine.

Then turned out `while block_number - best_block_number >= QUEUED_BLOCKS_LIMIT.into() {` was buggy since neither `best_block_number` was updated nor blocks were imported in between, essentially making this an infinite loop in case blocks are small enough to accumulate more than 2048 blocks in one segment.

Then turned out node was showing 0 peers on Substrate level due to pruned peers responding with no blocks when requested, but when we skip requests we can maintain connections, so I decided to start with paused sync mode and wait for networking to come alive and kick in DSN sync before anything else.

Last commit adds concurrency for piece retrieval, allowing to pull pieces at over 100 Mbps speed easily, making everything move much faster.

As the result sync from DSN should be much less broken than before.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
