### PR TITLE
Gemini 3f backport: Fix archiver restart when last block to archive is right on the edge of the segment

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -428,6 +428,7 @@ where
                     );
                 })
                 .checked_sub(confirmation_depth_k)
+                .filter(|&blocks_to_archive_to| blocks_to_archive_to >= blocks_to_archive_from)
                 .or({
                     if have_last_segment_header {
                         None


### PR DESCRIPTION
Identical to https://github.com/subspace/subspace/pull/2002

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
