### PR TITLE
Disable port reuse for DSN.

### DIFF
--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -78,9 +78,6 @@ const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: Option<u32> = Some(2);
 // TODO: Consider moving this constant to configuration or removing `Toggle` wrapper when we find a
 // use-case for gossipsub protocol.
 const ENABLE_GOSSIP_PROTOCOL: bool = false;
-//TODO: Investigate port reuse for QUIC
-/// Specifies whether we use the same outgoing port for TCP connections.
-const TCP_PORT_REUSE: bool = true;
 
 /// Base limit for number of concurrent tasks initiated towards Kademlia.
 ///
@@ -439,7 +436,6 @@ where
         Arc::clone(&temporary_bans),
         timeout,
         yamux_config,
-        TCP_PORT_REUSE,
     )?;
 
     info!(

--- a/crates/subspace-networking/src/create/transport.rs
+++ b/crates/subspace-networking/src/create/transport.rs
@@ -28,10 +28,9 @@ pub(super) fn build_transport(
     temporary_bans: Arc<Mutex<TemporaryBans>>,
     timeout: Duration,
     yamux_config: YamuxConfig,
-    port_reuse: bool,
 ) -> Result<Boxed<(PeerId, StreamMuxerBox)>, CreationError> {
     let wrapped_tcp_ws = {
-        let tcp_config = GenTcpConfig::default().nodelay(true).port_reuse(port_reuse);
+        let tcp_config = GenTcpConfig::default().nodelay(true);
         let wrapped_tcp = CustomTransportWrapper::new(
             TokioTcpTransport::new(tcp_config.clone()),
             allow_non_global_addresses_in_dht,
@@ -59,7 +58,6 @@ pub(super) fn build_transport(
             .boxed()
     };
 
-    // TODO: investigate port reuse for QUIC
     let quic = QuicTransport::new(QuicConfig::new(keypair))
         .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)));
 


### PR DESCRIPTION
This PR disables port reuse for TCP connection. Port reuse on two peers prevents establishing more than 1 connections and we have a limit of 2. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
