### PR TITLE
Fix typo resulting in confusing log message

### DIFF
--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -235,7 +235,7 @@ where
             {
                 let retrieved_pieces = incremental_piece_indices
                     .iter()
-                    .filter(|maybe_piece_index| maybe_piece_index.is_some())
+                    .filter(|maybe_piece_index| maybe_piece_index.is_none())
                     .count();
                 warn!(
                     %sector_index,


### PR DESCRIPTION
Piece indices that are `Some` are yet to be downloaded, this led to confusing warning

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
