### PR TITLE
Improve farmer CLI

### DIFF
--- a/crates/subspace-farmer/README.md
+++ b/crates/subspace-farmer/README.md
@@ -53,18 +53,28 @@ target/production/subspace-farmer --help
 
 ### Start the farmer
 ```
-target/production/subspace-farmer --farm path=/path/to/disk,size=100G farm --reward-address st...
+target/production/subspace-farmer farm --reward-address st... path=/path/to/farm,size=100G
 ```
 
-`st...` should be replaced with the reward address taken from Polkadot.js wallet (or similar), `/path/to/disk` with location where you want to store plot and `100G` replaced with desired plot size.
+`st...` should be replaced with the reward address taken from Polkadot.js wallet (or similar), `/path/to/farm` with location where you want to store plot and `100G` replaced with desired plot size.
 
 This will connect to local node and will try to solve on every slot notification, while also plotting all existing and new history of the blockchain in parallel.
 
 *NOTE: You need to have a `subspace-node` running before starting farmer, otherwise it will not be able to start*
 
-### Wipe the plot (same that was created previously)
+### Show information about the farm
 ```
-target/production/subspace-farmer --farm path=/path/to/disk,size=100G wipe
+target/production/subspace-farmer info /path/to/farm
+```
+
+### Scrub the farm to find and fix farm corruption
+```
+target/production/subspace-farmer scrub /path/to/farm
+```
+
+### Wipe the farm
+```
+target/production/subspace-farmer wipe /path/to/farm
 ```
 
 This would wipe plots in the OS-specific users local data directory.

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands.rs
@@ -3,6 +3,6 @@ mod info;
 mod scrub;
 mod shared;
 
-pub(crate) use farm::farm_multi_disk;
+pub(crate) use farm::farm;
 pub(crate) use info::info;
 pub(crate) use scrub::scrub;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -49,16 +49,11 @@ where
 
     let signal = shutdown_signal();
 
-    // TODO: Use variables and remove this suppression
-    #[allow(unused_variables)]
     let FarmingArgs {
         node_rpc_url,
         reward_address,
         max_pieces_in_sector,
-        disk_concurrency,
-        disable_farming,
         mut dsn,
-        max_concurrent_plots,
         cache_percentage,
         no_info: _,
     } = farming_args;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/info.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/info.rs
@@ -1,14 +1,12 @@
 use crate::commands::shared::print_disk_farm_info;
-use crate::DiskFarm;
+use std::path::PathBuf;
 
-pub(crate) fn info(disk_farms: Vec<DiskFarm>) {
+pub(crate) fn info(disk_farms: Vec<PathBuf>) {
     for (disk_farm_index, disk_farm) in disk_farms.into_iter().enumerate() {
         if disk_farm_index > 0 {
             println!();
         }
 
-        let DiskFarm { directory, .. } = disk_farm;
-
-        print_disk_farm_info(directory, disk_farm_index);
+        print_disk_farm_info(disk_farm, disk_farm_index);
     }
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -5,7 +5,7 @@ mod ss58;
 mod utils;
 
 use bytesize::ByteSize;
-use clap::{Parser, ValueEnum, ValueHint};
+use clap::{Parser, ValueHint};
 use ss58::parse_ss58_reward_address;
 use std::fs;
 use std::num::NonZeroU8;
@@ -15,7 +15,6 @@ use subspace_core_primitives::PublicKey;
 use subspace_farmer::single_disk_farm::SingleDiskFarm;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_proof_of_space::chia::ChiaTable;
-use tempfile::TempDir;
 use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
@@ -35,21 +34,49 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 /// Arguments for farmer
 #[derive(Debug, Parser)]
 struct FarmingArgs {
+    /// One or more farm located at specified path, each with its own allocated space.
+    ///
+    /// In case of multiple disks, it is recommended to specify them individually rather than using
+    /// RAID 0, that way farmer will be able to better take advantage of concurrency of individual
+    /// drives.
+    ///
+    /// Format for each farm is coma-separated list of strings like this:
+    ///
+    ///   path=/path/to/directory,size=5T
+    ///
+    /// `size` is max allocated size in human readable format (e.g. 10GB, 2TiB) or just bytes that
+    /// farmer will make sure not not exceed (and will pre-allocated all the space on startup to
+    /// ensure it will not run out of space in runtime).
+    disk_farms: Vec<DiskFarm>,
     /// WebSocket RPC URL of the Subspace node to connect to
     #[arg(long, value_hint = ValueHint::Url, default_value = "ws://127.0.0.1:9944")]
     node_rpc_url: String,
     /// Address for farming rewards
     #[arg(long, value_parser = parse_ss58_reward_address)]
     reward_address: PublicKey,
+    /// Percentage of allocated space dedicated for caching purposes, 99% max
+    #[arg(long, default_value = "1", value_parser = cache_percentage_parser)]
+    cache_percentage: NonZeroU8,
+    /// Sets some flags that are convenient during development, currently `--enable-private-ips`.
+    #[arg(long)]
+    dev: bool,
+    /// Run temporary farmer with specified plot size in human readable format (e.g. 10GB, 2TiB) or
+    /// just bytes (e.g. 4096), this will create a temporary directory for storing farmer data that
+    /// will be deleted at the end of the process.
+    #[arg(long, conflicts_with = "disk_farms")]
+    tmp: Option<ByteSize>,
     /// Maximum number of pieces in sector (can override protocol value to something lower).
+    ///
+    /// This will make plotting of individual sectors faster, decrease load on CPU proving, but also
+    /// proportionally increase amount of disk reads during audits since every sector needs to be
+    /// audited and there will be more of them.
+    ///
+    /// This is primarily for development and not recommended to use by regular users.
     #[arg(long)]
     max_pieces_in_sector: Option<u16>,
     /// DSN parameters
     #[clap(flatten)]
     dsn: DsnArgs,
-    /// Percentage of plot dedicated for caching purposes, 99% max.
-    #[arg(long, default_value = "1", value_parser = cache_percentage_parser)]
-    cache_percentage: NonZeroU8,
     /// Do not print info about configured farms on startup.
     #[arg(long)]
     no_info: bool,
@@ -59,7 +86,7 @@ fn cache_percentage_parser(s: &str) -> anyhow::Result<NonZeroU8> {
     let cache_percentage = NonZeroU8::from_str(s)?;
 
     if cache_percentage.get() > 99 {
-        return Err(anyhow::anyhow!("Cache percentage can't exceed 100"));
+        return Err(anyhow::anyhow!("Cache percentage can't exceed 99"));
     }
 
     Ok(cache_percentage)
@@ -75,7 +102,8 @@ struct DsnArgs {
     /// multiple are supported.
     #[arg(long, default_value = "/ip4/0.0.0.0/tcp/30533")]
     listen_on: Vec<Multiaddr>,
-    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
+    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in
+    /// Kademlia DHT.
     #[arg(long, default_value_t = false)]
     enable_private_ips: bool,
     /// Multiaddrs of reserved nodes to maintain a connection to, multiple are supported
@@ -99,32 +127,6 @@ struct DsnArgs {
     /// Known external addresses
     #[arg(long, alias = "external-address")]
     external_addresses: Vec<Multiaddr>,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum WriteToDisk {
-    Nothing,
-    Everything,
-}
-
-impl Default for WriteToDisk {
-    #[inline]
-    fn default() -> Self {
-        Self::Everything
-    }
-}
-
-#[allow(clippy::large_enum_variant)] // we allow large function parameter list and enums
-#[derive(Debug, clap::Subcommand)]
-enum Subcommand {
-    /// Wipes the farm
-    Wipe,
-    /// Start a farmer, does plotting and farming
-    Farm(FarmingArgs),
-    /// Print information about farm and its content
-    Info,
-    /// Checks the farm for corruption and repairs errors (caused by disk errors or something else)
-    Scrub,
 }
 
 #[derive(Debug, Clone)]
@@ -195,29 +197,33 @@ impl FromStr for DiskFarm {
 
 #[derive(Debug, Parser)]
 #[clap(about, version)]
-struct Command {
-    #[clap(subcommand)]
-    subcommand: Subcommand,
-    /// Specify single plot located at specified path, can be specified multiple times to use
-    /// multiple disks.
-    ///
-    /// Format is coma-separated string like this:
-    ///
-    ///   path=/path/to/directory,size=5T
-    ///
-    /// `size` is max allocated size in human readable format (e.g. 10GB, 2TiB) or just bytes that
-    /// farmer will make sure not not exceed (and will pre-allocated all the space on startup to
-    /// ensure it will not run out of space in runtime).
-    #[arg(long)]
-    farm: Vec<DiskFarm>,
-    /// Run temporary farmer with specified plot size in human readable format (e.g. 10GB, 2TiB) or
-    /// just bytes (e.g. 4096), this will create a temporary directory for storing farmer data that
-    /// will be deleted at the end of the process.
-    #[arg(long, conflicts_with = "farm")]
-    tmp: Option<ByteSize>,
-    /// Enables the "development mode". Toggles flags like `--enable-private-ips`
-    #[arg(long)]
-    dev: bool,
+enum Command {
+    /// Start a farmer, does plotting and farming
+    Farm(FarmingArgs),
+    /// Print information about farm and its content
+    Info {
+        /// One or more farm located at specified path.
+        ///
+        /// Example:
+        ///   /path/to/directory
+        disk_farms: Vec<PathBuf>,
+    },
+    /// Checks the farm for corruption and repairs errors (caused by disk errors or something else)
+    Scrub {
+        /// One or more farm located at specified path.
+        ///
+        /// Example:
+        ///   /path/to/directory
+        disk_farms: Vec<PathBuf>,
+    },
+    /// Wipes the farm
+    Wipe {
+        /// One or more farm located at specified path.
+        ///
+        /// Example:
+        ///   /path/to/directory
+        disk_farms: Vec<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -238,67 +244,34 @@ async fn main() -> anyhow::Result<()> {
 
     let command = Command::parse();
 
-    let (disk_farms, _tmp_directory) = if let Some(plot_size) = command.tmp {
-        let tmp_directory = TempDir::new()?;
-        (
-            vec![DiskFarm {
-                directory: tmp_directory.as_ref().to_path_buf(),
-                allocated_plotting_space: plot_size.as_u64(),
-            }],
-            Some(tmp_directory),
-        )
-    } else {
-        (command.farm, None)
-    };
-
-    match command.subcommand {
-        Subcommand::Wipe => {
-            for farm in &disk_farms {
-                if !farm.directory.exists() {
-                    panic!("Directory {} doesn't exist", farm.directory.display());
+    match command {
+        Command::Wipe { disk_farms } => {
+            for disk_farm in &disk_farms {
+                if !disk_farm.exists() {
+                    panic!("Directory {} doesn't exist", disk_farm.display());
                 }
             }
 
-            for farm in &disk_farms {
+            for disk_farm in &disk_farms {
                 // TODO: Delete this section once we don't have shared data anymore
                 info!("Wiping shared data");
-                let _ = fs::remove_file(farm.directory.join("known_addresses_db"));
-                let _ = fs::remove_file(farm.directory.join("known_addresses.bin"));
-                let _ = fs::remove_file(farm.directory.join("piece_cache_db"));
-                let _ = fs::remove_file(farm.directory.join("providers_db"));
+                let _ = fs::remove_file(disk_farm.join("known_addresses_db"));
+                let _ = fs::remove_file(disk_farm.join("known_addresses.bin"));
+                let _ = fs::remove_file(disk_farm.join("piece_cache_db"));
+                let _ = fs::remove_file(disk_farm.join("providers_db"));
 
-                SingleDiskFarm::wipe(&farm.directory)?;
+                SingleDiskFarm::wipe(disk_farm)?;
             }
 
             info!("Done");
         }
-        Subcommand::Farm(mut farming_args) => {
-            for farm in &disk_farms {
-                if !farm.directory.exists() {
-                    if let Err(error) = fs::create_dir(&farm.directory) {
-                        panic!(
-                            "Directory {} doesn't exist and can't be created: {}",
-                            farm.directory.display(),
-                            error
-                        );
-                    }
-                }
-            }
-
-            // Override the `--enable_private_ips` flag with `--dev`
-            farming_args.dsn.enable_private_ips =
-                farming_args.dsn.enable_private_ips || command.dev;
-
-            commands::farm_multi_disk::<PosTable>(disk_farms, farming_args).await?;
+        Command::Farm(farming_args) => {
+            commands::farm::<PosTable>(farming_args).await?;
         }
-        Subcommand::Info => {
+        Command::Info { disk_farms } => {
             commands::info(disk_farms);
         }
-        Subcommand::Scrub => {
-            let disk_farms = disk_farms
-                .into_iter()
-                .map(|disk_farm| disk_farm.directory)
-                .collect::<Vec<_>>();
+        Command::Scrub { disk_farms } => {
             commands::scrub(&disk_farms);
         }
     }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -8,7 +8,7 @@ use bytesize::ByteSize;
 use clap::{Parser, ValueEnum, ValueHint};
 use ss58::parse_ss58_reward_address;
 use std::fs;
-use std::num::{NonZeroU16, NonZeroU8, NonZeroUsize};
+use std::num::NonZeroU8;
 use std::path::PathBuf;
 use std::str::FromStr;
 use subspace_core_primitives::PublicKey;
@@ -44,18 +44,9 @@ struct FarmingArgs {
     /// Maximum number of pieces in sector (can override protocol value to something lower).
     #[arg(long)]
     max_pieces_in_sector: Option<u16>,
-    /// Number of major concurrent operations to allow for disk
-    #[arg(long, default_value = "2")]
-    disk_concurrency: NonZeroU16,
-    /// Disable farming
-    #[arg(long)]
-    disable_farming: bool,
     /// DSN parameters
     #[clap(flatten)]
     dsn: DsnArgs,
-    /// Number of plots that can be plotted concurrently, impacts RAM usage.
-    #[arg(long, default_value = "10")]
-    max_concurrent_plots: NonZeroUsize,
     /// Percentage of plot dedicated for caching purposes, 99% max.
     #[arg(long, default_value = "1", value_parser = cache_percentage_parser)]
     cache_percentage: NonZeroU8,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
@@ -3,7 +3,7 @@ use tokio::signal;
 pub(crate) fn raise_fd_limit() {
     match std::panic::catch_unwind(fdlimit::raise_fd_limit) {
         Ok(Some(limit)) => {
-            tracing::info!("Increase file limit from soft to hard (limit is {limit})")
+            tracing::debug!("Increase file limit from soft to hard (limit is {limit})")
         }
         Ok(None) => tracing::debug!("Failed to increase file limit"),
         Err(err) => {
@@ -18,6 +18,7 @@ pub(crate) fn raise_fd_limit() {
         }
     }
 }
+
 #[cfg(unix)]
 pub(crate) async fn shutdown_signal() {
     use futures::FutureExt;

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -77,11 +77,11 @@ If you're connected directly without any router, then again nothing needs to be 
 6. After running this command, Windows may ask you for permissions related to firewall, select `allow` in this case.
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```PowerShell
-# Replace `PATH_TO_PLOT` with location where you want you store plot files
+# Replace `PATH_TO_FARM` with location where you want you store plot files
 # Replace `FARMER_FILE_NAME.exe` with the name of the farmer file you downloaded from releases
 # Replace `WALLET_ADDRESS` below with your account address from Polkadot.js wallet
 # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
-.\FARMER_FILE_NAME.exe --farm path=PATH_TO_PLOT,size=PLOT_SIZE farm --reward-address WALLET_ADDRESS
+.\FARMER_FILE_NAME.exe farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
 ```
 
 ## 🐧 Ubuntu Instructions
@@ -128,11 +128,11 @@ If you're connected directly without any router, then again nothing needs to be 
 ```
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```bash
-# Replace `PATH_TO_PLOT` with location where you want you store plot files
+# Replace `PATH_TO_FARM` with location where you want you store plot files
 # Replace `FARMER_FILE_NAME` with the name of the farmer file you downloaded from releases
 # Replace `WALLET_ADDRESS` below with your account address from Polkadot.js wallet
 # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
-./FARMER_FILE_NAME --farm path=PATH_TO_PLOT,size=PLOT_SIZE farm --reward-address WALLET_ADDRESS
+./FARMER_FILE_NAME farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
 ```
 
 ## 🍎 macOS Instructions
@@ -183,11 +183,11 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 7. We will then open another terminal, change to the downloads directory, then start the farmer node with the following command:
 ```bash
-# Replace `PATH_TO_PLOT` with location where you want you store plot files
+# Replace `PATH_TO_FARM` with location where you want you store plot files
 # Replace `FARMER_FILE_NAME` with the name of the farmer file you downloaded from releases
 # Replace `WALLET_ADDRESS` below with your account address from Polkadot.js wallet
 # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
-./FARMER_FILE_NAME --farm path=PATH_TO_PLOT,size=PLOT_SIZE farm --reward-address WALLET_ADDRESS
+./FARMER_FILE_NAME farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
 ```
 7. It may prompt again in here. Refer to the note on step 4.
 
@@ -254,13 +254,13 @@ services:
       - "0.0.0.0:30533:30533"
     restart: unless-stopped
     command: [
-      # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
-      "--farm", "path=/var/subspace,size=PLOT_SIZE",
       "farm",
       "--node-rpc-url", "ws://node:9944",
       "--listen-on", "/ip4/0.0.0.0/tcp/30533",
 # Replace `WALLET_ADDRESS` with your Polkadot.js wallet address
       "--reward-address", "WALLET_ADDRESS",
+      # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
+      "path=/var/subspace,size=PLOT_SIZE",
     ]
 volumes:
   node-data:
@@ -292,7 +292,7 @@ Visit [Polkadot.js explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Feu-0.
 If you were running a node previously, and want to switch to a new snapshot, please perform these steps and then follow the guideline again:
 ```
 # Replace `FARMER_FILE_NAME` with the name of the node file you downloaded from releases
-./FARMER_FILE_NAME --farm path=PATH_TO_PLOT,size=PLOT_SIZE wipe
+./FARMER_FILE_NAME wipe PATH_TO_FARM
 # Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases
 ./NODE_FILE_NAME purge-chain --chain gemini-3f
 ```
@@ -314,10 +314,11 @@ There are extra commands and parameters you can use on farmer or node, use the `
 
 Below are some helpful samples:
 
-- `./FARMER_FILE_NAME --farm path=PATH_TO_PLOT,size=PLOT_SIZE farm ...` : will store data in `PATH_TO_PLOT` instead of default location
-- `./FARMER_FILE_NAME --farm path=PATH_TO_PLOT,size=PLOT_SIZE wipe` : erases everything related to farmer if data were stored in `PATH_TO_PLOT`
-- `./NODE_FILE_NAME --base-path PATH_TO_PLOT --chain gemini-3f ...` : start node and store data in `PATH_TO_PLOT` instead of default location
-- `./NODE_FILE_NAME purge-chain --base-path PATH_TO_PLOT --chain gemini-3f` : erases data related to the node if data were stored in `PATH_TO_PLOT`
+- `./FARMER_FILE_NAME info PATH_TO_FARM` : show information about the farm at `PATH_TO_FARM`
+- `./FARMER_FILE_NAME scrub PATH_TO_FARM` : Scrub the farm to find and fix farm at `PATH_TO_FARM` corruption
+- `./FARMER_FILE_NAME wipe PATH_TO_FARM` : erases everything related to farmer if data were stored in `PATH_TO_FARM`
+- `./NODE_FILE_NAME --base-path NODE_DATA_PATH --chain gemini-3f ...` : start node and store data in `NODE_DATA_PATH` instead of default location
+- `./NODE_FILE_NAME purge-chain --base-path NODE_DATA_PATH --chain gemini-3f` : erases data related to the node if data were stored in `NODE_DATA_PATH`
 
 Examples:
 ```bash
@@ -328,21 +329,15 @@ Examples:
 
 ## [Advanced] Support for multiple disks
 
-`--farm` argument you have seen above can be specified more than once to engage multiple disks.
+Farm path and size you have seen above can be specified more than once to engage multiple disks.
 It is recommended to specify multiple disks explicitly rather than using RAID for better hardware utilization and efficiency.
 
 Example:
 ```
-./FARMER_FILE_NAME \
-    --farm path=/media/ssd1,size=100GiB \
-    --farm path=/media/ssd2,size=10T \
-    --farm path=/media/ssd3,size=10T \
-    farm --reward-address WALLET_ADDRESS
-```
-
-You can also print info about farms with `info` command:
-```
-./FARMER_FILE_NAME --farm path=/media/ssd1,size=PLOT_SIZE info
+./FARMER_FILE_NAME farm --reward-address WALLET_ADDRESS \
+    path=/media/ssd1,size=100GiB \
+    path=/media/ssd2,size=10T \
+    path=/media/ssd3,size=10T
 ```
 
 ## [Advanced] Build from source (Linux)


### PR DESCRIPTION
This is a follow-up to https://github.com/subspace/subspace/pull/1778 and implements proposal from https://forum.subspace.network/t/farmer-cli-syntax-improvements/1603.

I also removed CLI arguments we did not use anyway and re-arranged remaining arguments such that those users will specify/change more likely appear sooner in help message.

I also tweaked some help messages and updated docs to mention `scrub` command.

Syntax before and after this PR:
| Before | After |
| ------ | ----- |
| --tmp X farm | farm --tmp X |
| --farm path=/path,size=X farm | farm path=/path,size=X |
| --farm path=/path,size=X scrub | scrub /path |

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
