### PR TITLE
Fix for solution sorting by quality

### DIFF
--- a/crates/subspace-farmer-components/src/auditing.rs
+++ b/crates/subspace-farmer-components/src/auditing.rs
@@ -106,10 +106,7 @@ where
                 return None;
             }
 
-            winning_audit_chunks.sort_by(|a, b| {
-                // Comparing `b` to `a` because we want smaller values first
-                b.solution_distance.cmp(&a.solution_distance)
-            });
+            winning_audit_chunks.sort_by(|a, b| a.solution_distance.cmp(&b.solution_distance));
 
             Some(ChunkCandidate {
                 chunk_offset: chunk_offset as u32,
@@ -135,8 +132,7 @@ where
             .expect("Lists of audit chunks are non-empty; qed")
             .solution_distance;
 
-        // Comparing `b` to `a` because we want smaller values first
-        b_solution_distance.cmp(&a_solution_distance)
+        a_solution_distance.cmp(&b_solution_distance)
     });
 
     let best_solution_distance = winning_chunks

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -189,8 +189,7 @@ where
                 let b_solution_distance =
                     b.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
 
-                // Comparing `b` to `a` because we want smaller values first
-                b_solution_distance.cmp(&a_solution_distance)
+                a_solution_distance.cmp(&b_solution_distance)
             });
 
             let mut solutions = Vec::<Solution<PublicKey, PublicKey>>::new();


### PR DESCRIPTION
The default sorting is actually from smaller to larger, what it was doing is the opposite :man_facepalming: 

The issue was introduced in https://github.com/subspace/subspace/pull/2020

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
