### PR TITLE
Fraud Proof: Invalid domain extrinsic root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10837,6 +10837,8 @@ dependencies = [
  "hexlit",
  "num-traits",
  "parity-scale-codec",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rs_merkle",
  "scale-info",
  "serde",
@@ -10856,6 +10858,7 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "thiserror",
+ "trie-db",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10830,6 +10830,7 @@ dependencies = [
 name = "sp-domains"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "blake2",
  "domain-runtime-primitives",
  "frame-support",
@@ -10848,6 +10849,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-externalities",
+ "sp-inherents",
  "sp-keystore",
  "sp-runtime",
  "sp-runtime-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10831,6 +10831,7 @@ name = "sp-domains"
 version = "0.1.0"
 dependencies = [
  "blake2",
+ "domain-runtime-primitives",
  "frame-support",
  "hash-db 0.16.0",
  "hexlit",

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -137,7 +137,7 @@ mod pallet {
     use frame_support::{Identity, PalletError};
     use frame_system::pallet_prelude::*;
     use sp_core::H256;
-    use sp_domains::fraud_proof::FraudProof;
+    use sp_domains::fraud_proof::{FraudProof, StorageKeys};
     use sp_domains::inherents::{InherentError, InherentType, INHERENT_IDENTIFIER};
     use sp_domains::transaction::InvalidTransactionCode;
     use sp_domains::{
@@ -283,6 +283,9 @@ mod pallet {
 
         /// Randomness source.
         type Randomness: RandomnessT<Self::Hash, BlockNumberFor<Self>>;
+
+        /// Trait impl to fetch storage keys.
+        type StorageKeys: StorageKeys;
     }
 
     #[pallet::pallet]
@@ -1597,6 +1600,7 @@ impl<T: Config> Pallet<T> {
                     T::DomainHash,
                     BalanceOf<T>,
                     T::Hashing,
+                    T::StorageKeys,
                 >(consensus_state_root, bad_receipt, proof)
                 .map_err(FraudProofError::InvalidExtrinsicRootFraudProof)?;
             }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -49,7 +49,8 @@ use sp_domains::verification::{
 };
 use sp_domains::{
     DomainBlockLimit, DomainId, DomainInstanceData, ExecutionReceipt, OpaqueBundle, OperatorId,
-    OperatorPublicKey, ProofOfElection, RuntimeId, EMPTY_EXTRINSIC_ROOT, EXTRINSICS_SHUFFLING_SEED,
+    OperatorPublicKey, ProofOfElection, RuntimeId, DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT,
+    EMPTY_EXTRINSIC_ROOT,
 };
 use sp_runtime::traits::{BlakeTwo256, CheckedSub, Hash, One, Zero};
 use sp_runtime::{RuntimeAppPublic, SaturatedConversion, Saturating};
@@ -1783,7 +1784,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn extrinsics_shuffling_seed() -> T::Hash {
-        let seed = EXTRINSICS_SHUFFLING_SEED;
+        let seed = DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT;
         let (randomness, _) = T::Randomness::random(seed);
         randomness
     }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -47,7 +47,7 @@ use sp_domains::fraud_proof::{FraudProof, InvalidTotalRewardsProof};
 use sp_domains::verification::verify_invalid_total_rewards_fraud_proof;
 use sp_domains::{
     DomainBlockLimit, DomainId, DomainInstanceData, ExecutionReceipt, OpaqueBundle, OperatorId,
-    OperatorPublicKey, ProofOfElection, RuntimeId, EMPTY_EXTRINSIC_ROOT,
+    OperatorPublicKey, ProofOfElection, RuntimeId, EMPTY_EXTRINSIC_ROOT, EXTRINSICS_SHUFFLING_SEED,
 };
 use sp_runtime::traits::{BlakeTwo256, CheckedSub, Hash, One, Zero};
 use sp_runtime::{RuntimeAppPublic, SaturatedConversion, Saturating};
@@ -1678,7 +1678,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn extrinsics_shuffling_seed() -> T::Hash {
-        let seed: &[u8] = b"extrinsics-shuffling-seed";
+        let seed = EXTRINSICS_SHUFFLING_SEED;
         let (randomness, _) = T::Randomness::random(seed);
         randomness
     }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -136,6 +136,7 @@ mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_core::H256;
     use sp_domains::fraud_proof::FraudProof;
+    use sp_domains::inherents::{InherentError, InherentType, INHERENT_IDENTIFIER};
     use sp_domains::transaction::InvalidTransactionCode;
     use sp_domains::{
         BundleDigest, DomainId, EpochIndex, GenesisDomain, OperatorId, ReceiptHash, RuntimeId,
@@ -481,16 +482,24 @@ mod pallet {
         OptionQuery,
     >;
 
-    /// The consensus block hash used to verify ER, only store the consensus block hash for a domain
+    /// The consensus block hash and state root used to verify ER and storage proofs,
+    /// only store the consensus block hash for a domain
     /// if that consensus block contains bundle of the domain, the hash will be pruned when the ER
     /// that point to the consensus block is pruned.
     ///
     /// TODO: this storage is unbounded in some cases, see https://github.com/subspace/subspace/issues/1673
     /// for more details, this will be fixed once https://github.com/subspace/subspace/issues/1731 is implemented.
     #[pallet::storage]
-    #[pallet::getter(fn consensus_hash)]
-    pub type ConsensusBlockHash<T: Config> =
-        StorageDoubleMap<_, Identity, DomainId, Identity, BlockNumberFor<T>, T::Hash, OptionQuery>;
+    #[pallet::getter(fn consensus_block_info)]
+    pub type ConsensusBlockInfo<T: Config> = StorageDoubleMap<
+        _,
+        Identity,
+        DomainId,
+        Identity,
+        BlockNumberFor<T>,
+        (T::Hash, T::Hash),
+        OptionQuery,
+    >;
 
     /// A set of `BundleDigest` from all bundles that successfully submitted to the consensus block,
     /// these bundles will be used to construct the domain block and `ExecutionInbox` is used to:
@@ -1112,6 +1121,27 @@ mod pallet {
 
             Ok(())
         }
+
+        /// Submit parent state root to the blockchain.
+        #[pallet::call_index(11)]
+        #[pallet::weight((Weight::from_all(10_000), DispatchClass::Mandatory, Pays::No))]
+        pub fn store_parent_state_root(
+            origin: OriginFor<T>,
+            parent_state_root: T::Hash,
+        ) -> DispatchResult {
+            ensure_none(origin)?;
+            let block_number = frame_system::Pallet::<T>::block_number();
+            let parent_number = block_number - One::one();
+
+            let domains_ids = DomainRegistry::<T>::iter_keys().collect::<Vec<DomainId>>();
+            for domain_id in domains_ids {
+                if let Some(info) = ConsensusBlockInfo::<T>::get(domain_id, parent_number) {
+                    let info = (info.0, parent_state_root);
+                    ConsensusBlockInfo::<T>::insert(domain_id, parent_number, info);
+                }
+            }
+            Ok(())
+        }
     }
 
     #[pallet::genesis_config]
@@ -1202,7 +1232,11 @@ mod pallet {
             let parent_number = block_number - One::one();
             let parent_hash = frame_system::Pallet::<T>::block_hash(parent_number);
             for (domain_id, _) in SuccessfulBundles::<T>::drain() {
-                ConsensusBlockHash::<T>::insert(domain_id, parent_number, parent_hash);
+                ConsensusBlockInfo::<T>::insert(
+                    domain_id,
+                    parent_number,
+                    (parent_hash, T::Hash::default()),
+                );
             }
 
             Weight::zero()
@@ -1224,6 +1258,42 @@ mod pallet {
             .build()
     }
 
+    #[pallet::inherent]
+    impl<T: Config> ProvideInherent for Pallet<T> {
+        type Call = Call<T>;
+        type Error = InherentError;
+        const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
+
+        fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+            let inherent_data = data
+                .get_data::<InherentType<T::Hash>>(&INHERENT_IDENTIFIER)
+                .expect("Domains inherent data not correctly encoded")
+                .expect("Domains inherent data must be provided");
+
+            let parent_state_root = inherent_data.parent_state_root;
+            Some(Call::store_parent_state_root { parent_state_root })
+        }
+
+        fn check_inherent(call: &Self::Call, data: &InherentData) -> Result<(), Self::Error> {
+            if let Call::store_parent_state_root { parent_state_root } = call {
+                let inherent_data = data
+                    .get_data::<InherentType<T::Hash>>(&INHERENT_IDENTIFIER)
+                    .expect("Domains inherent data not correctly encoded")
+                    .expect("Domains inherent data must be provided");
+
+                if parent_state_root != &inherent_data.parent_state_root {
+                    return Err(InherentError::IncorrectParentStateRoot);
+                }
+            }
+
+            Ok(())
+        }
+
+        fn is_inherent(call: &Self::Call) -> bool {
+            matches!(call, Call::store_parent_state_root { .. })
+        }
+    }
+
     #[pallet::validate_unsigned]
     impl<T: Config> ValidateUnsigned for Pallet<T> {
         type Call = Call<T>;
@@ -1233,6 +1303,7 @@ mod pallet {
                     .map_err(|_| InvalidTransaction::Call.into()),
                 Call::submit_fraud_proof { fraud_proof } => Self::validate_fraud_proof(fraud_proof)
                     .map_err(|_| InvalidTransaction::Call.into()),
+                Call::store_parent_state_root { .. } => Ok(()),
                 _ => Err(InvalidTransaction::Call.into()),
             }
         }
@@ -1272,6 +1343,13 @@ mod pallet {
 
                     // TODO: proper tag value.
                     unsigned_validity("SubspaceSubmitFraudProof", fraud_proof)
+                }
+                Call::store_parent_state_root { .. } => {
+                    ValidTransaction::with_tag_prefix("Domain Parent State root Inherent")
+                        .priority(TransactionPriority::MAX)
+                        .longevity(0)
+                        .propagate(false)
+                        .build()
                 }
 
                 _ => InvalidTransaction::Call.into(),

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -191,6 +191,16 @@ impl frame_support::traits::Randomness<Hash, BlockNumber> for MockRandomness {
     }
 }
 
+pub struct StorageKeys;
+impl sp_domains::fraud_proof::StorageKeys for StorageKeys {
+    fn block_randomness_key() -> StorageKey {
+        StorageKey(
+            frame_support::storage::storage_prefix("Subspace".as_ref(), "BlockRandomness".as_ref())
+                .to_vec(),
+        )
+    }
+}
+
 impl pallet_domains::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type DomainNumber = BlockNumber;
@@ -216,6 +226,7 @@ impl pallet_domains::Config for Test {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type SudoId = ();
     type Randomness = MockRandomness;
+    type StorageKeys = StorageKeys;
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
@@ -865,7 +876,9 @@ fn generate_invalid_domain_extrinsic_root_fraud_proof<T: Config>(
     bad_receipt_hash: ReceiptHash,
     randomness: Randomness,
 ) -> (FraudProof<BlockNumberFor<T>, T::Hash>, T::Hash) {
-    let storage_key = sp_domains::fraud_proof::block_randomness_final_key();
+    let storage_key =
+        frame_support::storage::storage_prefix("Subspace".as_ref(), "BlockRandomness".as_ref())
+            .to_vec();
     let mut root = T::Hash::default();
     let mut mdb = PrefixedMemoryDB::<T::Hashing>::default();
     {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::block_tree::DomainBlock;
 use crate::domain_registry::{DomainConfig, DomainObject};
 use crate::{
-    self as pallet_domains, BalanceOf, BlockTree, BundleError, Config, ConsensusBlockHash,
+    self as pallet_domains, BalanceOf, BlockTree, BundleError, Config, ConsensusBlockInfo,
     DomainBlocks, DomainRegistry, ExecutionInbox, ExecutionReceiptOf, FraudProofError,
     FungibleHoldId, HeadReceiptNumber, NextDomainId, Operator, OperatorStatus, Operators,
 };
@@ -859,7 +859,7 @@ fn test_basic_fraud_proof_processing() {
             assert!(
                 !ExecutionInbox::<Test>::get((domain_id, block_number, block_number)).is_empty()
             );
-            assert!(ConsensusBlockHash::<Test>::get(domain_id, block_number).is_some());
+            assert!(ConsensusBlockInfo::<Test>::get(domain_id, block_number).is_some());
         }
 
         // Re-submit the valid ER

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -15,7 +15,10 @@ use scale_info::TypeInfo;
 use sp_core::crypto::Pair;
 use sp_core::storage::{StateVersion, StorageKey};
 use sp_core::{Get, H256, U256};
-use sp_domains::fraud_proof::{FraudProof, InvalidTotalRewardsProof};
+use sp_domains::fraud_proof::{
+    ExtrinsicDigest, FraudProof, InvalidExtrinsicsRootProof, InvalidTotalRewardsProof,
+    ValidBundleDigest,
+};
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
     BundleHeader, DomainId, DomainInstanceData, DomainsHoldIdentifier, ExecutionReceipt,
@@ -31,7 +34,7 @@ use sp_trie::{PrefixedMemoryDB, StorageProof, TrieMut};
 use sp_version::RuntimeVersion;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use subspace_core_primitives::U256 as P256;
+use subspace_core_primitives::{Randomness, U256 as P256};
 use subspace_runtime_primitives::SSC;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -818,6 +821,73 @@ fn storage_proof_for_key<T: Config, B: Backend<T::Hashing> + AsTrieBackend<T::Ha
     let root = backend.storage_root(std::iter::empty(), state_version).0;
     let proof = StorageProof::new(prove_read(backend, &[key]).unwrap().iter_nodes().cloned());
     (root, proof)
+}
+
+#[test]
+fn test_invalid_domain_extrinsic_root_proof() {
+    let creator = 0u64;
+    let operator_id = 1u64;
+    let head_domain_number = 10;
+    let mut ext = new_test_ext_with_extensions();
+    ext.execute_with(|| {
+        let domain_id = register_genesis_domain(creator, vec![operator_id]);
+        extend_block_tree(domain_id, operator_id, head_domain_number + 1);
+        assert_eq!(
+            HeadReceiptNumber::<Test>::get(domain_id),
+            head_domain_number
+        );
+
+        let bad_receipt_at = 8;
+        let domain_block = get_block_tree_node_at::<Test>(domain_id, bad_receipt_at).unwrap();
+
+        let bad_receipt_hash = domain_block.execution_receipt.hash();
+        let (fraud_proof, root) = generate_invalid_domain_extrinsic_root_fraud_proof::<Test>(
+            domain_id,
+            bad_receipt_hash,
+            Randomness::from([1u8; 32]),
+        );
+        let (consensus_block_number, consensus_block_hash) = (
+            domain_block.execution_receipt.consensus_block_number,
+            domain_block.execution_receipt.consensus_block_hash,
+        );
+        ConsensusBlockInfo::<Test>::insert(
+            domain_id,
+            consensus_block_number,
+            (consensus_block_hash, root),
+        );
+        DomainBlocks::<Test>::insert(bad_receipt_hash, domain_block);
+        assert_ok!(Domains::validate_fraud_proof(&fraud_proof),);
+    });
+}
+
+fn generate_invalid_domain_extrinsic_root_fraud_proof<T: Config>(
+    domain_id: DomainId,
+    bad_receipt_hash: ReceiptHash,
+    randomness: Randomness,
+) -> (FraudProof<BlockNumberFor<T>, T::Hash>, T::Hash) {
+    let storage_key = sp_domains::fraud_proof::block_randomness_final_key();
+    let mut root = T::Hash::default();
+    let mut mdb = PrefixedMemoryDB::<T::Hashing>::default();
+    {
+        let mut trie = TrieDBMutBuilderV1::new(&mut mdb, &mut root).build();
+        trie.insert(&storage_key, &randomness.encode()).unwrap();
+    };
+
+    let backend = TrieBackendBuilder::new(mdb, root).build();
+    let (root, randomness_proof) = storage_proof_for_key::<T, _>(backend, StorageKey(storage_key));
+    let valid_bundle_digests = vec![ValidBundleDigest {
+        bundle_index: 0,
+        bundle_digest: vec![(Some(vec![1, 2, 3]), ExtrinsicDigest::Data(vec![4, 5, 6]))],
+    }];
+    (
+        FraudProof::InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof {
+            domain_id,
+            bad_receipt_hash,
+            randomness_proof,
+            valid_bundle_digests,
+        }),
+        root,
+    )
 }
 
 #[test]

--- a/crates/pallet-runtime-configs/Cargo.toml
+++ b/crates/pallet-runtime-configs/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://subspace.network"
 repository = "https://github.com/subspace/subspace"
 description = "Pallet for tweaking the runtime configs for multiple network"
 include = [
-  "/src",
-  "/Cargo.toml",
+    "/src",
+    "/Cargo.toml",
 ]
 
 [package.metadata.docs.rs]
@@ -28,17 +28,17 @@ sp-std = { version = "8.0.0", default-features = false, git = "https://github.co
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "frame-support/std",
-  "frame-system/std",
-  "scale-info/std",
-  "sp-runtime/std",
-  "sp-std?/std",
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "scale-info/std",
+    "sp-runtime/std",
+    "sp-std?/std",
 ]
 try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
-  "frame-benchmarking",
-  "frame-benchmarking/runtime-benchmarks",
-  "sp-core",
-  "sp-std",
+    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
+    "sp-core",
+    "sp-std",
 ]

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -103,7 +103,7 @@ struct VoteVerificationData {
 struct AuditChunkOffset(u8);
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
     use super::{AuditChunkOffset, EraChangeTrigger, VoteVerificationData};
     use crate::equivocation::HandleEquivocation;
     use crate::weights::WeightInfo;
@@ -449,7 +449,7 @@ mod pallet {
     /// The current block randomness, updated at block initialization. When the proof of time feature
     /// is enabled it derived from PoT otherwise PoR.
     #[pallet::storage]
-    pub(super) type BlockRandomness<T> = StorageValue<_, Randomness>;
+    pub type BlockRandomness<T> = StorageValue<_, Randomness>;
 
     /// Enable storage access for all users.
     #[pallet::storage]

--- a/crates/sp-domains/Cargo.toml
+++ b/crates/sp-domains/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 blake2 = { version = "0.10.6", default-features = false }
+domain-runtime-primitives = { version = "0.1.0", default-features = false, path = "../../domains/primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 hash-db = { version = "0.16.0", default-features = false }
 hexlit = "0.5.5"
@@ -43,28 +44,29 @@ num-traits = "0.2.16"
 [features]
 default = ["std"]
 std = [
-	"blake2/std",
-	"frame-support/std",
-	"hash-db/std",
-	"parity-scale-codec/std",
-	"rs_merkle/std",
-	"scale-info/std",
-	"serde/std",
-	"sp-api/std",
-	"sp-blockchain",
-	"sp-application-crypto/std",
-	"sp-consensus-slots/std",
-	"sp-core/std",
-	"sp-externalities/std",
-	"sp-keystore",
-	"sp-runtime/std",
-	"sp-runtime-interface/std",
-	"sp-state-machine/std",
-	"sp-std/std",
-	"sp-trie/std",
-	"sp-weights/std",
-	"subspace-core-primitives/std",
-	"subspace-runtime-primitives/std",
-	"thiserror",
+    "blake2/std",
+    "domain-runtime-primitives/std",
+    "frame-support/std",
+    "hash-db/std",
+    "parity-scale-codec/std",
+    "rs_merkle/std",
+    "scale-info/std",
+    "serde/std",
+    "sp-api/std",
+    "sp-blockchain",
+    "sp-application-crypto/std",
+    "sp-consensus-slots/std",
+    "sp-core/std",
+    "sp-externalities/std",
+    "sp-keystore",
+    "sp-runtime/std",
+    "sp-runtime-interface/std",
+    "sp-state-machine/std",
+    "sp-std/std",
+    "sp-trie/std",
+    "sp-weights/std",
+    "subspace-core-primitives/std",
+    "subspace-runtime-primitives/std",
+    "thiserror",
 ]
 runtime-benchmarks = []

--- a/crates/sp-domains/Cargo.toml
+++ b/crates/sp-domains/Cargo.toml
@@ -18,6 +18,8 @@ frame-support = { version = "4.0.0-dev", default-features = false, git = "https:
 hash-db = { version = "0.16.0", default-features = false }
 hexlit = "0.5.5"
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["derive"] }
+rand = { version = "0.8.5", default-features = false }
+rand_chacha = { version = "0.3.1", default-features = false }
 rs_merkle = { version = "1.4.1", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"] }
@@ -36,10 +38,12 @@ sp-trie = { version = "22.0.0", default-features = false, git = "https://github.
 sp-weights = { version = "20.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
+trie-db = { version = "0.28.0", default-features = false }
 thiserror = { version = "1.0.48", optional = true }
 
 [dev-dependencies]
 num-traits = "0.2.16"
+rand = { version = "0.8.5", features = ["min_const_gen"] }
 
 [features]
 default = ["std"]
@@ -49,6 +53,8 @@ std = [
     "frame-support/std",
     "hash-db/std",
     "parity-scale-codec/std",
+    "rand/std",
+    "rand_chacha/std",
     "rs_merkle/std",
     "scale-info/std",
     "serde/std",
@@ -67,6 +73,7 @@ std = [
     "sp-weights/std",
     "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",
+    "trie-db/std",
     "thiserror",
 ]
 runtime-benchmarks = []

--- a/crates/sp-domains/Cargo.toml
+++ b/crates/sp-domains/Cargo.toml
@@ -12,6 +12,7 @@ description = "Primitives of domains pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+async-trait = { version = "0.1.73", optional = true }
 blake2 = { version = "0.10.6", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", default-features = false, path = "../../domains/primitives/runtime" }
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
@@ -29,6 +30,7 @@ sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polk
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-externalities = { version = "0.19.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
+sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7", optional = true }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
@@ -48,6 +50,7 @@ rand = { version = "0.8.5", features = ["min_const_gen"] }
 [features]
 default = ["std"]
 std = [
+    "async-trait",
     "blake2/std",
     "domain-runtime-primitives/std",
     "frame-support/std",
@@ -64,6 +67,7 @@ std = [
     "sp-consensus-slots/std",
     "sp-core/std",
     "sp-externalities/std",
+    "sp-inherents/std",
     "sp-keystore",
     "sp-runtime/std",
     "sp-runtime-interface/std",

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -3,6 +3,7 @@ use hash_db::Hasher;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
+use sp_core::storage::StorageKey;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT, Header as HeaderT};
 use sp_std::vec::Vec;
@@ -406,6 +407,7 @@ pub struct ImproperTransactionSortitionProof {
     pub bad_receipt_hash: ReceiptHash,
 }
 
+/// Represents an invalid total rewards proof.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
 pub struct InvalidTotalRewardsProof {
     /// The id of the domain this fraud proof targeted
@@ -416,6 +418,7 @@ pub struct InvalidTotalRewardsProof {
     pub storage_proof: StorageProof,
 }
 
+/// Represents the extrinsic either as full data or hash of the data.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
 pub enum ExtrinsicDigest {
     /// Actual extrinsic data that is inlined since it is less than 33 bytes.
@@ -441,6 +444,7 @@ impl ExtrinsicDigest {
     }
 }
 
+/// Represents a valid bundle index and all the extrinsics within that bundle.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
 pub struct ValidBundleDigest {
     /// Index of this bundle in the original list of bundles in the consensus block.
@@ -452,6 +456,7 @@ pub struct ValidBundleDigest {
     )>,
 }
 
+/// Represents an Invalid domain extrinsics root proof with necessary info for verification.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
 pub struct InvalidExtrinsicsRootProof {
     /// The id of the domain this fraud proof targeted
@@ -474,15 +479,14 @@ impl InvalidTotalRewardsProof {
     }
 }
 
+/// Trait to get Storage keys.
+pub trait StorageKeys {
+    fn block_randomness_key() -> StorageKey;
+}
+
 /// This is a representation of actual Block Rewards storage in pallet-operator-rewards.
 /// Any change in key or value there should be changed here accordingly.
 pub fn operator_block_rewards_final_key() -> Vec<u8> {
     frame_support::storage::storage_prefix("OperatorRewards".as_ref(), "BlockRewards".as_ref())
         .to_vec()
-}
-
-/// This is a representation of actual Randomness on Consensus chain state.
-/// Any change in key or value there should be changed here accordingly.
-pub fn block_randomness_final_key() -> Vec<u8> {
-    frame_support::storage::storage_prefix("Subspace".as_ref(), "BlockRandomness".as_ref()).to_vec()
 }

--- a/crates/sp-domains/src/inherents.rs
+++ b/crates/sp-domains/src/inherents.rs
@@ -1,0 +1,74 @@
+//! Inherents for domain
+
+use parity_scale_codec::{Decode, Encode};
+use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
+
+/// The domain inherent identifier.
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"domains_";
+
+/// Errors that can occur while checking provided inherent data.
+#[derive(Debug, Encode)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub enum InherentError {
+    /// Incorrect parent state root.
+    IncorrectParentStateRoot,
+}
+
+impl IsFatalError for InherentError {
+    fn is_fatal_error(&self) -> bool {
+        true
+    }
+}
+
+/// The type of the Domains inherent data.
+#[derive(Debug, Encode, Decode)]
+pub struct InherentType<Hash> {
+    /// Parent state root.
+    pub parent_state_root: Hash,
+}
+
+/// Provides the parent state root for Domains inherent data
+#[cfg(feature = "std")]
+pub struct InherentDataProvider<Hash> {
+    data: InherentType<Hash>,
+}
+
+#[cfg(feature = "std")]
+impl<Hash> InherentDataProvider<Hash> {
+    /// Create new inherent data provider from the given `data`.
+    pub fn new(parent_state_root: Hash) -> Self {
+        Self {
+            data: InherentType { parent_state_root },
+        }
+    }
+
+    /// Returns the `data` of this inherent data provider.
+    pub fn data(&self) -> &InherentType<Hash> {
+        &self.data
+    }
+}
+
+#[cfg(feature = "std")]
+#[async_trait::async_trait]
+impl<Hash> sp_inherents::InherentDataProvider for InherentDataProvider<Hash>
+where
+    Hash: Send + Sync + Encode + Decode,
+{
+    async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
+        inherent_data.put_data(INHERENT_IDENTIFIER, &self.data)
+    }
+
+    async fn try_handle_error(
+        &self,
+        identifier: &InherentIdentifier,
+        error: &[u8],
+    ) -> Option<Result<(), Error>> {
+        if *identifier != INHERENT_IDENTIFIER {
+            return None;
+        }
+
+        let error = InherentError::decode(&mut &*error).ok()?;
+
+        Some(Err(Error::Application(Box::from(format!("{error:?}")))))
+    }
+}

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -23,6 +23,7 @@ pub mod merkle_tree;
 #[cfg(test)]
 mod tests;
 pub mod transaction;
+pub mod valued_trie_root;
 pub mod verification;
 
 use bundle_producer_election::{BundleProducerElectionParams, VrfProofError};
@@ -51,6 +52,9 @@ use subspace_runtime_primitives::{Balance, Moment};
 
 /// Key type for Operator.
 const KEY_TYPE: KeyTypeId = KeyTypeId(*b"oper");
+
+/// Extrinsics shuffling seed
+pub const EXTRINSICS_SHUFFLING_SEED: &[u8] = b"extrinsics-shuffling-seed";
 
 mod app {
     use super::KEY_TYPE;
@@ -351,7 +355,7 @@ pub struct ExecutionReceipt<Number, Hash, DomainNumber, DomainHash, Balance> {
     /// The block hash corresponding to `domain_block_number`.
     pub domain_block_hash: DomainHash,
     /// Extrinsic root field of the header of domain block referenced by this ER.
-    pub domain_block_extrinsic_root: DomainHash,
+    pub domain_block_extrinsic_root: H256,
     /// The hash of the ER for the last domain block.
     pub parent_domain_block_receipt_hash: ReceiptHash,
     /// A pointer to the consensus block index which contains all of the bundles that were used to derive and

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -55,7 +55,7 @@ use subspace_runtime_primitives::{Balance, Moment};
 const KEY_TYPE: KeyTypeId = KeyTypeId(*b"oper");
 
 /// Extrinsics shuffling seed
-pub const EXTRINSICS_SHUFFLING_SEED: &[u8] = b"extrinsics-shuffling-seed";
+pub const DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT: &[u8] = b"extrinsics-shuffling-seed";
 
 mod app {
     use super::KEY_TYPE;
@@ -733,7 +733,7 @@ pub struct ValidBundle {
     /// Index of this bundle in the original list of bundles in the consensus block.
     pub bundle_index: u32,
     /// Hash of `Vec<(tx_signer, tx_hash)>` of all domain extrinsic being included in the bundle.
-    pub bundle_digest: H256,
+    pub bundle_digest_hash: H256,
 }
 
 #[derive(Debug, Decode, Encode, TypeInfo, Clone, PartialEq, Eq)]

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -19,6 +19,7 @@
 
 pub mod bundle_producer_election;
 pub mod fraud_proof;
+pub mod inherents;
 pub mod merkle_tree;
 #[cfg(test)]
 mod tests;

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -800,6 +800,9 @@ sp_api::decl_runtime_apis! {
 
         /// Returns the chain state root at the given block.
         fn domain_state_root(domain_id: DomainId, number: DomainNumber, hash: DomainHash) -> Option<DomainHash>;
+
+        /// Block randomness key.
+        fn block_randomness_key() -> Vec<u8>;
     }
 
     pub trait BundleProducerElectionApi<Balance: Encode + Decode> {

--- a/crates/sp-domains/src/valued_trie_root.rs
+++ b/crates/sp-domains/src/valued_trie_root.rs
@@ -1,0 +1,292 @@
+use hash_db::Hasher;
+use parity_scale_codec::{Compact, Encode};
+use sp_std::cmp::max;
+use sp_std::vec::Vec;
+use trie_db::node::Value;
+use trie_db::{
+    nibble_ops, ChildReference, NibbleSlice, NodeCodec, ProcessEncodedNode, TrieHash, TrieLayout,
+    TrieRoot,
+};
+
+macro_rules! exponential_out {
+	(@3, [$($inpp:expr),*]) => { exponential_out!(@2, [$($inpp,)* $($inpp),*]) };
+	(@2, [$($inpp:expr),*]) => { exponential_out!(@1, [$($inpp,)* $($inpp),*]) };
+	(@1, [$($inpp:expr),*]) => { [$($inpp,)* $($inpp),*] };
+}
+
+type CacheNode<HO> = Option<ChildReference<HO>>;
+
+#[inline(always)]
+fn new_vec_slice_buffer<HO>() -> [CacheNode<HO>; 16] {
+    exponential_out!(@3, [None, None])
+}
+
+type ArrayNode<T> = [CacheNode<TrieHash<T>>; 16];
+
+/// This is a modified version of trie root that takes trie node values instead of deriving from
+/// the actual data. Taken from `trie-db` as is.
+/// Note: This is an opportunity to push this change upstream but I'm not sure how to present these
+/// changes yet. Need to be discussed further.
+pub fn valued_ordered_trie_root<Layout>(
+    input: Vec<Value>,
+) -> <<Layout as TrieLayout>::Hash as Hasher>::Out
+where
+    Layout: TrieLayout,
+{
+    let input = input
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| (Compact(i as u32).encode(), v))
+        .collect();
+
+    let mut cb = TrieRoot::<Layout>::default();
+    trie_visit::<Layout, _>(input, &mut cb);
+    cb.root.unwrap_or_default()
+}
+
+fn trie_visit<T, F>(input: Vec<(Vec<u8>, Value)>, callback: &mut F)
+where
+    T: TrieLayout,
+    F: ProcessEncodedNode<TrieHash<T>>,
+{
+    let mut depth_queue = CacheAccum::<T>::new();
+    // compare iter ordering
+    let mut iter_input = input.into_iter();
+    if let Some(mut previous_value) = iter_input.next() {
+        // depth of last item
+        let mut last_depth = 0;
+
+        let mut single = true;
+        for (k, v) in iter_input {
+            single = false;
+            let common_depth = nibble_ops::biggest_depth(&previous_value.0, &k);
+            // 0 is a reserved value : could use option
+            let depth_item = common_depth;
+            if common_depth == previous_value.0.len() * nibble_ops::NIBBLE_PER_BYTE {
+                // the new key include the previous one : branch value case
+                // just stored value at branch depth
+                depth_queue.set_cache_value(common_depth, Some(previous_value.1));
+            } else if depth_item >= last_depth {
+                // put previous with next (common branch previous value can be flush)
+                depth_queue.flush_value(callback, depth_item, &previous_value);
+            } else if depth_item < last_depth {
+                // do not put with next, previous is last of a branch
+                depth_queue.flush_value(callback, last_depth, &previous_value);
+                let ref_branches = previous_value.0;
+                depth_queue.flush_branch(callback, ref_branches, depth_item, false);
+            }
+
+            previous_value = (k, v);
+            last_depth = depth_item;
+        }
+        // last pendings
+        if single {
+            // one single element corner case
+            let (k2, v2) = previous_value;
+            let nkey = NibbleSlice::new_offset(&k2, last_depth);
+            let pr =
+                NibbleSlice::new_offset(&k2, k2.len() * nibble_ops::NIBBLE_PER_BYTE - nkey.len());
+
+            let encoded = T::Codec::leaf_node(nkey.right_iter(), nkey.len(), v2);
+            callback.process(pr.left(), encoded, true);
+        } else {
+            depth_queue.flush_value(callback, last_depth, &previous_value);
+            let ref_branches = previous_value.0;
+            depth_queue.flush_branch(callback, ref_branches, 0, true);
+        }
+    } else {
+        // nothing null root corner case
+        callback.process(hash_db::EMPTY_PREFIX, T::Codec::empty_node().to_vec(), true);
+    }
+}
+
+struct CacheAccum<'a, T: TrieLayout>(Vec<(ArrayNode<T>, Option<Value<'a>>, usize)>);
+
+/// Initially allocated cache depth.
+const INITIAL_DEPTH: usize = 10;
+
+impl<'a, T> CacheAccum<'a, T>
+where
+    T: TrieLayout,
+{
+    fn new() -> Self {
+        let v = Vec::with_capacity(INITIAL_DEPTH);
+        CacheAccum(v)
+    }
+
+    #[inline(always)]
+    fn set_cache_value(&mut self, depth: usize, value: Option<Value<'a>>) {
+        if self.0.is_empty() || self.0[self.0.len() - 1].2 < depth {
+            self.0.push((new_vec_slice_buffer(), None, depth));
+        }
+        let last = self.0.len() - 1;
+        debug_assert!(self.0[last].2 <= depth);
+        self.0[last].1 = value;
+    }
+
+    #[inline(always)]
+    fn set_node(&mut self, depth: usize, nibble_index: usize, node: CacheNode<TrieHash<T>>) {
+        if self.0.is_empty() || self.0[self.0.len() - 1].2 < depth {
+            self.0.push((new_vec_slice_buffer(), None, depth));
+        }
+
+        let last = self.0.len() - 1;
+        debug_assert!(self.0[last].2 == depth);
+
+        self.0[last].0.as_mut()[nibble_index] = node;
+    }
+
+    #[inline(always)]
+    fn last_depth(&self) -> usize {
+        let ix = self.0.len();
+        if ix > 0 {
+            let last = ix - 1;
+            self.0[last].2
+        } else {
+            0
+        }
+    }
+
+    #[inline(always)]
+    fn last_last_depth(&self) -> usize {
+        let ix = self.0.len();
+        if ix > 1 {
+            let last = ix - 2;
+            self.0[last].2
+        } else {
+            0
+        }
+    }
+
+    #[inline(always)]
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+    #[inline(always)]
+    fn is_one(&self) -> bool {
+        self.0.len() == 1
+    }
+
+    fn flush_value(
+        &mut self,
+        callback: &mut impl ProcessEncodedNode<TrieHash<T>>,
+        target_depth: usize,
+        (k2, v2): &(impl AsRef<[u8]>, Value),
+    ) {
+        let nibble_value = nibble_ops::left_nibble_at(k2.as_ref(), target_depth);
+        // is it a branch value (two candidate same ix)
+        let nkey = NibbleSlice::new_offset(k2.as_ref(), target_depth + 1);
+        let pr = NibbleSlice::new_offset(
+            k2.as_ref(),
+            k2.as_ref().len() * nibble_ops::NIBBLE_PER_BYTE - nkey.len(),
+        );
+
+        let encoded = T::Codec::leaf_node(nkey.right_iter(), nkey.len(), v2.clone());
+        let hash = callback.process(pr.left(), encoded, false);
+
+        // insert hash in branch (first level branch only at this point)
+        self.set_node(target_depth, nibble_value as usize, Some(hash));
+    }
+
+    fn flush_branch(
+        &mut self,
+        callback: &mut impl ProcessEncodedNode<TrieHash<T>>,
+        ref_branch: impl AsRef<[u8]> + Ord,
+        new_depth: usize,
+        is_last: bool,
+    ) {
+        while self.last_depth() > new_depth || is_last && !self.is_empty() {
+            let lix = self.last_depth();
+            let llix = max(self.last_last_depth(), new_depth);
+
+            let (offset, slice_size, is_root) = if llix == 0 && is_last && self.is_one() {
+                // branch root
+                (llix, lix - llix, true)
+            } else {
+                (llix + 1, lix - llix - 1, false)
+            };
+            let nkey = if slice_size > 0 {
+                Some((offset, slice_size))
+            } else {
+                None
+            };
+
+            let h = self.no_extension(ref_branch.as_ref(), callback, lix, is_root, nkey);
+            if !is_root {
+                // put hash in parent
+                let nibble: u8 = nibble_ops::left_nibble_at(ref_branch.as_ref(), llix);
+                self.set_node(llix, nibble as usize, Some(h));
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn no_extension(
+        &mut self,
+        key_branch: &[u8],
+        callback: &mut impl ProcessEncodedNode<TrieHash<T>>,
+        branch_d: usize,
+        is_root: bool,
+        nkey: Option<(usize, usize)>,
+    ) -> ChildReference<TrieHash<T>> {
+        let (children, v, depth) = self.0.pop().expect("checked");
+
+        debug_assert!(branch_d == depth);
+        // encode branch
+        let nkeyix = nkey.unwrap_or((branch_d, 0));
+        let pr = NibbleSlice::new_offset(key_branch, nkeyix.0);
+        let encoded = T::Codec::branch_node_nibbled(
+            pr.right_range_iter(nkeyix.1),
+            nkeyix.1,
+            children.iter(),
+            v,
+        );
+        callback.process(pr.left(), encoded, is_root)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::valued_trie_root::valued_ordered_trie_root;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+    use sp_runtime::traits::{BlakeTwo256, Hash};
+    use sp_trie::LayoutV1;
+    use trie_db::node::Value;
+
+    #[test]
+    fn test_extrinsics_root() {
+        let mut rng = StdRng::seed_from_u64(10000);
+        let exts_length = vec![35, 31, 50, 100, 20, 10, 120];
+        let mut exts = Vec::new();
+        let mut exts_hashed = Vec::new();
+        for ext_length in &exts_length {
+            let mut ext = vec![0u8; *ext_length];
+            rng.fill(ext.as_mut_slice());
+            let hashed = if *ext_length <= 32 {
+                ext.clone()
+            } else {
+                BlakeTwo256::hash(&ext).0.to_vec()
+            };
+            exts.push(ext);
+            exts_hashed.push(hashed);
+        }
+
+        let exts_values = exts_hashed
+            .iter()
+            .zip(exts_length)
+            .map(|(ext_hashed, ext_length)| {
+                let value = if ext_length <= 32 {
+                    Value::Inline(ext_hashed)
+                } else {
+                    Value::Node(ext_hashed)
+                };
+                value
+            })
+            .collect();
+
+        let root = BlakeTwo256::ordered_trie_root(exts, sp_core::storage::StateVersion::V1);
+        let got_root = valued_ordered_trie_root::<LayoutV1<BlakeTwo256>>(exts_values);
+        assert_eq!(root, got_root)
+    }
+}

--- a/crates/sp-domains/src/verification.rs
+++ b/crates/sp-domains/src/verification.rs
@@ -1,4 +1,4 @@
-use crate::fraud_proof::{ExtrinsicDigest, InvalidExtrinsicsRootProof};
+use crate::fraud_proof::{ExtrinsicDigest, InvalidExtrinsicsRootProof, StorageKeys};
 use crate::valued_trie_root::valued_ordered_trie_root;
 use crate::{ExecutionReceipt, EXTRINSICS_SHUFFLING_SEED};
 use domain_runtime_primitives::opaque::AccountId;
@@ -103,6 +103,7 @@ pub fn verify_invalid_domain_extrinsics_root_fraud_proof<
     DomainHash,
     Balance,
     Hashing,
+    SK,
 >(
     consensus_state_root: CBlock::Hash,
     bad_receipt: ExecutionReceipt<
@@ -117,6 +118,7 @@ pub fn verify_invalid_domain_extrinsics_root_fraud_proof<
 where
     CBlock: Block,
     Hashing: Hasher<Out = CBlock::Hash>,
+    SK: StorageKeys,
 {
     let InvalidExtrinsicsRootProof {
         valid_bundle_digests,
@@ -138,7 +140,7 @@ where
         ext_values.extend(bundle_digest.bundle_digest.clone());
     }
 
-    let storage_key = StorageKey(crate::fraud_proof::block_randomness_final_key());
+    let storage_key = SK::block_randomness_key();
     let storage_proof = randomness_proof.clone();
     let block_randomness = StorageProofVerifier::<Hashing>::verify_and_get_value::<Randomness>(
         &consensus_state_root,

--- a/crates/sp-domains/src/verification.rs
+++ b/crates/sp-domains/src/verification.rs
@@ -1,16 +1,16 @@
+use crate::ExecutionReceipt;
 use frame_support::PalletError;
 use hash_db::Hasher;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::storage::StorageKey;
+use sp_runtime::traits::{Block, NumberFor};
 use sp_std::marker::PhantomData;
 use sp_trie::{read_trie_value, LayoutV1, StorageProof};
 
 /// Verification error.
 #[derive(Debug, PartialEq, Eq, Encode, Decode, PalletError, TypeInfo)]
 pub enum VerificationError {
-    /// Emits when the expected state root doesn't exist
-    InvalidStateRoot,
     /// Emits when the given storage proof is invalid.
     InvalidProof,
     /// Value doesn't exist in the Db for the given key.
@@ -36,4 +36,47 @@ impl<H: Hasher> StorageProofVerifier<H> {
 
         Ok(decoded)
     }
+}
+
+pub fn verify_invalid_total_rewards_fraud_proof<
+    CBlock,
+    DomainNumber,
+    DomainHash,
+    Balance,
+    Hashing,
+>(
+    bad_receipt: ExecutionReceipt<
+        NumberFor<CBlock>,
+        CBlock::Hash,
+        DomainNumber,
+        DomainHash,
+        Balance,
+    >,
+    storage_proof: &StorageProof,
+) -> Result<(), VerificationError>
+where
+    CBlock: Block,
+    Balance: PartialEq + Decode,
+    Hashing: Hasher<Out = CBlock::Hash>,
+    DomainHash: Encode,
+{
+    let state_root = bad_receipt.final_state_root.encode();
+    let state_root = CBlock::Hash::decode(&mut state_root.as_slice())
+        .map_err(|_| VerificationError::FailedToDecode)?;
+    let storage_key = StorageKey(crate::fraud_proof::operator_block_rewards_final_key());
+    let storage_proof = storage_proof.clone();
+
+    let total_rewards = StorageProofVerifier::<Hashing>::verify_and_get_value::<Balance>(
+        &state_root,
+        storage_proof,
+        storage_key,
+    )
+    .map_err(|_| VerificationError::InvalidProof)?;
+
+    // if the rewards matches, then this is an invalid fraud proof since rewards must be different.
+    if bad_receipt.total_rewards == total_rewards {
+        return Err(VerificationError::InvalidProof);
+    }
+
+    Ok(())
 }

--- a/crates/sp-domains/src/verification.rs
+++ b/crates/sp-domains/src/verification.rs
@@ -161,7 +161,6 @@ where
         })
         .collect();
     // TODO: include timestamp and domain runtime upgrade extrinsic
-    // TODO: change Layout version used for deriving extrinsics root in frame system
     let extrinsics_root =
         valued_ordered_trie_root::<LayoutV1<BlakeTwo256>>(ordered_trie_node_values);
     if bad_receipt.domain_block_extrinsic_root == extrinsics_root {

--- a/crates/sp-domains/src/verification.rs
+++ b/crates/sp-domains/src/verification.rs
@@ -1,12 +1,26 @@
-use crate::ExecutionReceipt;
+use crate::fraud_proof::{ExtrinsicDigest, InvalidExtrinsicsRootProof};
+use crate::valued_trie_root::valued_ordered_trie_root;
+use crate::{ExecutionReceipt, EXTRINSICS_SHUFFLING_SEED};
+use domain_runtime_primitives::opaque::AccountId;
 use frame_support::PalletError;
 use hash_db::Hasher;
 use parity_scale_codec::{Decode, Encode};
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
 use scale_info::TypeInfo;
 use sp_core::storage::StorageKey;
-use sp_runtime::traits::{Block, NumberFor};
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, Block, Hash, NumberFor};
+use sp_state_machine::trace;
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::collections::vec_deque::VecDeque;
+use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
+use sp_std::vec::Vec;
 use sp_trie::{read_trie_value, LayoutV1, StorageProof};
+use subspace_core_primitives::Randomness;
+use trie_db::node::Value;
 
 /// Verification error.
 #[derive(Debug, PartialEq, Eq, Encode, Decode, PalletError, TypeInfo)]
@@ -17,6 +31,8 @@ pub enum VerificationError {
     MissingValue,
     /// Failed to decode value.
     FailedToDecode,
+    /// Invalid bundle digest
+    InvalidBundleDigest,
 }
 
 pub struct StorageProofVerifier<H: Hasher>(PhantomData<H>);
@@ -79,4 +95,157 @@ where
     }
 
     Ok(())
+}
+
+pub fn verify_invalid_domain_extrinsics_root_fraud_proof<
+    CBlock,
+    DomainNumber,
+    DomainHash,
+    Balance,
+    Hashing,
+>(
+    consensus_state_root: CBlock::Hash,
+    bad_receipt: ExecutionReceipt<
+        NumberFor<CBlock>,
+        CBlock::Hash,
+        DomainNumber,
+        DomainHash,
+        Balance,
+    >,
+    fraud_proof: InvalidExtrinsicsRootProof,
+) -> Result<(), VerificationError>
+where
+    CBlock: Block,
+    CBlock::Hash: Into<H256>,
+    Hashing: Hasher<Out = CBlock::Hash>,
+{
+    let InvalidExtrinsicsRootProof {
+        valid_bundle_digests,
+        randomness_proof,
+        ..
+    } = fraud_proof;
+
+    let mut ext_values = Vec::new();
+    for (valid_bundle, bundle_digest) in bad_receipt
+        .valid_bundles
+        .into_iter()
+        .zip(valid_bundle_digests)
+    {
+        let bundle_digest_hash = BlakeTwo256::hash_of(&bundle_digest.bundle_digest);
+        if bundle_digest_hash != valid_bundle.bundle_digest {
+            return Err(VerificationError::InvalidBundleDigest);
+        }
+
+        ext_values.extend(bundle_digest.bundle_digest);
+    }
+
+    let storage_key = StorageKey(crate::fraud_proof::block_randomness_final_key());
+    let storage_proof = randomness_proof.clone();
+    let block_randomness = StorageProofVerifier::<Hashing>::verify_and_get_value::<Randomness>(
+        &consensus_state_root,
+        storage_proof,
+        storage_key,
+    )
+    .map_err(|_| VerificationError::InvalidProof)?;
+
+    let shuffling_seed = extrinsics_shuffling_seed::<Hashing>(block_randomness)
+        .into()
+        .to_fixed_bytes();
+    let ordered_extrinsics =
+        deduplicate_and_shuffle_extrinsics(ext_values, Randomness::from(shuffling_seed));
+    let ordered_trie_node_values = ordered_extrinsics
+        .iter()
+        .map(|ext_digest| match ext_digest {
+            ExtrinsicDigest::Data(data) => Value::Inline(data),
+            ExtrinsicDigest::Hash(hash) => Value::Node(hash.0.as_slice()),
+        })
+        .collect();
+    // TODO: include timestamp and domain runtime upgrade extrinsic
+    // TODO: change Layout version used for deriving extrinsics root in frame system
+    let extrinsics_root =
+        valued_ordered_trie_root::<LayoutV1<BlakeTwo256>>(ordered_trie_node_values);
+    if bad_receipt.domain_block_extrinsic_root == extrinsics_root {
+        return Err(VerificationError::InvalidProof);
+    }
+
+    Ok(())
+}
+
+fn extrinsics_shuffling_seed<Hashing>(block_randomness: Randomness) -> Hashing::Out
+where
+    Hashing: Hasher,
+{
+    let mut subject = EXTRINSICS_SHUFFLING_SEED.to_vec();
+    subject.extend_from_slice(block_randomness.as_ref());
+    Hashing::hash(&subject)
+}
+
+pub fn deduplicate_and_shuffle_extrinsics<Extrinsic>(
+    mut extrinsics: Vec<(Option<AccountId>, Extrinsic)>,
+    shuffling_seed: Randomness,
+) -> Vec<Extrinsic>
+where
+    Extrinsic: Debug + PartialEq + Clone,
+{
+    let mut seen = Vec::new();
+    extrinsics.retain(|(_, uxt)| match seen.contains(uxt) {
+        true => {
+            trace!(extrinsic = ?uxt, "Duplicated extrinsic");
+            false
+        }
+        false => {
+            seen.push(uxt.clone());
+            true
+        }
+    });
+    drop(seen);
+    trace!(?extrinsics, "Origin deduplicated extrinsics");
+    shuffle_extrinsics::<Extrinsic, AccountId>(extrinsics, shuffling_seed)
+}
+
+/// Shuffles the extrinsics in a deterministic way.
+///
+/// The extrinsics are grouped by the signer. The extrinsics without a signer, i.e., unsigned
+/// extrinsics, are considered as a special group. The items in different groups are cross shuffled,
+/// while the order of items inside the same group is still maintained.
+pub fn shuffle_extrinsics<Extrinsic: Debug, AccountId: Ord + Clone>(
+    extrinsics: Vec<(Option<AccountId>, Extrinsic)>,
+    shuffling_seed: Randomness,
+) -> Vec<Extrinsic> {
+    let mut rng = ChaCha8Rng::from_seed(*shuffling_seed);
+
+    let mut positions = extrinsics
+        .iter()
+        .map(|(maybe_signer, _)| maybe_signer)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    // Shuffles the positions using Fisher–Yates algorithm.
+    positions.shuffle(&mut rng);
+
+    let mut grouped_extrinsics: BTreeMap<Option<AccountId>, VecDeque<_>> = extrinsics
+        .into_iter()
+        .fold(BTreeMap::new(), |mut groups, (maybe_signer, tx)| {
+            groups
+                .entry(maybe_signer)
+                .or_insert_with(VecDeque::new)
+                .push_back(tx);
+            groups
+        });
+
+    // The relative ordering for the items in the same group does not change.
+    let shuffled_extrinsics = positions
+        .into_iter()
+        .map(|maybe_signer| {
+            grouped_extrinsics
+                .get_mut(&maybe_signer)
+                .expect("Extrinsics are grouped correctly; qed")
+                .pop_front()
+                .expect("Extrinsic definitely exists as it's correctly grouped above; qed")
+        })
+        .collect::<Vec<_>>();
+
+    trace!(?shuffled_extrinsics, "Shuffled extrinsics");
+
+    shuffled_extrinsics
 }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -556,10 +556,12 @@ where
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
                     // TODO: Would be nice if the whole header was passed in here
-                    let parent_block_number = client
+                    let parent_header = client
                         .header(parent_hash)?
-                        .expect("Parent header must always exist when block is created; qed")
-                        .number;
+                        .expect("Parent header must always exist when block is created; qed");
+
+                    let parent_block_number = parent_header.number;
+                    let parent_state_root = parent_header.state_root;
 
                     let subspace_inherents =
                         sp_consensus_subspace::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
@@ -568,7 +570,10 @@ where
                             subspace_link.segment_headers_for_block(parent_block_number + 1),
                         );
 
-                    Ok((timestamp, subspace_inherents))
+                    let domain_inherents =
+                        sp_domains::inherents::InherentDataProvider::new(parent_state_root);
+
+                    Ok((timestamp, subspace_inherents, domain_inherents))
                 }
             }
         },

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -266,7 +266,7 @@ where
             header.extrinsics_root().clone(),
             HashingFor::<Block>::ordered_trie_root(
                 self.extrinsics.iter().map(Encode::encode).collect(),
-                sp_core::storage::StateVersion::V0 // TODO: switch to V1 once the upstream substrate switches.
+                sp_core::storage::StateVersion::V1
             ),
         );
 

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -294,7 +294,7 @@ where
                         .collect();
                     valid_bundles.push(ValidBundle {
                         bundle_index: index as u32,
-                        bundle_digest: BlakeTwo256::hash_of(&bundle_digest),
+                        bundle_digest_hash: BlakeTwo256::hash_of(&bundle_digest),
                     });
                     valid_extrinsics.extend(extrinsics);
                 }

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -246,6 +246,9 @@ pub(super) enum ReceiptMismatchInfo<CHash> {
         trace_index: u32,
         consensus_block_hash: CHash,
     },
+    DomainExtrinsicsRoot {
+        consensus_block_hash: CHash,
+    },
     InvalidBundles {
         mismatch_type: InvalidBundlesMismatchType,
         bundle_index: u32,
@@ -275,6 +278,9 @@ impl<CHash: Clone> ReceiptMismatchInfo<CHash> {
             ReceiptMismatchInfo::InvalidBundles {
                 consensus_block_hash,
                 ..
+            } => consensus_block_hash.clone(),
+            ReceiptMismatchInfo::DomainExtrinsicsRoot {
+                consensus_block_hash,
             } => consensus_block_hash.clone(),
         }
     }

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -148,6 +148,7 @@ where
     CClient: HeaderBackend<CBlock>
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>
+        + ProofProvider<CBlock>
         + ProvideRuntimeApi<CBlock>
         + 'static,
     CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -11,6 +11,7 @@ use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::BlockOrigin;
 use sp_core::traits::CodeExecutor;
+use sp_core::H256;
 use sp_domain_digests::AsPredigest;
 use sp_domains::{DomainId, DomainsApi, InvalidReceipt, ReceiptValidity};
 use sp_keystore::KeystorePtr;
@@ -133,6 +134,7 @@ where
     CBlock: BlockT,
     NumberFor<CBlock>: From<NumberFor<Block>> + Into<NumberFor<Block>>,
     CBlock::Hash: From<Block::Hash>,
+    Block::Hash: Into<H256>,
     Client: HeaderBackend<Block>
         + BlockBackend<Block>
         + AuxStore

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -686,7 +686,11 @@ where
         + 'static,
     Client::Api:
         DomainCoreApi<Block> + sp_block_builder::BlockBuilder<Block> + sp_api::ApiExt<Block>,
-    CClient: HeaderBackend<CBlock> + BlockBackend<CBlock> + ProvideRuntimeApi<CBlock> + 'static,
+    CClient: HeaderBackend<CBlock>
+        + BlockBackend<CBlock>
+        + ProofProvider<CBlock>
+        + ProvideRuntimeApi<CBlock>
+        + 'static,
     CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>,
     Backend: sc_client_api::Backend<Block> + 'static,
     E: CodeExecutor,

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -775,6 +775,20 @@ where
                     execution_receipt.hash(),
                     receipt_mismatch_info,
                 ));
+
+                continue;
+            }
+
+            if execution_receipt.domain_block_extrinsic_root
+                != local_receipt.domain_block_extrinsic_root
+            {
+                bad_receipts_to_write.push((
+                    execution_receipt.consensus_block_number,
+                    execution_receipt.hash(),
+                    ReceiptMismatchInfo::DomainExtrinsicsRoot {
+                        consensus_block_hash,
+                    },
+                ));
                 continue;
             }
 
@@ -924,6 +938,18 @@ where
                     .map_err(|err| {
                         sp_blockchain::Error::Application(Box::from(format!(
                             "Failed to generate invalid bundles field fraud proof: {err}"
+                        )))
+                    })?,
+                ReceiptMismatchInfo::DomainExtrinsicsRoot { .. } => self
+                    .fraud_proof_generator
+                    .generate_invalid_domain_extrinsics_root_proof::<ParentChainBlock>(
+                        self.domain_id,
+                        &local_receipt,
+                        bad_receipt_hash,
+                    )
+                    .map_err(|err| {
+                        sp_blockchain::Error::Application(Box::from(format!(
+                            "Failed to generate invalid domain extrinsics root fraud proof: {err}"
                         )))
                     })?,
             };

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -16,6 +16,7 @@ use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_blockchain::{HashAndNumber, HeaderBackend, HeaderMetadata};
 use sp_consensus::{BlockOrigin, SyncOracle};
 use sp_core::traits::CodeExecutor;
+use sp_core::H256;
 use sp_domains::fraud_proof::FraudProof;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{DomainId, DomainsApi, ExecutionReceipt};
@@ -100,6 +101,7 @@ where
     Block: BlockT,
     CBlock: BlockT,
     NumberFor<CBlock>: Into<NumberFor<Block>>,
+    Block::Hash: Into<H256>,
     Client: HeaderBackend<Block>
         + BlockBackend<Block>
         + AuxStore
@@ -371,7 +373,7 @@ where
         let execution_receipt = ExecutionReceipt {
             domain_block_number: header_number,
             domain_block_hash: header_hash,
-            domain_block_extrinsic_root: extrinsics_root,
+            domain_block_extrinsic_root: extrinsics_root.into(),
             parent_domain_block_receipt_hash: parent_receipt.hash(),
             consensus_block_number,
             consensus_block_hash,

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -88,6 +88,7 @@ pub(super) async fn start_worker<
     CClient: HeaderBackend<CBlock>
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>
+        + ProofProvider<CBlock>
         + ProvideRuntimeApi<CBlock>
         + BlockchainEvents<CBlock>
         + 'static,

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -31,6 +31,7 @@ use sp_api::{BlockT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_core::traits::{CodeExecutor, SpawnEssentialNamed};
+use sp_core::H256;
 use sp_domains::{BundleProducerElectionApi, DomainsApi};
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
@@ -70,6 +71,7 @@ pub(super) async fn start_worker<
     active_leaves: Vec<BlockInfo<CBlock>>,
 ) where
     Block: BlockT,
+    Block::Hash: Into<H256>,
     CBlock: BlockT,
     NumberFor<CBlock>: From<NumberFor<Block>> + Into<NumberFor<Block>>,
     CBlock::Hash: From<Block::Hash>,

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -79,6 +79,7 @@ where
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>
         + ProvideRuntimeApi<CBlock>
+        + ProofProvider<CBlock>
         + BlockchainEvents<CBlock>
         + Send
         + Sync

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -16,6 +16,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_consensus::SelectChain;
 use sp_core::traits::{CodeExecutor, SpawnEssentialNamed};
+use sp_core::H256;
 use sp_domains::{BundleProducerElectionApi, DomainsApi};
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
@@ -63,6 +64,7 @@ where
     CBlock: BlockT,
     NumberFor<CBlock>: From<NumberFor<Block>> + Into<NumberFor<Block>>,
     CBlock::Hash: From<Block::Hash>,
+    Block::Hash: Into<H256>,
     Client: HeaderBackend<Block>
         + BlockBackend<Block>
         + AuxStore

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1088,6 +1088,7 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
 
     // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
+    let mut fraud_proof_submitted = false;
     while let Some(ready_tx_hash) = import_tx_stream.next().await {
         let ready_tx = ferdie
             .transaction_pool
@@ -1104,10 +1105,13 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
             if let FraudProof::InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof { .. }) =
                 *fraud_proof
             {
+                fraud_proof_submitted = true;
                 break;
             }
         }
     }
+
+    assert!(fraud_proof_submitted, "Fraud proof must be submitted");
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified on
     // on the runtime itself

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -245,7 +245,7 @@ parameter_types! {
         })
         .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
         .build_or_panic();
-    pub const ExtrinsicsRootStateVersion: StateVersion = StateVersion::V0;
+    pub const ExtrinsicsRootStateVersion: StateVersion = StateVersion::V1;
 }
 
 impl frame_system::Config for Runtime {

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -245,7 +245,7 @@ parameter_types! {
         })
         .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
         .build_or_panic();
-    pub const ExtrinsicsRootStateVersion: StateVersion = StateVersion::V0;
+    pub const ExtrinsicsRootStateVersion: StateVersion = StateVersion::V1;
 }
 
 impl frame_system::Config for Runtime {

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -574,14 +574,19 @@ impl MockConsensusNode {
         extrinsics
     }
 
-    async fn mock_inherent_data(slot: Slot) -> Result<InherentData, Box<dyn Error>> {
+    async fn mock_inherent_data(
+        slot: Slot,
+        parent_state_root: <Block as BlockT>::Hash,
+    ) -> Result<InherentData, Box<dyn Error>> {
         let timestamp = sp_timestamp::InherentDataProvider::new(Timestamp::new(
             <Slot as Into<u64>>::into(slot) * SLOT_DURATION,
         ));
         let subspace_inherents =
             sp_consensus_subspace::inherents::InherentDataProvider::new(slot, vec![]);
 
-        let inherent_data = (subspace_inherents, timestamp)
+        let domain_inherents = sp_domains::inherents::InherentDataProvider::new(parent_state_root);
+
+        let inherent_data = (subspace_inherents, timestamp, domain_inherents)
             .create_inherent_data()
             .await?;
 
@@ -610,7 +615,9 @@ impl MockConsensusNode {
         extrinsics: Vec<<Block as BlockT>::Extrinsic>,
     ) -> Result<(Block, StorageChanges), Box<dyn Error>> {
         let digest = self.mock_subspace_digest(slot);
-        let inherent_data = Self::mock_inherent_data(slot).await?;
+        let parent_state_root = self.client.header(parent_hash)?.unwrap().state_root;
+
+        let inherent_data = Self::mock_inherent_data(slot, parent_state_root).await?;
 
         let mut block_builder = self.client.new_block_at(parent_hash, digest, false)?;
 


### PR DESCRIPTION
This PR generates invalid extrinsic root fraud when there is a mismatch between operator local receipt and submitted receipt.

Apart from this, there are two notable changes:
- All the domains will start using StateVersion::V1 for extrinsic root
- A modified version of extrinsic root derivation without actual extrinsic data that exceeds 32 bytes. This could be upstreamed but at the moment i'm not sure how to propose the change as the upstream trie needs some bit of refactor before this could be integrated. This can be done at a later time IMO and not a priority.

Note: The polkadot-sdk commit is from the PR that is yet to be merged. Once that is merged, i'll update the commit ref here and is a non blocker for the review.

Closes: #1888

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
