### PR TITLE
Rename `PotProof` to `PotOutput`

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -56,7 +56,7 @@ use sp_consensus_subspace::{
     ChainConstants, EquivocationProof, FarmerPublicKey, FarmerSignature, SignedVote, Vote,
 };
 #[cfg(feature = "pot")]
-use sp_consensus_subspace::{PotParameters, PotParametersChange, WrappedPotProof};
+use sp_consensus_subspace::{PotParameters, PotParametersChange, WrappedPotOutput};
 use sp_runtime::generic::DigestItem;
 #[cfg(feature = "pot")]
 use sp_runtime::traits::CheckedSub;
@@ -1659,7 +1659,7 @@ fn check_vote<T: Config>(
         BlockHash::try_from(parent_hash.as_ref())
             .expect("Must be able to convert to block hash type"),
         SlotNumber::from(slot),
-        WrappedPotProof::from(*proof_of_time),
+        WrappedPotOutput::from(*proof_of_time),
     ) {
         debug!(target: "runtime::subspace", "Invalid proof of time");
 
@@ -1674,7 +1674,7 @@ fn check_vote<T: Config>(
             BlockHash::try_from(parent_hash.as_ref())
                 .expect("Must be able to convert to block hash type"),
             SlotNumber::from(slot + T::BlockAuthoringDelay::get()),
-            WrappedPotProof::from(*future_proof_of_time),
+            WrappedPotOutput::from(*future_proof_of_time),
         )
     {
         debug!(target: "runtime::subspace", "Invalid future proof of time");

--- a/crates/sc-consensus-subspace/src/import_queue.rs
+++ b/crates/sc-consensus-subspace/src/import_queue.rs
@@ -268,7 +268,7 @@ where
         #[cfg(feature = "pot")]
         if !self
             .pot_verifier
-            .is_proof_valid(
+            .is_output_valid(
                 next_slot,
                 pot_seed,
                 slot_iterations,

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -837,7 +837,7 @@ where
         // verify the rest.
         if !self
             .pot_verifier
-            .is_proof_valid(
+            .is_output_valid(
                 parent_slot + Slot::from(1),
                 pot_seed,
                 slot_iterations,

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -64,7 +64,7 @@ use std::sync::Arc;
 use subspace_core_primitives::Randomness;
 use subspace_core_primitives::{BlockNumber, PublicKey, RewardSignature, SectorId, Solution};
 #[cfg(feature = "pot")]
-use subspace_core_primitives::{PotCheckpoints, PotProof};
+use subspace_core_primitives::{PotCheckpoints, PotOutput};
 use subspace_proof_of_space::Table;
 use subspace_verification::{
     check_reward_signature, verify_solution, PieceCheckParams, VerifySolutionParams,
@@ -381,7 +381,7 @@ where
             // Ensure proof of time and future proof of time included in upcoming block are valid
             if !self
                 .pot_verifier
-                .is_proof_valid(
+                .is_output_valid(
                     after_parent_slot,
                     pot_seed,
                     slot_iterations,
@@ -730,8 +730,8 @@ where
         parent_header: &Block::Header,
         slot: Slot,
         solution: Solution<FarmerPublicKey, FarmerPublicKey>,
-        #[cfg(feature = "pot")] proof_of_time: PotProof,
-        #[cfg(feature = "pot")] future_proof_of_time: PotProof,
+        #[cfg(feature = "pot")] proof_of_time: PotOutput,
+        #[cfg(feature = "pot")] future_proof_of_time: PotOutput,
     ) {
         let parent_hash = parent_header.hash();
         let runtime_api = self.client.runtime_api();

--- a/crates/sc-proof-of-time/src/verifier/tests.rs
+++ b/crates/sc-proof-of-time/src/verifier/tests.rs
@@ -23,7 +23,7 @@ fn test_basic() {
     let verifier = PotVerifier::new(genesis_seed, NonZeroUsize::new(1000).unwrap());
 
     // Expected to be valid
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(1),
         genesis_seed,
@@ -40,7 +40,7 @@ fn test_basic() {
     )));
 
     // Invalid number of slots
-    assert!(!block_on(verifier.is_proof_valid(
+    assert!(!block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(1),
         genesis_seed,
@@ -51,7 +51,7 @@ fn test_basic() {
         None
     )));
     // Invalid seed
-    assert!(!block_on(verifier.is_proof_valid(
+    assert!(!block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(1),
         checkpoints_1.output().seed(),
@@ -76,7 +76,7 @@ fn test_basic() {
     let checkpoints_2 = subspace_proof_of_time::prove(seed_1, slot_iterations).unwrap();
 
     // Expected to be valid
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(2),
         seed_1,
@@ -86,7 +86,7 @@ fn test_basic() {
         #[cfg(feature = "pot")]
         None
     )));
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(1),
         genesis_seed,
@@ -103,7 +103,7 @@ fn test_basic() {
     )));
 
     // Invalid number of slots
-    assert!(!block_on(verifier.is_proof_valid(
+    assert!(!block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(1),
         seed_1,
@@ -114,7 +114,7 @@ fn test_basic() {
         None
     )));
     // Invalid seed
-    assert!(!block_on(verifier.is_proof_valid(
+    assert!(!block_on(verifier.is_output_valid(
         #[cfg(feature = "pot")]
         Slot::from(1),
         seed_1,
@@ -126,7 +126,7 @@ fn test_basic() {
     )));
     // Invalid number of iterations
     assert!(!block_on(
-        verifier.is_proof_valid(
+        verifier.is_output_valid(
             #[cfg(feature = "pot")]
             Slot::from(1),
             genesis_seed,
@@ -160,7 +160,7 @@ fn parameters_change() {
     let verifier = PotVerifier::new(genesis_seed, NonZeroUsize::new(1000).unwrap());
 
     // Changing parameters after first slot
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         Slot::from(1),
         genesis_seed,
         slot_iterations_1,
@@ -173,7 +173,7 @@ fn parameters_change() {
         })
     )));
     // Changing parameters in the middle
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         Slot::from(1),
         genesis_seed,
         slot_iterations_1,
@@ -186,7 +186,7 @@ fn parameters_change() {
         })
     )));
     // Changing parameters on last slot
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         Slot::from(1),
         genesis_seed,
         slot_iterations_1,
@@ -199,7 +199,7 @@ fn parameters_change() {
         })
     )));
     // Not changing parameters because changes apply to the very first slot that is verified
-    assert!(block_on(verifier.is_proof_valid(
+    assert!(block_on(verifier.is_output_valid(
         Slot::from(2),
         checkpoints_1.output().seed_with_entropy(&entropy),
         slot_iterations_2,
@@ -213,7 +213,7 @@ fn parameters_change() {
     )));
 
     // Missing parameters change
-    assert!(!block_on(verifier.is_proof_valid(
+    assert!(!block_on(verifier.is_output_valid(
         Slot::from(1),
         genesis_seed,
         slot_iterations_1,
@@ -222,7 +222,7 @@ fn parameters_change() {
         None
     )));
     // Invalid slot
-    assert!(!block_on(verifier.is_proof_valid(
+    assert!(!block_on(verifier.is_output_valid(
         Slot::from(2),
         genesis_seed,
         slot_iterations_1,

--- a/crates/sp-consensus-subspace/src/digests.rs
+++ b/crates/sp-consensus-subspace/src/digests.rs
@@ -31,7 +31,7 @@ use sp_std::fmt;
 #[cfg(feature = "pot")]
 use sp_std::num::NonZeroU32;
 #[cfg(feature = "pot")]
-use subspace_core_primitives::PotProof;
+use subspace_core_primitives::PotOutput;
 #[cfg(not(feature = "pot"))]
 use subspace_core_primitives::Randomness;
 use subspace_core_primitives::{SegmentCommitment, SegmentIndex, Solution, SolutionRange};
@@ -87,9 +87,9 @@ pub enum PreDigestPotInfo {
     #[codec(index = 0)]
     V0 {
         /// Proof of time for this slot
-        proof_of_time: PotProof,
+        proof_of_time: PotOutput,
         /// Future proof of time
-        future_proof_of_time: PotProof,
+        future_proof_of_time: PotOutput,
     },
 }
 
@@ -98,7 +98,7 @@ impl PreDigestPotInfo {
     /// Proof of time for this slot
     #[cfg(feature = "pot")]
     #[inline]
-    pub fn proof_of_time(&self) -> PotProof {
+    pub fn proof_of_time(&self) -> PotOutput {
         let Self::V0 { proof_of_time, .. } = self;
         *proof_of_time
     }
@@ -106,7 +106,7 @@ impl PreDigestPotInfo {
     /// Future proof of time
     #[cfg(feature = "pot")]
     #[inline]
-    pub fn future_proof_of_time(&self) -> PotProof {
+    pub fn future_proof_of_time(&self) -> PotOutput {
         let Self::V0 {
             future_proof_of_time,
             ..

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -511,13 +511,13 @@ impl<'a> PassBy for WrappedVerifySolutionParams<'a> {
     type PassBy = pass_by::Codec<Self>;
 }
 
-/// Wrapped solution verification parameters for the purposes of runtime interface.
+/// Wrapped proof of time output for the purposes of runtime interface.
 #[derive(Debug, Encode, Decode)]
 #[cfg(feature = "pot")]
-pub struct WrappedPotProof(PotOutput);
+pub struct WrappedPotOutput(PotOutput);
 
 #[cfg(feature = "pot")]
-impl From<PotOutput> for WrappedPotProof {
+impl From<PotOutput> for WrappedPotOutput {
     #[inline]
     fn from(value: PotOutput) -> Self {
         Self(value)
@@ -525,7 +525,7 @@ impl From<PotOutput> for WrappedPotProof {
 }
 
 #[cfg(feature = "pot")]
-impl PassBy for WrappedPotProof {
+impl PassBy for WrappedPotOutput {
     type PassBy = pass_by::Codec<Self>;
 }
 
@@ -630,7 +630,7 @@ pub trait Consensus {
         &mut self,
         parent_hash: BlockHash,
         slot: SlotNumber,
-        proof_of_time: WrappedPotProof,
+        proof_of_time: WrappedPotOutput,
     ) -> bool {
         use sp_externalities::ExternalitiesExt;
 

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -50,7 +50,7 @@ use subspace_core_primitives::BlockHash;
 #[cfg(not(feature = "pot"))]
 use subspace_core_primitives::Randomness;
 #[cfg(feature = "pot")]
-use subspace_core_primitives::{Blake3Hash, PotProof};
+use subspace_core_primitives::{Blake3Hash, PotOutput};
 use subspace_core_primitives::{
     BlockNumber, HistorySize, PotCheckpoints, PublicKey, RewardSignature, SegmentCommitment,
     SegmentHeader, SegmentIndex, SlotNumber, Solution, SolutionRange, PUBLIC_KEY_LENGTH,
@@ -205,10 +205,10 @@ pub enum Vote<Number, Hash, RewardAddress> {
         solution: Solution<FarmerPublicKey, RewardAddress>,
         /// Proof of time for this slot
         #[cfg(feature = "pot")]
-        proof_of_time: PotProof,
+        proof_of_time: PotOutput,
         /// Future proof of time
         #[cfg(feature = "pot")]
-        future_proof_of_time: PotProof,
+        future_proof_of_time: PotOutput,
     },
 }
 
@@ -514,12 +514,12 @@ impl<'a> PassBy for WrappedVerifySolutionParams<'a> {
 /// Wrapped solution verification parameters for the purposes of runtime interface.
 #[derive(Debug, Encode, Decode)]
 #[cfg(feature = "pot")]
-pub struct WrappedPotProof(PotProof);
+pub struct WrappedPotProof(PotOutput);
 
 #[cfg(feature = "pot")]
-impl From<PotProof> for WrappedPotProof {
+impl From<PotOutput> for WrappedPotProof {
     #[inline]
-    fn from(value: PotProof) -> Self {
+    fn from(value: PotOutput) -> Self {
         Self(value)
     }
 }
@@ -563,14 +563,14 @@ impl PosExtension {
 #[cfg(all(feature = "std", feature = "pot"))]
 sp_externalities::decl_extension! {
     /// A Poof of time extension.
-    pub struct PotExtension(Box<dyn (Fn(BlockHash, SlotNumber, PotProof) -> bool) + Send + Sync>);
+    pub struct PotExtension(Box<dyn (Fn(BlockHash, SlotNumber, PotOutput) -> bool) + Send + Sync>);
 }
 
 #[cfg(all(feature = "std", feature = "pot"))]
 impl PotExtension {
     /// Create new instance.
     pub fn new(
-        verifier: Box<dyn (Fn(BlockHash, SlotNumber, PotProof) -> bool) + Send + Sync>,
+        verifier: Box<dyn (Fn(BlockHash, SlotNumber, PotOutput) -> bool) + Send + Sync>,
     ) -> Self {
         Self(verifier)
     }

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -26,7 +26,7 @@ use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 #[cfg(feature = "pot")]
-use subspace_core_primitives::PotProof;
+use subspace_core_primitives::PotOutput;
 use subspace_core_primitives::{
     BlockWeight, HistorySize, PublicKey, Randomness, Record, RecordedHistorySegment,
     SegmentCommitment, SegmentIndex, SlotNumber, Solution, SolutionRange,
@@ -130,9 +130,9 @@ struct ValidHeaderParams<'a> {
     #[cfg(not(feature = "pot"))]
     global_randomness: Randomness,
     #[cfg(feature = "pot")]
-    proof_of_time: PotProof,
+    proof_of_time: PotOutput,
     #[cfg(feature = "pot")]
-    future_proof_of_time: PotProof,
+    future_proof_of_time: PotOutput,
     farmer_parameters: &'a FarmerParameters,
 }
 
@@ -797,10 +797,10 @@ fn test_reorg_to_heavier_smaller_chain() {
                 global_randomness: digests_at_2.global_randomness,
                 // TODO: Correct value
                 #[cfg(feature = "pot")]
-                proof_of_time: PotProof::default(),
+                proof_of_time: PotOutput::default(),
                 // TODO: Correct value
                 #[cfg(feature = "pot")]
-                future_proof_of_time: PotProof::default(),
+                future_proof_of_time: PotOutput::default(),
                 farmer_parameters: &farmer_parameters,
             });
         seal_header(&keypair, &mut header);

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -332,7 +332,7 @@ impl PotSeed {
     }
 }
 
-/// Proof of time checkpoint
+/// Proof of time output, can be intermediate checkpoint or final slot output
 #[derive(
     Debug,
     Default,
@@ -351,15 +351,15 @@ impl PotSeed {
     MaxEncodedLen,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PotProof(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; Self::SIZE]);
+pub struct PotOutput(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; Self::SIZE]);
 
-impl fmt::Display for PotProof {
+impl fmt::Display for PotOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
     }
 }
 
-impl PotProof {
+impl PotOutput {
     /// Size of proof of time proof in bytes
     pub const SIZE: usize = 16;
 
@@ -400,7 +400,7 @@ impl PotProof {
     TypeInfo,
     MaxEncodedLen,
 )]
-pub struct PotCheckpoints([PotProof; Self::NUM_CHECKPOINTS.get() as usize]);
+pub struct PotCheckpoints([PotOutput; Self::NUM_CHECKPOINTS.get() as usize]);
 
 impl PotCheckpoints {
     /// Number of PoT checkpoints produced (used to optimize verification)
@@ -408,7 +408,7 @@ impl PotCheckpoints {
 
     /// Get proof of time output out of checkpoints (last checkpoint)
     #[inline]
-    pub fn output(&self) -> PotProof {
+    pub fn output(&self) -> PotOutput {
         self.0[Self::NUM_CHECKPOINTS.get() as usize - 1]
     }
 }

--- a/crates/subspace-proof-of-time/src/aes.rs
+++ b/crates/subspace-proof-of-time/src/aes.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
-use subspace_core_primitives::{PotCheckpoints, PotKey, PotProof, PotSeed};
+use subspace_core_primitives::{PotCheckpoints, PotKey, PotOutput, PotSeed};
 
 /// Creates the AES based proof.
 #[inline(always)]
@@ -48,7 +48,7 @@ fn create_generic(seed: PotSeed, key: PotKey, checkpoint_iterations: u32) -> Pot
 pub(crate) fn verify_sequential(
     seed: PotSeed,
     key: PotKey,
-    checkpoints: &[PotProof],
+    checkpoints: &[PotOutput],
     checkpoint_iterations: u32,
 ) -> bool {
     assert_eq!(checkpoint_iterations % 2, 0);
@@ -77,7 +77,7 @@ pub(crate) fn verify_sequential(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use subspace_core_primitives::{PotKey, PotProof, PotSeed};
+    use subspace_core_primitives::{PotKey, PotOutput, PotSeed};
 
     const SEED: [u8; 16] = [
         0xd6, 0x66, 0xcc, 0xd8, 0xd5, 0x93, 0xc2, 0x3d, 0xa8, 0xdb, 0x6b, 0x5b, 0x14, 0x13, 0xb1,
@@ -120,7 +120,7 @@ mod tests {
 
         // Decryption of invalid cipher text fails.
         let mut checkpoints_1 = checkpoints;
-        checkpoints_1[0] = PotProof::from(BAD_CIPHER);
+        checkpoints_1[0] = PotOutput::from(BAD_CIPHER);
         assert!(!verify_sequential(
             seed,
             key,

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -4,7 +4,7 @@
 mod aes;
 
 use core::num::NonZeroU32;
-use subspace_core_primitives::{PotCheckpoints, PotProof, PotSeed};
+use subspace_core_primitives::{PotCheckpoints, PotOutput, PotSeed};
 
 /// Proof of time error
 #[derive(Debug)]
@@ -50,7 +50,7 @@ pub fn prove(seed: PotSeed, iterations: NonZeroU32) -> Result<PotCheckpoints, Po
 pub fn verify(
     seed: PotSeed,
     iterations: NonZeroU32,
-    checkpoints: &[PotProof],
+    checkpoints: &[PotOutput],
 ) -> Result<bool, PotError> {
     let num_checkpoints = checkpoints.len() as u32;
     if iterations.get() % (num_checkpoints * 2) != 0 {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -351,7 +351,7 @@ where
 
                 // Ensure proof of time and future proof of time included in upcoming block are
                 // valid
-                block_on(pot_verifier.is_proof_valid(
+                block_on(pot_verifier.is_output_valid(
                     after_parent_slot,
                     pot_seed,
                     slot_iterations,

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -33,7 +33,7 @@ use subspace_core_primitives::crypto::{
     blake3_hash_list, Scalar,
 };
 use subspace_core_primitives::{
-    Blake2b256Hash, Blake3Hash, BlockNumber, BlockWeight, HistorySize, PotProof, PublicKey,
+    Blake2b256Hash, Blake3Hash, BlockNumber, BlockWeight, HistorySize, PotOutput, PublicKey,
     Randomness, Record, RewardSignature, SectorId, SectorSlotChallenge, SegmentCommitment,
     SlotNumber, Solution, SolutionRange,
 };
@@ -168,7 +168,7 @@ pub struct VerifySolutionParams {
     pub global_randomness: Randomness,
     /// Proof of time for which solution is built
     #[cfg(feature = "pot")]
-    pub proof_of_time: PotProof,
+    pub proof_of_time: PotOutput,
     /// Solution range
     pub solution_range: SolutionRange,
     /// Parameters for checking piece validity.
@@ -339,7 +339,7 @@ pub fn derive_randomness<PublicKey, RewardAddress>(
 }
 
 /// Derive proof of time entropy from chunk and proof of time for injection purposes.
-pub fn derive_pot_entropy(chunk: Scalar, proof_of_time: PotProof) -> Blake3Hash {
+pub fn derive_pot_entropy(chunk: Scalar, proof_of_time: PotOutput) -> Blake3Hash {
     blake3_hash_list(&[&chunk.to_bytes(), proof_of_time.as_ref()])
 }
 


### PR DESCRIPTION
Simple renaming as discussed previously

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
