### PR TITLE
No colors in farmer logs on Windows

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -257,8 +257,13 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
             fmt::layer()
-                // TODO: Workaround for https://github.com/tokio-rs/tracing/issues/2214
-                .with_ansi(supports_color::on(supports_color::Stream::Stderr).is_some())
+                // TODO: Workaround for https://github.com/tokio-rs/tracing/issues/2214, also on
+                //  Windows terminal doesn't support the same colors as bash does
+                .with_ansi(if cfg!(windows) {
+                    false
+                } else {
+                    supports_color::on(supports_color::Stream::Stderr).is_some()
+                })
                 .with_filter(
                     EnvFilter::builder()
                         .with_default_directive(LevelFilter::INFO.into())


### PR DESCRIPTION
All the logs provided by users have escape characters for no reason and look awful in logs. I have already fixed it for node in our fork of Substrate, but for farmer I forgot to disable colors on Windows, this fixes it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
