### PR TITLE
update actions cache and enable key restore

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,11 +45,16 @@ jobs:
 
       - name: Configure cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        env:
+          cache-name: cargo-fmt
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ runner.os == 'Windows' && format('{0}/.cargo/registry', env.USERPROFILE) || '~/.cargo/registry' }}
+            ${{ runner.os == 'Windows' && format('{0}/.cargo/git', env.USERPROFILE) || '~/.cargo/git' }}
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.cache-name }}-
+            ${{ runner.os }}-cargo-
 
       - name: cargo fmt
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
@@ -99,12 +104,17 @@ jobs:
         continue-on-error: true
 
       - name: Configure cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # @v3.0.11
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        env:
+          cache-name: cargo-clippy
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ matrix.os == 'Windows' && format('{0}/.cargo/registry', env.USERPROFILE) || '~/.cargo/registry' }}
+            ${{ matrix.os == 'Windows' && format('{0}/.cargo/git', env.USERPROFILE) || '~/.cargo/git' }}
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ matrix.os }}-cargo-${{ env.cache-name }}-
+            ${{ matrix.os }}-cargo-
 
       - name: cargo clippy
         uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # @v1.0.7
@@ -124,12 +134,17 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # @v3.0.11
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        env:
+          cache-name: cargo-docs
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+            ${{ runner.os == 'Windows' && format('{0}/.cargo/registry', env.USERPROFILE) || '~/.cargo/registry' }}
+            ${{ runner.os == 'Windows' && format('{0}/.cargo/git', env.USERPROFILE) || '~/.cargo/git' }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.cache-name }}-
+            ${{ runner.os }}-cargo-
 
       - name: Check Documentation
         run: cargo doc --locked --all --no-deps --lib
@@ -183,12 +198,17 @@ jobs:
           tool: cargo-nextest
 
       - name: Configure cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # @v3.0.11
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        env:
+          cache-name: cargo-test
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ matrix.os == 'Windows' && format('{0}/.cargo/registry', env.USERPROFILE) || '~/.cargo/registry' }}
+            ${{ matrix.os == 'Windows' && format('{0}/.cargo/git', env.USERPROFILE) || '~/.cargo/git' }}
           key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ matrix.os }}-cargo-${{ env.cache-name }}-
+            ${{ matrix.os }}-cargo-
 
       - name: cargo nextest run --locked
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1


### PR DESCRIPTION
The PR expands on #2043 and uses key restore based on [github docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-multiple-restore-keys) and fixes paths for windows. It also adds the upgrades the actions package for all jobs.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
