### PR TITLE
Upgrade Rust to nightly-2023-10-11, fix new lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11578,6 +11578,7 @@ dependencies = [
 name = "subspace-farmer-components"
 version = "0.1.0"
 dependencies = [
+ "async-lock",
  "async-trait",
  "backoff",
  "bitvec",
@@ -11588,7 +11589,6 @@ dependencies = [
  "libc",
  "lru 0.11.1",
  "parity-scale-codec",
- "parking_lot 0.12.1",
  "rand 0.8.5",
  "rayon",
  "schnorrkel",

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-07-21
+ARG RUSTC_VERSION=nightly-2023-10-11
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -398,7 +398,7 @@ impl<T: Config> Call<T> {
                         let mut co = object_mapping.try_into_call_object(
                             feed_id,
                             object.as_slice(),
-                            |data| crypto::blake3_hash(data),
+                            crypto::blake3_hash,
                         )?;
                         co.offset += base_offset;
                         Some(co)

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -81,7 +81,7 @@ impl<AS> SegmentHeadersStore<AS>
 where
     AS: AuxStore,
 {
-    const KEY_PREFIX: &[u8] = b"segment-headers";
+    const KEY_PREFIX: &'static [u8] = b"segment-headers";
     const INITIAL_CACHE_CAPACITY: usize = 1_000;
 
     /// Create new instance

--- a/crates/sp-domains/src/verification.rs
+++ b/crates/sp-domains/src/verification.rs
@@ -148,10 +148,7 @@ pub fn shuffle_extrinsics<Extrinsic: Debug, AccountId: Ord + Clone>(
     let mut grouped_extrinsics: BTreeMap<Option<AccountId>, VecDeque<_>> = extrinsics
         .into_iter()
         .fold(BTreeMap::new(), |mut groups, (maybe_signer, tx)| {
-            groups
-                .entry(maybe_signer)
-                .or_insert_with(VecDeque::new)
-                .push_back(tx);
+            groups.entry(maybe_signer).or_default().push_back(tx);
             groups
         });
 

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 bench = false
 
 [dependencies]
+async-lock = "2.8.0"
 async-trait = "0.1.73"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bitvec = "1.0.1"
@@ -25,7 +26,6 @@ hex = "0.4.3"
 libc = "0.2.146"
 lru = "0.11.0"
 parity-scale-codec = "3.6.5"
-parking_lot = "0.12.1"
 rand = "0.8.5"
 rayon = "1.7.0"
 schnorrkel = "0.9.1"

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -4,13 +4,13 @@ use crate::sector::{
 };
 use crate::segment_reconstruction::recover_missing_piece;
 use crate::FarmerProtocolInfo;
+use async_lock::Mutex;
 use async_trait::async_trait;
 use backoff::future::retry;
 use backoff::{Error as BackoffError, ExponentialBackoff};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use parity_scale_codec::Encode;
-use parking_lot::Mutex;
 use std::error::Error;
 use std::mem;
 use std::simd::Simd;
@@ -227,8 +227,8 @@ where
             Mutex::new(piece_indexes.iter().copied().map(Some).collect::<Vec<_>>());
 
         retry(default_backoff(), || async {
-            let mut raw_sector = raw_sector.lock();
-            let mut incremental_piece_indices = incremental_piece_indices.lock();
+            let mut raw_sector = raw_sector.lock().await;
+            let mut incremental_piece_indices = incremental_piece_indices.lock().await;
 
             if let Err(error) = download_sector(
                 &mut raw_sector,

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -3,7 +3,6 @@
     const_option,
     hash_extract_if,
     impl_trait_in_assoc_type,
-    io_error_other,
     int_roundings,
     iter_collect_into,
     let_chains,

--- a/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
+++ b/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
@@ -177,17 +177,14 @@ async fn test_reserved_peers_dial_event() {
 
     peer1.listen().await;
 
-    loop {
-        select! {
-            event = peer1.next_swarm_event().fuse() => {
-                if let SwarmEvent::Dialing{peer_id, ..} = event{
-                    assert_eq!(peer_id, Some(peer2_id));
-                }
-                break;
-            },
-            _ = sleep(long_delay).fuse() => {
-                panic!("No reserved peers dialing.");
+    select! {
+        event = peer1.next_swarm_event().fuse() => {
+            if let SwarmEvent::Dialing{peer_id, ..} = event{
+                assert_eq!(peer_id, Some(peer2_id));
             }
+        },
+        _ = sleep(long_delay).fuse() => {
+            panic!("No reserved peers dialing.");
         }
     }
 

--- a/crates/subspace-service/src/metrics.rs
+++ b/crates/subspace-service/src/metrics.rs
@@ -63,7 +63,7 @@ where
             .block_body(incoming_block.hash)
             .ok()
             .flatten()
-            .unwrap_or(vec![]);
+            .unwrap_or_default();
         self.blocks.inc();
         self.extrinsics.inc_by(extrinsics.len() as u64);
         let total_size: usize = extrinsics

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-07-21"
+channel = "nightly-2023-10-11"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
I was hoping for massive performance gains, but turns out they are much more minor from just compiler upgrade, kind of how I expected: https://forum.subspace.network/t/attempts-to-optimise-the-subspace-node-at-compile-time/1979/7?u=nazar-pc

It is still an improvement though.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
