### PR TITLE
Fix node DSN sync.

### DIFF
--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -435,6 +435,7 @@ fn main() -> Result<(), Error> {
                         sync_from_dsn: cli.sync_from_dsn,
                         enable_subspace_block_relay: cli.enable_subspace_block_relay
                             || cli.run.is_dev().unwrap_or(false),
+                        dsn_sync_parallelism_level: cli.dsn_sync_parallelism_level.get(),
                     };
 
                     let construct_domain_genesis_block_builder =

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -239,7 +239,7 @@ pub struct Cli {
     pub dsn_in_connections: u32,
 
     /// Defines max established outgoing swarm connection limit for DSN.
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 150)]
     pub dsn_out_connections: u32,
 
     /// Defines max pending incoming connection limit for DSN.
@@ -247,11 +247,11 @@ pub struct Cli {
     pub dsn_pending_in_connections: u32,
 
     /// Defines max pending outgoing swarm connection limit for DSN.
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 150)]
     pub dsn_pending_out_connections: u32,
 
     /// Defines target total (in and out) connection number for DSN that should be maintained.
-    #[arg(long, default_value_t = 50)]
+    #[arg(long, default_value_t = 30)]
     pub dsn_target_connections: u32,
 
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -30,6 +30,7 @@ use sc_subspace_chain_specs::ConsensusChainSpec;
 use sc_telemetry::serde_json;
 use serde_json::Value;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::{fs, io};
 use subspace_networking::libp2p::Multiaddr;
 
@@ -287,6 +288,12 @@ pub struct Cli {
     /// Assigned PoT role for this node.
     #[arg(long, default_value = "none", value_parser(EnumValueParser::< CliPotRole >::new()))]
     pub pot_role: CliPotRole,
+
+    /// Defines the parallelism level (number of simultaneous requests) for DSN synchronization.
+    /// It should be changed along with outgoing connection limits. Affects the sync performance,
+    /// error rate, and overall machine responsiveness.
+    #[arg(long, default_value_t = NonZeroUsize::new(5).expect("Manual setting"))]
+    pub dsn_sync_parallelism_level: NonZeroUsize,
 }
 
 impl SubstrateCli for Cli {

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -10,8 +10,8 @@ use subspace_networking::libp2p::{identity, Multiaddr};
 use subspace_networking::utils::strip_peer_id;
 use subspace_networking::{
     CreationError, NetworkParametersPersistenceError, NetworkingParametersManager, Node,
-    NodeRunner, PeerInfoProvider, SegmentHeaderBySegmentIndexesRequestHandler,
-    SegmentHeaderRequest, SegmentHeaderResponse,
+    NodeRunner, PeerInfoProvider, PieceByIndexRequestHandler,
+    SegmentHeaderBySegmentIndexesRequestHandler, SegmentHeaderRequest, SegmentHeaderResponse,
 };
 use thiserror::Error;
 use tracing::{debug, error, trace};
@@ -112,8 +112,10 @@ where
         listen_on: dsn_config.listen_on,
         allow_non_global_addresses_in_dht: dsn_config.allow_non_global_addresses_in_dht,
         networking_parameters_registry,
-        request_response_protocols: vec![SegmentHeaderBySegmentIndexesRequestHandler::create(
-            move |_, req| {
+        request_response_protocols: vec![
+            // We need to enable protocol to request pieces
+            PieceByIndexRequestHandler::create(|_, _| async { None }),
+            SegmentHeaderBySegmentIndexesRequestHandler::create(move |_, req| {
                 let segment_indexes = match req {
                     SegmentHeaderRequest::SegmentIndexes { segment_indexes } => {
                         segment_indexes.clone()
@@ -162,8 +164,8 @@ where
                 };
 
                 async move { result }
-            },
-        )],
+            }),
+        ],
         max_established_incoming_connections: dsn_config.max_in_connections,
         max_established_outgoing_connections: dsn_config.max_out_connections,
         max_pending_incoming_connections: dsn_config.max_pending_in_connections,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -199,6 +199,8 @@ pub struct SubspaceConfiguration {
     /// Use the block request handler implementation from subspace
     /// instead of the default substrate handler.
     pub enable_subspace_block_relay: bool,
+    /// Defines the parallelism level (number of simultaneous requests) for DSN synchronization.
+    pub dsn_sync_parallelism_level: usize,
 }
 
 struct SubspaceExtensionsFactory<PosTable> {
@@ -714,6 +716,7 @@ where
             import_queue_service,
             sync_mode,
             subspace_link.kzg().clone(),
+            config.dsn_sync_parallelism_level,
         );
         task_manager
             .spawn_handle()

--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -41,6 +41,7 @@ enum NotificationReason {
 
 /// Create node observer that will track node state and send notifications to worker to start sync
 /// from DSN.
+#[allow(clippy::too_many_arguments)] // we don't follow this convention
 pub(super) fn create_observer_and_worker<Block, AS, Client>(
     segment_headers_store: SegmentHeadersStore<AS>,
     network_service: Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
@@ -49,6 +50,7 @@ pub(super) fn create_observer_and_worker<Block, AS, Client>(
     mut import_queue_service: Box<dyn ImportQueueService<Block>>,
     sync_mode: Arc<Atomic<SyncMode>>,
     kzg: Kzg,
+    dsn_sync_parallelism_level: usize,
 ) -> (
     impl Future<Output = ()> + Send + 'static,
     impl Future<Output = Result<(), sc_service::Error>> + Send + 'static,
@@ -79,6 +81,7 @@ where
             sync_mode,
             rx,
             &kzg,
+            dsn_sync_parallelism_level,
         )
         .await
     };
@@ -200,6 +203,7 @@ async fn create_substrate_network_observer<Block>(
     }
 }
 
+#[allow(clippy::too_many_arguments)] // we don't follow this convention
 async fn create_worker<Block, AS, IQS, Client>(
     segment_headers_store: SegmentHeadersStore<AS>,
     node: &Node,
@@ -208,6 +212,7 @@ async fn create_worker<Block, AS, IQS, Client>(
     sync_mode: Arc<Atomic<SyncMode>>,
     mut notifications: mpsc::Receiver<NotificationReason>,
     kzg: &Kzg,
+    dsn_sync_parallelism_level: usize,
 ) -> Result<(), sc_service::Error>
 where
     Block: BlockT,
@@ -248,6 +253,7 @@ where
             import_queue_service,
             &mut last_processed_segment_index,
             &mut last_processed_block_number,
+            dsn_sync_parallelism_level,
         )
         .await
         {


### PR DESCRIPTION
This PR fixes a critical bug in DSN sync and decreases the chances of "missing piece recovery". 

#### Issues
 - We accidentally disabled the support of the "piece request protocol" on nodes when we removed the piece cache. It effectively broke the DSN sync process.
 - We had incorrect default settings for the piece retrieval process. The combination of 128 piece retrieval processes and default 100 outgoing connections led to a lot of "missing piece recovery" events that significantly affected performance.


#### Changes
- restore "piece request protocol" support on node
- introduce `--dsn-sync-parallelism-level` parameter that affects the piece request parallel acquiring. Default value is set to 5.
- change the default values for `--dsn-target-connections` (50->30), and `--dsn_out_connections`, `--dsn_pending_out_connections` both (100->150). 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
