### PR TITLE
Gemini 3f backport: Use dedicated thread pool per farm to avoid making audits of different farms sequential

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -177,13 +177,6 @@ where
         None => farmer_app_info.protocol_info.max_pieces_in_sector,
     };
 
-    let farming_thread_pool = Arc::new(
-        ThreadPoolBuilder::new()
-            .thread_name(move |thread_index| format!("farming#{thread_index}"))
-            .num_threads(farming_thread_pool_size)
-            .spawn_handler(tokio_rayon_spawn_handler())
-            .build()?,
-    );
     let plotting_thread_pool = Arc::new(
         ThreadPoolBuilder::new()
             .thread_name(move |thread_index| format!("plotting#{thread_index}"))
@@ -217,7 +210,7 @@ where
                 erasure_coding: erasure_coding.clone(),
                 piece_getter: piece_getter.clone(),
                 cache_percentage,
-                farming_thread_pool: Arc::clone(&farming_thread_pool),
+                farming_thread_pool_size,
                 plotting_thread_pool: Arc::clone(&plotting_thread_pool),
                 replotting_thread_pool: Arc::clone(&replotting_thread_pool),
             },

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -95,15 +95,18 @@ struct FarmingArgs {
     /// Do not print info about configured farms on startup
     #[arg(long)]
     no_info: bool,
-    /// Size of thread pool used for farming (mostly for blocking I/O, but also for some compute-intensive
-    /// operations during proving), defaults to number of CPU cores available in the system
+    /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
+    /// compute-intensive operations during proving), defaults to number of CPU cores available in
+    /// the system
     #[arg(long, default_value_t = available_parallelism())]
     farming_thread_pool_size: usize,
-    /// Size of thread pool used for plotting, defaults to number of CPU cores available in the system
+    /// Size of thread pool used for plotting, defaults to number of CPU cores available in the
+    /// system. This thread pool is global for all farms and generally doesn't need to be changed.
     #[arg(long, default_value_t = available_parallelism())]
     plotting_thread_pool_size: usize,
-    /// Size of thread pool used for replotting, typically smaller pool than for plotting to not affect farming as much,
-    /// defaults to half of the number of CPU cores available in the system.
+    /// Size of thread pool used for replotting, typically smaller pool than for plotting to not
+    /// affect farming as much, defaults to half of the number of CPU cores available in the system.
+    /// This thread pool is global for all farms and generally doesn't need to be changed.
     #[arg(long, default_value_t = available_parallelism() / 2)]
     replotting_thread_pool_size: usize,
 }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -285,9 +285,9 @@ pub struct SingleDiskFarmOptions<NC, PG> {
     pub erasure_coding: ErasureCoding,
     /// Percentage of allocated space dedicated for caching purposes
     pub cache_percentage: NonZeroU8,
-    /// Thread pool used for farming (mostly for blocking I/O, but also for some compute-intensive
-    /// operations during proving)
-    pub farming_thread_pool: Arc<ThreadPool>,
+    /// Thread pool size used for farming (mostly for blocking I/O, but also for some
+    /// compute-intensive operations during proving)
+    pub farming_thread_pool_size: usize,
     /// Thread pool used for plotting
     pub plotting_thread_pool: Arc<ThreadPool>,
     /// Thread pool used for replotting, typically smaller pool than for plotting to not affect
@@ -595,7 +595,7 @@ impl SingleDiskFarm {
             kzg,
             erasure_coding,
             cache_percentage,
-            farming_thread_pool,
+            farming_thread_pool_size,
             plotting_thread_pool,
             replotting_thread_pool,
         } = options;
@@ -991,6 +991,7 @@ impl SingleDiskFarm {
                         }
 
                         let farming_options = FarmingOptions {
+                            disk_farm_index,
                             public_key,
                             reward_address,
                             node_client,
@@ -1002,7 +1003,7 @@ impl SingleDiskFarm {
                             handlers,
                             modifying_sector_index,
                             slot_info_notifications: slot_info_forwarder_receiver,
-                            thread_pool: farming_thread_pool,
+                            thread_pool_size: farming_thread_pool_size,
                         };
                         farming::<PosTable, _>(farming_options).await
                     };


### PR DESCRIPTION
Identical to https://github.com/subspace/subspace/pull/2049

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
