### PR TITLE
add PATH_TO_FARM to wipe example in farming.md

### DIFF
--- a/docs/farming.md
+++ b/docs/farming.md
@@ -324,7 +324,7 @@ Examples:
 ```bash
 # Replace `FARMER_FILE_NAME` with the name of the node file you downloaded from releases
 ./FARMER_FILE_NAME farm --help
-./FARMER_FILE_NAME wipe
+./FARMER_FILE_NAME wipe PATH_TO_FARM
 ```
 
 ## [Advanced] Support for multiple disks


### PR DESCRIPTION
Fixed typo in farming docs due to missed PATH_TO_FARM

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
