### PR TITLE
Upgrade Substrate to polkadot-sdk fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-scale"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b08346a3e38e2be792ef53ee168623c9244d968ff00cd70fb9932f6fe36393"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "ark-secret-scalar"
 version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=c86ebd4#c86ebd4114d3165d05f9ce28c1d9e8d7a9a4e801"
+source = "git+https://github.com/w3f/ring-vrf?rev=f4fe253#f4fe2534ccc6d916cd10d9c16891e673728ec8b4"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -640,7 +653,7 @@ dependencies = [
 [[package]]
 name = "ark-transcript"
 version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=c86ebd4#c86ebd4114d3165d05f9ce28c1d9e8d7a9a4e801"
+source = "git+https://github.com/w3f/ring-vrf?rev=f4fe253#f4fe2534ccc6d916cd10d9c16891e673728ec8b4"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -982,7 +995,7 @@ dependencies = [
 [[package]]
 name = "bandersnatch_vrfs"
 version = "0.0.1"
-source = "git+https://github.com/w3f/ring-vrf?rev=c86ebd4#c86ebd4114d3165d05f9ce28c1d9e8d7a9a4e801"
+source = "git+https://github.com/w3f/ring-vrf?rev=f4fe253#f4fe2534ccc6d916cd10d9c16891e673728ec8b4"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1624,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#0e948f3c28cbacecdd3020403c4841c0eb339213"
+source = "git+https://github.com/w3f/ring-proof?rev=8657210#86572101f4210647984ab4efedba6b3fcc890895"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1633,6 +1646,7 @@ dependencies = [
  "ark-std",
  "fflonk",
  "merlin 3.0.0",
+ "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -2465,10 +2479,11 @@ dependencies = [
 [[package]]
 name = "dleq_vrf"
 version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=c86ebd4#c86ebd4114d3165d05f9ce28c1d9e8d7a9a4e801"
+source = "git+https://github.com/w3f/ring-vrf?rev=f4fe253#f4fe2534ccc6d916cd10d9c16891e673728ec8b4"
 dependencies = [
  "ark-ec",
  "ark-ff",
+ "ark-scale",
  "ark-secret-scalar",
  "ark-serialize",
  "ark-std",
@@ -2543,7 +2558,7 @@ dependencies = [
  "sp-messenger",
  "sp-runtime",
  "sp-state-machine",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "tracing",
@@ -2627,11 +2642,11 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-core",
  "sp-domain-digests",
  "sp-domains",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-messenger",
  "sp-runtime",
  "sp-state-machine",
@@ -2721,7 +2736,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
  "sp-version",
 ]
 
@@ -2774,7 +2789,7 @@ dependencies = [
  "sc-rpc-api",
  "sc-rpc-spec-v2",
  "sc-service",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -2783,11 +2798,11 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-core",
  "sp-domains",
  "sp-inherents",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-messenger",
  "sp-offchain",
  "sp-runtime",
@@ -2838,7 +2853,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-consensus-slots",
  "sc-executor",
  "sc-network",
  "sc-network-sync",
@@ -2851,8 +2866,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
+ "sp-arithmetic",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core",
@@ -2863,7 +2878,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
  "sp-transaction-pool",
  "subspace-networking",
  "subspace-proof-of-space",
@@ -3395,7 +3410,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3407,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3423,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "async-trait",
  "fc-api",
@@ -3442,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3463,7 +3478,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3501,14 +3516,14 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
- "sp-timestamp 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-timestamp",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -3517,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3530,7 +3545,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3678,7 +3693,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3695,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3707,14 +3722,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-runtime-interface",
  "sp-std",
 ]
 
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3726,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3739,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "evm",
  "frame-support",
@@ -3755,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3772,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3784,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -3799,7 +3814,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3811,11 +3826,11 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
  "sp-std",
  "sp-storage",
  "static_assertions",
@@ -3824,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -3843,7 +3858,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_pcg",
- "sc-block-builder 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-block-builder",
  "sc-cli",
  "sc-client-api",
  "sc-client-db",
@@ -3859,12 +3874,12 @@ dependencies = [
  "sp-externalities",
  "sp-inherents",
  "sp-io",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
  "sp-trie",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-wasm-interface",
  "thiserror",
  "thousands",
 ]
@@ -3872,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3884,7 +3899,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -3902,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "aquamarine",
  "bitflags 1.3.2",
@@ -3921,7 +3936,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
  "sp-core",
  "sp-core-hashing-proc-macro",
  "sp-debug-derive",
@@ -3933,7 +3948,7 @@ dependencies = [
  "sp-staking",
  "sp-state-machine",
  "sp-std",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -3942,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3960,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3972,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3982,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -4001,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4016,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4025,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7118,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7132,7 +7147,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7143,7 +7158,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core",
  "sp-io",
@@ -7156,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7171,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7220,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7243,7 +7258,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "environmental",
  "evm",
@@ -7268,7 +7283,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7280,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "fp-evm",
  "num",
@@ -7289,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7298,7 +7313,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=01b56190c0ed019b187c34d23422b9fea7ca4393#01b56190c0ed019b187c34d23422b9fea7ca4393"
+source = "git+https://github.com/subspace/frontier?rev=e74fdd2de2a1d5749c067d6fd8e244e405b256e1#e74fdd2de2a1d5749c067d6fd8e244e405b256e1"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -7335,7 +7350,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
  "sp-core",
  "sp-io",
@@ -7439,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7476,7 +7491,7 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "serde",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-io",
@@ -7496,8 +7511,9 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -7511,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7524,7 +7540,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-storage",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -7541,7 +7557,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7557,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7573,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7604,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8625,13 +8641,14 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#0e948f3c28cbacecdd3020403c4841c0eb339213"
+source = "git+https://github.com/w3f/ring-proof?rev=8657210#86572101f4210647984ab4efedba6b3fcc890895"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
  "ark-std",
+ "blake2",
  "common",
  "fflonk",
  "merlin 3.0.0",
@@ -8964,27 +8981,27 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-wasm-interface",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "sc-block-builder 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-block-builder",
  "sc-client-api",
  "sc-proposer-metrics",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-transaction-pool-api",
  "sp-api",
  "sp-blockchain",
@@ -8998,22 +9015,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "parity-scale-codec",
- "sc-client-api",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
-]
-
-[[package]]
-name = "sc-block-builder"
-version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9028,14 +9030,14 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "memmap2 0.5.10",
  "sc-chain-spec-derive",
  "sc-client-api",
  "sc-executor",
  "sc-network",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "serde",
  "serde_json",
  "sp-blockchain",
@@ -9047,7 +9049,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9058,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "atomic",
@@ -9078,7 +9080,7 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "sc-service",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-tracing",
  "sc-utils",
  "serde",
@@ -9086,7 +9088,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-keyring",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-panic-handler",
  "sp-runtime",
  "sp-version",
@@ -9098,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "fnv",
  "futures",
@@ -9124,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "hash-db 0.16.0",
  "kvdb",
@@ -9137,7 +9139,7 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
  "sp-database",
@@ -9149,7 +9151,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "futures",
@@ -9174,27 +9176,27 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "parity-scale-codec",
- "sc-block-builder 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
+ "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-slots 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
- "sc-telemetry 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
+ "sc-consensus-slots",
+ "sc-telemetry",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-aura 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
- "sp-keystore 0.27.0 (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -9217,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "futures",
@@ -9226,34 +9228,11 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
- "sc-telemetry 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
- "sp-arithmetic 16.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
+ "sc-telemetry",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
-]
-
-[[package]]
-name = "sc-consensus-slots"
-version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
-dependencies = [
- "async-trait",
- "futures",
- "futures-timer",
- "log",
- "parity-scale-codec",
- "sc-client-api",
- "sc-consensus",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -9276,9 +9255,9 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-consensus-slots",
  "sc-proof-of-time",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
  "schnorrkel",
@@ -9287,7 +9266,7 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-inherents",
@@ -9322,7 +9301,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-objects",
@@ -9338,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9350,21 +9329,21 @@ dependencies = [
  "sp-externalities",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-wasm-interface",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
 ]
@@ -9372,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9381,15 +9360,15 @@ dependencies = [
  "rustix 0.36.15",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "ansi_term",
  "futures",
@@ -9405,21 +9384,21 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.1",
  "serde_json",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-core",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9447,7 +9426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
@@ -9461,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-channel",
  "cid",
@@ -9481,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -9498,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "ahash 0.8.3",
  "futures",
@@ -9516,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9537,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -9559,7 +9538,7 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
@@ -9572,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9590,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -9614,7 +9593,7 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-externalities",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-offchain",
  "sp-runtime",
  "threadpool",
@@ -9635,13 +9614,13 @@ dependencies = [
  "parking_lot 0.12.1",
  "rayon",
  "sc-client-api",
- "sc-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-consensus-slots",
  "sc-network",
  "sc-network-gossip",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-inherents",
@@ -9656,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9665,14 +9644,14 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "futures",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "sc-block-builder 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc-api",
@@ -9683,7 +9662,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-offchain",
  "sp-rpc",
  "sp-runtime",
@@ -9696,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9715,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -9730,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9758,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "directories",
@@ -9771,7 +9750,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.8.5",
- "sc-block-builder 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -9789,7 +9768,7 @@ dependencies = [
  "sc-rpc-server",
  "sc-rpc-spec-v2",
  "sc-sysinfo",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-tracing",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
@@ -9801,7 +9780,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-externalities",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
@@ -9822,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9833,7 +9812,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "clap",
  "fs4",
@@ -9871,7 +9850,7 @@ version = "0.1.0"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "serde",
  "sp-core",
  "sp-runtime",
@@ -9880,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "futures",
  "libc",
@@ -9888,7 +9867,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_pcg",
  "regex",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "serde",
  "serde_json",
  "sp-core",
@@ -9899,26 +9878,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "chrono",
- "futures",
- "libp2p 0.51.3",
- "log",
- "parking_lot 0.12.1",
- "pin-project",
- "rand 0.8.5",
- "sc-utils",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-timer",
-]
-
-[[package]]
-name = "sc-telemetry"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "chrono",
  "futures",
@@ -9937,7 +9897,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "ansi_term",
  "atty",
@@ -9956,7 +9916,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
  "thiserror",
  "tracing",
  "tracing-log",
@@ -9966,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9977,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "futures",
@@ -9994,7 +9954,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -10003,7 +9963,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "futures",
@@ -10019,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-channel",
  "futures",
@@ -10028,7 +9988,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "prometheus",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -10552,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -10573,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "Inflector",
  "blake2",
@@ -10587,20 +10547,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-std",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "23.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10613,21 +10560,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "16.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10641,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -10652,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "futures",
  "log",
@@ -10670,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "futures",
@@ -10685,60 +10618,43 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-application-crypto",
+ "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "sp-timestamp 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
-]
-
-[[package]]
-name = "sp-consensus-aura"
-version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
+ "sp-consensus-slots",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10746,9 +10662,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-core",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-runtime",
  "sp-std",
 ]
@@ -10756,25 +10672,13 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-std",
- "sp-timestamp 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=master)",
-]
-
-[[package]]
-name = "sp-consensus-slots"
-version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -10787,16 +10691,16 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
+ "sp-consensus-slots",
  "sp-core",
  "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
  "sp-std",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-proof-of-space",
@@ -10808,15 +10712,14 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "21.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
- "arrayvec 0.7.4",
  "bandersnatch_vrfs",
  "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
- "bs58 0.4.0",
+ "bs58 0.5.0",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
@@ -10841,7 +10744,7 @@ dependencies = [
  "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
  "sp-std",
  "sp-storage",
  "ss58-registry",
@@ -10855,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "9.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -10868,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "9.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "quote",
  "sp-core-hashing",
@@ -10878,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10887,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "8.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10917,14 +10820,14 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-blockchain",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-core",
  "sp-externalities",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
  "sp-trie",
@@ -10937,7 +10840,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.19.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10948,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -10959,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10973,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "23.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.0.0",
@@ -10984,11 +10887,11 @@ dependencies = [
  "secp256k1",
  "sp-core",
  "sp-externalities",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
+ "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -10997,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "24.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11008,19 +10911,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.27.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.1",
- "sp-core",
- "sp-externalities",
- "thiserror",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.27.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -11039,8 +10930,8 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnorrkel",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-io",
  "sp-runtime",
@@ -11057,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -11084,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -11105,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11115,7 +11006,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "8.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11125,7 +11016,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11135,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "24.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11146,8 +11037,8 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "serde",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
+ "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-std",
@@ -11157,55 +11048,25 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
  "sp-externalities",
- "sp-runtime-interface-proc-macro 11.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
+ "sp-runtime-interface-proc-macro",
  "sp-std",
  "sp-storage",
- "sp-tracing 10.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/substrate?branch=master)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "17.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro 11.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-std",
- "sp-storage",
- "sp-tracing 10.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "Inflector",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "11.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11217,13 +11078,13 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-core",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-runtime",
  "sp-staking",
  "sp-std",
@@ -11232,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11246,7 +11107,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.28.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -11267,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek 4.1.0",
@@ -11278,11 +11139,11 @@ dependencies = [
  "scale-info",
  "sha2 0.10.7",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-core",
  "sp-externalities",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-runtime-interface",
  "sp-std",
  "thiserror",
  "x25519-dalek 2.0.0",
@@ -11291,12 +11152,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "8.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 
 [[package]]
 name = "sp-storage"
 version = "13.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11309,20 +11170,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "thiserror",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11335,19 +11183,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "parity-scale-codec",
- "sp-std",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "10.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11359,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11368,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11383,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "22.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "ahash 0.8.3",
  "hash-db 0.16.0",
@@ -11406,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "22.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11423,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "8.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11434,20 +11270,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#033d4e86cc7eff0066cd376b9375f815761d653c"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "sp-std",
- "wasmtime",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "14.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11460,13 +11283,13 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "20.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
  "sp-core",
  "sp-debug-derive",
  "sp-std",
@@ -11879,7 +11702,7 @@ dependencies = [
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-consensus-slots",
  "sc-consensus-subspace",
  "sc-executor",
  "sc-network",
@@ -11888,7 +11711,7 @@ dependencies = [
  "sc-service",
  "sc-storage-monitor",
  "sc-subspace-chain-specs",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-tracing",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -11903,7 +11726,7 @@ dependencies = [
  "sp-io",
  "sp-messenger",
  "sp-runtime",
- "sp-wasm-interface 14.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-wasm-interface",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-networking",
@@ -11989,7 +11812,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-block-builder",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-domains",
@@ -12047,7 +11870,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-fraud-proof",
- "sc-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-consensus-slots",
  "sc-consensus-subspace",
  "sc-consensus-subspace-rpc",
  "sc-executor",
@@ -12060,7 +11883,7 @@ dependencies = [
  "sc-rpc-spec-v2",
  "sc-service",
  "sc-subspace-block-relay",
- "sc-telemetry 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-telemetry",
  "sc-tracing",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
@@ -12068,7 +11891,7 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-domains",
@@ -12077,7 +11900,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
  "static_assertions",
@@ -12162,7 +11985,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-block-builder",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-domains",
@@ -12196,7 +12019,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "sc-block-builder 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-fraud-proof",
@@ -12209,10 +12032,10 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
- "sp-consensus-slots 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-core",
  "sp-domains",
@@ -12220,7 +12043,7 @@ dependencies = [
  "sp-inherents",
  "sp-keyring",
  "sp-runtime",
- "sp-timestamp 4.0.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-timestamp",
  "subspace-core-primitives",
  "subspace-fraud-proof",
  "subspace-node",
@@ -12267,7 +12090,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "schnorrkel",
- "sp-arithmetic 16.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-arithmetic",
  "sp-std",
  "subspace-archiving",
  "subspace-core-primitives",
@@ -12292,12 +12115,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12316,7 +12139,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "hyper",
  "log",
@@ -12328,7 +12151,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -12346,7 +12169,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-keyring",
- "sp-keystore 0.27.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
 ]
@@ -12354,7 +12177,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -12371,9 +12194,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-api",
- "sp-application-crypto 23.0.0 (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-application-crypto",
  "sp-block-builder",
- "sp-consensus-aura 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-consensus-grandpa",
  "sp-core",
@@ -12397,10 +12220,10 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "futures",
- "sc-block-builder 0.10.0-dev (git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898)",
+ "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
  "sp-api",
@@ -12415,28 +12238,16 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "futures",
- "substrate-test-utils-derive",
  "tokio",
-]
-
-[[package]]
-name = "substrate-test-utils-derive"
-version = "0.10.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/subspace/substrate?rev=48c5ebae44b90d45863195b91e0e489eca670898#48c5ebae44b90d45863195b91e0e489eca670898"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=20be5f33a3d2b3f4b31a894f9829184b29fba3ef#20be5f33a3d2b3f4b31a894f9829184b29fba3ef"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12956,9 +12767,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
+checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db 0.16.0",
  "hashbrown 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,35 +86,45 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
-# Reason: We need to patch substrate dependency of snowfork and frontier libraries to our fork
-# TODO: Remove when we are using upstream substrate instead of fork
-[patch."https://github.com/paritytech/substrate.git"]
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-db = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-database = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-storage = { version = "13.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-prometheus-endpoint = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+# Reason: We need to patch substrate dependency of frontier to our fork
+# TODO: Remove if/when we are using upstream substrate instead of fork
+[patch."https://github.com/paritytech/polkadot-sdk.git"]
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-db = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-application-crypto = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-database = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime-interface = { version = "17.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-storage = { version = "13.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-prometheus-endpoint = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -13,23 +13,23 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../sp-domains" }
-sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", features = ["serde"] }
+sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", features = ["serde"] }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [dev-dependencies]
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 
 [features]

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -11,10 +11,10 @@ use crate::{
     BalanceOf, Config, ElectionVerificationParams, FungibleHoldId, HoldIdentifier, NominatorId,
 };
 use codec::{Decode, Encode};
-use frame_support::dispatch::TypeInfo;
 use frame_support::traits::fungible::{InspectHold, Mutate, MutateHold};
 use frame_support::traits::tokens::{Fortitude, Precision, Restriction};
 use frame_support::PalletError;
+use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::{DomainId, EpochIndex, OperatorId};
 use sp_runtime::traits::{CheckedAdd, CheckedSub, One, Zero};

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -610,7 +610,10 @@ fn test_bundle_fromat_verification() {
     let opaque_extrinsic = |dest: u64, value: u128| -> OpaqueExtrinsic {
         UncheckedExtrinsic {
             signature: None,
-            function: RuntimeCall::Balances(pallet_balances::Call::transfer { dest, value }),
+            function: RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {
+                dest,
+                value,
+            }),
         }
         .into()
     };

--- a/crates/pallet-feeds/Cargo.toml
+++ b/crates/pallet-feeds/Cargo.toml
@@ -14,18 +14,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [dev-dependencies]
 serde = "1.0.183"
-sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-grandpa-finality-verifier/Cargo.toml
+++ b/crates/pallet-grandpa-finality-verifier/Cargo.toml
@@ -19,18 +19,18 @@ serde = { version = "1.0.183", optional = true }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-frame-system = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-core = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-runtime = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-std = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-trie = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-std = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 
 [dev-dependencies]
 ed25519-dalek = { version = "1.0", default-features = false, features = ["u64_backend"] }
-sp-io = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-application-crypto = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-object-store/Cargo.toml
+++ b/crates/pallet-object-store/Cargo.toml
@@ -14,19 +14,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [dev-dependencies]
 serde = "1.0.183"
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-offences-subspace/Cargo.toml
+++ b/crates/pallet-offences-subspace/Cargo.toml
@@ -14,17 +14,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../sp-consensus-subspace" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [dev-dependencies]
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 schnorrkel = "0.9.1"
 
 [features]

--- a/crates/pallet-rewards/Cargo.toml
+++ b/crates/pallet-rewards/Cargo.toml
@@ -19,10 +19,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [features]

--- a/crates/pallet-runtime-configs/Cargo.toml
+++ b/crates/pallet-runtime-configs/Cargo.toml
@@ -17,10 +17,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -14,19 +14,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 log = { version = "0.4.20", default-features = false }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
 serde = { version = "1.0.183", optional = true, default-features = false, features = ["derive"] }
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../sp-consensus-subspace" }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 subspace-solving = { version = "0.1.0", default-features = false, path = "../subspace-solving" }
@@ -35,12 +35,12 @@ subspace-verification = { version = "0.1.0", path = "../subspace-verification", 
 [dev-dependencies]
 env_logger = "0.10.0"
 futures = "0.3.28"
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-offences-subspace = { version = "0.1.0", path = "../pallet-offences-subspace" }
 rand = { version = "0.8.5", features = ["min_const_gen"] }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-weights = { version = "20.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-weights = { version = "20.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }

--- a/crates/pallet-transaction-fees/Cargo.toml
+++ b/crates/pallet-transaction-fees/Cargo.toml
@@ -19,8 +19,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 

--- a/crates/sc-consensus-fraud-proof/Cargo.toml
+++ b/crates/sc-consensus-fraud-proof/Cargo.toml
@@ -13,9 +13,9 @@ include = [
 [dependencies]
 async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.6.5", features = ["derive"] }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-fraud-proof = { version = "0.1.0", path = "../subspace-fraud-proof" }

--- a/crates/sc-consensus-subspace-rpc/Cargo.toml
+++ b/crates/sc-consensus-subspace-rpc/Cargo.toml
@@ -20,18 +20,18 @@ jsonrpsee = { version = "0.16.3", features = ["server", "macros"] }
 lru = "0.11.0"
 parity-scale-codec = "3.6.5"
 parking_lot = "0.12.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
-sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-objects = { version = "0.1.0", path = "../sp-objects" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -16,36 +16,36 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.6.5", features = ["derive"] }
-fork-tree = { version = "3.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+fork-tree = { version = "3.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 futures = "0.3.28"
 futures-timer = "3.0.2"
 log = "0.4.20"
 lru = "0.11.0"
 parking_lot = "0.12.1"
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", version = "0.10.0-dev" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", version = "0.10.0-dev" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 schnorrkel = "0.9.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-proof-of-time = { version = "0.1.0", path = "../sc-proof-of-time" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 serde = { version = "1.0.183", features = ["derive"] }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
-sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-objects = { version = "0.1.0", path = "../sp-objects" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -277,7 +277,7 @@ where
     }
 
     async fn claim_slot(
-        &self,
+        &mut self,
         parent_header: &Block::Header,
         slot: Slot,
         _aux_data: &Self::AuxData,

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -18,18 +18,18 @@ derive_more = "0.99.17"
 futures = "0.3.28"
 lru = "0.11.0"
 parity-scale-codec = { version = "3.6.1", features = ["derive"] }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time" }
 parking_lot = "0.12.1"

--- a/crates/sc-subspace-block-relay/Cargo.toml
+++ b/crates/sc-subspace-block-relay/Cargo.toml
@@ -16,14 +16,14 @@ async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 futures = "0.3.28"
 parking_lot = "0.12.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 thiserror = "1.0.48"
 tracing = "0.1.37"
 

--- a/crates/sc-subspace-chain-specs/Cargo.toml
+++ b/crates/sc-subspace-chain-specs/Cargo.toml
@@ -12,9 +12,9 @@ include = [
 ]
 
 [dependencies]
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 serde = "1.0.183"
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -18,17 +18,17 @@ codec = { package = "parity-scale-codec", version = "3.6.5", default-features = 
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-application-crypto = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-externalities = { version = "0.19.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-application-crypto = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-externalities = { version = "0.19.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving", default-features = false }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }

--- a/crates/sp-domains/Cargo.toml
+++ b/crates/sp-domains/Cargo.toml
@@ -18,19 +18,19 @@ parity-scale-codec = { version = "3.6.5", default-features = false, features = [
 rs_merkle = { version = "1.4.1", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-application-crypto = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-externalities = { version = "0.19.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-weights = { version = "20.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-application-crypto = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-externalities = { version = "0.19.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-weights = { version = "20.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 thiserror = { version = "1.0.48", optional = true }

--- a/crates/sp-lightclient/Cargo.toml
+++ b/crates/sp-lightclient/Cargo.toml
@@ -19,21 +19,21 @@ include = [
 codec = { package = "parity-scale-codec", version = "3.1.2", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
-sp-arithmetic = { version = "16.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-arithmetic = { version = "16.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace", default-features = false }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding", default-features = false }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving", default-features = false }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification", default-features = false }
 
 [dev-dependencies]
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 futures = "0.3.28"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving"}
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }

--- a/crates/sp-objects/Cargo.toml
+++ b/crates/sp-objects/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -15,33 +15,33 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.5", features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 domain-block-preprocessor = { version = "0.1.0", path = "../../domains/client/block-preprocessor" }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 futures = "0.3.28"
 hash-db = "0.16.0"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
 sp-domain-digests = { version = "0.1.0", path = "../../domains/primitives/digests" }
 sp-messenger = { version = "0.1.0", path = "../../domains/primitives/messenger" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tracing = "0.1.37"
 
 [dev-dependencies]
 domain-block-builder = { version = "0.1.0", path = "../../domains/client/block-builder" }
 domain-test-service = { version = "0.1.0", path = "../../domains/test/service" }
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-domains = { version = "0.1.0", path = "../../crates/pallet-domains" }
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-keyring = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-keyring = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-test-client = { version = "0.1.0", path = "../../test/subspace-test-client" }
 subspace-test-runtime = { version = "0.1.0", path = "../../test/subspace-test-runtime" }
 subspace-test-service = { version = "0.1.0", path = "../../test/subspace-test-service" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives" }
-substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tempfile = "3.8.0"
 tokio = "1.32.0"

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -91,7 +91,7 @@ impl VerifierApi for TestVerifierClient {
 // Use the system domain id for testing
 const TEST_DOMAIN_ID: DomainId = DomainId::new(3u32);
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn execution_proof_creation_and_verification_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
@@ -133,21 +133,21 @@ async fn execution_proof_creation_and_verification_should_work() {
     let alice_nonce = alice.account_nonce();
     let transfer_to_charlie = alice.construct_extrinsic(
         alice_nonce,
-        pallet_balances::Call::transfer {
+        pallet_balances::Call::transfer_allow_death {
             dest: Charlie.to_account_id(),
             value: 8,
         },
     );
     let transfer_to_dave = alice.construct_extrinsic(
         alice_nonce + 1,
-        pallet_balances::Call::transfer {
+        pallet_balances::Call::transfer_allow_death {
             dest: Dave.to_account_id(),
             value: 8,
         },
     );
     let transfer_to_charlie_again = alice.construct_extrinsic(
         alice_nonce + 2,
-        pallet_balances::Call::transfer {
+        pallet_balances::Call::transfer_allow_death {
             dest: Charlie.to_account_id(),
             value: 88,
         },
@@ -400,7 +400,7 @@ async fn execution_proof_creation_and_verification_should_work() {
     assert!(proof_verifier.verify(&fraud_proof).is_ok());
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn invalid_execution_proof_should_not_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
@@ -442,14 +442,14 @@ async fn invalid_execution_proof_should_not_work() {
     let alice_nonce = alice.account_nonce();
     let transfer_to_charlie = alice.construct_extrinsic(
         alice_nonce,
-        pallet_balances::Call::transfer {
+        pallet_balances::Call::transfer_allow_death {
             dest: Charlie.to_account_id(),
             value: 8,
         },
     );
     let transfer_to_charlie_again = alice.construct_extrinsic(
         alice_nonce + 1,
-        pallet_balances::Call::transfer {
+        pallet_balances::Call::transfer_allow_death {
             dest: Charlie.to_account_id(),
             value: 8,
         },
@@ -604,7 +604,7 @@ async fn invalid_execution_proof_should_not_work() {
 }
 
 // TODO: Unlock test when gossip message validator are supported in DecEx v2.
-// #[substrate_test_utils::test(flavor = "multi_thread")]
+// #[tokio::test(flavor = "multi_thread")]
 // async fn test_invalid_transaction_proof_creation_and_verification() {
 //     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -633,7 +633,7 @@ async fn invalid_execution_proof_should_not_work() {
 //     produce_blocks!(ferdie, alice, 3).await.unwrap();
 
 //     alice
-//         .construct_and_send_extrinsic(pallet_balances::Call::transfer {
+//         .construct_and_send_extrinsic(pallet_balances::Call::transfer_allow_death {
 //             dest: domain_test_service::evm_domain_test_runtime::Address::Id(One.public().into()),
 //             value: 500 + 1,
 //         })
@@ -651,7 +651,7 @@ async fn invalid_execution_proof_should_not_work() {
 //     // This is an invalid transaction.
 //     let transfer_from_one_to_bob = alice.construct_extrinsic_with_caller(
 //         One,
-//         pallet_balances::Call::transfer {
+//         pallet_balances::Call::transfer_allow_death {
 //             dest: domain_test_service::evm_domain_test_runtime::Address::Id(Bob.public().into()),
 //             value: 1000,
 //         },

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -29,44 +29,44 @@ domain-eth-service = { version = "0.1.0", path = "../../domains/client/eth-servi
 domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 evm-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/evm" }
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 futures = "0.3.28"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 log = "0.4.20"
 parity-scale-codec = "3.6.5"
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
 sc-proof-of-time = { version = "0.1.0", path = "../sc-proof-of-time" }
 sc-subspace-chain-specs = { version = "0.1.0", path = "../sc-subspace-chain-specs" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-storage-monitor = { version = "0.1.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-storage-monitor = { version = "0.1.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 serde = "1.0.183"
 serde_json = "1.0.106"
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
 sp-domain-digests = { version = "0.1.0", path = "../../domains/primitives/digests" }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", path = "../../domains/primitives/messenger" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-wasm-interface = { version = "14.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-wasm-interface = { version = "14.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
@@ -79,7 +79,7 @@ thiserror = "1.0.48"
 tokio = "1.32.0"
 
 [build-dependencies]
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["do-not-enforce-cost-of-storage"]

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -127,7 +127,9 @@ fn pot_external_entropy(
 }
 
 fn main() -> Result<(), Error> {
-    let cli = Cli::from_args();
+    let mut cli = Cli::from_args();
+    // Force UTC logs for Subspace node
+    cli.run.shared_params.use_utc_log_time = true;
 
     match &cli.subcommand {
         Some(Subcommand::Key(cmd)) => cmd.run(&cli)?,

--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -21,9 +21,9 @@ parity-scale-codec = { version = "3.6.5", default-features = false, features = [
 #  Substrate and as the result our custom `Block` implementation has to derive `serde` traits essentially
 #  unconditionally or else it doesn't compile
 serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"] }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [features]

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -18,14 +18,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", default-features = false, path = "../../domains/primitives/runtime" }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 orml-vesting = { version = "0.4.1-dev", default-features = false, path = "../../orml/vesting" }
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-domains = { version = "0.1.0", default-features = false, path = "../pallet-domains" }
 pallet-feeds = { version = "0.1.0", default-features = false, path = "../pallet-feeds" }
 pallet-grandpa-finality-verifier = { version = "0.1.0", default-features = false, path = "../pallet-grandpa-finality-verifier" }
@@ -35,40 +35,40 @@ pallet-offences-subspace = { version = "0.1.0", default-features = false, path =
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../pallet-rewards" }
 pallet-runtime-configs = { version = "0.1.0", default-features = false, path = "../pallet-runtime-configs" }
 pallet-subspace = { version = "0.1.0", default-features = false, features = ["serde"], path = "../pallet-subspace" }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transaction-fees = { version = "0.1.0", default-features = false, path = "../pallet-transaction-fees" }
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transporter = { version = "0.1.0", path = "../../domains/pallets/transporter", default-features = false }
-pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false, version = "4.0.0-dev"}
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false, version = "4.0.0-dev"}
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../sp-consensus-subspace" }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../sp-domains" }
-sp-inherents = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false, version = "4.0.0-dev"}
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false, version = "4.0.0-dev"}
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../domains/primitives/messenger" }
 sp-objects = { version = "0.1.0", default-features = false, path = "../sp-objects" }
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 static_assertions = "1.1.0"
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 subspace-verification = { version = "0.1.0", default-features = false, path = "../subspace-verification" }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -72,7 +72,7 @@ impl SignedExtension for DisablePallets {
         if matches!(
             call,
             RuntimeCall::Balances(
-                pallet_balances::Call::transfer { .. }
+                pallet_balances::Call::transfer_allow_death { .. }
                     | pallet_balances::Call::transfer_keep_alive { .. }
                     | pallet_balances::Call::transfer_all { .. }
             )

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -22,51 +22,51 @@ cross-domain-message-gossip = { version = "0.1.0", path = "../../domains/client/
 domain-block-preprocessor = { version = "0.1.0", path = "../../domains/client/block-preprocessor" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 either = "1.8.1"
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 futures = "0.3.28"
 hex = "0.4.3"
 jsonrpsee = { version = "0.16.3", features = ["server"] }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 parity-scale-codec = "3.6.5"
 parking_lot = "0.12.1"
 prometheus-client = "0.21.2"
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus-fraud-proof = { version = "0.1.0", path = "../sc-consensus-fraud-proof" }
 sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
 sc-consensus-subspace-rpc = { version = "0.1.0", path = "../sc-consensus-subspace-rpc" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-proof-of-time = { version = "0.1.0", path = "../sc-proof-of-time" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc-spec-v2 = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc-spec-v2 = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 sc-subspace-block-relay = { version = "0.1.0", path = "../sc-subspace-block-relay" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
-sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-objects = { version = "0.1.0", path = "../sp-objects" }
-sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 static_assertions = "1.1.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
@@ -76,15 +76,15 @@ subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 subspace-transaction-pool = { version = "0.1.0", path = "../subspace-transaction-pool" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 thiserror = "1.0.48"
 tokio = { version = "1.32.0", features = ["sync"] }
 tracing = "0.1.37"
 
-sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = []

--- a/crates/subspace-transaction-pool/Cargo.toml
+++ b/crates/subspace-transaction-pool/Cargo.toml
@@ -15,18 +15,18 @@ domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitive
 futures = "0.3.28"
 jsonrpsee = { version = "0.16.3", features = ["server"] }
 parking_lot = "0.12.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus-subspace = { version = "0.1.0", path = "../sc-consensus-subspace" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../sp-consensus-subspace" }
 sp-domains = { version = "0.1.0", path = "../sp-domains" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives" }
 tracing = "0.1.37"

--- a/crates/subspace-transaction-pool/src/lib.rs
+++ b/crates/subspace-transaction-pool/src/lib.rs
@@ -361,6 +361,10 @@ where
         self.inner.status()
     }
 
+    fn futures(&self) -> Vec<Self::InPoolTransaction> {
+        self.inner.futures()
+    }
+
     fn import_notification_stream(&self) -> ImportNotificationStream<TxHash<Self>> {
         self.inner.import_notification_stream()
     }

--- a/crates/subspace-verification/Cargo.toml
+++ b/crates/subspace-verification/Cargo.toml
@@ -19,8 +19,8 @@ include = [
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 schnorrkel = { version = "0.9.1", default-features = false, features = ["u64_backend"] }
-sp-arithmetic = { version = "16.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-arithmetic = { version = "16.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving", default-features = false }
 subspace-solving = { version = "0.1.0", path = "../subspace-solving", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }

--- a/domains/client/block-builder/Cargo.toml
+++ b/domains/client/block-builder/Cargo.toml
@@ -14,15 +14,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", features = ["derive"] }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tracing = "0.1.37"
 
 [dev-dependencies]
-substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/domains/client/block-preprocessor/Cargo.toml
+++ b/domains/client/block-preprocessor/Cargo.toml
@@ -17,22 +17,22 @@ codec = { package = "parity-scale-codec", version = "3.6.5", features = [ "deriv
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
 tracing = "0.1.37"
 
 [dev-dependencies]
-sp-keyring = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-keyring = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/domains/client/consensus-relay-chain/Cargo.toml
+++ b/domains/client/consensus-relay-chain/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 async-trait = "0.1.73"
 futures = "0.3.28"
 parking_lot = "0.12.1"
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/domains/client/cross-domain-message-gossip/Cargo.toml
+++ b/domains/client/cross-domain-message-gossip/Cargo.toml
@@ -15,13 +15,13 @@ include = [
 futures = "0.3.28"
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }
 parking_lot = "0.12.1"
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tracing = "0.1.37"

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -14,26 +14,26 @@ domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtim
 futures = "0.3.28"
 futures-timer = "3.0.1"
 parking_lot = "0.12.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
 sp-domain-digests = { version = "0.1.0", path = "../../primitives/digests" }
-sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-weights = { version = "20.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-weights = { version = "20.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }
 subspace-fraud-proof = { version = "0.1.0", path = "../../../crates/subspace-fraud-proof" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
@@ -46,21 +46,21 @@ domain-client-message-relayer = { version = "0.1.0", path = "../relayer" }
 domain-test-service = { version = "0.1.0", path = "../../test/service" }
 domain-test-primitives = { version = "0.1.0", path = "../../test/primitives" }
 evm-domain-test-runtime = { version = "0.1.0", path = "../../test/runtime/evm" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 num-traits = "0.2.16"
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-domains = { version = "0.1.0", path = "../../../crates/pallet-domains" }
 pallet-messenger = { version = "0.1.0", path = "../../pallets/messenger" }
 pallet-transporter = { version = "0.1.0", path = "../../pallets/transporter" }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-executor-common = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-node = { version = "0.1.0", path = "../../../crates/subspace-node" }
 subspace-test-runtime = { version = "0.1.0", path = "../../../test/subspace-test-runtime" }
 subspace-test-service = { version = "0.1.0", path = "../../../test/subspace-test-service" }
-substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tempfile = "3.8.0"

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -38,7 +38,7 @@ fn number_of(consensus_node: &MockConsensusNode, block_hash: Hash) -> u32 {
         .unwrap_or_else(|| panic!("header {block_hash} not in the chain"))
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_domain_instance_bootstrapper() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -88,7 +88,7 @@ async fn test_domain_instance_bootstrapper() {
         .expect("3 consensus blocks produced successfully");
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_domain_block_production() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -202,7 +202,7 @@ async fn test_domain_block_production() {
     assert_eq!(alice.client.info().best_number, domain_block_number + 10);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_processing_empty_consensus_block() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -286,7 +286,7 @@ async fn test_processing_empty_consensus_block() {
     assert_eq!(alice.client.info().best_number, 3);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_domain_block_deriving_from_multiple_bundles() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -321,7 +321,7 @@ async fn test_domain_block_deriving_from_multiple_bundles() {
     for i in 0..3 {
         let tx = alice.construct_extrinsic(
             alice_account_nonce + i,
-            pallet_balances::Call::transfer {
+            pallet_balances::Call::transfer_allow_death {
                 dest: Bob.to_account_id(),
                 value: 1,
             },
@@ -362,7 +362,7 @@ async fn test_domain_block_deriving_from_multiple_bundles() {
     assert_eq!(domain_block_number, head_receipt_number);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn collected_receipts_should_be_on_the_same_branch_with_current_best_block() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -546,7 +546,7 @@ async fn collected_receipts_should_be_on_the_same_branch_with_current_best_block
     );
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_domain_tx_propagate() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -592,7 +592,7 @@ async fn test_domain_tx_propagate() {
     let pre_bob_free_balance = alice.free_balance(bob.key.to_account_id());
     // Construct and send an extrinsic to bob, as bob is not a authority node, the extrinsic has
     // to propagate to alice to get executed
-    bob.construct_and_send_extrinsic(pallet_balances::Call::transfer {
+    bob.construct_and_send_extrinsic(pallet_balances::Call::transfer_allow_death {
         dest: Alice.to_account_id(),
         value: 123,
     })
@@ -613,7 +613,7 @@ async fn test_domain_tx_propagate() {
     .unwrap();
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_executor_full_node_catching_up() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -674,7 +674,7 @@ async fn test_executor_full_node_catching_up() {
     );
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_executor_inherent_timestamp_is_set() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -731,13 +731,13 @@ async fn test_executor_inherent_timestamp_is_set() {
     );
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn test_initialize_block_proof_creation_and_verification_should_work() {
     test_invalid_state_transition_proof_creation_and_verification(0).await
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn test_apply_extrinsic_proof_creation_and_verification_should_work() {
     test_invalid_state_transition_proof_creation_and_verification(1).await
@@ -746,7 +746,7 @@ async fn test_apply_extrinsic_proof_creation_and_verification_should_work() {
 // TODO: the test is ignored due to the invalid receipt can not pass the state root check
 // in the runtime now, thus can't construct `finalize_block` fraud proof, find a way to
 // bypass the check
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn test_finalize_block_proof_creation_and_verification_should_work() {
     test_invalid_state_transition_proof_creation_and_verification(2).await
@@ -794,7 +794,7 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     produce_blocks!(ferdie, alice, 5).await.unwrap();
 
     alice
-        .construct_and_send_extrinsic(pallet_balances::Call::transfer {
+        .construct_and_send_extrinsic(pallet_balances::Call::transfer_allow_death {
             dest: Bob.to_account_id(),
             value: 1,
         })
@@ -884,7 +884,7 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     ferdie.produce_blocks(1).await.unwrap();
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn fraud_proof_verification_in_tx_pool_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
@@ -1058,7 +1058,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
 
 // TODO: construct a minimal consensus runtime code and use the `set_code` extrinsic to actually
 // cover the case that the new domain runtime are updated accordingly upon the new consensus runtime.
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn set_new_code_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
@@ -1132,7 +1132,7 @@ async fn set_new_code_should_work() {
     assert_eq!(runtime_code, new_runtime_wasm_blob);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn pallet_domains_unsigned_extrinsics_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -1232,7 +1232,7 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
     // assert_eq!(head_receipt_number(), 2);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn duplicated_and_stale_bundle_should_be_rejected() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -1305,7 +1305,7 @@ async fn duplicated_and_stale_bundle_should_be_rejected() {
     }
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn existing_bundle_can_be_resubmitted_to_new_fork() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -1371,7 +1371,7 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 }
 
 // TODO: Unlock test when multiple domains are supported in DecEx v2.
-// #[substrate_test_utils::test(flavor = "multi_thread")]
+// #[tokio::test(flavor = "multi_thread")]
 // async fn test_cross_domains_message_should_work() {
 //     let directory = TempDir::new().expect("Must be able to create temporary directory");
 //
@@ -1554,7 +1554,7 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 // }
 
 // TODO: Unlock test when multiple domains are supported in DecEx v2.
-// #[substrate_test_utils::test(flavor = "multi_thread")]
+// #[tokio::test(flavor = "multi_thread")]
 // async fn test_unordered_cross_domains_message_should_work() {
 // let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -1749,7 +1749,7 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 // .unwrap();
 // }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 // TODO: https://github.com/subspace/subspace/pull/1954 broke this on Windows, we suspect the test
 //  is racy, but didn't find why and why it only fails on Windows. This needs to be fixed and test
 //  un-ignored on Windows.
@@ -1822,7 +1822,7 @@ async fn test_restart_domain_operator() {
     assert_eq!(alice.client.info().best_number, 10);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_domain_transaction_fee_and_operator_reward() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -1891,7 +1891,7 @@ async fn test_domain_transaction_fee_and_operator_reward() {
     assert_eq!(alice_free_balance_changes, receipt.total_rewards);
 }
 
-#[substrate_test_utils::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 

--- a/domains/client/eth-service/Cargo.toml
+++ b/domains/client/eth-service/Cargo.toml
@@ -15,28 +15,28 @@ include = [
 clap = { version = "4.4.3", features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime" }
 domain-service = { version = "0.1.0", path = "../../service" }
-fc-consensus = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fc-db = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393", default-features = false }
-fc-mapping-sync = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393", default-features = false }
-fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393", default-features = false, features = ['rpc-binary-search-estimate'] }
-fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fc-storage = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393", features = ['default'] }
+fc-consensus = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fc-db = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1", default-features = false }
+fc-mapping-sync = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1", default-features = false }
+fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1", default-features = false, features = ['rpc-binary-search-estimate'] }
+fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fc-storage = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1", features = ['default'] }
 futures = "0.3.28"
 jsonrpsee = { version = "0.16.3", features = ["server"] }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 serde = { version = "1.0.183", features = ["derive"] }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/domains/client/relayer/Cargo.toml
+++ b/domains/client/relayer/Cargo.toml
@@ -18,16 +18,16 @@ domain-runtime-primitives = { path = "../../primitives/runtime" }
 futures = "0.3.28"
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }
 parking_lot = "0.12.1"
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tracing = "0.1.37"

--- a/domains/client/subnet-gossip/Cargo.toml
+++ b/domains/client/subnet-gossip/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 futures = "0.3.28"
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }
 parking_lot = "0.12.1"
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-gossip = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
 tracing = "0.1.37"

--- a/domains/pallets/domain-id/Cargo.toml
+++ b/domains/pallets/domain-id/Cargo.toml
@@ -14,11 +14,11 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/pallets/executive/Cargo.toml
+++ b/domains/pallets/executive/Cargo.toml
@@ -13,23 +13,23 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-executive = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+frame-executive = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-std = { version = "8.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-tracing = { version = "10.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-std = { version = "8.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-tracing = { version = "10.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -15,23 +15,23 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [dev-dependencies]
 domain-runtime-primitives = { path = "../../primitives/runtime" }
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transporter = { version = "0.1.0", path = "../transporter" }
-sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -3,8 +3,8 @@ use crate::{
     InboxResponses, Nonce, Outbox, OutboxMessageResult, Pallet,
 };
 use codec::{Decode, Encode};
-use frame_support::dispatch::TypeInfo;
 use frame_support::ensure;
+use scale_info::TypeInfo;
 use sp_messenger::messages::{
     BlockMessageWithStorageKey, BlockMessagesWithStorageKey, ChainId, Message, MessageId,
     MessageWeightTag, Payload, ProtocolMessageRequest, ProtocolMessageResponse, RequestResponse,

--- a/domains/pallets/operator-rewards/Cargo.toml
+++ b/domains/pallets/operator-rewards/Cargo.toml
@@ -14,11 +14,11 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/pallets/transporter/Cargo.toml
+++ b/domains/pallets/transporter/Cargo.toml
@@ -16,19 +16,19 @@ include = [
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 domain-runtime-primitives = { path = "../../primitives/runtime" , default-features = false }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [dev-dependencies]
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/primitives/digests/Cargo.toml
+++ b/domains/primitives/digests/Cargo.toml
@@ -15,10 +15,10 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/primitives/messenger/Cargo.toml
+++ b/domains/primitives/messenger/Cargo.toml
@@ -15,17 +15,17 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 hash-db = { version = "0.16.0", default-features = false }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -14,13 +14,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives", default-features = false }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
-sp-weights = { version = "20.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-weights = { version = "20.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -20,52 +20,52 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive"] }
 domain-pallet-executive = { version = "0.1.0", path = "../../pallets/executive", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
-fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-evm = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-evm = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 hex-literal = { version = '0.4.0', optional = true }
 log = { version = "0.4.20", default-features = false }
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
+pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
 pallet-domain-id = { version = "0.1.0", path = "../../pallets/domain-id", default-features = false }
 pallet-operator-rewards = { version = "0.1.0", path = "../../pallets/operator-rewards", default-features = false }
-pallet-ethereum = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
+pallet-ethereum = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
 pallet-messenger = { version = "0.1.0", path = "../../pallets/messenger", default-features = false }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transporter = { version = "0.1.0", path = "../../pallets/transporter", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains", default-features = false }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives", default-features = false }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
 
 [features]
 default = [

--- a/domains/service/Cargo.toml
+++ b/domains/service/Cargo.toml
@@ -22,53 +22,53 @@ domain-client-message-relayer = { version = "0.1.0", path = "../client/relayer" 
 domain-client-operator = { version = "0.1.0", path = "../client/domain-operator" }
 domain-client-subnet-gossip = { version = "0.1.0", path = "../client/subnet-gossip" }
 domain-runtime-primitives = { version = "0.1.0", path = "../primitives/runtime" }
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 futures = "0.3.28"
 hex-literal = "0.4.1"
 jsonrpsee = { version = "0.16.3", features = ["server"] }
 log = "0.4.20"
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 parity-scale-codec = "3.6.5"
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-transactions = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc-spec-v2 = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-transactions = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc-spec-v2 = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 serde = { version = "1.0.183", features = ["derive"] }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../crates/sp-domains" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", path = "../../domains/primitives/messenger" }
-sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../../crates/subspace-core-primitives" }
 subspace-fraud-proof = { version = "0.1.0", path = "../../crates/subspace-fraud-proof" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives" }
 subspace-transaction-pool = { version = "0.1.0", path = "../../crates/subspace-transaction-pool" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-prometheus-endpoint = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tracing = "0.1.37"
 
 [build-dependencies]
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }

--- a/domains/test/primitives/Cargo.toml
+++ b/domains/test/primitives/Cargo.toml
@@ -13,7 +13,7 @@ include = [
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"]}
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }

--- a/domains/test/runtime/evm/Cargo.toml
+++ b/domains/test/runtime/evm/Cargo.toml
@@ -21,52 +21,52 @@ codec = { package = "parity-scale-codec", version = "3.2.1", default-features = 
 domain-pallet-executive = { version = "0.1.0", path = "../../../pallets/executive", default-features = false }
 domain-test-primitives = { version = "0.1.0", path = "../../primitives", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../../primitives/runtime", default-features = false }
-fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-evm = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-evm = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 hex-literal = { version = '0.4.0', optional = true }
 log = { version = "0.4.20", default-features = false }
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
+pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
 pallet-domain-id = { version = "0.1.0", path = "../../../pallets/domain-id", default-features = false }
 pallet-operator-rewards = { version = "0.1.0", path = "../../../pallets/operator-rewards", default-features = false }
-pallet-ethereum = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
+pallet-ethereum = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
 pallet-messenger = { version = "0.1.0", path = "../../../pallets/messenger", default-features = false }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transporter = { version = "0.1.0", path = "../../../pallets/transporter", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../../crates/sp-domains", default-features = false }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../../primitives/messenger" }
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../../crates/subspace-core-primitives", default-features = false }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../../crates/subspace-runtime-primitives", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
 
 [features]
 default = [

--- a/domains/test/service/Cargo.toml
+++ b/domains/test/service/Cargo.toml
@@ -20,45 +20,45 @@ domain-service = { version = "0.1.0", path = "../../service" }
 domain-test-primitives = { version = "0.1.0", path = "../primitives" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
 evm-domain-test-runtime = { version = "0.1.0", path = "../runtime/evm" }
-fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
-fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393", features = ['default'] }
+fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
+fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1", features = ['default'] }
 futures = "0.3.28"
-frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 rand = "0.8.5"
-pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.106"
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-application-crypto = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-arithmetic = { version = "16.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-application-crypto = { version = "23.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-arithmetic = { version = "16.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
-sp-keyring = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-keyring = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-messenger = { version = "0.1.0", path = "../../../domains/primitives/messenger" }
-sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sp-session = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-networking = { path = "../../../crates/subspace-networking" }
 subspace-proof-of-space = { path = "../../../crates/subspace-proof-of-space" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
@@ -66,7 +66,7 @@ subspace-service = { version = "0.1.0", path = "../../../crates/subspace-service
 subspace-test-client = { version = "0.1.0", path = "../../../test/subspace-test-client" }
 subspace-test-runtime = { version = "0.1.0", path = "../../../test/subspace-test-runtime" }
 subspace-test-service = { version = "0.1.0", path = "../../../test/subspace-test-service" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-substrate-test-client = { version = "2.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+substrate-test-client = { version = "2.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 tokio = { version = "1.32.0", features = ["macros"] }
 tracing = "0.1.37"

--- a/orml/vesting/Cargo.toml
+++ b/orml/vesting/Cargo.toml
@@ -12,15 +12,15 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.183", optional = true }
 
-frame-support = { default-features = false , git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { default-features = false , git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-io = { default-features = false , git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { default-features = false , git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { default-features = false , git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-support = { default-features = false , git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { default-features = false , git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-io = { default-features = false , git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { default-features = false , git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { default-features = false , git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 default = ["std"]

--- a/orml/vesting/src/tests.rs
+++ b/orml/vesting/src/tests.rs
@@ -3,7 +3,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::{assert_noop, assert_ok, error::BadOrigin};
+use frame_support::error::BadOrigin;
+use frame_support::{assert_noop, assert_ok};
 use mock::*;
 use pallet_balances::{BalanceLock, Reasons};
 use sp_runtime::traits::Dispatchable;
@@ -11,525 +12,586 @@ use sp_runtime::TokenError;
 
 #[test]
 fn vesting_from_chain_spec_works() {
-	ExtBuilder::build().execute_with(|| {
-		assert_ok!(PalletBalances::ensure_can_withdraw(
-			&CHARLIE,
-			10,
-			WithdrawReasons::TRANSFER,
-			20
-		));
-		assert!(PalletBalances::ensure_can_withdraw(&CHARLIE, 11, WithdrawReasons::TRANSFER, 19).is_err());
+    ExtBuilder::build().execute_with(|| {
+        assert_ok!(PalletBalances::ensure_can_withdraw(
+            &CHARLIE,
+            10,
+            WithdrawReasons::TRANSFER,
+            20
+        ));
+        assert!(
+            PalletBalances::ensure_can_withdraw(&CHARLIE, 11, WithdrawReasons::TRANSFER, 19)
+                .is_err()
+        );
 
-		assert_eq!(
-			Vesting::vesting_schedules(CHARLIE),
-			vec![
-				VestingSchedule {
-					start: 2u64,
-					period: 3u64,
-					period_count: 1u32,
-					per_period: 5u64,
-				},
-				VestingSchedule {
-					start: 2u64 + 3u64,
-					period: 3u64,
-					period_count: 3u32,
-					per_period: 5u64,
-				}
-			]
-		);
+        assert_eq!(
+            Vesting::vesting_schedules(CHARLIE),
+            vec![
+                VestingSchedule {
+                    start: 2u64,
+                    period: 3u64,
+                    period_count: 1u32,
+                    per_period: 5u64,
+                },
+                VestingSchedule {
+                    start: 2u64 + 3u64,
+                    period: 3u64,
+                    period_count: 3u32,
+                    per_period: 5u64,
+                }
+            ]
+        );
 
-		MockBlockNumberProvider::set(13);
+        MockBlockNumberProvider::set(13);
 
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(CHARLIE)));
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(CHARLIE)));
 
-		assert_ok!(PalletBalances::ensure_can_withdraw(
-			&CHARLIE,
-			25,
-			WithdrawReasons::TRANSFER,
-			5
-		));
-		assert!(PalletBalances::ensure_can_withdraw(&CHARLIE, 26, WithdrawReasons::TRANSFER, 4).is_err());
+        assert_ok!(PalletBalances::ensure_can_withdraw(
+            &CHARLIE,
+            25,
+            WithdrawReasons::TRANSFER,
+            5
+        ));
+        assert!(
+            PalletBalances::ensure_can_withdraw(&CHARLIE, 26, WithdrawReasons::TRANSFER, 4)
+                .is_err()
+        );
 
-		MockBlockNumberProvider::set(14);
+        MockBlockNumberProvider::set(14);
 
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(CHARLIE)));
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(CHARLIE)));
 
-		assert_ok!(PalletBalances::ensure_can_withdraw(
-			&CHARLIE,
-			30,
-			WithdrawReasons::TRANSFER,
-			0
-		));
-	});
+        assert_ok!(PalletBalances::ensure_can_withdraw(
+            &CHARLIE,
+            30,
+            WithdrawReasons::TRANSFER,
+            0
+        ));
+    });
 }
 
 #[test]
 fn vested_transfer_works() {
-	ExtBuilder::build().execute_with(|| {
-		System::set_block_number(1);
+    ExtBuilder::build().execute_with(|| {
+        System::set_block_number(1);
 
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 1u32,
-			per_period: 100u64,
-		};
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
-		assert_eq!(Vesting::vesting_schedules(BOB), vec![schedule.clone()]);
-		System::assert_last_event(RuntimeEvent::Vesting(crate::Event::VestingScheduleAdded {
-			from: ALICE,
-			to: BOB,
-			vesting_schedule: schedule,
-		}));
-	});
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 1u32,
+            per_period: 100u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule.clone()
+        ));
+        assert_eq!(Vesting::vesting_schedules(BOB), vec![schedule.clone()]);
+        System::assert_last_event(RuntimeEvent::Vesting(crate::Event::VestingScheduleAdded {
+            from: ALICE,
+            to: BOB,
+            vesting_schedule: schedule,
+        }));
+    });
 }
 
 #[test]
 fn self_vesting() {
-	ExtBuilder::build().execute_with(|| {
-		System::set_block_number(1);
+    ExtBuilder::build().execute_with(|| {
+        System::set_block_number(1);
 
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 1u32,
-			per_period: ALICE_BALANCE,
-		};
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 1u32,
+            per_period: ALICE_BALANCE,
+        };
 
-		let bad_schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 1u32,
-			per_period: 10 * ALICE_BALANCE,
-		};
+        let bad_schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 1u32,
+            per_period: 10 * ALICE_BALANCE,
+        };
 
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), ALICE, bad_schedule),
-			crate::Error::<Runtime>::InsufficientBalanceToLock
-		);
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), ALICE, bad_schedule),
+            crate::Error::<Runtime>::InsufficientBalanceToLock
+        );
 
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			ALICE,
-			schedule.clone()
-		));
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            ALICE,
+            schedule.clone()
+        ));
 
-		assert_eq!(Vesting::vesting_schedules(ALICE), vec![schedule.clone()]);
-		System::assert_last_event(RuntimeEvent::Vesting(crate::Event::VestingScheduleAdded {
-			from: ALICE,
-			to: ALICE,
-			vesting_schedule: schedule,
-		}));
-	});
+        assert_eq!(Vesting::vesting_schedules(ALICE), vec![schedule.clone()]);
+        System::assert_last_event(RuntimeEvent::Vesting(crate::Event::VestingScheduleAdded {
+            from: ALICE,
+            to: ALICE,
+            vesting_schedule: schedule,
+        }));
+    });
 }
 
 #[test]
 fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule
+        ));
 
-		MockBlockNumberProvider::set(12);
+        MockBlockNumberProvider::set(12);
 
-		let another_schedule = VestingSchedule {
-			start: 10u64,
-			period: 13u64,
-			period_count: 1u32,
-			per_period: 7u64,
-		};
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			another_schedule
-		));
+        let another_schedule = VestingSchedule {
+            start: 10u64,
+            period: 13u64,
+            period_count: 1u32,
+            per_period: 7u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            another_schedule
+        ));
 
-		assert_eq!(
-			PalletBalances::locks(BOB).get(0),
-			Some(&BalanceLock {
-				id: VESTING_LOCK_ID,
-				amount: 17u64,
-				reasons: Reasons::All,
-			})
-		);
-	});
+        assert_eq!(
+            PalletBalances::locks(BOB).get(0),
+            Some(&BalanceLock {
+                id: VESTING_LOCK_ID,
+                amount: 17u64,
+                reasons: Reasons::All,
+            })
+        );
+    });
 }
 
 #[test]
 fn cannot_use_fund_if_not_claimed() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 10u64,
-			period: 10u64,
-			period_count: 1u32,
-			per_period: 50u64,
-		};
-		assert_ok!(Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
-		assert!(PalletBalances::ensure_can_withdraw(&BOB, 1, WithdrawReasons::TRANSFER, 49).is_err());
-	});
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 10u64,
+            period: 10u64,
+            period_count: 1u32,
+            per_period: 50u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule
+        ));
+        assert!(
+            PalletBalances::ensure_can_withdraw(&BOB, 1, WithdrawReasons::TRANSFER, 49).is_err()
+        );
+    });
 }
 
 #[test]
 fn vested_transfer_fails_if_zero_period_or_count() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 1u64,
-			period: 0u64,
-			period_count: 1u32,
-			per_period: 100u64,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
-			Error::<Runtime>::ZeroVestingPeriod
-		);
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 1u64,
+            period: 0u64,
+            period_count: 1u32,
+            per_period: 100u64,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
+            Error::<Runtime>::ZeroVestingPeriod
+        );
 
-		let schedule = VestingSchedule {
-			start: 1u64,
-			period: 1u64,
-			period_count: 0u32,
-			per_period: 100u64,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
-			Error::<Runtime>::ZeroVestingPeriodCount
-		);
-	});
+        let schedule = VestingSchedule {
+            start: 1u64,
+            period: 1u64,
+            period_count: 0u32,
+            per_period: 100u64,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
+            Error::<Runtime>::ZeroVestingPeriodCount
+        );
+    });
 }
 
 #[test]
 fn vested_transfer_fails_if_transfer_err() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 1u64,
-			period: 1u64,
-			period_count: 1u32,
-			per_period: 100u64,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(BOB), ALICE, schedule),
-			TokenError::FundsUnavailable,
-		);
-	});
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 1u64,
+            period: 1u64,
+            period_count: 1u32,
+            per_period: 100u64,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(BOB), ALICE, schedule),
+            TokenError::FundsUnavailable,
+        );
+    });
 }
 
 #[test]
 fn vested_transfer_fails_if_overflow() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 1u64,
-			period: 1u64,
-			period_count: 2u32,
-			per_period: u64::MAX,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
-			ArithmeticError::Overflow,
-		);
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 1u64,
+            period: 1u64,
+            period_count: 2u32,
+            per_period: u64::MAX,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule),
+            ArithmeticError::Overflow,
+        );
 
-		let another_schedule = VestingSchedule {
-			start: u64::MAX,
-			period: 1u64,
-			period_count: 2u32,
-			per_period: 1u64,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, another_schedule),
-			ArithmeticError::Overflow,
-		);
-	});
+        let another_schedule = VestingSchedule {
+            start: u64::MAX,
+            period: 1u64,
+            period_count: 2u32,
+            per_period: 1u64,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, another_schedule),
+            ArithmeticError::Overflow,
+        );
+    });
 }
 
 #[test]
 fn vested_transfer_fails_if_bad_origin() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 1u32,
-			per_period: 100u64,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(CHARLIE), BOB, schedule),
-			BadOrigin
-		);
-	});
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 1u32,
+            per_period: 100u64,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(CHARLIE), BOB, schedule),
+            BadOrigin
+        );
+    });
 }
 
 #[test]
 fn claim_works() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule
+        ));
 
-		MockBlockNumberProvider::set(11);
-		// remain locked if not claimed
-		assert!(PalletBalances::transfer(RuntimeOrigin::signed(BOB), ALICE, 10).is_err());
-		// unlocked after claiming
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
-		assert!(VestingSchedules::<Runtime>::contains_key(BOB));
-		assert_ok!(PalletBalances::transfer(RuntimeOrigin::signed(BOB), ALICE, 10));
-		// more are still locked
-		assert!(PalletBalances::transfer(RuntimeOrigin::signed(BOB), ALICE, 1).is_err());
+        MockBlockNumberProvider::set(11);
+        // remain locked if not claimed
+        assert!(
+            PalletBalances::transfer_allow_death(RuntimeOrigin::signed(BOB), ALICE, 10).is_err()
+        );
+        // unlocked after claiming
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert!(VestingSchedules::<Runtime>::contains_key(BOB));
+        assert_ok!(PalletBalances::transfer_allow_death(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            10
+        ));
+        // more are still locked
+        assert!(
+            PalletBalances::transfer_allow_death(RuntimeOrigin::signed(BOB), ALICE, 1).is_err()
+        );
 
-		MockBlockNumberProvider::set(21);
-		// claim more
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
-		assert_ok!(PalletBalances::transfer(RuntimeOrigin::signed(BOB), ALICE, 10));
-		// all used up
-		assert_eq!(PalletBalances::free_balance(BOB), 0);
+        MockBlockNumberProvider::set(21);
+        // claim more
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+        assert_ok!(PalletBalances::transfer_allow_death(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            10
+        ));
+        // all used up
+        assert_eq!(PalletBalances::free_balance(BOB), 0);
 
-		// no locks anymore
-		assert_eq!(PalletBalances::locks(BOB), vec![]);
-	});
+        // no locks anymore
+        assert_eq!(PalletBalances::locks(BOB), vec![]);
+    });
 }
 
 #[test]
 fn claim_for_works() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule
+        ));
 
-		assert_ok!(Vesting::claim_for(RuntimeOrigin::signed(ALICE), BOB));
+        assert_ok!(Vesting::claim_for(RuntimeOrigin::signed(ALICE), BOB));
 
-		assert_eq!(
-			PalletBalances::locks(BOB).get(0),
-			Some(&BalanceLock {
-				id: VESTING_LOCK_ID,
-				amount: 20u64,
-				reasons: Reasons::All,
-			})
-		);
-		assert!(VestingSchedules::<Runtime>::contains_key(BOB));
+        assert_eq!(
+            PalletBalances::locks(BOB).get(0),
+            Some(&BalanceLock {
+                id: VESTING_LOCK_ID,
+                amount: 20u64,
+                reasons: Reasons::All,
+            })
+        );
+        assert!(VestingSchedules::<Runtime>::contains_key(BOB));
 
-		MockBlockNumberProvider::set(21);
+        MockBlockNumberProvider::set(21);
 
-		assert_ok!(Vesting::claim_for(RuntimeOrigin::signed(ALICE), BOB));
+        assert_ok!(Vesting::claim_for(RuntimeOrigin::signed(ALICE), BOB));
 
-		// no locks anymore
-		assert_eq!(PalletBalances::locks(BOB), vec![]);
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
-	});
+        // no locks anymore
+        assert_eq!(PalletBalances::locks(BOB), vec![]);
+        assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+    });
 }
 
 #[test]
 fn update_vesting_schedules_works() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(RuntimeOrigin::signed(ALICE), BOB, schedule));
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule
+        ));
 
-		let updated_schedule = VestingSchedule {
-			start: 0u64,
-			period: 20u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::update_vesting_schedules(
-			RuntimeOrigin::root(),
-			BOB,
-			vec![updated_schedule]
-		));
+        let updated_schedule = VestingSchedule {
+            start: 0u64,
+            period: 20u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::update_vesting_schedules(
+            RuntimeOrigin::root(),
+            BOB,
+            vec![updated_schedule]
+        ));
 
-		MockBlockNumberProvider::set(11);
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
-		assert!(PalletBalances::transfer(RuntimeOrigin::signed(BOB), ALICE, 1).is_err());
+        MockBlockNumberProvider::set(11);
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert!(
+            PalletBalances::transfer_allow_death(RuntimeOrigin::signed(BOB), ALICE, 1).is_err()
+        );
 
-		MockBlockNumberProvider::set(21);
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
-		assert_ok!(PalletBalances::transfer(RuntimeOrigin::signed(BOB), ALICE, 10));
+        MockBlockNumberProvider::set(21);
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert_ok!(PalletBalances::transfer_allow_death(
+            RuntimeOrigin::signed(BOB),
+            ALICE,
+            10
+        ));
 
-		// empty vesting schedules cleanup the storage and unlock the fund
-		assert!(VestingSchedules::<Runtime>::contains_key(BOB));
-		assert_eq!(
-			PalletBalances::locks(BOB).get(0),
-			Some(&BalanceLock {
-				id: VESTING_LOCK_ID,
-				amount: 10u64,
-				reasons: Reasons::All,
-			})
-		);
-		assert_ok!(Vesting::update_vesting_schedules(RuntimeOrigin::root(), BOB, vec![]));
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
-		assert_eq!(PalletBalances::locks(BOB), vec![]);
-	});
+        // empty vesting schedules cleanup the storage and unlock the fund
+        assert!(VestingSchedules::<Runtime>::contains_key(BOB));
+        assert_eq!(
+            PalletBalances::locks(BOB).get(0),
+            Some(&BalanceLock {
+                id: VESTING_LOCK_ID,
+                amount: 10u64,
+                reasons: Reasons::All,
+            })
+        );
+        assert_ok!(Vesting::update_vesting_schedules(
+            RuntimeOrigin::root(),
+            BOB,
+            vec![]
+        ));
+        assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+        assert_eq!(PalletBalances::locks(BOB), vec![]);
+    });
 }
 
 #[test]
 fn update_vesting_schedules_fails_if_unexpected_existing_locks() {
-	ExtBuilder::build().execute_with(|| {
-		assert_ok!(PalletBalances::transfer(RuntimeOrigin::signed(ALICE), BOB, 1));
-		PalletBalances::set_lock(*b"prelocks", &BOB, 0u64, WithdrawReasons::all());
-	});
+    ExtBuilder::build().execute_with(|| {
+        assert_ok!(PalletBalances::transfer_allow_death(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            1
+        ));
+        PalletBalances::set_lock(*b"prelocks", &BOB, 0u64, WithdrawReasons::all());
+    });
 }
 
 #[test]
 fn vested_transfer_check_for_min() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 1u64,
-			period: 1u64,
-			period_count: 1u32,
-			per_period: 3u64,
-		};
-		assert_noop!(
-			Vesting::vested_transfer(RuntimeOrigin::signed(BOB), ALICE, schedule),
-			Error::<Runtime>::AmountLow
-		);
-	});
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 1u64,
+            period: 1u64,
+            period_count: 1u32,
+            per_period: 3u64,
+        };
+        assert_noop!(
+            Vesting::vested_transfer(RuntimeOrigin::signed(BOB), ALICE, schedule),
+            Error::<Runtime>::AmountLow
+        );
+    });
 }
 
 #[test]
 fn multiple_vesting_schedule_claim_works() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule.clone()
+        ));
 
-		let schedule2 = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 3u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			schedule2.clone()
-		));
+        let schedule2 = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 3u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule2.clone()
+        ));
 
-		assert_eq!(Vesting::vesting_schedules(BOB), vec![schedule, schedule2.clone()]);
+        assert_eq!(
+            Vesting::vesting_schedules(BOB),
+            vec![schedule, schedule2.clone()]
+        );
 
-		MockBlockNumberProvider::set(21);
+        MockBlockNumberProvider::set(21);
 
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
 
-		assert_eq!(Vesting::vesting_schedules(BOB), vec![schedule2]);
+        assert_eq!(Vesting::vesting_schedules(BOB), vec![schedule2]);
 
-		MockBlockNumberProvider::set(31);
+        MockBlockNumberProvider::set(31);
 
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
 
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+        assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
 
-		assert_eq!(PalletBalances::locks(BOB), vec![]);
-	});
+        assert_eq!(PalletBalances::locks(BOB), vec![]);
+    });
 }
 
 #[test]
 fn exceeding_maximum_schedules_should_fail() {
-	ExtBuilder::build().execute_with(|| {
-		let schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 10u64,
-		};
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			schedule.clone()
-		));
+    ExtBuilder::build().execute_with(|| {
+        let schedule = VestingSchedule {
+            start: 0u64,
+            period: 10u64,
+            period_count: 2u32,
+            per_period: 10u64,
+        };
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule.clone()
+        ));
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            schedule.clone()
+        ));
 
-		let create = RuntimeCall::Vesting(crate::Call::<Runtime>::vested_transfer {
-			dest: BOB,
-			schedule: schedule.clone(),
-		});
-		assert_noop!(
-			create.dispatch(RuntimeOrigin::signed(ALICE)),
-			Error::<Runtime>::MaxVestingSchedulesExceeded
-		);
+        let create = RuntimeCall::Vesting(crate::Call::<Runtime>::vested_transfer {
+            dest: BOB,
+            schedule: schedule.clone(),
+        });
+        assert_noop!(
+            create.dispatch(RuntimeOrigin::signed(ALICE)),
+            Error::<Runtime>::MaxVestingSchedulesExceeded
+        );
 
-		let schedules = vec![schedule.clone(), schedule.clone(), schedule];
+        let schedules = vec![schedule.clone(), schedule.clone(), schedule];
 
-		assert_noop!(
-			Vesting::update_vesting_schedules(RuntimeOrigin::root(), BOB, schedules),
-			Error::<Runtime>::MaxVestingSchedulesExceeded
-		);
-	});
+        assert_noop!(
+            Vesting::update_vesting_schedules(RuntimeOrigin::root(), BOB, schedules),
+            Error::<Runtime>::MaxVestingSchedulesExceeded
+        );
+    });
 }
 
 #[test]
 fn cliff_vesting_works() {
-	const VESTING_AMOUNT: u64 = 12;
-	const VESTING_PERIOD: u64 = 20;
+    const VESTING_AMOUNT: u64 = 12;
+    const VESTING_PERIOD: u64 = 20;
 
-	ExtBuilder::build().execute_with(|| {
-		let cliff_schedule = VestingSchedule {
-			start: VESTING_PERIOD - 1,
-			period: 1,
-			period_count: 1,
-			per_period: VESTING_AMOUNT,
-		};
+    ExtBuilder::build().execute_with(|| {
+        let cliff_schedule = VestingSchedule {
+            start: VESTING_PERIOD - 1,
+            period: 1,
+            period_count: 1,
+            per_period: VESTING_AMOUNT,
+        };
 
-		let balance_lock = BalanceLock {
-			id: VESTING_LOCK_ID,
-			amount: VESTING_AMOUNT,
-			reasons: Reasons::All,
-		};
+        let balance_lock = BalanceLock {
+            id: VESTING_LOCK_ID,
+            amount: VESTING_AMOUNT,
+            reasons: Reasons::All,
+        };
 
-		assert_eq!(PalletBalances::free_balance(BOB), 0);
-		assert_ok!(Vesting::vested_transfer(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			cliff_schedule
-		));
-		assert_eq!(PalletBalances::free_balance(BOB), VESTING_AMOUNT);
-		assert_eq!(PalletBalances::locks(BOB), vec![balance_lock.clone()]);
+        assert_eq!(PalletBalances::free_balance(BOB), 0);
+        assert_ok!(Vesting::vested_transfer(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            cliff_schedule
+        ));
+        assert_eq!(PalletBalances::free_balance(BOB), VESTING_AMOUNT);
+        assert_eq!(PalletBalances::locks(BOB), vec![balance_lock.clone()]);
 
-		for i in 1..VESTING_PERIOD {
-			MockBlockNumberProvider::set(i);
-			assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
-			assert_eq!(PalletBalances::free_balance(BOB), VESTING_AMOUNT);
-			assert_eq!(PalletBalances::locks(BOB), vec![balance_lock.clone()]);
-			assert_noop!(
-				PalletBalances::transfer(RuntimeOrigin::signed(BOB), CHARLIE, VESTING_AMOUNT),
-				TokenError::Frozen,
-			);
-		}
+        for i in 1..VESTING_PERIOD {
+            MockBlockNumberProvider::set(i);
+            assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+            assert_eq!(PalletBalances::free_balance(BOB), VESTING_AMOUNT);
+            assert_eq!(PalletBalances::locks(BOB), vec![balance_lock.clone()]);
+            assert_noop!(
+                PalletBalances::transfer_allow_death(
+                    RuntimeOrigin::signed(BOB),
+                    CHARLIE,
+                    VESTING_AMOUNT
+                ),
+                TokenError::Frozen,
+            );
+        }
 
-		MockBlockNumberProvider::set(VESTING_PERIOD);
-		assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
-		assert!(PalletBalances::locks(BOB).is_empty());
-		assert_ok!(PalletBalances::transfer(
-			RuntimeOrigin::signed(BOB),
-			CHARLIE,
-			VESTING_AMOUNT
-		));
-	});
+        MockBlockNumberProvider::set(VESTING_PERIOD);
+        assert_ok!(Vesting::claim(RuntimeOrigin::signed(BOB)));
+        assert!(PalletBalances::locks(BOB).is_empty());
+        assert_ok!(PalletBalances::transfer_allow_death(
+            RuntimeOrigin::signed(BOB),
+            CHARLIE,
+            VESTING_AMOUNT
+        ));
+    });
 }

--- a/test/subspace-test-client/Cargo.toml
+++ b/test/subspace-test-client/Cargo.toml
@@ -16,20 +16,20 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 evm-domain-test-runtime = { version = "0.1.0", path = "../../domains/test/runtime/evm" }
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "01b56190c0ed019b187c34d23422b9fea7ca4393" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "e74fdd2de2a1d5749c067d6fd8e244e405b256e1" }
 futures = "0.3.28"
 schnorrkel = "0.9.1"
-sc-chain-spec = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus-subspace = { version = "0.1.0", path = "../../crates/sc-consensus-subspace" }
-sc-executor = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
 serde_json = "1.0.106"
-sp-api = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../../crates/sp-consensus-subspace" }
-sp-core = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../crates/sp-domains" }
-sp-runtime = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-archiving = { path = "../../crates/subspace-archiving" }
 subspace-core-primitives = { path = "../../crates/subspace-core-primitives" }
 subspace-erasure-coding = { path = "../../crates/subspace-erasure-coding" }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -18,12 +18,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", default-features = false, path = "../../domains/primitives/runtime" }
-frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 hex-literal = { version = "0.4.0", optional = true }
 orml-vesting = { version = "0.4.1-dev", default-features = false, path = "../../orml/vesting" }
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-domains = { version = "0.1.0", default-features = false, path = "../../crates/pallet-domains" }
 pallet-feeds = { version = "0.1.0", default-features = false, path = "../../crates/pallet-feeds" }
 pallet-grandpa-finality-verifier = { version = "0.1.0", default-features = false, path = "../../crates/pallet-grandpa-finality-verifier" }
@@ -32,39 +32,39 @@ pallet-object-store = { version = "0.1.0", default-features = false, path = "../
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../../crates/pallet-offences-subspace" }
 pallet-rewards = { version = "0.1.0", default-features = false, path = "../../crates/pallet-rewards" }
 pallet-subspace = { version = "0.1.0", default-features = false, features = ["serde"], path = "../../crates/pallet-subspace" }
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transaction-fees = { version = "0.1.0", default-features = false, path = "../../crates/pallet-transaction-fees" }
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 pallet-transporter = { version = "0.1.0", path = "../../domains/pallets/transporter", default-features = false }
-pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-block-builder = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false, version = "4.0.0-dev"}
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false, version = "4.0.0-dev"}
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../../crates/sp-consensus-subspace" }
-sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../crates/sp-domains" }
-sp-inherents = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false, version = "4.0.0-dev"}
+sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false, version = "4.0.0-dev"}
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../domains/primitives/messenger" }
 sp-objects = { version = "0.1.0", default-features = false, path = "../../crates/sp-objects" }
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 static_assertions = "1.1.0"
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../../crates/subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../../crates/subspace-runtime-primitives" }
 subspace-verification = { version = "0.1.0", default-features = false, path = "../../crates/subspace-verification" }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", optional = true }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", optional = true }
 
 [features]
 default = ["std"]

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -25,31 +25,31 @@ jsonrpsee = { version = "0.16.3", features = ["server"] }
 rand = "0.8.5"
 pallet-domains = { version = "0.1.0", path = "../../crates/pallet-domains" }
 parking_lot = "0.12.1"
-sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-client-api = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-executor = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus-fraud-proof = { version = "0.1.0", path = "../../crates/sc-consensus-fraud-proof" }
-sc-network = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-service = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898", default-features = false }
-sc-tracing = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-application-crypto = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-blockchain = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-consensus = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", default-features = false }
+sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-application-crypto = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-consensus-subspace = { version = "0.1.0", path = "../../crates/sp-consensus-subspace" }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sp-domains = { version = "0.1.0", path = "../../crates/sp-domains" }
-sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-keyring = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
-sp-runtime = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
+sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../../crates/subspace-core-primitives" }
 subspace-fraud-proof = { path = "../../crates/subspace-fraud-proof" }
 subspace-node = { path = "../../crates/subspace-node" }
@@ -62,7 +62,7 @@ tokio = "1.32.0"
 tracing = "0.1.37"
 
 [dev-dependencies]
-sp-keyring = { git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+sp-keyring = { git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 
 [features]
 pot = [


### PR DESCRIPTION
This upgrades Susbtrate to latest version from polkadot-sdk fork using branch [`subspace-v1`](https://github.com/subspace/polkadot-sdk/tree/subspace-v1) and Frontier with minor fixes that is also pushed into https://github.com/paritytech/frontier/pull/1193

@ParthDesai note how to enable UTC time such that the format for both node and farmer is the same, also you'll need to disable colors manually for node on Windows, CLI defaults to no colors on Windows in https://github.com/paritytech/polkadot-sdk/pull/1500 due to PowerShell not supporting the same escape sequences used for colors in *nix shells.

Fixes https://github.com/subspace/subspace/issues/602 using https://github.com/paritytech/polkadot-sdk/pull/1500

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
