### PR TITLE
Temporarily disable connected-peers tests on Windows.

### DIFF
--- a/crates/subspace-networking/src/protocols/connected_peers.rs
+++ b/crates/subspace-networking/src/protocols/connected_peers.rs
@@ -23,6 +23,8 @@
 //! a single connection for each peer. Multiple protocol instances could be instantiated.
 
 mod handler;
+
+#[cfg(not(windows))] // TODO: Restore tests on windows after changing the waiting algorithm
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
This PR temporarily disables tests for `connected peers` protocol on Windows. It will be restored after changing the waiting algorithm crucial for tests.

Relates to https://github.com/subspace/subspace/issues/2045


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
