### PR TITLE
Support for votes verification when proof of time is enabled

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1512,7 +1512,7 @@ fn check_vote<T: Config>(
 
     let current_vote_verification_data = current_vote_verification_data::<T>(pre_dispatch);
     let parent_vote_verification_data = ParentVoteVerificationData::<T>::get()
-        .expect("Above check for block number ensures that this value is always present");
+        .expect("Above check for block number ensures that this value is always present; qed");
 
     if pre_dispatch {
         // New time slot is already set, whatever time slot is in the vote it must be smaller or the
@@ -1528,7 +1528,7 @@ fn check_vote<T: Config>(
     }
 
     let parent_slot = if pre_dispatch {
-        // For pre-dispatch parent slot is `current_slot` if the parent vote verification data (it
+        // For pre-dispatch parent slot is `current_slot` in the parent vote verification data (it
         // was updated in current block because initialization hook was already called) if vote is
         // at the same height as the current block, otherwise it is one level older and
         // `parent_slot` from parent vote verification data needs to be taken instead
@@ -1538,8 +1538,8 @@ fn check_vote<T: Config>(
             parent_vote_verification_data.parent_slot
         }
     } else {
-        // Otherwise parent slot is `current_slot` if the current vote verification data (that
-        // wan't updated from parent block because initialization hook wasn't called yet) if vote
+        // Otherwise parent slot is `current_slot` in the current vote verification data (that
+        // wasn't updated from parent block because initialization hook wasn't called yet) if vote
         // is at the same height as the current block, otherwise it is one level older and
         // `parent_slot` from current vote verification data needs to be taken instead
         if height == current_block_number {

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -31,6 +31,8 @@ use sp_consensus_slots::Slot;
 #[cfg(feature = "pot")]
 use sp_consensus_subspace::digests::PreDigestPotInfo;
 use sp_consensus_subspace::digests::{CompatibleDigestItem, PreDigest};
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::PotExtension;
 use sp_consensus_subspace::{FarmerSignature, KzgExtension, PosExtension, SignedVote, Vote};
 use sp_core::crypto::UncheckedFrom;
 use sp_core::H256;
@@ -306,6 +308,10 @@ pub fn new_test_ext() -> TestExternalities {
 
     ext.register_extension(KzgExtension::new(Kzg::new(embedded_kzg_settings())));
     ext.register_extension(PosExtension::new::<PosTable>());
+    #[cfg(feature = "pot")]
+    ext.register_extension(PotExtension::new(Box::new(
+        |parent_hash, slot, proof_of_time| todo!(),
+    )));
 
     ext
 }

--- a/crates/sc-proof-of-time/src/verifier.rs
+++ b/crates/sc-proof-of-time/src/verifier.rs
@@ -89,6 +89,7 @@ impl PotVerifier {
     ///
     /// NOTE: Potentially much slower than checkpoints, prefer [`Self::verify_checkpoints()`]
     /// whenever possible.
+    // TODO: Version of this API that never invokes proving, just checks
     pub async fn is_proof_valid(
         &self,
         #[cfg(feature = "pot")] mut slot: Slot,

--- a/crates/sp-lightclient/src/mock.rs
+++ b/crates/sp-lightclient/src/mock.rs
@@ -3,6 +3,8 @@ use codec::{Decode, Encode};
 use frame_support::sp_io::TestExternalities;
 use scale_info::TypeInfo;
 use sp_arithmetic::traits::Zero;
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::PotExtension;
 use sp_consensus_subspace::{KzgExtension, PosExtension};
 use sp_runtime::traits::{BlakeTwo256, Header as HeaderT};
 use std::collections::{BTreeMap, HashMap};
@@ -203,6 +205,10 @@ pub fn new_test_ext() -> TestExternalities {
 
     ext.register_extension(KzgExtension::new(Kzg::new(embedded_kzg_settings())));
     ext.register_extension(PosExtension::new::<PosTable>());
+    #[cfg(feature = "pot")]
+    ext.register_extension(PotExtension::new(Box::new(
+        |parent_hash, slot, proof_of_time| todo!(),
+    )));
 
     ext
 }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -131,6 +131,9 @@ impl Randomness {
 /// Block number in Subspace network.
 pub type BlockNumber = u32;
 
+/// Block hash in Subspace network.
+pub type BlockHash = [u8; 32];
+
 /// Slot number in Subspace network.
 pub type SlotNumber = u64;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1325,6 +1325,8 @@ impl_runtime_apis! {
                 parent_hash,
                 slot,
                 solution,
+                proof_of_time,
+                future_proof_of_time,
             } = vote;
 
             Subspace::submit_vote(SignedVote {
@@ -1333,6 +1335,8 @@ impl_runtime_apis! {
                     parent_hash,
                     slot,
                     solution: solution.into_reward_address_format::<RewardAddress, AccountId32>(),
+                    proof_of_time,
+                    future_proof_of_time,
                 },
                 signature,
             })

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1594,6 +1594,8 @@ impl_runtime_apis! {
                 parent_hash,
                 slot,
                 solution,
+                proof_of_time,
+                future_proof_of_time,
             } = vote;
 
             Subspace::submit_vote(SignedVote {
@@ -1602,6 +1604,8 @@ impl_runtime_apis! {
                     parent_hash,
                     slot,
                     solution: solution.into_reward_address_format::<RewardAddress, AccountId32>(),
+                    proof_of_time,
+                    future_proof_of_time,
                 },
                 signature,
             })


### PR DESCRIPTION
This builds on top of https://github.com/subspace/subspace/pull/1939 and is actually fairly straightforward all things considered.

Votes here are extended with proof of time and future proof of time, the same way header pre-digest was modified.

Since votes have to follow parent block they point to just like blocks and we have future proofs in blocks, it must be possible to cheaply verify (meaning we don't need to actually run verification, just check against previously verified proofs) where proof of time is valid (though cheap API is a new TODO in the code, it may involve fairly expensive verification in practice).

Future proof of time is not verified until vote is supposed to be included into the block and since vote can be in future comparing to the block, at which point all proofs of the block itself were already verified and verification of vote's future proof should also be cheap or else future proof is invalid. Also it wouldn't make much sense for farmer to produce otherwise correct proof, but invalid future proof of time, it doesn't make economic sense.

Since runtime can't possibly know future proofs (relative to parent block), the only way to cheaply verify proofs of time is to call into the client where verifier should have proofs cached. This is why new host function is introduced.

Major things lacking from eventual implementation:
* checkpoints in justifications
* optimistic verification during major sync
* gossip tuning and punishment, it fuctional as is, but very easy to attack
* cheap PoT verification
* unlock and fix tests in `pallet-subspace` and `sp-lightclient`, add a bunch more tests

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
