### PR TITLE
Fix DSN sync for nodes.

### DIFF
--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -217,7 +217,7 @@ pub struct Cli {
     pub dsn_in_connections: u32,
 
     /// Defines max established outgoing swarm connection limit for DSN.
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 150)]
     pub dsn_out_connections: u32,
 
     /// Defines max pending incoming connection limit for DSN.
@@ -225,11 +225,11 @@ pub struct Cli {
     pub dsn_pending_in_connections: u32,
 
     /// Defines max pending outgoing swarm connection limit for DSN.
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 150)]
     pub dsn_pending_out_connections: u32,
 
     /// Defines target total (in and out) connection number for DSN that should be maintained.
-    #[arg(long, default_value_t = 50)]
+    #[arg(long, default_value_t = 30)]
     pub dsn_target_connections: u32,
 
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses


### PR DESCRIPTION
This PR contains DSN sync changes from the PR for gemini-3f: https://github.com/subspace/subspace/pull/1955

It fixes a critical bug in DSN sync and changes several default values for CLI argument. 

#### Issue
 - We accidentally disabled the support of the "piece request protocol" on nodes when we removed the piece cache. It effectively broke the DSN sync process.

#### Changes
- restore "piece request protocol" support on node
- change the default values for `--dsn-target-connections` (50->30), and `--dsn_out_connections`, `--dsn_pending_out_connections` both (100->150). 


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
