### PR TITLE
Fraud Proof: Timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7230,6 +7230,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-balances",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -25,37 +25,39 @@ sp-runtime = { version = "24.0.0", default-features = false, git = "https://gith
 sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-version = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7", features = ["serde"] }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
+subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
 sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }
-subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "frame-benchmarking?/std",
-  "frame-support/std",
-  "frame-system/std",
-  "log/std",
-  "scale-info/std",
-  "sp-core/std",
-  "sp-domains/std",
-  "sp-io/std",
-  "sp-runtime/std",
-  "sp-std/std",
-  "sp-version/std",
-  "subspace-core-primitives/std",
+    "codec/std",
+    "frame-benchmarking?/std",
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "scale-info/std",
+    "sp-core/std",
+    "sp-domains/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "sp-version/std",
+    "subspace-core-primitives/std",
+    "subspace-runtime-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
-  "frame-support/runtime-benchmarks",
-  "frame-system/runtime-benchmarks",
-  "frame-benchmarking",
-  "frame-benchmarking/runtime-benchmarks",
-  "sp-domains/runtime-benchmarks",
-  "sp-runtime/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "frame-benchmarking",
+    "frame-benchmarking/runtime-benchmarks",
+    "sp-domains/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
 ]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1599,6 +1599,7 @@ impl<T: Config> Pallet<T> {
                 )
                 .ok_or(FraudProofError::MissingConsensusStateRoot)?
                 .1;
+
                 verify_invalid_domain_extrinsics_root_fraud_proof::<
                     T::Block,
                     T::DomainNumber,
@@ -1606,6 +1607,7 @@ impl<T: Config> Pallet<T> {
                     BalanceOf<T>,
                     T::Hashing,
                     T::StorageKeys,
+                    T::DeriveExtrinsics,
                 >(consensus_state_root, bad_receipt, proof)
                 .map_err(FraudProofError::InvalidExtrinsicRootFraudProof)?;
             }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -138,7 +138,7 @@ mod pallet {
     use frame_support::{Identity, PalletError};
     use frame_system::pallet_prelude::*;
     use sp_core::H256;
-    use sp_domains::fraud_proof::{FraudProof, StorageKeys};
+    use sp_domains::fraud_proof::{DeriveExtrinsics, FraudProof, StorageKeys};
     use sp_domains::inherents::{InherentError, InherentType, INHERENT_IDENTIFIER};
     use sp_domains::transaction::InvalidTransactionCode;
     use sp_domains::{
@@ -157,6 +157,7 @@ mod pallet {
     use sp_std::vec;
     use sp_std::vec::Vec;
     use subspace_core_primitives::U256;
+    use subspace_runtime_primitives::Moment;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -287,6 +288,9 @@ mod pallet {
 
         /// Trait impl to fetch storage keys.
         type StorageKeys: StorageKeys;
+
+        /// Derive extrinsics trait impl.
+        type DeriveExtrinsics: DeriveExtrinsics<Moment>;
     }
 
     #[pallet::pallet]

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -472,6 +472,8 @@ pub struct InvalidExtrinsicsRootProof {
     pub valid_bundle_digests: Vec<ValidBundleDigest>,
     /// Randomness Storage proof
     pub randomness_proof: StorageProof,
+    /// Timestamp storage proof
+    pub timestamp_proof: StorageProof,
 }
 
 impl InvalidTotalRewardsProof {

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -70,8 +70,9 @@ impl ExecutionPhase {
     }
 }
 
-/// Trait to derive extrinsics.
+/// Trait to derive domain extrinsics such as timestamp on Consensus chain.
 pub trait DeriveExtrinsics<Moment> {
+    /// Derives pallet_timestamp::set extrinsic.
     fn derive_timestamp_extrinsic(moment: Moment) -> Vec<u8>;
 }
 
@@ -471,9 +472,9 @@ pub struct InvalidExtrinsicsRootProof {
     /// Valid Bundle digests
     pub valid_bundle_digests: Vec<ValidBundleDigest>,
     /// Randomness Storage proof
-    pub randomness_proof: StorageProof,
-    /// Timestamp storage proof
-    pub timestamp_proof: StorageProof,
+    pub randomness_storage_proof: StorageProof,
+    /// Timestamp Storage proof
+    pub timestamp_storage_proof: StorageProof,
 }
 
 impl InvalidTotalRewardsProof {
@@ -488,7 +489,7 @@ impl InvalidTotalRewardsProof {
 
 /// Trait to get Storage keys.
 pub trait StorageKeys {
-    fn block_randomness_key() -> StorageKey;
+    fn block_randomness_storage_key() -> StorageKey;
     fn timestamp_storage_key() -> StorageKey;
 }
 

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -70,6 +70,11 @@ impl ExecutionPhase {
     }
 }
 
+/// Trait to derive extrinsics.
+pub trait DeriveExtrinsics<Moment> {
+    fn derive_timestamp_extrinsic(moment: Moment) -> Vec<u8>;
+}
+
 /// Error type of fraud proof verification on consensus node.
 #[derive(Debug)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
@@ -482,6 +487,7 @@ impl InvalidTotalRewardsProof {
 /// Trait to get Storage keys.
 pub trait StorageKeys {
     fn block_randomness_key() -> StorageKey;
+    fn timestamp_storage_key() -> StorageKey;
 }
 
 /// This is a representation of actual Block Rewards storage in pallet-operator-rewards.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -803,6 +803,9 @@ sp_api::decl_runtime_apis! {
 
         /// Block randomness key.
         fn block_randomness_key() -> Vec<u8>;
+
+        /// Returns the storage key for timestamp;
+        fn timestamp_storage_key() -> Vec<u8>;
     }
 
     pub trait BundleProducerElectionApi<Balance: Encode + Decode> {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -801,8 +801,8 @@ sp_api::decl_runtime_apis! {
         /// Returns the chain state root at the given block.
         fn domain_state_root(domain_id: DomainId, number: DomainNumber, hash: DomainHash) -> Option<DomainHash>;
 
-        /// Block randomness key.
-        fn block_randomness_key() -> Vec<u8>;
+        /// Returns the storage key for block randomness.
+        fn block_randomness_storage_key() -> Vec<u8>;
 
         /// Returns the storage key for timestamp;
         fn timestamp_storage_key() -> Vec<u8>;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -627,6 +627,18 @@ impl sp_domains::fraud_proof::StorageKeys for StorageKeys {
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec(),
         )
     }
+
+    fn timestamp_storage_key() -> StorageKey {
+        StorageKey(pallet_timestamp::pallet::Now::<Runtime>::storage_value_final_key().to_vec())
+    }
+}
+
+pub struct DeriveExtrinsics;
+impl sp_domains::fraud_proof::DeriveExtrinsics<Moment> for DeriveExtrinsics {
+    fn derive_timestamp_extrinsic(now: Moment) -> Vec<u8> {
+        UncheckedExtrinsic::new_unsigned(pallet_timestamp::Call::<Runtime>::set { now }.into())
+            .encode()
+    }
 }
 
 impl pallet_domains::Config for Runtime {
@@ -655,6 +667,7 @@ impl pallet_domains::Config for Runtime {
     type SudoId = SudoId;
     type Randomness = Subspace;
     type StorageKeys = StorageKeys;
+    type DeriveExtrinsics = DeriveExtrinsics;
 }
 
 pub struct StakingOnReward;
@@ -1103,6 +1116,10 @@ impl_runtime_apis! {
 
         fn block_randomness_key() -> Vec<u8> {
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec()
+        }
+
+        fn timestamp_storage_key() -> Vec<u8> {
+            pallet_timestamp::pallet::Now::<Runtime>::storage_value_final_key().to_vec()
         }
     }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -622,7 +622,7 @@ parameter_types! {
 
 pub struct StorageKeys;
 impl sp_domains::fraud_proof::StorageKeys for StorageKeys {
-    fn block_randomness_key() -> StorageKey {
+    fn block_randomness_storage_key() -> StorageKey {
         StorageKey(
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec(),
         )
@@ -1114,7 +1114,7 @@ impl_runtime_apis! {
             Domains::domain_state_root(domain_id, number, hash)
         }
 
-        fn block_randomness_key() -> Vec<u8> {
+        fn block_randomness_storage_key() -> Vec<u8> {
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec()
         }
 

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -214,17 +214,18 @@ where
         }
 
         let consensus_runtime = self.consensus_client.runtime_api();
-        let block_randomness_key = consensus_runtime.block_randomness_key(consensus_block_hash)?;
-
-        let randomness_proof = self.consensus_client.read_proof(
+        let block_randomness_storage_key =
+            consensus_runtime.block_randomness_storage_key(consensus_block_hash)?;
+        let randomness_storage_proof = self.consensus_client.read_proof(
             consensus_block_hash,
-            &mut [block_randomness_key.as_slice()].into_iter(),
+            &mut [block_randomness_storage_key.as_slice()].into_iter(),
         )?;
 
-        let timestamp_key = consensus_runtime.timestamp_storage_key(consensus_block_hash)?;
-        let timestamp_proof = self.consensus_client.read_proof(
+        let timestamp_storage_key =
+            consensus_runtime.timestamp_storage_key(consensus_block_hash)?;
+        let timestamp_storage_proof = self.consensus_client.read_proof(
             consensus_block_hash,
-            &mut [timestamp_key.as_slice()].into_iter(),
+            &mut [timestamp_storage_key.as_slice()].into_iter(),
         )?;
 
         Ok(FraudProof::InvalidExtrinsicsRoot(
@@ -232,8 +233,8 @@ where
                 domain_id,
                 bad_receipt_hash,
                 valid_bundle_digests,
-                randomness_proof,
-                timestamp_proof,
+                randomness_storage_proof,
+                timestamp_storage_proof,
             },
         ))
     }

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -150,7 +150,6 @@ where
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn generate_invalid_domain_extrinsics_root_proof<PCB>(
         &self,
         domain_id: DomainId,
@@ -222,12 +221,19 @@ where
             &mut [block_randomness_key.as_slice()].into_iter(),
         )?;
 
+        let timestamp_key = consensus_runtime.timestamp_storage_key(consensus_block_hash)?;
+        let timestamp_proof = self.consensus_client.read_proof(
+            consensus_block_hash,
+            &mut [timestamp_key.as_slice()].into_iter(),
+        )?;
+
         Ok(FraudProof::InvalidExtrinsicsRoot(
             InvalidExtrinsicsRootProof {
                 domain_id,
                 bad_receipt_hash,
                 valid_bundle_digests,
                 randomness_proof,
+                timestamp_proof,
             },
         ))
     }

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -603,6 +603,9 @@ construct_runtime!(
     pub struct Runtime {
         // System support stuff.
         System: frame_system = 0,
+        // Note: Ensure index of the timestamp matches with the index of timestamp on Consensus
+        //  so that consensus can constructed encoded extrinsic that matches with Domain encoded
+        //  extrinsic.
         Timestamp: pallet_timestamp = 1,
         ExecutivePallet: domain_pallet_executive = 2,
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -646,7 +646,7 @@ parameter_types! {
 
 pub struct StorageKeys;
 impl sp_domains::fraud_proof::StorageKeys for StorageKeys {
-    fn block_randomness_key() -> StorageKey {
+    fn block_randomness_storage_key() -> StorageKey {
         StorageKey(
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec(),
         )
@@ -1403,7 +1403,7 @@ impl_runtime_apis! {
             Domains::domain_state_root(domain_id, number, hash)
         }
 
-        fn block_randomness_key() -> Vec<u8> {
+        fn block_randomness_storage_key() -> Vec<u8> {
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec()
         }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -651,6 +651,18 @@ impl sp_domains::fraud_proof::StorageKeys for StorageKeys {
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec(),
         )
     }
+
+    fn timestamp_storage_key() -> StorageKey {
+        StorageKey(pallet_timestamp::pallet::Now::<Runtime>::storage_value_final_key().to_vec())
+    }
+}
+
+pub struct DeriveExtrinsics;
+impl sp_domains::fraud_proof::DeriveExtrinsics<Moment> for DeriveExtrinsics {
+    fn derive_timestamp_extrinsic(now: Moment) -> Vec<u8> {
+        UncheckedExtrinsic::new_unsigned(pallet_timestamp::Call::<Runtime>::set { now }.into())
+            .encode()
+    }
 }
 
 impl pallet_domains::Config for Runtime {
@@ -679,6 +691,7 @@ impl pallet_domains::Config for Runtime {
     type SudoId = SudoId;
     type Randomness = Subspace;
     type StorageKeys = StorageKeys;
+    type DeriveExtrinsics = DeriveExtrinsics;
 }
 
 parameter_types! {
@@ -1392,6 +1405,10 @@ impl_runtime_apis! {
 
         fn block_randomness_key() -> Vec<u8> {
             pallet_subspace::pallet::BlockRandomness::<Runtime>::storage_value_final_key().to_vec()
+        }
+
+        fn timestamp_storage_key() -> Vec<u8> {
+            pallet_timestamp::pallet::Now::<Runtime>::storage_value_final_key().to_vec()
         }
     }
 


### PR DESCRIPTION
This PR add timestamp proof to the invalid domain extrinsic fraud proof and uses the timestamp to reconstruct the timestamp extrinsic while fraud proof veriifcation

Closes: #1896 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
