### PR TITLE
Fix domain operator node restarting

### DIFF
--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -176,10 +176,8 @@ where
         let consensus_to = consensus_block_hash;
 
         if consensus_from == consensus_to {
-            return Err(sp_blockchain::Error::Application(
-                format!("Consensus block {consensus_block_hash:?} has already been processed.",)
-                    .into(),
-            ));
+            tracing::debug!("Consensus block {consensus_block_hash:?} has already been processed");
+            return Ok(None);
         }
 
         let route =

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1765,7 +1765,7 @@ async fn test_restart_domain_operator() {
     ferdie.produce_block_with_slot(1.into()).await.unwrap();
 
     // Run Alice (a evm domain authority node)
-    let alice = domain_test_service::DomainNodeBuilder::new(
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -1798,7 +1798,7 @@ async fn test_restart_domain_operator() {
     ferdie.set_next_slot(next_slot);
 
     // Restart Alice
-    let alice = domain_test_service::DomainNodeBuilder::new(
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -249,19 +249,8 @@ async fn test_processing_empty_consensus_block() {
             .pending_imported_consensus_blocks(consensus_best_hash, consensus_best_number);
         match res {
             // The consensus block is processed in the above `produce_block_with_extrinsics` call,
-            // thus calling `pending_imported_consensus_blocks` again will result in an error
-            Err(err) => {
-                // `sp_blockchain::Error` is not impl `PartialEq` thus comparing the string
-                assert_eq!(
-                    err.to_string(),
-                    sp_blockchain::Error::Application(
-                        format!(
-                            "Consensus block {consensus_best_hash:?} has already been processed.",
-                        )
-                        .into()
-                    )
-                    .to_string()
-                );
+            // thus calling `pending_imported_consensus_blocks` again will result in an `Ok(None)`
+            Ok(None) => {
                 // The `latest_consensus_block` that mapped to the genesis domain block must be updated
                 let latest_consensus_block: Hash =
                     crate::aux_schema::latest_consensus_block_hash_for(
@@ -1746,3 +1735,72 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 // .await
 // .unwrap();
 // }
+
+#[substrate_test_utils::test(flavor = "multi_thread")]
+async fn test_restart_domain_operator() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
+
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Ferdie,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+
+    // Produce 1 consensus block to initialize genesis domain
+    ferdie.produce_block_with_slot(1.into()).await.unwrap();
+
+    // Run Alice (a evm domain authority node)
+    let alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Alice,
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .await;
+
+    produce_blocks!(ferdie, alice, 5).await.unwrap();
+    let next_slot = ferdie.next_slot();
+
+    // Stop Ferdie and Alice and delete their database lock files
+    drop(ferdie);
+    drop(alice);
+    std::fs::remove_file(directory.path().join("ferdie/paritydb/lock")).unwrap();
+    std::fs::remove_file(
+        directory
+            .path()
+            .join(format!("alice/domain-{GENESIS_DOMAIN_ID:?}"))
+            .as_path()
+            .join("paritydb/lock"),
+    )
+    .unwrap();
+
+    // Restart Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Ferdie,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+    ferdie.set_next_slot(next_slot);
+
+    // Restart Alice
+    let alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Alice,
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .await;
+
+    produce_blocks!(ferdie, alice, 5).await.unwrap();
+
+    // Chain should progress base on previous run
+    assert_eq!(ferdie.client.info().best_number, 11);
+    assert_eq!(alice.client.info().best_number, 10);
+}

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -410,6 +410,11 @@ impl MockConsensusNode {
         self.next_slot
     }
 
+    /// Set the next slot number
+    pub fn set_next_slot(&mut self, next_slot: u64) {
+        self.next_slot = next_slot;
+    }
+
     /// Produce a slot only, without waiting for the potential slot handlers.
     pub fn produce_slot(&mut self) -> Slot {
         let slot = Slot::from(self.next_slot);


### PR DESCRIPTION
Stop an operator node and restarting it again will result in an error due to the operator try to re-processing a consensus block:
https://github.com/subspace/subspace/blob/37e70fb34e8ba24b731168fbfa6c94abbbb8f2e5/domains/client/domain-operator/src/domain_block_processor.rs#L178-L183

This error is unnecessary since it is not a fatal error and we can just skip repeat processing of the consensus block.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
