### PR TITLE
Stream solutions

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -19,6 +19,7 @@
 
 #![feature(try_blocks)]
 
+use futures::channel::mpsc;
 use futures::{future, FutureExt, StreamExt};
 use jsonrpsee::core::{async_trait, Error as JsonRpseeError, RpcResult};
 use jsonrpsee::proc_macros::rpc;
@@ -61,7 +62,9 @@ use subspace_rpc_primitives::{
 };
 use tracing::{debug, error, warn};
 
-const SOLUTION_TIMEOUT: Duration = Duration::from_secs(2);
+/// This is essentially equal to expected number of votes per block, one more is added implicitly by
+/// the fact that channel sender exists
+const SOLUTION_SENDER_CHANNEL_CAPACITY: usize = 9;
 const REWARD_SIGNING_TIMEOUT: Duration = Duration::from_millis(500);
 const NODE_SYNC_STATUS_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -201,8 +204,7 @@ where
     new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
     archived_segment_notification_stream: SubspaceNotificationStream<ArchivedSegmentNotification>,
-    solution_response_senders:
-        Arc<Mutex<LruCache<SlotNumber, Vec<async_oneshot::Sender<SolutionResponse>>>>>,
+    solution_response_senders: Arc<Mutex<LruCache<SlotNumber, mpsc::Sender<SolutionResponse>>>>,
     reward_signature_senders: Arc<Mutex<BlockSignatureSenders>>,
     dsn_bootstrap_nodes: Vec<Multiaddr>,
     segment_headers_store: SegmentHeadersStore<AS>,
@@ -320,19 +322,12 @@ where
     fn submit_solution_response(&self, solution_response: SolutionResponse) -> RpcResult<()> {
         self.deny_unsafe.check_if_safe()?;
 
-        let solution_response_senders = self.solution_response_senders.clone();
-
-        // TODO: This doesn't track what client sent a solution, allowing some clients to send
-        //  multiple (https://github.com/paritytech/jsonrpsee/issues/452)
-
-        let mut solution_response_senders = solution_response_senders.lock();
-
         let slot = solution_response.slot_number;
+        let mut solution_response_senders = self.solution_response_senders.lock();
 
         let success = solution_response_senders
             .peek_mut(&slot)
-            .and_then(|senders| senders.pop())
-            .and_then(|mut sender| sender.send(solution_response).ok())
+            .and_then(|sender| sender.try_send(solution_response).ok())
             .is_some();
 
         if !success {
@@ -350,98 +345,90 @@ where
         let solution_response_senders = self.solution_response_senders.clone();
         let allow_solutions = self.deny_unsafe.check_if_safe().is_ok();
 
-        let stream =
-            self.new_slot_notification_stream
-                .subscribe()
-                .map(move |new_slot_notification| {
-                    let NewSlotNotification {
-                        new_slot_info,
-                        mut solution_sender,
-                    } = new_slot_notification;
+        let handle_slot_notification = move |new_slot_notification| {
+            let NewSlotNotification {
+                new_slot_info,
+                mut solution_sender,
+            } = new_slot_notification;
 
-                    // Only handle solution responses in case unsafe APIs are allowed
-                    if allow_solutions {
-                        let (response_sender, response_receiver) = async_oneshot::oneshot();
+            let slot_number = SlotNumber::from(new_slot_info.slot);
 
-                        // Store solution sender so that we can retrieve it when solution comes from
-                        // the farmer
-                        {
-                            let mut solution_response_senders = solution_response_senders.lock();
+            // Only handle solution responses in case unsafe APIs are allowed
+            if allow_solutions {
+                // Store solution sender so that we can retrieve it when solution comes from
+                // the farmer
+                let mut solution_response_senders = solution_response_senders.lock();
+                if solution_response_senders.peek(&slot_number).is_none() {
+                    let (response_sender, mut response_receiver) =
+                        mpsc::channel(SOLUTION_SENDER_CHANNEL_CAPACITY);
 
-                            solution_response_senders
-                                .get_or_insert_mut(SlotNumber::from(new_slot_info.slot), Vec::new)
-                                .push(response_sender);
-                        }
+                    solution_response_senders.push(slot_number, response_sender);
 
-                        // Wait for solutions and transform proposed proof of space solutions into
-                        // data structure `sc-consensus-subspace` expects
-                        let forward_solution_fut = async move {
-                            if let Ok(solution_response) = response_receiver.await {
-                                for solution in solution_response.solutions {
-                                    let public_key =
-                                        FarmerPublicKey::from_slice(solution.public_key.as_ref())
-                                            .expect("Always correct length; qed");
-                                    let reward_address = FarmerPublicKey::from_slice(
-                                        solution.reward_address.as_ref(),
-                                    )
-                                    .expect("Always correct length; qed");
+                    // Wait for solutions and transform proposed proof of space solutions
+                    // into data structure `sc-consensus-subspace` expects
+                    let forward_solution_fut = async move {
+                        while let Some(solution_response) = response_receiver.next().await {
+                            for solution in solution_response.solutions {
+                                let public_key =
+                                    FarmerPublicKey::from_slice(solution.public_key.as_ref())
+                                        .expect("Always correct length; qed");
+                                let reward_address =
+                                    FarmerPublicKey::from_slice(solution.reward_address.as_ref())
+                                        .expect("Always correct length; qed");
 
-                                    let sector_index = solution.sector_index;
+                                let sector_index = solution.sector_index;
 
-                                    let solution = Solution {
-                                        public_key: public_key.clone(),
-                                        reward_address,
-                                        sector_index,
-                                        history_size: solution.history_size,
-                                        piece_offset: solution.piece_offset,
-                                        record_commitment: solution.record_commitment,
-                                        record_witness: solution.record_witness,
-                                        chunk: solution.chunk,
-                                        chunk_witness: solution.chunk_witness,
-                                        audit_chunk_offset: solution.audit_chunk_offset,
-                                        proof_of_space: solution.proof_of_space,
-                                    };
+                                let solution = Solution {
+                                    public_key: public_key.clone(),
+                                    reward_address,
+                                    sector_index,
+                                    history_size: solution.history_size,
+                                    piece_offset: solution.piece_offset,
+                                    record_commitment: solution.record_commitment,
+                                    record_witness: solution.record_witness,
+                                    chunk: solution.chunk,
+                                    chunk_witness: solution.chunk_witness,
+                                    audit_chunk_offset: solution.audit_chunk_offset,
+                                    proof_of_space: solution.proof_of_space,
+                                };
 
-                                    if solution_sender.try_send(solution).is_err() {
-                                        warn!(
-                                            slot = %solution_response.slot_number,
-                                            %sector_index,
-                                            %public_key,
-                                            "Solution receiver is closed, likely because farmer \
-                                            was too slow"
-                                        );
-                                    }
+                                if solution_sender.try_send(solution).is_err() {
+                                    warn!(
+                                        slot = %solution_response.slot_number,
+                                        %sector_index,
+                                        %public_key,
+                                        "Solution receiver is closed, likely because farmer was too \
+                                        slow"
+                                    );
                                 }
                             }
-                        };
+                        }
+                    };
 
-                        // Run above future with timeout
-                        executor.spawn(
-                            "subspace-slot-info-forward",
-                            Some("rpc"),
-                            future::select(
-                                futures_timer::Delay::new(SOLUTION_TIMEOUT),
-                                Box::pin(forward_solution_fut),
-                            )
-                            .map(|_| ())
-                            .boxed(),
-                        );
-                    }
+                    executor.spawn(
+                        "subspace-slot-info-forward",
+                        Some("rpc"),
+                        Box::pin(forward_solution_fut),
+                    );
+                }
+            }
 
-                    let slot_number = new_slot_info.slot.into();
+            let global_challenge = new_slot_info
+                .global_randomness
+                .derive_global_challenge(slot_number);
 
-                    let global_challenge = new_slot_info
-                        .global_randomness
-                        .derive_global_challenge(slot_number);
-
-                    // This will be sent to the farmer
-                    SlotInfo {
-                        slot_number,
-                        global_challenge,
-                        solution_range: new_slot_info.solution_range,
-                        voting_solution_range: new_slot_info.voting_solution_range,
-                    }
-                });
+            // This will be sent to the farmer
+            SlotInfo {
+                slot_number,
+                global_challenge,
+                solution_range: new_slot_info.solution_range,
+                voting_solution_range: new_slot_info.voting_solution_range,
+            }
+        };
+        let stream = self
+            .new_slot_notification_stream
+            .subscribe()
+            .map(handle_slot_notification);
 
         let fut = async move {
             sink.pipe_from_stream(stream).await;

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -301,6 +301,7 @@ where
             })?;
 
         let farmer_app_info: Result<FarmerAppInfo, ApiError> = try {
+            let slot_duration = runtime_api.slot_duration(best_hash)?;
             let chain_constants = runtime_api.chain_constants(best_hash)?;
             let protocol_info = FarmerProtocolInfo {
                 history_size: runtime_api.history_size(best_hash)?,
@@ -313,6 +314,9 @@ where
             FarmerAppInfo {
                 genesis_hash,
                 dsn_bootstrap_nodes: self.dsn_bootstrap_nodes.clone(),
+                farming_timeout: slot_duration
+                    .as_duration()
+                    .mul_f64(SlotNumber::from(chain_constants.block_authoring_delay()) as f64),
                 protocol_info,
             }
         };

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -1,16 +1,17 @@
 use crate::node_client;
 use crate::node_client::NodeClient;
 use crate::single_disk_farm::Handlers;
+use crate::utils::AsyncJoinOnDrop;
 use futures::channel::mpsc;
 use futures::StreamExt;
 use parking_lot::{Mutex, RwLock};
 use rayon::prelude::*;
-use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
+use rayon::ThreadPoolBuildError;
 use std::fs::File;
 use std::io;
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::Kzg;
-use subspace_core_primitives::{PosSeed, PublicKey, SectorIndex, Solution, SolutionRange};
+use subspace_core_primitives::{PosSeed, PublicKey, SectorIndex, SolutionRange};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::proving::ProvableSolutions;
@@ -20,12 +21,6 @@ use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
 use tracing::{debug, error, info, trace, warn};
-
-/// Self-imposed limit for number of solutions that farmer will not go over per challenge.
-///
-/// Only useful for initial network bootstrapping where due to initial plot size there might be too
-/// many solutions.
-const SOLUTIONS_LIMIT: usize = 1;
 
 /// Errors that happen during farming
 #[derive(Debug, Error)]
@@ -47,12 +42,6 @@ pub enum FarmingError {
     FailedToMapMetadata {
         /// Lower-level error
         error: io::Error,
-    },
-    /// Failed to submit solutions response
-    #[error("Failed to submit solutions response: {error}")]
-    FailedToSubmitSolutionsResponse {
-        /// Lower-level error
-        error: node_client::Error,
     },
     /// Low-level proving error
     #[error("Low-level proving error: {0}")]
@@ -95,7 +84,6 @@ where
 }
 
 pub(super) struct FarmingOptions<'a, NC> {
-    pub(super) disk_farm_index: usize,
     pub(super) public_key: PublicKey,
     pub(super) reward_address: PublicKey,
     pub(super) node_client: NC,
@@ -107,7 +95,6 @@ pub(super) struct FarmingOptions<'a, NC> {
     pub(super) handlers: Arc<Handlers>,
     pub(super) modifying_sector_index: Arc<RwLock<Option<SectorIndex>>>,
     pub(super) slot_info_notifications: mpsc::Receiver<SlotInfo>,
-    pub(super) thread_pool_size: usize,
 }
 
 /// Starts farming process.
@@ -122,7 +109,6 @@ where
     NC: NodeClient,
 {
     let FarmingOptions {
-        disk_farm_index,
         public_key,
         reward_address,
         node_client,
@@ -134,36 +120,24 @@ where
         handlers,
         modifying_sector_index,
         mut slot_info_notifications,
-        thread_pool_size,
     } = farming_options;
-
-    let thread_pool = ThreadPoolBuilder::new()
-        .thread_name(move |thread_index| format!("farming-{disk_farm_index}.{thread_index}"))
-        .num_threads(thread_pool_size)
-        .build()?;
 
     let table_generator = Arc::new(Mutex::new(PosTable::generator()));
 
     while let Some(slot_info) = slot_info_notifications.next().await {
-        let modifying_sector_index = Arc::clone(&modifying_sector_index);
-        let sectors_metadata = Arc::clone(&sectors_metadata);
-        let table_generator = Arc::clone(&table_generator);
-        let kzg = kzg.clone();
-        let erasure_coding = erasure_coding.clone();
+        let slot = slot_info.slot_number;
+        let sectors_metadata = sectors_metadata.read();
+        let sector_count = sectors_metadata.len();
 
-        let response = thread_pool.install(move || {
-            let slot = slot_info.slot_number;
-            let sectors_metadata = sectors_metadata.read();
-            let sector_count = sectors_metadata.len();
+        debug!(%slot, %sector_count, "Reading sectors");
 
-            debug!(%slot, %sector_count, "Reading sectors");
+        let sectors = (0..sector_count)
+            .map(|sector_index| plot_file.offset(sector_index * sector_size))
+            .collect::<Vec<_>>();
 
+        let sectors_solutions = {
             let modifying_sector_guard = modifying_sector_index.read();
             let maybe_sector_being_modified = modifying_sector_guard.as_ref().copied();
-
-            let sectors = (0..sector_count)
-                .map(|sector_index| plot_file.offset(sector_index * sector_size))
-                .collect::<Vec<_>>();
 
             let mut sectors_solutions = sectors_metadata
                 .par_iter()
@@ -226,53 +200,49 @@ where
                 a_solution_distance.cmp(&b_solution_distance)
             });
 
-            let mut solutions = Vec::<Solution<PublicKey, PublicKey>>::new();
+            sectors_solutions
+        };
 
-            for (sector_index, sector_solutions) in sectors_solutions {
-                for maybe_solution in sector_solutions {
-                    let solution = match maybe_solution {
-                        Ok(solution) => solution,
-                        Err(error) => {
-                            error!(%slot, %sector_index, %error, "Failed to prove");
-                            // Do not error completely as disk corruption or other reasons why
-                            // proving might fail
-                            continue;
-                        }
-                    };
+        // Holds futures such that this function doesn't exit until all solutions were sent out
+        let mut sending_solutions = Vec::new();
 
-                    debug!(%slot, %sector_index, "Solution found");
-                    trace!(?solution, "Solution found");
-
-                    solutions.push(solution);
-
-                    if solutions.len() >= SOLUTIONS_LIMIT {
-                        break;
+        // TODO: This loop can take too long, abort if solutions will not make it into block/vote
+        //  anyway
+        for (sector_index, sector_solutions) in sectors_solutions {
+            for maybe_solution in sector_solutions {
+                let solution = match maybe_solution {
+                    Ok(solution) => solution,
+                    Err(error) => {
+                        error!(%slot, %sector_index, %error, "Failed to prove");
+                        // Do not error completely as disk corruption or other reasons why
+                        // proving might fail
+                        continue;
                     }
-                }
+                };
 
-                if solutions.len() >= SOLUTIONS_LIMIT {
-                    break;
-                }
-                // TODO: It is known that decoding is slow now and we'll only be
-                //  able to decode a single sector within time slot reliably, in the
-                //  future we may want allow more than one sector to be valid within
-                //  the same disk plot.
-                if !solutions.is_empty() {
-                    break;
-                }
+                debug!(%slot, %sector_index, "Solution found");
+                trace!(?solution, "Solution found");
+
+                let response = SolutionResponse {
+                    slot_number: slot_info.slot_number,
+                    solution,
+                };
+
+                handlers.solution.call_simple(&response);
+
+                let sending_solution = tokio::task::spawn({
+                    let node_client = node_client.clone();
+
+                    async move {
+                        if let Err(error) = node_client.submit_solution_response(response).await {
+                            warn!(%error, "Failed to submit solutions response");
+                        }
+                    }
+                });
+
+                sending_solutions.push(AsyncJoinOnDrop::new(sending_solution));
             }
-
-            SolutionResponse {
-                slot_number: slot_info.slot_number,
-                solutions,
-            }
-        });
-
-        handlers.solution.call_simple(&response);
-        node_client
-            .submit_solution_response(response)
-            .await
-            .map_err(|error| FarmingError::FailedToSubmitSolutionsResponse { error })?;
+        }
     }
 
     Ok(())

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -16,6 +16,7 @@
 //! Primitives for Subspace RPC.
 
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use subspace_core_primitives::{
     Blake2b256Hash, PublicKey, RewardSignature, SlotNumber, Solution, SolutionRange,
 };
@@ -32,8 +33,10 @@ pub struct FarmerAppInfo {
     /// Genesis hash of the chain
     #[serde(with = "hex::serde")]
     pub genesis_hash: [u8; 32],
-    /// Bootstrap nodes for DSN.
+    /// Bootstrap nodes for DSN
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
+    /// How much time farmer has to audit sectors and generate a solution
+    pub farming_timeout: Duration,
     /// Protocol info for farmer
     pub protocol_info: FarmerProtocolInfo,
 }

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -62,7 +62,7 @@ pub struct SolutionResponse {
     /// Solution farmer has for the challenge.
     ///
     /// Corresponds to `slot_number` above.
-    pub solutions: Vec<Solution<PublicKey, PublicKey>>,
+    pub solution: Solution<PublicKey, PublicKey>,
 }
 
 /// Reward info that needs to be signed.


### PR DESCRIPTION
With this change farmer will start streaming individual solutions to the node rather than sending all solutions as a batch before. The benefit here is that in case multiple solutions are present we no longer have to guess if farmer will be able to prove them all, it'll just send as many as it manages to prove within allocated time limit as described in https://github.com/subspace/subspace/issues/2021

Review individual commits with whitespaces ignored for smaller diff.

Resolves https://github.com/subspace/subspace/issues/2021

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
