### PR TITLE
Fix block authoring with local timekeeper after restart

### DIFF
--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -356,7 +356,7 @@ where
             // Ensure proof of time and future proof of time included in upcoming block are valid
             if !self
                 .pot_verifier
-                .try_is_output_valid(
+                .is_output_valid(
                     after_parent_slot,
                     pot_seed,
                     slot_iterations,


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/1966 introduced an interesting regression that prevented node from producing blocks after restart if it is the only node on the network producing blocks.

When producing block we check if proof of time and future proof of time (and implicitly checkpoints by extension) are valid, but before this PR on restart following could be observed:
```
2023-09-29T00:27:58.076194Z [Consensus] Proof of time or future proof of time is invalid, skipping block production at slot Slot(5317)    
```

The reason for that is that timekeeper restarts and produces proofs right after parent blocks's future slot. So if parent block's future slot was 5000, timekeeper will start with proving slot 5001.

Things go wrong during block production though since slot worker will try to verify proofs relatively to parent block's proof (not its future proof), but we don't have corresponding proofs cached in verifier because we have just restarted it and started producing proofs that we have no seen on chain yet. Replacing `try_is_output_valid` with `is_output_valid` allows verifier to run proving in those cases for a few older slots and finish verification successfully.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
