### PR TITLE
Farmer disk I/O refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11578,7 +11578,6 @@ dependencies = [
  "hex",
  "libc",
  "lru 0.11.1",
- "memmap2 0.7.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11534,7 +11534,6 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "lru 0.11.1",
- "memmap2 0.7.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "prometheus-client 0.21.2",

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -43,7 +43,6 @@ tracing = "0.1.37"
 [dev-dependencies]
 criterion = "0.5.1"
 futures = "0.3.28"
-memmap2 = "0.7.1"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["chia"] }
 

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
-use memmap2::Mmap;
 use rand::prelude::*;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -20,7 +19,7 @@ use subspace_farmer_components::reading::read_piece;
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::{FarmerProtocolInfo, ReadAt};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 
@@ -183,24 +182,18 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 .unwrap();
         }
 
-        let plot_mmap = unsafe { Mmap::map(&plot_file).unwrap() };
-
-        #[cfg(unix)]
-        {
-            plot_mmap.advise(memmap2::Advice::Random).unwrap();
-        }
-
         group.throughput(Throughput::Elements(sectors_count));
-        group.bench_function("piece/disk", move |b| {
+        group.bench_function("piece/disk", |b| {
             b.iter_custom(|iters| {
                 let start = Instant::now();
                 for _i in 0..iters {
-                    for sector in plot_mmap.chunks_exact(sector_size) {
+                    for sector_index in 0..sectors_count as usize {
+                        let sector = plot_file.offset(sector_index * sector_size);
                         read_piece::<PosTable, _>(
                             black_box(piece_offset),
                             black_box(&plotted_sector.sector_id),
                             black_box(&plotted_sector.sector_metadata),
-                            black_box(sector),
+                            black_box(&sector),
                             black_box(&erasure_coding),
                             black_box(&mut table_generator),
                         )

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -148,7 +148,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
     group.bench_function("piece/memory", |b| {
         b.iter(|| {
-            read_piece::<PosTable>(
+            read_piece::<PosTable, _>(
                 black_box(piece_offset),
                 black_box(&plotted_sector.sector_id),
                 black_box(&plotted_sector.sector_metadata),
@@ -196,7 +196,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 let start = Instant::now();
                 for _i in 0..iters {
                     for sector in plot_mmap.chunks_exact(sector_size) {
-                        read_piece::<PosTable>(
+                        read_piece::<PosTable, _>(
                             black_box(piece_offset),
                             black_box(&plotted_sector.sector_id),
                             black_box(&plotted_sector.sector_metadata),

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -22,13 +22,26 @@ pub mod reading;
 pub mod sector;
 mod segment_reconstruction;
 
+use crate::file_ext::FileExt;
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
+use std::fs::File;
 use std::io;
 use subspace_core_primitives::HistorySize;
 
 /// Trait for reading data at specific offset
 pub trait ReadAt: Send + Sync {
+    /// Get implementation of [`ReadAt`] that add specified offset to all attempted reads
+    fn offset(&self, offset: usize) -> ReadAtOffset<&Self>
+    where
+        Self: Sized,
+    {
+        ReadAtOffset {
+            inner: self,
+            offset,
+        }
+    }
+
     /// Fill the buffer by reading bytes at a specific offset
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()>;
 }
@@ -51,6 +64,33 @@ impl ReadAt for [u8] {
 impl ReadAt for Vec<u8> {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.as_slice().read_at(buf, offset)
+    }
+}
+
+impl ReadAt for File {
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        self.read_exact_at(buf, offset as u64)
+    }
+}
+
+impl ReadAt for &File {
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        self.read_exact_at(buf, offset as u64)
+    }
+}
+
+/// Reader with fixed offset added to all attempted reads
+pub struct ReadAtOffset<T> {
+    inner: T,
+    offset: usize,
+}
+
+impl<T> ReadAt for ReadAtOffset<T>
+where
+    T: ReadAt,
+{
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        self.inner.read_at(buf, offset + self.offset)
     }
 }
 

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -24,7 +24,35 @@ mod segment_reconstruction;
 
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
+use std::io;
 use subspace_core_primitives::HistorySize;
+
+/// Trait for reading data at specific offset
+pub trait ReadAt: Send + Sync {
+    /// Fill the buffer by reading bytes at a specific offset
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()>;
+}
+
+impl ReadAt for [u8] {
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        if buf.len() + offset > self.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Buffer length with offset exceeds own length",
+            ));
+        }
+
+        buf.copy_from_slice(&self[offset..][..buf.len()]);
+
+        Ok(())
+    }
+}
+
+impl ReadAt for Vec<u8> {
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        self.as_slice().read_at(buf, offset)
+    }
+}
 
 // Refuse to compile on non-64-bit platforms, offsets may fail on those when converting from u64 to
 // usize depending on chain parameters

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -28,7 +28,6 @@ futures = "0.3.28"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.16.3", features = ["client"] }
 lru = "0.11.0"
-memmap2 = "0.7.1"
 parity-scale-codec = "3.6.5"
 parking_lot = "0.12.1"
 prometheus-client = "0.21.2"

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -1,5 +1,4 @@
 use derive_more::Display;
-use memmap2::{Mmap, MmapOptions};
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::sync::Arc;
@@ -43,8 +42,7 @@ pub struct Offset(usize);
 #[derive(Debug)]
 struct Inner {
     file: File,
-    read_mmap: Mmap,
-    file_size: usize,
+    num_elements: usize,
 }
 
 /// Piece cache stored on one disk
@@ -67,6 +65,8 @@ impl DiskPieceCache {
             .create(true)
             .open(directory.join(Self::FILE_NAME))?;
 
+        file.advise_random_access()?;
+
         let expected_size = Self::element_size() * capacity;
         // Allocating the whole file (`set_len` below can create a sparse file, which will cause
         // writes to fail later)
@@ -75,17 +75,10 @@ impl DiskPieceCache {
         // Truncating file (if necessary)
         file.set_len(expected_size as u64)?;
 
-        let read_mmap = unsafe { MmapOptions::new().len(expected_size).map(&file)? };
-        #[cfg(unix)]
-        {
-            read_mmap.advise(memmap2::Advice::Random)?;
-        }
-
         Ok(Self {
             inner: Arc::new(Inner {
                 file,
-                read_mmap,
-                file_size: expected_size,
+                num_elements: expected_size / Self::element_size(),
             }),
         })
     }
@@ -101,28 +94,33 @@ impl DiskPieceCache {
     pub(crate) fn contents(
         &self,
     ) -> impl ExactSizeIterator<Item = (Offset, Option<PieceIndex>)> + '_ {
-        self.inner
-            .read_mmap
-            .array_chunks::<{ Self::element_size() }>()
-            .enumerate()
-            .map(|(offset, chunk)| {
-                let (piece_index_bytes, piece_bytes) = chunk.split_at(PieceIndex::SIZE);
-                let piece_index = PieceIndex::from_bytes(
-                    piece_index_bytes
-                        .try_into()
-                        .expect("Statically known to have correct size; qed"),
-                );
-                // Piece index zero might mean we have piece index zero or just an empty space
-                let piece_index = if piece_index != PieceIndex::ZERO
-                    || piece_bytes.iter().any(|&byte| byte != 0)
-                {
+        let file = &self.inner.file;
+        let mut element = vec![0; Self::element_size()];
+
+        (0..self.inner.num_elements).map(move |offset| {
+            if let Err(error) =
+                file.read_exact_at(&mut element, (offset * Self::element_size()) as u64)
+            {
+                warn!(%error, %offset, "Failed to read cache element #1");
+                return (Offset(offset), None);
+            }
+
+            let (piece_index_bytes, piece_bytes) = element.split_at(PieceIndex::SIZE);
+            let piece_index = PieceIndex::from_bytes(
+                piece_index_bytes
+                    .try_into()
+                    .expect("Statically known to have correct size; qed"),
+            );
+            // Piece index zero might mean we have piece index zero or just an empty space
+            let piece_index =
+                if piece_index != PieceIndex::ZERO || piece_bytes.iter().any(|&byte| byte != 0) {
                     Some(piece_index)
                 } else {
                     None
                 };
 
-                (Offset(offset), piece_index)
-            })
+            (Offset(offset), piece_index)
+        })
     }
 
     /// Store piece in cache at specified offset, replacing existing piece if there is any
@@ -136,27 +134,26 @@ impl DiskPieceCache {
         piece: &Piece,
     ) -> Result<(), DiskPieceCacheError> {
         let Offset(offset) = offset;
-        if offset >= self.inner.file_size / Self::element_size() {
+        if offset >= self.inner.num_elements {
             return Err(DiskPieceCacheError::OffsetOutsideOfRange {
                 provided: offset,
-                max: self.inner.file_size / Self::element_size() - 1,
+                max: self.inner.num_elements - 1,
             });
         }
 
-        let mut write_mmap = unsafe {
-            MmapOptions::new()
-                .offset((offset * Self::element_size()) as u64)
-                .len(Self::element_size())
-                .map_mut(&self.inner.file)?
-        };
+        let element_offset = (offset * Self::element_size()) as u64;
 
-        let (piece_index_bytes, remaining_bytes) = write_mmap.split_at_mut(PieceIndex::SIZE);
-        piece_index_bytes.copy_from_slice(&piece_index.to_bytes());
-        let (piece_bytes, checksum) = remaining_bytes.split_at_mut(Piece::SIZE);
-        piece_bytes.copy_from_slice(piece.as_ref());
-        checksum.copy_from_slice(&blake3_hash_list(&[piece_index_bytes, piece.as_ref()]));
-
-        write_mmap.flush()?;
+        let piece_index_bytes = piece_index.to_bytes();
+        self.inner
+            .file
+            .write_all_at(&piece_index_bytes, element_offset)?;
+        self.inner
+            .file
+            .write_all_at(piece.as_ref(), element_offset + PieceIndex::SIZE as u64)?;
+        self.inner.file.write_all_at(
+            &blake3_hash_list(&[&piece_index_bytes, piece.as_ref()]),
+            element_offset + PieceIndex::SIZE as u64 + Piece::SIZE as u64,
+        )?;
 
         Ok(())
     }
@@ -169,16 +166,22 @@ impl DiskPieceCache {
     /// doesn't happen for the same piece being accessed!
     pub(crate) fn read_piece_index(&self, offset: Offset) -> Option<PieceIndex> {
         let Offset(offset) = offset;
-        if offset >= self.inner.file_size / Self::element_size() {
+        if offset >= self.inner.num_elements {
             warn!(%offset, "Trying to read piece out of range, this must be an implementation bug");
             return None;
         }
 
-        Some(PieceIndex::from_bytes(
-            self.inner.read_mmap[Self::element_size() * offset..][..PieceIndex::SIZE]
-                .try_into()
-                .expect("Statically guaranteed to be correct size; qed"),
-        ))
+        let mut piece_index_bytes = [0; PieceIndex::SIZE];
+
+        if let Err(error) = self.inner.file.read_exact_at(
+            &mut piece_index_bytes,
+            (offset * Self::element_size()) as u64,
+        ) {
+            warn!(%error, %offset, "Failed to read cache piece index");
+            return None;
+        }
+
+        Some(PieceIndex::from_bytes(piece_index_bytes))
     }
 
     /// Read piece from cache at specified offset.
@@ -189,14 +192,17 @@ impl DiskPieceCache {
     /// doesn't happen for the same piece being accessed!
     pub(crate) fn read_piece(&self, offset: Offset) -> Result<Option<Piece>, DiskPieceCacheError> {
         let Offset(offset) = offset;
-        if offset >= self.inner.file_size / Self::element_size() {
+        if offset >= self.inner.num_elements {
             warn!(%offset, "Trying to read piece out of range, this must be an implementation bug");
             return Ok(None);
         }
 
-        let piece_element_memory =
-            &self.inner.read_mmap[offset * Self::element_size()..][..Self::element_size()];
-        let (piece_index_bytes, remaining_bytes) = piece_element_memory.split_at(PieceIndex::SIZE);
+        let mut element = vec![0; Self::element_size()];
+        self.inner
+            .file
+            .read_exact_at(&mut element, (offset * Self::element_size()) as u64)?;
+
+        let (piece_index_bytes, remaining_bytes) = element.split_at(PieceIndex::SIZE);
         let (piece_bytes, expected_checksum) = remaining_bytes.split_at(Piece::SIZE);
         let mut piece = Piece::default();
         piece.copy_from_slice(piece_bytes);

--- a/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
@@ -195,7 +195,7 @@ where
 
     let sector_id = SectorId::new(public_key.hash(), sector_index);
 
-    let piece = match reading::read_piece::<PosTable>(
+    let piece = match reading::read_piece::<PosTable, _>(
         piece_offset,
         &sector_id,
         sector_metadata,


### PR DESCRIPTION
As I was researching https://github.com/subspace/subspace/issues/1946 turned out that memory-mapped I/O is not ideal for our use case.

This PR removed memory-mapped I/O and replaces with regular file API (with abstraction on top that allows `subspace-farmer-components` to still work with memory-mapped I/O or something else if desired, which also helped with refactoring).

This is a preparation, next PR will introduce separate global thread pools for plotting, replotting and farming that will allow to use CPU more efficiently and not impact farming as much while replotting is happening.

As a side effect this should fix what appears to be large memory usage on Windows that was caused by usage of memory-mapped I/O.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
