### PR TITLE
Derive global randomness from PoT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9198,6 +9198,7 @@ dependencies = [
 name = "sc-proof-of-time"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9202,6 +9202,7 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.1",
+ "sc-client-api",
  "sc-network",
  "sc-network-gossip",
  "sp-blockchain",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -171,6 +171,7 @@ parameter_types! {
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
     pub const ShouldAdjustSolutionRange: bool = false;
+    pub const IsPotEnabled: bool = false;
 }
 
 impl Config for Test {
@@ -193,6 +194,7 @@ impl Config for Test {
     type HandleEquivocation = EquivocationHandler<OffencesSubspace, ReportLongevity>;
 
     type WeightInfo = ();
+    type IsPotEnabled = IsPotEnabled;
 }
 
 pub fn go_to_block(

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -95,19 +95,19 @@ use subspace_verification::{
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum PotVerifyError<Block: BlockT> {
+    /// Block has no proof of time digest.
+    #[error("Block missing proof of time : {block_number}/{parent_slot_number:?}/{slot_number}")]
+    MissingPotDigest {
+        block_number: BlockNumberFor<Block>,
+        parent_slot_number: Option<SlotNumber>,
+        slot_number: SlotNumber,
+    },
+
     /// Parent block has no proof of time digest.
     #[error(
         "Parent block missing proof of time : {block_number}/{parent_slot_number}/{slot_number}"
     )]
     ParentMissingPotDigest {
-        block_number: BlockNumberFor<Block>,
-        parent_slot_number: SlotNumber,
-        slot_number: SlotNumber,
-    },
-
-    /// Block has no proof of time digest.
-    #[error("Block missing proof of time : {block_number}/{parent_slot_number}/{slot_number}")]
-    MissingPotDigest {
         block_number: BlockNumberFor<Block>,
         parent_slot_number: SlotNumber,
         slot_number: SlotNumber,
@@ -180,7 +180,7 @@ where
 
 /// Errors encountered by the Subspace authorship task.
 #[derive(Debug, thiserror::Error)]
-pub enum Error<Header: HeaderT> {
+pub enum Error<Block: BlockT, Header: HeaderT> {
     /// Error during digest item extraction
     #[error("Digest item error: {0}")]
     DigestItemError(#[from] DigestError),
@@ -299,10 +299,14 @@ pub enum Error<Header: HeaderT> {
     /// Runtime Api error.
     #[error(transparent)]
     RuntimeApi(#[from] ApiError),
+    /// Proof of time verification failed.
+    #[error("PoT verification failed: {0}")]
+    PotVerifyError(#[from] PotVerifyError<Block>),
 }
 
-impl<Header> From<VerificationError<Header>> for Error<Header>
+impl<Block, Header> From<VerificationError<Header>> for Error<Block, Header>
 where
+    Block: BlockT,
     Header: HeaderT,
 {
     #[inline]
@@ -350,12 +354,13 @@ where
     }
 }
 
-impl<Header> From<Error<Header>> for String
+impl<Block, Header> From<Error<Block, Header>> for String
 where
+    Block: BlockT,
     Header: HeaderT,
 {
     #[inline]
-    fn from(error: Error<Header>) -> String {
+    fn from(error: Error<Block, Header>) -> String {
         error.to_string()
     }
 }
@@ -624,7 +629,7 @@ where
         header: &Block::Header,
         author: &FarmerPublicKey,
         origin: &BlockOrigin,
-    ) -> Result<(), Error<Block::Header>> {
+    ) -> Result<(), Error<Block, Block::Header>> {
         // don't report any equivocations during initial sync
         // as they are most likely stale.
         if *origin == BlockOrigin::NetworkInitialSync {
@@ -709,7 +714,7 @@ where
             FarmerPublicKey,
             FarmerSignature,
         >(&block.header)
-        .map_err(Error::<Block::Header>::from)?;
+        .map_err(Error::<Block, Block::Header>::from)?;
         let pre_digest = subspace_digest_items.pre_digest;
 
         // Check if farmer's plot is burned.
@@ -722,7 +727,7 @@ where
                 if block.state_action.skip_execution_checks() {
                     Ok(false)
                 } else {
-                    Err(Error::<Block::Header>::RuntimeApi(error))
+                    Err(Error::<Block, Block::Header>::RuntimeApi(error))
                 }
             })?
         {
@@ -732,7 +737,7 @@ where
                 pre_digest.solution.public_key
             );
 
-            return Err(Error::<Block::Header>::FarmerInBlockList(
+            return Err(Error::<Block, Block::Header>::FarmerInBlockList(
                 pre_digest.solution.public_key.clone(),
             )
             .into());
@@ -765,7 +770,7 @@ where
                 Some(pre_digest),
                 &self.kzg,
             )
-            .map_err(Error::<Block::Header>::from)?
+            .map_err(Error::<Block, Block::Header>::from)?
         };
 
         match checked_header {
@@ -814,7 +819,7 @@ where
                     "subspace.header_too_far_in_future";
                     "hash" => ?hash, "a" => ?a, "b" => ?b
                 );
-                Err(Error::<Block::Header>::TooFarInFuture(hash).into())
+                Err(Error::<Block, Block::Header>::TooFarInFuture(hash).into())
             }
         }
     }
@@ -904,7 +909,7 @@ where
             FarmerSignature,
         >,
         skip_runtime_access: bool,
-    ) -> Result<(), Error<Block::Header>> {
+    ) -> Result<(), Error<Block, Block::Header>> {
         let block_number = *header.number();
         let parent_hash = *header.parent_hash();
 
@@ -926,7 +931,7 @@ where
                 if skip_runtime_access {
                     Ok(false)
                 } else {
-                    Err(Error::<Block::Header>::RuntimeApi(error))
+                    Err(Error::<Block, Block::Header>::RuntimeApi(error))
                 }
             })?
         {
@@ -946,6 +951,8 @@ where
             .header(parent_hash)?
             .ok_or(Error::ParentUnavailable(parent_hash, block_hash))?;
 
+        #[cfg(feature = "pot")]
+        let mut parent_pre_digest = None;
         let (correct_global_randomness, correct_solution_range) = if block_number.is_one() {
             // Genesis block doesn't contain usual digest items, we need to query runtime API
             // instead
@@ -977,21 +984,28 @@ where
             };
 
             #[cfg(feature = "pot")]
-            if let Some(proof_of_time) = self.proof_of_time.as_ref() {
-                let ret = self.proof_of_time_verification(
-                    proof_of_time.as_ref(),
-                    block_number,
-                    pre_digest,
-                    &parent_subspace_digest_items.pre_digest,
-                );
-                debug!(
-                    target: "subspace",
-                    "block_import_verification: {block_number}/{}/{}/{origin:?}, ret={ret:?}",
-                    pre_digest.slot, parent_subspace_digest_items.pre_digest.slot
-                );
+            {
+                parent_pre_digest = Some(parent_subspace_digest_items.pre_digest);
             }
-
             (correct_global_randomness, correct_solution_range)
+        };
+
+        #[cfg(feature = "pot")]
+        let correct_global_randomness = if let Some(proof_of_time) = self.proof_of_time.as_ref() {
+            let ret = self.proof_of_time_verification(
+                proof_of_time.as_ref(),
+                block_number,
+                pre_digest,
+                parent_pre_digest.as_ref(),
+            );
+            debug!(
+                target: "subspace",
+                "block_import_verification: {block_number}/{}/{:?}/{origin:?}, ret={ret:?}",
+                pre_digest.slot, parent_pre_digest.as_ref().map(|p| p.slot)
+            );
+            ret.map_err(Error::PotVerifyError)?
+        } else {
+            correct_global_randomness
         };
 
         if subspace_digest_items.global_randomness != correct_global_randomness {
@@ -1116,7 +1130,8 @@ where
         Ok(())
     }
 
-    /// Verifies the proof of time in the received block.
+    /// Verifies the proof of time in the received block,
+    /// returns the randomness from the PoT pre digest if successful.
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "pot")]
     fn proof_of_time_verification(
@@ -1124,8 +1139,23 @@ where
         proof_of_time: &dyn PotConsensusState,
         block_number: NumberFor<Block>,
         pre_digest: &PreDigest<FarmerPublicKey, FarmerPublicKey>,
-        parent_pre_digest: &PreDigest<FarmerPublicKey, FarmerPublicKey>,
-    ) -> Result<(), PotVerifyError<Block>> {
+        parent_pre_digest: Option<&PreDigest<FarmerPublicKey, FarmerPublicKey>>,
+    ) -> Result<Randomness, PotVerifyError<Block>> {
+        let pot_digest =
+            pre_digest
+                .proof_of_time
+                .as_ref()
+                .ok_or_else(|| PotVerifyError::MissingPotDigest {
+                    block_number,
+                    parent_slot_number: parent_pre_digest.map(|p| p.slot.into()),
+                    slot_number: pre_digest.slot.into(),
+                })?;
+        let randomness = pot_digest.derive_global_randomness();
+        let parent_pre_digest = match parent_pre_digest {
+            Some(parent_pre_digest) => parent_pre_digest,
+            None => return Ok(randomness),
+        };
+
         let parent_pot_digest = parent_pre_digest.proof_of_time.as_ref().ok_or_else(|| {
             PotVerifyError::ParentMissingPotDigest {
                 block_number,
@@ -1133,15 +1163,6 @@ where
                 slot_number: pre_digest.slot.into(),
             }
         })?;
-        let pot_digest =
-            pre_digest
-                .proof_of_time
-                .as_ref()
-                .ok_or_else(|| PotVerifyError::MissingPotDigest {
-                    block_number,
-                    parent_slot_number: parent_pre_digest.slot.into(),
-                    slot_number: pre_digest.slot.into(),
-                })?;
 
         proof_of_time
             .verify_block_proofs(
@@ -1151,7 +1172,9 @@ where
                 parent_pre_digest.slot.into(),
                 parent_pot_digest,
             )
-            .map_err(PotVerifyError::PotVerifyBlockProofsError)
+            .map_err(PotVerifyError::PotVerifyBlockProofsError)?;
+
+        Ok(randomness)
     }
 }
 
@@ -1204,7 +1227,7 @@ where
             .client
             .runtime_api()
             .root_plot_public_key(*block.header.parent_hash())
-            .map_err(Error::<Block::Header>::RuntimeApi)
+            .map_err(Error::<Block, Block::Header>::RuntimeApi)
             .map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
 
         self.block_import_verification(
@@ -1226,7 +1249,7 @@ where
                 .map_err(|e| ConsensusError::ClientImport(e.to_string()))?
                 .ok_or_else(|| {
                     ConsensusError::ClientImport(
-                        Error::<Block::Header>::ParentBlockNoAssociatedWeight(block_hash)
+                        Error::<Block, Block::Header>::ParentBlockNoAssociatedWeight(block_hash)
                             .to_string(),
                     )
                 })?
@@ -1264,7 +1287,8 @@ where
                     found_segment_commitment
                 );
                 return Err(ConsensusError::ClientImport(
-                    Error::<Block::Header>::DifferentSegmentCommitment(segment_index).to_string(),
+                    Error::<Block, Block::Header>::DifferentSegmentCommitment(segment_index)
+                        .to_string(),
                 ));
             }
         }
@@ -1317,7 +1341,7 @@ where
 /// Get chain constant configurations
 pub fn get_chain_constants<Block, Client>(
     client: &Client,
-) -> Result<ChainConstants, Error<Block::Header>>
+) -> Result<ChainConstants, Error<Block, Block::Header>>
 where
     Block: BlockT,
     Client: ProvideRuntimeApi<Block> + HeaderBackend<Block> + AuxStore,
@@ -1331,7 +1355,7 @@ where
             let chain_constants = client
                 .runtime_api()
                 .chain_constants(client.info().best_hash)
-                .map_err(Error::<Block::Header>::RuntimeApi)?;
+                .map_err(Error::<Block, Block::Header>::RuntimeApi)?;
 
             aux_schema::write_chain_constants(&chain_constants, |values| {
                 client.insert_aux(

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -62,12 +62,6 @@ use subspace_verification::{
     check_reward_signature, verify_solution, PieceCheckParams, VerifySolutionParams,
 };
 
-/// Time to wait for proofs, if proofs are currently unavailable.
-/// Substrate would cancel the async await if we don't complete
-/// in the remaining slot duration.
-#[cfg(feature = "pot")]
-const POT_WAIT_TIME: std::time::Duration = Duration::from_millis(1000);
-
 /// Errors while building the block proof of time.
 #[cfg(feature = "pot")]
 #[derive(Debug, thiserror::Error)]
@@ -653,7 +647,7 @@ where
                 block_number.into(),
                 slot_number,
                 parent_pot_digest,
-                Some(POT_WAIT_TIME),
+                Some(self.subspace_link.slot_duration().as_duration()),
             )
             .await
             .map(|proofs| {

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -14,6 +14,7 @@ include = [
 async-trait = "0.1.68"
 futures = "0.3.28"
 parity-scale-codec = { version = "3.6.1", features = ["derive"] }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -11,6 +11,7 @@ include = [
 ]
 
 [dependencies]
+async-trait = "0.1.68"
 futures = "0.3.28"
 parity-scale-codec = { version = "3.6.1", features = ["derive"] }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -88,7 +88,7 @@ impl PotComponents {
         let proof_of_time = ProofOfTime::new(config.pot_iterations, config.num_checkpoints)
             // TODO: Proper error handling or proof
             .expect("Failed to initialize proof of time");
-        let (protocol_state, consensus_state) = init_pot_state(config);
+        let (protocol_state, consensus_state) = init_pot_state(config, proof_of_time.clone());
 
         Self {
             is_time_keeper,

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -6,7 +6,6 @@ mod gossip;
 mod node_client;
 mod state_manager;
 mod time_keeper;
-mod utils;
 
 use crate::state_manager::{init_pot_state, PotProtocolState};
 use core::num::{NonZeroU32, NonZeroU8};

--- a/crates/sc-proof-of-time/src/node_client.rs
+++ b/crates/sc-proof-of-time/src/node_client.rs
@@ -82,7 +82,7 @@ where
                 }
             };
 
-            let pot_pre_digest = match pre_digest.proof_of_time {
+            let pot_pre_digest = match pre_digest.pot_pre_digest() {
                 Some(pot_pre_digest) => pot_pre_digest,
                 None => {
                     warn!(

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use subspace_core_primitives::{BlockNumber, NonEmptyVec, PotKey, PotProof, PotSeed, SlotNumber};
 use subspace_proof_of_time::{PotVerificationError, ProofOfTime};
-use tracing::trace;
+use tracing::{info, trace};
 
 /// The maximum size of the PoT chain to keep (about 5 min worth of proofs for now).
 /// TODO: remove this when purging is implemented.
@@ -839,7 +839,7 @@ impl PotConsensusState for StateManager {
                 .map(|tip| (tip.slot_number + 1) == block_proofs.first().slot_number)
                 .unwrap_or(true);
             if should_append {
-                return self.verify_and_append(
+                let ret = self.verify_and_append(
                     block_number,
                     slot_number,
                     block_proofs,
@@ -847,6 +847,7 @@ impl PotConsensusState for StateManager {
                     tip,
                     summary,
                 );
+                info!("state_manager: verify_and_append: {pre_digest:?}, {ret:?}");
             }
         }
 

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use subspace_core_primitives::{BlockNumber, NonEmptyVec, PotKey, PotProof, PotSeed, SlotNumber};
+use subspace_proof_of_time::{PotVerificationError, ProofOfTime};
 use tracing::trace;
 
 /// The maximum size of the PoT chain to keep (about 5 min worth of proofs for now).
@@ -106,6 +107,48 @@ pub enum PotVerifyBlockProofsError {
         parent_slot: SlotNumber,
         expected_slot: SlotNumber,
         actual_slot: SlotNumber,
+    },
+
+    #[error("Unexpected seed: {summary:?}/{block_number}/{slot}/{parent_slot}/{error_slot}")]
+    UnexpectedSeed {
+        summary: PotStateSummary,
+        block_number: BlockNumber,
+        slot: SlotNumber,
+        parent_slot: SlotNumber,
+        error_slot: SlotNumber,
+    },
+
+    #[error("Unexpected key: {summary:?}/{block_number}/{slot}/{parent_slot}/{error_slot}")]
+    UnexpectedKey {
+        summary: PotStateSummary,
+        block_number: BlockNumber,
+        slot: SlotNumber,
+        parent_slot: SlotNumber,
+        error_slot: SlotNumber,
+    },
+
+    #[error(
+    "Verification failed: {summary:?}/{block_number}/{slot}/{parent_slot}/{error_slot:?}/{err:?}"
+    )]
+    VerificationFailed {
+        summary: PotStateSummary,
+        block_number: BlockNumber,
+        slot: SlotNumber,
+        parent_slot: SlotNumber,
+        error_slot: SlotNumber,
+        err: PotVerificationError,
+    },
+
+    #[error(
+        "Tip mismatch: {summary:?}/{block_number}/{slot}/{parent_slot}/{expected:?}/{actual:?}"
+    )]
+    TipMismatch {
+        summary: PotStateSummary,
+        block_number: BlockNumber,
+        slot: SlotNumber,
+        parent_slot: SlotNumber,
+        expected: Option<SlotNumber>,
+        actual: Option<SlotNumber>,
     },
 
     #[error(
@@ -228,6 +271,15 @@ impl InternalState {
     fn extend_and_merge(&mut self, proof: PotProof) {
         self.future_proofs.remove(&proof.slot_number);
         self.chain.extend(proof);
+        self.merge_future_proofs();
+    }
+
+    /// Adds the batch of proofs to the current tip and merged possible future proofs.
+    fn extend_and_merge_batch(&mut self, proofs: Vec<PotProof>) {
+        for proof in proofs.into_iter() {
+            self.future_proofs.remove(&proof.slot_number);
+            self.chain.extend(proof);
+        }
         self.merge_future_proofs();
     }
 
@@ -547,14 +599,101 @@ impl InternalState {
 struct StateManager {
     /// The PoT state
     state: Mutex<InternalState>,
+
+    /// For AES verification
+    proof_of_time: ProofOfTime,
 }
 
 impl StateManager {
     /// Creates the state.
-    pub fn new(config: PotConfig) -> Self {
+    pub fn new(config: PotConfig, proof_of_time: ProofOfTime) -> Self {
         Self {
             state: Mutex::new(InternalState::new(config)),
+            proof_of_time,
         }
+    }
+
+    /// Verify the proofs and append to the chain.
+    #[allow(clippy::too_many_arguments)]
+    fn verify_and_append(
+        &self,
+        block_number: BlockNumber,
+        slot_number: SlotNumber,
+        proofs: &NonEmptyVec<PotProof>,
+        parent_slot_number: SlotNumber,
+        tip: Option<PotProof>,
+        summary: PotStateSummary,
+    ) -> Result<(), PotVerifyBlockProofsError> {
+        // Perform the validation, AES verification outside the lock.
+        let mut prev_proof = tip.clone();
+        let mut to_add = Vec::with_capacity(proofs.len());
+        for proof in proofs.iter() {
+            if let Some(prev_proof) = prev_proof.as_ref() {
+                if proof.slot_number != (prev_proof.slot_number + 1) {
+                    return Err(PotVerifyBlockProofsError::UnexpectedSlot {
+                        summary: summary.clone(),
+                        block_number,
+                        slot: slot_number,
+                        parent_slot: parent_slot_number,
+                        expected_slot: prev_proof.slot_number + 1,
+                        actual_slot: proof.slot_number,
+                    });
+                }
+
+                if proof.seed != prev_proof.next_seed(None) {
+                    return Err(PotVerifyBlockProofsError::UnexpectedSeed {
+                        summary: summary.clone(),
+                        block_number,
+                        slot: slot_number,
+                        parent_slot: parent_slot_number,
+                        error_slot: proof.slot_number,
+                    });
+                }
+
+                if proof.key != prev_proof.next_key() {
+                    return Err(PotVerifyBlockProofsError::UnexpectedKey {
+                        summary: summary.clone(),
+                        block_number,
+                        slot: slot_number,
+                        parent_slot: parent_slot_number,
+                        error_slot: proof.slot_number,
+                    });
+                }
+
+                // Perform the AES check
+                self.proof_of_time.verify(proof).map_err(|err| {
+                    PotVerifyBlockProofsError::VerificationFailed {
+                        summary: summary.clone(),
+                        block_number,
+                        slot: slot_number,
+                        parent_slot: parent_slot_number,
+                        error_slot: proof.slot_number,
+                        err,
+                    }
+                })?;
+            }
+            to_add.push(proof.clone());
+            prev_proof = Some(proof.clone());
+        }
+
+        // Checks passed, take the lock and try to append.
+        let mut state = self.state.lock();
+        let cur_tip = state.tip();
+        if cur_tip != tip {
+            // Fail if the tip moved meanwhile.
+            // TODO: fall back to regular path if needed.
+            return Err(PotVerifyBlockProofsError::TipMismatch {
+                summary: summary.clone(),
+                block_number,
+                slot: slot_number,
+                parent_slot: parent_slot_number,
+                expected: tip.map(|p| p.slot_number),
+                actual: cur_tip.map(|p| p.slot_number),
+            });
+        }
+        state.extend_and_merge_batch(to_add);
+
+        Ok(())
     }
 }
 
@@ -688,6 +827,29 @@ impl PotConsensusState for StateManager {
         parent_slot_number: SlotNumber,
         parent_pre_digest: &PotPreDigest,
     ) -> Result<(), PotVerifyBlockProofsError> {
+        if let Some(block_proofs) = pre_digest.proofs() {
+            // Opportunistically try to extend the chain with
+            // the proofs from the block.
+            let (tip, summary) = {
+                let state = self.state.lock();
+                (state.tip(), state.summary())
+            };
+            let should_append = tip
+                .as_ref()
+                .map(|tip| (tip.slot_number + 1) == block_proofs.first().slot_number)
+                .unwrap_or(true);
+            if should_append {
+                return self.verify_and_append(
+                    block_number,
+                    slot_number,
+                    block_proofs,
+                    parent_slot_number,
+                    tip,
+                    summary,
+                );
+            }
+        }
+
         self.state.lock().verify_block_proofs(
             block_number,
             slot_number,
@@ -700,7 +862,8 @@ impl PotConsensusState for StateManager {
 
 pub(crate) fn init_pot_state(
     config: PotConfig,
+    proof_of_time: ProofOfTime,
 ) -> (Arc<dyn PotProtocolState>, Arc<dyn PotConsensusState>) {
-    let state = Arc::new(StateManager::new(config));
+    let state = Arc::new(StateManager::new(config, proof_of_time));
     (state.clone(), state)
 }

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -323,6 +323,9 @@ pub enum ChainConstants {
         recent_history_fraction: (HistorySize, HistorySize),
         /// Minimum lifetime of a plotted sector, measured in archived segment.
         min_sector_lifetime: HistorySize,
+        /// If true, use the proof of time in the pre digest as source of global
+        /// randomness.
+        is_pot_enabled: bool,
     },
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -307,6 +307,7 @@ impl pallet_subspace::Config for Runtime {
     >;
 
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
+    // TODO: this needs to come from the cmd line enable PoT flag
     type IsPotEnabled = ConstBool<false>;
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -42,7 +42,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use core::mem;
 use core::num::NonZeroU64;
 use domain_runtime_primitives::{BlockNumber as DomainNumber, Hash as DomainHash};
-use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Everything, Get};
+use frame_support::traits::{ConstBool, ConstU16, ConstU32, ConstU64, ConstU8, Everything, Get};
 use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types, PalletId};
@@ -307,6 +307,7 @@ impl pallet_subspace::Config for Runtime {
     >;
 
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
+    type IsPotEnabled = ConstBool<false>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -822,6 +822,7 @@ where
                     client.clone(),
                     network_service.clone(),
                     sync_service.clone(),
+                    subspace_link.slot_duration().as_duration(),
                 );
 
                 task_manager.spawn_essential_handle().spawn_blocking(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -252,6 +252,7 @@ parameter_types! {
         HistorySize::new(NonZeroU64::new(10).unwrap()),
     );
     pub const MinSectorLifetime: HistorySize = HistorySize::new(NonZeroU64::new(4).unwrap());
+    pub const IsPotEnabled: bool = false;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -277,6 +278,7 @@ impl pallet_subspace::Config for Runtime {
     >;
 
     type WeightInfo = ();
+    type IsPotEnabled = IsPotEnabled;
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
Main changes:
1. Global randomness is derived from the proofs in pre digest and used in verification (if feature enabled)
2. If the proofs are not yet ready when proposing the block, wait instead of failing
3. If the imported block has proofs not yet available locally, verify and include in local chain
4. Improvements in initialization: use block import notification instead of sync oracle
5. Use same slot duration for the proof production and consensus. Otherwise this causes divergence and leads to other erros.

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
