### PR TITLE
Fix equivocation check in case two pieces end up containing the same chunk

### DIFF
--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -45,7 +45,7 @@ use std::assert_matches::assert_matches;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use subspace_core_primitives::crypto::Scalar;
-use subspace_core_primitives::{PotOutput, SegmentIndex, SolutionRange};
+use subspace_core_primitives::{PieceOffset, PotOutput, SegmentIndex, SolutionRange};
 use subspace_runtime_primitives::{FindBlockRewardAddress, FindVotingRewardAddresses};
 
 #[test]
@@ -1217,6 +1217,7 @@ fn vote_equivocation_current_block_plus_vote() {
         CurrentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             signed_vote.vote.solution().sector_index,
+            signed_vote.vote.solution().piece_offset,
             signed_vote.vote.solution().chunk,
             AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
             slot,
@@ -1271,6 +1272,7 @@ fn vote_equivocation_parent_block_plus_vote() {
         ParentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             signed_vote.vote.solution().sector_index,
+            signed_vote.vote.solution().piece_offset,
             signed_vote.vote.solution().chunk,
             AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
             slot,
@@ -1336,6 +1338,7 @@ fn vote_equivocation_current_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(voter_keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
                     AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
@@ -1357,6 +1360,7 @@ fn vote_equivocation_current_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(voter_keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
                     AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
@@ -1418,6 +1422,7 @@ fn vote_equivocation_parent_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
                     AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
@@ -1439,6 +1444,7 @@ fn vote_equivocation_parent_voters_duplicate() {
                 (
                     FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
                     signed_vote.vote.solution().sector_index,
+                    signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
                     AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
@@ -1470,6 +1476,7 @@ fn enabling_block_rewards_works() {
         CurrentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(Keypair::generate().public.to_bytes()),
             0,
+            PieceOffset::ZERO,
             Scalar::default(),
             AuditChunkOffset(0),
             Subspace::current_slot(),
@@ -1481,6 +1488,7 @@ fn enabling_block_rewards_works() {
                 (
                     FarmerPublicKey::unchecked_from(Keypair::generate().public.to_bytes()),
                     0,
+                    PieceOffset::ZERO,
                     Scalar::default(),
                     AuditChunkOffset(0),
                     Subspace::current_slot(),


### PR DESCRIPTION
I hit an interesting edge-case locally. Given how small our audit chunks are (just 8 bytes) there is small probability that two audit chunks at the same offset of the record chunk, but belonging to different pieces in the same sector end up being the same.

This is exactly what I hit locally and got my local farmer banned by itself :facepalm: What are the odds of this, right? :exploding_head: 

This PR simply adds missing piece of "uniqueness" aspect to the runtime.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
