### PR TITLE
Parallel block verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9297,6 +9297,7 @@ dependencies = [
  "subspace-verification",
  "substrate-prometheus-endpoint",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -52,6 +52,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.48"
+tokio = { version = "1.32.0", features = ["sync"] }
 
 [dev-dependencies]
 # TODO: Restore in the future, currently tests are mostly broken and useless

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -694,7 +694,6 @@ where
         }
 
         // Check if farmer's plot is burned.
-        // TODO: Add to header and store in aux storage?
         if self
             .client
             .runtime_api()


### PR DESCRIPTION
Now that Substrate was upgraded in https://github.com/subspace/subspace/pull/2010 and parallel block verification is available (though upstream PR https://github.com/paritytech/polkadot-sdk/pull/1598 is stuck), this PR takes advantage of it while accounting for two edge-cases: equivocation and runtime API call concurrency.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
