### PR TITLE
Fix last archived segment search

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -40,6 +40,7 @@ use sp_consensus::SyncOracle;
 use sp_consensus_subspace::{FarmerPublicKey, SubspaceApi};
 use sp_objects::ObjectsApi;
 use sp_runtime::traits::{Block as BlockT, CheckedSub, Header, NumberFor, One, Zero};
+use sp_runtime::Saturating;
 use std::error::Error;
 use std::future::Future;
 use std::slice;
@@ -209,6 +210,7 @@ pub(crate) const FINALIZATION_DEPTH_IN_SEGMENTS: usize = 5;
 fn find_last_archived_block<Block, Client, AS>(
     client: &Client,
     segment_headers_store: &SegmentHeadersStore<AS>,
+    best_block_to_archive: NumberFor<Block>,
 ) -> sp_blockchain::Result<Option<(SegmentHeader, Block, BlockObjectMapping)>>
 where
     Block: BlockT,
@@ -230,6 +232,12 @@ where
         .filter_map(|segment_index| segment_headers_store.get_segment_header(segment_index))
     {
         let last_archived_block_number = segment_header.last_archived_block().number;
+        if NumberFor::<Block>::from(last_archived_block_number) > best_block_to_archive {
+            // Last archived block in segment header it too high for current stat of the chain
+            // (segment headers store may know about more blocks in existence than is currently
+            // imported)
+            continue;
+        }
         let Some(last_archived_block_hash) = client.hash(last_archived_block_number.into())? else {
             // This block number is not in our chain yet (segment headers store may know about more
             // blocks in existence than is currently imported)
@@ -362,7 +370,11 @@ where
         .chain_constants(best_block_hash)?
         .confirmation_depth_k();
 
-    let maybe_last_archived_block = find_last_archived_block(client, segment_headers_store)?;
+    let maybe_last_archived_block = find_last_archived_block(
+        client,
+        segment_headers_store,
+        best_block_number.saturating_sub(confirmation_depth_k.into()),
+    )?;
     let have_last_segment_header = maybe_last_archived_block.is_some();
     let mut best_archived_block = None;
 

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -233,7 +233,7 @@ where
     {
         let last_archived_block_number = segment_header.last_archived_block().number;
         if NumberFor::<Block>::from(last_archived_block_number) > best_block_to_archive {
-            // Last archived block in segment header it too high for current stat of the chain
+            // Last archived block in segment header is too high for current state of the chain
             // (segment headers store may know about more blocks in existence than is currently
             // imported)
             continue;


### PR DESCRIPTION
This is a fix for regression introduced in https://github.com/subspace/subspace/pull/1980

Basically during archiver restart it was ignoring that blocks need to be at a certain depth before they can be archivd. One user ended up in a situation where their block was exactly the block in one of the segment headers: https://forum.subspace.network/t/thread-main-panicked-at-must-always-set-if-there-is-no-logical-error/1901

The fix here is to restrict what blocks are supposed to be archived at this point and which are not yet.

This can also potentially cause nodes to archive incorrect history if before restart they wereon a short fork and in similarly unlucky conditions as the post on the forum above.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
