### PR TITLE
Parallelize audit across multiple cores

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -990,6 +990,7 @@ impl SingleDiskFarm {
                         }
 
                         farming::<_, PosTable>(
+                            disk_farm_index,
                             public_key,
                             reward_address,
                             node_client,


### PR DESCRIPTION
Turns out going through it sequentially either incurs a lot of wait time or can even be limited by single core performance just to generate all the challenges for large farms.

Parallelization fixes both of these issues.

If you ignore whitespace changes the diff is really small.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
