### PR TITLE
Introduce Autonat protocol for DSN.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,6 +4912,7 @@ dependencies = [
  "getrandom 0.2.10",
  "instant",
  "libp2p-allow-block-list 0.2.0",
+ "libp2p-autonat",
  "libp2p-connection-limits 0.2.1",
  "libp2p-core 0.40.0",
  "libp2p-dns 0.40.0",
@@ -4954,6 +4955,25 @@ dependencies = [
  "libp2p-identity 0.2.2",
  "libp2p-swarm 0.43.2",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e907be08be5e4152317a79d310a6f501a1b5c02a81dcb065dc865475bbae9498"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.0",
+ "libp2p-identity 0.2.2",
+ "libp2p-request-response 0.25.0",
+ "libp2p-swarm 0.43.2",
+ "log",
+ "quick-protobuf",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -52,6 +52,7 @@ void = "1.0.2"
 version = "0.52.1"
 default-features = false
 features = [
+    "autonat",
     "dns",
     "gossipsub",
     "identify",

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -159,6 +159,7 @@ pub async fn configure_dsn(
         kademlia_mode: Some(Mode::Client),
         request_response_protocols: vec![PieceByIndexRequestHandler::create(|_, _| async { None })],
         bootstrap_addresses,
+        enable_autonat: false,
         ..default_config
     };
     let (node, mut node_runner_1) = subspace_networking::create(config).unwrap();

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -18,6 +18,7 @@ use crate::reserved_peers::{
 use crate::PeerInfoProvider;
 use derive_more::From;
 use libp2p::allow_block_list::{Behaviour as AllowBlockListBehaviour, BlockedPeers};
+use libp2p::autonat::{Behaviour as Autonat, Config as AutonatConfig, Event as AutonatEvent};
 use libp2p::connection_limits::{Behaviour as ConnectionLimitsBehaviour, ConnectionLimits};
 use libp2p::gossipsub::{
     Behaviour as Gossipsub, Config as GossipsubConfig, Event as GossipsubEvent, MessageAuthenticity,
@@ -57,6 +58,8 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     pub(crate) general_connected_peers_config: Option<ConnectedPeersConfig>,
     /// The configuration for the [`ConnectedPeers`] protocol (special instance).
     pub(crate) special_connected_peers_config: Option<ConnectedPeersConfig>,
+    /// Autonat configuration (optional).
+    pub(crate) autonat: Option<AutonatConfig>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -81,6 +84,7 @@ pub(crate) struct Behavior<RecordStore> {
         Toggle<ConnectedPeersBehaviour<GeneralConnectedPeersInstance>>,
     pub(crate) special_connected_peers:
         Toggle<ConnectedPeersBehaviour<SpecialConnectedPeersInstance>>,
+    pub(crate) autonat: Toggle<Autonat>,
 }
 
 impl<RecordStore> Behavior<RecordStore>
@@ -130,6 +134,10 @@ where
                 .special_connected_peers_config
                 .map(ConnectedPeersBehaviour::new)
                 .into(),
+            autonat: config
+                .autonat
+                .map(|autonat_config| Autonat::new(config.peer_id, autonat_config))
+                .into(),
         }
     }
 }
@@ -147,4 +155,5 @@ pub(crate) enum Event {
     PeerInfo(PeerInfoEvent),
     GeneralConnectedPeers(ConnectedPeersEvent<GeneralConnectedPeersInstance>),
     SpecialConnectedPeers(ConnectedPeersEvent<SpecialConnectedPeersInstance>),
+    Autonat(AutonatEvent),
 }

--- a/crates/subspace-networking/src/create.rs
+++ b/crates/subspace-networking/src/create.rs
@@ -74,7 +74,7 @@ const SWARM_TARGET_CONNECTION_NUMBER: u32 = 30;
 // "Good citizen" supports the network health.
 const YAMUX_MAX_STREAMS: usize = 256;
 const KADEMLIA_QUERY_TIMEOUT: Duration = Duration::from_secs(40);
-const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: Option<u32> = Some(2);
+const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: Option<u32> = Some(3);
 // TODO: Consider moving this constant to configuration or removing `Toggle` wrapper when we find a
 // use-case for gossipsub protocol.
 const ENABLE_GOSSIP_PROTOCOL: bool = false;


### PR DESCRIPTION
This PR introduces the autonat protocol to find out the status of the public addresses of the peers. Autonat is configured to use only currently connected peers. The PR also increases the connection limit per peer (2 -> 3) to give autonat more chances to establish a new connection. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
