### PR TITLE
Fix tokio re-entrance due to rayon thread pool behavior

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -23,7 +23,7 @@ use subspace_farmer::single_disk_farm::{
 use subspace_farmer::utils::farmer_piece_getter::FarmerPieceGetter;
 use subspace_farmer::utils::piece_validator::SegmentCommitmentPieceValidator;
 use subspace_farmer::utils::readers_and_pieces::ReadersAndPieces;
-use subspace_farmer::utils::run_future_in_dedicated_thread;
+use subspace_farmer::utils::{run_future_in_dedicated_thread, tokio_rayon_spawn_handler};
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_metrics::{start_prometheus_metrics_server, RegistryAdapter};
@@ -195,18 +195,21 @@ where
         ThreadPoolBuilder::new()
             .thread_name(move |thread_index| format!("farming#{thread_index}"))
             .num_threads(farming_thread_pool_size)
+            .spawn_handler(tokio_rayon_spawn_handler())
             .build()?,
     );
     let plotting_thread_pool = Arc::new(
         ThreadPoolBuilder::new()
             .thread_name(move |thread_index| format!("plotting#{thread_index}"))
             .num_threads(plotting_thread_pool_size)
+            .spawn_handler(tokio_rayon_spawn_handler())
             .build()?,
     );
     let replotting_thread_pool = Arc::new(
         ThreadPoolBuilder::new()
             .thread_name(move |thread_index| format!("replotting#{thread_index}"))
             .num_threads(replotting_thread_pool_size)
+            .spawn_handler(tokio_rayon_spawn_handler())
             .build()?,
     );
 


### PR DESCRIPTION
Here is a backtrace for issue described in https://forum.subspace.network/t/cannot-stat-a-runtime-from-within-a-runtime/1931:
```
thread ‘plotting#0’ panicked at ‘Cannot start a runtime from within a runtime. This happens because a function (like block_on) attempted to block the current thread while the thread is being used to drive asynchronous tasks.’, crates/subspace-farmer/src/single_disk_farm/plotting.rs:226:28
stack backtrace:
0: rust_begin_unwind
1: core::panicking::panic_fmt
2: tokio::runtime::context::runtime::enter_runtime
3: rayon_core::thread_pool::ThreadPool::install::{{closure}}
4: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
5: rayon_core::registry::WorkerThread::wait_until_cold
6: rayon_core::join::join_context::{{closure}}
7: rayon::iter::plumbing::bridge_producer_consumer::helper
8: rayon_core::join::join_context::{{closure}}
9: rayon::iter::plumbing::bridge_producer_consumer::helper
10: rayon_core::join::join_context::{{closure}}
11: rayon::iter::plumbing::bridge_producer_consumer::helper
12: subspace_proof_of_space::chiapos::tables::TablesGeneric<_>::create_parallel
13: subspace_farmer_components::plotting::plot_sector::{{closure}}
14: tokio::runtime::context::runtime::enter_runtime
15: rayon_core::thread_pool::ThreadPool::install::{{closure}}
16: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
17: rayon_core::registry::WorkerThread::wait_until_cold
note: Some details are omitted, run with RUST_BACKTRACE=full for a verbose backtrace.
```

What was happening here is that in case multiple farms are present, it may happen such that one farm started plotting inside of `block_on` call, but then yielded control to another farmer process that called another `block_on` on the same thread. It was kind of racy and not really guaranteed, but still happening.

There were a couple of ways to fix this, I decided to go for the most robust version where we enter tokio runtime on the thread spawning level, which makes all things running on thread pool having tokio context and avoiding the problem of re-entering that way.

Fundamentally the lesson here is that we should never do `block_on` without `block_in_place` or thread creation around it. I just didn't expect this.

While at it I also removed a bit of code duplication in plotting.

Farming thread pool right now doesn't require tokio runtime, but to avoid potential surprises in the future I decided to include it there as well.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
