### PR TITLE
Pot verification preparation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,14 @@ sha2 = { opt-level = 3 }
 sha3 = { opt-level = 3 }
 smallvec = { opt-level = 3 }
 snow = { opt-level = 3 }
+sc-proof-of-time = { opt-level = 3 }
 subspace-archiving = { opt-level = 3 }
 subspace-chiapos = { opt-level = 3 }
 subspace-core-primitives = { opt-level = 3 }
 subspace-erasure-coding = { opt-level = 3 }
 subspace-farmer-components = { opt-level = 3 }
 subspace-proof-of-space = { opt-level = 3 }
+subspace-proof-of-time = { opt-level = 3 }
 twox-hash = { opt-level = 3 }
 uint = { opt-level = 3 }
 x25519-dalek = { opt-level = 3 }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -785,15 +785,15 @@ impl<T: Config> Pallet<T> {
         // On the first non-zero block (i.e. block #1) we need to adjust internal storage
         // accordingly.
         if *GenesisSlot::<T>::get() == 0 {
-            GenesisSlot::<T>::put(pre_digest.slot);
+            GenesisSlot::<T>::put(pre_digest.slot());
             debug_assert_ne!(*GenesisSlot::<T>::get(), 0);
         }
 
         // The slot number of the current block being initialized.
-        CurrentSlot::<T>::put(pre_digest.slot);
+        CurrentSlot::<T>::put(pre_digest.slot());
 
         {
-            let farmer_public_key = pre_digest.solution.public_key.clone();
+            let farmer_public_key = pre_digest.solution().public_key.clone();
 
             // Optional restriction for block authoring to the root user
             if !AllowAuthoringByAnyone::<T>::get() {
@@ -817,10 +817,10 @@ impl<T: Config> Pallet<T> {
 
             let key = (
                 farmer_public_key,
-                pre_digest.solution.sector_index,
-                pre_digest.solution.chunk,
-                AuditChunkOffset(pre_digest.solution.audit_chunk_offset),
-                pre_digest.slot,
+                pre_digest.solution().sector_index,
+                pre_digest.solution().chunk,
+                AuditChunkOffset(pre_digest.solution().audit_chunk_offset),
+                pre_digest.slot(),
             );
             if ParentBlockVoters::<T>::get().contains_key(&key) {
                 let (public_key, _sector_index, _chunk, _audit_chunk_offset, slot) = key;
@@ -848,7 +848,7 @@ impl<T: Config> Pallet<T> {
                     chunk,
                     audit_chunk_offset,
                     slot,
-                    pre_digest.solution.reward_address.clone(),
+                    pre_digest.solution().reward_address.clone(),
                 ));
             }
         }
@@ -883,7 +883,7 @@ impl<T: Config> Pallet<T> {
 
         // Extract PoR randomness from pre-digest.
         #[cfg(not(feature = "pot"))]
-        let por_randomness = derive_randomness(&pre_digest.solution, pre_digest.slot.into());
+        let por_randomness = derive_randomness(pre_digest.solution(), pre_digest.slot().into());
         // Store PoR randomness for block duration as it might be useful.
         #[cfg(not(feature = "pot"))]
         PorRandomness::<T>::put(por_randomness);

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -68,7 +68,7 @@ use sp_std::collections::btree_map::BTreeMap;
 use sp_std::prelude::*;
 use subspace_core_primitives::crypto::Scalar;
 #[cfg(feature = "pot")]
-use subspace_core_primitives::PotCheckpoint;
+use subspace_core_primitives::PotProof;
 use subspace_core_primitives::{
     ArchivedHistorySegment, HistorySize, PublicKey, Randomness, RewardSignature, SectorId,
     SectorIndex, SegmentHeader, SegmentIndex, SolutionRange,
@@ -1447,7 +1447,7 @@ fn check_vote<T: Config>(
             global_randomness: vote_verification_data.global_randomness,
             // TODO: This is incorrect, find a way to verify votes
             #[cfg(feature = "pot")]
-            proof_of_time: PotCheckpoint::default(),
+            proof_of_time: PotProof::default(),
             solution_range: vote_verification_data.solution_range,
             piece_check_params: Some(PieceCheckParams {
                 max_pieces_in_sector: T::MaxPiecesInSector::get(),

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -380,21 +380,9 @@ mod pallet {
     pub(super) type GlobalRandomnesses<T> =
         StorageValue<_, sp_consensus_subspace::GlobalRandomnesses, ValueQuery>;
 
-    pub(super) struct DefaultPotSlotIterations {}
-
-    impl Get<NonZeroU32> for DefaultPotSlotIterations {
-        fn get() -> NonZeroU32 {
-            // TODO: Replace with below panic if/when https://github.com/paritytech/polkadot-sdk/issues/1282
-            //  is resolved upstream
-            NonZeroU32::MIN
-            // unreachable!("Always instantiated during genesis; qed");
-        }
-    }
-
     /// Number of iterations for proof of time per slot
     #[pallet::storage]
-    pub(super) type PotSlotIterations<T> =
-        StorageValue<_, NonZeroU32, ValueQuery, DefaultPotSlotIterations>;
+    pub(super) type PotSlotIterations<T> = StorageValue<_, NonZeroU32>;
 
     /// Solution ranges used for challenges.
     #[pallet::storage]
@@ -954,7 +942,7 @@ impl<T: Config> Pallet<T> {
 
         #[cfg(feature = "pot")]
         frame_system::Pallet::<T>::deposit_log(DigestItem::pot_slot_iterations(
-            PotSlotIterations::<T>::get(),
+            PotSlotIterations::<T>::get().expect("Always instantiated during genesis; qed"),
         ));
         // TODO: Once we have entropy injection, it might take effect right here and should be
         //  accounted for
@@ -1117,7 +1105,8 @@ impl<T: Config> Pallet<T> {
     #[cfg(feature = "pot")]
     pub fn pot_parameters() -> PotParameters {
         PotParameters::V0 {
-            iterations: PotSlotIterations::<T>::get(),
+            iterations: PotSlotIterations::<T>::get()
+                .expect("Always instantiated during genesis; qed"),
             // TODO: This is where adjustment for number of iterations and entropy injection will
             //  happen for runtime API calls
             next_change: None,

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -28,6 +28,8 @@ use futures::executor::block_on;
 use rand::Rng;
 use schnorrkel::Keypair;
 use sp_consensus_slots::Slot;
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::digests::PreDigestPotInfo;
 use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest};
 use sp_consensus_subspace::{FarmerSignature, KzgExtension, PosExtension, SignedVote, Vote};
 use sp_core::crypto::UncheckedFrom;
@@ -264,9 +266,11 @@ pub fn make_pre_digest(
         slot,
         solution,
         #[cfg(feature = "pot")]
-        proof_of_time: Default::default(),
-        #[cfg(feature = "pot")]
-        future_proof_of_time: Default::default(),
+        pot_info: PreDigestPotInfo::Regular {
+            iterations: NonZeroU32::new(100_000).unwrap(),
+            proof_of_time: Default::default(),
+            future_proof_of_time: Default::default(),
+        },
     });
     Digest { logs: vec![log] }
 }

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -18,8 +18,8 @@
 
 use crate::equivocation::EquivocationHandler;
 use crate::{
-    self as pallet_subspace, Config, CurrentSlot, FarmerPublicKey, NormalEraChange,
-    NormalGlobalRandomnessInterval,
+    self as pallet_subspace, AllowAuthoringBy, Config, CurrentSlot, FarmerPublicKey,
+    NormalEraChange, NormalGlobalRandomnessInterval,
 };
 use frame_support::pallet_prelude::Weight;
 use frame_support::parameter_types;
@@ -39,7 +39,7 @@ use sp_runtime::testing::{Digest, DigestItem, Header, TestXt};
 use sp_runtime::traits::{Block as BlockT, Header as _, IdentityLookup};
 use sp_runtime::Perbill;
 use std::iter;
-use std::num::NonZeroU64;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::sync::Once;
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
@@ -286,7 +286,12 @@ pub fn new_test_ext() -> TestExternalities {
         .unwrap();
 
     GenesisBuild::<Test>::assimilate_storage(
-        &pallet_subspace::GenesisConfig::default(),
+        &pallet_subspace::GenesisConfig {
+            enable_rewards: true,
+            enable_storage_access: true,
+            allow_authoring_by: AllowAuthoringBy::Anyone,
+            pot_slot_iterations: NonZeroU32::new(100_000).unwrap(),
+        },
         &mut storage,
     )
     .unwrap();

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -260,7 +260,7 @@ pub fn make_pre_digest(
     slot: Slot,
     solution: Solution<FarmerPublicKey, <Test as frame_system::Config>::AccountId>,
 ) -> Digest {
-    let log = DigestItem::subspace_pre_digest(&PreDigest {
+    let log = DigestItem::subspace_pre_digest(&PreDigest::V0 {
         slot,
         solution,
         #[cfg(feature = "pot")]

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -266,7 +266,7 @@ pub fn make_pre_digest(
         slot,
         solution,
         #[cfg(feature = "pot")]
-        pot_info: PreDigestPotInfo::Regular {
+        pot_info: PreDigestPotInfo::V0 {
             iterations: NonZeroU32::new(100_000).unwrap(),
             proof_of_time: Default::default(),
             future_proof_of_time: Default::default(),

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -755,7 +755,7 @@ where
                         #[cfg(not(feature = "pot"))]
                         global_randomness: subspace_digest_items.global_randomness,
                         #[cfg(feature = "pot")]
-                        proof_of_time: pre_digest.proof_of_time(),
+                        proof_of_time: pre_digest.pot_info().proof_of_time(),
                         solution_range: subspace_digest_items.solution_range,
                         piece_check_params: None,
                     },
@@ -1045,7 +1045,7 @@ where
                 #[cfg(not(feature = "pot"))]
                 global_randomness: subspace_digest_items.global_randomness,
                 #[cfg(feature = "pot")]
-                proof_of_time: subspace_digest_items.pre_digest.proof_of_time(),
+                proof_of_time: subspace_digest_items.pre_digest.pot_info().proof_of_time(),
                 solution_range: subspace_digest_items.solution_range,
                 piece_check_params: Some(PieceCheckParams {
                     max_pieces_in_sector,

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -710,7 +710,10 @@ where
         if self
             .client
             .runtime_api()
-            .is_in_block_list(*block.header.parent_hash(), &pre_digest.solution.public_key)
+            .is_in_block_list(
+                *block.header.parent_hash(),
+                &pre_digest.solution().public_key,
+            )
             .or_else(|error| {
                 if block.state_action.skip_execution_checks() {
                     Ok(false)
@@ -722,11 +725,11 @@ where
             warn!(
                 target: "subspace",
                 "Verifying block with solution provided by farmer in block list: {}",
-                pre_digest.solution.public_key
+                pre_digest.solution().public_key
             );
 
             return Err(Error::<Block::Header>::FarmerInBlockList(
-                pre_digest.solution.public_key.clone(),
+                pre_digest.solution().public_key.clone(),
             )
             .into());
         }
@@ -752,7 +755,7 @@ where
                         #[cfg(not(feature = "pot"))]
                         global_randomness: subspace_digest_items.global_randomness,
                         #[cfg(feature = "pot")]
-                        proof_of_time: pre_digest.proof_of_time,
+                        proof_of_time: pre_digest.proof_of_time(),
                         solution_range: subspace_digest_items.solution_range,
                         piece_check_params: None,
                     },
@@ -766,7 +769,7 @@ where
 
         match checked_header {
             CheckedHeader::Checked(pre_header, verified_info) => {
-                let slot = verified_info.pre_digest.slot;
+                let slot = verified_info.pre_digest.slot();
 
                 // the header is valid but let's check if there was something else already
                 // proposed at the same slot by the given author. if there was, we will
@@ -776,7 +779,7 @@ where
                         slot_now,
                         slot,
                         &block.header,
-                        &verified_info.pre_digest.solution.public_key,
+                        &verified_info.pre_digest.solution().public_key,
                         &block.origin,
                     )
                     .await
@@ -902,7 +905,7 @@ where
 
         let pre_digest = &subspace_digest_items.pre_digest;
         if let Some(root_plot_public_key) = root_plot_public_key {
-            if &pre_digest.solution.public_key != root_plot_public_key {
+            if &pre_digest.solution().public_key != root_plot_public_key {
                 // Only root plot public key is allowed.
                 return Err(Error::OnlyRootPlotPublicKeyAllowed);
             }
@@ -913,7 +916,7 @@ where
         if self
             .client
             .runtime_api()
-            .is_in_block_list(parent_hash, &pre_digest.solution.public_key)
+            .is_in_block_list(parent_hash, &pre_digest.solution().public_key)
             .or_else(|error| {
                 if skip_runtime_access {
                     Ok(false)
@@ -925,11 +928,11 @@ where
             warn!(
                 target: "subspace",
                 "Ignoring block with solution provided by farmer in block list: {}",
-                pre_digest.solution.public_key
+                pre_digest.solution().public_key
             );
 
             return Err(Error::FarmerInBlockList(
-                pre_digest.solution.public_key.clone(),
+                pre_digest.solution().public_key.clone(),
             ));
         }
 
@@ -992,8 +995,8 @@ where
         }
 
         let sector_id = SectorId::new(
-            PublicKey::from(&pre_digest.solution.public_key).hash(),
-            pre_digest.solution.sector_index,
+            PublicKey::from(&pre_digest.solution().public_key).hash(),
+            pre_digest.solution().sector_index,
         );
 
         let chain_constants = get_chain_constants(self.client.as_ref())?;
@@ -1005,8 +1008,8 @@ where
             .runtime_api()
             .max_pieces_in_sector(parent_hash)?;
         let piece_index = sector_id.derive_piece_index(
-            pre_digest.solution.piece_offset,
-            pre_digest.solution.history_size,
+            pre_digest.solution().piece_offset,
+            pre_digest.solution().history_size,
             max_pieces_in_sector,
             chain_constants.recent_segments(),
             chain_constants.recent_history_fraction(),
@@ -1024,7 +1027,7 @@ where
             .get_segment_header(
                 subspace_digest_items
                     .pre_digest
-                    .solution
+                    .solution()
                     .history_size
                     .sector_expiration_check(chain_constants.min_sector_lifetime())
                     .ok_or(Error::InvalidHistorySize)?
@@ -1035,14 +1038,14 @@ where
         // Piece is not checked during initial block verification because it requires access to
         // segment header and runtime, check it now.
         subspace_verification::verify_solution::<PosTable, _, _>(
-            &pre_digest.solution,
+            pre_digest.solution(),
             // Slot was already checked during initial block verification
-            pre_digest.slot.into(),
+            pre_digest.slot().into(),
             &VerifySolutionParams {
                 #[cfg(not(feature = "pot"))]
                 global_randomness: subspace_digest_items.global_randomness,
                 #[cfg(feature = "pot")]
-                proof_of_time: subspace_digest_items.pre_digest.proof_of_time,
+                proof_of_time: subspace_digest_items.pre_digest.proof_of_time(),
                 solution_range: subspace_digest_items.solution_range,
                 piece_check_params: Some(PieceCheckParams {
                     max_pieces_in_sector,
@@ -1059,13 +1062,13 @@ where
             },
             &self.subspace_link.kzg,
         )
-        .map_err(|error| VerificationError::VerificationError(pre_digest.slot, error))?;
+        .map_err(|error| VerificationError::VerificationError(pre_digest.slot(), error))?;
 
-        let parent_slot = extract_pre_digest(&parent_header).map(|d| d.slot)?;
+        let parent_slot = extract_pre_digest(&parent_header).map(|d| d.slot())?;
 
         // Make sure that slot number is strictly increasing
-        if pre_digest.slot <= parent_slot {
-            return Err(Error::SlotMustIncrease(parent_slot, pre_digest.slot));
+        if pre_digest.slot() <= parent_slot {
+            return Err(Error::SlotMustIncrease(parent_slot, pre_digest.slot()));
         }
 
         if !skip_runtime_access {

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -297,8 +297,6 @@ where
         let (solution_range, voting_solution_range) =
             extract_solution_ranges_for_block(self.client.as_ref(), parent_hash).ok()?;
 
-        #[cfg(feature = "pot")]
-        let pot_slot_iterations = runtime_api.pot_slot_iterations(parent_hash).ok()?;
         let maybe_root_plot_public_key = runtime_api.root_plot_public_key(parent_hash).ok()?;
 
         #[cfg(feature = "pot")]
@@ -471,8 +469,7 @@ where
                             slot,
                             solution,
                             #[cfg(feature = "pot")]
-                            pot_info: PreDigestPotInfo::Regular {
-                                iterations: pot_slot_iterations,
+                            pot_info: PreDigestPotInfo::V0 {
                                 proof_of_time,
                                 future_proof_of_time,
                             },

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -54,8 +54,6 @@ use sp_runtime::DigestItem;
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::marker::PhantomData;
-#[cfg(feature = "pot")]
-use std::num::NonZeroU32;
 use std::pin::Pin;
 use std::sync::Arc;
 #[cfg(feature = "pot")]
@@ -299,9 +297,10 @@ where
         let (solution_range, voting_solution_range) =
             extract_solution_ranges_for_block(self.client.as_ref(), parent_hash).ok()?;
 
+        #[cfg(feature = "pot")]
+        let pot_slot_iterations = runtime_api.pot_slot_iterations(parent_hash).ok()?;
         let maybe_root_plot_public_key = runtime_api.root_plot_public_key(parent_hash).ok()?;
 
-        // TODO: Store `new_checkpoints`
         #[cfg(feature = "pot")]
         let (proof_of_time, future_proof_of_time, new_checkpoints) = {
             let mut pot_checkpoints = self.pot_checkpoints.lock();
@@ -473,8 +472,7 @@ where
                             solution,
                             #[cfg(feature = "pot")]
                             pot_info: PreDigestPotInfo::Regular {
-                                // TODO: Replace with correct value from runtime state
-                                iterations: NonZeroU32::MIN,
+                                iterations: pot_slot_iterations,
                                 proof_of_time,
                                 future_proof_of_time,
                             },

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -40,6 +40,8 @@ use sp_api::{ApiError, NumberFor, ProvideRuntimeApi, TransactionFor};
 use sp_blockchain::{Error as ClientError, HeaderBackend, HeaderMetadata};
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SyncOracle};
 use sp_consensus_slots::Slot;
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::digests::PreDigestPotInfo;
 use sp_consensus_subspace::digests::{extract_pre_digest, CompatibleDigestItem, PreDigest};
 #[cfg(feature = "pot")]
 use sp_consensus_subspace::SubspaceJustification;
@@ -52,6 +54,8 @@ use sp_runtime::DigestItem;
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::marker::PhantomData;
+#[cfg(feature = "pot")]
+use std::num::NonZeroU32;
 use std::pin::Pin;
 use std::sync::Arc;
 #[cfg(feature = "pot")]
@@ -468,9 +472,12 @@ where
                             slot,
                             solution,
                             #[cfg(feature = "pot")]
-                            proof_of_time,
-                            #[cfg(feature = "pot")]
-                            future_proof_of_time,
+                            pot_info: PreDigestPotInfo::Regular {
+                                // TODO: Replace with correct value from runtime state
+                                iterations: NonZeroU32::MIN,
+                                proof_of_time,
+                                future_proof_of_time,
+                            },
                         });
                     } else if !parent_header.number().is_zero() {
                         // Not sending vote on top of genesis block since segment headers since piece

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -107,10 +107,6 @@ pub async fn start_slot_worker<Block, Client, SC, Worker, SO, CIDP>(
 
         if let Some(slot_info) = slot_info_producer.produce_slot_info(slot_to_claim).await {
             let _ = worker.on_slot(slot_info).await;
-
-            // TODO: Remove this hack, it restricts slot production with extremely low number of
-            //  iterations
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 }

--- a/crates/sc-proof-of-time/src/source.rs
+++ b/crates/sc-proof-of-time/src/source.rs
@@ -74,7 +74,9 @@ where
         #[cfg(feature = "pot")]
         let runtime_api = client.runtime_api();
         #[cfg(feature = "pot")]
-        let iterations = runtime_api.pot_slot_iterations(best_hash)?;
+        let iterations = runtime_api
+            .pot_parameters(best_hash)?
+            .iterations(Slot::from(start_slot));
         #[cfg(not(feature = "pot"))]
         let iterations = NonZeroU32::new(100_000_000).expect("Not zero; qed");
 

--- a/crates/sc-proof-of-time/src/source.rs
+++ b/crates/sc-proof-of-time/src/source.rs
@@ -5,7 +5,7 @@ use futures::SinkExt;
 use sp_consensus_slots::Slot;
 use std::num::NonZeroU32;
 use std::thread;
-use subspace_core_primitives::{PotBytes, PotCheckpoints, PotKey, PotSeed, SlotNumber};
+use subspace_core_primitives::{PotCheckpoints, PotKey, PotSeed, SlotNumber};
 use subspace_proof_of_time::PotError;
 use tracing::{debug, error};
 
@@ -85,15 +85,11 @@ fn run_timekeeper(
     iterations: NonZeroU32,
     mut slot_sender: mpsc::Sender<PotSlotInfo>,
 ) -> Result<(), PotError> {
-    // TODO
     loop {
         let checkpoints = subspace_proof_of_time::prove(seed, key, iterations)?;
 
-        // TODO: Store checkpoints somewhere
-
-        // TODO: These two are wrong and need to be updated
-        seed = PotSeed::from(PotBytes::from(checkpoints.output()));
-        key = PotKey::from(PotBytes::from(checkpoints.output()));
+        seed = checkpoints.output().seed();
+        key = seed.key();
 
         let slot_info = PotSlotInfo {
             slot: Slot::from(slot),

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -27,7 +27,7 @@ use sp_runtime::DigestItem;
 use sp_std::collections::btree_map::{BTreeMap, Entry};
 use sp_std::fmt;
 #[cfg(feature = "pot")]
-use subspace_core_primitives::PotCheckpoint;
+use subspace_core_primitives::PotProof;
 #[cfg(not(feature = "pot"))]
 use subspace_core_primitives::Randomness;
 use subspace_core_primitives::{SegmentCommitment, SegmentIndex, Solution, SolutionRange};
@@ -47,10 +47,10 @@ pub enum PreDigest<PublicKey, RewardAddress> {
         solution: Solution<PublicKey, RewardAddress>,
         /// Proof of time for this slot
         #[cfg(feature = "pot")]
-        proof_of_time: PotCheckpoint,
+        proof_of_time: PotProof,
         /// Future proof of time
         #[cfg(feature = "pot")]
-        future_proof_of_time: PotCheckpoint,
+        future_proof_of_time: PotProof,
     },
 }
 
@@ -70,14 +70,14 @@ impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
     /// Proof of time for this slot
     #[cfg(feature = "pot")]
     #[inline]
-    pub fn proof_of_time(&self) -> PotCheckpoint {
+    pub fn proof_of_time(&self) -> PotProof {
         let Self::V0 { proof_of_time, .. } = self;
         *proof_of_time
     }
     /// Future proof of time
     #[cfg(feature = "pot")]
     #[inline]
-    pub fn future_proof_of_time(&self) -> PotCheckpoint {
+    pub fn future_proof_of_time(&self) -> PotProof {
         let Self::V0 {
             future_proof_of_time,
             ..

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -16,6 +16,8 @@
 
 //! Private implementation details of Subspace consensus digests.
 
+#[cfg(feature = "pot")]
+use crate::PotParametersChange;
 use crate::{ConsensusLog, FarmerPublicKey, FarmerSignature, SUBSPACE_ENGINE_ID};
 use codec::{Decode, Encode};
 use log::trace;
@@ -28,10 +30,10 @@ use sp_std::collections::btree_map::{BTreeMap, Entry};
 use sp_std::fmt;
 #[cfg(feature = "pot")]
 use sp_std::num::NonZeroU32;
-#[cfg(feature = "pot")]
-use subspace_core_primitives::PotProof;
 #[cfg(not(feature = "pot"))]
 use subspace_core_primitives::Randomness;
+#[cfg(feature = "pot")]
+use subspace_core_primitives::{PotProof, PotSeed};
 use subspace_core_primitives::{SegmentCommitment, SegmentIndex, Solution, SolutionRange};
 #[cfg(not(feature = "pot"))]
 use subspace_verification::derive_randomness;
@@ -81,11 +83,9 @@ impl<PublicKey, RewardAddress> PreDigest<PublicKey, RewardAddress> {
 #[cfg(feature = "pot")]
 #[derive(Debug, Clone, Encode, Decode)]
 pub enum PreDigestPotInfo {
-    /// Regular information
+    /// Initial version of proof of time information
     #[codec(index = 0)]
-    Regular {
-        /// Number of iterations per slot in proof of time
-        iterations: NonZeroU32,
+    V0 {
         /// Proof of time for this slot
         proof_of_time: PotProof,
         /// Future proof of time
@@ -99,8 +99,19 @@ impl PreDigestPotInfo {
     #[cfg(feature = "pot")]
     #[inline]
     pub fn proof_of_time(&self) -> PotProof {
-        let Self::Regular { proof_of_time, .. } = self;
+        let Self::V0 { proof_of_time, .. } = self;
         *proof_of_time
+    }
+
+    /// Future proof of time
+    #[cfg(feature = "pot")]
+    #[inline]
+    pub fn future_proof_of_time(&self) -> PotProof {
+        let Self::V0 {
+            future_proof_of_time,
+            ..
+        } = self;
+        *future_proof_of_time
     }
 }
 
@@ -122,6 +133,14 @@ pub trait CompatibleDigestItem: Sized {
     /// If this item is a Subspace signature, return the signature.
     fn as_subspace_seal(&self) -> Option<FarmerSignature>;
 
+    /// Number of iterations for proof of time per slot
+    #[cfg(feature = "pot")]
+    fn pot_slot_iterations(pot_slot_iterations: NonZeroU32) -> Self;
+
+    /// If this item is a Subspace proof of time slot iterations, return it.
+    #[cfg(feature = "pot")]
+    fn as_pot_slot_iterations(&self) -> Option<NonZeroU32>;
+
     /// Construct a digest item which contains a global randomness.
     #[cfg(not(feature = "pot"))]
     fn global_randomness(global_randomness: Randomness) -> Self;
@@ -135,6 +154,14 @@ pub trait CompatibleDigestItem: Sized {
 
     /// If this item is a Subspace solution range, return it.
     fn as_solution_range(&self) -> Option<SolutionRange>;
+
+    /// Change of parameters to apply to PoT chain
+    #[cfg(feature = "pot")]
+    fn pot_parameters_change(pot_parameters_change: PotParametersChange) -> Self;
+
+    /// If this item is a Subspace proof of time change of parameters, return it.
+    #[cfg(feature = "pot")]
+    fn as_pot_parameters_change(&self) -> Option<PotParametersChange>;
 
     /// Construct a digest item which contains next global randomness.
     #[cfg(not(feature = "pot"))]
@@ -169,11 +196,20 @@ pub trait CompatibleDigestItem: Sized {
     /// range, return it.
     fn as_enable_solution_range_adjustment_and_override(&self) -> Option<Option<SolutionRange>>;
 
-    /// Construct digest item than indicates update of root plot public key.
+    /// Construct digest item that indicates update of root plot public key.
     fn root_plot_public_key_update(root_plot_public_key: Option<FarmerPublicKey>) -> Self;
 
     /// If this item is a Subspace update of root plot public key, return it.
     fn as_root_plot_public_key_update(&self) -> Option<Option<FarmerPublicKey>>;
+
+    /// Construct a digest item which contains future proof of time seed, essentially output of
+    /// parent block's future proof of time.
+    #[cfg(feature = "pot")]
+    fn future_pot_seed(pot_seed: PotSeed) -> Self;
+
+    /// If this item is a Subspace future proof of time seed, return it.
+    #[cfg(feature = "pot")]
+    fn as_future_pot_seed(&self) -> Option<PotSeed>;
 }
 
 impl CompatibleDigestItem for DigestItem {
@@ -195,6 +231,25 @@ impl CompatibleDigestItem for DigestItem {
 
     fn as_subspace_seal(&self) -> Option<FarmerSignature> {
         self.seal_try_to(&SUBSPACE_ENGINE_ID)
+    }
+
+    #[cfg(feature = "pot")]
+    fn pot_slot_iterations(pot_slot_iterations: NonZeroU32) -> Self {
+        Self::Consensus(
+            SUBSPACE_ENGINE_ID,
+            ConsensusLog::PotSlotIterations(pot_slot_iterations).encode(),
+        )
+    }
+
+    #[cfg(feature = "pot")]
+    fn as_pot_slot_iterations(&self) -> Option<NonZeroU32> {
+        self.consensus_try_to(&SUBSPACE_ENGINE_ID).and_then(|c| {
+            if let ConsensusLog::PotSlotIterations(pot_slot_iterations) = c {
+                Some(pot_slot_iterations)
+            } else {
+                None
+            }
+        })
     }
 
     #[cfg(not(feature = "pot"))]
@@ -227,6 +282,25 @@ impl CompatibleDigestItem for DigestItem {
         self.consensus_try_to(&SUBSPACE_ENGINE_ID).and_then(|c| {
             if let ConsensusLog::SolutionRange(solution_range) = c {
                 Some(solution_range)
+            } else {
+                None
+            }
+        })
+    }
+
+    #[cfg(feature = "pot")]
+    fn pot_parameters_change(pot_parameters_change: PotParametersChange) -> Self {
+        Self::Consensus(
+            SUBSPACE_ENGINE_ID,
+            ConsensusLog::PotParametersChange(pot_parameters_change).encode(),
+        )
+    }
+
+    #[cfg(feature = "pot")]
+    fn as_pot_parameters_change(&self) -> Option<PotParametersChange> {
+        self.consensus_try_to(&SUBSPACE_ENGINE_ID).and_then(|c| {
+            if let ConsensusLog::PotParametersChange(pot_parameters_change) = c {
+                Some(pot_parameters_change)
             } else {
                 None
             }
@@ -328,6 +402,25 @@ impl CompatibleDigestItem for DigestItem {
             }
         })
     }
+
+    #[cfg(feature = "pot")]
+    fn future_pot_seed(pot_seed: PotSeed) -> Self {
+        Self::Consensus(
+            SUBSPACE_ENGINE_ID,
+            ConsensusLog::FuturePotSeed(pot_seed).encode(),
+        )
+    }
+
+    #[cfg(feature = "pot")]
+    fn as_future_pot_seed(&self) -> Option<PotSeed> {
+        self.consensus_try_to(&SUBSPACE_ENGINE_ID).and_then(|c| {
+            if let ConsensusLog::FuturePotSeed(pot_seed) = c {
+                Some(pot_seed)
+            } else {
+                None
+            }
+        })
+    }
 }
 
 /// Various kinds of digest types used in errors
@@ -337,11 +430,17 @@ pub enum ErrorDigestType {
     PreDigest,
     /// Seal (signature)
     Seal,
+    /// Number of iterations for proof of time per slot
+    #[cfg(feature = "pot")]
+    PotSlotIterations,
     /// Global randomness
     #[cfg(not(feature = "pot"))]
     GlobalRandomness,
     /// Solution range
     SolutionRange,
+    /// Change of parameters to apply to PoT chain
+    #[cfg(feature = "pot")]
+    PotParametersChange,
     /// Next global randomness
     #[cfg(not(feature = "pot"))]
     NextGlobalRandomness,
@@ -355,6 +454,9 @@ pub enum ErrorDigestType {
     EnableSolutionRangeAdjustmentAndOverride,
     /// Root plot public key was updated
     RootPlotPublicKeyUpdate,
+    /// Future proof of time seed, essentially output of parent block's future proof of time.
+    #[cfg(feature = "pot")]
+    FuturePotSeed,
 }
 
 impl fmt::Display for ErrorDigestType {
@@ -366,12 +468,20 @@ impl fmt::Display for ErrorDigestType {
             ErrorDigestType::Seal => {
                 write!(f, "Seal")
             }
+            #[cfg(feature = "pot")]
+            ErrorDigestType::PotSlotIterations => {
+                write!(f, "PotSlotIterations")
+            }
             #[cfg(not(feature = "pot"))]
             ErrorDigestType::GlobalRandomness => {
                 write!(f, "GlobalRandomness")
             }
             ErrorDigestType::SolutionRange => {
                 write!(f, "SolutionRange")
+            }
+            #[cfg(feature = "pot")]
+            ErrorDigestType::PotParametersChange => {
+                write!(f, "PotParametersChange")
             }
             #[cfg(not(feature = "pot"))]
             ErrorDigestType::NextGlobalRandomness => {
@@ -391,6 +501,10 @@ impl fmt::Display for ErrorDigestType {
             }
             ErrorDigestType::RootPlotPublicKeyUpdate => {
                 write!(f, "RootPlotPublicKeyUpdate")
+            }
+            #[cfg(feature = "pot")]
+            ErrorDigestType::FuturePotSeed => {
+                write!(f, "FuturePotSeed")
             }
         }
     }
@@ -446,11 +560,17 @@ pub struct SubspaceDigestItems<PublicKey, RewardAddress, Signature> {
     pub pre_digest: PreDigest<PublicKey, RewardAddress>,
     /// Signature (seal) if present
     pub signature: Option<Signature>,
+    /// Number of iterations for proof of time per slot
+    #[cfg(feature = "pot")]
+    pub pot_slot_iterations: NonZeroU32,
     /// Global randomness
     #[cfg(not(feature = "pot"))]
     pub global_randomness: Randomness,
     /// Solution range
     pub solution_range: SolutionRange,
+    /// Change of parameters to apply to PoT chain
+    #[cfg(feature = "pot")]
+    pub pot_parameters_change: Option<PotParametersChange>,
     /// Next global randomness
     #[cfg(not(feature = "pot"))]
     pub next_global_randomness: Option<Randomness>,
@@ -462,6 +582,9 @@ pub struct SubspaceDigestItems<PublicKey, RewardAddress, Signature> {
     pub enable_solution_range_adjustment_and_override: Option<Option<SolutionRange>>,
     /// Root plot public key was updated
     pub root_plot_public_key_update: Option<Option<FarmerPublicKey>>,
+    /// Future proof of time seed, essentially output of parent block's future proof of time.
+    #[cfg(feature = "pot")]
+    pub future_pot_seed: PotSeed,
 }
 
 /// Extract the Subspace global randomness from the given header.
@@ -476,15 +599,21 @@ where
 {
     let mut maybe_pre_digest = None;
     let mut maybe_seal = None;
+    #[cfg(feature = "pot")]
+    let mut maybe_pot_slot_iterations = None;
     #[cfg(not(feature = "pot"))]
     let mut maybe_global_randomness = None;
     let mut maybe_solution_range = None;
+    #[cfg(feature = "pot")]
+    let mut maybe_pot_parameters_change = None;
     #[cfg(not(feature = "pot"))]
     let mut maybe_next_global_randomness = None;
     let mut maybe_next_solution_range = None;
     let mut segment_commitments = BTreeMap::new();
     let mut maybe_enable_and_override_solution_range = None;
     let mut maybe_root_plot_public_key_update = None;
+    #[cfg(feature = "pot")]
+    let mut maybe_future_pot_seed = None;
 
     for log in header.digest().logs() {
         match log {
@@ -516,6 +645,17 @@ where
                     .map_err(|error| Error::FailedToDecode(ErrorDigestType::Consensus, error))?;
 
                 match consensus {
+                    #[cfg(feature = "pot")]
+                    ConsensusLog::PotSlotIterations(pot_slot_iterations) => {
+                        match maybe_pot_slot_iterations {
+                            Some(_) => {
+                                return Err(Error::Duplicate(ErrorDigestType::PotSlotIterations));
+                            }
+                            None => {
+                                maybe_pot_slot_iterations.replace(pot_slot_iterations);
+                            }
+                        }
+                    }
                     #[cfg(not(feature = "pot"))]
                     ConsensusLog::GlobalRandomness(global_randomness) => {
                         match maybe_global_randomness {
@@ -535,6 +675,17 @@ where
                             maybe_solution_range.replace(solution_range);
                         }
                     },
+                    #[cfg(feature = "pot")]
+                    ConsensusLog::PotParametersChange(pot_parameters_change) => {
+                        match maybe_pot_parameters_change {
+                            Some(_) => {
+                                return Err(Error::Duplicate(ErrorDigestType::PotParametersChange));
+                            }
+                            None => {
+                                maybe_pot_parameters_change.replace(pot_parameters_change);
+                            }
+                        }
+                    }
                     #[cfg(not(feature = "pot"))]
                     ConsensusLog::NextGlobalRandomness(global_randomness) => {
                         match maybe_next_global_randomness {
@@ -568,29 +719,38 @@ where
                     ConsensusLog::EnableSolutionRangeAdjustmentAndOverride(
                         override_solution_range,
                     ) => match maybe_enable_and_override_solution_range {
-                        None => {
-                            maybe_enable_and_override_solution_range
-                                .replace(override_solution_range);
-                        }
                         Some(_) => {
                             return Err(Error::Duplicate(
                                 ErrorDigestType::EnableSolutionRangeAdjustmentAndOverride,
                             ));
                         }
+                        None => {
+                            maybe_enable_and_override_solution_range
+                                .replace(override_solution_range);
+                        }
                     },
                     ConsensusLog::RootPlotPublicKeyUpdate(root_plot_public_key_update) => {
-                        match maybe_enable_and_override_solution_range {
-                            None => {
-                                maybe_root_plot_public_key_update
-                                    .replace(root_plot_public_key_update);
-                            }
+                        match maybe_root_plot_public_key_update {
                             Some(_) => {
                                 return Err(Error::Duplicate(
                                     ErrorDigestType::EnableSolutionRangeAdjustmentAndOverride,
                                 ));
                             }
+                            None => {
+                                maybe_root_plot_public_key_update
+                                    .replace(root_plot_public_key_update);
+                            }
                         }
                     }
+                    #[cfg(feature = "pot")]
+                    ConsensusLog::FuturePotSeed(pot_seed) => match maybe_future_pot_seed {
+                        Some(_) => {
+                            return Err(Error::Duplicate(ErrorDigestType::FuturePotSeed));
+                        }
+                        None => {
+                            maybe_future_pot_seed.replace(pot_seed);
+                        }
+                    },
                 }
             }
             DigestItem::Seal(id, data) => {
@@ -622,17 +782,25 @@ where
     Ok(SubspaceDigestItems {
         pre_digest: maybe_pre_digest.ok_or(Error::Missing(ErrorDigestType::PreDigest))?,
         signature: maybe_seal,
+        #[cfg(feature = "pot")]
+        pot_slot_iterations: maybe_pot_slot_iterations
+            .ok_or(Error::Missing(ErrorDigestType::PotSlotIterations))?,
         #[cfg(not(feature = "pot"))]
         global_randomness: maybe_global_randomness
             .ok_or(Error::Missing(ErrorDigestType::GlobalRandomness))?,
         solution_range: maybe_solution_range
             .ok_or(Error::Missing(ErrorDigestType::SolutionRange))?,
+        #[cfg(feature = "pot")]
+        pot_parameters_change: maybe_pot_parameters_change,
         #[cfg(not(feature = "pot"))]
         next_global_randomness: maybe_next_global_randomness,
         next_solution_range: maybe_next_solution_range,
         segment_commitments,
         enable_solution_range_adjustment_and_override: maybe_enable_and_override_solution_range,
         root_plot_public_key_update: maybe_root_plot_public_key_update,
+        #[cfg(feature = "pot")]
+        future_pot_seed: maybe_future_pot_seed
+            .ok_or(Error::Missing(ErrorDigestType::FuturePotSeed))?,
     })
 }
 
@@ -654,8 +822,7 @@ where
                 FarmerPublicKey::unchecked_from([0u8; 32]),
             ),
             #[cfg(feature = "pot")]
-            pot_info: PreDigestPotInfo::Regular {
-                iterations: NonZeroU32::MIN,
+            pot_info: PreDigestPotInfo::V0 {
                 proof_of_time: Default::default(),
                 future_proof_of_time: Default::default(),
             },

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -41,6 +41,8 @@ use sp_io::hashing;
 use sp_runtime::{ConsensusEngineId, DigestItem, Justification};
 use sp_runtime_interface::pass_by::PassBy;
 use sp_runtime_interface::{pass_by, runtime_interface};
+#[cfg(feature = "pot")]
+use sp_std::num::NonZeroU32;
 use sp_std::vec::Vec;
 use subspace_core_primitives::crypto::kzg::Kzg;
 #[cfg(not(feature = "pot"))]
@@ -620,6 +622,9 @@ sp_api::decl_runtime_apis! {
     pub trait SubspaceApi<RewardAddress: Encode + Decode> {
         /// The slot duration in milliseconds for Subspace.
         fn slot_duration() -> SlotDuration;
+
+        /// Number of iterations for proof of time per slot
+        fn pot_slot_iterations() -> NonZeroU32;
 
         /// Solution ranges.
         fn solution_ranges() -> SolutionRanges;

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -340,6 +340,7 @@ impl Default for SolutionRanges {
 #[derive(Debug, Encode, Decode, MaxEncodedLen, PartialEq, Eq, Clone, Copy, TypeInfo)]
 pub enum ChainConstants {
     /// V0 of the chain constants.
+    #[codec(index = 0)]
     V0 {
         /// Depth `K` after which a block enters the recorded history.
         confirmation_depth_k: BlockNumber,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -279,17 +279,17 @@ where
 
     // both headers must be targeting the same slot and it must
     // be the same as the one in the proof.
-    if !(proof.slot == first_pre_digest.slot && proof.slot == second_pre_digest.slot) {
+    if !(proof.slot == first_pre_digest.slot() && proof.slot == second_pre_digest.slot()) {
         return false;
     }
 
     // both headers must have the same sector index
-    if first_pre_digest.solution.sector_index != second_pre_digest.solution.sector_index {
+    if first_pre_digest.solution().sector_index != second_pre_digest.solution().sector_index {
         return false;
     }
 
     // both headers must have been authored by the same farmer
-    if first_pre_digest.solution.public_key != second_pre_digest.solution.public_key {
+    if first_pre_digest.solution().public_key != second_pre_digest.solution().public_key {
         return false;
     }
 
@@ -761,7 +761,7 @@ where
         None => find_pre_digest::<Header, RewardAddress>(&header)
             .ok_or(VerificationError::NoPreRuntimeDigest)?,
     };
-    let slot = pre_digest.slot;
+    let slot = pre_digest.slot();
 
     let seal = header
         .digest_mut()
@@ -775,16 +775,16 @@ where
     // The pre-hash of the header doesn't include the seal and that's what we sign
     let pre_hash = header.hash();
 
-    if pre_digest.slot > slot_now {
+    if pre_digest.slot() > slot_now {
         header.digest_mut().push(seal);
-        return Ok(CheckedHeader::Deferred(header, pre_digest.slot));
+        return Ok(CheckedHeader::Deferred(header, pre_digest.slot()));
     }
 
     // Verify that block is signed properly
     if check_reward_signature(
         pre_hash.as_ref(),
         &RewardSignature::from(&signature),
-        &PublicKey::from(&pre_digest.solution.public_key),
+        &PublicKey::from(&pre_digest.solution().public_key),
         reward_signing_context,
     )
     .is_err()
@@ -794,7 +794,7 @@ where
 
     // Verify that solution is valid
     verify_solution::<PosTable, _, _>(
-        &pre_digest.solution,
+        pre_digest.solution(),
         slot.into(),
         verify_solution_params,
         kzg,

--- a/crates/sp-consensus-subspace/src/tests.rs
+++ b/crates/sp-consensus-subspace/src/tests.rs
@@ -39,7 +39,7 @@ fn test_is_equivocation_proof_valid() {
         state_root: Default::default(),
         extrinsics_root: Default::default(),
         digest: Digest {
-            logs: vec![DigestItem::subspace_pre_digest(&PreDigest {
+            logs: vec![DigestItem::subspace_pre_digest(&PreDigest::V0 {
                 slot,
                 solution: solution.clone(),
                 #[cfg(feature = "pot")]
@@ -67,7 +67,7 @@ fn test_is_equivocation_proof_valid() {
         state_root: Default::default(),
         extrinsics_root: Default::default(),
         digest: Digest {
-            logs: vec![DigestItem::subspace_pre_digest(&PreDigest {
+            logs: vec![DigestItem::subspace_pre_digest(&PreDigest::V0 {
                 slot,
                 solution,
                 #[cfg(feature = "pot")]

--- a/crates/sp-consensus-subspace/src/tests.rs
+++ b/crates/sp-consensus-subspace/src/tests.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "pot")]
+use crate::digests::PreDigestPotInfo;
 use crate::{
     is_equivocation_proof_valid, CompatibleDigestItem, EquivocationProof, FarmerPublicKey,
     FarmerSignature,
@@ -7,6 +9,8 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::BlakeTwo256;
 use sp_runtime::{Digest, DigestItem};
+#[cfg(feature = "pot")]
+use std::num::NonZeroU32;
 use std::num::NonZeroU64;
 use subspace_core_primitives::{HistorySize, PieceOffset, Solution};
 use subspace_solving::REWARD_SIGNING_CONTEXT;
@@ -43,9 +47,11 @@ fn test_is_equivocation_proof_valid() {
                 slot,
                 solution: solution.clone(),
                 #[cfg(feature = "pot")]
-                proof_of_time: Default::default(),
-                #[cfg(feature = "pot")]
-                future_proof_of_time: Default::default(),
+                pot_info: PreDigestPotInfo::Regular {
+                    iterations: NonZeroU32::MIN,
+                    proof_of_time: Default::default(),
+                    future_proof_of_time: Default::default(),
+                },
             })],
         },
     };
@@ -71,9 +77,11 @@ fn test_is_equivocation_proof_valid() {
                 slot,
                 solution,
                 #[cfg(feature = "pot")]
-                proof_of_time: Default::default(),
-                #[cfg(feature = "pot")]
-                future_proof_of_time: Default::default(),
+                pot_info: PreDigestPotInfo::Regular {
+                    iterations: NonZeroU32::MIN,
+                    proof_of_time: Default::default(),
+                    future_proof_of_time: Default::default(),
+                },
             })],
         },
     };

--- a/crates/sp-consensus-subspace/src/tests.rs
+++ b/crates/sp-consensus-subspace/src/tests.rs
@@ -9,8 +9,6 @@ use sp_consensus_slots::Slot;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::BlakeTwo256;
 use sp_runtime::{Digest, DigestItem};
-#[cfg(feature = "pot")]
-use std::num::NonZeroU32;
 use std::num::NonZeroU64;
 use subspace_core_primitives::{HistorySize, PieceOffset, Solution};
 use subspace_solving::REWARD_SIGNING_CONTEXT;
@@ -47,8 +45,7 @@ fn test_is_equivocation_proof_valid() {
                 slot,
                 solution: solution.clone(),
                 #[cfg(feature = "pot")]
-                pot_info: PreDigestPotInfo::Regular {
-                    iterations: NonZeroU32::MIN,
+                pot_info: PreDigestPotInfo::V0 {
                     proof_of_time: Default::default(),
                     future_proof_of_time: Default::default(),
                 },
@@ -77,8 +74,7 @@ fn test_is_equivocation_proof_valid() {
                 slot,
                 solution,
                 #[cfg(feature = "pot")]
-                pot_info: PreDigestPotInfo::Regular {
-                    iterations: NonZeroU32::MIN,
+                pot_info: PreDigestPotInfo::V0 {
                     proof_of_time: Default::default(),
                     future_proof_of_time: Default::default(),
                 },

--- a/crates/sp-lightclient/src/lib.rs
+++ b/crates/sp-lightclient/src/lib.rs
@@ -409,7 +409,7 @@ impl<Header: HeaderT, Store: Storage<Header>> HeaderImporter<Header, Store> {
                 #[cfg(not(feature = "pot"))]
                 global_randomness: header_digests.global_randomness,
                 #[cfg(feature = "pot")]
-                proof_of_time: header_digests.pre_digest.proof_of_time(),
+                proof_of_time: header_digests.pre_digest.pot_info().proof_of_time(),
                 solution_range: header_digests.solution_range,
                 piece_check_params: Some(PieceCheckParams {
                     max_pieces_in_sector,

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -26,7 +26,7 @@ use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 #[cfg(feature = "pot")]
-use subspace_core_primitives::PotCheckpoint;
+use subspace_core_primitives::PotProof;
 use subspace_core_primitives::{
     BlockWeight, HistorySize, PublicKey, Randomness, Record, RecordedHistorySegment,
     SegmentCommitment, SegmentIndex, SlotNumber, Solution, SolutionRange,
@@ -130,9 +130,9 @@ struct ValidHeaderParams<'a> {
     #[cfg(not(feature = "pot"))]
     global_randomness: Randomness,
     #[cfg(feature = "pot")]
-    proof_of_time: PotCheckpoint,
+    proof_of_time: PotProof,
     #[cfg(feature = "pot")]
-    future_proof_of_time: PotCheckpoint,
+    future_proof_of_time: PotProof,
     farmer_parameters: &'a FarmerParameters,
 }
 
@@ -797,10 +797,10 @@ fn test_reorg_to_heavier_smaller_chain() {
                 global_randomness: digests_at_2.global_randomness,
                 // TODO: Correct value
                 #[cfg(feature = "pot")]
-                proof_of_time: PotCheckpoint::default(),
+                proof_of_time: PotProof::default(),
                 // TODO: Correct value
                 #[cfg(feature = "pot")]
-                future_proof_of_time: PotCheckpoint::default(),
+                future_proof_of_time: PotProof::default(),
                 farmer_parameters: &farmer_parameters,
             });
         seal_header(&keypair, &mut header);

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -250,7 +250,7 @@ pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<GenesisConfig>, Str
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::FirstFarmer,
-                    pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
+                    pot_slot_iterations: NonZeroU32::new(150_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_transfer: true,
                     confirmation_depth_k: 100, // TODO: Proper value here
@@ -308,7 +308,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig>, String> {
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
-                    pot_slot_iterations: NonZeroU32::new(150_000_000).expect("Not zero; qed"),
+                    pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_transfer: true,
                     confirmation_depth_k: 5,

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -25,6 +25,7 @@ use sp_consensus_subspace::FarmerPublicKey;
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_domains::RuntimeType;
 use sp_runtime::Percent;
+use std::num::NonZeroU32;
 use subspace_core_primitives::PotKey;
 use subspace_runtime::{
     AllowAuthoringBy, BalancesConfig, DomainsConfig, GenesisConfig, MaxDomainBlockSize,
@@ -81,6 +82,7 @@ struct GenesisParams {
     enable_rewards: bool,
     enable_storage_access: bool,
     allow_authoring_by: AllowAuthoringBy,
+    pot_slot_iterations: NonZeroU32,
     enable_domains: bool,
     enable_transfer: bool,
     confirmation_depth_k: u32,
@@ -149,6 +151,8 @@ pub fn gemini_3f_compiled() -> Result<ConsensusChainSpec<GenesisConfig>, String>
                             "8aecbcf0b404590ddddc01ebacb205a562d12fdb5c2aa6a4035c1a20f23c9515"
                         )),
                     ),
+                    // TODO: Adjust once we bench PoT on faster hardware
+                    pot_slot_iterations: NonZeroU32::new(183_270_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_transfer: false,
                     confirmation_depth_k: 100, // TODO: Proper value here
@@ -246,6 +250,7 @@ pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<GenesisConfig>, Str
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::FirstFarmer,
+                    pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_transfer: true,
                     confirmation_depth_k: 100, // TODO: Proper value here
@@ -303,6 +308,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<GenesisConfig>, String> {
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
+                    pot_slot_iterations: NonZeroU32::new(150_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_transfer: true,
                     confirmation_depth_k: 5,
@@ -365,6 +371,7 @@ pub fn local_config() -> Result<ConsensusChainSpec<GenesisConfig>, String> {
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
+                    pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_transfer: true,
                     confirmation_depth_k: 1,
@@ -406,6 +413,7 @@ fn subspace_genesis_config(
         enable_rewards,
         enable_storage_access,
         allow_authoring_by,
+        pot_slot_iterations,
         enable_domains,
         enable_transfer,
         confirmation_depth_k,
@@ -433,6 +441,7 @@ fn subspace_genesis_config(
             enable_rewards,
             enable_storage_access,
             allow_authoring_by,
+            pot_slot_iterations,
         },
         vesting: VestingConfig { vesting },
         runtime_configs: RuntimeConfigsConfig {

--- a/crates/subspace-proof-of-time/src/aes.rs
+++ b/crates/subspace-proof-of-time/src/aes.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
-use subspace_core_primitives::{PotBytes, PotCheckpoint, PotCheckpoints, PotKey, PotSeed};
+use subspace_core_primitives::{PotBytes, PotCheckpoints, PotKey, PotProof, PotSeed};
 
 /// Creates the AES based proof.
 #[inline(always)]
@@ -35,7 +35,7 @@ fn create_generic(seed: &PotSeed, key: &PotKey, checkpoint_iterations: u32) -> P
             // Encrypt in place to produce the next block.
             cipher.encrypt_block(&mut cur_block);
         }
-        *checkpoint = PotCheckpoint::from(PotBytes::from(cur_block));
+        *checkpoint = PotProof::from(PotBytes::from(cur_block));
     }
 
     checkpoints
@@ -48,7 +48,7 @@ fn create_generic(seed: &PotSeed, key: &PotKey, checkpoint_iterations: u32) -> P
 pub(crate) fn verify_sequential(
     seed: &PotSeed,
     key: &PotKey,
-    checkpoints: &[PotCheckpoint],
+    checkpoints: &[PotProof],
     checkpoint_iterations: u64,
 ) -> bool {
     assert_eq!(checkpoint_iterations % 2, 0);
@@ -77,7 +77,7 @@ pub(crate) fn verify_sequential(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use subspace_core_primitives::{PotCheckpoint, PotKey, PotSeed};
+    use subspace_core_primitives::{PotKey, PotProof, PotSeed};
 
     const SEED: [u8; 16] = [
         0xd6, 0x66, 0xcc, 0xd8, 0xd5, 0x93, 0xc2, 0x3d, 0xa8, 0xdb, 0x6b, 0x5b, 0x14, 0x13, 0xb1,
@@ -122,7 +122,7 @@ mod tests {
 
         // Decryption of invalid cipher text fails.
         let mut checkpoints_1 = checkpoints;
-        checkpoints_1[0] = PotCheckpoint::from(BAD_CIPHER);
+        checkpoints_1[0] = PotProof::from(BAD_CIPHER);
         assert!(!verify_sequential(
             &seed,
             &key,

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -4,7 +4,7 @@
 mod aes;
 
 use core::num::{NonZeroU32, NonZeroU64};
-use subspace_core_primitives::{PotCheckpoint, PotCheckpoints, PotKey, PotSeed};
+use subspace_core_primitives::{PotCheckpoints, PotKey, PotProof, PotSeed};
 
 /// Proof of time error
 #[derive(Debug)]
@@ -57,7 +57,7 @@ pub fn verify(
     seed: PotSeed,
     key: PotKey,
     iterations: NonZeroU64,
-    checkpoints: &[PotCheckpoint],
+    checkpoints: &[PotProof],
 ) -> Result<bool, PotError> {
     let num_checkpoints = checkpoints.len() as u64;
     if iterations.get() % (num_checkpoints * 2) != 0 {

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -43,8 +43,8 @@ pub fn prove(
     }
 
     Ok(aes::create(
-        &seed,
-        &key,
+        seed,
+        key,
         iterations.get() / u32::from(PotCheckpoints::NUM_CHECKPOINTS.get()),
     ))
 }
@@ -68,8 +68,8 @@ pub fn verify(
     }
 
     Ok(aes::verify_sequential(
-        &seed,
-        &key,
+        seed,
+        key,
         checkpoints,
         iterations.get() / num_checkpoints,
     ))

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -103,7 +103,7 @@ pub(crate) fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) ->
         let pre_digest = pre_digest.expect("Header must contain one pre-runtime digest; qed");
 
         let seed: &[u8] = b"extrinsics-shuffling-seed";
-        let randomness = derive_randomness(&pre_digest.solution, pre_digest.slot.into());
+        let randomness = derive_randomness(pre_digest.solution(), pre_digest.slot().into());
         let mut data = Vec::with_capacity(seed.len() + randomness.len());
         data.extend_from_slice(seed);
         data.extend_from_slice(randomness.as_ref());

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -58,6 +58,8 @@ use sp_api::{impl_runtime_apis, BlockT};
 use sp_consensus_slots::SlotDuration;
 #[cfg(not(feature = "pot"))]
 use sp_consensus_subspace::GlobalRandomnesses;
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::PotParameters;
 use sp_consensus_subspace::{
     ChainConstants, EquivocationProof, FarmerPublicKey, SignedVote, SolutionRanges, Vote,
 };
@@ -78,8 +80,6 @@ use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{
     create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, Perbill, SaturatedConversion,
 };
-#[cfg(feature = "pot")]
-use sp_std::num::NonZeroU32;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -1269,8 +1269,8 @@ impl_runtime_apis! {
             SlotDuration::from_millis(SLOT_DURATION)
         }
 
-        fn pot_slot_iterations() -> NonZeroU32 {
-            Subspace::pot_slot_iterations()
+        fn pot_parameters() -> PotParameters {
+            Subspace::pot_parameters()
         }
 
         fn solution_ranges() -> SolutionRanges {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -78,6 +78,8 @@ use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{
     create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, Perbill, SaturatedConversion,
 };
+#[cfg(feature = "pot")]
+use sp_std::num::NonZeroU32;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -1263,16 +1265,12 @@ impl_runtime_apis! {
     }
 
     impl sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey> for Runtime {
-        fn history_size() -> HistorySize {
-            <pallet_subspace::Pallet<Runtime>>::history_size()
-        }
-
-        fn max_pieces_in_sector() -> u16 {
-            MAX_PIECES_IN_SECTOR
-        }
-
         fn slot_duration() -> SlotDuration {
             SlotDuration::from_millis(SLOT_DURATION)
+        }
+
+        fn pot_slot_iterations() -> NonZeroU32 {
+            Subspace::pot_slot_iterations()
         }
 
         fn solution_ranges() -> SolutionRanges {
@@ -1311,6 +1309,14 @@ impl_runtime_apis! {
             // TODO: Either check tx pool too for pending equivocations or replace equivocation
             //  mechanism with an alternative one, so that blocking happens faster
             Subspace::is_in_block_list(farmer_public_key)
+        }
+
+        fn history_size() -> HistorySize {
+            <pallet_subspace::Pallet<Runtime>>::history_size()
+        }
+
+        fn max_pieces_in_sector() -> u16 {
+            MAX_PIECES_IN_SECTOR
         }
 
         fn segment_commitment(segment_index: SegmentIndex) -> Option<SegmentCommitment> {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1409,6 +1409,14 @@ impl_runtime_apis! {
         fn non_empty_er_exists(domain_id: DomainId) -> bool {
             Domains::non_empty_er_exists(domain_id)
         }
+
+        fn domain_best_number(domain_id: DomainId) -> Option<DomainNumber> {
+            Domains::domain_best_number(domain_id)
+        }
+
+        fn domain_state_root(domain_id: DomainId, number: DomainNumber, hash: DomainHash) -> Option<DomainHash>{
+            Domains::domain_state_root(domain_id, number, hash)
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {
@@ -1457,6 +1465,52 @@ impl_runtime_apis! {
         }
         fn query_length_to_fee(length: u32) -> Balance {
             TransactionPayment::length_to_fee(length)
+        }
+    }
+
+    impl sp_messenger::MessengerApi<Block, BlockNumber> for Runtime {
+        fn extract_xdm_proof_state_roots(
+            extrinsic: Vec<u8>,
+        ) -> Option<ExtractedStateRootsFromProof<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>> {
+            extract_xdm_proof_state_roots(extrinsic)
+        }
+
+        fn is_domain_info_confirmed(
+            domain_id: DomainId,
+            domain_block_info: BlockInfo<BlockNumber, <Block as BlockT>::Hash>,
+            domain_state_root: <Block as BlockT>::Hash,
+        ) -> bool{
+            Messenger::is_domain_info_confirmed(domain_id, domain_block_info, domain_state_root)
+        }
+    }
+
+    impl sp_messenger::RelayerApi<Block, BlockNumber> for Runtime {
+        fn chain_id() -> ChainId {
+            SelfChainId::get()
+        }
+
+        fn relay_confirmation_depth() -> BlockNumber {
+            RelayConfirmationDepth::get()
+        }
+
+        fn block_messages() -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages()
+        }
+
+        fn outbox_message_unsigned(msg: CrossDomainMessage<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+            Messenger::outbox_message_unsigned(msg)
+        }
+
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+            Messenger::inbox_response_message_unsigned(msg)
+        }
+
+        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
+            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        }
+
+        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
+            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
         }
     }
 

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -764,7 +764,9 @@ where
 
     if config.role.is_authority() || config.force_new_slot_notifications {
         #[cfg(feature = "pot")]
-        let (pot_source, pot_slot_info_stream) = PotSource::new(config.pot_source_config);
+        let (pot_source, pot_slot_info_stream) =
+            PotSource::new(config.pot_source_config, client.clone())
+                .map_err(|error| Error::Other(error.into()))?;
         #[cfg(feature = "pot")]
         {
             task_manager.spawn_essential_handle().spawn_blocking(

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -32,7 +32,7 @@ use subspace_core_primitives::crypto::{
     blake2b_256_254_hash_to_scalar, blake2b_256_hash_list, blake2b_256_hash_with_key,
 };
 #[cfg(feature = "pot")]
-use subspace_core_primitives::PotCheckpoint;
+use subspace_core_primitives::PotProof;
 use subspace_core_primitives::{
     Blake2b256Hash, BlockNumber, BlockWeight, HistorySize, PublicKey, Randomness, Record,
     RewardSignature, SectorId, SectorSlotChallenge, SegmentCommitment, SlotNumber, Solution,
@@ -169,7 +169,7 @@ pub struct VerifySolutionParams {
     pub global_randomness: Randomness,
     /// Proof of time for which solution is built
     #[cfg(feature = "pot")]
-    pub proof_of_time: PotCheckpoint,
+    pub proof_of_time: PotProof,
     /// Solution range
     pub solution_range: SolutionRange,
     /// Parameters for checking piece validity.

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -6,6 +6,7 @@ use sp_core::{sr25519, Pair, Public};
 use sp_domains::{GenesisDomain, OperatorPublicKey, RuntimeType};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::Percent;
+use std::num::NonZeroU32;
 use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, Signature};
 use subspace_test_runtime::{
     AllowAuthoringBy, BalancesConfig, DomainsConfig, GenesisConfig, MaxDomainBlockSize,
@@ -99,6 +100,7 @@ fn create_genesis_config(
             enable_rewards: false,
             enable_storage_access: false,
             allow_authoring_by: AllowAuthoringBy::Anyone,
+            pot_slot_iterations: NonZeroU32::new(50_000_000).expect("Not zero; qed"),
         },
         vesting: VestingConfig { vesting },
         domains: DomainsConfig {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -48,6 +48,8 @@ use sp_consensus_slots::SlotDuration;
 use sp_consensus_subspace::digests::CompatibleDigestItem;
 #[cfg(not(feature = "pot"))]
 use sp_consensus_subspace::GlobalRandomnesses;
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::PotParameters;
 use sp_consensus_subspace::{
     ChainConstants, EquivocationProof, FarmerPublicKey, SignedVote, SolutionRanges, Vote,
 };
@@ -77,8 +79,6 @@ use sp_runtime::{
 };
 use sp_std::iter::Peekable;
 use sp_std::marker::PhantomData;
-#[cfg(feature = "pot")]
-use sp_std::num::NonZeroU32;
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -1568,8 +1568,8 @@ impl_runtime_apis! {
             SlotDuration::from_millis(SLOT_DURATION)
         }
 
-        fn pot_slot_iterations() -> NonZeroU32 {
-            Subspace::pot_slot_iterations()
+        fn pot_parameters() -> PotParameters {
+            Subspace::pot_parameters()
         }
 
         fn solution_ranges() -> SolutionRanges {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1708,6 +1708,14 @@ impl_runtime_apis! {
         fn non_empty_er_exists(domain_id: DomainId) -> bool {
             Domains::non_empty_er_exists(domain_id)
         }
+
+        fn domain_best_number(domain_id: DomainId) -> Option<DomainNumber> {
+            Domains::domain_best_number(domain_id)
+        }
+
+        fn domain_state_root(domain_id: DomainId, number: DomainNumber, hash: DomainHash) -> Option<DomainHash>{
+            Domains::domain_state_root(domain_id, number, hash)
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {
@@ -1756,6 +1764,52 @@ impl_runtime_apis! {
         }
         fn query_length_to_fee(length: u32) -> Balance {
             TransactionPayment::length_to_fee(length)
+        }
+    }
+
+    impl sp_messenger::MessengerApi<Block, BlockNumber> for Runtime {
+        fn extract_xdm_proof_state_roots(
+            extrinsic: Vec<u8>,
+        ) -> Option<ExtractedStateRootsFromProof<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>> {
+            extract_xdm_proof_state_roots(extrinsic)
+        }
+
+        fn is_domain_info_confirmed(
+            domain_id: DomainId,
+            domain_block_info: BlockInfo<BlockNumber, <Block as BlockT>::Hash>,
+            domain_state_root: <Block as BlockT>::Hash,
+        ) -> bool{
+            Messenger::is_domain_info_confirmed(domain_id, domain_block_info, domain_state_root)
+        }
+    }
+
+    impl sp_messenger::RelayerApi<Block, BlockNumber> for Runtime {
+        fn chain_id() -> ChainId {
+            SelfChainId::get()
+        }
+
+        fn relay_confirmation_depth() -> BlockNumber {
+            RelayConfirmationDepth::get()
+        }
+
+        fn block_messages() -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages()
+        }
+
+        fn outbox_message_unsigned(msg: CrossDomainMessage<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+            Messenger::outbox_message_unsigned(msg)
+        }
+
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<BlockNumber, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+            Messenger::inbox_response_message_unsigned(msg)
+        }
+
+        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
+            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        }
+
+        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
+            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
         }
     }
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -77,6 +77,8 @@ use sp_runtime::{
 };
 use sp_std::iter::Peekable;
 use sp_std::marker::PhantomData;
+#[cfg(feature = "pot")]
+use sp_std::num::NonZeroU32;
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -1562,16 +1564,12 @@ impl_runtime_apis! {
     }
 
     impl sp_consensus_subspace::SubspaceApi<Block, FarmerPublicKey> for Runtime {
-        fn history_size() -> HistorySize {
-            <pallet_subspace::Pallet<Runtime>>::history_size()
-        }
-
-        fn max_pieces_in_sector() -> u16 {
-            MAX_PIECES_IN_SECTOR
-        }
-
         fn slot_duration() -> SlotDuration {
             SlotDuration::from_millis(SLOT_DURATION)
+        }
+
+        fn pot_slot_iterations() -> NonZeroU32 {
+            Subspace::pot_slot_iterations()
         }
 
         fn solution_ranges() -> SolutionRanges {
@@ -1610,6 +1608,14 @@ impl_runtime_apis! {
             // TODO: Either check tx pool too for pending equivocations or replace equivocation
             //  mechanism with an alternative one, so that blocking happens faster
             Subspace::is_in_block_list(farmer_public_key)
+        }
+
+        fn history_size() -> HistorySize {
+            <pallet_subspace::Pallet<Runtime>>::history_size()
+        }
+
+        fn max_pieces_in_sector() -> u16 {
+            MAX_PIECES_IN_SECTOR
         }
 
         fn segment_commitment(segment_index: SegmentIndex) -> Option<SegmentCommitment> {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1127,7 +1127,7 @@ fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness
         let pre_digest = pre_digest.expect("Header must contain one pre-runtime digest; qed");
 
         let seed: &[u8] = b"extrinsics-shuffling-seed";
-        let randomness = derive_randomness(&pre_digest.solution, pre_digest.slot.into());
+        let randomness = derive_randomness(pre_digest.solution(), pre_digest.slot().into());
         let mut data = Vec::with_capacity(seed.len() + randomness.len());
         data.extend_from_slice(seed);
         data.extend_from_slice(randomness.as_ref());

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -52,6 +52,8 @@ use sp_application_crypto::UncheckedFrom;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockOrigin, Error as ConsensusError};
 use sp_consensus_slots::Slot;
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::digests::PreDigestPotInfo;
 use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest};
 use sp_consensus_subspace::FarmerPublicKey;
 use sp_core::traits::SpawnEssentialNamed;
@@ -66,6 +68,8 @@ use sp_runtime::{DigestItem, OpaqueExtrinsic};
 use sp_timestamp::Timestamp;
 use std::error::Error;
 use std::marker::PhantomData;
+#[cfg(feature = "pot")]
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::{Randomness, Solution};
@@ -600,9 +604,11 @@ impl MockConsensusNode {
             slot,
             solution: self.mock_solution.clone(),
             #[cfg(feature = "pot")]
-            proof_of_time: Default::default(),
-            #[cfg(feature = "pot")]
-            future_proof_of_time: Default::default(),
+            pot_info: PreDigestPotInfo::Regular {
+                iterations: NonZeroU32::MIN,
+                proof_of_time: Default::default(),
+                future_proof_of_time: Default::default(),
+            },
         };
         let mut digest = Digest::default();
         digest.push(DigestItem::subspace_pre_digest(&pre_digest));

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -596,7 +596,7 @@ impl MockConsensusNode {
     }
 
     fn mock_subspace_digest(&self, slot: Slot) -> Digest {
-        let pre_digest: PreDigest<FarmerPublicKey, AccountId> = PreDigest {
+        let pre_digest: PreDigest<FarmerPublicKey, AccountId> = PreDigest::V0 {
             slot,
             solution: self.mock_solution.clone(),
             #[cfg(feature = "pot")]

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -68,8 +68,6 @@ use sp_runtime::{DigestItem, OpaqueExtrinsic};
 use sp_timestamp::Timestamp;
 use std::error::Error;
 use std::marker::PhantomData;
-#[cfg(feature = "pot")]
-use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time;
 use subspace_core_primitives::{Randomness, Solution};
@@ -604,8 +602,7 @@ impl MockConsensusNode {
             slot,
             solution: self.mock_solution.clone(),
             #[cfg(feature = "pot")]
-            pot_info: PreDigestPotInfo::Regular {
-                iterations: NonZeroU32::MIN,
+            pot_info: PreDigestPotInfo::V0 {
                 proof_of_time: Default::default(),
                 future_proof_of_time: Default::default(),
             },


### PR DESCRIPTION
This is a preparation for PoT verification since a few consensus parameters were missing and information in the header wasn't sufficient.

For example we didn't have expected number of PoT iterations in consensus and corresponding number of iterations in the header to facilitate initial stateless PoT verification. I'm not excited that we have to add iterations into the header, but at the same time otherwise all PoT verification will be delayed to block import time.

`PreDigestPotInfo` is an enum as well, currently it has just one variant `Regular` that means no entropy injection and no adjustment of number of iterations happened yet. Once we have either of those, second enum variant will be added to handle those cases.

Since we no longer need to be compatible with Gemini 3f I have done some breaking refactoring like making `PreDigest` an enum to facilitate future protocol upgrades.

I have set number of PoT iterations to what my machine can do for Gemini network and lower numbers such that it takes ~1s on other machines (roughly), workaround with sleep is removed and no longer necessary since PoT is doing actual work now.

There is still a lot of work left, but we're already cleaning up some TODOs.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
