### PR TITLE
Relay protocol upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9850,6 +9850,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "async-trait",
+ "derive_more",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.1",

--- a/crates/sc-subspace-block-relay/Cargo.toml
+++ b/crates/sc-subspace-block-relay/Cargo.toml
@@ -14,6 +14,7 @@ include = [
 async-channel = "1.9.0"
 async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
+derive_more = "0.99.17"
 futures = "0.3.28"
 parking_lot = "0.12.1"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "c90d6edfd8c63168eff0dce6f2ace4d66dd139f7" }

--- a/crates/sc-subspace-block-relay/src/protocol.rs
+++ b/crates/sc-subspace-block-relay/src/protocol.rs
@@ -42,8 +42,6 @@
 pub(crate) mod compact_block;
 
 use crate::types::RelayError;
-use crate::utils::NetworkPeerHandle;
-use async_trait::async_trait;
 use codec::{Decode, Encode};
 
 /// The resolved protocol unit related info
@@ -57,53 +55,6 @@ pub(crate) struct Resolved<ProtocolUnitId, ProtocolUnit> {
     /// If it was resolved locally, or if it had to be
     /// fetched from the server (local miss)
     pub(crate) locally_resolved: bool,
-}
-
-/// The client side of the relay protocol
-#[async_trait]
-pub(crate) trait ProtocolClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-where
-    Self: Send + Sync,
-{
-    type Request: Send + Sync + Encode + Decode + 'static;
-    type Response: Send + Sync + Encode + Decode + 'static;
-
-    /// Builds the protocol portion of the initial request
-    fn build_initial_request(
-        &self,
-        backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
-    ) -> Self::Request;
-
-    /// Resolves the initial response to produce the protocol units.
-    async fn resolve_initial_response<Request>(
-        &self,
-        response: Self::Response,
-        network_peer_handle: &NetworkPeerHandle,
-        backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
-    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>
-    where
-        Request: From<Self::Request> + Encode + Send + Sync;
-}
-
-/// The server side of the relay protocol
-pub(crate) trait ProtocolServer<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
-    type Request: Encode + Decode;
-    type Response: Encode + Decode;
-
-    /// Builds the protocol response to the initial request
-    fn build_initial_response(
-        &self,
-        download_unit_id: &DownloadUnitId,
-        initial_request: Self::Request,
-        backend: &dyn ServerBackend<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
-    ) -> Result<Self::Response, RelayError>;
-
-    /// Handles the additional client messages during the reconcile phase
-    fn on_request(
-        &self,
-        request: Self::Request,
-        backend: &dyn ServerBackend<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
-    ) -> Result<Self::Response, RelayError>;
 }
 
 /// The relay user specific backend for the client side

--- a/crates/sc-subspace-block-relay/src/protocol/compact_block.rs
+++ b/crates/sc-subspace-block-relay/src/protocol/compact_block.rs
@@ -1,16 +1,70 @@
 //! Compact block implementation.
 
-use crate::protocol::{
-    ClientBackend, ProtocolClient, ProtocolServer, ProtocolUnitInfo, Resolved, ServerBackend,
-};
+use crate::protocol::{ClientBackend, ProtocolUnitInfo, Resolved, ServerBackend};
 use crate::types::RelayError;
 use crate::utils::NetworkPeerHandle;
 use crate::LOG_TARGET;
-use async_trait::async_trait;
 use codec::{Decode, Encode};
+use derive_more::From;
 use std::collections::BTreeMap;
 use tracing::{trace, warn};
 
+/// The initial request(currently we don't need to do send anything
+/// as part of the initial download request for compact blocks).
+#[derive(From, Encode, Decode)]
+pub(crate) enum CompactBlockInitialRequest {
+    V0,
+}
+
+/// The compact block initial response from the server.
+#[derive(Encode, Decode)]
+pub(crate) struct CompactBlockInitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
+    /// The download unit
+    download_unit_id: DownloadUnitId,
+
+    /// List of the protocol units Ids.
+    protocol_units: Vec<ProtocolUnitInfo<ProtocolUnitId, ProtocolUnit>>,
+}
+
+/// The handshake messages from the client.
+#[derive(From, Encode, Decode)]
+pub(crate) enum CompactBlockHandshake<DownloadUnitId, ProtocolUnitId> {
+    /// Request for missing transactions
+    MissingEntries(MissingEntriesRequest<DownloadUnitId, ProtocolUnitId>),
+}
+
+/// The handshake reply from the server.
+#[derive(From, Encode, Decode)]
+pub(crate) enum CompactBlockHandshakeResponse<ProtocolUnit> {
+    /// Response for missing transactions
+    MissingEntries(MissingEntriesResponse<ProtocolUnit>),
+}
+
+/// Request for missing transactions
+#[derive(Encode, Decode)]
+pub(crate) struct MissingEntriesRequest<DownloadUnitId, ProtocolUnitId> {
+    /// The download unit
+    download_unit_id: DownloadUnitId,
+
+    /// Map of missing entry Id ->  protocol unit Id.
+    /// The missing entry Id is an opaque identifier used by the client
+    /// side. The server side just returns it as is with the response.
+    protocol_unit_ids: BTreeMap<u64, ProtocolUnitId>,
+}
+
+/// Response for missing transactions
+#[derive(Encode, Decode)]
+pub(crate) struct MissingEntriesResponse<ProtocolUnit> {
+    /// Map of missing entry Id ->  protocol unit.
+    protocol_units: BTreeMap<u64, ProtocolUnit>,
+}
+
+struct ResolveContext<ProtocolUnitId, ProtocolUnit> {
+    resolved: BTreeMap<u64, Resolved<ProtocolUnitId, ProtocolUnit>>,
+    local_miss: BTreeMap<u64, ProtocolUnitId>,
+}
+
+/*
 /// Request messages
 #[derive(Encode, Decode)]
 pub(crate) enum CompactBlockRequest<DownloadUnitId, ProtocolUnitId> {
@@ -41,29 +95,7 @@ pub(crate) struct InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit> 
     protocol_units: Vec<ProtocolUnitInfo<ProtocolUnitId, ProtocolUnit>>,
 }
 
-/// Request for missing transactions
-#[derive(Encode, Decode)]
-pub(crate) struct MissingEntriesRequest<DownloadUnitId, ProtocolUnitId> {
-    /// The download unit
-    download_unit_id: DownloadUnitId,
-
-    /// Map of missing entry Id ->  protocol unit Id.
-    /// The missing entry Id is an opaque identifier used by the client
-    /// side. The server side just returns it as is with the response.
-    protocol_unit_ids: BTreeMap<u64, ProtocolUnitId>,
-}
-
-/// Response for missing transactions
-#[derive(Encode, Decode)]
-pub(crate) struct MissingEntriesResponse<ProtocolUnit> {
-    /// Map of missing entry Id ->  protocol unit.
-    protocol_units: BTreeMap<u64, ProtocolUnit>,
-}
-
-struct ResolveContext<ProtocolUnitId, ProtocolUnit> {
-    resolved: BTreeMap<u64, Resolved<ProtocolUnitId, ProtocolUnit>>,
-    local_miss: BTreeMap<u64, ProtocolUnitId>,
-}
+ */
 
 pub(crate) struct CompactBlockClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
     _phantom_data: std::marker::PhantomData<(DownloadUnitId, ProtocolUnitId, ProtocolUnit)>,
@@ -72,7 +104,7 @@ pub(crate) struct CompactBlockClient<DownloadUnitId, ProtocolUnitId, ProtocolUni
 impl<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
     CompactBlockClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
 where
-    DownloadUnitId: Send + Sync + Encode + Decode + Clone,
+    DownloadUnitId: Send + Sync + Encode + Decode + Clone + std::fmt::Debug,
     ProtocolUnitId: Send + Sync + Encode + Decode + Clone,
     ProtocolUnit: Send + Sync + Encode + Decode + Clone,
 {
@@ -83,10 +115,63 @@ where
         }
     }
 
-    /// Tries to resolve the entries in InitialResponse locally
+    /// Builds the initial request.
+    pub(crate) fn build_initial_request(
+        &self,
+        _backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
+    ) -> CompactBlockInitialRequest {
+        CompactBlockInitialRequest::V0
+    }
+
+    /// Resolves the initial response to produce the protocol units.
+    pub(crate) async fn resolve_initial_response<Request>(
+        &self,
+        compact_response: CompactBlockInitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
+        network_peer_handle: &NetworkPeerHandle,
+        backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
+    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>
+    where
+        Request: From<CompactBlockHandshake<DownloadUnitId, ProtocolUnitId>> + Encode + Send + Sync,
+    {
+        // Try to resolve the hashes locally first.
+        let context = self.resolve_local(&compact_response, backend)?;
+        if context.resolved.len() == compact_response.protocol_units.len() {
+            trace!(
+                target: LOG_TARGET,
+                "relay::resolve: {:?}: resolved locally[{}]",
+                compact_response.download_unit_id,
+                compact_response.protocol_units.len()
+            );
+            return Ok((
+                compact_response.download_unit_id,
+                context.resolved.into_values().collect(),
+            ));
+        }
+
+        // Resolve the misses from the server
+        let misses = context.local_miss.len();
+        let download_unit_id = compact_response.download_unit_id.clone();
+        let resolved = self
+            .resolve_misses::<Request>(compact_response, context, network_peer_handle)
+            .await?;
+        trace!(
+            target: LOG_TARGET,
+            "relay::resolve: {:?}: resolved by server[{},{}]",
+            download_unit_id,
+            resolved.len(),
+            misses,
+        );
+        Ok((download_unit_id, resolved))
+    }
+
+    /// Tries to resolve the entries in InitialResponse locally.
     fn resolve_local(
         &self,
-        compact_response: &InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
+        compact_response: &CompactBlockInitialResponse<
+            DownloadUnitId,
+            ProtocolUnitId,
+            ProtocolUnit,
+        >,
         backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
     ) -> Result<ResolveContext<ProtocolUnitId, ProtocolUnit>, RelayError> {
         let mut context = ResolveContext {
@@ -129,15 +214,15 @@ where
         Ok(context)
     }
 
-    /// Fetches the missing entries from the server
+    /// Fetches the missing entries from the server.
     async fn resolve_misses<Request>(
         &self,
-        compact_response: InitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
+        compact_response: CompactBlockInitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
         context: ResolveContext<ProtocolUnitId, ProtocolUnit>,
         network_peer_handle: &NetworkPeerHandle,
     ) -> Result<Vec<Resolved<ProtocolUnitId, ProtocolUnit>>, RelayError>
     where
-        Request: From<CompactBlockRequest<DownloadUnitId, ProtocolUnitId>> + Encode + Send + Sync,
+        Request: From<CompactBlockHandshake<DownloadUnitId, ProtocolUnitId>> + Encode + Send + Sync,
     {
         let ResolveContext {
             mut resolved,
@@ -145,18 +230,13 @@ where
         } = context;
         let missing = local_miss.len();
         // Request the missing entries from the server
-        let request = CompactBlockRequest::MissingEntries(MissingEntriesRequest {
+        let request = CompactBlockHandshake::from(MissingEntriesRequest {
             download_unit_id: compact_response.download_unit_id.clone(),
             protocol_unit_ids: local_miss.clone(),
         });
-        let response: CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit> =
+
+        let missing_entries_response: MissingEntriesResponse<ProtocolUnit> =
             network_peer_handle.request(Request::from(request)).await?;
-        let missing_entries_response =
-            if let CompactBlockResponse::MissingEntries(response) = response {
-                response
-            } else {
-                return Err(RelayError::UnexpectedProtocolRespone);
-            };
 
         if missing_entries_response.protocol_units.len() != missing {
             return Err(RelayError::ResolveMismatch {
@@ -185,77 +265,16 @@ where
     }
 }
 
-#[async_trait]
-impl<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-    ProtocolClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-    for CompactBlockClient<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-where
-    DownloadUnitId: Send + Sync + Encode + Decode + Clone + std::fmt::Debug + 'static,
-    ProtocolUnitId: Send + Sync + Encode + Decode + Clone + 'static,
-    ProtocolUnit: Send + Sync + Encode + Decode + Clone + 'static,
-{
-    type Request = CompactBlockRequest<DownloadUnitId, ProtocolUnitId>;
-    type Response = CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>;
-
-    fn build_initial_request(
-        &self,
-        _backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
-    ) -> Self::Request {
-        CompactBlockRequest::Initial
-    }
-
-    async fn resolve_initial_response<Request>(
-        &self,
-        response: Self::Response,
-        network_peer_handle: &NetworkPeerHandle,
-        backend: &dyn ClientBackend<ProtocolUnitId, ProtocolUnit>,
-    ) -> Result<(DownloadUnitId, Vec<Resolved<ProtocolUnitId, ProtocolUnit>>), RelayError>
-    where
-        Request: From<Self::Request> + Encode + Send + Sync,
-    {
-        let compact_response = match response {
-            CompactBlockResponse::Initial(compact_response) => compact_response,
-            _ => return Err(RelayError::UnexpectedInitialResponse),
-        };
-
-        // Try to resolve the hashes locally first.
-        let context = self.resolve_local(&compact_response, backend)?;
-        if context.resolved.len() == compact_response.protocol_units.len() {
-            trace!(
-                target: LOG_TARGET,
-                "relay::resolve: {:?}: resolved locally[{}]",
-                compact_response.download_unit_id,
-                compact_response.protocol_units.len()
-            );
-            return Ok((
-                compact_response.download_unit_id,
-                context.resolved.into_values().collect(),
-            ));
-        }
-
-        // Resolve the misses from the server
-        let misses = context.local_miss.len();
-        let download_unit_id = compact_response.download_unit_id.clone();
-        let resolved = self
-            .resolve_misses::<Request>(compact_response, context, network_peer_handle)
-            .await?;
-        trace!(
-            target: LOG_TARGET,
-            "relay::resolve: {:?}: resolved by server[{},{}]",
-            download_unit_id,
-            resolved.len(),
-            misses,
-        );
-        Ok((download_unit_id, resolved))
-    }
-}
-
 pub(crate) struct CompactBlockServer<DownloadUnitId, ProtocolUnitId, ProtocolUnit> {
     _phantom_data: std::marker::PhantomData<(DownloadUnitId, ProtocolUnitId, ProtocolUnit)>,
 }
 
 impl<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
     CompactBlockServer<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
+where
+    DownloadUnitId: Encode + Decode + Clone,
+    ProtocolUnitId: Encode + Decode + Clone,
+    ProtocolUnit: Encode + Decode,
 {
     /// Creates the server.
     pub(crate) fn new() -> Self {
@@ -263,47 +282,29 @@ impl<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
             _phantom_data: Default::default(),
         }
     }
-}
 
-#[async_trait]
-impl<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-    ProtocolServer<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-    for CompactBlockServer<DownloadUnitId, ProtocolUnitId, ProtocolUnit>
-where
-    DownloadUnitId: Encode + Decode + Clone,
-    ProtocolUnitId: Encode + Decode + Clone,
-    ProtocolUnit: Encode + Decode,
-{
-    type Request = CompactBlockRequest<DownloadUnitId, ProtocolUnitId>;
-    type Response = CompactBlockResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>;
-
-    fn build_initial_response(
+    /// Builds the protocol response to the initial request.
+    pub(crate) fn build_initial_response(
         &self,
         download_unit_id: &DownloadUnitId,
-        initial_request: Self::Request,
+        _initial_request: CompactBlockInitialRequest,
         backend: &dyn ServerBackend<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
-    ) -> Result<Self::Response, RelayError> {
-        if !matches!(initial_request, CompactBlockRequest::Initial) {
-            return Err(RelayError::UnexpectedInitialRequest);
-        }
-
+    ) -> Result<CompactBlockInitialResponse<DownloadUnitId, ProtocolUnitId, ProtocolUnit>, RelayError>
+    {
         // Return the info of the members in the download unit.
-        let response = InitialResponse {
+        Ok(CompactBlockInitialResponse {
             download_unit_id: download_unit_id.clone(),
             protocol_units: backend.download_unit_members(download_unit_id)?,
-        };
-        Ok(CompactBlockResponse::Initial(response))
+        })
     }
 
-    fn on_request(
+    /// Handles the additional client messages during the reconcile phase.
+    pub(crate) fn on_protocol_message(
         &self,
-        request: Self::Request,
+        message: CompactBlockHandshake<DownloadUnitId, ProtocolUnitId>,
         backend: &dyn ServerBackend<DownloadUnitId, ProtocolUnitId, ProtocolUnit>,
-    ) -> Result<Self::Response, RelayError> {
-        let request = match request {
-            CompactBlockRequest::MissingEntries(req) => req,
-            _ => return Err(RelayError::UnexpectedProtocolRequest),
-        };
+    ) -> Result<CompactBlockHandshakeResponse<ProtocolUnit>, RelayError> {
+        let CompactBlockHandshake::MissingEntries(request) = message;
 
         let mut protocol_units = BTreeMap::new();
         let total_len = request.protocol_unit_ids.len();
@@ -326,7 +327,7 @@ where
                 protocol_units.len()
             );
         }
-        Ok(CompactBlockResponse::MissingEntries(
+        Ok(CompactBlockHandshakeResponse::from(
             MissingEntriesResponse { protocol_units },
         ))
     }

--- a/crates/sc-subspace-block-relay/src/types.rs
+++ b/crates/sc-subspace-block-relay/src/types.rs
@@ -47,18 +47,6 @@ pub(crate) enum RelayError {
     #[error("Resolved entry not found: {0}")]
     ResolvedNotFound(usize),
 
-    #[error("Unexpected initial request")]
-    UnexpectedInitialRequest,
-
-    #[error("Unexpected initial response")]
-    UnexpectedInitialResponse,
-
-    #[error("Unexpected protocol request")]
-    UnexpectedProtocolRequest,
-
-    #[error("Unexpected protocol response")]
-    UnexpectedProtocolRespone,
-
     #[error("Request/response error: {0}")]
     RequestResponse(#[from] RequestResponseErr),
 }


### PR DESCRIPTION
Main changes:
1. Remove the `ProtocolClient/ProtocolServer` abstraction. Consensus relay
    layer interacts with the protocol implementation directly.
2. Versioned messages between client/server. This enables both protocol
    upgrade and making changes to the handshake messages.

Fixes https://github.com/subspace/subspace/issues/1449
### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
