### PR TITLE
PoT bootstrapping initial seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11335,7 +11335,6 @@ dependencies = [
  "sc-executor",
  "sc-network",
  "sc-network-sync",
- "sc-proof-of-time",
  "sc-service",
  "sc-storage-monitor",
  "sc-subspace-chain-specs",

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -9,7 +9,7 @@ mod time_keeper;
 use crate::state_manager::{init_pot_state, PotProtocolState};
 use core::num::{NonZeroU32, NonZeroU8};
 use std::sync::Arc;
-use subspace_core_primitives::{BlockNumber, PotKey, SlotNumber};
+use subspace_core_primitives::{BlockNumber, PotKey, PotSeed, SlotNumber};
 use subspace_proof_of_time::ProofOfTime;
 
 pub use state_manager::{
@@ -21,8 +21,10 @@ pub use time_keeper::TimeKeeper;
 // TODO: CLean up unused fields
 #[derive(Debug, Clone)]
 pub struct PotConfig {
+    /// PoT seed used initially when PoT chain starts.
+    pub initial_seed: PotSeed,
+
     /// PoT key used initially when PoT chain starts.
-    // TODO: Also add seed field here
     pub initial_key: PotKey,
 
     /// Frequency of entropy injection from consensus.
@@ -53,6 +55,10 @@ pub struct PotConfig {
 /// Components initialized during the new_partial() phase of set up.
 #[derive(Debug)]
 pub struct PotComponents {
+    /// PoT seed used initially when PoT chain starts.
+    // TODO: Remove this from here, shouldn't be necessary eventually
+    pub(crate) initial_seed: PotSeed,
+
     /// PoT key used initially when PoT chain starts.
     // TODO: Remove this from here, shouldn't be necessary eventually
     pub(crate) initial_key: PotKey,
@@ -76,10 +82,12 @@ impl PotComponents {
         let proof_of_time = ProofOfTime::new(config.pot_iterations, config.num_checkpoints)
             // TODO: Proper error handling or proof
             .expect("Failed to initialize proof of time");
+        let initial_seed = config.initial_seed;
         let initial_key = config.initial_key;
         let (protocol_state, consensus_state) = init_pot_state(config, proof_of_time);
 
         Self {
+            initial_seed,
             initial_key,
             is_time_keeper,
             proof_of_time,

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -18,6 +18,7 @@ pub use state_manager::{
 pub use time_keeper::TimeKeeper;
 
 // TODO: change the fields that can't be zero to NonZero types.
+// TODO: CLean up unused fields
 #[derive(Debug, Clone)]
 pub struct PotConfig {
     /// PoT key used initially when PoT chain starts.

--- a/crates/sc-proof-of-time/src/time_keeper.rs
+++ b/crates/sc-proof-of-time/src/time_keeper.rs
@@ -26,6 +26,8 @@ const PROOFS_CHANNEL_SIZE: usize = 12; // 2 * reveal lag.
 /// The time keeper manages the protocol: periodic proof generation/verification, gossip.
 pub struct TimeKeeper<Block, Client> {
     // TODO: Remove this from here, shouldn't be necessary eventually
+    initial_seed: PotSeed,
+    // TODO: Remove this from here, shouldn't be necessary eventually
     initial_key: PotKey,
     proof_of_time: ProofOfTime,
     pot_state: Arc<dyn PotProtocolState>,
@@ -51,6 +53,7 @@ where
         gossip_sender: mpsc::Sender<PotProof>,
     ) -> Self {
         Self {
+            initial_seed: components.initial_seed,
             initial_key: components.initial_key,
             proof_of_time: components.proof_of_time,
             pot_state: Arc::clone(&components.protocol_state),
@@ -115,7 +118,7 @@ where
                 //  proofs to exist
                 // No proof of time means genesis block, produce the very first proof
                 let proof = self.proof_of_time.create(
-                    PotSeed::from_genesis_block_hash(best_hash.into()),
+                    self.initial_seed,
                     self.initial_key,
                     0,
                     best_hash.into(),

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -45,7 +45,6 @@ sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspac
 sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "../sc-subspace-chain-specs" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
-sc-proof-of-time = { version = "0.1.0", path = "../sc-proof-of-time" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-storage-monitor = { version = "0.1.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
@@ -79,9 +78,9 @@ substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/su
 default = ["do-not-enforce-cost-of-storage"]
 pot = [
 	"sc-consensus-subspace/pot",
-	"sc-proof-of-time/pot",
 	"sp-consensus-subspace/pot",
 	"subspace-runtime/pot",
+	"subspace-service/pot",
 ]
 do-not-enforce-cost-of-storage = [
 	"subspace-runtime/do-not-enforce-cost-of-storage"

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -493,7 +493,7 @@ fn main() -> Result<(), Error> {
                             ))
                         })?;
 
-                    subspace_service::new_full::<PosTable, _, _, _>(
+                    subspace_service::new_full::<PosTable, _, _>(
                         consensus_chain_config,
                         partial_components,
                         true,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -82,7 +82,7 @@ use std::marker::PhantomData;
 use std::num::{NonZeroU32, NonZeroU8};
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
-use subspace_core_primitives::PotKey;
+use subspace_core_primitives::{PotKey, PotSeed};
 use subspace_fraud_proof::verifier_api::VerifierClient;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
@@ -398,6 +398,7 @@ where
             // CPU and take less than 1 sec to produce per proof
             // during the initial testing.
             PotConfig {
+                initial_seed: PotSeed::from_genesis_block_hash(client.info().genesis_hash.into()),
                 initial_key: pot_config.initial_key,
                 randomness_update_interval_blocks: 18,
                 injection_depth_blocks: 90,


### PR DESCRIPTION
This is a simple upgrade over https://github.com/subspace/subspace/pull/1854 that introduces `initial_seed` in PoT configuration just like initial key, this is used to bootstrap PoT.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
