### PR TITLE
Conditionally compiled PoT support

### DIFF
--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -48,6 +48,9 @@ subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-spac
 
 [features]
 default = ["std"]
+pot = [
+	"sp-consensus-subspace/pot",
+]
 std = [
 	"codec/std",
 	"frame-benchmarking?/std",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -257,6 +257,7 @@ pub fn make_pre_digest(
     let log = DigestItem::subspace_pre_digest(&PreDigest {
         slot,
         solution,
+        #[cfg(feature = "pot")]
         proof_of_time: Default::default(),
     });
     Digest { logs: vec![log] }

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -65,3 +65,9 @@ thiserror = "1.0.38"
 #substrate-test-runtime = { version = "2.0.0", path = "../../substrate/substrate-test-runtime" }
 #substrate-test-runtime-client = { version = "2.0.0", path = "../../substrate/substrate-test-runtime-client" }
 #tokio = "1.27.0"
+
+[features]
+pot = [
+    "sc-proof-of-time/pot",
+    "sp-consensus-subspace/pot",
+]

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -61,9 +61,10 @@ use sp_consensus::{
     BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain, SyncOracle,
 };
 use sp_consensus_slots::{Slot, SlotDuration};
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::digests::PreDigest;
 use sp_consensus_subspace::digests::{
-    extract_pre_digest, extract_subspace_digest_items, Error as DigestError, PreDigest,
-    SubspaceDigestItems,
+    extract_pre_digest, extract_subspace_digest_items, Error as DigestError, SubspaceDigestItems,
 };
 use sp_consensus_subspace::{
     check_header, ChainConstants, CheckedHeader, FarmerPublicKey, FarmerSignature, SubspaceApi,
@@ -975,6 +976,7 @@ where
                 None => parent_subspace_digest_items.solution_range,
             };
 
+            #[cfg(feature = "pot")]
             if let Some(proof_of_time) = self.proof_of_time.as_ref() {
                 let ret = self.proof_of_time_verification(
                     proof_of_time.as_ref(),
@@ -1116,6 +1118,7 @@ where
 
     /// Verifies the proof of time in the received block.
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "pot")]
     fn proof_of_time_verification(
         &self,
         proof_of_time: &dyn PotConsensusState,

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -26,3 +26,6 @@ parking_lot = "0.12.1"
 thiserror = "1.0.38"
 tokio = { version = "1.28.2", features = ["time"] }
 tracing = "0.1.37"
+
+[features]
+pot = []

--- a/crates/sc-proof-of-time/src/utils.rs
+++ b/crates/sc-proof-of-time/src/utils.rs
@@ -57,6 +57,9 @@ where
         block_hash: info.best_hash.to_fixed_bytes(),
         block_number: info.best_number,
         slot_number: pre_digest.slot.into(),
+        #[cfg(feature = "pot")]
         pot_pre_digest: pre_digest.proof_of_time.unwrap_or_default(),
+        #[cfg(not(feature = "pot"))]
+        pot_pre_digest: Default::default(),
     })
 }

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = { version = "1.0.38", optional = true }
 
 [features]
 default = ["std"]
+pot = []
 std = [
 	"async-trait",
 	"codec/std",

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -40,6 +40,7 @@ pub struct PreDigest<PublicKey, RewardAddress> {
     pub slot: Slot,
     /// Solution (includes PoR)
     pub solution: Solution<PublicKey, RewardAddress>,
+    #[cfg(feature = "pot")]
     /// Proof of time included in the block
     /// TODO: It is Option<> for now for testing, to be removed
     /// when PoT feature is permanently enabled.
@@ -648,6 +649,7 @@ where
                 FarmerPublicKey::unchecked_from([0u8; 32]),
                 FarmerPublicKey::unchecked_from([0u8; 32]),
             ),
+            #[cfg(feature = "pot")]
             proof_of_time: Default::default(),
         });
     }

--- a/crates/sp-consensus-subspace/src/tests.rs
+++ b/crates/sp-consensus-subspace/src/tests.rs
@@ -42,6 +42,7 @@ fn test_is_equivocation_proof_valid() {
             logs: vec![DigestItem::subspace_pre_digest(&PreDigest {
                 slot,
                 solution: solution.clone(),
+                #[cfg(feature = "pot")]
                 proof_of_time: Default::default(),
             })],
         },
@@ -67,6 +68,7 @@ fn test_is_equivocation_proof_valid() {
             logs: vec![DigestItem::subspace_pre_digest(&PreDigest {
                 slot,
                 solution,
+                #[cfg(feature = "pot")]
                 proof_of_time: Default::default(),
             })],
         },

--- a/crates/sp-lightclient/Cargo.toml
+++ b/crates/sp-lightclient/Cargo.toml
@@ -40,6 +40,9 @@ subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-spac
 
 [features]
 default = ["std"]
+pot = [
+    "sp-consensus-subspace/pot",
+]
 std = [
     "codec/std",
     "scale-info/std",

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -235,6 +235,7 @@ fn valid_header(
         let pre_digest = PreDigest {
             slot: slot.into(),
             solution,
+            #[cfg(feature = "pot")]
             proof_of_time: Default::default(),
         };
         let digests = vec![

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -77,6 +77,12 @@ substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/su
 
 [features]
 default = ["do-not-enforce-cost-of-storage"]
+pot = [
+	"sc-consensus-subspace/pot",
+	"sc-proof-of-time/pot",
+	"sp-consensus-subspace/pot",
+	"subspace-runtime/pot",
+]
 do-not-enforce-cost-of-storage = [
 	"subspace-runtime/do-not-enforce-cost-of-storage"
 ]

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -68,6 +68,10 @@ hex-literal = "0.4.0"
 
 [features]
 default = ["std"]
+pot = [
+	"pallet-subspace/pot",
+	"sp-consensus-subspace/pot",
+]
 std = [
 	"codec/std",
 	"domain-runtime-primitives/std",

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -86,3 +86,8 @@ pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "htt
 
 [features]
 default = []
+pot = [
+	"sc-consensus-subspace/pot",
+	"sc-proof-of-time/pot",
+	"sp-consensus-subspace/pot",
+]

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -63,3 +63,6 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 sp-keyring = { git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+
+[features]
+pot = []

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -594,6 +594,7 @@ impl MockConsensusNode {
         let pre_digest: PreDigest<FarmerPublicKey, AccountId> = PreDigest {
             slot,
             solution: self.mock_solution.clone(),
+            #[cfg(feature = "pot")]
             proof_of_time: Default::default(),
         };
         let mut digest = Digest::default();


### PR DESCRIPTION
This by default doesn't compile PoT support in a few places (it is still largely in place, but shouldn't break compatibility with devnet), can be enabled like this:
```bash
cargo clippy --all-targets --features subspace-node/pot,sp-lightclient/pot,subspace-test-service/pot
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
