### PR TITLE
Implement `subspace-farmer scrub` command for checking farm contents for corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11110,6 +11110,7 @@ dependencies = [
  "backoff",
  "base58",
  "blake2",
+ "blake3",
  "bytesize",
  "clap",
  "cuckoofilter",

--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -13,6 +13,10 @@ pub trait FileExt {
     /// undesirable
     fn advise_random_access(&self) -> Result<()>;
 
+    /// Advise OS/file system that file will use sequential access and read-ahead behavior is
+    /// desirable
+    fn advise_sequential_access(&self) -> Result<()>;
+
     /// Read exact number of bytes at a specific offset
     fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> Result<()>;
 
@@ -48,6 +52,34 @@ impl FileExt for File {
 
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     fn advise_random_access(&self) -> Result<()> {
+        // Not supported
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn advise_sequential_access(&self) -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+        let err =
+            unsafe { libc::posix_fadvise(self.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL) };
+        if err != 0 {
+            Err(std::io::Error::from_raw_os_error(err))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn advise_sequential_access(&self) -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+        if unsafe { libc::fcntl(self.as_raw_fd(), libc::F_RDAHEAD, 1) } != 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    fn advise_sequential_access(&self) -> Result<()> {
         // Not supported
         Ok(())
     }

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -18,6 +18,7 @@ atomic = "0.5.3"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base58 = "0.2.0"
 blake2 = "0.10.6"
+blake3 = { version = "1.4.1", default-features = false }
 bytesize = "1.2.0"
 clap = { version = "4.2.1", features = ["color", "derive"] }
 cuckoofilter = { version = "0.5.0", features = ["serde_support"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -1,6 +1,8 @@
 mod farm;
 mod info;
+mod scrub;
 mod shared;
 
 pub(crate) use farm::farm_multi_disk;
 pub(crate) use info::info;
+pub(crate) use scrub::scrub;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/scrub.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/scrub.rs
@@ -1,0 +1,35 @@
+use rayon::prelude::*;
+use std::path::PathBuf;
+use subspace_farmer::single_disk_farm::SingleDiskFarm;
+use tracing::{error, info, info_span};
+
+pub(crate) fn scrub(disk_farms: &[PathBuf]) {
+    disk_farms
+        .into_par_iter()
+        .enumerate()
+        .for_each(|(disk_farm_index, directory)| {
+            let span = info_span!("single_disk_farm", %disk_farm_index);
+            let _span_guard = span.enter();
+            info!(
+                path = %directory.display(),
+                "Start scrubbing farm"
+            );
+
+            match SingleDiskFarm::scrub(directory) {
+                Ok(()) => {
+                    info!(
+                        path = %directory.display(),
+                        "Farm checked successfully"
+                    );
+                }
+                Err(error) => {
+                    error!(
+                        path = %directory.display(),
+                        %error,
+                        "Irrecoverable farm error occurred, your file system might need to be \
+                        repaired or disk might need to be replaced"
+                    );
+                }
+            }
+        });
+}

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -126,12 +126,14 @@ impl Default for WriteToDisk {
 #[allow(clippy::large_enum_variant)] // we allow large function parameter list and enums
 #[derive(Debug, clap::Subcommand)]
 enum Subcommand {
-    /// Wipes plot and identity
+    /// Wipes the farm
     Wipe,
-    /// Start a farmer using previously created plot
+    /// Start a farmer, does plotting and farming
     Farm(FarmingArgs),
     /// Print information about farm and its content
     Info,
+    /// Checks the farm for corruption and repairs errors (caused by disk errors or something else)
+    Scrub,
 }
 
 #[derive(Debug, Clone)]
@@ -300,6 +302,13 @@ async fn main() -> anyhow::Result<()> {
         }
         Subcommand::Info => {
             commands::info(disk_farms);
+        }
+        Subcommand::Scrub => {
+            let disk_farms = disk_farms
+                .into_iter()
+                .map(|disk_farm| disk_farm.directory)
+                .collect::<Vec<_>>();
+            commands::scrub(&disk_farms);
         }
     }
     Ok(())

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -54,7 +54,7 @@ pub struct DiskPieceCache {
 }
 
 impl DiskPieceCache {
-    const PIECE_CACHE_FILE: &'static str = "piece_cache.bin";
+    pub(super) const FILE_NAME: &'static str = "piece_cache.bin";
 
     pub(super) fn open(directory: &Path, capacity: usize) -> Result<Self, DiskPieceCacheError> {
         if capacity == 0 {
@@ -65,7 +65,7 @@ impl DiskPieceCache {
             .read(true)
             .write(true)
             .create(true)
-            .open(directory.join(Self::PIECE_CACHE_FILE))?;
+            .open(directory.join(Self::FILE_NAME))?;
 
         let expected_size = Self::element_size() * capacity;
         // Allocating the whole file (`set_len` below can create a sparse file, which will cause
@@ -217,7 +217,7 @@ impl DiskPieceCache {
     }
 
     pub(crate) fn wipe(directory: &Path) -> io::Result<()> {
-        let piece_cache = directory.join(Self::PIECE_CACHE_FILE);
+        let piece_cache = directory.join(Self::FILE_NAME);
         info!("Deleting piece cache file at {}", piece_cache.display());
         fs::remove_file(piece_cache)
     }

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -178,8 +178,8 @@ where
         sector.flush()?;
         sector_metadata.flush()?;
 
-        if sector_index + 1 > metadata_header.sector_count {
-            metadata_header.sector_count = sector_index + 1;
+        if sector_index + 1 > metadata_header.plotted_sector_count {
+            metadata_header.plotted_sector_count = sector_index + 1;
             metadata_header.encode_to(&mut metadata_header_mmap.as_mut());
         }
         {


### PR DESCRIPTION
Addresses last item in https://github.com/subspace/subspace/issues/1723.

Basically goes through the things farmer application writes to disk and checks that it makes sense. It will not check that sectors are expired or anything like that, but it will find size and checksum mismatches and will replace broken/unreadable data with something that generally makes sense and will allow the farmer to continue working. For instance broken sectors will start replotting on farmer restart after scrub, broken cached pieces will be re-synced.

It is a lot of boilerplate due to error handling and user-facing messages.

Fixes https://github.com/subspace/subspace/issues/1723

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
