### PR TITLE
Domains: Use randomness using frame support trait and removed constant operator rewards

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -97,6 +97,8 @@ mod benchmarks {
         let epoch_duration = T::StakeEpochDuration::get();
         let minimum_nominator_stake = T::Currency::minimum_balance();
         let withdraw_amount = T::MinOperatorStake::get();
+        let operator_rewards =
+            T::Currency::minimum_balance().saturating_mul(BalanceOf::<T>::from(100u32));
 
         let domain_id = register_domain::<T>();
         let (_, operator_id) = register_helper_operator::<T>(domain_id, minimum_nominator_stake);
@@ -138,12 +140,8 @@ mod benchmarks {
 
         #[block]
         {
-            do_reward_operators::<T>(
-                domain_id,
-                vec![operator_id].into_iter(),
-                T::DomainBlockReward::get(),
-            )
-            .expect("reward operator should success");
+            do_reward_operators::<T>(domain_id, vec![operator_id].into_iter(), operator_rewards)
+                .expect("reward operator should success");
 
             do_finalize_domain_current_epoch::<T>(domain_id, epoch_duration * 2u32.into())
                 .expect("finalize domain staking should success");

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -221,8 +221,6 @@ pub(crate) fn verify_execution_receipt<T: Config>(
 pub(crate) struct PrunedDomainBlockInfo<DomainNumber, Balance> {
     pub domain_block_number: DomainNumber,
     pub operator_ids: Vec<OperatorId>,
-    #[allow(dead_code)]
-    // TODO: use once actual rewards are set
     pub rewards: Balance,
 }
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -264,11 +264,6 @@ mod pallet {
         #[pallet::constant]
         type TreasuryAccount: Get<Self::AccountId>;
 
-        /// A fixed domain block reward.
-        // TODO: remove once we have operator rewards on client side is available
-        #[pallet::constant]
-        type DomainBlockReward: Get<BalanceOf<Self>>;
-
         /// The maximum number of pending staking operation that can perform upon epoch transition.
         #[pallet::constant]
         type MaxPendingStakingOperation: Get<u32>;
@@ -728,7 +723,7 @@ mod pallet {
                         do_reward_operators::<T>(
                             domain_id,
                             pruned_block_info.operator_ids.into_iter(),
-                            T::DomainBlockReward::get(),
+                            pruned_block_info.rewards,
                         )
                         .map_err(Error::<T>::from)?;
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -36,7 +36,7 @@ use crate::staking::{do_nominate_operator, Operator, OperatorStatus};
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use frame_support::traits::fungible::{Inspect, InspectHold};
-use frame_support::traits::Get;
+use frame_support::traits::{Get, Randomness as RandomnessT};
 use frame_system::offchain::SubmitTransaction;
 pub use pallet::*;
 use scale_info::TypeInfo;
@@ -124,6 +124,7 @@ mod pallet {
     use codec::FullCodec;
     use frame_support::pallet_prelude::{StorageMap, *};
     use frame_support::traits::fungible::{InspectHold, Mutate, MutateHold};
+    use frame_support::traits::Randomness as RandomnessT;
     use frame_support::weights::Weight;
     use frame_support::{Identity, PalletError};
     use frame_system::pallet_prelude::*;
@@ -270,6 +271,9 @@ mod pallet {
 
         #[pallet::constant]
         type SudoId: Get<Self::AccountId>;
+
+        /// Randomness source.
+        type Randomness: RandomnessT<Self::Hash, Self::BlockNumber>;
     }
 
     #[pallet::pallet]
@@ -1517,6 +1521,12 @@ impl<T: Config> Pallet<T> {
         }
 
         false
+    }
+
+    pub fn extrinsics_shuffling_seed() -> T::Hash {
+        let seed: &[u8] = b"extrinsics-shuffling-seed";
+        let (randomness, _) = T::Randomness::random(seed);
+        randomness
     }
 }
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -191,7 +191,6 @@ impl pallet_domains::Config for Test {
     type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
-    type DomainBlockReward = BlockReward;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type SudoId = ();
 }

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -169,6 +169,14 @@ parameter_types! {
     pub const MaxPendingStakingOperation: u32 = 100;
 }
 
+pub struct MockRandomness;
+
+impl frame_support::traits::Randomness<Hash, BlockNumber> for MockRandomness {
+    fn random(_: &[u8]) -> (Hash, BlockNumber) {
+        (Default::default(), Default::default())
+    }
+}
+
 impl pallet_domains::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type DomainNumber = BlockNumber;
@@ -193,6 +201,7 @@ impl pallet_domains::Config for Test {
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type SudoId = ();
+    type Randomness = MockRandomness;
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -739,7 +739,7 @@ sp_api::decl_runtime_apis! {
         ) -> OpaqueBundles<Block, DomainNumber, DomainHash, Balance>;
 
         /// Generates a randomness seed for extrinsics shuffling.
-        fn extrinsics_shuffling_seed(header: Block::Header) -> Randomness;
+        fn extrinsics_shuffling_seed() -> Randomness;
 
         /// Returns the WASM bundle for given `domain_id`.
         fn domain_runtime_code(domain_id: DomainId) -> Option<Vec<u8>>;

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -1,14 +1,9 @@
 use crate::{Balance, Block, BlockNumber, Domains, Hash, RuntimeCall, UncheckedExtrinsic};
 use domain_runtime_primitives::{BlockNumber as DomainNumber, Hash as DomainHash};
-use sp_consensus_subspace::digests::CompatibleDigestItem;
-use sp_consensus_subspace::FarmerPublicKey;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::transaction::PreValidationObject;
 use sp_domains::{DomainId, ExecutionReceipt};
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT, Zero};
 use sp_std::vec::Vec;
-use subspace_core_primitives::Randomness;
-use subspace_verification::derive_randomness;
 
 pub(crate) fn extract_successful_bundles(
     domain_id: DomainId,
@@ -81,33 +76,5 @@ pub(crate) fn extract_pre_validation_object(
             PreValidationObject::Bundle(opaque_bundle)
         }
         _ => PreValidationObject::Null,
-    }
-}
-
-pub(crate) fn extrinsics_shuffling_seed<Block: BlockT>(header: Block::Header) -> Randomness {
-    if header.number().is_zero() {
-        Randomness::default()
-    } else {
-        let mut pre_digest: Option<_> = None;
-        for log in header.digest().logs() {
-            match (
-                log.as_subspace_pre_digest::<FarmerPublicKey>(),
-                pre_digest.is_some(),
-            ) {
-                (Some(_), true) => panic!("Multiple Subspace pre-runtime digests in a header"),
-                (None, _) => {}
-                (s, false) => pre_digest = s,
-            }
-        }
-
-        let pre_digest = pre_digest.expect("Header must contain one pre-runtime digest; qed");
-
-        let seed: &[u8] = b"extrinsics-shuffling-seed";
-        let randomness = derive_randomness(&pre_digest.solution, pre_digest.slot.into());
-        let mut data = Vec::with_capacity(seed.len() + randomness.len());
-        data.extend_from_slice(seed);
-        data.extend_from_slice(randomness.as_ref());
-
-        Randomness::from(BlakeTwo256::hash_of(&data).to_fixed_bytes())
     }
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -609,7 +609,6 @@ impl pallet_domains::Config for Runtime {
     type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
-    type DomainBlockReward = BlockReward;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type SudoId = SudoId;
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -611,6 +611,7 @@ impl pallet_domains::Config for Runtime {
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type SudoId = SudoId;
+    type Randomness = Subspace;
 }
 
 pub struct StakingOnReward;
@@ -991,8 +992,8 @@ impl_runtime_apis! {
             crate::domains::extract_successful_bundles(domain_id, extrinsics)
         }
 
-        fn extrinsics_shuffling_seed(header: <Block as BlockT>::Header) -> Randomness {
-            crate::domains::extrinsics_shuffling_seed::<Block>(header)
+        fn extrinsics_shuffling_seed() -> Randomness {
+            Randomness::from(Domains::extrinsics_shuffling_seed().to_fixed_bytes())
         }
 
         fn domain_runtime_code(domain_id: DomainId) -> Option<Vec<u8>> {
@@ -1356,7 +1357,7 @@ impl_runtime_apis! {
         }
 
         fn extrinsics_shuffling_seed(header: <Block as BlockT>::Header) -> Randomness {
-            crate::domains::extrinsics_shuffling_seed::<Block>(header)
+            Randomness::from(Domains::extrinsics_shuffling_seed().to_fixed_bytes())
         }
 
         fn domain_runtime_code(domain_id: DomainId) -> Option<Vec<u8>> {

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -103,7 +103,7 @@ where
 
     let shuffling_seed = consensus_client
         .runtime_api()
-        .extrinsics_shuffling_seed(block_hash, header)?;
+        .extrinsics_shuffling_seed(block_hash)?;
 
     Ok((extrinsics, shuffling_seed, maybe_new_runtime))
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -653,7 +653,6 @@ impl pallet_domains::Config for Runtime {
     type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
-    type DomainBlockReward = BlockReward;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type SudoId = SudoId;
 }


### PR DESCRIPTION
This PR brings following changes
- Use `frame_support::traits::Randomenss` impl from Subspace instead of deriving from the Header.
- Removed the dummy Block reward now that ER carries the correct rewards

Closes: #1906 

Update:
- It turns out PorRandomness was being removed during on_finalization. Had to remove that to use on Domains. This was causing tests to fail.
- I have also ensured PorRandomness is always set in on_initialize even in pot feature. Derived it from `PotCheckpoint`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
