### PR TITLE
Check for inherents in initial response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9611,6 +9611,8 @@ dependencies = [
  "sc-network-sync",
  "sc-service",
  "sc-transaction-pool-api",
+ "sp-api",
+ "sp-consensus-subspace",
  "sp-runtime",
  "thiserror",
  "tracing",

--- a/crates/sc-subspace-block-relay/Cargo.toml
+++ b/crates/sc-subspace-block-relay/Cargo.toml
@@ -22,6 +22,8 @@ sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substr
 sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", default-features = false }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
+sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71" }
 thiserror = "1.0.38"

--- a/crates/sc-subspace-block-relay/src/lib.rs
+++ b/crates/sc-subspace-block-relay/src/lib.rs
@@ -106,11 +106,16 @@ pub(crate) trait ProtocolServer<DownloadUnitId> {
 
 /// The relay user specific backend interface
 pub(crate) trait ProtocolBackend<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
-    /// Returns all the protocol units for the given download unit
+    /// Returns the protocol units for the given download unit, to be returned
+    /// with the initial response. Some of the items may have the full entry
+    /// along with the Id (e.g) consensus may choose to return the full
+    /// transaction for inherents/small transactions in the block. And return
+    /// only the Tx hash for the remaining extrinsics. Further protocol
+    /// handshake would be used only for resolving these remaining items.
     fn download_unit_members(
         &self,
         id: &DownloadUnitId,
-    ) -> Result<Vec<(ProtocolUnitId, ProtocolUnit)>, RelayError>;
+    ) -> Result<Vec<ProtocolUnitInfo<ProtocolUnitId, ProtocolUnit>>, RelayError>;
 
     /// Returns the protocol unit for the given download/protocol unit
     fn protocol_unit(
@@ -118,4 +123,16 @@ pub(crate) trait ProtocolBackend<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
         download_unit_id: &DownloadUnitId,
         protocol_unit_id: &ProtocolUnitId,
     ) -> Result<Option<ProtocolUnit>, RelayError>;
+}
+
+/// The protocol unit info carried in the initial response
+#[derive(Encode, Decode)]
+struct ProtocolUnitInfo<ProtocolUnitId, ProtocolUnit> {
+    /// The protocol unit Id
+    id: ProtocolUnitId,
+
+    /// The server can optionally return the protocol unit
+    /// as part of the initial response. No further
+    /// action is needed on client side to resolve it
+    unit: Option<ProtocolUnit>,
 }

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -632,6 +632,9 @@ sp_api::decl_runtime_apis! {
         /// Returns `Vec<SegmentHeader>` if a given extrinsic has them.
         fn extract_segment_headers(ext: &Block::Extrinsic) -> Option<Vec<SegmentHeader >>;
 
+        /// Checks if the extrinsic is an inherent.
+        fn is_inherent(ext: &Block::Extrinsic) -> bool;
+
         /// Returns root plot public key in case block authoring is restricted.
         fn root_plot_public_key() -> Option<FarmerPublicKey>;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -44,6 +44,7 @@ use core::num::NonZeroU64;
 use domain_runtime_primitives::{
     BlockNumber as DomainNumber, Hash as DomainHash, MultiAccountId, TryConvertBack,
 };
+use frame_support::inherent::ProvideInherent;
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Currency, Everything, Get};
 use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
@@ -957,6 +958,14 @@ impl_runtime_apis! {
 
         fn extract_segment_headers(ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<SegmentHeader >> {
             extract_segment_headers(ext)
+        }
+
+        fn is_inherent(ext: &<Block as BlockT>::Extrinsic) -> bool {
+            match &ext.function {
+                RuntimeCall::Subspace(call) => Subspace::is_inherent(call),
+                RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
+                _ => false,
+            }
         }
 
         fn root_plot_public_key() -> Option<FarmerPublicKey> {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -28,6 +28,7 @@ use core::num::NonZeroU64;
 use domain_runtime_primitives::{
     BlockNumber as DomainNumber, Hash as DomainHash, MultiAccountId, TryConvertBack,
 };
+use frame_support::inherent::ProvideInherent;
 use frame_support::traits::{
     ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Currency, ExistenceRequirement, Get,
     Imbalance, WithdrawReasons,
@@ -1297,6 +1298,14 @@ impl_runtime_apis! {
 
         fn extract_segment_headers(ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<SegmentHeader >> {
             extract_segment_headers(ext)
+        }
+
+        fn is_inherent(ext: &<Block as BlockT>::Extrinsic) -> bool {
+            match &ext.function {
+                RuntimeCall::Subspace(call) => Subspace::is_inherent(call),
+                RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
+                _ => false,
+            }
         }
 
         fn root_plot_public_key() -> Option<FarmerPublicKey> {


### PR DESCRIPTION
We currently use a size threshold on the server side, to send the full extrinsic as part of the initial response. This works for most inherents (like pallet_timestamp inherents), but can miss bigger inherents like segment headers. This PR adds support for checking for inherents explicitly.

Fixes https://github.com/subspace/subspace/issues/1425

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
