### PR TITLE
Mandatory PoT checkpoints in justifications

### DIFF
--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -132,6 +132,13 @@ impl SubspaceJustification {
         (*consensus_engine_id == SUBSPACE_ENGINE_ID)
             .then(|| Self::decode(&mut encoded_justification.as_slice()))
     }
+
+    /// Returns `true` if justification must be archived, implies that it is canonical
+    pub fn must_be_archived(&self) -> bool {
+        match self {
+            SubspaceJustification::PotCheckpoints { .. } => true,
+        }
+    }
 }
 
 /// An equivocation proof for multiple block authorships on the same slot (i.e. double vote).

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -24,6 +24,7 @@ pub mod domain_chain_spec;
 use futures::executor::block_on;
 use futures::StreamExt;
 use sc_client_api::{BlockBackend, HeaderBackend};
+use sc_consensus_subspace::archiver::encode_block;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::{NewSlotNotification, RewardSigningNotification};
 use sp_api::ProvideRuntimeApi;
@@ -226,13 +227,13 @@ where
     let mut archiver = subspace_archiving::archiver::Archiver::new(kzg.clone())
         .expect("Incorrect parameters for archiver");
 
-    let genesis_block = client
-        .block(client.info().genesis_hash)
-        .unwrap()
-        .unwrap()
-        .block;
+    let genesis_block = client.block(client.info().genesis_hash).unwrap().unwrap();
     let archived_segment = archiver
-        .add_block(genesis_block.encode(), BlockObjectMapping::default(), true)
+        .add_block(
+            encode_block(genesis_block),
+            BlockObjectMapping::default(),
+            true,
+        )
         .into_iter()
         .next()
         .expect("First block is always producing one segment; qed");


### PR DESCRIPTION
As discussed in https://forum.subspace.network/t/not-requiring-justifications-in-blocks-can-lead-to-trivial-dos-attacks/1926 this allows us to efficiently verify each slot and avoid some DoS attacks.

Note that this is a breaking change to the archiving process, I have added utility functions to centralize block encoding/decoding and reduce the chance of breaking changes during future refactoring.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
