### PR TITLE
Operator rewards: fix evm txn fee noting

### DIFF
--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -477,18 +477,7 @@ parameter_types! {
     pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
 }
 
-// `BaseFeeHandler` is used to handle the base fee of the evm extrinsic separately, this is necessary
-// because `InnerEVMCurrencyAdapter::pallet_operator_rewards` only return the tip of the evm extrinsic.
-struct BaseFeeHandler;
-
-impl OnUnbalanced<NegativeImbalance> for BaseFeeHandler {
-    fn on_nonzero_unbalanced(base_fee: NegativeImbalance) {
-        // Record the evm transaction base fee
-        OperatorRewards::note_operator_rewards(base_fee.peek())
-    }
-}
-
-type InnerEVMCurrencyAdapter = pallet_evm::EVMCurrencyAdapter<Balances, BaseFeeHandler>;
+type InnerEVMCurrencyAdapter = pallet_evm::EVMCurrencyAdapter<Balances, ()>;
 
 // Implementation of [`pallet_transaction_payment::OnChargeTransaction`] that charges evm transaction
 // fees from the transaction sender and collect all the fees (including both the base fee and tip) in
@@ -511,15 +500,14 @@ impl pallet_evm::OnChargeEVMTransaction<Runtime> for EVMCurrencyAdapter {
         base_fee: U256,
         already_withdrawn: Self::LiquidityInfo,
     ) -> Self::LiquidityInfo {
-        let tip =
-            <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<
-                Runtime,
-            >>::correct_and_deposit_fee(who, corrected_fee, base_fee, already_withdrawn);
-        if let Some(t) = tip.as_ref() {
-            // Record the evm transaction tip
-            OperatorRewards::note_operator_rewards(t.peek())
+        if already_withdrawn.is_some() {
+            // Record the evm actual transaction fee
+            OperatorRewards::note_operator_rewards(corrected_fee.as_u128());
         }
-        tip
+
+        <InnerEVMCurrencyAdapter as pallet_evm::OnChargeEVMTransaction<
+            Runtime,
+        >>::correct_and_deposit_fee(who, corrected_fee, base_fee, already_withdrawn)
     }
 
     fn pay_priority_fee(tip: Self::LiquidityInfo) {


### PR DESCRIPTION
Turns out we BaseFee handler is not required and EVMCurrencyAdapter already gives the total txn fees including any priority fees. This PR fixes that and notes correct txn fee.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
