### PR TITLE
Fix slot worker after PoT reorg

### DIFF
--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -298,7 +298,7 @@ where
             parent_slot + self.chain_constants.block_authoring_delay()
         };
 
-        let (proof_of_time, future_proof_of_time, new_checkpoints) = {
+        let (proof_of_time, future_proof_of_time, pot_justification) = {
             // Remove checkpoints from old slots we will not need anymore
             self.pot_checkpoints
                 .retain(|&stored_slot, _checkpoints| stored_slot > parent_slot);
@@ -307,18 +307,6 @@ where
 
             // Future slot for which proof must be available before authoring block at this slot
             let future_slot = slot + self.chain_constants.block_authoring_delay();
-            let future_proof_of_time = self.pot_checkpoints.get(&future_slot)?.output();
-
-            // New checkpoints that were produced since parent block's future slot up to current
-            // future slot (inclusive)
-            let new_checkpoints = self
-                .pot_checkpoints
-                .iter()
-                .filter_map(|(&stored_slot, &checkpoints)| {
-                    (stored_slot > parent_future_slot && stored_slot <= future_slot)
-                        .then_some(checkpoints)
-                })
-                .collect::<Vec<_>>();
 
             let pot_input = if parent_header.number().is_zero() {
                 PotNextSlotInput {
@@ -335,26 +323,73 @@ where
                 )
             };
 
-            // Ensure proof of time and future proof of time included in upcoming block are valid
+            // Ensure proof of time is valid according to parent block
             if !self
                 .pot_verifier
                 .is_output_valid(
                     pot_input,
-                    Slot::from(u64::from(future_slot) - u64::from(parent_slot)),
-                    future_proof_of_time,
+                    Slot::from(u64::from(slot) - u64::from(parent_slot)),
+                    proof_of_time,
                     parent_pot_parameters.next_parameters_change(),
                 )
                 .await
             {
                 warn!(
                     target: "subspace",
-                    "Proof of time or future proof of time is invalid, skipping block \
-                    production at slot {slot:?}"
+                    "Proof of time is invalid, skipping block authoring at slot {slot:?}"
                 );
                 return None;
             }
 
-            (proof_of_time, future_proof_of_time, new_checkpoints)
+            let mut checkpoints_pot_input = if parent_header.number().is_zero() {
+                PotNextSlotInput {
+                    slot: parent_slot + Slot::from(1),
+                    slot_iterations: parent_pot_parameters.slot_iterations(),
+                    seed: self.pot_verifier.genesis_seed(),
+                }
+            } else {
+                let parent_pot_info = parent_pre_digest.pot_info();
+
+                PotNextSlotInput::derive(
+                    parent_pot_parameters.slot_iterations(),
+                    parent_future_slot,
+                    parent_pot_info.future_proof_of_time(),
+                    &parent_pot_parameters.next_parameters_change(),
+                )
+            };
+            let seed = checkpoints_pot_input.seed;
+
+            let mut checkpoints = Vec::with_capacity((*future_slot - *parent_future_slot) as usize);
+
+            for slot in *parent_future_slot + 1..=*future_slot {
+                let slot = Slot::from(slot);
+                let maybe_slot_checkpoints_fut = self.pot_verifier.get_checkpoints(
+                    checkpoints_pot_input.slot_iterations,
+                    checkpoints_pot_input.seed,
+                );
+                let Some(slot_checkpoints) = maybe_slot_checkpoints_fut.await else {
+                    warn!("Proving failed during block authoring");
+                    return None;
+                };
+
+                checkpoints.push(slot_checkpoints);
+
+                checkpoints_pot_input = PotNextSlotInput::derive(
+                    checkpoints_pot_input.slot_iterations,
+                    slot,
+                    slot_checkpoints.output(),
+                    &parent_pot_parameters.next_parameters_change(),
+                );
+            }
+
+            let future_proof_of_time = checkpoints
+                .last()
+                .expect("Never empty, there is at least one slot between blocks; qed")
+                .output();
+
+            let pot_justification = SubspaceJustification::PotCheckpoints { seed, checkpoints };
+
+            (proof_of_time, future_proof_of_time, pot_justification)
         };
 
         let mut solution_receiver = {
@@ -515,29 +550,7 @@ where
             }
         }
 
-        let pot_seed = if parent_header.number().is_zero() {
-            self.pot_verifier.genesis_seed()
-        } else {
-            let parent_pot_info = parent_pre_digest.pot_info();
-
-            PotNextSlotInput::derive(
-                parent_pot_parameters.slot_iterations(),
-                parent_future_slot,
-                parent_pot_info.future_proof_of_time(),
-                &parent_pot_parameters.next_parameters_change(),
-            )
-            .seed
-        };
-
-        maybe_pre_digest.map(|pre_digest| {
-            (
-                pre_digest,
-                SubspaceJustification::PotCheckpoints {
-                    seed: pot_seed,
-                    checkpoints: new_checkpoints,
-                },
-            )
-        })
+        maybe_pre_digest.map(|pre_digest| (pre_digest, pot_justification))
     }
 
     fn pre_digest_data(

--- a/crates/sc-proof-of-time/src/source/gossip.rs
+++ b/crates/sc-proof-of-time/src/source/gossip.rs
@@ -214,7 +214,7 @@ where
 
                 if let Some(verified_checkpoints) = self
                     .pot_verifier
-                    .try_get_checkpoints(proof.seed, proof.slot_iterations)
+                    .try_get_checkpoints(proof.slot_iterations, proof.seed)
                 {
                     if verified_checkpoints != proof.checkpoints {
                         trace!(
@@ -334,7 +334,7 @@ where
             if proof.slot != next_slot_input.slot {
                 let invalid_proof = self
                     .pot_verifier
-                    .try_get_checkpoints(proof.seed, proof.slot_iterations)
+                    .try_get_checkpoints(proof.slot_iterations, proof.seed)
                     .map(|verified_checkpoints| verified_checkpoints != proof.checkpoints)
                     .unwrap_or_default();
 

--- a/crates/sc-proof-of-time/src/source/state.rs
+++ b/crates/sc-proof-of-time/src/source/state.rs
@@ -33,8 +33,8 @@ impl InnerState {
 
             // Advance further as far as possible using previously verified proofs/checkpoints
             if let Some(checkpoints) = pot_verifier.try_get_checkpoints(
-                self.next_slot_input.seed,
                 self.next_slot_input.slot_iterations,
+                self.next_slot_input.seed,
             ) {
                 best_slot = self.next_slot_input.slot;
                 best_output = checkpoints.output();
@@ -163,7 +163,7 @@ impl PotState {
             {
                 let slot = Slot::from(slot);
 
-                let Some(checkpoints) = self.verifier.try_get_checkpoints(seed, slot_iterations)
+                let Some(checkpoints) = self.verifier.try_get_checkpoints(slot_iterations, seed)
                 else {
                     break;
                 };


### PR DESCRIPTION
There is an interesting edge-case on `main` right now: when PoT reorg happens, it is not guaranteed that all checkpoints contained are actually consistent. It is technically possible that both proof of time and future proof of time are valid, but some internal checkpoints are not, even though the chances of this are slim. Another possibility is more annoying: it is possible that reorg will jump a bit into the future, leaving gaps in the buffer that slot worker is storing.

As such, the most reliable thing to do here is to start with block's slot proof of time and try to get to the future proof with verifier, that way we ensure that we always have correct number of checkpoints and they are always valid.

Refactoring in https://github.com/subspace/subspace/pull/2037 was done to make this PR smaller and nicer to look at.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
