### PR TITLE
PoT tests pallet-subspace

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -22,10 +22,9 @@ extern crate alloc;
 
 pub mod equivocation;
 
-// TODO: Unlock tests for PoT as well once PoT implementation settled
-#[cfg(all(test, not(feature = "pot")))]
+#[cfg(test)]
 mod mock;
-#[cfg(all(test, not(feature = "pot")))]
+#[cfg(test)]
 mod tests;
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -47,9 +47,13 @@ use std::sync::{Once, OnceLock};
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::crypto::Scalar;
+#[cfg(feature = "pot")]
+use subspace_core_primitives::PotOutput;
+#[cfg(not(feature = "pot"))]
+use subspace_core_primitives::Randomness;
 use subspace_core_primitives::{
     ArchivedBlockProgress, ArchivedHistorySegment, Blake2b256Hash, BlockNumber, HistorySize,
-    LastArchivedBlock, Piece, PieceOffset, PublicKey, Randomness, Record, RecordedHistorySegment,
+    LastArchivedBlock, Piece, PieceOffset, PublicKey, Record, RecordedHistorySegment,
     SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, Solution, SolutionRange,
     REWARD_SIGNING_CONTEXT,
 };
@@ -172,7 +176,6 @@ pub const INITIAL_SOLUTION_RANGE: SolutionRange =
     u64::MAX / (1024 * 1024 * 1024 / Piece::SIZE as u64) * SLOT_PROBABILITY.0 / SLOT_PROBABILITY.1;
 
 parameter_types! {
-    #[cfg(not(feature = "pot"))]
     pub const GlobalRandomnessUpdateInterval: u64 = 10;
     pub const BlockAuthoringDelay: SlotNumber = 2;
     pub const PotEntropyInjectionInterval: BlockNumber = 5;
@@ -286,7 +289,6 @@ pub fn make_pre_digest(
         solution,
         #[cfg(feature = "pot")]
         pot_info: PreDigestPotInfo::V0 {
-            iterations: NonZeroU32::new(100_000).unwrap(),
             proof_of_time: Default::default(),
             future_proof_of_time: Default::default(),
         },
@@ -294,7 +296,14 @@ pub fn make_pre_digest(
     Digest { logs: vec![log] }
 }
 
-pub fn new_test_ext() -> TestExternalities {
+#[cfg(feature = "pot")]
+pub fn allow_all_pot_extension() -> PotExtension {
+    PotExtension::new(Box::new(
+        |_parent_hash, _slot, _proof_of_time, _quick_verification| true,
+    ))
+}
+
+pub fn new_test_ext(#[cfg(feature = "pot")] pot_extension: PotExtension) -> TestExternalities {
     static INITIALIZE_LOGGER: Once = Once::new();
     INITIALIZE_LOGGER.call_once(|| {
         let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("error"));
@@ -319,9 +328,7 @@ pub fn new_test_ext() -> TestExternalities {
     ext.register_extension(KzgExtension::new(kzg_instance().clone()));
     ext.register_extension(PosExtension::new::<PosTable>());
     #[cfg(feature = "pot")]
-    ext.register_extension(PotExtension::new(Box::new(
-        |parent_hash, slot, proof_of_time| todo!(),
-    )));
+    ext.register_extension(pot_extension);
 
     ext
 }
@@ -439,7 +446,9 @@ pub fn create_signed_vote(
     height: u64,
     parent_hash: <Block as BlockT>::Hash,
     slot: Slot,
-    global_randomness: &Randomness,
+    #[cfg(not(feature = "pot"))] global_randomness: &Randomness,
+    #[cfg(feature = "pot")] proof_of_time: PotOutput,
+    #[cfg(feature = "pot")] future_proof_of_time: PotOutput,
     archived_history_segment: &ArchivedHistorySegment,
     reward_address: <Test as frame_system::Config>::AccountId,
     solution_range: SolutionRange,
@@ -486,7 +495,12 @@ pub fn create_signed_vote(
         let maybe_solution_candidates = audit_sector(
             &public_key,
             sector_index,
+            #[cfg(not(feature = "pot"))]
             &global_randomness.derive_global_challenge(slot.into()),
+            #[cfg(feature = "pot")]
+            &proof_of_time
+                .derive_global_randomness()
+                .derive_global_challenge(slot.into()),
             solution_range,
             &plotted_sector_bytes,
             &plotted_sector.sector_metadata,
@@ -521,6 +535,10 @@ pub fn create_signed_vote(
                 audit_chunk_offset: solution.audit_chunk_offset,
                 proof_of_space: solution.proof_of_space,
             },
+            #[cfg(feature = "pot")]
+            proof_of_time,
+            #[cfg(feature = "pot")]
+            future_proof_of_time,
         };
 
         let signature = FarmerSignature::unchecked_from(

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -44,11 +44,8 @@ use sp_runtime::transaction_validity::{
 use sp_runtime::DispatchError;
 use std::assert_matches::assert_matches;
 use std::collections::BTreeMap;
-use std::num::NonZeroUsize;
-use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::crypto::Scalar;
-use subspace_core_primitives::{Record, SegmentIndex, SolutionRange};
-use subspace_erasure_coding::ErasureCoding;
+use subspace_core_primitives::{SegmentIndex, SolutionRange};
 use subspace_runtime_primitives::{FindBlockRewardAddress, FindVotingRewardAddresses};
 
 #[test]
@@ -628,12 +625,7 @@ fn store_segment_header_validate_unsigned_prevents_duplicates() {
 fn vote_block_listed() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         BlockList::<Test>::insert(
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
@@ -649,8 +641,6 @@ fn vote_block_listed() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -665,12 +655,7 @@ fn vote_block_listed() {
 fn vote_after_genesis() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         // Can't submit vote right after genesis block
         let signed_vote = create_signed_vote(
@@ -681,8 +666,6 @@ fn vote_after_genesis() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -697,12 +680,7 @@ fn vote_after_genesis() {
 fn vote_too_low_height() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 1, 1);
 
@@ -717,8 +695,6 @@ fn vote_too_low_height() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -734,12 +710,7 @@ fn vote_too_low_height() {
 fn vote_past_future_height() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 4, 1);
 
@@ -753,8 +724,6 @@ fn vote_past_future_height() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -774,8 +743,6 @@ fn vote_past_future_height() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -791,12 +758,7 @@ fn vote_past_future_height() {
 fn vote_wrong_parent() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -809,8 +771,6 @@ fn vote_wrong_parent() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -825,12 +785,7 @@ fn vote_wrong_parent() {
 fn vote_past_future_slot() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         SegmentCommitment::<Test>::insert(
             archived_segment.segment_header.segment_index(),
@@ -854,8 +809,6 @@ fn vote_past_future_slot() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -879,8 +832,6 @@ fn vote_past_future_slot() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -903,8 +854,6 @@ fn vote_past_future_slot() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -918,12 +867,7 @@ fn vote_past_future_slot() {
 fn vote_same_slot() {
     new_test_ext().execute_with(|| {
         let block_keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         // Move to the block 3, but time slot 4, but in two time slots
         go_to_block(&block_keypair, 3, 4, 1);
@@ -949,8 +893,6 @@ fn vote_same_slot() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -969,8 +911,6 @@ fn vote_same_slot() {
                 &Subspace::global_randomnesses().current,
                 &archived_segment.pieces,
                 1,
-                &kzg,
-                &erasure_coding,
                 SolutionRange::MAX,
             );
 
@@ -986,12 +926,7 @@ fn vote_same_slot() {
 fn vote_bad_reward_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1004,8 +939,6 @@ fn vote_bad_reward_signature() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1022,12 +955,7 @@ fn vote_bad_reward_signature() {
 fn vote_unknown_segment_commitment() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1040,8 +968,6 @@ fn vote_unknown_segment_commitment() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1056,12 +982,7 @@ fn vote_unknown_segment_commitment() {
 fn vote_outside_of_solution_range() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1079,8 +1000,6 @@ fn vote_outside_of_solution_range() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1096,12 +1015,7 @@ fn vote_outside_of_solution_range() {
 fn vote_correct_signature() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1124,8 +1038,6 @@ fn vote_correct_signature() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1137,12 +1049,7 @@ fn vote_correct_signature() {
 fn vote_randomness_update() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         SegmentCommitment::<Test>::insert(
             archived_segment.segment_header.segment_index(),
@@ -1168,8 +1075,6 @@ fn vote_randomness_update() {
             &Subspace::global_randomnesses().next.unwrap(),
             &archived_segment.pieces,
             1,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1181,12 +1086,7 @@ fn vote_randomness_update() {
 fn vote_equivocation_current_block_plus_vote() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1211,8 +1111,6 @@ fn vote_equivocation_current_block_plus_vote() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             reward_address,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1241,12 +1139,7 @@ fn vote_equivocation_current_block_plus_vote() {
 fn vote_equivocation_parent_block_plus_vote() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1271,8 +1164,6 @@ fn vote_equivocation_parent_block_plus_vote() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             reward_address,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1309,12 +1200,7 @@ fn vote_equivocation_parent_block_plus_vote() {
 #[test]
 fn vote_equivocation_current_voters_duplicate() {
     new_test_ext().execute_with(|| {
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&Keypair::generate(), 2, 1);
 
@@ -1341,8 +1227,6 @@ fn vote_equivocation_current_voters_duplicate() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             reward_address,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 
@@ -1398,12 +1282,7 @@ fn vote_equivocation_current_voters_duplicate() {
 fn vote_equivocation_parent_voters_duplicate() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
-        let kzg = Kzg::new(embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = create_archived_segment(kzg.clone());
+        let archived_segment = create_archived_segment();
 
         progress_to_block(&keypair, 2, 1);
 
@@ -1429,8 +1308,6 @@ fn vote_equivocation_parent_voters_duplicate() {
             &Subspace::global_randomnesses().current,
             &archived_segment.pieces,
             reward_address,
-            &kzg,
-            &erasure_coding,
             SolutionRange::MAX,
         );
 

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -16,11 +16,14 @@
 
 //! Consensus extension module tests for Subspace consensus.
 
+#[cfg(feature = "pot")]
+use crate::mock::allow_all_pot_extension;
+#[cfg(not(feature = "pot"))]
+use crate::mock::GlobalRandomnessUpdateInterval;
 use crate::mock::{
     create_archived_segment, create_segment_header, create_signed_vote,
-    generate_equivocation_proof, go_to_block, new_test_ext, progress_to_block,
-    GlobalRandomnessUpdateInterval, ReportLongevity, RuntimeEvent, RuntimeOrigin, Subspace, System,
-    Test, INITIAL_SOLUTION_RANGE, SLOT_PROBABILITY,
+    generate_equivocation_proof, go_to_block, new_test_ext, progress_to_block, ReportLongevity,
+    RuntimeEvent, RuntimeOrigin, Subspace, System, Test, INITIAL_SOLUTION_RANGE, SLOT_PROBABILITY,
 };
 use crate::{
     pallet, AllowAuthoringByAnyone, AuditChunkOffset, BlockList, Call, CheckVoteError, Config,
@@ -50,7 +53,11 @@ use subspace_runtime_primitives::{FindBlockRewardAddress, FindVotingRewardAddres
 
 #[test]
 fn genesis_slot_is_correct() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         // this sets the genesis slot to 6;
@@ -60,8 +67,13 @@ fn genesis_slot_is_correct() {
 }
 
 #[test]
+#[cfg(not(feature = "pot"))]
 fn can_update_global_randomness() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         assert_eq!(<Test as Config>::GlobalRandomnessUpdateInterval::get(), 10);
@@ -96,9 +108,15 @@ fn can_update_global_randomness() {
     })
 }
 
+// TODO: Tests for proof of time correctness in votes
+
 #[test]
 fn can_update_solution_range_on_era_change() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         assert_eq!(<Test as Config>::EraDuration::get(), 4);
@@ -170,7 +188,11 @@ fn can_update_solution_range_on_era_change() {
 
 #[test]
 fn can_override_solution_range_update() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         assert_eq!(
@@ -220,7 +242,11 @@ fn can_override_solution_range_update() {
 
 #[test]
 fn solution_range_should_not_update_when_disabled() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         assert_eq!(<Test as Config>::EraDuration::get(), 4);
@@ -286,7 +312,11 @@ fn solution_range_should_not_update_when_disabled() {
 
 #[test]
 fn report_equivocation_current_session_works() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -311,7 +341,11 @@ fn report_equivocation_current_session_works() {
 
 #[test]
 fn report_equivocation_old_session_works() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -339,7 +373,11 @@ fn report_equivocation_old_session_works() {
 
 #[test]
 fn report_equivocation_invalid_equivocation_proof() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -409,7 +447,11 @@ fn report_equivocation_invalid_equivocation_proof() {
 
 #[test]
 fn report_equivocation_validate_unsigned_prevents_duplicates() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -472,7 +514,11 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 
 #[test]
 fn valid_equivocation_reports_dont_pay_fees() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -517,7 +563,11 @@ fn valid_equivocation_reports_dont_pay_fees() {
 
 #[test]
 fn store_segment_header_works() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -544,7 +594,11 @@ fn store_segment_header_works() {
 
 #[test]
 fn store_segment_header_validate_unsigned_prevents_duplicates() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -623,7 +677,11 @@ fn store_segment_header_validate_unsigned_prevents_duplicates() {
 
 #[test]
 fn vote_block_listed() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -638,7 +696,12 @@ fn vote_block_listed() {
             0,
             <Test as frame_system::Config>::Hash::default(),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -653,7 +716,11 @@ fn vote_block_listed() {
 
 #[test]
 fn vote_after_genesis() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -663,7 +730,12 @@ fn vote_after_genesis() {
             0,
             <Test as frame_system::Config>::Hash::default(),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -678,7 +750,11 @@ fn vote_after_genesis() {
 
 #[test]
 fn vote_too_low_height() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -692,7 +768,12 @@ fn vote_too_low_height() {
                 height,
                 <Test as frame_system::Config>::Hash::default(),
                 Subspace::current_slot() + 1,
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -708,7 +789,11 @@ fn vote_too_low_height() {
 
 #[test]
 fn vote_past_future_height() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -721,7 +806,12 @@ fn vote_past_future_height() {
                 5,
                 <Test as frame_system::Config>::Hash::default(),
                 Subspace::current_slot() + 1,
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -740,7 +830,12 @@ fn vote_past_future_height() {
                 2,
                 <Test as frame_system::Config>::Hash::default(),
                 Subspace::current_slot() + 1,
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -756,7 +851,11 @@ fn vote_past_future_height() {
 
 #[test]
 fn vote_wrong_parent() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -768,7 +867,12 @@ fn vote_wrong_parent() {
             2,
             <Test as frame_system::Config>::Hash::default(),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -783,7 +887,11 @@ fn vote_wrong_parent() {
 
 #[test]
 fn vote_past_future_slot() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -806,7 +914,12 @@ fn vote_past_future_slot() {
                 3,
                 frame_system::Pallet::<Test>::block_hash(2),
                 2.into(),
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -829,7 +942,12 @@ fn vote_past_future_slot() {
                 3,
                 frame_system::Pallet::<Test>::block_hash(2),
                 4.into(),
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -851,7 +969,12 @@ fn vote_past_future_slot() {
                 2,
                 frame_system::Pallet::<Test>::block_hash(1),
                 2.into(),
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -865,7 +988,11 @@ fn vote_past_future_slot() {
 
 #[test]
 fn vote_same_slot() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let block_keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -890,7 +1017,12 @@ fn vote_same_slot() {
                 3,
                 frame_system::Pallet::<Test>::block_hash(2),
                 Subspace::current_slot(),
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -908,7 +1040,12 @@ fn vote_same_slot() {
                 2,
                 frame_system::Pallet::<Test>::block_hash(1),
                 Subspace::current_slot(),
+                #[cfg(not(feature = "pot"))]
                 &Subspace::global_randomnesses().current,
+                #[cfg(feature = "pot")]
+                Default::default(),
+                #[cfg(feature = "pot")]
+                Default::default(),
                 &archived_segment.pieces,
                 1,
                 SolutionRange::MAX,
@@ -924,7 +1061,11 @@ fn vote_same_slot() {
 
 #[test]
 fn vote_bad_reward_signature() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -936,7 +1077,12 @@ fn vote_bad_reward_signature() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -953,7 +1099,11 @@ fn vote_bad_reward_signature() {
 
 #[test]
 fn vote_unknown_segment_commitment() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -965,7 +1115,12 @@ fn vote_unknown_segment_commitment() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -980,7 +1135,11 @@ fn vote_unknown_segment_commitment() {
 
 #[test]
 fn vote_outside_of_solution_range() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -997,7 +1156,12 @@ fn vote_outside_of_solution_range() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -1013,7 +1177,11 @@ fn vote_outside_of_solution_range() {
 
 #[test]
 fn vote_correct_signature() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -1035,7 +1203,12 @@ fn vote_correct_signature() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             Subspace::current_slot() + 1,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             1,
             SolutionRange::MAX,
@@ -1046,8 +1219,13 @@ fn vote_correct_signature() {
 }
 
 #[test]
+#[cfg(not(feature = "pot"))]
 fn vote_randomness_update() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -1084,7 +1262,11 @@ fn vote_randomness_update() {
 
 #[test]
 fn vote_equivocation_current_block_plus_vote() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -1108,7 +1290,12 @@ fn vote_equivocation_current_block_plus_vote() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             slot,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             reward_address,
             SolutionRange::MAX,
@@ -1137,7 +1324,11 @@ fn vote_equivocation_current_block_plus_vote() {
 
 #[test]
 fn vote_equivocation_parent_block_plus_vote() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -1161,7 +1352,12 @@ fn vote_equivocation_parent_block_plus_vote() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             slot,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             reward_address,
             SolutionRange::MAX,
@@ -1199,7 +1395,11 @@ fn vote_equivocation_parent_block_plus_vote() {
 
 #[test]
 fn vote_equivocation_current_voters_duplicate() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let archived_segment = create_archived_segment();
 
         progress_to_block(&Keypair::generate(), 2, 1);
@@ -1224,7 +1424,12 @@ fn vote_equivocation_current_voters_duplicate() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             slot,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             reward_address,
             SolutionRange::MAX,
@@ -1280,7 +1485,11 @@ fn vote_equivocation_current_voters_duplicate() {
 
 #[test]
 fn vote_equivocation_parent_voters_duplicate() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
         let archived_segment = create_archived_segment();
 
@@ -1305,7 +1514,12 @@ fn vote_equivocation_parent_voters_duplicate() {
             2,
             frame_system::Pallet::<Test>::block_hash(1),
             slot,
+            #[cfg(not(feature = "pot"))]
             &Subspace::global_randomnesses().current,
+            #[cfg(feature = "pot")]
+            Default::default(),
+            #[cfg(feature = "pot")]
+            Default::default(),
             &archived_segment.pieces,
             reward_address,
             SolutionRange::MAX,
@@ -1389,7 +1603,11 @@ fn enabling_block_rewards_works() {
             map
         });
     }
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair = Keypair::generate();
 
         progress_to_block(&keypair, 1, 1);
@@ -1427,7 +1645,11 @@ fn enabling_block_rewards_works() {
 
 #[test]
 fn allow_authoring_by_anyone_works() {
-    new_test_ext().execute_with(|| {
+    new_test_ext(
+        #[cfg(feature = "pot")]
+        allow_all_pot_extension(),
+    )
+    .execute_with(|| {
         let keypair1 = Keypair::generate();
         let keypair2 = Keypair::generate();
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::mock::{new_test_ext, Header, MockStorage, PosTable};
+use crate::mock::{kzg_instance, new_test_ext, Header, MockStorage, PosTable};
 use crate::{
     ChainConstants, DigestError, HashOf, HeaderExt, HeaderImporter, ImportError, NextDigestItems,
     NumberOf, Storage, StorageBound,
@@ -22,9 +22,8 @@ use sp_runtime::traits::Header as HeaderT;
 use sp_runtime::{Digest, DigestItem};
 use std::iter;
 use std::num::{NonZeroU64, NonZeroUsize};
+use std::sync::OnceLock;
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
-use subspace_core_primitives::crypto::kzg;
-use subspace_core_primitives::crypto::kzg::Kzg;
 #[cfg(feature = "pot")]
 use subspace_core_primitives::PotOutput;
 use subspace_core_primitives::{
@@ -40,6 +39,17 @@ use subspace_proof_of_space::Table;
 #[cfg(not(feature = "pot"))]
 use subspace_verification::derive_randomness;
 use subspace_verification::{calculate_block_weight, verify_solution, VerifySolutionParams};
+
+fn erasure_coding_instance() -> &'static ErasureCoding {
+    static ERASURE_CODING: OnceLock<ErasureCoding> = OnceLock::new();
+
+    ERASURE_CODING.get_or_init(|| {
+        ErasureCoding::new(
+            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
+        )
+        .unwrap()
+    })
+}
 
 #[cfg(not(feature = "pot"))]
 fn default_randomness() -> Randomness {
@@ -71,36 +81,31 @@ fn default_test_constants() -> ChainConstants<Header> {
     }
 }
 
-fn archived_segment(kzg: Kzg) -> NewArchivedSegment {
-    // we don't care about the block data
-    let mut rng = StdRng::seed_from_u64(0);
-    let mut block = vec![0u8; RecordedHistorySegment::SIZE];
-    rng.fill(block.as_mut_slice());
+fn archived_segment() -> &'static NewArchivedSegment {
+    static ARCHIVED_SEGMENT: OnceLock<NewArchivedSegment> = OnceLock::new();
 
-    let mut archiver = Archiver::new(kzg).unwrap();
+    ARCHIVED_SEGMENT.get_or_init(|| {
+        // we don't care about the block data
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut block = vec![0u8; RecordedHistorySegment::SIZE];
+        rng.fill(block.as_mut_slice());
 
-    archiver
-        .add_block(block, Default::default(), true)
-        .into_iter()
-        .next()
-        .unwrap()
+        let mut archiver = Archiver::new(kzg_instance().clone()).unwrap();
+
+        archiver
+            .add_block(block, Default::default(), true)
+            .into_iter()
+            .next()
+            .unwrap()
+    })
 }
 
 struct FarmerParameters {
-    kzg: Kzg,
-    erasure_coding: ErasureCoding,
-    archived_segment: NewArchivedSegment,
     farmer_protocol_info: FarmerProtocolInfo,
 }
 
 impl FarmerParameters {
     fn new() -> Self {
-        let kzg = Kzg::new(kzg::embedded_kzg_settings());
-        let erasure_coding = ErasureCoding::new(
-            NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize).unwrap(),
-        )
-        .unwrap();
-        let archived_segment = archived_segment(kzg.clone());
         let farmer_protocol_info = FarmerProtocolInfo {
             history_size: HistorySize::from(SegmentIndex::ZERO),
             max_pieces_in_sector: 1,
@@ -113,9 +118,6 @@ impl FarmerParameters {
         };
 
         Self {
-            kzg,
-            erasure_coding,
-            archived_segment,
             farmer_protocol_info,
         }
     }
@@ -158,14 +160,10 @@ fn valid_header(
         farmer_parameters,
     } = params;
 
-    let segment_index = farmer_parameters
-        .archived_segment
-        .segment_header
-        .segment_index();
-    let segment_commitment = farmer_parameters
-        .archived_segment
-        .segment_header
-        .segment_commitment();
+    let archived_segment = archived_segment();
+
+    let segment_index = archived_segment.segment_header.segment_index();
+    let segment_commitment = archived_segment.segment_header.segment_commitment();
     let public_key = PublicKey::from(keypair.public.to_bytes());
 
     let pieces_in_sector = farmer_parameters.farmer_protocol_info.max_pieces_in_sector;
@@ -180,11 +178,11 @@ fn valid_header(
         let plotted_sector = block_on(plot_sector::<_, PosTable>(
             &public_key,
             sector_index,
-            &farmer_parameters.archived_segment.pieces,
+            &archived_segment.pieces,
             PieceGetterRetryPolicy::default(),
             &farmer_parameters.farmer_protocol_info,
-            &farmer_parameters.kzg,
-            &farmer_parameters.erasure_coding,
+            kzg_instance(),
+            erasure_coding_instance(),
             pieces_in_sector,
             &mut plotted_sector_bytes,
             &mut plotted_sector_metadata_bytes,
@@ -213,8 +211,8 @@ fn valid_header(
         let solution = solution_candidates
             .into_iter::<_, PosTable>(
                 &public_key,
-                &farmer_parameters.kzg,
-                &farmer_parameters.erasure_coding,
+                kzg_instance(),
+                erasure_coding_instance(),
                 &mut table_generator,
             )
             .unwrap()
@@ -247,7 +245,7 @@ fn valid_header(
                 solution_range: SolutionRange::MAX,
                 piece_check_params: None,
             },
-            &farmer_parameters.kzg,
+            kzg_instance(),
         )
         .unwrap();
         let solution_range = solution_distance * 2;


### PR DESCRIPTION
This unlocks tests with `pot` feature enabled in `pallet-subspace` as well as adds some tests for votes verification. There are more tests to write, but this is the basics.

I also added some tweaks in the first commit to run tests faster, on my machine improvement is 4x+ by not doing archiving and KZG instantiation multiple times for different tests.

This resolves the first item in https://github.com/subspace/subspace/issues/1952.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
