### PR TITLE
Fix segment reconstruction

### DIFF
--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -229,11 +229,11 @@ impl PiecesReconstructor {
         segment_pieces: &[Option<Piece>],
         piece_position: usize,
     ) -> Result<Piece, ReconstructorError> {
-        let (reconstructed_records, polynomial) = self.reconstruct_shards(segment_pieces)?;
-
         if piece_position >= ArchivedHistorySegment::NUM_PIECES {
             return Err(ReconstructorError::IncorrectPiecePosition);
         }
+
+        let (reconstructed_records, polynomial) = self.reconstruct_shards(segment_pieces)?;
 
         let mut piece = Piece::from(&reconstructed_records[piece_position]);
 

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -77,73 +77,45 @@ impl PiecesReconstructor {
     ) -> Result<(ArchivedHistorySegment, Polynomial), ReconstructorError> {
         let mut reconstructed_pieces = ArchivedHistorySegment::default();
 
-        if !input_pieces
-            .iter()
-            // Take each source shards here
-            .step_by(2)
-            .zip(
-                reconstructed_pieces
-                    .iter_mut()
-                    .map(|piece| piece.record_mut().iter_mut()),
-            )
-            .all(|(maybe_piece, raw_record)| {
-                if let Some(piece) = maybe_piece {
-                    piece
-                        .record()
-                        .iter()
-                        .zip(raw_record)
-                        .for_each(|(source, target)| {
-                            *target = *source;
-                        });
-                    true
-                } else {
-                    false
-                }
-            })
-        {
-            // If not all data pieces are available, need to reconstruct data shards using erasure
-            // coding.
-
-            // Scratch buffer to avoid re-allocation
-            let mut tmp_shards_scalars =
-                Vec::<Option<Scalar>>::with_capacity(ArchivedHistorySegment::NUM_PIECES);
-            // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
-            for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
-                // Collect chunks of each record at the same offset
-                for maybe_piece in input_pieces.iter() {
-                    let maybe_scalar = maybe_piece
-                        .as_ref()
-                        .map(|piece| {
-                            piece
-                                .record()
-                                .iter()
-                                .nth(record_offset)
-                                .expect("Statically guaranteed to exist in a piece; qed")
-                        })
-                        .map(Scalar::try_from)
-                        .transpose()
-                        .map_err(ReconstructorError::DataShardsReconstruction)?;
-
-                    tmp_shards_scalars.push(maybe_scalar);
-                }
-
-                self.erasure_coding
-                    .recover(&tmp_shards_scalars)
-                    .map_err(ReconstructorError::DataShardsReconstruction)?
-                    .into_iter()
-                    .zip(reconstructed_pieces.iter_mut().map(|piece| {
+        // Scratch buffer to avoid re-allocation
+        let mut tmp_shards_scalars =
+            Vec::<Option<Scalar>>::with_capacity(ArchivedHistorySegment::NUM_PIECES);
+        // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
+        for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
+            // Collect chunks of each record at the same offset
+            for maybe_piece in input_pieces.iter() {
+                let maybe_scalar = maybe_piece
+                    .as_ref()
+                    .map(|piece| {
                         piece
-                            .record_mut()
-                            .iter_mut()
+                            .record()
+                            .iter()
                             .nth(record_offset)
                             .expect("Statically guaranteed to exist in a piece; qed")
-                    }))
-                    .for_each(|(source_scalar, segment_data)| {
-                        segment_data.copy_from_slice(&source_scalar.to_bytes());
-                    });
+                    })
+                    .map(Scalar::try_from)
+                    .transpose()
+                    .map_err(ReconstructorError::DataShardsReconstruction)?;
 
-                tmp_shards_scalars.clear();
+                tmp_shards_scalars.push(maybe_scalar);
             }
+
+            self.erasure_coding
+                .recover(&tmp_shards_scalars)
+                .map_err(ReconstructorError::DataShardsReconstruction)?
+                .into_iter()
+                .zip(reconstructed_pieces.iter_mut().map(|piece| {
+                    piece
+                        .record_mut()
+                        .iter_mut()
+                        .nth(record_offset)
+                        .expect("Statically guaranteed to exist in a piece; qed")
+                }))
+                .for_each(|(source_scalar, segment_data)| {
+                    segment_data.copy_from_slice(&source_scalar.to_bytes());
+                });
+
+            tmp_shards_scalars.clear();
         }
 
         let source_record_commitments = {

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -78,8 +78,8 @@ fn piece_reconstruction_works() {
     let missing_pieces = maybe_pieces
         .iter_mut()
         .enumerate()
-        .skip(100)
-        .take(40)
+        .skip(120)
+        .take(10)
         .map(|(piece_position, piece)| (piece_position, piece.take().unwrap()))
         .collect::<Vec<_>>();
 

--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -37,7 +37,7 @@ pub(crate) async fn recover_missing_piece<PG: PieceGetter>(
     let required_pieces_number = RecordedHistorySegment::NUM_RAW_RECORDS;
 
     let mut received_segment_pieces = segment_index
-        .segment_piece_indexes_source_first()
+        .segment_piece_indexes()
         .map(|piece_index| async move {
             let _permit = match semaphore.acquire().await {
                 Ok(permit) => permit,


### PR DESCRIPTION
This time bug is really funny and here is what was happening:
* Piece is missing on DSN, reconstruction kicks in
* Reconstructor (unnecessarily, see second commit) prefers source pieces (which works in many cases, but not always, it is async after all)
* If all source pieces are successfully acquired, reconstructor doesn't recover pieces (only commitments and witnesses from source pieces)
* Despite retrieving all valid pieces we end up with a broken reconstructed piece

Reconstructor had an optimization that had incorrect assumptions. The funny thing is that it always worked if source piece was actually missing, but as long as input for reconstruction contained 100% source pieces things didn't work basically at all. Test wasn't checking this unexpected edge case, during DSN sync we never needed to reconstruct parity pieces.

The fix is to simply remove unnecessary condition checking for all source pieces being present (ignore whitespaces to see how small and trivial diff is).

Fixes https://github.com/subspace/subspace/issues/1837

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
