### PR TITLE
Prefer higher quality solutions

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -48,9 +48,9 @@ use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::{
     ArchivedBlockProgress, ArchivedHistorySegment, Blake2b256Hash, BlockNumber, HistorySize,
-    LastArchivedBlock, Piece, PieceOffset, PotOutput, PublicKey, Record, RecordedHistorySegment,
-    SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, Solution, SolutionRange,
-    REWARD_SIGNING_CONTEXT,
+    LastArchivedBlock, Piece, PieceOffset, PosSeed, PotOutput, PublicKey, Record,
+    RecordedHistorySegment, SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, Solution,
+    SolutionRange, REWARD_SIGNING_CONTEXT,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
@@ -58,7 +58,7 @@ use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
 use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::shim::ShimTable;
-use subspace_proof_of_space::Table;
+use subspace_proof_of_space::{Table, TableGenerator};
 
 type PosTable = ShimTable;
 
@@ -486,12 +486,9 @@ pub fn create_signed_vote(
 
         let solution = audit_result
             .solution_candidates
-            .into_solutions::<_, PosTable>(
-                &reward_address,
-                kzg,
-                erasure_coding,
-                &mut table_generator,
-            )
+            .into_solutions(&reward_address, kzg, erasure_coding, |seed: &PosSeed| {
+                table_generator.generate_parallel(seed)
+            })
             .unwrap()
             .next()
             .unwrap()

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -468,7 +468,7 @@ pub fn create_signed_vote(
         ))
         .unwrap();
 
-        let maybe_solution_candidates = audit_sector(
+        let maybe_audit_result = audit_sector(
             &public_key,
             sector_index,
             &proof_of_time
@@ -479,13 +479,19 @@ pub fn create_signed_vote(
             &plotted_sector.sector_metadata,
         );
 
-        let Some(solution_candidates) = maybe_solution_candidates else {
+        let Some(audit_result) = maybe_audit_result else {
             // Sector didn't have any solutions
             continue;
         };
 
-        let solution = solution_candidates
-            .into_iter::<_, PosTable>(&reward_address, kzg, erasure_coding, &mut table_generator)
+        let solution = audit_result
+            .solution_candidates
+            .into_solutions::<_, PosTable>(
+                &reward_address,
+                kzg,
+                erasure_coding,
+                &mut table_generator,
+            )
             .unwrap()
             .next()
             .unwrap()

--- a/crates/subspace-farmer-components/src/auditing.rs
+++ b/crates/subspace-farmer-components/src/auditing.rs
@@ -7,6 +7,7 @@ use subspace_core_primitives::{Blake2b256Hash, PublicKey, SectorId, SectorIndex,
 use subspace_verification::is_within_solution_range;
 use tracing::warn;
 
+/// Result of sector audit
 #[derive(Debug, Clone)]
 pub struct AuditResult<'a, Sector>
 where

--- a/crates/subspace-farmer-components/src/auditing.rs
+++ b/crates/subspace-farmer-components/src/auditing.rs
@@ -1,7 +1,6 @@
 use crate::proving::SolutionCandidates;
 use crate::sector::{SectorContentsMap, SectorMetadataChecksummed};
 use crate::ReadAt;
-use std::collections::VecDeque;
 use std::mem;
 use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::{Blake2b256Hash, PublicKey, SectorId, SectorIndex, SolutionRange};
@@ -9,11 +8,33 @@ use subspace_verification::is_within_solution_range;
 use tracing::warn;
 
 #[derive(Debug, Clone)]
+pub struct AuditResult<'a, Sector>
+where
+    Sector: ?Sized,
+{
+    /// Solution candidates
+    pub solution_candidates: SolutionCandidates<'a, Sector>,
+    /// Best solution distance found
+    pub best_solution_distance: SolutionRange,
+}
+
+/// Audit chunk candidate
+#[derive(Debug, Clone)]
+pub(crate) struct AuditChunkCandidate {
+    /// Audit chunk offset
+    pub(crate) offset: u8,
+    /// Solution distance of this audit chunk, can be used to prioritize higher quality solutions
+    pub(crate) solution_distance: SolutionRange,
+}
+
+/// Chunk candidate, contains one or more potentially winning audit chunks (in case chunk itself was
+/// encoded and eligible for claiming a reward)
+#[derive(Debug, Clone)]
 pub(crate) struct ChunkCandidate {
     /// Chunk offset within s-bucket
     pub(crate) chunk_offset: u32,
-    /// Audit chunk offsets in above chunk
-    pub(crate) audit_chunk_offsets: VecDeque<u8>,
+    /// Audit chunk candidates in above chunk
+    pub(crate) audit_chunks: Vec<AuditChunkCandidate>,
 }
 
 /// Audit a single sector and generate a stream of solutions, where `sector` must be positioned
@@ -26,7 +47,7 @@ pub fn audit_sector<'a, Sector>(
     solution_range: SolutionRange,
     sector: &'a Sector,
     sector_metadata: &'a SectorMetadataChecksummed,
-) -> Option<SolutionCandidates<'a, Sector>>
+) -> Option<AuditResult<'a, Sector>>
 where
     Sector: ReadAt + ?Sized,
 {
@@ -51,7 +72,7 @@ where
     let s_bucket_audit_offset_in_sector = sector_contents_map_size + s_bucket_audit_offset;
 
     // Map all winning chunks
-    let winning_chunks = (0..s_bucket_audit_size)
+    let mut winning_chunks = (0..s_bucket_audit_size)
         .filter_map(|chunk_offset| {
             let mut chunk = [0; Scalar::FULL_BYTES];
             if let Err(error) = sector.read_at(
@@ -62,7 +83,7 @@ where
                 return None;
             }
             // Check all audit chunks within chunk, there might be more than one winning
-            let winning_audit_chunk_offsets = chunk
+            let mut winning_audit_chunks = chunk
                 .array_chunks::<{ mem::size_of::<SolutionRange>() }>()
                 .enumerate()
                 .filter_map(|(audit_chunk_offset, &audit_chunk)| {
@@ -72,34 +93,69 @@ where
                         &sector_slot_challenge,
                         solution_range,
                     )
-                    .then_some(audit_chunk_offset as u8)
+                    .map(|solution_distance| AuditChunkCandidate {
+                        offset: audit_chunk_offset as u8,
+                        solution_distance,
+                    })
                 })
-                .collect::<VecDeque<_>>();
+                .collect::<Vec<_>>();
 
             // In case none of the audit chunks are winning, we don't care about this sector
-            if winning_audit_chunk_offsets.is_empty() {
+            if winning_audit_chunks.is_empty() {
                 return None;
             }
 
+            winning_audit_chunks.sort_by(|a, b| {
+                // Comparing `b` to `a` because we want smaller values first
+                b.solution_distance.cmp(&a.solution_distance)
+            });
+
             Some(ChunkCandidate {
                 chunk_offset: chunk_offset as u32,
-                audit_chunk_offsets: winning_audit_chunk_offsets,
+                audit_chunks: winning_audit_chunks,
             })
         })
-        .collect::<VecDeque<_>>();
+        .collect::<Vec<_>>();
 
     // Check if there are any solutions possible
     if winning_chunks.is_empty() {
         return None;
     }
 
-    Some(SolutionCandidates::new(
-        public_key,
-        sector_index,
-        sector_id,
-        s_bucket_audit_index,
-        sector,
-        sector_metadata,
-        winning_chunks,
-    ))
+    winning_chunks.sort_by(|a, b| {
+        let a_solution_distance = a
+            .audit_chunks
+            .first()
+            .expect("Lists of audit chunks are non-empty; qed")
+            .solution_distance;
+        let b_solution_distance = b
+            .audit_chunks
+            .first()
+            .expect("Lists of audit chunks are non-empty; qed")
+            .solution_distance;
+
+        // Comparing `b` to `a` because we want smaller values first
+        b_solution_distance.cmp(&a_solution_distance)
+    });
+
+    let best_solution_distance = winning_chunks
+        .first()
+        .expect("Not empty, checked above; qed")
+        .audit_chunks
+        .first()
+        .expect("Lists of audit chunks are non-empty; qed")
+        .solution_distance;
+
+    Some(AuditResult {
+        solution_candidates: SolutionCandidates::new(
+            public_key,
+            sector_index,
+            sector_id,
+            s_bucket_audit_index,
+            sector,
+            sector_metadata,
+            winning_chunks.into(),
+        ),
+        best_solution_distance,
+    })
 }

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -1,4 +1,4 @@
-use crate::auditing::ChunkCandidate;
+use crate::auditing::{AuditChunkCandidate, ChunkCandidate};
 use crate::reading::{read_record_metadata, read_sector_record_chunks, ReadingError};
 use crate::sector::{
     SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadataChecksummed,
@@ -10,10 +10,17 @@ use subspace_core_primitives::crypto::kzg::{Commitment, Kzg, Witness};
 use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::{
     PieceOffset, PosProof, PublicKey, Record, SBucket, SectorId, SectorIndex, Solution,
+    SolutionRange,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_proof_of_space::{Quality, Table, TableGenerator};
 use thiserror::Error;
+
+/// Solutions that can be proven if necessary
+pub trait ProvableSolutions: ExactSizeIterator {
+    /// Best solution distance found, `None` in case iterator is empty
+    fn best_solution_distance(&self) -> Option<SolutionRange>;
+}
 
 /// Errors that happen during proving
 #[derive(Debug, Error)]
@@ -67,8 +74,8 @@ struct WinningChunk {
     chunk_offset: u32,
     /// Piece offset in a sector
     piece_offset: PieceOffset,
-    /// Audit chunk offsets in above chunk
-    audit_chunk_offsets: VecDeque<u8>,
+    /// Audit chunk in above chunk
+    audit_chunks: VecDeque<AuditChunkCandidate>,
 }
 
 /// Container for solutions
@@ -131,7 +138,7 @@ where
     pub fn len(&self) -> usize {
         self.chunk_candidates
             .iter()
-            .map(|winning_chunk| winning_chunk.audit_chunk_offsets.len())
+            .map(|winning_chunk| winning_chunk.audit_chunks.len())
             .sum()
     }
 
@@ -140,21 +147,21 @@ where
         self.chunk_candidates.is_empty()
     }
 
-    pub fn into_iter<RewardAddress, PosTable>(
+    pub fn into_solutions<RewardAddress, PosTable>(
         self,
         reward_address: &'a RewardAddress,
         kzg: &'a Kzg,
         erasure_coding: &'a ErasureCoding,
         table_generator: &'a mut PosTable::Generator,
     ) -> Result<
-        impl ExactSizeIterator<Item = Result<Solution<PublicKey, RewardAddress>, ProvingError>> + 'a,
+        impl ProvableSolutions<Item = Result<Solution<PublicKey, RewardAddress>, ProvingError>> + 'a,
         ProvingError,
     >
     where
         RewardAddress: Copy,
         PosTable: Table,
     {
-        SolutionCandidatesIterator::<'a, RewardAddress, Sector, PosTable>::new(
+        SolutionsIterator::<'a, RewardAddress, Sector, PosTable>::new(
             self.public_key,
             reward_address,
             self.sector_index,
@@ -179,7 +186,7 @@ struct ChunkCache {
     proof_of_space: PosProof,
 }
 
-struct SolutionCandidatesIterator<'a, RewardAddress, Sector, PosTable>
+struct SolutionsIterator<'a, RewardAddress, Sector, PosTable>
 where
     Sector: ?Sized,
     PosTable: Table,
@@ -198,12 +205,13 @@ where
     winning_chunks: VecDeque<WinningChunk>,
     count: usize,
     chunk_cache: Option<ChunkCache>,
+    best_solution_distance: Option<SolutionRange>,
     table_generator: &'a mut PosTable::Generator,
 }
 
 // TODO: This can be potentially parallelized with rayon
 impl<RewardAddress, Sector, PosTable> Iterator
-    for SolutionCandidatesIterator<'_, RewardAddress, Sector, PosTable>
+    for SolutionsIterator<'_, RewardAddress, Sector, PosTable>
 where
     RewardAddress: Copy,
     Sector: ReadAt + ?Sized,
@@ -215,16 +223,16 @@ where
         let (chunk_offset, piece_offset, audit_chunk_offset) = {
             let winning_chunk = self.winning_chunks.front_mut()?;
 
-            let audit_chunk_offset = winning_chunk.audit_chunk_offsets.pop_front()?;
+            let audit_chunk = winning_chunk.audit_chunks.pop_front()?;
             let chunk_offset = winning_chunk.chunk_offset;
             let piece_offset = winning_chunk.piece_offset;
 
-            if winning_chunk.audit_chunk_offsets.is_empty() {
+            if winning_chunk.audit_chunks.is_empty() {
                 // When all audit chunk offsets are removed, the winning chunks entry itself can be removed
                 self.winning_chunks.pop_front();
             }
 
-            (chunk_offset, piece_offset, audit_chunk_offset)
+            (chunk_offset, piece_offset, audit_chunk.offset)
         };
 
         self.count -= 1;
@@ -325,7 +333,7 @@ where
                         if winning_chunk.chunk_offset == chunk_offset {
                             // Subsequent attempts to generate solutions for this chunk offset will
                             // fail too, remove it so save potential computation
-                            self.count -= winning_chunk.audit_chunk_offsets.len();
+                            self.count -= winning_chunk.audit_chunks.len();
                             self.winning_chunks.pop_front();
                         }
                     }
@@ -365,7 +373,7 @@ where
 }
 
 impl<RewardAddress, Sector, PosTable> ExactSizeIterator
-    for SolutionCandidatesIterator<'_, RewardAddress, Sector, PosTable>
+    for SolutionsIterator<'_, RewardAddress, Sector, PosTable>
 where
     RewardAddress: Copy,
     Sector: ReadAt + ?Sized,
@@ -373,8 +381,19 @@ where
 {
 }
 
-impl<'a, RewardAddress, Sector, PosTable>
-    SolutionCandidatesIterator<'a, RewardAddress, Sector, PosTable>
+impl<RewardAddress, Sector, PosTable> ProvableSolutions
+    for SolutionsIterator<'_, RewardAddress, Sector, PosTable>
+where
+    RewardAddress: Copy,
+    Sector: ReadAt + ?Sized,
+    PosTable: Table,
+{
+    fn best_solution_distance(&self) -> Option<SolutionRange> {
+        self.best_solution_distance
+    }
+}
+
+impl<'a, RewardAddress, Sector, PosTable> SolutionsIterator<'a, RewardAddress, Sector, PosTable>
 where
     Sector: ReadAt + ?Sized,
     PosTable: Table,
@@ -428,7 +447,7 @@ where
                     return encoded_chunk_used.then_some(WinningChunk {
                         chunk_offset,
                         piece_offset,
-                        audit_chunk_offsets: chunk_candidate.audit_chunk_offsets,
+                        audit_chunks: chunk_candidate.audit_chunks.into(),
                     });
                 }
             })
@@ -436,8 +455,15 @@ where
 
         let count = winning_chunks
             .iter()
-            .map(|winning_chunk| winning_chunk.audit_chunk_offsets.len())
+            .map(|winning_chunk| winning_chunk.audit_chunks.len())
             .sum();
+
+        let best_solution_distance = winning_chunks.front().and_then(|winning_chunk| {
+            winning_chunk
+                .audit_chunks
+                .front()
+                .map(|audit_chunk| audit_chunk.solution_distance)
+        });
 
         let s_bucket_offsets = sector_metadata.s_bucket_offsets();
 
@@ -456,6 +482,7 @@ where
             winning_chunks,
             count,
             chunk_cache: None,
+            best_solution_distance,
             table_generator,
         })
     }

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -201,8 +201,8 @@ where
                         Ok(solution) => solution,
                         Err(error) => {
                             error!(%slot, %sector_index, %error, "Failed to prove");
-                            // Do not error completely on disk corruption or other
-                            // reasons why proving might fail
+                            // Do not error completely as disk corruption or other reasons why
+                            // proving might fail
                             continue;
                         }
                     };

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -3,22 +3,23 @@ use crate::node_client::NodeClient;
 use crate::single_disk_farm::Handlers;
 use futures::channel::mpsc;
 use futures::StreamExt;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rayon::prelude::*;
 use rayon::{ThreadPool, ThreadPoolBuildError};
 use std::fs::File;
 use std::io;
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::Kzg;
-use subspace_core_primitives::{PublicKey, SectorIndex, Solution};
+use subspace_core_primitives::{PosSeed, PublicKey, SectorIndex, Solution, SolutionRange};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
+use subspace_farmer_components::proving::ProvableSolutions;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_farmer_components::{proving, ReadAt};
-use subspace_proof_of_space::Table;
+use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 /// Self-imposed limit for number of solutions that farmer will not go over per challenge.
 ///
@@ -107,25 +108,30 @@ where
         thread_pool,
     } = farming_options;
 
-    let mut table_generator = PosTable::generator();
+    let table_generator = Arc::new(Mutex::new(PosTable::generator()));
 
     while let Some(slot_info) = slot_info_notifications.next().await {
-        let slot = slot_info.slot_number;
-        let sectors_metadata = sectors_metadata.read();
-        let sector_count = sectors_metadata.len();
+        let modifying_sector_index = Arc::clone(&modifying_sector_index);
+        let sectors_metadata = Arc::clone(&sectors_metadata);
+        let table_generator = Arc::clone(&table_generator);
+        let kzg = kzg.clone();
+        let erasure_coding = erasure_coding.clone();
 
-        debug!(%slot, %sector_count, "Reading sectors");
+        let response = thread_pool.install(move || {
+            let slot = slot_info.slot_number;
+            let sectors_metadata = sectors_metadata.read();
+            let sector_count = sectors_metadata.len();
 
-        let modifying_sector_guard = modifying_sector_index.read();
-        let maybe_sector_being_modified = modifying_sector_guard.as_ref().copied();
-        let mut solutions = Vec::<Solution<PublicKey, PublicKey>>::new();
+            debug!(%slot, %sector_count, "Reading sectors");
 
-        let sectors = (0..sector_count)
-            .map(|sector_index| plot_file.offset(sector_index * sector_size))
-            .collect::<Vec<_>>();
+            let modifying_sector_guard = modifying_sector_index.read();
+            let maybe_sector_being_modified = modifying_sector_guard.as_ref().copied();
 
-        let audit_results = thread_pool.install(|| {
-            sectors_metadata
+            let sectors = (0..sector_count)
+                .map(|sector_index| plot_file.offset(sector_index * sector_size))
+                .collect::<Vec<_>>();
+
+            let mut sectors_solutions = sectors_metadata
                 .par_iter()
                 .zip(&sectors)
                 .enumerate()
@@ -137,7 +143,7 @@ where
                     }
                     trace!(%slot, %sector_index, "Auditing sector");
 
-                    let solution_candidates = audit_sector(
+                    let audit_results = audit_sector(
                         &public_key,
                         sector_index,
                         &slot_info.global_challenge,
@@ -146,61 +152,89 @@ where
                         sector_metadata,
                     )?;
 
-                    Some((sector_index, solution_candidates))
+                    Some((sector_index, audit_results.solution_candidates))
                 })
                 .collect::<Vec<_>>()
-        });
+                .into_iter()
+                .filter_map(|(sector_index, solution_candidates)| {
+                    let sector_solutions = match solution_candidates.into_solutions(
+                        &reward_address,
+                        &kzg,
+                        &erasure_coding,
+                        |seed: &PosSeed| table_generator.lock().generate_parallel(seed),
+                    ) {
+                        Ok(solutions) => solutions,
+                        Err(error) => {
+                            warn!(
+                                %error,
+                                %sector_index,
+                                "Failed to turn solution candidates into solutions",
+                            );
 
-        // TODO: Prefer solution candidates with better solution distance
-        for (sector_index, audit_result) in audit_results {
-            for maybe_solution in audit_result
-                .solution_candidates
-                .into_solutions::<_, PosTable>(
-                    &reward_address,
-                    &kzg,
-                    &erasure_coding,
-                    &mut table_generator,
-                )?
-            {
-                let solution = match maybe_solution {
-                    Ok(solution) => solution,
-                    Err(error) => {
-                        error!(%slot, %sector_index, %error, "Failed to prove");
-                        // Do not error completely on disk corruption or other
-                        // reasons why proving might fail
-                        continue;
+                            return None;
+                        }
+                    };
+
+                    if sector_solutions.len() == 0 {
+                        return None;
                     }
-                };
 
-                debug!(%slot, %sector_index, "Solution found");
-                trace!(?solution, "Solution found");
+                    Some((sector_index, sector_solutions))
+                })
+                .collect::<Vec<_>>();
 
-                solutions.push(solution);
+            sectors_solutions.sort_by(|a, b| {
+                let a_solution_distance =
+                    a.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
+                let b_solution_distance =
+                    b.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
+
+                // Comparing `b` to `a` because we want smaller values first
+                b_solution_distance.cmp(&a_solution_distance)
+            });
+
+            let mut solutions = Vec::<Solution<PublicKey, PublicKey>>::new();
+
+            for (sector_index, sector_solutions) in sectors_solutions {
+                for maybe_solution in sector_solutions {
+                    let solution = match maybe_solution {
+                        Ok(solution) => solution,
+                        Err(error) => {
+                            error!(%slot, %sector_index, %error, "Failed to prove");
+                            // Do not error completely on disk corruption or other
+                            // reasons why proving might fail
+                            continue;
+                        }
+                    };
+
+                    debug!(%slot, %sector_index, "Solution found");
+                    trace!(?solution, "Solution found");
+
+                    solutions.push(solution);
+
+                    if solutions.len() >= SOLUTIONS_LIMIT {
+                        break;
+                    }
+                }
 
                 if solutions.len() >= SOLUTIONS_LIMIT {
                     break;
                 }
+                // TODO: It is known that decoding is slow now and we'll only be
+                //  able to decode a single sector within time slot reliably, in the
+                //  future we may want allow more than one sector to be valid within
+                //  the same disk plot.
+                if !solutions.is_empty() {
+                    break;
+                }
             }
 
-            if solutions.len() >= SOLUTIONS_LIMIT {
-                break;
+            SolutionResponse {
+                slot_number: slot_info.slot_number,
+                solutions,
             }
-            // TODO: It is known that decoding is slow now and we'll only be
-            //  able to decode a single sector within time slot reliably, in the
-            //  future we may want allow more than one sector to be valid within
-            //  the same disk plot.
-            if !solutions.is_empty() {
-                break;
-            }
-        }
+        });
 
-        drop(sectors_metadata);
-        drop(modifying_sector_guard);
-
-        let response = SolutionResponse {
-            slot_number: slot_info.slot_number,
-            solutions,
-        };
         handlers.solution.call_simple(&response);
         node_client
             .submit_solution_response(response)

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -129,15 +129,17 @@ fn calculate_solution_distance(
     )
 }
 
-/// Returns true if solution distance is within the solution range for provided parameters.
+/// Returns `Some(solution_distance)` if solution distance is within the solution range for provided
+/// parameters.
 pub fn is_within_solution_range(
     global_challenge: &Blake2b256Hash,
     audit_chunk: SolutionRange,
     sector_slot_challenge: &SectorSlotChallenge,
     solution_range: SolutionRange,
-) -> bool {
-    calculate_solution_distance(global_challenge, audit_chunk, sector_slot_challenge)
-        <= solution_range / 2
+) -> Option<SolutionRange> {
+    let solution_distance =
+        calculate_solution_distance(global_challenge, audit_chunk, sector_slot_challenge);
+    (solution_distance <= solution_range / 2).then_some(solution_distance)
 }
 
 /// Parameters for checking piece validity

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -34,14 +34,14 @@ use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    HistorySize, PublicKey, Record, SegmentIndex, Solution, REWARD_SIGNING_CONTEXT,
+    HistorySize, PosSeed, PublicKey, Record, SegmentIndex, Solution, REWARD_SIGNING_CONTEXT,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
 use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
-use subspace_proof_of_space::Table;
+use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_service::tx_pre_validator::ConsensusChainTxPreValidator;
 use subspace_service::{FullClient, NewFull};
@@ -198,12 +198,9 @@ async fn start_farming<PosTable, Client>(
 
             let solution = audit_result
                 .solution_candidates
-                .into_solutions::<_, PosTable>(
-                    &public_key,
-                    &kzg,
-                    &erasure_coding,
-                    &mut table_generator,
-                )
+                .into_solutions(&public_key, &kzg, &erasure_coding, |seed: &PosSeed| {
+                    table_generator.generate_parallel(seed)
+                })
                 .unwrap()
                 .next()
                 .expect("With max solution range there must be a solution; qed")

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -186,7 +186,7 @@ async fn start_farming<PosTable, Client>(
             let global_challenge = new_slot_info
                 .global_randomness
                 .derive_global_challenge(new_slot_info.slot.into());
-            let solution_candidates = audit_sector(
+            let audit_result = audit_sector(
                 &public_key,
                 sector_index,
                 &global_challenge,
@@ -196,8 +196,14 @@ async fn start_farming<PosTable, Client>(
             )
             .expect("With max solution range there must be a sector eligible; qed");
 
-            let solution = solution_candidates
-                .into_iter::<_, PosTable>(&public_key, &kzg, &erasure_coding, &mut table_generator)
+            let solution = audit_result
+                .solution_candidates
+                .into_solutions::<_, PosTable>(
+                    &public_key,
+                    &kzg,
+                    &erasure_coding,
+                    &mut table_generator,
+                )
                 .unwrap()
                 .next()
                 .expect("With max solution range there must be a solution; qed")


### PR DESCRIPTION
When switching to v2 consensus we had to restrict how many solutions farmer can generate to 1 because otherwise farmer wouldn't be able to make it in time.

The way it was implemented was by picking the first solution found, however we are auditing solutions with solution range corresponding to voting, so the first solution may end up being not the best solution found and solution range/estimated space pledged will not actually represent reality.

It was a bit tricky to implement in a not super confusing way, but this PR gets it done.

Follow-up will be to change the way solutions are sent to the node from a vector to individual solutions, such that farmer can "stream" all the solutions they can produce within prediction window starting from highest quality to lowest quality This way farmer will get more rewards if there happens to be more than one valid solution in their plot and they can prove it fast enough.

I expect this will both increase apparent space pledged on Gemini 3f (I'll create a backport) and reduce solution range fluctuations.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
