### PR TITLE
Use non-rayon thread pool for non-CPU-intensive tasks

### DIFF
--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -35,7 +35,7 @@ subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time"
 parking_lot = "0.12.1"
 rayon = "1.7.0"
 thiserror = "1.0.48"
-tokio = { version = "1.32.0", features = ["time"] }
+tokio = { version = "1.32.0", features = ["macros", "time"] }
 tracing = "0.1.37"
 
 [features]

--- a/crates/sc-proof-of-time/src/verifier.rs
+++ b/crates/sc-proof-of-time/src/verifier.rs
@@ -155,7 +155,7 @@ impl PotVerifier {
         loop {
             // TODO: This "proxy" is a workaround for https://github.com/rust-lang/rust/issues/57478
             let (result_sender, result_receiver) = oneshot::channel();
-            rayon::spawn({
+            tokio::task::spawn_blocking({
                 let verifier = self.clone();
 
                 move || {
@@ -298,7 +298,7 @@ impl PotVerifier {
     ) -> bool {
         // TODO: This "proxy" is a workaround for https://github.com/rust-lang/rust/issues/57478
         let (result_sender, result_receiver) = oneshot::channel();
-        rayon::spawn({
+        tokio::task::spawn_blocking({
             let verifier = self.clone();
             let checkpoints = *checkpoints;
 

--- a/crates/sc-proof-of-time/src/verifier/tests.rs
+++ b/crates/sc-proof-of-time/src/verifier/tests.rs
@@ -1,5 +1,4 @@
 use crate::verifier::PotVerifier;
-use futures::executor::block_on;
 use sp_consensus_slots::Slot;
 #[cfg(feature = "pot")]
 use sp_consensus_subspace::PotParametersChange;
@@ -14,8 +13,8 @@ const SEED: [u8; 16] = [
     0xd6, 0x66, 0xcc, 0xd8, 0xd5, 0x93, 0xc2, 0x3d, 0xa8, 0xdb, 0x6b, 0x5b, 0x14, 0x13, 0xb1, 0x3a,
 ];
 
-#[test]
-fn test_basic() {
+#[tokio::test]
+async fn test_basic() {
     let genesis_seed = PotSeed::from(SEED);
     let slot_iterations = NonZeroU32::new(512).unwrap();
     let checkpoints_1 = subspace_proof_of_time::prove(genesis_seed, slot_iterations).unwrap();
@@ -23,127 +22,159 @@ fn test_basic() {
     let verifier = PotVerifier::new(genesis_seed, NonZeroUsize::new(1000).unwrap());
 
     // Expected to be valid
-    assert!(block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations,
-        Slot::from(1),
-        checkpoints_1.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
-    assert!(block_on(verifier.verify_checkpoints(
-        genesis_seed,
-        slot_iterations,
-        &checkpoints_1
-    )));
+    assert!(
+        verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations,
+                Slot::from(1),
+                checkpoints_1.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
+    assert!(
+        verifier
+            .verify_checkpoints(genesis_seed, slot_iterations, &checkpoints_1)
+            .await
+    );
 
     // Invalid number of slots
-    assert!(!block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations,
-        Slot::from(2),
-        checkpoints_1.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
+    assert!(
+        !verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations,
+                Slot::from(2),
+                checkpoints_1.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
     // Invalid seed
-    assert!(!block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(1),
-        checkpoints_1.output().seed(),
-        slot_iterations,
-        Slot::from(1),
-        checkpoints_1.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
+    assert!(
+        !verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                checkpoints_1.output().seed(),
+                slot_iterations,
+                Slot::from(1),
+                checkpoints_1.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
     // Invalid number of iterations
-    assert!(!block_on(
-        verifier.verify_checkpoints(
-            genesis_seed,
-            slot_iterations
-                .checked_mul(NonZeroU32::new(2).unwrap())
-                .unwrap(),
-            &checkpoints_1
-        )
-    ));
+    assert!(
+        !verifier
+            .verify_checkpoints(
+                genesis_seed,
+                slot_iterations
+                    .checked_mul(NonZeroU32::new(2).unwrap())
+                    .unwrap(),
+                &checkpoints_1
+            )
+            .await
+    );
 
     let seed_1 = checkpoints_1.output().seed();
     let checkpoints_2 = subspace_proof_of_time::prove(seed_1, slot_iterations).unwrap();
 
     // Expected to be valid
-    assert!(block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(2),
-        seed_1,
-        slot_iterations,
-        Slot::from(1),
-        checkpoints_2.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
-    assert!(block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations,
-        Slot::from(2),
-        checkpoints_2.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
-    assert!(block_on(verifier.verify_checkpoints(
-        seed_1,
-        slot_iterations,
-        &checkpoints_2
-    )));
+    assert!(
+        verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(2),
+                seed_1,
+                slot_iterations,
+                Slot::from(1),
+                checkpoints_2.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
+    assert!(
+        verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations,
+                Slot::from(2),
+                checkpoints_2.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
+    assert!(
+        verifier
+            .verify_checkpoints(seed_1, slot_iterations, &checkpoints_2)
+            .await
+    );
 
     // Invalid number of slots
-    assert!(!block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(1),
-        seed_1,
-        slot_iterations,
-        Slot::from(2),
-        checkpoints_2.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
+    assert!(
+        !verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                seed_1,
+                slot_iterations,
+                Slot::from(2),
+                checkpoints_2.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
     // Invalid seed
-    assert!(!block_on(verifier.is_output_valid(
-        #[cfg(feature = "pot")]
-        Slot::from(1),
-        seed_1,
-        slot_iterations,
-        Slot::from(2),
-        checkpoints_2.output(),
-        #[cfg(feature = "pot")]
-        None
-    )));
+    assert!(
+        !verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                seed_1,
+                slot_iterations,
+                Slot::from(2),
+                checkpoints_2.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
     // Invalid number of iterations
-    assert!(!block_on(
-        verifier.is_output_valid(
-            #[cfg(feature = "pot")]
-            Slot::from(1),
-            genesis_seed,
-            slot_iterations
-                .checked_mul(NonZeroU32::new(2).unwrap())
-                .unwrap(),
-            Slot::from(2),
-            checkpoints_2.output(),
-            #[cfg(feature = "pot")]
-            None
-        )
-    ));
+    assert!(
+        !verifier
+            .is_output_valid(
+                #[cfg(feature = "pot")]
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations
+                    .checked_mul(NonZeroU32::new(2).unwrap())
+                    .unwrap(),
+                Slot::from(2),
+                checkpoints_2.output(),
+                #[cfg(feature = "pot")]
+                None
+            )
+            .await
+    );
 }
 
 #[cfg(feature = "pot")]
-#[test]
-fn parameters_change() {
+#[tokio::test]
+async fn parameters_change() {
     let genesis_seed = PotSeed::from(SEED);
     let slot_iterations_1 = NonZeroU32::new(512).unwrap();
     let entropy = [1; mem::size_of::<Blake3Hash>()];
@@ -160,78 +191,102 @@ fn parameters_change() {
     let verifier = PotVerifier::new(genesis_seed, NonZeroUsize::new(1000).unwrap());
 
     // Changing parameters after first slot
-    assert!(block_on(verifier.is_output_valid(
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations_1,
-        Slot::from(1),
-        checkpoints_1.output(),
-        Some(PotParametersChange {
-            slot: Slot::from(2),
-            slot_iterations: slot_iterations_2,
-            entropy,
-        })
-    )));
+    assert!(
+        verifier
+            .is_output_valid(
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations_1,
+                Slot::from(1),
+                checkpoints_1.output(),
+                Some(PotParametersChange {
+                    slot: Slot::from(2),
+                    slot_iterations: slot_iterations_2,
+                    entropy,
+                })
+            )
+            .await
+    );
     // Changing parameters in the middle
-    assert!(block_on(verifier.is_output_valid(
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations_1,
-        Slot::from(3),
-        checkpoints_3.output(),
-        Some(PotParametersChange {
-            slot: Slot::from(2),
-            slot_iterations: slot_iterations_2,
-            entropy,
-        })
-    )));
+    assert!(
+        verifier
+            .is_output_valid(
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations_1,
+                Slot::from(3),
+                checkpoints_3.output(),
+                Some(PotParametersChange {
+                    slot: Slot::from(2),
+                    slot_iterations: slot_iterations_2,
+                    entropy,
+                })
+            )
+            .await
+    );
     // Changing parameters on last slot
-    assert!(block_on(verifier.is_output_valid(
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations_1,
-        Slot::from(2),
-        checkpoints_2.output(),
-        Some(PotParametersChange {
-            slot: Slot::from(2),
-            slot_iterations: slot_iterations_2,
-            entropy,
-        })
-    )));
+    assert!(
+        verifier
+            .is_output_valid(
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations_1,
+                Slot::from(2),
+                checkpoints_2.output(),
+                Some(PotParametersChange {
+                    slot: Slot::from(2),
+                    slot_iterations: slot_iterations_2,
+                    entropy,
+                })
+            )
+            .await
+    );
     // Not changing parameters because changes apply to the very first slot that is verified
-    assert!(block_on(verifier.is_output_valid(
-        Slot::from(2),
-        checkpoints_1.output().seed_with_entropy(&entropy),
-        slot_iterations_2,
-        Slot::from(2),
-        checkpoints_3.output(),
-        Some(PotParametersChange {
-            slot: Slot::from(2),
-            slot_iterations: slot_iterations_2,
-            entropy,
-        })
-    )));
+    assert!(
+        verifier
+            .is_output_valid(
+                Slot::from(2),
+                checkpoints_1.output().seed_with_entropy(&entropy),
+                slot_iterations_2,
+                Slot::from(2),
+                checkpoints_3.output(),
+                Some(PotParametersChange {
+                    slot: Slot::from(2),
+                    slot_iterations: slot_iterations_2,
+                    entropy,
+                })
+            )
+            .await
+    );
 
     // Missing parameters change
-    assert!(!block_on(verifier.is_output_valid(
-        Slot::from(1),
-        genesis_seed,
-        slot_iterations_1,
-        Slot::from(3),
-        checkpoints_3.output(),
-        None
-    )));
+    assert!(
+        !verifier
+            .is_output_valid(
+                Slot::from(1),
+                genesis_seed,
+                slot_iterations_1,
+                Slot::from(3),
+                checkpoints_3.output(),
+                None
+            )
+            .await
+    );
     // Invalid slot
-    assert!(!block_on(verifier.is_output_valid(
-        Slot::from(2),
-        genesis_seed,
-        slot_iterations_1,
-        Slot::from(3),
-        checkpoints_3.output(),
-        Some(PotParametersChange {
-            slot: Slot::from(2),
-            slot_iterations: slot_iterations_2,
-            entropy,
-        })
-    )));
+    assert!(
+        !verifier
+            .is_output_valid(
+                Slot::from(2),
+                genesis_seed,
+                slot_iterations_1,
+                Slot::from(3),
+                checkpoints_3.output(),
+                Some(PotParametersChange {
+                    slot: Slot::from(2),
+                    slot_iterations: slot_iterations_2,
+                    entropy,
+                })
+            )
+            .await
+    );
 }


### PR DESCRIPTION
Rayon's thread pool is meant for CPU-heavy tasks. By using it for other purposes we are limiting the amount of work that can be done. I also thought just now that it can potentially lead to deadlock where all rayon threads are used for outer thread and inner thread is not able to make any progress.

We could remove `rayon::spawn()` in the inner functions of a verifier, but I do hope that the workarounds are temporary, so would prefer to keep the code the way it is.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
