### PR TITLE
Fix runtime constants accidentally changed recently

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -92,7 +92,7 @@ sp_runtime::impl_opaque_keys! {
 }
 
 /// How many pieces one sector is supposed to contain (max)
-const MAX_PIECES_IN_SECTOR: u16 = 32;
+const MAX_PIECES_IN_SECTOR: u16 = 1000;
 
 // To learn more about runtime versioning and what each of the following value means:
 //   https://substrate.dev/docs/en/knowledgebase/runtime/upgrades#runtime-versioning
@@ -133,7 +133,7 @@ pub fn native_version() -> NativeVersion {
 ///
 /// Based on:
 /// <https://research.web3.foundation/en/latest/polkadot/block-production/Babe.html#-6.-practical-results>
-pub const MILLISECS_PER_BLOCK: u64 = 1000;
+pub const MILLISECS_PER_BLOCK: u64 = 6000;
 
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.
@@ -141,7 +141,7 @@ const SLOT_DURATION: u64 = 1000;
 
 /// 1 in 6 slots (on average, not counting collisions) will have a block.
 /// Must match ratio between block and slot duration in constants above.
-const SLOT_PROBABILITY: (u64, u64) = (1, 1);
+const SLOT_PROBABILITY: (u64, u64) = (1, 6);
 
 /// The amount of time, in blocks, between updates of global randomness.
 const GLOBAL_RANDOMNESS_UPDATE_INTERVAL: BlockNumber = 256;
@@ -187,7 +187,7 @@ const RECENT_HISTORY_FRACTION: (HistorySize, HistorySize) = (
 );
 /// Minimum lifetime of a plotted sector, measured in archived segment.
 const MIN_SECTOR_LIFETIME: HistorySize =
-    HistorySize::new(NonZeroU64::new(1).expect("Not zero; qed"));
+    HistorySize::new(NonZeroU64::new(4).expect("Not zero; qed"));
 
 /// The block weight for 2 seconds of compute
 const BLOCK_WEIGHT_FOR_2_SEC: Weight =


### PR DESCRIPTION
These changes were accidentally included in https://github.com/subspace/subspace/pull/1884 and must be reverted

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
