### PR TITLE
Fix DSN sync in case current canonical chain from the point of view of the node is different from canonical chain in archived history

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -218,6 +218,7 @@ where
     // Corresponds to contents of block one, everyone has it, so we consider it being processed
     // right away
     let mut last_processed_segment_index = SegmentIndex::ZERO;
+    let mut last_processed_block_number = client.info().finalized_number;
     let segment_header_downloader = SegmentHeaderDownloader::new(node);
     let piece_provider = PieceProvider::new(
         node.clone(),
@@ -246,7 +247,7 @@ where
             &piece_provider,
             import_queue_service,
             &mut last_processed_segment_index,
-            false,
+            &mut last_processed_block_number,
         )
         .await
         {


### PR DESCRIPTION
Fixes https://github.com/subspace/subspace/issues/1803 by looking at finalized blocks when checking what blocks we should skip completely.

In order to not process the same blocks over and over, in addition to looking at finalized blocks, we also keep track of the last processed block number (that corresponds to archived history and as such should be fine to track by number).

Overall fairly minimal changes if you ignore whitespaces.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
