### PR TITLE
Improve PoT proving performance on x86-64

### DIFF
--- a/crates/subspace-proof-of-time/benches/pot.rs
+++ b/crates/subspace-proof-of-time/benches/pot.rs
@@ -15,7 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let checkpoints_1 = NonZeroU8::new(1).expect("Not zero; qed");
     let checkpoints_8 = NonZeroU8::new(8).expect("Not zero; qed");
     // About 1s on 5.5 GHz Raptor Lake CPU
-    let pot_iterations = NonZeroU32::new(166_000_000).expect("Not zero; qed");
+    let pot_iterations = NonZeroU32::new(183_270_000).expect("Not zero; qed");
     let proof_of_time_sequential = ProofOfTime::new(pot_iterations, checkpoints_1).unwrap();
     let proof_of_time = ProofOfTime::new(pot_iterations, checkpoints_8).unwrap();
 

--- a/crates/subspace-proof-of-time/src/pot_aes/x86_64.rs
+++ b/crates/subspace-proof-of-time/src/pot_aes/x86_64.rs
@@ -1,0 +1,90 @@
+use core::arch::x86_64::*;
+use std::mem;
+
+/// Create PoT proof with checkpoints
+#[target_feature(enable = "aes")]
+pub(super) unsafe fn create(
+    seed: &[u8; 16],
+    key: &[u8; 16],
+    num_checkpoints: u8,
+    checkpoint_iterations: u32,
+) -> Vec<[u8; 16]> {
+    let mut checkpoints = Vec::with_capacity(usize::from(num_checkpoints));
+
+    let keys_reg = expand_key(key);
+    let xor_key = _mm_xor_si128(keys_reg[10], keys_reg[0]);
+    let mut seed_reg = _mm_loadu_si128(seed.as_ptr() as *const __m128i);
+    seed_reg = _mm_xor_si128(seed_reg, keys_reg[0]);
+    for _ in 0..num_checkpoints {
+        for _ in 0..checkpoint_iterations {
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[1]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[2]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[3]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[4]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[5]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[6]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[7]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[8]);
+            seed_reg = _mm_aesenc_si128(seed_reg, keys_reg[9]);
+            seed_reg = _mm_aesenclast_si128(seed_reg, xor_key);
+        }
+
+        let checkpoint_reg = _mm_xor_si128(seed_reg, keys_reg[0]);
+        let mut checkpoint: [u8; 16] = mem::zeroed();
+        _mm_storeu_si128(checkpoint.as_mut_ptr() as *mut __m128i, checkpoint_reg);
+
+        checkpoints.push(checkpoint);
+    }
+
+    checkpoints
+}
+
+// Below code copied with minor changes from following place under MIT/Apache-2.0 license by Artyom
+// Pavlov:
+// https://github.com/RustCrypto/block-ciphers/blob/9413fcadd28d53854954498c0589b747d8e4ade2/aes/src/ni/aes128.rs
+
+/// AES-128 round keys
+type RoundKeys = [__m128i; 11];
+
+macro_rules! expand_round {
+    ($keys:expr, $pos:expr, $round:expr) => {
+        let mut t1 = $keys[$pos - 1];
+        let mut t2;
+        let mut t3;
+
+        t2 = _mm_aeskeygenassist_si128(t1, $round);
+        t2 = _mm_shuffle_epi32(t2, 0xff);
+        t3 = _mm_slli_si128(t1, 0x4);
+        t1 = _mm_xor_si128(t1, t3);
+        t3 = _mm_slli_si128(t3, 0x4);
+        t1 = _mm_xor_si128(t1, t3);
+        t3 = _mm_slli_si128(t3, 0x4);
+        t1 = _mm_xor_si128(t1, t3);
+        t1 = _mm_xor_si128(t1, t2);
+
+        $keys[$pos] = t1;
+    };
+}
+
+#[target_feature(enable = "aes")]
+unsafe fn expand_key(key: &[u8; 16]) -> RoundKeys {
+    // SAFETY: `RoundKeys` is a `[__m128i; 11]` which can be initialized
+    // with all zeroes.
+    let mut keys: RoundKeys = mem::zeroed();
+
+    let k = _mm_loadu_si128(key.as_ptr() as *const __m128i);
+    keys[0] = k;
+
+    expand_round!(keys, 1, 0x01);
+    expand_round!(keys, 2, 0x02);
+    expand_round!(keys, 3, 0x04);
+    expand_round!(keys, 4, 0x08);
+    expand_round!(keys, 5, 0x10);
+    expand_round!(keys, 6, 0x20);
+    expand_round!(keys, 7, 0x40);
+    expand_round!(keys, 8, 0x80);
+    expand_round!(keys, 9, 0x1B);
+    expand_round!(keys, 10, 0x36);
+
+    keys
+}


### PR DESCRIPTION
This makes proving 1.104x faster on x86-64 (on my machine at least) and resolves the first element in https://github.com/subspace/subspace/issues/1754 (proving).

Verification is less critical and can be done later, also would be nice if someone did it for aarch64.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
