### PR TITLE
Ensure `dsnBootstrapNodes` key exists in chain spec by default

### DIFF
--- a/crates/subspace-node/src/chain_spec_utils.rs
+++ b/crates/subspace-node/src/chain_spec_utils.rs
@@ -11,6 +11,7 @@ use subspace_runtime_primitives::DECIMAL_PLACES;
 pub(crate) fn chain_spec_properties() -> Properties {
     let mut properties = Properties::new();
 
+    properties.insert("dsnBootstrapNodes".into(), Vec::<String>::new().into());
     properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
     properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
     properties.insert("tokenSymbol".into(), "tSSC".into());


### PR DESCRIPTION
Essentially a bit of self-documentation. Otherwise without reading all usages of chain spec you wouldn't guess that there could be a field there.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
