### PR TITLE
Advise random file access on Windows too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11595,6 +11595,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -40,6 +40,9 @@ thiserror = "1.0.48"
 tokio = { version = "1.32.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync"] }
 tracing = "0.1.37"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
+
 [dev-dependencies]
 criterion = "0.5.1"
 futures = "0.3.28"

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -15,7 +15,7 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
-use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
@@ -168,6 +168,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .write(true)
             .create(true)
             .truncate(true)
+            .advise_random_access()
             .open(&plot_file_path)
             .unwrap();
 

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -16,7 +16,7 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
-use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
@@ -223,6 +223,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .write(true)
             .create(true)
             .truncate(true)
+            .advise_random_access()
             .open(&plot_file_path)
             .unwrap();
 

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -13,7 +13,7 @@ use subspace_core_primitives::{
     HistorySize, PieceOffset, PublicKey, Record, RecordedHistorySegment, SectorId,
 };
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
 use subspace_farmer_components::reading::read_piece;
 use subspace_farmer_components::sector::{
@@ -168,6 +168,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .write(true)
             .create(true)
             .truncate(true)
+            .advise_random_access()
             .open(&plot_file_path)
             .unwrap();
 

--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -1,7 +1,55 @@
 //! File extension trait
 
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::Result;
+
+pub trait OpenOptionsExt {
+    /// Advise OS/file system that file will use random access and read-ahead behavior is
+    /// undesirable, only has impact on Windows, for other operating systems see [`FileExt`]
+    fn advise_random_access(&mut self) -> &mut Self;
+
+    /// Advise OS/file system that file will use sequential access and read-ahead behavior is
+    /// desirable, only has impact on Windows, for other operating systems see [`FileExt`]
+    fn advise_sequential_access(&mut self) -> &mut Self;
+}
+
+impl OpenOptionsExt for OpenOptions {
+    #[cfg(target_os = "linux")]
+    fn advise_random_access(&mut self) -> &mut Self {
+        // Not supported
+        self
+    }
+
+    #[cfg(target_os = "macos")]
+    fn advise_random_access(&mut self) -> &mut Self {
+        // Not supported
+        self
+    }
+
+    #[cfg(windows)]
+    fn advise_random_access(&mut self) -> &mut Self {
+        use std::os::windows::fs::OpenOptionsExt;
+        self.custom_flags(winapi::um::winbase::FILE_FLAG_RANDOM_ACCESS)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn advise_sequential_access(&mut self) -> &mut Self {
+        // Not supported
+        self
+    }
+
+    #[cfg(target_os = "macos")]
+    fn advise_sequential_access(&mut self) -> &mut Self {
+        // Not supported
+        self
+    }
+
+    #[cfg(windows)]
+    fn advise_sequential_access(&mut self) -> &mut Self {
+        use std::os::windows::fs::OpenOptionsExt;
+        self.custom_flags(winapi::um::winbase::FILE_FLAG_SEQUENTIAL_SCAN)
+    }
+}
 
 /// Extension convenience trait that allows pre-allocating files, suggesting random access pattern
 /// and doing cross-platform exact reads/writes
@@ -10,11 +58,11 @@ pub trait FileExt {
     fn preallocate(&self, len: u64) -> Result<()>;
 
     /// Advise OS/file system that file will use random access and read-ahead behavior is
-    /// undesirable
+    /// undesirable, on Windows this can only be set when file is opened, see [`OpenOptionsExt`]
     fn advise_random_access(&self) -> Result<()>;
 
     /// Advise OS/file system that file will use sequential access and read-ahead behavior is
-    /// desirable
+    /// desirable, on Windows this can only be set when file is opened, see [`OpenOptionsExt`]
     fn advise_sequential_access(&self) -> Result<()>;
 
     /// Read exact number of bytes at a specific offset
@@ -50,7 +98,7 @@ impl FileExt for File {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(windows)]
     fn advise_random_access(&self) -> Result<()> {
         // Not supported
         Ok(())
@@ -78,7 +126,7 @@ impl FileExt for File {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(windows)]
     fn advise_sequential_access(&self) -> Result<()> {
         // Not supported
         Ok(())

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -44,7 +44,7 @@ use subspace_core_primitives::{
     SegmentIndex,
 };
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{PieceGetter, PlottedSector};
 use subspace_farmer_components::sector::{sector_size, SectorMetadata, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
@@ -748,6 +748,7 @@ impl SingleDiskFarm {
             .read(true)
             .write(true)
             .create(true)
+            .advise_random_access()
             .open(directory.join(Self::METADATA_FILE))?;
 
         metadata_file.advise_random_access()?;
@@ -823,6 +824,7 @@ impl SingleDiskFarm {
                 .read(true)
                 .write(true)
                 .create(true)
+                .advise_random_access()
                 .open(directory.join(Self::PLOT_FILE))?,
         );
 

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::{fs, io, mem};
 use subspace_core_primitives::crypto::blake3_hash_list;
 use subspace_core_primitives::{Blake3Hash, Piece, PieceIndex};
-use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
@@ -63,6 +63,7 @@ impl DiskPieceCache {
             .read(true)
             .write(true)
             .create(true)
+            .advise_random_access()
             .open(directory.join(Self::FILE_NAME))?;
 
         file.advise_random_access()?;


### PR DESCRIPTION
It was lacking on Windows, but turns out there is a way to get it, it just needs to be done during file opening and cant't be changed later, at least I have not seen the API for that.

We did advise random access on memory-mapped I/O previously, but since it was removed users repoted that Linux works fine, but Windows doesn't. I suspect this is the reason, I see no other thigns that would be fundamentally different.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
