### PR TITLE
Introduce valid_bundles field to the execution receipt

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -268,6 +268,7 @@ pub(crate) fn create_dummy_receipt(
         parent_domain_block_receipt_hash,
         consensus_block_number: block_number,
         consensus_block_hash,
+        valid_bundles: Vec::new(),
         invalid_bundles: Vec::new(),
         block_extrinsics_roots,
         final_state_root: Default::default(),

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -705,6 +705,8 @@ pub enum InvalidBundleType {
     OutOfRangeTx,
     /// Transaction is illegal (unable to pay the fee, etc).
     IllegalTx,
+    /// Transaction is an invalid XDM
+    InvalidXDM,
     /// Receipt is invalid.
     InvalidReceipt(InvalidReceipt),
 }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -359,6 +359,8 @@ pub struct ExecutionReceipt<Number, Hash, DomainNumber, DomainHash, Balance> {
     pub consensus_block_number: Number,
     /// The block hash corresponding to `consensus_block_number`.
     pub consensus_block_hash: Hash,
+    /// All the bundles that are included in the domain block building.
+    pub valid_bundles: Vec<ValidBundle>,
     /// Potential bundles that are excluded from the domain block building.
     pub invalid_bundles: Vec<InvalidBundle>,
     /// All `extrinsics_roots` for all bundles being executed by this block.
@@ -400,6 +402,7 @@ impl<
             parent_domain_block_receipt_hash: Default::default(),
             consensus_block_hash: consensus_genesis_hash,
             consensus_block_number: Zero::zero(),
+            valid_bundles: Vec::new(),
             invalid_bundles: Vec::new(),
             block_extrinsics_roots: sp_std::vec![],
             final_state_root: genesis_state_root.clone(),
@@ -434,6 +437,7 @@ impl<
             parent_domain_block_receipt_hash,
             consensus_block_number,
             consensus_block_hash,
+            valid_bundles: Vec::new(),
             invalid_bundles: Vec::new(),
             block_extrinsics_roots: sp_std::vec![Default::default()],
             final_state_root: Default::default(),
@@ -714,6 +718,15 @@ pub struct InvalidBundle {
     pub bundle_index: u32,
     /// Specific type of invalidity.
     pub invalid_bundle_type: InvalidBundleType,
+}
+
+/// [`ValidBundle`] represents a bundle that was used when building the domain block.
+#[derive(Debug, Decode, Encode, TypeInfo, Clone, PartialEq, Eq)]
+pub struct ValidBundle {
+    /// Index of this bundle in the original list of bundles in the consensus block.
+    pub bundle_index: u32,
+    /// Hash of `Vec<(tx_signer, tx_hash)>` of all domain extrinsic being included in the bundle.
+    pub bundle_digest: H256,
 }
 
 #[derive(Debug, Decode, Encode, TypeInfo, Clone, PartialEq, Eq)]

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -27,14 +27,14 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use runtime_api::InherentExtrinsicConstructor;
 use sc_client_api::BlockBackend;
-use sp_api::ProvideRuntimeApi;
+use sp_api::{HashT, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_domains::{
     BundleValidity, DomainId, DomainsApi, DomainsDigestItem, ExecutionReceipt, ExtrinsicsRoot,
-    InvalidBundle, InvalidBundleType, OpaqueBundle, OpaqueBundles, ReceiptValidity,
+    InvalidBundle, InvalidBundleType, OpaqueBundle, OpaqueBundles, ReceiptValidity, ValidBundle,
 };
 use sp_messenger::MessengerApi;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Header as HeaderT, NumberFor};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Debug;
@@ -108,18 +108,15 @@ where
     Ok((extrinsics, shuffling_seed, maybe_new_runtime))
 }
 
-fn deduplicate_and_shuffle_extrinsics<Block, SE>(
-    parent_hash: Block::Hash,
-    signer_extractor: &SE,
-    mut extrinsics: Vec<Block::Extrinsic>,
+fn deduplicate_and_shuffle_extrinsics<Block>(
+    mut extrinsics: Vec<(Option<AccountId>, Block::Extrinsic)>,
     shuffling_seed: Randomness,
 ) -> Result<Vec<Block::Extrinsic>, sp_blockchain::Error>
 where
     Block: BlockT,
-    SE: SignerExtractor<Block>,
 {
     let mut seen = Vec::new();
-    extrinsics.retain(|uxt| match seen.contains(uxt) {
+    extrinsics.retain(|(_, uxt)| match seen.contains(uxt) {
         true => {
             tracing::trace!(extrinsic = ?uxt, "Duplicated extrinsic");
             false
@@ -132,14 +129,6 @@ where
     drop(seen);
 
     tracing::trace!(?extrinsics, "Origin deduplicated extrinsics");
-
-    let extrinsics: Vec<_> = match signer_extractor.extract_signer(parent_hash, extrinsics) {
-        Ok(res) => res,
-        Err(e) => {
-            tracing::error!(error = ?e, "Error at calling runtime api: extract_signer");
-            return Err(e.into());
-        }
-    };
 
     let extrinsics =
         shuffle_extrinsics::<<Block as BlockT>::Extrinsic, AccountId>(extrinsics, shuffling_seed);
@@ -197,6 +186,7 @@ fn shuffle_extrinsics<Extrinsic: Debug, AccountId: Ord + Clone>(
 pub struct PreprocessResult<Block: BlockT> {
     pub extrinsics: Vec<Block::Extrinsic>,
     pub extrinsics_roots: Vec<ExtrinsicsRoot>,
+    pub valid_bundles: Vec<ValidBundle>,
     pub invalid_bundles: Vec<InvalidBundle>,
 }
 
@@ -312,15 +302,11 @@ where
             .runtime_api()
             .domain_tx_range(consensus_block_hash, self.domain_id)?;
 
-        let (invalid_bundles, extrinsics) =
+        let (valid_bundles, invalid_bundles, extrinsics) =
             self.compile_bundles_to_extrinsics(bundles, tx_range, domain_hash)?;
 
-        let extrinsics_in_bundle = deduplicate_and_shuffle_extrinsics(
-            domain_hash,
-            &self.runtime_api,
-            extrinsics,
-            shuffling_seed,
-        )?;
+        let extrinsics_in_bundle =
+            deduplicate_and_shuffle_extrinsics::<Block>(extrinsics, shuffling_seed)?;
 
         // Fetch inherent extrinsics
         let mut extrinsics = construct_inherent_extrinsics(
@@ -347,6 +333,7 @@ where
         Ok(Some(PreprocessResult {
             extrinsics,
             extrinsics_roots,
+            valid_bundles,
             invalid_bundles,
         }))
     }
@@ -359,13 +346,35 @@ where
         bundles: OpaqueBundles<CBlock, NumberFor<Block>, Block::Hash, Balance>,
         tx_range: U256,
         at: Block::Hash,
-    ) -> sp_blockchain::Result<(Vec<InvalidBundle>, Vec<Block::Extrinsic>)> {
+    ) -> sp_blockchain::Result<(
+        Vec<ValidBundle>,
+        Vec<InvalidBundle>,
+        Vec<(Option<AccountId>, Block::Extrinsic)>,
+    )> {
         let mut invalid_bundles = Vec::with_capacity(bundles.len());
+        let mut valid_bundles = Vec::with_capacity(bundles.len());
         let mut valid_extrinsics = Vec::new();
 
         for (index, bundle) in bundles.into_iter().enumerate() {
             match self.check_bundle_validity(&bundle, &tx_range, at)? {
-                BundleValidity::Valid(extrinsics) => valid_extrinsics.extend(extrinsics),
+                BundleValidity::Valid(extrinsics) => {
+                    let extrinsics: Vec<_> = match self.runtime_api.extract_signer(at, extrinsics) {
+                        Ok(res) => res,
+                        Err(e) => {
+                            tracing::error!(error = ?e, "Error at calling runtime api: extract_signer");
+                            return Err(e.into());
+                        }
+                    };
+                    let bundle_digest: Vec<_> = extrinsics
+                        .iter()
+                        .map(|(signer, tx)| (signer.clone(), BlakeTwo256::hash_of(tx)))
+                        .collect();
+                    valid_bundles.push(ValidBundle {
+                        bundle_index: index as u32,
+                        bundle_digest: BlakeTwo256::hash_of(&bundle_digest),
+                    });
+                    valid_extrinsics.extend(extrinsics);
+                }
                 BundleValidity::Invalid(invalid_bundle_type) => {
                     invalid_bundles.push(InvalidBundle {
                         bundle_index: index as u32,
@@ -375,7 +384,7 @@ where
             }
         }
 
-        Ok((invalid_bundles, valid_extrinsics))
+        Ok((valid_bundles, invalid_bundles, valid_extrinsics))
     }
 
     fn check_bundle_validity(

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -493,6 +493,7 @@ mod tests {
             parent_domain_block_receipt_hash: H256::random(),
             consensus_block_number,
             consensus_block_hash: H256::random(),
+            valid_bundles: Vec::new(),
             invalid_bundles: Vec::new(),
             block_extrinsics_roots: Default::default(),
             final_state_root: Default::default(),

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -3,7 +3,7 @@ use crate::domain_block_processor::{
 };
 use crate::{DomainParentChain, ExecutionReceiptFor};
 use domain_block_preprocessor::runtime_api_full::RuntimeApiFull;
-use domain_block_preprocessor::{DomainBlockPreprocessor, PreprocessResult};
+use domain_block_preprocessor::DomainBlockPreprocessor;
 use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use sc_client_api::{AuxStore, BlockBackend, Finalizer, ProofProvider};
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy, StateAction};
@@ -269,11 +269,7 @@ where
             .head_receipt_number(consensus_block_hash, self.domain_id)?
             .into();
 
-        let Some(PreprocessResult {
-            extrinsics,
-            extrinsics_roots,
-            invalid_bundles,
-        }) = self
+        let Some(preprocess_result) = self
             .domain_block_preprocessor
             .preprocess_consensus_block(consensus_block_hash, parent_hash)?
         else {
@@ -299,9 +295,7 @@ where
             .process_domain_block(
                 (consensus_block_hash, consensus_block_number),
                 (parent_hash, parent_number),
-                extrinsics,
-                invalid_bundles,
-                extrinsics_roots,
+                preprocess_result,
                 digest,
             )
             .await?;

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -369,6 +369,8 @@ where
             parent_domain_block_receipt_hash: parent_receipt.hash(),
             consensus_block_number,
             consensus_block_hash,
+            // TODO: set to proper value
+            valid_bundles: Vec::new(),
             invalid_bundles,
             block_extrinsics_roots: bundle_extrinsics_roots,
             final_state_root: state_root,


### PR DESCRIPTION
This PR is part of #1962, it introduces the `valid_bundles` field to the execution receipt, which is used to bypass the size limit issue of the invalid extrinsic ordering fraud proof in #1888

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
