### PR TITLE
Faster archiver restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9255,6 +9255,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rayon",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-slots",

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -25,6 +25,7 @@ parking_lot = "0.12.1"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef", version = "0.10.0-dev" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
+rayon = "1.7.0"
 schnorrkel = "0.9.1"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "20be5f33a3d2b3f4b31a894f9829184b29fba3ef" }


### PR DESCRIPTION
If you ever restarted your node and though that archiver takes a really long time to start you were absolutely right!

This set of changes turns this (note timestamps):
```
2023-09-19 01:18:43.110  [Consensus] 🏷  Local node identity is: 12D3KooWRcri8BhpLfMYVKCh5oEP1YCdQfhy7pEKHcmmESPTkcaq    
2023-09-19 01:19:32.272  [Consensus] Last archived block 171381    
2023-09-19 01:19:32.272  [Consensus] Archiving already produced blocks 171382..=181309    
2023-09-19 01:22:24.775  [Consensus] 🧑‍🌾 Starting Subspace Authorship worker    
```

Into this:
```
2023-09-19 03:16:56.388  [Consensus] 🏷  Local node identity is: 12D3KooWRcri8BhpLfMYVKCh5oEP1YCdQfhy7pEKHcmmESPTkcaq    
2023-09-19 03:16:56.400  [Consensus] Last archived block 171381    
2023-09-19 03:16:56.400  [Consensus] Archiving already produced blocks 171382..=181309    
2023-09-19 03:17:12.856  [Consensus] 🧑‍🌾 Starting Subspace Authorship worker    
```

That is 3m41s vs 16s initialization time!

I expect similarly massive changes in block import performance (for essentialy empty blocks) once https://github.com/paritytech/polkadot-sdk/pull/1598 or similar is incorporated.

Resolves https://github.com/subspace/subspace/issues/1852

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
