### PR TITLE
Fix archiver restart when last block to archive is right on the edge of the segment

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -432,6 +432,7 @@ where
                     );
                 })
                 .checked_sub(confirmation_depth_k)
+                .filter(|&blocks_to_archive_to| blocks_to_archive_to >= blocks_to_archive_from)
                 .or({
                     if have_last_segment_header {
                         None


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/1997 fixed part of the problem, what remained is an issue when last block to archive is right on the edge of the archived segment.

Here is what segment header looks like from Gemini 3f logs:
```
2023-09-25 17:46:44.745 TRACE tokio-runtime-worker subspace_service::sync_from_dsn::import_blocks: [Consensus] Checking segment header segment_index=39 last_archived_block_number=585667 last_archived_block_progress=Partial(10531)
```

This is how node can crash:
```
2023-09-25 16:02:20 [Consensus] Last archived block 585667
2023-09-25 16:02:20 [Consensus] Archiving already produced blocks 585668..=585667
====================
Version: 0.1.0-69b9b8b2113
   0: sp_panic_handler::set::{{closure}}
   1: std::panicking::rust_panic_with_hook
   2: std::panicking::begin_panic_handler::{{closure}}
   3: std::sys_common::backtrace::__rust_end_short_backtrace
   4: rust_begin_unwind
   5: core::panicking::panic_fmt
   6: core::option::expect_failed
   7: subspace_service::new_full::{{closure}}
   8: subspace_node::main::{{closure}}::{{closure}}
   9: sc_cli::runner::Runner<C>::run_node_until_exit
  10: subspace_node::main
  11: std::sys_common::backtrace::__rust_begin_short_backtrace
  12: std::rt::lang_start::{{closure}}
  13: main
  14: __libc_start_main
  15: _start
Thread 'main' panicked at 'Must always set if there is no logical error; qed', /home/runner/work/subspace/subspace/crates/sc-consensus-subspace/src/archiver.rs:542
This is a bug. Please report it at:
        https://forum.subspace.network
```

The reason for this is that we have processed block `585667` and initialized archived, but there is nothing to process beyond that yet, the range `585668..=585667` is backwards and not iterable as the result.

What we need is to add an extra check that there is at least one block to process or else
```rust
            best_archived_block = blocks_to_archive
                .last()
                .map(|(block, _block_object_mappings)| (block.hash(), *block.header().number()));
```

will replace best archived block with `None` and cause above panic. We could have added check that `blocks_to_archive` is not empty, but I think it makes more sense to prevent non-iterable range creation in the first place.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
