### PR TITLE
Domains: do epoch transition for the first operator registration and bump runtime version

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -855,12 +855,21 @@ mod pallet {
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
 
-            let operator_id = do_register_operator::<T>(owner, domain_id, amount, config)
-                .map_err(Error::<T>::from)?;
+            let (operator_id, current_epoch_index) =
+                do_register_operator::<T>(owner, domain_id, amount, config)
+                    .map_err(Error::<T>::from)?;
+
             Self::deposit_event(Event::OperatorRegistered {
                 operator_id,
                 domain_id,
             });
+
+            // if the domain's current epoch is 0,
+            // then do an epoch transition so that operator can start producing bundles
+            if current_epoch_index.is_zero() {
+                do_finalize_domain_current_epoch::<T>(domain_id, One::one())
+                    .map_err(Error::<T>::from)?;
+            }
 
             Ok(())
         }
@@ -1066,6 +1075,18 @@ mod pallet {
         fn on_finalize(_: T::BlockNumber) {
             let _ = LastEpochStakingDistribution::<T>::clear(u32::MAX, None);
             Self::update_domain_tx_range();
+        }
+
+        // TODO: remove once the migration is done
+        fn on_runtime_upgrade() -> Weight {
+            for (domain_id, stake_summary) in DomainStakingSummary::<T>::iter() {
+                if stake_summary.current_epoch_index.is_zero() {
+                    if let Err(err) = do_finalize_domain_current_epoch::<T>(domain_id, One::one()) {
+                        log::error!(target: "runtime::domains", "Failed to do epoch transition for {domain_id:?}: {err:?}");
+                    }
+                }
+            }
+            Weight::zero()
         }
     }
 

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -1065,8 +1065,8 @@ mod tests {
                 domain_stake_summary.current_total_stake,
                 total_updated_stake
             );
-            // epoch should be 2 since we did 3 epoch transitions
-            assert_eq!(domain_stake_summary.current_epoch_index, 2);
+            // epoch should be 3 since we did 3 epoch transitions
+            assert_eq!(domain_stake_summary.current_epoch_index, 3);
         });
     }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -101,7 +101,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,


### PR DESCRIPTION
Also include runtime upgrade migration to do epoch transition of the domain instances that are still in epoch 0

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
