### PR TITLE
Restore correct slot duration

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -137,7 +137,7 @@ pub const MILLISECS_PER_BLOCK: u64 = 6000;
 
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.
-const SLOT_DURATION: u64 = 2000;
+const SLOT_DURATION: u64 = 1000;
 
 /// 1 in 6 slots (on average, not counting collisions) will have a block.
 /// Must match ratio between block and slot duration in constants above.


### PR DESCRIPTION
I tend to believe it was changed by accident in https://github.com/subspace/subspace/commit/31cdcc6bb2749bfe1d5f18315d73a68b5efc193b#diff-fbb221bbf0e3e406038048d471e781c3ea4fb288187395151b7d46c6da088a96R131 (@liuchengxu is that assumption correct?).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
