### PR TITLE
Stop proving on RPC error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11531,6 +11531,7 @@ name = "subspace-farmer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-lock",
  "async-trait",
  "atomic",
  "backoff",

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -343,6 +343,8 @@ where
                 %slot,
                 "Solution was ignored, likely because farmer was too slow"
             );
+
+            return Err(JsonRpseeError::Custom("Solution was ignored".to_string()));
         }
 
         Ok(())

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -13,6 +13,7 @@ include = [
 
 [dependencies]
 anyhow = "1.0.75"
+async-lock = "2.8.0"
 async-trait = "0.1.73"
 atomic = "0.5.3"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }

--- a/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
@@ -1,6 +1,6 @@
+use async_lock::RwLock;
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
-use parking_lot::RwLock;
 use std::fs::File;
 use std::future::Future;
 use std::sync::Arc;
@@ -104,7 +104,7 @@ async fn read_pieces<PosTable>(
             continue;
         }
 
-        let modifying_sector_guard = modifying_sector_index.read();
+        let modifying_sector_guard = modifying_sector_index.read().await;
 
         if *modifying_sector_guard == Some(sector_index) {
             // Skip sector that is being modified right now
@@ -112,7 +112,7 @@ async fn read_pieces<PosTable>(
         }
 
         let (sector_metadata, sector_count) = {
-            let sectors_metadata = sectors_metadata.read();
+            let sectors_metadata = sectors_metadata.read().await;
 
             let sector_count = sectors_metadata.len() as SectorIndex;
 


### PR DESCRIPTION
This PR tries to address the edge-case when farmer "thinks" it still has time to prove, while it is actually not the case anymore.

Previously node didn't provide any feedback to farmer about ignored solutions, this PR changes that. Also since RPC request should barely take any significant time, farmer will wait for response before attempting to prove the next solution.

This is essentially an improved self-throttling mechanism in addition to existing time limit.

The first commit simply changes sync RwLock to async version to ensure we don't hold it across newly introduced `.await` point.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
