### PR TITLE
Improve sync start speed on restart

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -13,8 +13,10 @@ use sc_consensus::import_queue::ImportQueueService;
 use sc_consensus_subspace::archiver::SegmentHeadersStore;
 use sc_network::config::SyncMode;
 use sc_network::{NetworkPeers, NetworkService};
-use sp_api::BlockT;
+use sp_api::{BlockT, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
+use sp_consensus_subspace::{FarmerPublicKey, SubspaceApi};
+use sp_runtime::Saturating;
 use std::future::Future;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -59,9 +61,11 @@ where
     Client: HeaderBackend<Block>
         + BlockBackend<Block>
         + BlockchainEvents<Block>
+        + ProvideRuntimeApi<Block>
         + Send
         + Sync
         + 'static,
+    Client::Api: SubspaceApi<Block, FarmerPublicKey>,
 {
     let (tx, rx) = mpsc::channel(0);
     let observer_fut = {
@@ -212,13 +216,31 @@ async fn create_worker<Block, AS, IQS, Client>(
 where
     Block: BlockT,
     AS: AuxStore + Send + Sync + 'static,
-    Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
+    Client: HeaderBackend<Block>
+        + BlockBackend<Block>
+        + ProvideRuntimeApi<Block>
+        + Send
+        + Sync
+        + 'static,
+    Client::Api: SubspaceApi<Block, FarmerPublicKey>,
     IQS: ImportQueueService<Block> + ?Sized,
 {
     // Corresponds to contents of block one, everyone has it, so we consider it being processed
     // right away
     let mut last_processed_segment_index = SegmentIndex::ZERO;
-    let mut last_processed_block_number = client.info().finalized_number;
+    // TODO: We'll be able to just take finalized block once we are able to decouple pruning from
+    //  finality: https://github.com/paritytech/polkadot-sdk/issues/1570
+    let mut last_processed_block_number = {
+        let info = client.info();
+        info.best_number.saturating_sub(
+            client
+                .runtime_api()
+                .chain_constants(info.best_hash)
+                .map_err(|error| error.to_string())?
+                .confirmation_depth_k()
+                .into(),
+        )
+    };
     let segment_header_downloader = SegmentHeaderDownloader::new(node);
     let piece_provider = PieceProvider::new(
         node.clone(),

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -115,10 +115,9 @@ where
             .is_some();
 
         let info = client.info();
-        // We already have this block imported and it is finalized, so can't change
-        if last_archived_block <= info.finalized_number {
+        // We have already processed this block, it can't change
+        if last_archived_block <= *last_processed_block_number {
             *last_processed_segment_index = segment_index;
-            *last_processed_block_number = last_archived_block;
             // Reset reconstructor instance
             reconstructor = Reconstructor::new().map_err(|error| error.to_string())?;
             continue;


### PR DESCRIPTION
Couple important improvements here.

First of all, instead of starting with last finalized block it makes more sense to start with best block minus archiving confirmation depth. The reason for this is that finalized block is very deep due to https://github.com/paritytech/polkadot-sdk/issues/1570 and we will end up downloading much more data and checking many more blocks than we actually need.

Second tweak is a fix for checking against last processed block rather than finalized block in actual block import that will make things both faster and remove unfortunate situation where last processed block number actually goes DOWN instead of up.

Both of these improvements greatly improve DSN sync, especially on restart (but also after temporary network outages).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
