### PR TITLE
Increase injection interval and reduce lookback depth

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -163,10 +163,10 @@ const GLOBAL_RANDOMNESS_UPDATE_INTERVAL: BlockNumber = 256;
 const BLOCK_AUTHORING_DELAY: SlotNumber = 4;
 
 /// Interval, in blocks, between blockchain entropy injection into proof of time chain.
-const POT_ENTROPY_INJECTION_INTERVAL: BlockNumber = 20;
+const POT_ENTROPY_INJECTION_INTERVAL: BlockNumber = 50;
 
 /// Interval, in entropy injection intervals, where to take entropy for injection from.
-const POT_ENTROPY_INJECTION_LOOKBACK_DEPTH: u8 = 5;
+const POT_ENTROPY_INJECTION_LOOKBACK_DEPTH: u8 = 2;
 
 /// Delay after block, in slots, when entropy injection takes effect.
 const POT_ENTROPY_INJECTION_DELAY: SlotNumber = 15;


### PR DESCRIPTION
Increasing injection interval _c_ to 50 blocks allows us to tolerate up to 3% more adversarial storage. Also, the ratio between injection delay and injection interval becomes much smaller 15/300 vs 15/120 and is closer to original PoSaT paper analysis.
Lookback depth is subsequently reduced to 2 intervals instead of 5, so that it stays 100 blocks, the archiving depth.
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
