### PR TITLE
Update connected-peers tests in subspace-networking crate.

### DIFF
--- a/crates/subspace-networking/src/protocols/connected_peers.rs
+++ b/crates/subspace-networking/src/protocols/connected_peers.rs
@@ -24,7 +24,6 @@
 
 mod handler;
 
-#[cfg(not(windows))] // TODO: Restore tests on windows after changing the waiting algorithm
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
This PR introduces a different delay mechanism in tests for windows and other systems. Windows will get its "delay signal" from a separate thread. Relates to https://github.com/subspace/subspace/issues/2045

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
