### PR TITLE
Invalid timestamp fraud proof

### DIFF
--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -167,6 +167,15 @@ pub enum VerificationError {
     /// Domain state root not found.
     #[cfg_attr(feature = "thiserror", error("Domain state root not found"))]
     DomainStateRootNotFound,
+    /// Consensus state root not found.
+    #[cfg_attr(feature = "thiserror", error("Consensus state root not found"))]
+    ConsensusStateRootNotFound,
+    /// Failed to construct Timestamp extrinsic
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Failed to construct Timestamp extrinsic")
+    )]
+    FailedToConstructTimestampExtrinsic,
     /// Fail to get runtime code.
     // The `String` here actually repersenting the `sc_executor_common::error::WasmError`
     // error, but it will be improper to use `WasmError` directly here since it will make

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -28,6 +28,7 @@ sp-messenger = { version = "0.1.0", path = "../../domains/primitives/messenger" 
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
 sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
 sp-trie = { version = "22.0.0", git = "https://github.com/subspace/substrate", rev = "48c5ebae44b90d45863195b91e0e489eca670898" }
+subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives", default-features = false }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -281,6 +281,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         bad_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         consensus_parent_hash,
+        consensus_hash: primary_hash,
         pre_state_root: *parent_header.state_root(),
         post_state_root: intermediate_roots[0].into(),
         proof: storage_proof,
@@ -338,6 +339,7 @@ async fn execution_proof_creation_and_verification_should_work() {
             bad_receipt_hash: Hash::random(),
             parent_number: parent_number_alice,
             consensus_parent_hash,
+            consensus_hash: primary_hash,
             pre_state_root: intermediate_roots[target_extrinsic_index].into(),
             post_state_root: intermediate_roots[target_extrinsic_index + 1].into(),
             proof: storage_proof,
@@ -391,6 +393,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         bad_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         consensus_parent_hash,
+        consensus_hash: primary_hash,
         pre_state_root: intermediate_roots.last().unwrap().into(),
         post_state_root: post_execution_root,
         proof: storage_proof,
@@ -479,7 +482,7 @@ async fn invalid_execution_proof_should_not_work() {
     let best_hash = alice.client.info().best_hash;
     let header = alice.client.header(best_hash).unwrap().unwrap();
     let parent_header = alice.client.header(*header.parent_hash()).unwrap().unwrap();
-
+    let primary_hash = ferdie.client.hash(*header.number()).unwrap().unwrap();
     let create_block_builder = || {
         BlockBuilder::new(
             &*alice.client,
@@ -568,6 +571,7 @@ async fn invalid_execution_proof_should_not_work() {
         bad_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         consensus_parent_hash,
+        consensus_hash: primary_hash,
         pre_state_root: post_delta_root0,
         post_state_root: post_delta_root1,
         proof: proof1,
@@ -581,6 +585,7 @@ async fn invalid_execution_proof_should_not_work() {
         bad_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         consensus_parent_hash,
+        consensus_hash: primary_hash,
         pre_state_root: post_delta_root0,
         post_state_root: post_delta_root1,
         proof: proof0.clone(),
@@ -594,6 +599,7 @@ async fn invalid_execution_proof_should_not_work() {
         bad_receipt_hash: Hash::random(),
         parent_number: parent_number_alice,
         consensus_parent_hash,
+        consensus_hash: primary_hash,
         pre_state_root: post_delta_root0,
         post_state_root: post_delta_root1,
         proof: proof0,

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -158,6 +158,7 @@ where
     CClient: HeaderBackend<CBlock>
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>
+        + ProofProvider<CBlock>
         + ProvideRuntimeApi<CBlock>
         + 'static,
     CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -599,7 +599,11 @@ where
         + 'static,
     Client::Api:
         DomainCoreApi<Block> + sp_block_builder::BlockBuilder<Block> + sp_api::ApiExt<Block>,
-    CClient: HeaderBackend<CBlock> + BlockBackend<CBlock> + ProvideRuntimeApi<CBlock> + 'static,
+    CClient: HeaderBackend<CBlock>
+        + BlockBackend<CBlock>
+        + ProofProvider<CBlock>
+        + ProvideRuntimeApi<CBlock>
+        + 'static,
     CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>,
     Backend: sc_client_api::Backend<Block> + 'static,
     E: CodeExecutor,

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -91,6 +91,7 @@ pub(super) async fn start_worker<
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>
         + ProvideRuntimeApi<CBlock>
+        + ProofProvider<CBlock>
         + BlockchainEvents<CBlock>
         + 'static,
     CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -79,6 +79,7 @@ where
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>
         + ProvideRuntimeApi<CBlock>
+        + ProofProvider<CBlock>
         + BlockchainEvents<CBlock>
         + Send
         + Sync

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1066,6 +1066,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
         .unwrap()
         .unwrap();
     let parent_header = alice.client.header(*header.parent_hash()).unwrap().unwrap();
+    let primary_hash = ferdie.client.hash(*header.number()).unwrap().unwrap();
 
     let intermediate_roots = alice
         .client
@@ -1123,6 +1124,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
         bad_receipt_hash: bad_receipt.hash(),
         parent_number: parent_number_ferdie,
         consensus_parent_hash: parent_hash_ferdie,
+        consensus_hash: primary_hash,
         pre_state_root: *parent_header.state_root(),
         post_state_root: intermediate_roots[0].into(),
         proof: storage_proof,


### PR DESCRIPTION
This PR adds Timestamp specific fraud proof for the first extrinsic mismatch. Since the call data can be constructed using RuntimeLightApi and Timestamp in the storage proof, execution is verified statelessly.

Closes: #1896 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
