### PR TITLE
Require AES instructions on aarch64 and x86-64 by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(target_arch = "x64_64")']
+# Require AES-NI on x86-64 by default
+rustflags = "-C target-feature=+aes"
+
+[target.'cfg(target_arch = "aarch64")']
+# TODO: Try to remove once https://github.com/paritytech/substrate/issues/11538 is resolved
+# TODO: AES flag is such that we have decent performance on ARMv8, remove once `aes` crate bumps MSRV to at least
+#  1.61: https://github.com/RustCrypto/block-ciphers/issues/373
+rustflags = "--cfg aes_armv8"


### PR DESCRIPTION
This is a more appropriate solution for underlying issue that https://github.com/subspace/subspace/pull/2059 was trying to address

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
