### PR TITLE
networking: Update libp2p to v.0.52.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4902,9 +4902,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.52.1"
+version = "0.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38039ba2df4f3255842050845daef4a004cc1f26da03dbc645535088b51910ef"
+checksum = "ca4894076bfa3051e4f1725747308861af1e6641213640aeeb784f583e40e7d9"
 dependencies = [
  "bytes",
  "futures",
@@ -4919,16 +4919,16 @@ dependencies = [
  "libp2p-gossipsub",
  "libp2p-identify 0.43.0",
  "libp2p-identity 0.2.2",
- "libp2p-kad 0.44.3",
+ "libp2p-kad 0.44.4",
  "libp2p-mdns 0.44.0",
- "libp2p-metrics 0.13.0",
+ "libp2p-metrics 0.13.1",
  "libp2p-noise 0.43.0",
  "libp2p-ping 0.43.0",
- "libp2p-request-response 0.25.0",
- "libp2p-swarm 0.43.2",
+ "libp2p-request-response 0.25.1",
+ "libp2p-swarm 0.43.3",
  "libp2p-tcp 0.40.0",
  "libp2p-websocket 0.42.0",
- "libp2p-yamux 0.44.0",
+ "libp2p-yamux 0.44.1",
  "multiaddr 0.18.0",
  "pin-project",
 ]
@@ -4953,7 +4953,7 @@ checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
 dependencies = [
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "void",
 ]
 
@@ -4969,8 +4969,8 @@ dependencies = [
  "instant",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-request-response 0.25.0",
- "libp2p-swarm 0.43.2",
+ "libp2p-request-response 0.25.1",
+ "libp2p-swarm 0.43.3",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -4996,7 +4996,7 @@ checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
 dependencies = [
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "void",
 ]
 
@@ -5088,9 +5088,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e378da62e8c9251f6e885ed173a561663f29b251e745586cf6ae6150b295c37"
+checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.2",
@@ -5105,7 +5105,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "log",
  "prometheus-client 0.21.2",
  "quick-protobuf",
@@ -5153,7 +5153,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "log",
  "lru 0.10.0",
  "quick-protobuf",
@@ -5229,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.44.3"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2584b0c27f879a1cca4b753fd96874109e5a2f46bd6e30924096456c2ba9b2"
+checksum = "fc125f83d8f75322c79e4ade74677d299b34aa5c9d9b5251c03ec28c683cb765"
 dependencies = [
  "arrayvec 0.7.4",
  "asynchronous-codec",
@@ -5243,7 +5243,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5288,7 +5288,7 @@ dependencies = [
  "if-watch",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5314,18 +5314,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3787ea81798dcc5bf1d8b40a8e8245cf894b168d04dd70aa48cb3ff2fff141d2"
+checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
 dependencies = [
  "instant",
  "libp2p-core 0.40.0",
  "libp2p-gossipsub",
  "libp2p-identify 0.43.0",
  "libp2p-identity 0.2.2",
- "libp2p-kad 0.44.3",
+ "libp2p-kad 0.44.4",
  "libp2p-ping 0.43.0",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "once_cell",
  "prometheus-client 0.21.2",
 ]
@@ -5407,7 +5407,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "log",
  "rand 0.8.5",
  "void",
@@ -5475,16 +5475,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd837798cdcce4283d2675f08bcd3756a650d56eab4d4367e1b3f27eed6887"
+checksum = "49e2cb9befb57e55f53d9463a6ea9b1b8a09a48174ad7be149c9cbebaa5e8e9b"
 dependencies = [
  "async-trait",
  "futures",
  "instant",
  "libp2p-core 0.40.0",
  "libp2p-identity 0.2.2",
- "libp2p-swarm 0.43.2",
+ "libp2p-swarm 0.43.3",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5514,9 +5514,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.2"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43106820057e0f65c77b01a3873593f66e676da4e40c70c3a809b239109f1d30"
+checksum = "28016944851bd73526d3c146aabf0fa9bbe27c558f080f9e5447da3a1772c01a"
 dependencies = [
  "either",
  "fnv",
@@ -5724,20 +5724,20 @@ dependencies = [
  "libp2p-core 0.39.2",
  "log",
  "thiserror",
- "yamux",
+ "yamux 0.10.2",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.44.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a9b42ab6de15c6f076d8fb11dc5f48d899a10b55a2e16b12be9012a05287b0"
+checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
 dependencies = [
  "futures",
  "libp2p-core 0.40.0",
  "log",
  "thiserror",
- "yamux",
+ "yamux 0.12.0",
 ]
 
 [[package]]
@@ -5993,7 +5993,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -6002,7 +6002,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -8260,13 +8260,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -8279,6 +8280,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+dependencies = [
+ "aho-corasick 1.0.2",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8286,9 +8298,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "resolv-conf"
@@ -11269,9 +11281,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex",
- "libp2p 0.52.1",
+ "libp2p 0.52.2",
  "libp2p-connection-limits 0.2.1",
- "libp2p-kad 0.44.3",
+ "libp2p-kad 0.44.4",
  "libp2p-quic 0.8.0-alpha",
  "lru 0.10.0",
  "memmap2 0.7.1",
@@ -13702,6 +13714,21 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0329ef377816896f014435162bb3711ea7a07729c23d0960e6f8048b21b8fe91"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.1",
+ "pin-project",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -49,7 +49,7 @@ unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_code
 void = "1.0.2"
 
 [dependencies.libp2p]
-version = "0.52.1"
+version = "0.52.2"
 default-features = false
 features = [
     "autonat",


### PR DESCRIPTION
This PR upgrades libp2p to v.0.52.2. 

No code changes are required. The change log doesn't contain any concerning changes as well: https://github.com/libp2p/rust-libp2p/blob/libp2p-v0.52.2/CHANGELOG.md

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
