### PR TITLE
Reduce PoT iterations for dev

### DIFF
--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -311,7 +311,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, String> 
                     enable_rewards: false,
                     enable_storage_access: false,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
-                    pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
+                    pot_slot_iterations: NonZeroU32::new(3_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_balance_transfers: true,
                     confirmation_depth_k: 5,


### PR DESCRIPTION
PoT iterations is currently set to 100M which takes around 35 sec on M1. Reduce the iterations to bring it around 1 sec

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
