### PR TITLE
Remove `chia` and `shim` features in `subspace-proof-of-space`

### DIFF
--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -43,7 +43,7 @@ subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding" }
-subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["shim"] }
+subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 
 [features]
 default = ["std"]

--- a/crates/sp-consensus-subspace/Cargo.toml
+++ b/crates/sp-consensus-subspace/Cargo.toml
@@ -56,8 +56,6 @@ std = [
 	"sp-timestamp/std",
 	"subspace-archiving/std",
 	"subspace-core-primitives/std",
-	"subspace-proof-of-space/chia",
-	"subspace-proof-of-space/shim",
 	"subspace-proof-of-space/std",
 	"subspace-verification/std",
 	"thiserror",

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -47,7 +47,7 @@ winapi = "0.3.9"
 criterion = "0.5.1"
 futures = "0.3.28"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
-subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["chia"] }
+subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 
 [[bench]]
 name = "plotting"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -45,7 +45,7 @@ subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-com
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-metrics = { version = "0.1.0", path = "../../shared/subspace-metrics" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
-subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["chia"] }
+subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
 substrate-bip39 = "0.4.4"
 supports-color = "2.0.0"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -70,7 +70,7 @@ sp-wasm-interface = { version = "14.0.0", git = "https://github.com/subspace/pol
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
-subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["chia"] }
+subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-runtime = { version = "0.1.0", path = "../subspace-runtime" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 subspace-service = { version = "0.1.0", path = "../subspace-service" }

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -16,11 +16,11 @@ include = [
 bench = false
 
 [dependencies]
-chacha20 = { version = "0.9.1", default-features = false, optional = true }
-derive_more = { version = "0.99.17", optional = true }
+chacha20 = { version = "0.9.1", default-features = false }
+derive_more = "0.99.17"
 rayon = { version = "1.7.0", optional = true }
-seq-macro = { version = "0.3.5", optional = true }
-sha2 = { version = "0.10.7", optional = true }
+seq-macro = "0.3.5"
+sha2 = { version = "0.10.7", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
@@ -36,7 +36,8 @@ harness = false
 [features]
 default = ["std"]
 std = [
-    "chacha20?/std",
+    "chacha20/std",
+    "sha2/std",
     "subspace-core-primitives/std",
 ]
 parallel = [
@@ -44,13 +45,3 @@ parallel = [
     # Parallel implementation requires std due to usage of channels to achieve highest performance
     "std",
 ]
-# Enable Chia proof of space support
-chia = [
-    "chacha20",
-    "derive_more",
-    "seq-macro",
-    "sha2",
-]
-# Enables shim proof of space that works much faster than Chia and can be used for testing purposes to reduce memory
-# and CPU usage
-shim = []

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -1,16 +1,11 @@
 #![feature(const_trait_impl)]
 
-#[cfg(any(feature = "chia", feature = "shim"))]
-use criterion::black_box;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[cfg(feature = "parallel")]
 use rayon::ThreadPoolBuilder;
-#[cfg(any(feature = "chia", feature = "shim"))]
 use subspace_core_primitives::PosSeed;
-#[cfg(any(feature = "chia", feature = "shim"))]
 use subspace_proof_of_space::{Quality, Table, TableGenerator};
 
-#[cfg(any(feature = "chia", feature = "shim"))]
 fn pos_bench<PosTable>(
     c: &mut Criterion,
     name: &'static str,
@@ -91,12 +86,6 @@ fn pos_bench<PosTable>(
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    #[cfg(not(any(feature = "chia", feature = "shim")))]
-    {
-        let _ = c;
-        panic!(r#"Enable "chia" and/or "shim" feature to run benches"#);
-    }
-    #[cfg(feature = "chia")]
     {
         // This challenge index with above seed is known to not have a solution
         let challenge_index_without_solution = 1232460437;
@@ -110,7 +99,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             challenge_index_with_solution,
         )
     }
-    #[cfg(feature = "shim")]
     {
         // This challenge index with above seed is known to not have a solution
         let challenge_index_without_solution = 0;

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -13,11 +13,10 @@ use alloc::vec::Vec;
 use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
 use chacha20::{ChaCha8, Key, Nonce};
 use core::mem;
-use core::simd::Simd;
+use core::simd::{Simd, SimdUint};
 #[cfg(any(feature = "parallel", test))]
 use rayon::prelude::*;
 use seq_macro::seq;
-use std::simd::SimdUint;
 #[cfg(any(feature = "parallel", test))]
 use std::sync::mpsc;
 use subspace_core_primitives::crypto::{blake3_hash, blake3_hash_list};

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests;
 
+extern crate alloc;
+
 use crate::chiapos::table::types::{Metadata, Position, X, Y};
 pub use crate::chiapos::table::TablesCache;
 use crate::chiapos::table::{
@@ -9,6 +11,7 @@ use crate::chiapos::table::{
 };
 use crate::chiapos::utils::EvaluatableUsize;
 use crate::chiapos::{Challenge, Quality, Seed};
+use alloc::vec::Vec;
 use core::mem;
 use sha2::{Digest, Sha256};
 

--- a/crates/subspace-proof-of-space/src/lib.rs
+++ b/crates/subspace-proof-of-space/src/lib.rs
@@ -13,11 +13,8 @@
     step_trait
 )]
 
-#[cfg(feature = "chia")]
 pub mod chia;
-#[cfg(feature = "chia")]
 pub mod chiapos;
-#[cfg(feature = "shim")]
 pub mod shim;
 
 use core::fmt;
@@ -36,10 +33,8 @@ pub trait Quality {
 #[derive(Debug, Clone, Copy)]
 pub enum PosTableType {
     /// Chia table
-    #[cfg(feature = "chia")]
     Chia,
     /// Shim table
-    #[cfg(feature = "shim")]
     Shim,
 }
 

--- a/crates/subspace-proof-of-space/src/shim.rs
+++ b/crates/subspace-proof-of-space/src/shim.rs
@@ -1,4 +1,5 @@
-//! Shim proof of space implementation
+//! Shim proof of space implementation that works much faster than Chia and can be used for testing
+//! purposes to reduce memory and CPU usage
 
 use crate::{PosTableType, Quality, Table, TableGenerator};
 use core::iter;


### PR DESCRIPTION
Chia was especially annoying to compile in the past, but now that it doesn't depend on C++ library there is no significant benefit for those features to exist.

I also added/fixed no-std support for Chia, there were some issues with imports.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
