### PR TITLE
Fix DSN sync

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -216,17 +216,21 @@ where
             }
         }
 
-        // Import queue handles verification and importing it into the client
-        let last_segment = segment_indices_iter.peek().is_none();
-        if last_segment {
-            let last_block = blocks_to_import
-                .pop()
-                .expect("Not empty, checked above; qed");
-            import_queue_service.import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
-            // This will notify Substrate's sync mechanism and allow regular Substrate sync to continue gracefully
-            import_queue_service.import_blocks(BlockOrigin::NetworkBroadcast, vec![last_block]);
-        } else {
-            import_queue_service.import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
+        if !blocks_to_import.is_empty() {
+            // Import queue handles verification and importing it into the client
+            let last_segment = segment_indices_iter.peek().is_none();
+            if last_segment {
+                let last_block = blocks_to_import
+                    .pop()
+                    .expect("Not empty, checked above; qed");
+                import_queue_service
+                    .import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
+                // This will notify Substrate's sync mechanism and allow regular Substrate sync to continue gracefully
+                import_queue_service.import_blocks(BlockOrigin::NetworkBroadcast, vec![last_block]);
+            } else {
+                import_queue_service
+                    .import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
+            }
         }
 
         *last_processed_segment_index = segment_index;


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/1807 introduced a regression that was visible in some cases. Specifically it started attempt to import blocks starting with last finalized block rather than simply best block, such that it is possible to reorg to correct fork during DSN sync. However, that also meant that sometimes we may download a segment, all of the blocks from which are already in our chain. As the result the assumption that we have some blocks to import is wrong and we were getting following panic:
```
subspace[1031327]: ====================
  subspace[1031327]: Version: 0.1.0-5c2433599f4
  subspace[1031327]:    0: sp_panic_handler::set::{{closure}}
  subspace[1031327]:    1: std::panicking::rust_panic_with_hook
  subspace[1031327]:    2: std::panicking::begin_panic_handler::{{closure}}
  subspace[1031327]:    3: std::sys_common::backtrace::__rust_end_short_backtrace
  subspace[1031327]:    4: rust_begin_unwind
  subspace[1031327]:    5: core::panicking::panic_fmt
  subspace[1031327]:    6: core::option::expect_failed
  subspace[1031327]:    7: subspace_service::sync_from_dsn::import_blocks::import_blocks_from_dsn::{{closure}}
  subspace[1031327]:    8: subspace_service::new_full::{{closure}}::{{closure}}
  subspace[1031327]:    9: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
  subspace[1031327]:   10: <tracing_futures::Instrumented<T> as core::future::future::Future>::poll
  subspace[1031327]:   11: tokio::runtime::task::raw::poll
  subspace[1031327]:   12: std::sys_common::backtrace::__rust_begin_short_backtrace
  subspace[1031327]:   13: core::ops::function::FnOnce::call_once{{vtable.shim}}
  subspace[1031327]:   14: std::sys::unix::thread::Thread::new::thread_start
  subspace[1031327]:   15: start_thread
  subspace[1031327]:   16: clone
  subspace[1031327]: Thread 'tokio-runtime-worker' panicked at 'Not empty, checked above; qed', /home/runner/work/subspace/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs:230
  subspace[1031327]: This is a bug. Please report it at:
  subspace[1031327]:         https://forum.subspace.network
```

The only reason we didn't see it before is because sync from DSN didn't work, but it got fixed by https://github.com/subspace/subspace/pull/1955

Review with whitespaces ignored, it is quite trivial. Tested on Gemini 3f successfully.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
