### PR TITLE
Faster auditing on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,6 +6511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11537,6 +11546,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "lru 0.11.1",
+ "memmap2 0.9.0",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "prometheus-client 0.21.2",

--- a/crates/subspace-farmer-components/src/auditing.rs
+++ b/crates/subspace-farmer-components/src/auditing.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 #[derive(Debug, Clone)]
 pub struct AuditResult<'a, Sector>
 where
-    Sector: ?Sized,
+    Sector: 'a,
 {
     /// Solution candidates
     pub solution_candidates: SolutionCandidates<'a, Sector>,
@@ -46,11 +46,11 @@ pub fn audit_sector<'a, Sector>(
     sector_index: SectorIndex,
     global_challenge: &Blake2b256Hash,
     solution_range: SolutionRange,
-    sector: &'a Sector,
+    sector: Sector,
     sector_metadata: &'a SectorMetadataChecksummed,
 ) -> Option<AuditResult<'a, Sector>>
 where
-    Sector: ReadAt + ?Sized,
+    Sector: ReadAt + 'a,
 {
     let sector_id = SectorId::new(public_key.hash(), sector_index);
 

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -56,3 +56,6 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 zeroize = "1.6.0"
+
+[target.'cfg(windows)'.dependencies]
+memmap2 = "0.9.0"

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -166,8 +166,6 @@ where
 
                     Some((sector_index, audit_results.solution_candidates))
                 })
-                .collect::<Vec<_>>()
-                .into_iter()
                 .filter_map(|(sector_index, solution_candidates)| {
                     let sector_solutions = match solution_candidates.into_solutions(
                         &reward_address,

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -4,6 +4,8 @@ use crate::single_disk_farm::Handlers;
 use crate::utils::AsyncJoinOnDrop;
 use futures::channel::mpsc;
 use futures::StreamExt;
+#[cfg(windows)]
+use memmap2::Mmap;
 use parking_lot::{Mutex, RwLock};
 use rayon::prelude::*;
 use rayon::ThreadPoolBuildError;
@@ -15,9 +17,11 @@ use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{PosSeed, PublicKey, SectorIndex, SolutionRange};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
+use subspace_farmer_components::proving;
 use subspace_farmer_components::proving::ProvableSolutions;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
-use subspace_farmer_components::{proving, ReadAt};
+#[cfg(not(windows))]
+use subspace_farmer_components::ReadAt;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
@@ -125,6 +129,8 @@ where
     // We assume that each slot is one second
     let farming_timeout = farmer_app_info.farming_timeout;
 
+    #[cfg(windows)]
+    let plot_mmap = unsafe { Mmap::map(plot_file)? };
     let table_generator = Arc::new(Mutex::new(PosTable::generator()));
 
     while let Some(slot_info) = slot_info_notifications.next().await {
@@ -135,9 +141,15 @@ where
 
         debug!(%slot, %sector_count, "Reading sectors");
 
+        #[cfg(not(windows))]
         let sectors = (0..sector_count)
-            .map(|sector_index| plot_file.offset(sector_index * sector_size))
-            .collect::<Vec<_>>();
+            .into_par_iter()
+            .map(|sector_index| plot_file.offset(sector_index * sector_size));
+        // On Windows random read is horrible in terms of performance, memory-mapped I/O helps
+        // TODO: Remove this once https://internals.rust-lang.org/t/introduce-write-all-at-read-exact-at-on-windows/19649
+        //  or similar exists in standard library
+        #[cfg(windows)]
+        let sectors = plot_mmap.par_chunks_exact(sector_size);
 
         let sectors_solutions = {
             let modifying_sector_guard = modifying_sector_index.read();
@@ -145,7 +157,7 @@ where
 
             let mut sectors_solutions = sectors_metadata
                 .par_iter()
-                .zip(&sectors)
+                .zip(sectors)
                 .enumerate()
                 .filter_map(|(sector_index, (sector_metadata, sector))| {
                     let sector_index = sector_index as u16;


### PR DESCRIPTION
I was trying to understand what is going on with Windows users reporting auditing performance downgrade in releases after `sep-25` where memory-mapped I/O was removed.

The best guess is that file operations exposed by standard library are too slow in Windows: https://internals.rust-lang.org/t/introduce-write-at-write-all-at-read-at-read-exact-at-on-windows/19649

Even when we have enough threads to scan the plot, it is not able to prove fast enough (which involves reading of A LOT of 32-byte chunks).

The solution I came up with is to still use memory-mapped I/O on Windows, but only map a single sector at a time rather than the whole plot (to fix high apparent memory usage and avoid hitting OS limits). I hope mapping a sector is not too expensive for it to be significantly worse than the old design.

I tried to find a library that does efficient random reads in Rust and didn't find any, so this is my best guess. Test snapshot for Gemini 3f is already building, I'll merge this once users confirm it helps.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
