### PR TITLE
Migrate proof of time to use chain height

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -51,7 +51,9 @@ use sp_consensus_subspace::{
     ChainConstants, EquivocationProof, FarmerPublicKey, FarmerSignature, SignedVote, Vote,
 };
 use sp_runtime::generic::DigestItem;
-use sp_runtime::traits::{BlockNumberProvider, Hash, One, SaturatedConversion, Saturating, Zero};
+#[cfg(not(feature = "pot"))]
+use sp_runtime::traits::SaturatedConversion;
+use sp_runtime::traits::{BlockNumberProvider, Hash, One, Saturating, Zero};
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
     TransactionValidityError, ValidTransaction,
@@ -1560,6 +1562,7 @@ fn check_segment_headers<T: Config>(
     Ok(())
 }
 
+#[cfg(not(feature = "pot"))]
 impl<T: Config> OnTimestampSet<T::Moment> for Pallet<T> {
     fn on_timestamp_set(moment: T::Moment) {
         let slot_duration = Self::slot_duration();
@@ -1576,6 +1579,19 @@ impl<T: Config> OnTimestampSet<T::Moment> for Pallet<T> {
             timestamp_slot,
             "Timestamp slot must match `CurrentSlot`",
         );
+    }
+}
+
+#[cfg(feature = "pot")]
+impl<T: Config> OnTimestampSet<T::Moment> for Pallet<T> {
+    fn on_timestamp_set(_moment: T::Moment) {
+        let slot_duration = Self::slot_duration();
+        assert!(
+            !slot_duration.is_zero(),
+            "Subspace slot duration cannot be zero."
+        );
+
+        // TODO: more checks
     }
 }
 

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -17,6 +17,7 @@ pub use gossip::pot_gossip_peers_set_config;
 pub use node_client::PotClient;
 pub use state_manager::{
     PotConsensusState, PotGetBlockProofsError, PotStateSummary, PotVerifyBlockProofsError,
+    ProofReceiver,
 };
 pub use time_keeper::TimeKeeper;
 

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -20,6 +20,9 @@ pub use state_manager::{
 };
 pub use time_keeper::TimeKeeper;
 
+/// The slot number of the first proof in the chain.
+pub(crate) const INITIAL_SLOT_NUMBER: SlotNumber = 0;
+
 // TODO: change the fields that can't be zero to NonZero types.
 #[derive(Debug, Clone)]
 pub struct PotConfig {

--- a/crates/sc-proof-of-time/src/node_client.rs
+++ b/crates/sc-proof-of-time/src/node_client.rs
@@ -3,35 +3,28 @@
 use crate::gossip::PotGossip;
 use crate::state_manager::PotProtocolState;
 use crate::PotComponents;
-use futures::StreamExt;
-use sc_client_api::BlockchainEvents;
 use sc_network::PeerId;
 use sc_network_gossip::{Network as GossipNetwork, Syncing as GossipSyncing};
-use sp_blockchain::HeaderBackend;
-use sp_consensus_subspace::digests::extract_pre_digest;
 use sp_core::H256;
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 use std::time::Instant;
 use subspace_core_primitives::PotProof;
-use tracing::{debug, error, trace, warn};
+use tracing::{error, trace};
 
 /// The PoT client implementation
-pub struct PotClient<Block: BlockT<Hash = H256>, Client> {
+pub struct PotClient<Block: BlockT<Hash = H256>> {
     pot_state: Arc<dyn PotProtocolState>,
     gossip: PotGossip<Block>,
-    client: Arc<Client>,
 }
 
-impl<Block, Client> PotClient<Block, Client>
+impl<Block> PotClient<Block>
 where
     Block: BlockT<Hash = H256>,
-    Client: HeaderBackend<Block> + BlockchainEvents<Block>,
 {
     /// Creates the PoT client instance.
     pub fn new<Network, GossipSync>(
         components: PotComponents,
-        client: Arc<Client>,
         network: Network,
         sync: Arc<GossipSync>,
     ) -> Self
@@ -47,13 +40,11 @@ where
                 components.protocol_state,
                 components.proof_of_time,
             ),
-            client,
         }
     }
 
     /// Runs the node client processing loop.
     pub async fn run(self) {
-        self.initialize().await;
         let handle_gossip_message: Arc<dyn Fn(PeerId, PotProof) + Send + Sync> =
             Arc::new(|sender, proof| {
                 self.handle_gossip_message(sender, proof);
@@ -62,50 +53,6 @@ where
             .process_incoming_messages(handle_gossip_message)
             .await;
         error!("Gossip engine has terminated");
-    }
-
-    /// Initializes the chain state from the consensus tip info.
-    async fn initialize(&self) {
-        debug!("Waiting for initialization");
-
-        // Wait for a block with proofs.
-        let mut block_import = self.client.import_notification_stream();
-        while let Some(incoming_block) = block_import.next().await {
-            let pre_digest = match extract_pre_digest(&incoming_block.header) {
-                Ok(pre_digest) => pre_digest,
-                Err(error) => {
-                    warn!(
-                        %error,
-                        block_hash = %incoming_block.hash,
-                        origin = ?incoming_block.origin,
-                        "Failed to get pre_digest",
-                    );
-                    continue;
-                }
-            };
-
-            let pot_pre_digest = match pre_digest.pot_pre_digest() {
-                Some(pot_pre_digest) => pot_pre_digest,
-                None => {
-                    warn!(
-                        block_hash = %incoming_block.hash,
-                        origin = ?incoming_block.origin,
-                        "Failed to get pot_pre_digest",
-                    );
-                    continue;
-                }
-            };
-
-            if pot_pre_digest.proofs().is_some() {
-                trace!(
-                    block_hash = %incoming_block.hash,
-                    origin = ?incoming_block.origin,
-                    ?pot_pre_digest,
-                    "Initialization complete",
-                );
-                return;
-            }
-        }
     }
 
     /// Handles the incoming gossip message.

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -67,14 +67,6 @@ impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
 /// versioning added on the proof side
 #[derive(Clone, Encode, Decode)]
 pub enum PotPreDigest {
-    /// The block was produced in the bootstrapping phase, where
-    /// the genesis slot has not yet been determined and the proof
-    /// production has not started.
-    Bootstrapping,
-
-    /// Genesis slot determined by the bootstrap node.
-    FirstBlock(SlotNumber),
-
     /// V0 proof.
     V0(NonEmptyVec<PotProof>),
 }
@@ -86,50 +78,31 @@ impl PotPreDigest {
     }
 
     /// Returns a reference to the proofs.
-    pub fn proofs(&self) -> Option<&NonEmptyVec<PotProof>> {
+    pub fn proofs(&self) -> &NonEmptyVec<PotProof> {
         match self {
-            Self::Bootstrapping | Self::FirstBlock(_) => None,
-            Self::V0(proofs) => Some(proofs),
+            Self::V0(proofs) => proofs,
         }
     }
 
     /// Returns the starting slot number for the proofs in the next
     /// block.
-    pub fn next_block_initial_slot(&self) -> Option<SlotNumber> {
+    pub fn next_block_initial_slot(&self) -> SlotNumber {
         match self {
-            Self::Bootstrapping => None,
-            Self::FirstBlock(slot_number) => Some(slot_number + 1),
-            Self::V0(proofs) => Some(proofs.last().slot_number + 1),
+            Self::V0(proofs) => proofs.last().slot_number + 1,
         }
     }
 
     /// Returns the global randomness from the proofs in the block pre digest.
     pub fn derive_global_randomness(&self) -> Randomness {
         match self {
-            Self::Bootstrapping | Self::FirstBlock(_) => Randomness::default(),
             Self::V0(proofs) => proofs.last().derive_global_randomness().into(),
         }
-    }
-}
-
-impl Default for PotPreDigest {
-    fn default() -> Self {
-        Self::Bootstrapping
     }
 }
 
 impl fmt::Debug for PotPreDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Bootstrapping => {
-                write!(f, "PotPreDigest::Bootstrapping")
-            }
-            Self::FirstBlock(slot_number) => {
-                write!(
-                    f,
-                    "PotPreDigest::FirstBlock => genesis_slot = {slot_number}"
-                )
-            }
             Self::V0(proofs) => {
                 write!(
                     f,

--- a/crates/sp-consensus-subspace/src/inherents.rs
+++ b/crates/sp-consensus-subspace/src/inherents.rs
@@ -105,6 +105,11 @@ impl InherentDataProvider {
         Self::new(slot, segment_headers)
     }
 
+    /// Creates the inherent data provider from the slot.
+    pub fn from_slot(slot: Slot, segment_headers: Vec<SegmentHeader>) -> Self {
+        Self::new(slot, segment_headers)
+    }
+
     /// Returns the `data` of this inherent data provider.
     pub fn data(&self) -> &InherentType {
         &self.data


### PR DESCRIPTION
We currently use timestamp as the slot number in the proofs. This is changed to use block chain style height in the slot number.

Main changes:
1. Since the genesis slot issue is no longer applicable, the workarounds are cleaned up. Time keeper, node client initialization becomes much simpler now. The pre digest also clean up.
2. Consensus uses PoT chain as the slot mechanism, to drive block proposal. The pre digest slot now keeps the PoT slot number
3. Other clean ups, more checks in proof validation path.

https://github.com/subspace/subspace/issues/1827

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
