### PR TITLE
Fix the broken purge-chain subcommand

### DIFF
--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -187,23 +187,29 @@ fn main() -> Result<(), Error> {
             let runner = cli.create_runner(&cmd.base)?;
 
             runner.sync_run(|consensus_chain_config| {
-                let domain_cli = DomainCli::new(
-                    cmd.base
-                        .base_path()?
-                        .map(|base_path| base_path.path().to_path_buf()),
-                    cli.domain_args.into_iter(),
-                );
+                let domain_config = if cmd.domain_args.is_empty() {
+                    None
+                } else {
+                    let domain_cli = DomainCli::new(
+                        cmd.base
+                            .base_path()?
+                            .map(|base_path| base_path.path().to_path_buf()),
+                        cmd.domain_args.clone().into_iter(),
+                    );
 
-                let domain_config = SubstrateCli::create_configuration(
-                    &domain_cli,
-                    &domain_cli,
-                    consensus_chain_config.tokio_handle.clone(),
-                )
-                .map_err(|error| {
-                    sc_service::Error::Other(format!(
-                        "Failed to create domain configuration: {error:?}"
-                    ))
-                })?;
+                    let domain_config = SubstrateCli::create_configuration(
+                        &domain_cli,
+                        &domain_cli,
+                        consensus_chain_config.tokio_handle.clone(),
+                    )
+                    .map_err(|error| {
+                        sc_service::Error::Other(format!(
+                            "Failed to create domain configuration: {error:?}"
+                        ))
+                    })?;
+
+                    Some(domain_config)
+                };
 
                 cmd.run(consensus_chain_config, domain_config)
             })?;


### PR DESCRIPTION
close #1773 

The PR fixes the broken purge-chain subcommand by:
- Explicitly adding the `domain-args` arg to the `purge-chain` subcommand instead of taking from the `cli.domain-args`
    - Because all args followed by the `purge-chain` subcommand are parsing as the args of the subcommand if we need `domain-args` as the args of the subcommand we should add it explicitly.
- Only parse the `domain-args` if it is specified through `subspace-node purge-chain [cosensus-args] -- [domain-args]`
    - To bypass the mandatory `domain-id` arg issue

I have built the binary and tested it locally, the behavior is now expected as what we wanted.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
