### PR TITLE
PoT checkpoints in justifications

### DIFF
--- a/crates/sc-consensus-subspace/src/import_queue.rs
+++ b/crates/sc-consensus-subspace/src/import_queue.rs
@@ -251,7 +251,7 @@ where
         }
 
         // The case where we have justifications is a happy case because we can verify most things
-        // right way and more efficiently than without justifications. But justifications are not
+        // right away and more efficiently than without justifications. But justifications are not
         // always available, so fallback is still needed.
         #[cfg(feature = "pot")]
         if let Some(subspace_justification) = justifications.as_ref().and_then(|justifications| {
@@ -267,7 +267,7 @@ where
                 checkpoints,
             } = subspace_justification;
 
-            // Last checkpoint must be out future proof of time, this is how we anchor the rest of
+            // Last checkpoint must be our future proof of time, this is how we anchor the rest of
             // checks together
             if checkpoints.last().map(|checkpoints| checkpoints.output())
                 != Some(pre_digest.pot_info().future_proof_of_time())
@@ -314,7 +314,7 @@ where
             }
             // Try to find invalid checkpoints
             if verification_results
-                // TODO: Ideally we'd use `find` here instead, but it does not yet exists:
+                // TODO: Ideally we'd use `find` here instead, but it does not yet exist:
                 //  https://github.com/rust-lang/futures-rs/issues/2705
                 .filter(|&success| async move { !success })
                 .boxed()

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -60,10 +60,14 @@ use sp_consensus_slots::{Slot, SlotDuration};
 use sp_consensus_subspace::digests::{
     extract_pre_digest, extract_subspace_digest_items, Error as DigestError, SubspaceDigestItems,
 };
+#[cfg(feature = "pot")]
+use sp_consensus_subspace::SubspaceJustification;
 use sp_consensus_subspace::{ChainConstants, FarmerPublicKey, FarmerSignature, SubspaceApi};
 use sp_core::H256;
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
 use sp_runtime::traits::One;
+#[cfg(feature = "pot")]
+use sp_runtime::Justifications;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
@@ -170,6 +174,14 @@ pub enum Error<Header: HeaderT> {
     /// Bad reward signature
     #[error("Bad reward signature on {0:?}")]
     BadRewardSignature(Header::Hash),
+    /// Invalid Subspace justification
+    #[cfg(feature = "pot")]
+    #[error("Invalid Subspace justification: {0}")]
+    InvalidSubspaceJustification(codec::Error),
+    /// Invalid Subspace justification contents
+    #[cfg(feature = "pot")]
+    #[error("Invalid Subspace justification contents")]
+    InvalidSubspaceJustificationContents,
     /// Invalid proof of time
     #[cfg(feature = "pot")]
     #[error("Invalid proof of time")]
@@ -279,6 +291,14 @@ where
             VerificationError::HeaderUnsealed(block_hash) => Error::HeaderUnsealed(block_hash),
             VerificationError::BadRewardSignature(block_hash) => {
                 Error::BadRewardSignature(block_hash)
+            }
+            #[cfg(feature = "pot")]
+            VerificationError::InvalidSubspaceJustification(error) => {
+                Error::InvalidSubspaceJustification(error)
+            }
+            #[cfg(feature = "pot")]
+            VerificationError::InvalidSubspaceJustificationContents => {
+                Error::InvalidSubspaceJustificationContents
             }
             #[cfg(feature = "pot")]
             VerificationError::InvalidProofOfTime => Error::InvalidProofOfTime,
@@ -691,6 +711,7 @@ where
             FarmerPublicKey,
             FarmerSignature,
         >,
+        #[cfg(feature = "pot")] justifications: &Option<Justifications>,
         skip_runtime_access: bool,
     ) -> Result<(), Error<Block::Header>> {
         let block_number = *header.number();
@@ -757,6 +778,17 @@ where
         #[allow(clippy::needless_late_init)]
         let correct_solution_range;
 
+        let parent_subspace_digest_items = if block_number.is_one() {
+            None
+        } else {
+            Some(extract_subspace_digest_items::<
+                _,
+                FarmerPublicKey,
+                FarmerPublicKey,
+                FarmerSignature,
+            >(&parent_header)?)
+        };
+
         if block_number.is_one() {
             // Genesis block doesn't contain usual digest items, we need to query runtime API
             // instead
@@ -772,13 +804,9 @@ where
                 slot_worker::extract_solution_ranges_for_block(self.client.as_ref(), parent_hash)?
                     .0;
         } else {
-            let parent_subspace_digest_items = extract_subspace_digest_items::<
-                _,
-                FarmerPublicKey,
-                FarmerPublicKey,
-                FarmerSignature,
-            >(&parent_header)?;
-
+            let parent_subspace_digest_items = parent_subspace_digest_items
+                .as_ref()
+                .expect("Always Some for non-first block; qed");
             #[cfg(not(feature = "pot"))]
             {
                 correct_global_randomness =
@@ -803,71 +831,128 @@ where
             return Err(Error::InvalidGlobalRandomness(block_hash));
         }
 
+        // The case where we have justifications is a happy case because we only need to check the
+        // seed and number of checkpoints. But justifications are not always available, so fallback
+        // is still needed.
         #[cfg(feature = "pot")]
-        let pot_seed;
-        #[cfg(feature = "pot")]
-        let slot_iterations;
+        if let Some(subspace_justification) = justifications.as_ref().and_then(|justifications| {
+            justifications
+                .iter()
+                .find_map(SubspaceJustification::try_from_justification)
+        }) {
+            let subspace_justification =
+                subspace_justification.map_err(Error::InvalidSubspaceJustification)?;
 
-        #[cfg(feature = "pot")]
-        if block_number.is_one() {
-            // Genesis block doesn't contain usual digest items, we need to query runtime API
-            // instead
-            slot_iterations = self
-                .client
-                .runtime_api()
-                .pot_parameters(parent_hash)?
-                .slot_iterations();
-            pot_seed = self.pot_verifier.genesis_seed();
-        } else {
-            let parent_subspace_digest_items = extract_subspace_digest_items::<
-                _,
-                FarmerPublicKey,
-                FarmerPublicKey,
-                FarmerSignature,
-            >(&parent_header)?;
+            let SubspaceJustification::PotCheckpoints { seed, checkpoints } =
+                subspace_justification;
 
-            // In case parameters change in the very first slot after slot of the parent block,
-            // account for them
-            if let Some(parameters_change) = subspace_digest_items.pot_parameters_change
-                && parameters_change.slot == (parent_slot + Slot::from(1))
-            {
-                slot_iterations = parameters_change.slot_iterations;
-                pot_seed = parent_subspace_digest_items
-                    .pre_digest
-                    .pot_info()
-                    .proof_of_time()
-                    .seed_with_entropy(&parameters_change.entropy);
+            let future_slot = pre_digest.slot() + self.chain_constants.block_authoring_delay();
+
+            if block_number.is_one() {
+                // In case of first block seed must match genesis seed
+                if seed != self.pot_verifier.genesis_seed() {
+                    return Err(Error::InvalidSubspaceJustificationContents);
+                }
+
+                // Number of checkpoints must match future slot number
+                if checkpoints.len() as u64 != *future_slot {
+                    return Err(Error::InvalidSubspaceJustificationContents);
+                }
             } else {
-                slot_iterations = subspace_digest_items.pot_slot_iterations;
-                pot_seed = parent_subspace_digest_items
-                    .pre_digest
-                    .pot_info()
-                    .proof_of_time()
-                    .seed();
-            }
-        }
+                let parent_subspace_digest_items = parent_subspace_digest_items
+                    .as_ref()
+                    .expect("Always Some for non-first block; qed");
 
-        #[cfg(feature = "pot")]
-        // TODO: Extend/optimize this check once we have checkpoints in justifications
-        // Here we check that there is continuity from parent block's proof of time (but not future
-        // entropy since this block may be produced before slot corresponding to parent block's
-        // future proof of time) to current block's proof of time. During stateless verification we
-        // do not have access to parent block, thus only verify proofs after proof of time of at
-        // current slot up until future proof of time (inclusive), here during block import we
-        // verify the rest.
-        if !self
-            .pot_verifier
-            .is_output_valid(
-                parent_slot + Slot::from(1),
-                pot_seed,
-                slot_iterations,
-                slots_since_parent,
-                subspace_digest_items.pre_digest.pot_info().proof_of_time(),
-                subspace_digest_items.pot_parameters_change,
-            )
-            .await
-        {
-            return Err(Error::InvalidProofOfTime);
+                let parent_future_slot = parent_slot + self.chain_constants.block_authoring_delay();
+                let after_parent_future_slot = parent_future_slot + Slot::from(1);
+                let correct_seed;
+
+                // In case parameters change in the very first slot after future slot of the parent
+                // block, account for them
+                if let Some(parameters_change) = subspace_digest_items.pot_parameters_change
+                    && parameters_change.slot == after_parent_future_slot
+                {
+                     correct_seed = parent_subspace_digest_items
+                        .pre_digest
+                        .pot_info()
+                        .future_proof_of_time()
+                        .seed_with_entropy(&parameters_change.entropy);
+                } else {
+                    correct_seed = parent_subspace_digest_items
+                        .pre_digest
+                        .pot_info()
+                        .future_proof_of_time()
+                        .seed();
+                }
+
+                if seed != correct_seed {
+                    return Err(Error::InvalidSubspaceJustificationContents);
+                }
+
+                // Number of checkpoints must match number of proofs that were not yet seen on chain
+                if checkpoints.len() as u64 != (*future_slot - *parent_future_slot) {
+                    return Err(Error::InvalidSubspaceJustificationContents);
+                }
+            }
+        } else {
+            let pot_seed;
+            let slot_iterations;
+
+            if block_number.is_one() {
+                // Genesis block doesn't contain usual digest items, we need to query runtime API
+                // instead
+                slot_iterations = self
+                    .client
+                    .runtime_api()
+                    .pot_parameters(parent_hash)?
+                    .slot_iterations();
+                pot_seed = self.pot_verifier.genesis_seed();
+            } else {
+                let parent_subspace_digest_items = parent_subspace_digest_items
+                    .as_ref()
+                    .expect("Always Some for non-first block; qed");
+
+                // In case parameters change in the very first slot after slot of the parent block,
+                // account for them
+                if let Some(parameters_change) = subspace_digest_items.pot_parameters_change
+                    && parameters_change.slot == (parent_slot + Slot::from(1))
+                {
+                    slot_iterations = parameters_change.slot_iterations;
+                    pot_seed = parent_subspace_digest_items
+                        .pre_digest
+                        .pot_info()
+                        .proof_of_time()
+                        .seed_with_entropy(&parameters_change.entropy);
+                } else {
+                    slot_iterations = subspace_digest_items.pot_slot_iterations;
+                    pot_seed = parent_subspace_digest_items
+                        .pre_digest
+                        .pot_info()
+                        .proof_of_time()
+                        .seed();
+                }
+            }
+
+            // Here we check that there is continuity from parent block's proof of time (but not future
+            // entropy since this block may be produced before slot corresponding to parent block's
+            // future proof of time) to current block's proof of time. During stateless verification we
+            // do not have access to parent block, thus only verify proofs after proof of time of at
+            // current slot up until future proof of time (inclusive), here during block import we
+            // verify the rest.
+            if !self
+                .pot_verifier
+                .is_output_valid(
+                    parent_slot + Slot::from(1),
+                    pot_seed,
+                    slot_iterations,
+                    slots_since_parent,
+                    subspace_digest_items.pre_digest.pot_info().proof_of_time(),
+                    subspace_digest_items.pot_parameters_change,
+                )
+                .await
+            {
+                return Err(Error::InvalidProofOfTime);
+            }
         }
 
         let sector_id = SectorId::new(
@@ -1034,6 +1119,8 @@ where
             block.body.clone(),
             &root_plot_public_key,
             &subspace_digest_items,
+            #[cfg(feature = "pot")]
+            &block.justifications,
             skip_execution_checks,
         )
         .await

--- a/crates/sc-proof-of-time/src/verifier.rs
+++ b/crates/sc-proof-of-time/src/verifier.rs
@@ -77,7 +77,7 @@ impl PotVerifier {
 
         self.cache
             .lock()
-            .peek(&cache_key)
+            .get(&cache_key)
             .and_then(|value| value.checkpoints.try_lock()?.as_ref().copied())
     }
 
@@ -155,7 +155,7 @@ impl PotVerifier {
         loop {
             // TODO: This "proxy" is a workaround for https://github.com/rust-lang/rust/issues/57478
             let (result_sender, result_receiver) = oneshot::channel();
-            std::thread::spawn({
+            rayon::spawn({
                 let verifier = self.clone();
 
                 move || {
@@ -225,7 +225,7 @@ impl PotVerifier {
 
         loop {
             let mut cache = self.cache.lock();
-            let maybe_cache_value = cache.peek(&cache_key).cloned();
+            let maybe_cache_value = cache.get(&cache_key).cloned();
             if let Some(cache_value) = maybe_cache_value {
                 drop(cache);
                 let correct_checkpoints = cache_value.checkpoints.lock().await;
@@ -298,7 +298,7 @@ impl PotVerifier {
     ) -> bool {
         // TODO: This "proxy" is a workaround for https://github.com/rust-lang/rust/issues/57478
         let (result_sender, result_receiver) = oneshot::channel();
-        std::thread::spawn({
+        rayon::spawn({
             let verifier = self.clone();
             let checkpoints = *checkpoints;
 
@@ -335,7 +335,7 @@ impl PotVerifier {
 
         loop {
             let mut cache = self.cache.lock();
-            if let Some(cache_value) = cache.peek(&cache_key).cloned() {
+            if let Some(cache_value) = cache.get(&cache_key).cloned() {
                 drop(cache);
                 let correct_checkpoints = cache_value.checkpoints.lock().await;
                 if let Some(correct_checkpoints) = correct_checkpoints.as_ref() {

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -52,9 +52,9 @@ use subspace_core_primitives::Randomness;
 #[cfg(feature = "pot")]
 use subspace_core_primitives::{Blake3Hash, PotOutput};
 use subspace_core_primitives::{
-    BlockNumber, HistorySize, PotCheckpoints, PublicKey, RewardSignature, SegmentCommitment,
-    SegmentHeader, SegmentIndex, SlotNumber, Solution, SolutionRange, PUBLIC_KEY_LENGTH,
-    REWARD_SIGNATURE_LENGTH,
+    BlockNumber, HistorySize, PotCheckpoints, PotSeed, PublicKey, RewardSignature,
+    SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, Solution, SolutionRange,
+    PUBLIC_KEY_LENGTH, REWARD_SIGNATURE_LENGTH,
 };
 #[cfg(feature = "std")]
 use subspace_proof_of_space::chia::ChiaTable;
@@ -113,7 +113,13 @@ const SUBSPACE_ENGINE_ID: ConsensusEngineId = *b"SUB_";
 pub enum SubspaceJustification {
     /// Proof of time checkpoints that were not seen before
     #[codec(index = 0)]
-    Checkpoints(Vec<PotCheckpoints>),
+    PotCheckpoints {
+        /// Proof of time seed, the input for computing checkpoints
+        seed: PotSeed,
+        /// Proof of time checkpoints from after future proof of parent block to current block's
+        /// future proof (inclusive)
+        checkpoints: Vec<PotCheckpoints>,
+    },
 }
 
 impl From<SubspaceJustification> for Justification {


### PR DESCRIPTION
With recent Substrate upgade that removed finality restriction from justifications, we can put checkpoints there to accelerate verification.

We store checkpoints that were not seen yet only to minimize size alongside with seed such that we can verify all of them before importing a block.

In terms of checks in block verification we first check justifictions that will populate verifier's cache, ensure last checkpoint's output is the same as future proof of time of the block and then do regular verification (that will be quick due to cache usage) to ensure regular proof of time ties into it.

During block import in case justifications are present we simply need to check that both seed and number of checkpoints match our expectations, the rest is deterministic and must be correct too.

Fixes https://github.com/subspace/subspace/issues/1948

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
