### PR TITLE
allow raw genesis to be passed during the domain instantiation to enable sudo

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -412,6 +412,7 @@ mod tests {
                 bundle_slot_probability: (1, 1),
                 target_bundles_per_block: 1,
             },
+            vec![],
         )
         .unwrap();
 
@@ -629,7 +630,7 @@ mod tests {
             );
             assert!(ConsensusBlockHash::<Test>::get(
                 domain_id,
-                pruned_receipt.consensus_block_number
+                pruned_receipt.consensus_block_number,
             )
             .is_none());
         });

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -193,6 +193,7 @@ impl pallet_domains::Config for Test {
     type TreasuryAccount = TreasuryAccount;
     type DomainBlockReward = BlockReward;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
+    type SudoId = ();
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -488,6 +488,7 @@ parameter_types! {
     pub const StakeEpochDuration: DomainNumber = 100;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 100;
+    pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
 }
 
 impl pallet_domains::Config for Runtime {
@@ -514,6 +515,7 @@ impl pallet_domains::Config for Runtime {
     type TreasuryAccount = TreasuryAccount;
     type DomainBlockReward = BlockReward;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
+    type SudoId = SudoId;
 }
 
 pub struct StakingOnReward;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -543,6 +543,7 @@ parameter_types! {
     pub const StakeEpochDuration: DomainNumber = 5;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 100;
+    pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
 }
 
 impl pallet_domains::Config for Runtime {
@@ -569,6 +570,7 @@ impl pallet_domains::Config for Runtime {
     type TreasuryAccount = TreasuryAccount;
     type DomainBlockReward = BlockReward;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
+    type SudoId = SudoId;
 }
 
 parameter_types! {


### PR DESCRIPTION
This fix should let us have sudo on the new domain instance instead of just Genesis domains.
This will be removed once we have the XDM working

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
