### PR TITLE
XDM: Update fee model and soft deprecate relayers

### DIFF
--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -4,7 +4,8 @@ use super::*;
 use crate::Pallet as Messenger;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
-use frame_support::traits::{Get, ReservableCurrency};
+use frame_support::traits::fungible::Mutate;
+use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use sp_messenger::endpoint::{Endpoint, EndpointRequest};
 use sp_messenger::messages::{
@@ -21,10 +22,11 @@ mod benchmarks {
     #[benchmark]
     fn initiate_channel() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
         unchecked_join_relayer_set::<T>(relayer);
         let dst_chain_id: ChainId = u32::MAX.into();
         assert_ne!(T::SelfChainId::get(), dst_chain_id);
@@ -44,10 +46,11 @@ mod benchmarks {
     #[benchmark]
     fn close_channel() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
         unchecked_join_relayer_set::<T>(relayer);
 
         let dst_chain_id: ChainId = u32::MAX.into();
@@ -67,10 +70,11 @@ mod benchmarks {
     #[benchmark]
     fn do_open_channel() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
         unchecked_join_relayer_set::<T>(relayer);
 
         let dst_chain_id: ChainId = u32::MAX.into();
@@ -95,10 +99,11 @@ mod benchmarks {
     #[benchmark]
     fn do_close_channel() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
         unchecked_join_relayer_set::<T>(relayer);
 
         let dst_chain_id: ChainId = u32::MAX.into();
@@ -120,10 +125,11 @@ mod benchmarks {
     #[benchmark]
     fn relay_message<T: Config>() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
         unchecked_join_relayer_set::<T>(relayer);
 
         let endpoint = Endpoint::Id(100);
@@ -175,10 +181,11 @@ mod benchmarks {
     #[benchmark]
     fn relay_message_response() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
         unchecked_join_relayer_set::<T>(relayer);
 
         let endpoint = Endpoint::Id(100);
@@ -197,7 +204,7 @@ mod benchmarks {
         // Insert a dummy outbox request message which will be handled during the `relay_message_response` call
         let req_msg: Message<BalanceOf<T>> = Message {
             src_chain_id: T::SelfChainId::get(),
-            dst_chain_id: dst_chain_id,
+            dst_chain_id,
             channel_id,
             nonce: next_outbox_nonce,
             payload: VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(
@@ -246,10 +253,11 @@ mod benchmarks {
     #[benchmark]
     fn join_relayer_set() {
         let relayer = account("relayer", 1, SEED);
-        T::Currency::make_free_balance_be(
+        T::Currency::mint_into(
             &relayer,
             T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-        );
+        )
+        .unwrap();
 
         #[extrinsic_call]
         _(RawOrigin::Signed(relayer.clone()), relayer.clone());
@@ -264,10 +272,11 @@ mod benchmarks {
         let mut relayers = Vec::new();
         for i in 0..10 {
             let relayer = account("relayer", i, SEED);
-            T::Currency::make_free_balance_be(
+            T::Currency::mint_into(
                 &relayer,
                 T::RelayerDeposit::get() + T::Currency::minimum_balance(),
-            );
+            )
+            .unwrap();
             unchecked_join_relayer_set::<T>(relayer.clone());
             relayers.push(relayer);
 

--- a/domains/pallets/messenger/src/fees.rs
+++ b/domains/pallets/messenger/src/fees.rs
@@ -32,7 +32,7 @@ impl<T: Config> Pallet<T> {
         let src_chain_outbox_response_execution_fee =
             T::WeightToFee::weight_to_fee(&handler.message_response_weight());
         let src_chain_fee = src_chain_outbox_response_execution_fee
-            .checked_add(&src_chain_outbox_response_execution_fee)
+            .checked_add(&fee_model.relay_fee)
             .ok_or(Error::<T>::BalanceOverflow)?;
         OutboxFee::<T>::insert(message_id, src_chain_fee);
 

--- a/domains/pallets/messenger/src/fees.rs
+++ b/domains/pallets/messenger/src/fees.rs
@@ -1,62 +1,106 @@
-use crate::pallet::RelayerRewards;
+use crate::pallet::{InboxFee, InboxResponses, OutboxFee, RelayerRewards};
 use crate::{BalanceOf, Config, Error, Pallet};
-use frame_support::traits::fungible::{Inspect, Mutate};
-use frame_support::traits::tokens::{Fortitude, Precision, Preservation};
-use frame_support::PalletId;
-use sp_messenger::messages::FeeModel;
-use sp_runtime::traits::{AccountIdConversion, CheckedAdd};
-use sp_runtime::{ArithmeticError, DispatchResult};
-
-/// Messenger Id used to store deposits and fees.
-const MESSENGER_PALLET_ID: PalletId = PalletId(*b"messengr");
+use frame_support::traits::fungible::Mutate;
+use frame_support::traits::tokens::{Fortitude, Precision};
+use frame_support::weights::WeightToFee;
+use sp_messenger::endpoint::Endpoint;
+use sp_messenger::messages::{ChainId, ChannelId, FeeModel, MessageId, Nonce};
+use sp_runtime::traits::CheckedAdd;
+use sp_runtime::DispatchResult;
 
 impl<T: Config> Pallet<T> {
-    /// Returns the account_id to holds fees and and acts as treasury for messenger.
-    pub(crate) fn messenger_account_id() -> T::AccountId {
-        MESSENGER_PALLET_ID.into_account_truncating()
-    }
-
     /// Ensures the fees from the sender per FeeModel provided for a single request for a response.
     #[inline]
-    pub(crate) fn ensure_fees_for_outbox_message(
+    pub(crate) fn collect_fees_for_message(
         sender: &T::AccountId,
+        message_id: (ChainId, MessageId),
         fee_model: &FeeModel<BalanceOf<T>>,
+        endpoint: &Endpoint,
     ) -> DispatchResult {
-        let msgr_acc_id = Self::messenger_account_id();
-        // reserve outbox fee by transferring it to the messenger account.
-        // we will use the funds to pay the relayers once the response is received.
-        let outbox_fee = fee_model.outbox_fee().ok_or(ArithmeticError::Overflow)?;
-        T::Currency::transfer(sender, &msgr_acc_id, outbox_fee, Preservation::Preserve)?;
+        let handler = T::get_endpoint_handler(endpoint).ok_or(Error::<T>::NoMessageHandler)?;
 
-        // burn the fees that need to be paid on the dst_chain
-        let inbox_fee = fee_model.inbox_fee().ok_or(ArithmeticError::Overflow)?;
-        T::Currency::burn_from(sender, inbox_fee, Precision::Exact, Fortitude::Polite)?;
+        // fees need to be paid for following
+        // - Execution on dst_chain + Relay Fee. This is burned here and minted on dst_chain
+        let dst_chain_inbox_execution_fee =
+            T::WeightToFee::weight_to_fee(&handler.message_weight());
+        let dst_chain_fee = dst_chain_inbox_execution_fee
+            .checked_add(&fee_model.relay_fee)
+            .ok_or(Error::<T>::BalanceOverflow)?;
+
+        // - Execution of response on src_chain + relay fee.
+        // - This is collected and given to operators once response is received.
+        let src_chain_outbox_response_execution_fee =
+            T::WeightToFee::weight_to_fee(&handler.message_response_weight());
+        let src_chain_fee = src_chain_outbox_response_execution_fee
+            .checked_add(&src_chain_outbox_response_execution_fee)
+            .ok_or(Error::<T>::BalanceOverflow)?;
+        OutboxFee::<T>::insert(message_id, src_chain_fee);
+
+        // burn the total fees
+        let total_fees = dst_chain_fee
+            .checked_add(&src_chain_fee)
+            .ok_or(Error::<T>::BalanceOverflow)?;
+        T::Currency::burn_from(sender, total_fees, Precision::Exact, Fortitude::Polite)?;
+
         Ok(())
     }
 
-    /// Ensures the fee paid by the sender on the src_chain are minted here and paid to
-    /// relayer set when the acknowledgments are received.
+    /// Ensures the fee paid by the sender on the src_chain for execution on this chain are stored as operator rewards
     #[inline]
-    pub(crate) fn ensure_fees_for_inbox_message(
+    pub(crate) fn store_fees_for_inbox_message(
+        message_id: (ChainId, MessageId),
         fee_model: &FeeModel<BalanceOf<T>>,
+        endpoint: &Endpoint,
     ) -> DispatchResult {
-        let inbox_fee = fee_model.inbox_fee().ok_or(ArithmeticError::Overflow)?;
-        let msngr_acc_id = Self::messenger_account_id();
-        T::Currency::mint_into(&msngr_acc_id, inbox_fee)?;
+        let handler = T::get_endpoint_handler(endpoint).ok_or(Error::<T>::NoMessageHandler)?;
+        let inbox_execution_fee = T::WeightToFee::weight_to_fee(&handler.message_weight());
+        let inbox_fee = inbox_execution_fee
+            .checked_add(&fee_model.relay_fee)
+            .ok_or(Error::<T>::BalanceOverflow)?;
+
+        InboxFee::<T>::insert(message_id, inbox_fee);
+        Ok(())
+    }
+
+    /// Rewards operators for executing an inbox message since src_chain signalled that responses are delivered.
+    /// Removes messages responses from Inbox responses.
+    /// All the messages with nonce <= latest_confirmed_nonce are deleted.
+    pub(crate) fn reward_operators_for_inbox_execution(
+        dst_chain_id: ChainId,
+        channel_id: ChannelId,
+        latest_confirmed_nonce: Option<Nonce>,
+    ) -> DispatchResult {
+        let mut current_nonce = latest_confirmed_nonce;
+
+        while let Some(nonce) = current_nonce {
+            // for every inbox response we take, distribute the reward to the operators.
+            if InboxResponses::<T>::take((dst_chain_id, channel_id, nonce)).is_none() {
+                return Ok(());
+            }
+
+            if let Some(inbox_fee) = InboxFee::<T>::take((dst_chain_id, (channel_id, nonce))) {
+                Self::reward_operators(inbox_fee)?;
+            }
+
+            current_nonce = nonce.checked_sub(Nonce::one())
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn reward_operators_for_outbox_execution(
+        dst_chain_id: ChainId,
+        message_id: MessageId,
+    ) -> DispatchResult {
+        if let Some(fee) = OutboxFee::<T>::take((dst_chain_id, message_id)) {
+            Self::reward_operators(fee)?;
+        }
+
         Ok(())
     }
 
     /// Increments the current block's relayer rewards.
-    /// Operation is no-op if there is not enough balance to pay.
-    pub(crate) fn reward_relayers(reward: BalanceOf<T>) -> DispatchResult {
-        // ensure we have enough to pay but maintain minimum existential deposit
-        let msngr_acc_id = Self::messenger_account_id();
-        let balance =
-            T::Currency::reducible_balance(&msngr_acc_id, Preservation::Protect, Fortitude::Polite);
-        if balance < reward {
-            return Ok(());
-        }
-
+    fn reward_operators(reward: BalanceOf<T>) -> DispatchResult {
         RelayerRewards::<T>::try_mutate(|current_reward| {
             *current_reward = current_reward
                 .checked_add(&reward)

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -103,6 +103,7 @@ mod pallet {
     };
     use frame_support::pallet_prelude::*;
     use frame_support::traits::fungible::Mutate;
+    use frame_support::weights::WeightToFee;
     use frame_system::pallet_prelude::*;
     use sp_core::storage::StorageKey;
     use sp_messenger::endpoint::{DomainInfo, Endpoint, EndpointHandler, EndpointRequest, Sender};
@@ -111,7 +112,7 @@ mod pallet {
         Payload, ProtocolMessageRequest, RequestResponse, VersionedPayload,
     };
     use sp_messenger::verification::{StorageProofVerifier, VerificationError};
-    use sp_runtime::traits::CheckedSub;
+    use sp_runtime::traits::{CheckedSub, Zero};
     use sp_runtime::ArithmeticError;
     use sp_std::boxed::Box;
     use sp_std::vec::Vec;
@@ -122,9 +123,8 @@ mod pallet {
         /// Gets the chain_id that is treated as src_chain_id for outgoing messages.
         type SelfChainId: Get<ChainId>;
         /// function to fetch endpoint response handler by Endpoint.
-        fn get_endpoint_response_handler(
-            endpoint: &Endpoint,
-        ) -> Option<Box<dyn EndpointHandler<MessageId>>>;
+        fn get_endpoint_handler(endpoint: &Endpoint)
+            -> Option<Box<dyn EndpointHandler<MessageId>>>;
         /// Currency type pallet uses for fees and deposits.
         type Currency: Mutate<Self::AccountId>;
         /// Maximum number of relayers that can join this chain.
@@ -137,6 +137,8 @@ mod pallet {
         type ConfirmationDepth: Get<Self::BlockNumber>;
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
+        /// Weight to fee conversion.
+        type WeightToFee: WeightToFee<Balance = BalanceOf<Self>>;
     }
 
     /// Pallet messenger used to communicate between chains and other blockchains.
@@ -169,6 +171,21 @@ mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn inbox)]
     pub(super) type Inbox<T: Config> = StorageValue<_, Message<BalanceOf<T>>, OptionQuery>;
+
+    /// A temporary storage of fees for executing an inbox message.
+    /// The storage is cleared when the acknowledgement of inbox response is received
+    /// from the src_chain.
+    #[pallet::storage]
+    #[pallet::getter(fn inbox_fees)]
+    pub(super) type InboxFee<T: Config> =
+        StorageMap<_, Identity, (ChainId, MessageId), BalanceOf<T>, OptionQuery>;
+
+    /// A temporary storage of fees for executing an outbox message and its response from dst_chain.
+    /// The storage is cleared when src_chain receives the response from dst_chain.
+    #[pallet::storage]
+    #[pallet::getter(fn outbox_fees)]
+    pub(super) type OutboxFee<T: Config> =
+        StorageMap<_, Identity, (ChainId, MessageId), BalanceOf<T>, OptionQuery>;
 
     /// Stores the message responses of the incoming processed responses.
     /// Used by the dst_chains to verify the message response.
@@ -499,10 +516,11 @@ mod pallet {
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(_now: BlockNumberFor<T>) -> Weight {
             let results = RelayerMessages::<T>::clear(u32::MAX, None);
+            RelayerRewards::<T>::set(Zero::zero());
             let db_weight = T::DbWeight::get();
             db_weight
                 .reads(results.loops as u64)
-                .saturating_add(db_weight.writes(1))
+                .saturating_add(db_weight.writes(2))
         }
     }
 
@@ -618,15 +636,22 @@ mod pallet {
             let (channel_id, fee_model) =
                 Self::get_open_channel_for_chain(dst_chain_id).ok_or(Error::<T>::NoOpenChannel)?;
 
-            // ensure fees are paid by the sender
-            Self::ensure_fees_for_outbox_message(sender, &fee_model)?;
-
+            let src_endpoint = req.src_endpoint.clone();
             let nonce = Self::new_outbox_message(
                 T::SelfChainId::get(),
                 dst_chain_id,
                 channel_id,
                 VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(req))),
             )?;
+
+            // ensure fees are paid by the sender
+            Self::collect_fees_for_message(
+                sender,
+                (dst_chain_id, (channel_id, nonce)),
+                &fee_model,
+                &src_endpoint,
+            )?;
+
             Ok((channel_id, nonce))
         }
 
@@ -635,8 +660,7 @@ mod pallet {
         #[cfg(feature = "runtime-benchmarks")]
         fn unchecked_open_channel(dst_chain_id: ChainId) -> Result<(), DispatchError> {
             let fee_model = FeeModel {
-                outbox_fee: Default::default(),
-                inbox_fee: Default::default(),
+                relay_fee: Default::default(),
             };
             let init_params = InitiateChannelParams {
                 max_outgoing_messages: 100,
@@ -655,13 +679,13 @@ mod pallet {
                 MessageWeightTag::ProtocolChannelOpen => T::WeightInfo::do_open_channel(),
                 MessageWeightTag::ProtocolChannelClose => T::WeightInfo::do_close_channel(),
                 MessageWeightTag::EndpointRequest(endpoint) => {
-                    T::get_endpoint_response_handler(endpoint)
+                    T::get_endpoint_handler(endpoint)
                         .map(|endpoint_handler| endpoint_handler.message_weight())
                         // If there is no endpoint handler the request won't be handled thus reture zero weight
                         .unwrap_or(Weight::zero())
                 }
                 MessageWeightTag::EndpointResponse(endpoint) => {
-                    T::get_endpoint_response_handler(endpoint)
+                    T::get_endpoint_handler(endpoint)
                         .map(|endpoint_handler| endpoint_handler.message_response_weight())
                         // If there is no endpoint handler the request won't be handled thus reture zero weight
                         .unwrap_or(Weight::zero())
@@ -855,14 +879,6 @@ mod pallet {
                     return Err(InvalidTransaction::Call.into());
                 }
             }
-
-            let channel = Channels::<T>::get(msg.src_chain_id, msg.channel_id)
-                .ok_or(InvalidTransaction::Call)?;
-
-            // ensure the fees are deposited to the messenger account to pay
-            // for relayer set.
-            Self::ensure_fees_for_inbox_message(&channel.fee)
-                .map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
 
             Self::deposit_event(Event::InboxMessage {
                 chain_id: msg.src_chain_id,

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BalanceOf, ChannelId, Channels, Config, Error, Event, FeeModel, InboxResponses, Nonce, Outbox,
+    BalanceOf, ChannelId, Channels, Config, Error, Event, InboxResponses, Nonce, Outbox,
     OutboxMessageResult, Pallet, RelayerMessages,
 };
 use frame_support::ensure;
@@ -80,29 +80,6 @@ impl<T: Config> Pallet<T> {
         )
     }
 
-    /// Removes messages responses from Inbox responses as the src_chain signalled that responses are delivered.
-    /// all the messages with nonce <= latest_confirmed_nonce are deleted.
-    fn distribute_rewards_for_delivered_message_responses(
-        dst_chain_id: ChainId,
-        channel_id: ChannelId,
-        latest_confirmed_nonce: Option<Nonce>,
-        fee_model: &FeeModel<BalanceOf<T>>,
-    ) -> DispatchResult {
-        let mut current_nonce = latest_confirmed_nonce;
-
-        while let Some(nonce) = current_nonce {
-            // for every inbox response we take, distribute the reward to the relayers.
-            if InboxResponses::<T>::take((dst_chain_id, channel_id, nonce)).is_none() {
-                return Ok(());
-            }
-
-            Self::reward_relayers(fee_model.inbox_fee.relayer_pool_fee)?;
-            current_nonce = nonce.checked_sub(Nonce::one())
-        }
-
-        Ok(())
-    }
-
     /// Process the incoming messages from given chain_id and channel_id.
     pub(crate) fn process_inbox_messages(
         msg: Message<BalanceOf<T>>,
@@ -134,12 +111,20 @@ impl<T: Config> Pallet<T> {
             // process incoming endpoint message.
             VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(req))) => {
                 let response = if let Some(endpoint_handler) =
-                    T::get_endpoint_response_handler(&req.dst_endpoint)
+                    T::get_endpoint_handler(&req.dst_endpoint)
                 {
                     if msg_weight_tag != MessageWeightTag::EndpointRequest(req.dst_endpoint.clone())
                     {
                         return Err(Error::<T>::WeightTagNotMatch.into());
                     }
+
+                    // store fees for inbox message execution
+                    Self::store_fees_for_inbox_message(
+                        (dst_chain_id, (channel_id, nonce)),
+                        &channel.fee,
+                        &req.src_endpoint,
+                    )?;
+
                     endpoint_handler.message(dst_chain_id, (channel_id, nonce), req)
                 } else {
                     Err(Error::<T>::NoMessageHandler.into())
@@ -199,11 +184,10 @@ impl<T: Config> Pallet<T> {
 
         // reward relayers for relaying message responses to src_chain.
         // clean any delivered inbox responses
-        Self::distribute_rewards_for_delivered_message_responses(
+        Self::reward_operators_for_inbox_execution(
             dst_chain_id,
             channel_id,
             msg.last_delivered_message_response_nonce,
-            &channel.fee,
         )?;
 
         Self::deposit_event(Event::InboxMessageResponse {
@@ -301,14 +285,23 @@ impl<T: Config> Pallet<T> {
                 VersionedPayload::V0(Payload::Endpoint(RequestResponse::Request(req))),
                 VersionedPayload::V0(Payload::Endpoint(RequestResponse::Response(resp))),
             ) => {
-                if let Some(endpoint_handler) = T::get_endpoint_response_handler(&req.dst_endpoint)
-                {
+                if let Some(endpoint_handler) = T::get_endpoint_handler(&req.dst_endpoint) {
                     if resp_msg_weight_tag
                         != MessageWeightTag::EndpointResponse(req.dst_endpoint.clone())
                     {
                         return Err(Error::<T>::WeightTagNotMatch.into());
                     }
-                    endpoint_handler.message_response(dst_chain_id, (channel_id, nonce), req, resp)
+
+                    let resp = endpoint_handler.message_response(
+                        dst_chain_id,
+                        (channel_id, nonce),
+                        req,
+                        resp,
+                    );
+
+                    Self::reward_operators_for_outbox_execution(dst_chain_id, (channel_id, nonce))?;
+
+                    resp
                 } else {
                     Err(Error::<T>::NoMessageHandler.into())
                 }
@@ -316,9 +309,6 @@ impl<T: Config> Pallet<T> {
 
             (_, _) => Err(Error::<T>::InvalidMessagePayload.into()),
         };
-
-        // distribute rewards to relayers for relaying the outbox messages.
-        Self::reward_relayers(channel.fee.outbox_fee.relayer_pool_fee)?;
 
         Channels::<T>::mutate(
             dst_chain_id,

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -96,7 +96,7 @@ impl<T: Config> Pallet<T> {
                 return Ok(());
             }
 
-            Self::distribute_reward_to_relayers(fee_model.inbox_fee.relayer_pool_fee)?;
+            Self::reward_relayers(fee_model.inbox_fee.relayer_pool_fee)?;
             current_nonce = nonce.checked_sub(Nonce::one())
         }
 
@@ -318,7 +318,7 @@ impl<T: Config> Pallet<T> {
         };
 
         // distribute rewards to relayers for relaying the outbox messages.
-        Self::distribute_reward_to_relayers(channel.fee.outbox_fee.relayer_pool_fee)?;
+        Self::reward_relayers(channel.fee.outbox_fee.relayer_pool_fee)?;
 
         Channels::<T>::mutate(
             dst_chain_id,

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -101,8 +101,9 @@ macro_rules! impl_runtime {
             type ConfirmationDepth = RelayerConfirmationDepth;
             type DomainInfo = ();
             type WeightInfo = ();
+            type WeightToFee = frame_support::weights::IdentityFee<u64>;
             /// function to fetch endpoint response handler by Endpoint.
-            fn get_endpoint_response_handler(
+            fn get_endpoint_handler(
                 endpoint: &Endpoint,
             ) -> Option<Box<dyn EndpointHandler<MessageId>>>{
                 // Return a dummy handler for benchmark to observe the outer weight when processing cross chain

--- a/domains/pallets/messenger/src/relayer.rs
+++ b/domains/pallets/messenger/src/relayer.rs
@@ -4,7 +4,6 @@ use crate::{
     RelayerMessages as RelayerMessageStore, Relayers, RelayersInfo, TypeInfo,
 };
 use frame_support::ensure;
-use frame_support::traits::ReservableCurrency;
 use sp_messenger::messages::{
     ChainId, MessageId, MessageWeightTag, RelayerMessageWithStorageKey,
     RelayerMessagesWithStorageKey,
@@ -44,9 +43,6 @@ impl<T: Config> Pallet<T> {
             !RelayersInfo::<T>::contains_key(&relayer_id),
             Error::<T>::AlreadyRelayer
         );
-
-        // reserve the deposit
-        T::Currency::reserve(&owner, T::RelayerDeposit::get())?;
 
         // add the relayer to the pool
         RelayersInfo::<T>::insert(
@@ -103,9 +99,6 @@ impl<T: Config> Pallet<T> {
 
         // ensure caller is the owner of the relayer
         ensure!(relayer.owner == caller, Error::<T>::NotOwner);
-
-        // release the deposit
-        T::Currency::unreserve(&caller, relayer.deposit_reserved);
 
         // remove relayer_id from the list
         let idx = Relayers::<T>::mutate(|relayers| -> Result<usize, DispatchError> {

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -863,25 +863,6 @@ fn test_transport_funds_between_chains_failed_no_open_channel() {
 }
 
 #[test]
-fn test_join_relayer_low_balance() {
-    let mut chain_a_test_ext = chain_a::new_test_ext();
-    // account with no balance
-    let account_id = 2;
-    let relayer_id = 100;
-
-    chain_a_test_ext.execute_with(|| {
-        let res = chain_a::Messenger::join_relayer_set(
-            chain_a::RuntimeOrigin::signed(account_id),
-            relayer_id,
-        );
-        assert_err!(
-            res,
-            pallet_balances::Error::<chain_a::Runtime>::InsufficientBalance
-        );
-    });
-}
-
-#[test]
 fn test_join_relayer_set() {
     let mut chain_a_test_ext = chain_a::new_test_ext();
     // account with balance
@@ -902,7 +883,6 @@ fn test_join_relayer_set() {
                 deposit_reserved: RelayerDeposit::get(),
             }
         );
-        assert_eq!(chain_a::Balances::free_balance(account_id), 500);
 
         // cannot rejoin again
         let res = chain_a::Messenger::join_relayer_set(
@@ -954,7 +934,6 @@ fn test_exit_relayer_set() {
                 }
             );
         }
-        assert_eq!(chain_a::Balances::free_balance(account_id), 500);
 
         let assigned_relayer_id = chain_a::Messenger::next_relayer().unwrap();
         assert_eq!(assigned_relayer_id, RELAYER_ID);

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -18,7 +18,7 @@ use sp_core::storage::StorageKey;
 use sp_core::{Blake2Hasher, H256};
 use sp_messenger::endpoint::{Endpoint, EndpointPayload, EndpointRequest, Sender};
 use sp_messenger::messages::{
-    BlockInfo, ChainId, CrossDomainMessage, ExecutionFee, InitiateChannelParams, Payload, Proof,
+    BlockInfo, ChainId, CrossDomainMessage, InitiateChannelParams, Payload, Proof,
     ProtocolMessageRequest, RequestResponse, VersionedPayload,
 };
 use sp_messenger::verification::{StorageProofVerifier, VerificationError};
@@ -682,17 +682,8 @@ fn initiate_transfer_on_chain(chain_a_ext: &mut TestExternalities) {
         let fee_model = chain_b::Messenger::channels(chain_b::SelfChainId::get(), U256::zero())
             .unwrap_or_default()
             .fee;
-        let fees = fee_model.inbox_fee.relayer_pool_fee
-            + fee_model.inbox_fee.compute_fee
-            + fee_model.outbox_fee.compute_fee
-            + fee_model.outbox_fee.relayer_pool_fee;
-
+        let fees = fee_model.relay_fee;
         assert_eq!(chain_a::Balances::free_balance(account_id), 500 - fees);
-        // source chain take 2 fees and dst_chain takes 2
-        assert_eq!(
-            chain_a::Balances::free_balance(chain_a::Messenger::messenger_account_id()),
-            fee_model.outbox_fee.compute_fee + fee_model.outbox_fee.relayer_pool_fee
-        );
         assert!(chain_a::Transporter::outgoing_transfers(
             chain_b::SelfChainId::get(),
             (U256::zero(), U256::one()),
@@ -726,10 +717,6 @@ fn verify_transfer_on_chain(
             },
         ));
         assert_eq!(chain_a::Balances::free_balance(account_id), 496);
-        assert_eq!(
-            chain_a::Balances::free_balance(chain_a::Messenger::messenger_account_id()),
-            1
-        );
         let relayer_a_balance = chain_a::Balances::free_balance(chain_a::RELAYER_ID);
         assert_eq!(relayer_a_balance, 1);
         assert!(chain_a::Transporter::outgoing_transfers(
@@ -758,10 +745,6 @@ fn verify_transfer_on_chain(
             relayer_id: chain_b::RELAYER_ID,
         }));
         assert_eq!(chain_b::Balances::free_balance(account_id), 1500);
-        assert_eq!(
-            chain_b::Balances::free_balance(chain_b::Messenger::messenger_account_id()),
-            1
-        );
         let relayer_b_balance = chain_b::Balances::free_balance(chain_b::RELAYER_ID);
         assert_eq!(relayer_b_balance, 1);
     })
@@ -785,16 +768,7 @@ fn test_transport_funds_between_chains() {
     let channel_id = open_channel_between_chains(
         &mut chain_a_test_ext,
         &mut chain_b_test_ext,
-        FeeModel {
-            outbox_fee: ExecutionFee {
-                relayer_pool_fee: 1,
-                compute_fee: 1,
-            },
-            inbox_fee: ExecutionFee {
-                relayer_pool_fee: 1,
-                compute_fee: 1,
-            },
-        },
+        FeeModel { relay_fee: 1 },
     );
 
     // initiate transfer

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::storage::StorageKey;
 use sp_domains::DomainId;
 use sp_runtime::app_crypto::sp_core::U256;
-use sp_runtime::traits::CheckedAdd;
 use sp_runtime::{sp_std, DispatchError};
 use sp_std::marker::PhantomData;
 use sp_std::vec::Vec;
@@ -24,45 +23,11 @@ pub type Nonce = U256;
 /// Unique Id of a message between two chains.
 pub type MessageId = (ChannelId, Nonce);
 
-/// Execution Fee to execute a send or receive request.
-#[derive(Default, Debug, Encode, Decode, Clone, Copy, Eq, PartialEq, TypeInfo)]
-pub struct ExecutionFee<Balance> {
-    /// Fee paid to the relayer pool for the execution.
-    pub relayer_pool_fee: Balance,
-    /// Fee paid to the network for computation.
-    pub compute_fee: Balance,
-}
-
 /// Fee model to send a request and receive a response from another chain.
-/// A user of the endpoint will pay
-///     - outbox_fee on src_chain
-///     - inbox_fee on dst_chain
-/// The reward is distributed to
-///     - src_chain relayer pool when the response is received
-///     - dst_chain relayer pool when the response acknowledgement from src_chain.
 #[derive(Default, Debug, Encode, Decode, Clone, Copy, Eq, PartialEq, TypeInfo)]
 pub struct FeeModel<Balance> {
-    /// Fee paid by the endpoint user for any outgoing message.
-    pub outbox_fee: ExecutionFee<Balance>,
-    /// Fee paid by the endpoint user any incoming message.
-    pub inbox_fee: ExecutionFee<Balance>,
-}
-
-// TODO: `compute_fee` and `relayer_pool_fee` should be distributed separately, where
-// `compute_fee` should be distributed to executor and `relayer_pool_fee` should be
-// distributed to relayer.
-impl<Balance: CheckedAdd> FeeModel<Balance> {
-    pub fn outbox_fee(&self) -> Option<Balance> {
-        self.outbox_fee
-            .compute_fee
-            .checked_add(&self.outbox_fee.relayer_pool_fee)
-    }
-
-    pub fn inbox_fee(&self) -> Option<Balance> {
-        self.inbox_fee
-            .compute_fee
-            .checked_add(&self.inbox_fee.relayer_pool_fee)
-    }
+    /// Fee to relay message from one chain to another
+    pub relay_fee: Balance,
 }
 
 /// Parameters for a new channel between two chains.

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -384,9 +384,7 @@ impl pallet_messenger::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
 
-    fn get_endpoint_response_handler(
-        endpoint: &Endpoint,
-    ) -> Option<Box<dyn EndpointHandlerT<MessageId>>> {
+    fn get_endpoint_handler(endpoint: &Endpoint) -> Option<Box<dyn EndpointHandlerT<MessageId>>> {
         if endpoint == &Endpoint::Id(TransporterEndpointId::get()) {
             Some(Box::new(EndpointHandler(PhantomData::<Runtime>)))
         } else {
@@ -400,6 +398,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainInfo = ();
     type ConfirmationDepth = RelayConfirmationDepth;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
+    type WeightToFee = IdentityFee<Balance>;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -383,9 +383,7 @@ impl pallet_messenger::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
 
-    fn get_endpoint_response_handler(
-        endpoint: &Endpoint,
-    ) -> Option<Box<dyn EndpointHandlerT<MessageId>>> {
+    fn get_endpoint_handler(endpoint: &Endpoint) -> Option<Box<dyn EndpointHandlerT<MessageId>>> {
         if endpoint == &Endpoint::Id(TransporterEndpointId::get()) {
             Some(Box::new(EndpointHandler(PhantomData::<Runtime>)))
         } else {
@@ -399,6 +397,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainInfo = ();
     type ConfirmationDepth = RelayConfirmationDepth;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
+    type WeightToFee = IdentityFee<Balance>;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime


### PR DESCRIPTION
This PR changes the following
- Fee model is updated to capture actual execution fee using the weights specific to the handler
- Temporarily store XDM rewards until operator rewards are enabled.
- Soft deprecate relayers as every operator is a relayer. I have also removed the actual deposit for relayers in this PR. Relayers will be completely removed in the next PR.

Closes: #1869
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
