### PR TITLE
Implement the fraud proof v2 processing

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -266,7 +266,7 @@ pub(crate) fn process_execution_receipt<T: Config>(
                 // the ER may just submitted a few blocks ago and `receipts_at_number` may contains more than one block.
                 //
                 // In current implementatiomn, the correct finalized ER should be the one that has `BlockTreePruningDepth`
-                // lenght of descendants which is non-trival to find, but once https://github.com/subspace/subspace/issues/1731
+                // length of descendants which is non-trival to find, but once https://github.com/subspace/subspace/issues/1731
                 // is implemented this issue should be fixed automatically.
                 if receipts_at_number.len() != 1 {
                     return Err(Error::MultipleERsAfterChallengePeriod);

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -567,6 +567,8 @@ mod pallet {
         BadReceiptNotFound,
         /// The genesis receipt is unchallengeable.
         ChallengingGenesisReceipt,
+        /// The descendants of the fraudulent ER is not pruned
+        DescendantsOfFraudulentERNotPruned,
     }
 
     impl<T> From<FraudProofError> for Error<T> {
@@ -866,11 +868,14 @@ mod pallet {
                             {
                                 // `next_head_receipt_number` is `Some` means all the ER at prior height are pruned
                                 // thus the descendants must also be pruned
-                                panic!("The descendants of pruned ER must also be pruned; qed");
+                                return Err::<(), Error<T>>(
+                                    FraudProofError::DescendantsOfFraudulentERNotPruned.into(),
+                                );
                             }
                         }
+                        Ok(())
                     },
-                );
+                )?;
 
                 _ = StateRoots::<T>::take((
                     domain_id,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -447,6 +447,13 @@ mod pallet {
         OptionQuery,
     >;
 
+    // Mapping of the parent ER to all its immediate descendants ER
+    // TODO: remove this mapping once https://github.com/subspace/subspace/issues/1731 is implemented
+    // by then every parent ER should only have one immediate descendants ER
+    #[pallet::storage]
+    pub(super) type DomainBlockDescendants<T: Config> =
+        StorageMap<_, Identity, ReceiptHash, BTreeSet<ReceiptHash>, ValueQuery>;
+
     /// The head receipt number of each domain
     #[pallet::storage]
     pub(super) type HeadReceiptNumber<T: Config> =

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -19,6 +19,7 @@ use sp_runtime::traits::{CheckedAdd, CheckedSub, One, Zero};
 use sp_runtime::{Perbill, Percent};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
+use sp_std::iter::Iterator;
 use sp_std::vec::{IntoIter, Vec};
 
 /// Type that represents an operator status.
@@ -501,12 +502,10 @@ pub(crate) fn do_auto_stake_block_rewards<T: Config>(
     Ok(())
 }
 
-#[allow(dead_code)]
-// TODO: remove once fraud proof is done
 /// Freezes the slashed operators and moves the operator to be removed once the domain they are
 /// operating finishes the epoch.
-pub(crate) fn do_slash_operators<T: Config>(
-    operator_ids: IntoIter<OperatorId>,
+pub(crate) fn do_slash_operators<T: Config, Iter: Iterator<Item = OperatorId>>(
+    operator_ids: Iter,
 ) -> Result<(), Error> {
     for operator_id in operator_ids {
         Operators::<T>::try_mutate(operator_id, |maybe_operator| {
@@ -1285,7 +1284,7 @@ pub(crate) mod tests {
                 do_nominate_operator::<Test>(operator_id, deposit.0, deposit.1).unwrap();
             }
 
-            do_slash_operators::<Test>(vec![operator_id].into_iter()).unwrap();
+            do_slash_operators::<Test, _>(vec![operator_id].into_iter()).unwrap();
 
             let domain_stake_summary = DomainStakingSummary::<Test>::get(domain_id).unwrap();
             assert!(!domain_stake_summary.next_operators.contains(&operator_id));

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,20 +1,29 @@
+use crate::block_tree::DomainBlock;
 use crate::domain_registry::{DomainConfig, DomainObject};
-use crate::{self as pallet_domains, BundleError, DomainRegistry, FungibleHoldId};
+use crate::{
+    self as pallet_domains, BalanceOf, BlockTree, BundleError, Config, ConsensusBlockHash,
+    DomainBlocks, DomainRegistry, ExecutionInbox, FraudProofError, FungibleHoldId,
+    HeadReceiptNumber, NextDomainId, Operator, OperatorStatus, Operators,
+};
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::traits::{ConstU16, ConstU32, ConstU64, Hooks};
+use frame_support::dispatch::RawOrigin;
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, Currency, Hooks};
 use frame_support::weights::Weight;
 use frame_support::{assert_err, assert_ok, parameter_types, PalletId};
 use scale_info::TypeInfo;
 use sp_core::crypto::Pair;
 use sp_core::{Get, H256, U256};
+use sp_domains::fraud_proof::FraudProof;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
     BundleHeader, DomainId, DomainInstanceData, DomainsHoldIdentifier, ExecutionReceipt,
     GenerateGenesisStateRoot, GenesisReceiptExtension, OpaqueBundle, OperatorId, OperatorPair,
-    ProofOfElection, SealedBundleHeader, StakingHoldIdentifier,
+    ProofOfElection, RuntimeType, SealedBundleHeader, StakingHoldIdentifier,
 };
 use sp_runtime::testing::Header;
-use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, Hash as HashT, IdentityLookup};
+use sp_runtime::traits::{
+    AccountIdConversion, BlakeTwo256, BlockNumberProvider, Hash as HashT, IdentityLookup, Zero,
+};
 use sp_runtime::OpaqueExtrinsic;
 use sp_version::RuntimeVersion;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -336,6 +345,113 @@ impl sp_core::traits::ReadRuntimeVersion for ReadRuntimeVersion {
     ) -> Result<Vec<u8>, String> {
         Ok(self.0.clone())
     }
+}
+
+pub(crate) fn run_to_block<T: Config>(block_number: T::BlockNumber, parent_hash: T::Hash) {
+    frame_system::Pallet::<T>::set_block_number(block_number);
+    frame_system::Pallet::<T>::initialize(&block_number, &parent_hash, &Default::default());
+    <crate::Pallet<T> as Hooks<T::BlockNumber>>::on_initialize(block_number);
+    frame_system::Pallet::<T>::finalize();
+}
+
+pub(crate) fn register_genesis_domain(creator: u64, operator_ids: Vec<OperatorId>) -> DomainId {
+    assert_ok!(crate::Pallet::<Test>::register_domain_runtime(
+        RawOrigin::Root.into(),
+        b"evm".to_vec(),
+        RuntimeType::Evm,
+        vec![1, 2, 3, 4],
+    ));
+
+    let domain_id = NextDomainId::<Test>::get();
+    <Test as Config>::Currency::make_free_balance_be(
+        &creator,
+        <Test as Config>::DomainInstantiationDeposit::get()
+            + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
+    );
+    crate::Pallet::<Test>::instantiate_domain(
+        RawOrigin::Signed(creator).into(),
+        DomainConfig {
+            domain_name: b"evm-domain".to_vec(),
+            runtime_id: 0,
+            max_block_size: 1u32,
+            max_block_weight: Weight::from_parts(1, 0),
+            bundle_slot_probability: (1, 1),
+            target_bundles_per_block: 1,
+        },
+        vec![],
+    )
+    .unwrap();
+
+    let pair = OperatorPair::from_seed(&U256::from(0u32).into());
+    for operator_id in operator_ids {
+        Operators::<Test>::insert(
+            operator_id,
+            Operator {
+                signing_key: pair.public(),
+                current_domain_id: domain_id,
+                next_domain_id: domain_id,
+                minimum_nominator_stake: SSC,
+                nomination_tax: Default::default(),
+                current_total_stake: Zero::zero(),
+                current_epoch_rewards: Zero::zero(),
+                total_shares: Zero::zero(),
+                status: OperatorStatus::Registered,
+            },
+        );
+    }
+
+    domain_id
+}
+
+// Submit new head receipt to extend the block tree
+pub(crate) fn extend_block_tree(domain_id: DomainId, operator_id: u64, to: u64) {
+    let head_receipt_number = HeadReceiptNumber::<Test>::get(domain_id);
+    assert!(head_receipt_number < to);
+
+    let head_node = get_block_tree_node_at::<Test>(domain_id, head_receipt_number).unwrap();
+    let mut receipt = head_node.execution_receipt;
+    assert_eq!(
+        receipt.consensus_block_number,
+        frame_system::Pallet::<Test>::current_block_number()
+    );
+    for block_number in (head_receipt_number + 1)..=to {
+        // Finilize parent block and initialize block at `block_number`
+        run_to_block::<Test>(block_number, receipt.consensus_block_hash);
+
+        // Submit a bundle with the receipt of the last block
+        let bundle_extrinsics_root = H256::random();
+        let bundle = create_dummy_bundle_with_receipts(
+            domain_id,
+            operator_id,
+            bundle_extrinsics_root,
+            receipt,
+        );
+        assert_ok!(crate::Pallet::<Test>::submit_bundle(
+            RawOrigin::None.into(),
+            bundle,
+        ));
+
+        // Construct a `NewHead` receipt of the just submitted bundle, which will be included in the next bundle
+        let head_receipt_number = HeadReceiptNumber::<Test>::get(domain_id);
+        let parent_block_tree_node =
+            get_block_tree_node_at::<Test>(domain_id, head_receipt_number).unwrap();
+        receipt = create_dummy_receipt(
+            block_number,
+            H256::random(),
+            parent_block_tree_node.execution_receipt.hash(),
+            vec![bundle_extrinsics_root],
+        );
+    }
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn get_block_tree_node_at<T: Config>(
+    domain_id: DomainId,
+    block_number: T::DomainNumber,
+) -> Option<DomainBlock<T::BlockNumber, T::Hash, T::DomainNumber, T::DomainHash, BalanceOf<T>>> {
+    BlockTree::<T>::get(domain_id, block_number)
+        .first()
+        .and_then(DomainBlocks::<T>::get)
 }
 
 // TODO: Unblock once bundle producer election v2 is finished.

--- a/crates/subspace-fraud-proof/src/invalid_transaction_proof.rs
+++ b/crates/subspace-fraud-proof/src/invalid_transaction_proof.rs
@@ -156,6 +156,7 @@ where
             domain_block_hash,
             invalid_extrinsic,
             storage_proof,
+            ..
         } = invalid_transaction_proof;
 
         // TODO: Validate bundle solution.


### PR DESCRIPTION
close #1529 

This PR implements the fraud proof v2 processing, which includes:
- Remove the fraudulent ER and all of its descendants from the block tree
- Potentially update the head receipt number
- Slash the operator who has submitted the pruned fraudulent ER

NOTE: there is a `DomainBlockDescendants` storage item introduced in this PR to keep track of the immediate descendant of an ER, and it is used to determine and remove all of the descendants of the targetted ER. This tracking can be removed once #1731 is implemented because by then every ER should only have one immediate descendant.

Recommend to review this PR commit by commit.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
