### PR TITLE
Domain client refactoring

### DIFF
--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -632,7 +632,6 @@ fn main() -> Result<(), Error> {
                             .new_slot_notification_stream
                             .clone(),
                         consensus_sync_service: consensus_chain_node.sync_service.clone(),
-                        select_chain: consensus_chain_node.select_chain.clone(),
                         domain_message_receiver,
                         gossip_message_sink: xdm_gossip_worker_builder.gossip_msg_sink(),
                     };

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -91,7 +91,6 @@ impl DomainInstanceStarter {
                     (
                         slot_notification.new_slot_info.slot,
                         slot_notification.new_slot_info.global_randomness,
-                        None::<futures::channel::mpsc::Sender<()>>,
                     )
                 })
         };
@@ -102,6 +101,7 @@ impl DomainInstanceStarter {
             block_importing_notification_stream: block_importing_notification_stream(),
             imported_block_notification_stream,
             new_slot_notification_stream: new_slot_notification_stream(),
+            acknowledgement_sender_stream: futures::stream::empty(),
             _phantom: Default::default(),
         };
 
@@ -140,6 +140,7 @@ impl DomainInstanceStarter {
                 };
 
                 let mut domain_node = domain_service::new_full::<
+                    _,
                     _,
                     _,
                     _,

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -19,7 +19,7 @@ use sp_domains::{DomainInstanceData, RuntimeType};
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_service::{FullClient as CFullClient, FullSelectChain};
+use subspace_service::FullClient as CFullClient;
 
 /// `DomainInstanceStarter` used to start a domain instance node based on the given
 /// bootstrap result
@@ -32,7 +32,6 @@ pub struct DomainInstanceStarter {
         SubspaceNotificationStream<BlockImportingNotification<CBlock>>,
     pub new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     pub consensus_sync_service: Arc<sc_network_sync::SyncingService<CBlock>>,
-    pub select_chain: FullSelectChain,
     pub domain_message_receiver: TracingUnboundedReceiver<Vec<u8>>,
     pub gossip_message_sink: TracingUnboundedSender<Message>,
 }
@@ -61,7 +60,6 @@ impl DomainInstanceStarter {
             block_importing_notification_stream,
             new_slot_notification_stream,
             consensus_sync_service,
-            select_chain,
             domain_message_receiver,
             gossip_message_sink,
         } = self;
@@ -135,7 +133,6 @@ impl DomainInstanceStarter {
                     consensus_client,
                     consensus_offchain_tx_pool_factory,
                     consensus_network_sync_oracle: consensus_sync_service.clone(),
-                    select_chain,
                     operator_streams,
                     gossip_message_sink,
                     domain_message_receiver,
@@ -143,7 +140,6 @@ impl DomainInstanceStarter {
                 };
 
                 let mut domain_node = domain_service::new_full::<
-                    _,
                     _,
                     _,
                     _,

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -9,7 +9,7 @@ use sp_api::{HeaderT, NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
 use sp_domains::{BundleHeader, ExecutionReceipt, ProofOfElection};
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, One, Saturating, Zero};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, One, Zero};
 use sp_weights::Weight;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -153,7 +153,7 @@ where
             sp_core::storage::StateVersion::V1,
         );
 
-        let receipt = self.load_bundle_receipt(parent_number, parent_hash, parent_chain)?;
+        let receipt = self.load_bundle_receipt(parent_number, parent_chain)?;
 
         let header = BundleHeader {
             proof_of_election,
@@ -170,7 +170,6 @@ where
     fn load_bundle_receipt<ParentChain, ParentChainBlock>(
         &self,
         header_number: NumberFor<Block>,
-        header_hash: Block::Hash,
         parent_chain: ParentChain,
     ) -> sp_blockchain::Result<ExecutionReceiptFor<Block, CBlock>>
     where
@@ -179,36 +178,14 @@ where
     {
         let parent_chain_block_hash = parent_chain.best_hash();
         let head_receipt_number = parent_chain.head_receipt_number(parent_chain_block_hash)?;
-        let max_drift = parent_chain.block_tree_pruning_depth(parent_chain_block_hash)?;
+        let receipt_number = (head_receipt_number + One::one()).min(header_number);
 
         tracing::trace!(
             ?header_number,
             ?head_receipt_number,
-            ?max_drift,
+            ?receipt_number,
             "Collecting receipts at {parent_chain_block_hash:?}"
         );
-
-        let header_block_receipt_is_written = crate::aux_schema::latest_consensus_block_hash_for::<
-            _,
-            _,
-            CBlock::Hash,
-        >(&*self.client, &header_hash)?
-        .is_some();
-
-        // TODO: remove once the receipt generation can be done before the domain block is
-        // committed to the database, in other words, only when the receipt of block N+1 has
-        // been generated can the `client.info().best_number` be updated from N to N+1.
-        //
-        // This requires:
-        // 1. Reimplement `runtime_api.intermediate_roots()` on the client side.
-        // 2. Add a hook before the upstream `client.commit_operation(op)`.
-        let available_best_receipt_number = if header_block_receipt_is_written {
-            header_number
-        } else {
-            header_number.saturating_sub(One::one())
-        };
-
-        let receipt_number = (head_receipt_number + One::one()).min(available_best_receipt_number);
 
         if receipt_number.is_zero() {
             let genesis_hash = self.client.info().genesis_hash;

--- a/domains/client/domain-operator/src/domain_worker.rs
+++ b/domains/client/domain-operator/src/domain_worker.rs
@@ -12,6 +12,7 @@ use sp_domains::{DomainsApi, OpaqueBundle};
 use sp_runtime::traits::{Header as HeaderT, NumberFor};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use subspace_runtime_primitives::Balance;
 
 type OpaqueBundleFor<Block, CBlock> = OpaqueBundle<
@@ -22,161 +23,106 @@ type OpaqueBundleFor<Block, CBlock> = OpaqueBundle<
     Balance,
 >;
 
-pub(crate) async fn handle_slot_notifications<Block, CBlock, CClient, BundlerFn>(
-    consensus_client: &CClient,
-    consensus_offchain_tx_pool_factory: &OffchainTransactionPoolFactory<CBlock>,
-    bundler: BundlerFn,
-    mut slots: impl Stream<Item = (OperatorSlotInfo, Option<mpsc::Sender<()>>)> + Unpin,
-) where
-    Block: BlockT,
-    CBlock: BlockT,
-    CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock>,
-    CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>,
-    BundlerFn: Fn(
-            HashAndNumber<CBlock>,
-            OperatorSlotInfo,
-        ) -> Pin<Box<dyn Future<Output = Option<OpaqueBundleFor<Block, CBlock>>> + Send>>
-        + Send
-        + Sync,
-{
-    while let Some((operator_slot_info, slot_acknowledgement_sender)) = slots.next().await {
-        let slot = operator_slot_info.slot;
-        if let Err(error) = on_new_slot::<Block, CBlock, _, _>(
-            consensus_client,
-            consensus_offchain_tx_pool_factory.clone(),
-            &bundler,
-            operator_slot_info,
-        )
-        .await
-        {
-            tracing::error!(
-                ?error,
-                "Error occurred on producing a bundle at slot {slot}"
-            );
-            break;
-        }
-        if let Some(mut sender) = slot_acknowledgement_sender {
-            let _ = sender.send(()).await;
-        }
-    }
-}
-
+/// Throttle the consensus block import notification based on the `consensus_block_import_throttling_buffer_size`
+/// to pause the consensus block import in case the consensus chain runs much faster than the domain.
+///
+/// Return the throttled block import notification stream
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn handle_block_import_notifications<
+pub(crate) fn throttling_block_import_notifications<
     Block,
     CBlock,
     CClient,
-    ProcessorFn,
     BlocksImporting,
     BlocksImported,
 >(
     spawn_essential: Box<dyn SpawnEssentialNamed>,
-    consensus_client: &CClient,
-    processor: ProcessorFn,
+    consensus_client: Arc<CClient>,
     mut blocks_importing: BlocksImporting,
     mut blocks_imported: BlocksImported,
     consensus_block_import_throttling_buffer_size: u32,
-) where
+) -> mpsc::Receiver<Option<BlockInfo<CBlock>>>
+where
     Block: BlockT,
     CBlock: BlockT,
     CClient: HeaderBackend<CBlock>
         + BlockBackend<CBlock>
         + ProvideRuntimeApi<CBlock>
-        + BlockchainEvents<CBlock>,
-    CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>,
-    ProcessorFn: Fn(
-            (CBlock::Hash, NumberFor<CBlock>, bool),
-        ) -> Pin<Box<dyn Future<Output = Result<(), sp_blockchain::Error>> + Send>>
-        + Send
-        + Sync
+        + BlockchainEvents<CBlock>
         + 'static,
-    BlocksImporting: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Unpin,
-    BlocksImported: Stream<Item = BlockImportNotification<CBlock>> + Unpin,
+    CClient::Api: DomainsApi<CBlock, NumberFor<Block>, Block::Hash>,
+    BlocksImporting: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Unpin + Send + 'static,
+    BlocksImported: Stream<Item = BlockImportNotification<CBlock>> + Unpin + Send + 'static,
 {
     // The consensus chain can be ahead of the domain by up to `block_import_throttling_buffer_size/2`
     // blocks, for there are two notifications per block sent to this buffer (one will be actually
     // consumed by the domain processor, the other from `sc-consensus-subspace` is used to discontinue
     // the consensus block import in case the consensus chain runs much faster than the domain.).
-    let (mut block_info_sender, mut block_info_receiver) = mpsc::channel::<Option<BlockInfo<CBlock>>>(
+    let (mut block_info_sender, block_info_receiver) = mpsc::channel::<Option<BlockInfo<CBlock>>>(
         consensus_block_import_throttling_buffer_size as usize,
     );
 
-    // Run the actual processor in a dedicated task, otherwise `tokio::select!` might hang forever
-    // when the throttling buffer is full.
-    spawn_essential.spawn_essential_blocking(
-        "consensus-block-processor",
+    spawn_essential.spawn_essential(
+        "consensus-block-import-throttler",
         None,
         Box::pin(async move {
-            while let Some(maybe_block_info) = block_info_receiver.next().await {
-                if let Some(block_info) = maybe_block_info {
-                    if let Err(error) =
-                        processor((block_info.hash, block_info.number, block_info.is_new_best))
-                            .await
-                    {
-                        tracing::error!(?error, "Failed to process consensus block");
-                        // Bring down the service as bundles processor is an essential task.
-                        // TODO: more graceful shutdown.
-                        break;
+            loop {
+                tokio::select! {
+                    // Ensure the `blocks_imported` branch will be checked before the `blocks_importing` branch.
+                    // Currently this is only necessary for the test to ensure when both `block_imported` notification
+                    // and `blocks_importing` notification are arrived, the `block_imported` notification will be processed
+                    // first, such that we can ensure when the `blocks_importing` acknowledgement is responded, the
+                    // imported block must being processed by the executor.
+                    // Please see https://github.com/subspace/subspace/pull/1363#discussion_r1162571291 for more details.
+                    biased;
+
+                    maybe_block_imported = blocks_imported.next() => {
+                        let block_imported = match maybe_block_imported {
+                            Some(block_imported) => block_imported,
+                            None => {
+                                // Can be None on graceful shutdown.
+                                break;
+                            }
+                        };
+                        let header = match consensus_client.header(block_imported.hash) {
+                            Ok(Some(header)) => header,
+                            res => {
+                                tracing::error!(
+                                    result = ?res,
+                                    header = ?block_imported.header,
+                                    "Imported consensus block header not found",
+                                );
+                                return;
+                            }
+                        };
+                        let block_info = BlockInfo {
+                            hash: header.hash(),
+                            number: *header.number(),
+                            is_new_best: block_imported.is_new_best,
+                        };
+                        let _ = block_info_sender.feed(Some(block_info)).await;
+                    }
+                    maybe_block_importing = blocks_importing.next() => {
+                        let (_block_number, mut acknowledgement_sender) =
+                            match maybe_block_importing {
+                                Some(block_importing) => block_importing,
+                                None => {
+                                    // Can be None on graceful shutdown.
+                                    break;
+                                }
+                            };
+                        // Pause the consensus block import when the sink is full.
+                        let _ = block_info_sender.feed(None).await;
+                        let _ = acknowledgement_sender.send(()).await;
                     }
                 }
             }
         }),
     );
 
-    loop {
-        tokio::select! {
-            // Ensure the `blocks_imported` branch will be checked before the `blocks_importing` branch.
-            // Currently this is only necessary for the test to ensure when both `block_imported` notification
-            // and `blocks_importing` notification are arrived, the `block_imported` notification will be processed
-            // first, such that we can ensure when the `blocks_importing` acknowledgement is responded, the
-            // imported block must being processed by the executor.
-            // Please see https://github.com/subspace/subspace/pull/1363#discussion_r1162571291 for more details.
-            biased;
-
-            maybe_block_imported = blocks_imported.next() => {
-                let block_imported = match maybe_block_imported {
-                    Some(block_imported) => block_imported,
-                    None => {
-                        // Can be None on graceful shutdown.
-                        break;
-                    }
-                };
-                let header = match consensus_client.header(block_imported.hash) {
-                    Ok(Some(header)) => header,
-                    res => {
-                        tracing::error!(
-                            result = ?res,
-                            header = ?block_imported.header,
-                            "Imported consensus block header not found",
-                        );
-                        return;
-                    }
-                };
-                let block_info = BlockInfo {
-                    hash: header.hash(),
-                    number: *header.number(),
-                    is_new_best: block_imported.is_new_best,
-                };
-                let _ = block_info_sender.feed(Some(block_info)).await;
-            }
-            maybe_block_importing = blocks_importing.next() => {
-                let (_block_number, mut acknowledgement_sender) =
-                    match maybe_block_importing {
-                        Some(block_importing) => block_importing,
-                        None => {
-                            // Can be None on graceful shutdown.
-                            break;
-                        }
-                    };
-                // Pause the consensus block import when the sink is full.
-                let _ = block_info_sender.feed(None).await;
-                let _ = acknowledgement_sender.send(()).await;
-            }
-        }
-    }
+    block_info_receiver
 }
 
-async fn on_new_slot<Block, CBlock, CClient, BundlerFn>(
+pub(crate) async fn on_new_slot<Block, CBlock, CClient, BundlerFn>(
     consensus_client: &CClient,
     consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
     bundler: &BundlerFn,

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -82,21 +82,19 @@ pub use self::bootstrapper::{BootstrapResult, Bootstrapper};
 pub use self::operator::Operator;
 pub use self::parent_chain::DomainParentChain;
 pub use self::utils::{DomainBlockImportNotification, DomainImportNotifications};
-use crate::utils::BlockInfo;
 use futures::channel::mpsc;
 use futures::Stream;
 use sc_client_api::{AuxStore, BlockImportNotification};
 use sc_consensus::SharedBlockImport;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::TracingUnboundedSender;
-use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
-use sp_consensus::{SelectChain, SyncOracle};
+use sp_consensus::SyncOracle;
 use sp_consensus_slots::Slot;
 use sp_domain_digests::AsPredigest;
 use sp_domains::{Bundle, DomainId, ExecutionReceipt};
 use sp_keystore::KeystorePtr;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One, Saturating, Zero};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_runtime::DigestItem;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -175,67 +173,6 @@ pub struct OperatorParams<
     pub operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS>,
     pub domain_confirmation_depth: NumberFor<Block>,
     pub block_import: SharedBlockImport<Block>,
-}
-
-/// Returns the active leaves the operator should start with.
-///
-/// The longest chain is used as the fork choice for the leaves as the consensus block's fork choice
-/// is only available in the imported consensus block notifications.
-async fn active_leaves<CBlock, CClient, SC>(
-    client: &CClient,
-    select_chain: &SC,
-) -> Result<Vec<BlockInfo<CBlock>>, sp_consensus::Error>
-where
-    CBlock: BlockT,
-    CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + 'static,
-    SC: SelectChain<CBlock>,
-{
-    let best_block = select_chain.best_chain().await?;
-
-    // No leaves if starting from the genesis.
-    if best_block.number().is_zero() {
-        return Ok(Vec::new());
-    }
-
-    let mut leaves = select_chain
-        .leaves()
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|hash| {
-            let number = client.number(hash).ok()??;
-
-            // Only consider leaves that are in maximum an uncle of the best block.
-            if number < best_block.number().saturating_sub(One::one()) || hash == best_block.hash()
-            {
-                return None;
-            };
-
-            let parent_hash = *client.header(hash).ok()??.parent_hash();
-
-            Some(BlockInfo {
-                hash,
-                parent_hash,
-                number,
-                is_new_best: false,
-            })
-        })
-        .collect::<Vec<_>>();
-
-    // Sort by block number and get the maximum number of leaves
-    leaves.sort_by_key(|b| b.number);
-
-    leaves.push(BlockInfo {
-        hash: best_block.hash(),
-        parent_hash: *best_block.parent_hash(),
-        number: *best_block.number(),
-        is_new_best: true,
-    });
-
-    /// The maximum number of active leaves we forward to the [`Operator`] on startup.
-    const MAX_ACTIVE_LEAVES: usize = 4;
-
-    Ok(leaves.into_iter().rev().take(MAX_ACTIVE_LEAVES).collect())
 }
 
 pub(crate) fn load_execution_receipt_by_domain_hash<Block, CBlock, Client>(

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -93,7 +93,7 @@ where
     E: CodeExecutor,
 {
     /// Create a new instance.
-    pub async fn new<IBNS, CIBNS, NSNS>(
+    pub async fn new<IBNS, CIBNS, NSNS, ASS>(
         spawn_essential: Box<dyn SpawnEssentialNamed>,
         params: OperatorParams<
             Block,
@@ -106,12 +106,14 @@ where
             IBNS,
             CIBNS,
             NSNS,
+            ASS,
         >,
     ) -> Result<Self, sp_consensus::Error>
     where
         IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
         CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
         NSNS: Stream<Item = NewSlotNotification> + Send + 'static,
+        ASS: Stream<Item = mpsc::Sender<()>> + Send + 'static,
     {
         let parent_chain =
             DomainParentChain::new(params.domain_id, params.consensus_client.clone());

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -4,7 +4,7 @@ use crate::domain_bundle_producer::DomainBundleProducer;
 use crate::domain_bundle_proposer::DomainBundleProposer;
 use crate::fraud_proof::FraudProofGenerator;
 use crate::parent_chain::DomainParentChain;
-use crate::{active_leaves, DomainImportNotifications, NewSlotNotification, OperatorParams};
+use crate::{DomainImportNotifications, NewSlotNotification, OperatorParams};
 use domain_runtime_primitives::{DomainCoreApi, InherentExtrinsicApi};
 use futures::channel::mpsc;
 use futures::{FutureExt, Stream};
@@ -14,7 +14,6 @@ use sc_client_api::{
 use sc_utils::mpsc::tracing_unbounded;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
-use sp_consensus::SelectChain;
 use sp_core::traits::{CodeExecutor, SpawnEssentialNamed};
 use sp_core::H256;
 use sp_domains::{BundleProducerElectionApi, DomainsApi};
@@ -94,9 +93,8 @@ where
     E: CodeExecutor,
 {
     /// Create a new instance.
-    pub async fn new<SC, IBNS, CIBNS, NSNS>(
+    pub async fn new<IBNS, CIBNS, NSNS>(
         spawn_essential: Box<dyn SpawnEssentialNamed>,
-        select_chain: &SC,
         params: OperatorParams<
             Block,
             CBlock,
@@ -111,13 +109,10 @@ where
         >,
     ) -> Result<Self, sp_consensus::Error>
     where
-        SC: SelectChain<CBlock>,
         IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
         CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
         NSNS: Stream<Item = NewSlotNotification> + Send + 'static,
     {
-        let active_leaves = active_leaves(params.consensus_client.as_ref(), select_chain).await?;
-
         let parent_chain =
             DomainParentChain::new(params.domain_id, params.consensus_client.clone());
 
@@ -182,12 +177,10 @@ where
                 spawn_essential.clone(),
                 params.consensus_client.clone(),
                 params.consensus_offchain_tx_pool_factory.clone(),
-                params.client.clone(),
                 params.is_authority,
                 bundle_producer,
                 bundle_processor.clone(),
                 params.operator_streams,
-                active_leaves,
             )
             .boxed(),
         );

--- a/domains/client/domain-operator/src/utils.rs
+++ b/domains/client/domain-operator/src/utils.rs
@@ -22,8 +22,6 @@ where
 {
     /// hash of the block.
     pub hash: Block::Hash,
-    /// hash of the parent block.
-    pub parent_hash: Block::Hash,
     /// block's number.
     pub number: NumberFor<Block>,
     /// Is this the new best block.

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -233,7 +233,7 @@ where
     Ok(params)
 }
 
-pub struct DomainParams<CBlock, CClient, IBNS, CIBNS, NSNS, Provider>
+pub struct DomainParams<CBlock, CClient, IBNS, CIBNS, NSNS, ASS, Provider>
 where
     CBlock: BlockT,
 {
@@ -243,7 +243,7 @@ where
     pub consensus_client: Arc<CClient>,
     pub consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
     pub consensus_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
-    pub operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS>,
+    pub operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS, ASS>,
     pub gossip_message_sink: GossipMessageSink,
     pub domain_message_receiver: TracingUnboundedReceiver<Vec<u8>>,
     pub provider: Provider,
@@ -256,12 +256,13 @@ pub async fn new_full<
     IBNS,
     CIBNS,
     NSNS,
+    ASS,
     RuntimeApi,
     ExecutorDispatch,
     AccountId,
     Provider,
 >(
-    domain_params: DomainParams<CBlock, CClient, IBNS, CIBNS, NSNS, Provider>,
+    domain_params: DomainParams<CBlock, CClient, IBNS, CIBNS, NSNS, ASS, Provider>,
 ) -> sc_service::error::Result<
     NewFull<
         Arc<FullClient<Block, RuntimeApi, ExecutorDispatch>>,
@@ -293,7 +294,8 @@ where
         + BundleProducerElectionApi<CBlock, subspace_runtime_primitives::Balance>,
     IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
     CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
-    NSNS: Stream<Item = (Slot, Randomness, Option<mpsc::Sender<()>>)> + Send + 'static,
+    NSNS: Stream<Item = (Slot, Randomness)> + Send + 'static,
+    ASS: Stream<Item = mpsc::Sender<()>> + Send + 'static,
     RuntimeApi: ConstructRuntimeApi<Block, FullClient<Block, RuntimeApi, ExecutorDispatch>>
         + Send
         + Sync

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -24,7 +24,7 @@ use serde::de::DeserializeOwned;
 use sp_api::{ApiExt, BlockT, ConstructRuntimeApi, Metadata, NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
-use sp_consensus::{SelectChain, SyncOracle};
+use sp_consensus::SyncOracle;
 use sp_consensus_slots::Slot;
 use sp_core::traits::SpawnEssentialNamed;
 use sp_core::{Decode, Encode};
@@ -233,7 +233,7 @@ where
     Ok(params)
 }
 
-pub struct DomainParams<CBlock, CClient, SC, IBNS, CIBNS, NSNS, Provider>
+pub struct DomainParams<CBlock, CClient, IBNS, CIBNS, NSNS, Provider>
 where
     CBlock: BlockT,
 {
@@ -243,7 +243,6 @@ where
     pub consensus_client: Arc<CClient>,
     pub consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
     pub consensus_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
-    pub select_chain: SC,
     pub operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS>,
     pub gossip_message_sink: GossipMessageSink,
     pub domain_message_receiver: TracingUnboundedReceiver<Vec<u8>>,
@@ -254,7 +253,6 @@ where
 pub async fn new_full<
     CBlock,
     CClient,
-    SC,
     IBNS,
     CIBNS,
     NSNS,
@@ -263,7 +261,7 @@ pub async fn new_full<
     AccountId,
     Provider,
 >(
-    domain_params: DomainParams<CBlock, CClient, SC, IBNS, CIBNS, NSNS, Provider>,
+    domain_params: DomainParams<CBlock, CClient, IBNS, CIBNS, NSNS, Provider>,
 ) -> sc_service::error::Result<
     NewFull<
         Arc<FullClient<Block, RuntimeApi, ExecutorDispatch>>,
@@ -293,7 +291,6 @@ where
         + RelayerApi<CBlock, NumberFor<CBlock>>
         + MessengerApi<CBlock, NumberFor<CBlock>>
         + BundleProducerElectionApi<CBlock, subspace_runtime_primitives::Balance>,
-    SC: SelectChain<CBlock>,
     IBNS: Stream<Item = (NumberFor<CBlock>, mpsc::Sender<()>)> + Send + 'static,
     CIBNS: Stream<Item = BlockImportNotification<CBlock>> + Send + 'static,
     NSNS: Stream<Item = (Slot, Randomness, Option<mpsc::Sender<()>>)> + Send + 'static,
@@ -346,7 +343,6 @@ where
         consensus_client,
         consensus_offchain_tx_pool_factory,
         consensus_network_sync_oracle,
-        select_chain,
         operator_streams,
         gossip_message_sink,
         domain_message_receiver,
@@ -455,7 +451,6 @@ where
 
     let operator = Operator::new(
         Box::new(spawn_essential.clone()),
-        &select_chain,
         OperatorParams {
             domain_id,
             domain_created_at,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -211,6 +211,7 @@ where
                 .block_importing_notification_stream(),
             imported_block_notification_stream,
             new_slot_notification_stream: mock_consensus_node.new_slot_notification_stream(),
+            acknowledgement_sender_stream: mock_consensus_node.new_acknowledgement_sender_stream(),
             _phantom: Default::default(),
         };
 
@@ -235,12 +236,20 @@ where
             provider: DefaultProvider,
         };
 
-        let domain_node =
-            domain_service::new_full::<_, _, _, _, _, RuntimeApi, ExecutorDispatch, AccountId, _>(
-                domain_params,
-            )
-            .await
-            .expect("failed to build domain node");
+        let domain_node = domain_service::new_full::<
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            RuntimeApi,
+            ExecutorDispatch,
+            AccountId,
+            _,
+        >(domain_params)
+        .await
+        .expect("failed to build domain node");
 
         let domain_service::NewFull {
             task_manager,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -229,27 +229,18 @@ where
                 mock_consensus_node.transaction_pool.clone(),
             ),
             consensus_network_sync_oracle: mock_consensus_node.sync_service.clone(),
-            select_chain: mock_consensus_node.select_chain.clone(),
             operator_streams,
             gossip_message_sink: gossip_msg_sink,
             domain_message_receiver,
             provider: DefaultProvider,
         };
 
-        let domain_node = domain_service::new_full::<
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            RuntimeApi,
-            ExecutorDispatch,
-            AccountId,
-            _,
-        >(domain_params)
-        .await
-        .expect("failed to build domain node");
+        let domain_node =
+            domain_service::new_full::<_, _, _, _, _, RuntimeApi, ExecutorDispatch, AccountId, _>(
+                domain_params,
+            )
+            .await
+            .expect("failed to build domain node");
 
         let domain_service::NewFull {
             task_manager,


### PR DESCRIPTION
This PR brings some refactoring to the domain client, including changes of:
-  Do not process the consensus chain leaves on the operator node setup
    - This was introduced so long time ago but is not needed anymore because the domain client is fork-aware, these leaves will be processed properly when their descendant block is imported
- Handling consensus block import and new slot one by one sequentially
    - In main, they are handled concurrently, if the consensus block processing is not finished (the ER is not generated) and there is a new slot hence bundle produced, the bundle will submitted along with a stale ER and cause the whole bundle to be rejected (especially when #1731 is implemented), so it is more rational to wait consensus block processing finish before handle new slot
    - Another way to achieve the goal is to use async `Mutex` to block the slot handler when there is consensus block under processing, which will bring more complexity with little performance improve
- Add testing infra support to have a way to know when all of the operator's previous tasks are finished, this will fix the domain test in #1974

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
