### PR TITLE
Tune piece retrieval parameters for DSN (gemini-3f backport).

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -113,13 +113,13 @@ struct DsnArgs {
     #[arg(long, default_value_t = 50)]
     in_connections: u32,
     /// Defines max established outgoing swarm connection limit.
-    #[arg(long, default_value_t = 50)]
+    #[arg(long, default_value_t = 100)]
     out_connections: u32,
     /// Defines max pending incoming connection limit.
     #[arg(long, default_value_t = 50)]
     pending_in_connections: u32,
     /// Defines max pending outgoing swarm connection limit.
-    #[arg(long, default_value_t = 50)]
+    #[arg(long, default_value_t = 100)]
     pending_out_connections: u32,
     /// Defines target total (in and out) connection number that should be maintained.
     #[arg(long, default_value_t = 50)]

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -62,9 +62,9 @@ const SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "special-connected-pee
 // It must be set for large plots.
 const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 /// The default maximum established incoming connection number for the swarm.
-const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 80;
+const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 100;
 /// The default maximum established incoming connection number for the swarm.
-const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 80;
+const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 100;
 /// The default maximum pending incoming connection number for the swarm.
 const SWARM_MAX_PENDING_INCOMING_CONNECTIONS: u32 = 80;
 /// The default maximum pending incoming connection number for the swarm.

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -14,7 +14,7 @@ use subspace_core_primitives::{Piece, PieceIndex};
 use tracing::{debug, trace, warn};
 
 /// Defines initial duration between get_piece calls.
-const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(3);
+const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(5);
 /// Defines max duration between get_piece calls.
 const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(40);
 
@@ -132,6 +132,7 @@ where
             max_interval: GET_PIECE_MAX_INTERVAL,
             // Try until we get a valid piece
             max_elapsed_time: None,
+            multiplier: 1.75,
             ..ExponentialBackoff::default()
         };
 

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 #![feature(
+    const_option,
     impl_trait_in_assoc_type,
     int_roundings,
     type_alias_impl_trait,


### PR DESCRIPTION
This PR backports piece retrieval parameter tuning for gemini-3f maintenance branch originally introduced [here](https://github.com/subspace/subspace/pull/1925).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
