### PR TITLE
Block relay improvements

### DIFF
--- a/crates/sc-subspace-block-relay/src/lib.rs
+++ b/crates/sc-subspace-block-relay/src/lib.rs
@@ -43,7 +43,6 @@
 use crate::utils::{NetworkPeerHandle, RelayError};
 use async_trait::async_trait;
 use codec::{Decode, Encode};
-use std::time::Duration;
 
 mod consensus;
 mod protocol;
@@ -53,22 +52,6 @@ pub use crate::consensus::build_consensus_relay;
 pub use crate::utils::NetworkWrapper;
 
 pub(crate) const LOG_TARGET: &str = "block_relay";
-
-/// The downloaded entry and meta info
-pub(crate) struct DownloadResult<DownloadUnitId, DownloadUnit: Encode> {
-    /// Downloaded unit Id
-    download_unit_id: DownloadUnitId,
-
-    /// Downloaded entry
-    downloaded: DownloadUnit,
-
-    /// Total transactions (in bytes) that could not be resolved
-    /// locally, and had to be fetched from the server
-    local_miss: usize,
-
-    /// Download latency
-    latency: Duration,
-}
 
 /// The resolved protocol unit related info
 pub(crate) struct Resolved<ProtocolUnitId, ProtocolUnit> {

--- a/crates/sc-subspace-block-relay/src/utils.rs
+++ b/crates/sc-subspace-block-relay/src/utils.rs
@@ -1,11 +1,14 @@
 //! Common utils.
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, Input};
 use futures::channel::oneshot;
 use parking_lot::Mutex;
 use sc_network::request_responses::IfDisconnected;
 use sc_network::types::ProtocolName;
 use sc_network::{NetworkRequest, PeerId, RequestFailure};
+use sc_network_common::sync::message::BlockData;
+use sp_runtime::traits::Block as BlockT;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 type NetworkRequestService = Arc<dyn NetworkRequest + Send + Sync + 'static>;
@@ -61,14 +64,13 @@ impl NetworkPeerHandle {
         }
     }
 
-    /// Performs the request
-    pub(crate) async fn request<Request, Response>(
+    /// Performs the request, returns the received bytes.
+    pub(crate) async fn request_raw<Request>(
         &self,
         request: Request,
-    ) -> Result<Response, RequestResponseErr>
+    ) -> Result<Vec<u8>, RequestResponseErr>
     where
         Request: Encode,
-        Response: Decode,
     {
         let (tx, rx) = oneshot::channel();
         self.network.start_request(
@@ -84,9 +86,130 @@ impl NetworkPeerHandle {
             .map_err(|_cancelled| RequestResponseErr::Canceled)?
             .map_err(RequestResponseErr::RequestFailure)?;
 
+        Ok(response_bytes)
+    }
+
+    /// Performs the request, decodes the received bytes as
+    /// into `Response` type.
+    pub(crate) async fn request<Request, Response>(
+        &self,
+        request: Request,
+    ) -> Result<Response, RequestResponseErr>
+    where
+        Request: Encode,
+        Response: Decode,
+    {
+        let response_bytes = self.request_raw(request).await?;
         let response_len = response_bytes.len();
         Response::decode(&mut response_bytes.as_ref())
             .map_err(|err| RequestResponseErr::DecodeFailed { response_len, err })
+    }
+}
+
+/// We want to be able to encode a Vec<Block> so that the total encoded size
+/// doesn't exceed a max limit. The BlockEncoder/BlockDecoder wrappers
+/// achieve this without repeated encoded_size() computation as the Vec<>
+/// grows, and avoid expensive rollback of the last entry when the limit is
+/// reached. Blocks are incrementally encoded/appended to the output, until
+/// the limit is reached.
+///
+/// The encoding scheme is a simple prefix followed by the encoded entries:
+///  Num entries ([u8; 4], big endian), Block_0 encoding, Block_1 encoding,...
+type BlockDataPrefix = [u8; 4];
+
+/// Incrementally encodes the block data until byte limit is reached, without having
+/// to do any expensive rollback when the limit is reached.
+pub(crate) struct BlockEncoder {
+    /// Number of blocks accumulated so far.
+    num_blocks: u32,
+
+    /// Encoded blocks accumulated so far.
+    block_data: Vec<u8>,
+
+    /// Maximum allowed encoded data size.
+    max_bytes: NonZeroUsize,
+}
+
+impl BlockEncoder {
+    /// Creates the block encoder.
+    pub(crate) fn new(max_bytes: NonZeroUsize) -> Self {
+        Self {
+            num_blocks: 0,
+            block_data: Vec::new(),
+            max_bytes,
+        }
+    }
+
+    /// Adds the block to the serialized data, if the byte limit
+    /// allows. Returns true if it could be appended, false otherwise.
+    pub(crate) fn append<Block: BlockT>(&mut self, block: BlockData<Block>) -> bool {
+        let mut block = block.encode();
+        let new_len = std::mem::size_of::<BlockDataPrefix>() + self.block_data.len() + block.len();
+        if self.num_blocks == 0 || new_len <= self.max_bytes.into() {
+            self.block_data.append(&mut block);
+            self.num_blocks += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the number of blocks.
+    pub(crate) fn num_blocks(&self) -> u32 {
+        self.num_blocks
+    }
+
+    /// Returns the encoded bytes.
+    pub(crate) fn encode(mut self) -> Vec<u8> {
+        let prefix: BlockDataPrefix = self.num_blocks.to_be_bytes();
+        let mut encoded = prefix.to_vec();
+        encoded.append(&mut self.block_data);
+        encoded
+    }
+}
+
+/// Decodes the block data.
+pub(crate) struct BlockDecoder(Vec<u8>);
+
+impl BlockDecoder {
+    /// Creates the decoder.
+    pub(crate) fn new(encoded: Vec<u8>) -> Self {
+        Self(encoded)
+    }
+
+    /// Returns the decoded blocks.
+    pub(crate) fn decode<Block: BlockT>(self) -> Result<Vec<BlockData<Block>>, RelayError> {
+        let mut input = Box::new(self.0.as_slice());
+        Self::decode_blocks::<_, Block>(input.as_mut())
+    }
+
+    /// Helper to decode.
+    fn decode_blocks<I: Input, Block: BlockT>(
+        input: &mut I,
+    ) -> Result<Vec<BlockData<Block>>, RelayError> {
+        let encoded_len = input.remaining_len();
+
+        let mut prefix_bytes: BlockDataPrefix = [0; 4];
+        input
+            .read(&mut prefix_bytes)
+            .map_err(|err| RelayError::BlockPrefixDecode {
+                encoded_len: encoded_len.clone(),
+                err,
+            })?;
+        let num_blocks = u32::from_be_bytes(prefix_bytes);
+
+        let mut blocks = Vec::new();
+        for i in 0..num_blocks {
+            let block_data: BlockData<Block> =
+                Decode::decode(input).map_err(|err| RelayError::BlockDecode {
+                    encoded_len: encoded_len.clone(),
+                    num_blocks,
+                    failed_block: i,
+                    err,
+                })?;
+            blocks.push(block_data)
+        }
+        Ok(blocks)
     }
 }
 
@@ -148,4 +271,18 @@ pub(crate) enum RelayError {
 
     #[error("Request/response error: {0}")]
     RequestResponse(#[from] RequestResponseErr),
+
+    #[error("Block prefix decode failed: {encoded_len:?}/{err}")]
+    BlockPrefixDecode {
+        encoded_len: Result<Option<usize>, codec::Error>,
+        err: codec::Error,
+    },
+
+    #[error("Block decode failed: {encoded_len:?}/{num_blocks}/{failed_block}/{err}")]
+    BlockDecode {
+        encoded_len: Result<Option<usize>, codec::Error>,
+        num_blocks: u32,
+        failed_block: u32,
+        err: codec::Error,
+    },
 }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -462,8 +462,7 @@ fn main() -> Result<(), Error> {
                         force_new_slot_notifications: !cli.domain_args.is_empty(),
                         subspace_networking: SubspaceNetworking::Create { config: dsn_config },
                         sync_from_dsn: cli.sync_from_dsn,
-                        enable_subspace_block_relay: cli.enable_subspace_block_relay
-                            || cli.run.is_dev().unwrap_or(false),
+                        enable_subspace_block_relay: cli.enable_subspace_block_relay,
                         #[cfg(feature = "pot")]
                         pot_source_config,
                     };

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -257,7 +257,7 @@ pub struct Cli {
 
     /// Use the block request handler implementation from subspace
     /// instead of the default substrate handler.
-    #[arg(long)]
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub enable_subspace_block_relay: bool,
 
     /// Assigned PoT role for this node.


### PR DESCRIPTION
1. Add support for returning multiple complete blocks, without going through the protocol. This is meant for scenarios where a node is syncing upon start
2. Enable block relay by default.
3. Clean ups

Fixes https://github.com/subspace/subspace/issues/1901

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
