### PR TITLE
Include domains inherent in inherent check.

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1016,6 +1016,7 @@ impl_runtime_apis! {
 
         fn is_inherent(ext: &<Block as BlockT>::Extrinsic) -> bool {
             match &ext.function {
+                RuntimeCall::Domains(call) => Domains::is_inherent(call),
                 RuntimeCall::Subspace(call) => Subspace::is_inherent(call),
                 RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
                 _ => false,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1305,6 +1305,7 @@ impl_runtime_apis! {
 
         fn is_inherent(ext: &<Block as BlockT>::Extrinsic) -> bool {
             match &ext.function {
+                RuntimeCall::Domains(call) => Domains::is_inherent(call),
                 RuntimeCall::Subspace(call) => Subspace::is_inherent(call),
                 RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
                 _ => false,


### PR DESCRIPTION
Domains recently introduced an inherent type that is not accounted for in the runtime `is_inherent()` API. This resulted in local Tx pool miss with block relay.

### Code contributor checklist:
* [ ] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
