### PR TITLE
Tweak a retry number for piece retrieval operations on DSN L2.

### DIFF
--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -6,15 +6,14 @@ use parking_lot::RwLock;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::mem;
+use std::num::NonZeroU16;
 use std::sync::Arc;
 use subspace_core_primitives::{Piece, PieceIndex, SegmentIndex};
 use subspace_farmer_components::plotting::{PieceGetter, PieceGetterRetryPolicy};
 use subspace_networking::libp2p::kad::{ProviderRecord, RecordKey};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::multihash::ToMultihash;
-use subspace_networking::{
-    KeyWrapper, LocalRecordProvider, UniqueRecordBinaryHeap, PIECE_GETTER_RETRY_NUMBER,
-};
+use subspace_networking::{KeyWrapper, LocalRecordProvider, UniqueRecordBinaryHeap};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
@@ -22,6 +21,8 @@ const WORKER_CHANNEL_CAPACITY: usize = 100;
 /// Make caches available as they are building without waiting for the initialization to finish,
 /// this number defines an interval in pieces after which cache is updated
 const INTERMEDIATE_CACHE_UPDATE_INTERVAL: usize = 100;
+/// Get piece retry attempts number.
+const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");
 
 #[derive(Debug, Clone)]
 struct DiskPieceCacheState {

--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -12,7 +12,9 @@ use subspace_farmer_components::plotting::{PieceGetter, PieceGetterRetryPolicy};
 use subspace_networking::libp2p::kad::{ProviderRecord, RecordKey};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::multihash::ToMultihash;
-use subspace_networking::{KeyWrapper, LocalRecordProvider, UniqueRecordBinaryHeap};
+use subspace_networking::{
+    KeyWrapper, LocalRecordProvider, UniqueRecordBinaryHeap, PIECE_GETTER_RETRY_NUMBER,
+};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
@@ -255,7 +257,10 @@ where
         // TODO: Can probably do concurrency here
         for (index, piece_index) in piece_indices_to_store.into_values().enumerate() {
             let result = piece_getter
-                .get_piece(piece_index, PieceGetterRetryPolicy::Limited(1))
+                .get_piece(
+                    piece_index,
+                    PieceGetterRetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
+                )
                 .await;
 
             let piece = match result {
@@ -432,7 +437,10 @@ where
             trace!(%piece_index, "Piece needs to be cached #1");
 
             let result = piece_getter
-                .get_piece(piece_index, PieceGetterRetryPolicy::Limited(1))
+                .get_piece(
+                    piece_index,
+                    PieceGetterRetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
+                )
                 .await;
 
             let piece = match result {

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -12,7 +12,7 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io;
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU16, NonZeroUsize};
 use std::ops::Range;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -28,7 +28,6 @@ use subspace_farmer_components::plotting::{
     plot_sector, PieceGetter, PieceGetterRetryPolicy, PlottedSector,
 };
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
-use subspace_networking::PIECE_GETTER_RETRY_NUMBER;
 use subspace_proof_of_space::Table;
 use thiserror::Error;
 use tracing::{debug, info, trace, warn};
@@ -36,6 +35,8 @@ use tracing::{debug, info, trace, warn};
 const FARMER_APP_INFO_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 /// Size of the cache of archived segments for the purposes of faster sector expiration checks.
 const ARCHIVED_SEGMENTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).expect("Not zero; qed");
+/// Get piece retry attempts number.
+const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");
 
 /// Errors that happen during plotting
 #[derive(Debug, Error)]

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -12,7 +12,7 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io;
-use std::num::{NonZeroU16, NonZeroUsize};
+use std::num::NonZeroUsize;
 use std::ops::Range;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -28,13 +28,12 @@ use subspace_farmer_components::plotting::{
     plot_sector, PieceGetter, PieceGetterRetryPolicy, PlottedSector,
 };
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
+use subspace_networking::PIECE_GETTER_RETRY_NUMBER;
 use subspace_proof_of_space::Table;
 use thiserror::Error;
 use tracing::{debug, info, trace, warn};
 
 const FARMER_APP_INFO_RETRY_INTERVAL: Duration = Duration::from_millis(500);
-/// Get piece retry attempts number.
-const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");
 /// Size of the cache of archived segments for the purposes of faster sector expiration checks.
 const ARCHIVED_SEGMENTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).expect("Not zero; qed");
 

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -49,10 +49,6 @@ pub use protocols::request_response::handlers::segment_header::{
     SegmentHeaderBySegmentIndexesRequestHandler, SegmentHeaderRequest, SegmentHeaderResponse,
 };
 pub use shared::NewPeerInfo;
-use std::num::NonZeroU16;
 pub use utils::multihash::Multihash;
 pub use utils::prometheus::start_prometheus_metrics_server;
 pub use utils::unique_record_binary_heap::{KeyWrapper, UniqueRecordBinaryHeap};
-
-/// Get piece retry attempts number.
-pub const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -49,6 +49,10 @@ pub use protocols::request_response::handlers::segment_header::{
     SegmentHeaderBySegmentIndexesRequestHandler, SegmentHeaderRequest, SegmentHeaderResponse,
 };
 pub use shared::NewPeerInfo;
+use std::num::NonZeroU16;
 pub use utils::multihash::Multihash;
 pub use utils::prometheus::start_prometheus_metrics_server;
 pub use utils::unique_record_binary_heap::{KeyWrapper, UniqueRecordBinaryHeap};
+
+/// Get piece retry attempts number.
+pub const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(3).expect("Not zero; qed");


### PR DESCRIPTION
This PR tweaks a retry number for piece retrieval operations on L2 cache population.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
