### PR TITLE
Support output without colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,6 +4565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11135,6 +11141,7 @@ dependencies = [
  "subspace-rpc-primitives",
  "subspace-solving",
  "substrate-bip39",
+ "supports-color",
  "tempfile",
  "thiserror",
  "tokio",
@@ -11859,6 +11866,16 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "supports-color"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -49,6 +49,7 @@ subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["chia"] }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
 substrate-bip39 = "0.4.4"
+supports-color = "2.0.0"
 tempfile = "3.4.0"
 thiserror = "1.0.38"
 tokio = { version = "1.28.2", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -231,11 +231,14 @@ struct Command {
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
-            fmt::layer().with_filter(
-                EnvFilter::builder()
-                    .with_default_directive(LevelFilter::INFO.into())
-                    .from_env_lossy(),
-            ),
+            fmt::layer()
+                // TODO: Workaround for https://github.com/tokio-rs/tracing/issues/2214
+                .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
+                .with_filter(
+                    EnvFilter::builder()
+                        .with_default_directive(LevelFilter::INFO.into())
+                        .from_env_lossy(),
+                ),
         )
         .init();
     utils::raise_fd_limit();


### PR DESCRIPTION
Basically `tracing-subscriber` defaults are a bit problematic, see https://github.com/tokio-rs/tracing/issues/2214, I used recommended workaround in that issue. It also handles issue described in https://github.com/tokio-rs/tracing/issues/2388, so `NO_COLOR` environment variable now works as well.

Fixes https://github.com/subspace/subspace/issues/1779

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
