### PR TITLE
Add domain block extrinsic root in execution receipt

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -250,6 +250,7 @@ pub(crate) fn create_dummy_receipt(
     ExecutionReceipt {
         domain_block_number: block_number,
         domain_block_hash: H256::random(),
+        domain_block_extrinsic_root: Default::default(),
         parent_domain_block_receipt_hash,
         consensus_block_number: block_number,
         consensus_block_hash,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -347,6 +347,8 @@ pub struct ExecutionReceipt<Number, Hash, DomainNumber, DomainHash, Balance> {
     pub domain_block_number: DomainNumber,
     /// The block hash corresponding to `domain_block_number`.
     pub domain_block_hash: DomainHash,
+    /// Extrinsic root field of the header of domain block referenced by this ER.
+    pub domain_block_extrinsic_root: DomainHash,
     /// The hash of the ER for the last domain block.
     pub parent_domain_block_receipt_hash: ReceiptHash,
     /// A pointer to the consensus block index which contains all of the bundles that were used to derive and
@@ -391,6 +393,7 @@ impl<
         ExecutionReceipt {
             domain_block_number: Zero::zero(),
             domain_block_hash: Default::default(),
+            domain_block_extrinsic_root: Default::default(),
             parent_domain_block_receipt_hash: Default::default(),
             consensus_block_hash: consensus_genesis_hash,
             consensus_block_number: Zero::zero(),
@@ -424,6 +427,7 @@ impl<
         ExecutionReceipt {
             domain_block_number,
             domain_block_hash: Default::default(),
+            domain_block_extrinsic_root: Default::default(),
             parent_domain_block_receipt_hash,
             consensus_block_number,
             consensus_block_hash,

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -494,6 +494,7 @@ mod tests {
         ExecutionReceipt {
             domain_block_number: consensus_block_number,
             domain_block_hash: H256::random(),
+            domain_block_extrinsic_root: H256::random(),
             parent_domain_block_receipt_hash: H256::random(),
             consensus_block_number,
             consensus_block_hash: H256::random(),

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -21,6 +21,16 @@ use sp_runtime::Digest;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+struct DomainBlockBuildResult<Block>
+where
+    Block: BlockT,
+{
+    header_number: NumberFor<Block>,
+    header_hash: Block::Hash,
+    state_root: Block::Hash,
+    extrinsics_root: Block::Hash,
+}
+
 pub(crate) struct DomainBlockResult<Block, CBlock>
 where
     Block: BlockT,
@@ -277,7 +287,12 @@ where
         // new best domain block after processing each imported consensus block.
         let fork_choice = ForkChoiceStrategy::LongestChain;
 
-        let (header_hash, header_number, state_root) = self
+        let DomainBlockBuildResult {
+            extrinsics_root,
+            state_root,
+            header_number,
+            header_hash,
+        } = self
             .build_and_import_block(parent_hash, parent_number, extrinsics, fork_choice, digests)
             .await?;
 
@@ -359,6 +374,7 @@ where
         let execution_receipt = ExecutionReceipt {
             domain_block_number: header_number,
             domain_block_hash: header_hash,
+            domain_block_extrinsic_root: extrinsics_root,
             parent_domain_block_receipt_hash: parent_receipt.hash(),
             consensus_block_number,
             consensus_block_hash,
@@ -384,7 +400,7 @@ where
         extrinsics: Vec<Block::Extrinsic>,
         fork_choice: ForkChoiceStrategy,
         digests: Digest,
-    ) -> Result<(Block::Hash, NumberFor<Block>, Block::Hash), sp_blockchain::Error> {
+    ) -> Result<DomainBlockBuildResult<Block>, sp_blockchain::Error> {
         let block_builder = BlockBuilder::new(
             &*self.client,
             parent_hash,
@@ -403,6 +419,7 @@ where
 
         let (header, body) = block.deconstruct();
         let state_root = *header.state_root();
+        let extrinsics_root = *header.extrinsics_root();
         let header_hash = header.hash();
         let header_number = *header.number();
 
@@ -416,7 +433,12 @@ where
         };
         self.import_domain_block(block_import_params).await?;
 
-        Ok((header_hash, header_number, state_root))
+        Ok(DomainBlockBuildResult {
+            header_hash,
+            header_number,
+            state_root,
+            extrinsics_root,
+        })
     }
 
     pub(crate) async fn import_domain_block(


### PR DESCRIPTION
## Description
This PR adds domain block's extrinsic root to the execution receipt. Fixes: https://github.com/subspace/subspace/issues/1866

The extrinsic root is taken from newly constructed domain block.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
