### PR TITLE
PoT bootstrapping initial key

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -864,7 +864,6 @@ impl<T: Config> Pallet<T> {
         PorRandomness::<T>::put(por_randomness);
 
         // Deposit global randomness data such that light client can validate blocks later.
-        #[cfg(not(feature = "pot"))]
         frame_system::Pallet::<T>::deposit_log(DigestItem::global_randomness(
             GlobalRandomnesses::<T>::get().current,
         ));

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -63,6 +63,7 @@ impl Default for PotConfig {
 }
 
 /// Components initialized during the new_partial() phase of set up.
+#[derive(Debug)]
 pub struct PotComponents {
     /// If the role is time keeper or node client.
     is_time_keeper: bool,

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -21,7 +21,7 @@ pub use time_keeper::TimeKeeper;
 #[derive(Debug, Clone)]
 pub struct PotConfig {
     /// PoT key used initially when PoT chain starts.
-    // TODO: Use this field
+    // TODO: Also add seed field here
     pub initial_key: PotKey,
 
     /// Frequency of entropy injection from consensus.
@@ -52,6 +52,10 @@ pub struct PotConfig {
 /// Components initialized during the new_partial() phase of set up.
 #[derive(Debug)]
 pub struct PotComponents {
+    /// PoT key used initially when PoT chain starts.
+    // TODO: Remove this from here, shouldn't be necessary eventually
+    pub(crate) initial_key: PotKey,
+
     /// If the role is time keeper or node client.
     is_time_keeper: bool,
 
@@ -71,9 +75,11 @@ impl PotComponents {
         let proof_of_time = ProofOfTime::new(config.pot_iterations, config.num_checkpoints)
             // TODO: Proper error handling or proof
             .expect("Failed to initialize proof of time");
+        let initial_key = config.initial_key;
         let (protocol_state, consensus_state) = init_pot_state(config, proof_of_time);
 
         Self {
+            initial_key,
             is_time_keeper,
             proof_of_time,
             protocol_state,

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -8,6 +8,7 @@ use sc_network::PeerId;
 use sp_consensus_subspace::digests::PotPreDigest;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, VecDeque};
+use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use subspace_core_primitives::{BlockNumber, NonEmptyVec, PotKey, PotProof, PotSeed, SlotNumber};
@@ -603,6 +604,15 @@ struct StateManager {
     proof_of_time: ProofOfTime,
 }
 
+impl fmt::Debug for StateManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StateManager")
+            .field("state", &"<InternalState>")
+            .field("proof_of_time", &self.proof_of_time)
+            .finish()
+    }
+}
+
 impl StateManager {
     /// Creates the state.
     pub fn new(config: PotConfig, proof_of_time: ProofOfTime) -> Self {
@@ -697,7 +707,7 @@ impl StateManager {
 }
 
 /// Interface to the internal protocol components (time keeper, PoT client).
-pub(crate) trait PotProtocolState: Send + Sync {
+pub(crate) trait PotProtocolState: fmt::Debug + Send + Sync {
     /// Re(initializes) the chain with the given set of proofs.
     /// TODO: the proofs are assumed to have been validated, validate
     /// if needed.
@@ -754,7 +764,7 @@ impl PotProtocolState for StateManager {
 
 /// Interface to consensus.
 #[async_trait]
-pub trait PotConsensusState: Send + Sync {
+pub trait PotConsensusState: fmt::Debug + Send + Sync {
     /// Called by consensus when trying to claim the slot.
     /// Returns the proofs in the slot range
     /// [start_slot, current_slot - global_randomness_reveal_lag_slots].

--- a/crates/sc-proof-of-time/src/state_manager.rs
+++ b/crates/sc-proof-of-time/src/state_manager.rs
@@ -53,14 +53,6 @@ pub(crate) enum PotProtocolStateError {
 /// Error codes for PotConsensusState::get_block_proofs().
 #[derive(Debug, thiserror::Error)]
 pub enum PotGetBlockProofsError {
-    #[error("Failed to get start slot: {summary:?}/{block_number}/{proof_slot}/{current_slot}")]
-    StartSlotMissing {
-        summary: PotStateSummary,
-        block_number: BlockNumber,
-        proof_slot: SlotNumber,
-        current_slot: SlotNumber,
-    },
-
     #[error(
         "Invalid slot range: {summary:?}/{block_number}/{start_slot}/{proof_slot}/{current_slot}"
     )]
@@ -84,22 +76,6 @@ pub enum PotGetBlockProofsError {
 /// Error codes for PotConsensusState::verify_block_proofs().
 #[derive(Debug, thiserror::Error)]
 pub enum PotVerifyBlockProofsError {
-    #[error("Block has no proofs: {summary:?}/{block_number}/{slot}/{parent_slot}")]
-    NoProofs {
-        summary: PotStateSummary,
-        block_number: BlockNumber,
-        slot: SlotNumber,
-        parent_slot: SlotNumber,
-    },
-
-    #[error("Failed to get start slot: {summary:?}/{block_number}/{slot}/{parent_slot}")]
-    StartSlotMissing {
-        summary: PotStateSummary,
-        block_number: BlockNumber,
-        slot: SlotNumber,
-        parent_slot: SlotNumber,
-    },
-
     #[error("Unexpected slot number: {summary:?}/{block_number}/{slot}/{parent_slot}/{expected_slot}/{actual_slot}")]
     UnexpectedSlot {
         summary: PotStateSummary,
@@ -211,7 +187,7 @@ impl PotChain {
         if let Some(tip) = self.entries.back() {
             // This is a debug assert for now, as this should not happen.
             // Change to return error if needed.
-            debug_assert!((tip.slot_number + 1) == proof.slot_number);
+            debug_assert_eq!((tip.slot_number + 1), proof.slot_number);
         }
         if self.entries.len() == self.max_entries {
             // Evict the oldest entry if full
@@ -361,6 +337,13 @@ impl InternalState {
         let tip = match self.chain.tip() {
             Some(tip) => tip.clone(),
             None => {
+                if proof.key != self.config.initial_key {
+                    return Err(PotProtocolStateError::InvalidKey {
+                        expected: self.config.initial_key,
+                        actual: proof.key,
+                    });
+                }
+                // TODO: Check initial seed
                 // Chain is empty, possible first proof.
                 return Ok(());
             }
@@ -477,18 +460,22 @@ impl InternalState {
         &self,
         block_number: BlockNumber,
         current_slot: SlotNumber,
-        parent_pre_digest: &PotPreDigest,
+        maybe_parent_pre_digest: &Option<PotPreDigest>,
     ) -> Result<NonEmptyVec<PotProof>, PotGetBlockProofsError> {
         let summary = self.summary();
-        let proof_slot = current_slot - self.config.global_randomness_reveal_lag_slots;
-        let start_slot = parent_pre_digest.next_block_initial_slot().ok_or_else(|| {
-            PotGetBlockProofsError::StartSlotMissing {
-                summary: summary.clone(),
-                block_number,
-                proof_slot,
-                current_slot,
-            }
-        })?;
+        // TODO: Saturating sub is a hack here to make things work for now, this will need to change
+        let proof_slot =
+            current_slot.saturating_sub(self.config.global_randomness_reveal_lag_slots);
+        // Get the expected slot of the first proof in this block.
+        let start_slot = maybe_parent_pre_digest
+            .as_ref()
+            .map(|parent_pre_digest| parent_pre_digest.next_block_initial_slot())
+            // TODO: This fallback slot does not make sense and is just used to make things "run"
+            //  for now
+            .unwrap_or(0);
+
+        // TODO: This hack does not make sense and is just used to make things "run" for now
+        let proof_slot = proof_slot.max(start_slot);
 
         if start_slot > proof_slot {
             return Err(PotGetBlockProofsError::InvalidRange {
@@ -505,7 +492,7 @@ impl InternalState {
         let mut iter = self.chain.iter().skip_while(|p| p.slot_number < start_slot);
         for slot in start_slot..=proof_slot {
             if let Some(proof) = iter.next() {
-                debug_assert!(proof.slot_number == slot);
+                debug_assert_eq!(proof.slot_number, slot);
                 proofs.push(proof.clone());
             } else {
                 return Err(PotGetBlockProofsError::ProofUnavailable {
@@ -527,27 +514,18 @@ impl InternalState {
         slot_number: SlotNumber,
         pre_digest: &PotPreDigest,
         parent_slot_number: SlotNumber,
-        parent_pre_digest: &PotPreDigest,
+        maybe_parent_pre_digest: &Option<PotPreDigest>,
     ) -> Result<(), PotVerifyBlockProofsError> {
         let summary = self.summary();
-        let block_proofs = pre_digest
-            .proofs()
-            .ok_or(PotVerifyBlockProofsError::NoProofs {
-                summary: summary.clone(),
-                block_number,
-                slot: slot_number,
-                parent_slot: parent_slot_number,
-            })?;
+        let block_proofs = pre_digest.proofs();
 
         // Get the expected slot of the first proof in this block.
-        let start_slot = parent_pre_digest.next_block_initial_slot().ok_or_else(|| {
-            PotVerifyBlockProofsError::StartSlotMissing {
-                summary: summary.clone(),
-                block_number,
-                slot: slot_number,
-                parent_slot: parent_slot_number,
-            }
-        })?;
+        let start_slot = maybe_parent_pre_digest
+            .as_ref()
+            .map(|parent_pre_digest| parent_pre_digest.next_block_initial_slot())
+            // TODO: This fallback slot does not make sense and is just used to make things "run"
+            //  for now
+            .unwrap_or(0);
 
         // Since we check the first proof starts with the parent.last_proof.slot + 1,
         // and we already verified the seed/key of the proofs in the chain were was
@@ -680,6 +658,19 @@ impl StateManager {
                         err,
                     }
                 })?;
+            } else {
+                // TODO: This is ugly, but we need initial key here right now
+                let initial_key = self.state.lock().config.initial_key;
+                if proof.key != initial_key {
+                    return Err(PotVerifyBlockProofsError::UnexpectedKey {
+                        summary: summary.clone(),
+                        block_number,
+                        slot: slot_number,
+                        parent_slot: parent_slot_number,
+                        error_slot: proof.slot_number,
+                    });
+                }
+                // TODO: Check initial seed
             }
             to_add.push(proof.clone());
             prev_proof = Some(proof.clone());
@@ -773,7 +764,7 @@ pub trait PotConsensusState: fmt::Debug + Send + Sync {
         &self,
         block_number: BlockNumber,
         current_slot: SlotNumber,
-        parent_pre_digest: &PotPreDigest,
+        maybe_parent_pre_digest: &Option<PotPreDigest>,
         wait_time: Option<Duration>,
     ) -> Result<NonEmptyVec<PotProof>, PotGetBlockProofsError>;
 
@@ -785,7 +776,7 @@ pub trait PotConsensusState: fmt::Debug + Send + Sync {
         slot_number: SlotNumber,
         pre_digest: &PotPreDigest,
         parent_slot_number: SlotNumber,
-        parent_pre_digest: &PotPreDigest,
+        maybe_parent_pre_digest: &Option<PotPreDigest>,
     ) -> Result<(), PotVerifyBlockProofsError>;
 }
 
@@ -795,7 +786,7 @@ impl PotConsensusState for StateManager {
         &self,
         block_number: BlockNumber,
         current_slot: SlotNumber,
-        parent_pre_digest: &PotPreDigest,
+        maybe_parent_pre_digest: &Option<PotPreDigest>,
         wait_time: Option<Duration>,
     ) -> Result<NonEmptyVec<PotProof>, PotGetBlockProofsError> {
         let start_ts = Instant::now();
@@ -807,10 +798,11 @@ impl PotConsensusState for StateManager {
         let retry_delay = Duration::from_millis(200);
         let mut retries = 0;
         loop {
-            let result =
-                self.state
-                    .lock()
-                    .get_block_proofs(block_number, current_slot, parent_pre_digest);
+            let result = self.state.lock().get_block_proofs(
+                block_number,
+                current_slot,
+                maybe_parent_pre_digest,
+            );
             match result {
                 Ok(_) => return result,
                 Err(PotGetBlockProofsError::ProofUnavailable { .. }) => {
@@ -838,32 +830,31 @@ impl PotConsensusState for StateManager {
         slot_number: SlotNumber,
         pre_digest: &PotPreDigest,
         parent_slot_number: SlotNumber,
-        parent_pre_digest: &PotPreDigest,
+        maybe_parent_pre_digest: &Option<PotPreDigest>,
     ) -> Result<(), PotVerifyBlockProofsError> {
-        if let Some(block_proofs) = pre_digest.proofs() {
-            // Opportunistically try to extend the chain with
-            // the proofs from the block.
-            // TODO: this also is done when the chain is empty and
-            // we don't have a previous proof to verify against.
-            // This needs to be revisited as part of the node sync.
-            let (tip, summary) = {
-                let state = self.state.lock();
-                (state.tip(), state.summary())
-            };
-            let should_append = tip
-                .as_ref()
-                .map(|tip| (tip.slot_number + 1) == block_proofs.first().slot_number)
-                .unwrap_or(true);
-            if should_append {
-                return self.verify_and_append(
-                    block_number,
-                    slot_number,
-                    block_proofs,
-                    parent_slot_number,
-                    tip,
-                    summary,
-                );
-            }
+        let block_proofs = pre_digest.proofs();
+        // Opportunistically try to extend the chain with
+        // the proofs from the block.
+        // TODO: this also is done when the chain is empty and
+        // we don't have a previous proof to verify against.
+        // This needs to be revisited as part of the node sync.
+        let (tip, summary) = {
+            let state = self.state.lock();
+            (state.tip(), state.summary())
+        };
+        let should_append = tip
+            .as_ref()
+            .map(|tip| (tip.slot_number + 1) == block_proofs.first().slot_number)
+            .unwrap_or(true);
+        if should_append {
+            return self.verify_and_append(
+                block_number,
+                slot_number,
+                block_proofs,
+                parent_slot_number,
+                tip,
+                summary,
+            );
         }
 
         self.state.lock().verify_block_proofs(
@@ -871,7 +862,7 @@ impl PotConsensusState for StateManager {
             slot_number,
             pre_digest,
             parent_slot_number,
-            parent_pre_digest,
+            maybe_parent_pre_digest,
         )
     }
 }

--- a/crates/sc-proof-of-time/src/time_keeper.rs
+++ b/crates/sc-proof-of-time/src/time_keeper.rs
@@ -115,7 +115,7 @@ where
                 // TODO: Proper error handling or proof
                 let block_hash = incoming_block.hash.into();
                 let proof = self.proof_of_time.create(
-                    PotSeed::from_block_hash(block_hash),
+                    PotSeed::from_genesis_block_hash(block_hash),
                     Default::default(), // TODO: key from cmd line or BTC
                     pot_pre_digest
                         .next_block_initial_slot()

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -52,6 +52,7 @@ use core::fmt;
 use core::iter::Iterator;
 use core::num::NonZeroU64;
 use core::simd::Simd;
+use core::str::FromStr;
 use derive_more::{Add, AsMut, AsRef, Deref, DerefMut, Display, Div, From, Into, Mul, Rem, Sub};
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -254,7 +255,19 @@ impl PosProof {
     TypeInfo,
     MaxEncodedLen,
 )]
-pub struct PotKey(PotBytes);
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PotKey(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; 16]);
+
+impl FromStr for PotKey {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut bytes = PotBytes::default();
+        hex::decode_to_slice(s, &mut bytes)?;
+
+        Ok(Self(bytes))
+    }
+}
 
 /// Proof of time seed (input to the encryption).
 #[derive(

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -289,10 +289,9 @@ impl FromStr for PotKey {
 pub struct PotSeed(PotBytes);
 
 impl PotSeed {
-    /// Builds the seed from block hash (e.g) used to create initial seed from
-    /// genesis block hash.
+    /// Derive initial PoT seed from genesis block hash.
     #[inline]
-    pub fn from_block_hash(block_hash: BlockHash) -> Self {
+    pub fn from_genesis_block_hash(block_hash: BlockHash) -> Self {
         Self(truncate_32_bytes(block_hash))
     }
 }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -20,14 +20,16 @@ use domain_client_operator::Bootstrapper;
 use domain_runtime_primitives::opaque::Block as DomainBlock;
 use frame_benchmarking_cli::BenchmarkCmd;
 use futures::future::TryFutureExt;
+use log::warn;
 use sc_cli::{ChainSpec, CliConfiguration, SubstrateCli};
 use sc_consensus_slots::SlotProportion;
-use sc_proof_of_time::PotComponents;
+use sc_proof_of_time::{PotComponents, PotConfig};
 use sc_service::PartialComponents;
 use sc_storage_monitor::StorageMonitorService;
 use sp_core::crypto::Ss58AddressFormat;
 use sp_core::traits::SpawnEssentialNamed;
 use sp_domains::GenerateGenesisStateRoot;
+use std::num::{NonZeroU32, NonZeroU8};
 use std::sync::Arc;
 use subspace_node::domain::{
     AccountId32ToAccountId20Converter, DomainCli, DomainGenesisBlockBuilder, DomainInstanceStarter,
@@ -354,8 +356,46 @@ fn main() -> Result<(), Error> {
             runner.run_node_until_exit(|consensus_chain_config| async move {
                 let tokio_handle = consensus_chain_config.tokio_handle.clone();
                 let database_source = consensus_chain_config.database.clone();
+                let maybe_chain_spec_pot_initial_key = consensus_chain_config
+                    .chain_spec
+                    .properties()
+                    .get("potInitialKey")
+                    .map(|d| serde_json::from_value(d.clone()))
+                    .transpose()
+                    .map_err(|error| {
+                        sc_service::Error::Other(format!(
+                            "Failed to decode PoT initial key: {error:?}"
+                        ))
+                    })?
+                    .flatten();
+                if maybe_chain_spec_pot_initial_key.is_some()
+                    && cli.pot_initial_key.is_some()
+                    && maybe_chain_spec_pot_initial_key != cli.pot_initial_key
+                {
+                    warn!(
+                        "--pot-initial-key CLI argument was ignored due to chain spec having a \
+                        different explicit value"
+                    );
+                }
                 let pot_components = if cli.pot_role.is_pot_enabled() {
-                    Some(PotComponents::new(cli.pot_role.is_time_keeper()))
+                    Some(PotComponents::new(
+                        cli.pot_role.is_time_keeper(),
+                        // TODO: fill proper values. These are set to use less
+                        // CPU and take less than 1 sec to produce per proof
+                        // during the initial testing.
+                        PotConfig {
+                            initial_key: maybe_chain_spec_pot_initial_key
+                                .or(cli.pot_initial_key)
+                                .unwrap_or_default(),
+                            randomness_update_interval_blocks: 18,
+                            injection_depth_blocks: 90,
+                            global_randomness_reveal_lag_slots: 6,
+                            pot_injection_lag_slots: 6,
+                            max_future_slots: 10,
+                            pot_iterations: NonZeroU32::new(4 * 1_000).expect("Not zero; qed"),
+                            num_checkpoints: NonZeroU8::new(4).expect("Not zero; qed"),
+                        },
+                    ))
                 } else {
                     None
                 };
@@ -388,7 +428,7 @@ fn main() -> Result<(), Error> {
                                 .transpose()
                                 .map_err(|error| {
                                     sc_service::Error::Other(format!(
-                                        "Failed to decode DSN bootsrap nodes: {error:?}"
+                                        "Failed to decode DSN bootstrap nodes: {error:?}"
                                     ))
                                 })?
                                 .unwrap_or_default()
@@ -522,7 +562,7 @@ fn main() -> Result<(), Error> {
                                     {
                                         Err(err) => {
                                             log::error!(
-                                                "Domain bootsrapper exited with an error {err:?}"
+                                                "Domain bootstrapper exited with an error {err:?}"
                                             );
                                             return;
                                         }

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -25,6 +25,7 @@ use sp_consensus_subspace::FarmerPublicKey;
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_domains::RuntimeType;
 use sp_runtime::Percent;
+use subspace_core_primitives::PotKey;
 use subspace_runtime::{
     AllowAuthoringBy, BalancesConfig, DomainsConfig, GenesisConfig, MaxDomainBlockSize,
     MaxDomainBlockWeight, RuntimeConfigsConfig, SubspaceConfig, SudoConfig, SystemConfig,
@@ -166,7 +167,14 @@ pub fn gemini_3f_compiled() -> Result<ConsensusChainSpec<GenesisConfig>, String>
         Some("subspace-gemini-3f"),
         None,
         // Properties
-        Some(chain_spec_properties()),
+        Some({
+            let mut properties = chain_spec_properties();
+            properties.insert(
+                "potInitialKey".to_string(),
+                serde_json::to_value(None::<PotKey>).expect("Serialization is not infallible; qed"),
+            );
+            properties
+        }),
         // Extensions
         NoExtension::None,
     ))
@@ -256,7 +264,14 @@ pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<GenesisConfig>, Str
         Some("subspace-devnet"),
         None,
         // Properties
-        Some(chain_spec_properties()),
+        Some({
+            let mut properties = chain_spec_properties();
+            properties.insert(
+                "potInitialKey".to_string(),
+                serde_json::to_value(None::<PotKey>).expect("Serialization is not infallible; qed"),
+            );
+            properties
+        }),
         // Extensions
         NoExtension::None,
     ))
@@ -303,7 +318,14 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig>, String> {
         None,
         None,
         // Properties
-        Some(chain_spec_properties()),
+        Some({
+            let mut properties = chain_spec_properties();
+            properties.insert(
+                "potInitialKey".to_string(),
+                serde_json::to_value(None::<PotKey>).expect("Serialization is not infallible; qed"),
+            );
+            properties
+        }),
         // Extensions
         NoExtension::None,
     ))
@@ -358,7 +380,14 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig>, String> {
         None,
         None,
         // Properties
-        Some(chain_spec_properties()),
+        Some({
+            let mut properties = chain_spec_properties();
+            properties.insert(
+                "potInitialKey".to_string(),
+                serde_json::to_value(None::<PotKey>).expect("Serialization is not infallible; qed"),
+            );
+            properties
+        }),
         // Extensions
         NoExtension::None,
     ))

--- a/crates/subspace-node/src/chain_spec_utils.rs
+++ b/crates/subspace-node/src/chain_spec_utils.rs
@@ -11,10 +11,13 @@ use subspace_runtime_primitives::DECIMAL_PLACES;
 pub(crate) fn chain_spec_properties() -> Properties {
     let mut properties = Properties::new();
 
-    properties.insert("dsnBootstrapNodes".into(), Vec::<String>::new().into());
-    properties.insert("ss58Format".into(), <SS58Prefix as Get<u16>>::get().into());
-    properties.insert("tokenDecimals".into(), DECIMAL_PLACES.into());
-    properties.insert("tokenSymbol".into(), "tSSC".into());
+    properties.insert("dsnBootstrapNodes".to_string(), Vec::<String>::new().into());
+    properties.insert(
+        "ss58Format".to_string(),
+        <SS58Prefix as Get<u16>>::get().into(),
+    );
+    properties.insert("tokenDecimals".to_string(), DECIMAL_PLACES.into());
+    properties.insert("tokenSymbol".to_string(), "tSSC".into());
 
     properties
 }

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -31,6 +31,7 @@ use sc_telemetry::serde_json;
 use serde_json::Value;
 use std::io::Write;
 use std::{fs, io};
+use subspace_core_primitives::PotKey;
 use subspace_networking::libp2p::Multiaddr;
 
 /// Executor dispatch for subspace runtime
@@ -287,6 +288,12 @@ pub struct Cli {
     /// Assigned PoT role for this node.
     #[arg(long, default_value = "none", value_parser(EnumValueParser::< CliPotRole >::new()))]
     pub pot_role: CliPotRole,
+
+    /// Initial PoT key (unless specified in chain spec already).
+    ///
+    /// Key is a 16-byte hex string.
+    #[arg(long)]
+    pub pot_initial_key: Option<PotKey>,
 }
 
 impl SubstrateCli for Cli {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -773,9 +773,8 @@ where
             .as_ref()
             .map(|component| component.consensus_state());
         if let Some(components) = pot_components {
-            let pot_gossip_worker = PotGossipWorker::new(
+            let pot_gossip_worker = PotGossipWorker::<Block>::new(
                 &components,
-                client.clone(),
                 network_service.clone(),
                 sync_service.clone(),
             );


### PR DESCRIPTION
This breaks a lot of things and introduces a bunch of hacks to make things compile and produce blocks with timekeeper (client no longer works) while slots are still driven in the old way with time.

I'm very confused with how randomness was derived, so I basically removed checks for PoT feature flag for now until it fixed and works the way it should. State management doesn't really seem to fit well the use case where we have initial seed and key known beforehand, it expects proofs that we don't have and shouldn't have initially, we just have key+seed+slot.

This PR primarily adds support for `potInitialKey` in chain spec and `--pot-initial-key` until key is known and can be placed into chain spec. Then timekeeper bootstrapping is changed to not wait for any blocks to be produced, but rather start with either best known block's PoT or initial key mentioned before this.

This is probably a decent intermediate step before moving further towards https://github.com/subspace/subspace/issues/1827

I'm not sure how meaningful review here is, but give it a try.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
