### PR TITLE
Add `PotVerifier::try_is_output_valid()` method for quick and cheap verification of proofs

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1669,6 +1669,8 @@ fn check_vote<T: Config>(
             .expect("Must be able to convert to block hash type"),
         SlotNumber::from(slot),
         WrappedPotOutput::from(*proof_of_time),
+        // Quick verification when entering transaction pool, but not when constructing the block
+        !pre_dispatch,
     ) {
         debug!(target: "runtime::subspace", "Invalid proof of time");
 
@@ -1684,6 +1686,7 @@ fn check_vote<T: Config>(
                 .expect("Must be able to convert to block hash type"),
             SlotNumber::from(slot + T::BlockAuthoringDelay::get()),
             WrappedPotOutput::from(*future_proof_of_time),
+            false,
         )
     {
         debug!(target: "runtime::subspace", "Invalid future proof of time");

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -366,7 +366,7 @@ where
             // Ensure proof of time and future proof of time included in upcoming block are valid
             if !self
                 .pot_verifier
-                .is_output_valid(
+                .try_is_output_valid(
                     after_parent_slot,
                     pot_seed,
                     slot_iterations,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -563,14 +563,14 @@ impl PosExtension {
 #[cfg(all(feature = "std", feature = "pot"))]
 sp_externalities::decl_extension! {
     /// A Poof of time extension.
-    pub struct PotExtension(Box<dyn (Fn(BlockHash, SlotNumber, PotOutput) -> bool) + Send + Sync>);
+    pub struct PotExtension(Box<dyn (Fn(BlockHash, SlotNumber, PotOutput, bool) -> bool) + Send + Sync>);
 }
 
 #[cfg(all(feature = "std", feature = "pot"))]
 impl PotExtension {
     /// Create new instance.
     pub fn new(
-        verifier: Box<dyn (Fn(BlockHash, SlotNumber, PotOutput) -> bool) + Send + Sync>,
+        verifier: Box<dyn (Fn(BlockHash, SlotNumber, PotOutput, bool) -> bool) + Send + Sync>,
     ) -> Self {
         Self(verifier)
     }
@@ -631,6 +631,7 @@ pub trait Consensus {
         parent_hash: BlockHash,
         slot: SlotNumber,
         proof_of_time: WrappedPotOutput,
+        quick_verification: bool,
     ) -> bool {
         use sp_externalities::ExternalitiesExt;
 
@@ -639,7 +640,7 @@ pub trait Consensus {
             .expect("No `PotExtension` associated for the current context!")
             .0;
 
-        verifier(parent_hash, slot, proof_of_time.0)
+        verifier(parent_hash, slot, proof_of_time.0, quick_verification)
     }
 }
 


### PR DESCRIPTION
In contexts like block execution or block production we are guaranteed to have proofs of time already available and should not need to run proving. This is especially important for vote verification that by including invalid proof of time may cause expensive extrinsic verification.

Fixes https://github.com/subspace/subspace/issues/1951

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
