### PR TITLE
Slash invalid bundle authors when the corresponding ER is confirmed

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -110,8 +110,9 @@ mod pallet {
     };
     use crate::staking::{
         do_auto_stake_block_rewards, do_deregister_operator, do_nominate_operator,
-        do_register_operator, do_reward_operators, do_switch_operator_domain, do_withdraw_stake,
-        Error as StakingError, Nominator, Operator, OperatorConfig, StakingSummary, Withdraw,
+        do_register_operator, do_reward_operators, do_slash_operators, do_switch_operator_domain,
+        do_withdraw_stake, Error as StakingError, Nominator, Operator, OperatorConfig,
+        StakingSummary, Withdraw,
     };
     use crate::staking_epoch::{
         do_finalize_domain_current_epoch, do_unlock_pending_withdrawals,
@@ -727,6 +728,11 @@ mod pallet {
                             domain_id,
                             confirmed_block_info.operator_ids.into_iter(),
                             confirmed_block_info.rewards,
+                        )
+                        .map_err(Error::<T>::from)?;
+
+                        do_slash_operators::<T>(
+                            confirmed_block_info.invalid_bundle_authors.into_iter(),
                         )
                         .map_err(Error::<T>::from)?;
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -708,7 +708,7 @@ mod pallet {
                 }
                 // Add the exeuctione receipt to the block tree
                 ReceiptType::Accepted(accepted_receipt_type) => {
-                    let maybe_pruned_domain_block_info = process_execution_receipt::<T>(
+                    let maybe_confirmed_domain_block_info = process_execution_receipt::<T>(
                         domain_id,
                         operator_id,
                         receipt,
@@ -716,26 +716,26 @@ mod pallet {
                     )
                     .map_err(Error::<T>::from)?;
 
-                    // If any domain block is pruned, then we have a new head added
+                    // If any domain block is confirmed, then we have a new head added
                     // so distribute the operator rewards and, if required, do epoch transition as well.
                     //
                     // NOTE: Skip the following staking related operations when benchmarking the
                     // `submit_bundle` call, these operations will be benchmarked separately.
                     #[cfg(not(feature = "runtime-benchmarks"))]
-                    if let Some(pruned_block_info) = maybe_pruned_domain_block_info {
+                    if let Some(confirmed_block_info) = maybe_confirmed_domain_block_info {
                         do_reward_operators::<T>(
                             domain_id,
-                            pruned_block_info.operator_ids.into_iter(),
-                            pruned_block_info.rewards,
+                            confirmed_block_info.operator_ids.into_iter(),
+                            confirmed_block_info.rewards,
                         )
                         .map_err(Error::<T>::from)?;
 
-                        if pruned_block_info.domain_block_number % T::StakeEpochDuration::get()
+                        if confirmed_block_info.domain_block_number % T::StakeEpochDuration::get()
                             == Zero::zero()
                         {
                             let completed_epoch_index = do_finalize_domain_current_epoch::<T>(
                                 domain_id,
-                                pruned_block_info.domain_block_number,
+                                confirmed_block_info.domain_block_number,
                             )
                             .map_err(Error::<T>::from)?;
 
@@ -747,7 +747,7 @@ mod pallet {
 
                         do_unlock_pending_withdrawals::<T>(
                             domain_id,
-                            pruned_block_info.domain_block_number,
+                            confirmed_block_info.domain_block_number,
                         )
                         .map_err(Error::<T>::from)?;
                     }

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -501,8 +501,6 @@ pub(crate) fn do_auto_stake_block_rewards<T: Config>(
     Ok(())
 }
 
-#[allow(dead_code)]
-// TODO: remove once fraud proof is done
 /// Freezes the slashed operators and moves the operator to be removed once the domain they are
 /// operating finishes the epoch.
 pub(crate) fn do_slash_operators<T: Config>(


### PR DESCRIPTION
This PR is part of #1899, it takes care of slashing the invalid bundle authors.

Another missing piece of #1899 is slashing the operator who submitted the fraudulent ER which was implemented in #1932.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
