### PR TITLE
Adjustable plotting concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11394,12 +11394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "std-semaphore"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11552,7 +11546,6 @@ dependencies = [
  "serde_json",
  "ss58-registry",
  "static_assertions",
- "std-semaphore",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -467,6 +467,8 @@ pub fn create_signed_vote(
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
             sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            downloading_semaphore: None,
+            encoding_semaphore: None,
             table_generator: &mut table_generator,
         }))
         .unwrap();

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -55,7 +55,9 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
+use subspace_farmer_components::plotting::{
+    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions,
+};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::{Table, TableGenerator};
@@ -454,19 +456,19 @@ pub fn create_signed_vote(
         let mut plotted_sector_bytes = Vec::new();
         let mut plotted_sector_metadata_bytes = Vec::new();
 
-        let plotted_sector = block_on(plot_sector::<_, PosTable>(
-            &public_key,
+        let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
+            public_key: &public_key,
             sector_index,
-            archived_history_segment,
-            PieceGetterRetryPolicy::default(),
-            &farmer_protocol_info,
+            piece_getter: archived_history_segment,
+            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
+            farmer_protocol_info: &farmer_protocol_info,
             kzg,
             erasure_coding,
             pieces_in_sector,
-            &mut plotted_sector_bytes,
-            &mut plotted_sector_metadata_bytes,
-            &mut table_generator,
-        ))
+            sector_output: &mut plotted_sector_bytes,
+            sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            table_generator: &mut table_generator,
+        }))
         .unwrap();
 
         let global_challenge = proof_of_time

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -175,7 +175,7 @@ fn valid_header(
         let mut plotted_sector_bytes = Vec::new();
         let mut plotted_sector_metadata_bytes = Vec::new();
 
-        let plotted_sector = block_on(plot_sector::<_, PosTable>(
+        let plotted_sector = block_on(plot_sector::<PosTable, _>(
             &public_key,
             sector_index,
             &archived_segment.pieces,

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -16,7 +16,9 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
+use subspace_farmer_components::plotting::{
+    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
+};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
@@ -116,19 +118,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let mut plotted_sector_bytes = Vec::new();
         let mut plotted_sector_metadata_bytes = Vec::new();
 
-        let plotted_sector = block_on(plot_sector::<_, PosTable>(
-            &public_key,
+        let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
+            public_key: &public_key,
             sector_index,
-            &archived_history_segment,
-            PieceGetterRetryPolicy::default(),
-            &farmer_protocol_info,
-            &kzg,
-            &erasure_coding,
+            piece_getter: &archived_history_segment,
+            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
+            farmer_protocol_info: &farmer_protocol_info,
+            kzg: &kzg,
+            erasure_coding: &erasure_coding,
             pieces_in_sector,
-            &mut plotted_sector_bytes,
-            &mut plotted_sector_metadata_bytes,
-            &mut table_generator,
-        ))
+            sector_output: &mut plotted_sector_bytes,
+            sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            table_generator: &mut table_generator,
+        }))
         .unwrap();
 
         (plotted_sector, plotted_sector_bytes)

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -129,6 +129,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
             sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            downloading_semaphore: black_box(None),
+            encoding_semaphore: black_box(None),
             table_generator: &mut table_generator,
         }))
         .unwrap();

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -8,7 +8,9 @@ use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{HistorySize, PublicKey, Record, RecordedHistorySegment};
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
+use subspace_farmer_components::plotting::{
+    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions,
+};
 use subspace_farmer_components::sector::sector_size;
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
@@ -65,19 +67,19 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(sector_size as u64));
     group.bench_function("in-memory", |b| {
         b.iter(|| {
-            block_on(plot_sector::<_, PosTable>(
-                black_box(&public_key),
-                black_box(sector_index),
-                black_box(&archived_history_segment),
-                black_box(PieceGetterRetryPolicy::default()),
-                black_box(&farmer_protocol_info),
-                black_box(&kzg),
-                black_box(&erasure_coding),
-                black_box(pieces_in_sector),
-                black_box(&mut sector_bytes),
-                black_box(&mut sector_metadata_bytes),
-                black_box(&mut table_generator),
-            ))
+            block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
+                public_key: black_box(&public_key),
+                sector_index: black_box(sector_index),
+                piece_getter: black_box(&archived_history_segment),
+                piece_getter_retry_policy: black_box(PieceGetterRetryPolicy::default()),
+                farmer_protocol_info: black_box(&farmer_protocol_info),
+                kzg: black_box(&kzg),
+                erasure_coding: black_box(&erasure_coding),
+                pieces_in_sector: black_box(pieces_in_sector),
+                sector_output: black_box(&mut sector_bytes),
+                sector_metadata_output: black_box(&mut sector_metadata_bytes),
+                table_generator: black_box(&mut table_generator),
+            }))
             .unwrap();
         })
     });

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -78,6 +78,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                 pieces_in_sector: black_box(pieces_in_sector),
                 sector_output: black_box(&mut sector_bytes),
                 sector_metadata_output: black_box(&mut sector_metadata_bytes),
+                downloading_semaphore: black_box(None),
+                encoding_semaphore: black_box(None),
                 table_generator: black_box(&mut table_generator),
             }))
             .unwrap();

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -17,7 +17,9 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
+use subspace_farmer_components::plotting::{
+    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
+};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
@@ -119,19 +121,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let mut plotted_sector_bytes = Vec::new();
         let mut plotted_sector_metadata_bytes = Vec::new();
 
-        let plotted_sector = block_on(plot_sector::<_, PosTable>(
-            &public_key,
+        let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
+            public_key: &public_key,
             sector_index,
-            &archived_history_segment,
-            PieceGetterRetryPolicy::default(),
-            &farmer_protocol_info,
-            &kzg,
-            &erasure_coding,
+            piece_getter: &archived_history_segment,
+            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
+            farmer_protocol_info: &farmer_protocol_info,
+            kzg: &kzg,
+            erasure_coding: &erasure_coding,
             pieces_in_sector,
-            &mut plotted_sector_bytes,
-            &mut plotted_sector_metadata_bytes,
-            &mut table_generator,
-        ))
+            sector_output: &mut plotted_sector_bytes,
+            sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            table_generator: &mut table_generator,
+        }))
         .unwrap();
 
         (plotted_sector, plotted_sector_bytes)

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -132,6 +132,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
             sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            downloading_semaphore: black_box(None),
+            encoding_semaphore: black_box(None),
             table_generator: &mut table_generator,
         }))
         .unwrap();

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -14,7 +14,9 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
+use subspace_farmer_components::plotting::{
+    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
+};
 use subspace_farmer_components::reading::read_piece;
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
@@ -113,19 +115,19 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let mut plotted_sector_bytes = Vec::new();
         let mut plotted_sector_metadata_bytes = Vec::new();
 
-        let plotted_sector = block_on(plot_sector::<_, PosTable>(
-            &public_key,
+        let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
+            public_key: &public_key,
             sector_index,
-            &archived_history_segment,
-            PieceGetterRetryPolicy::default(),
-            &farmer_protocol_info,
-            &kzg,
-            &erasure_coding,
+            piece_getter: &archived_history_segment,
+            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
+            farmer_protocol_info: &farmer_protocol_info,
+            kzg: &kzg,
+            erasure_coding: &erasure_coding,
             pieces_in_sector,
-            &mut plotted_sector_bytes,
-            &mut plotted_sector_metadata_bytes,
-            &mut table_generator,
-        ))
+            sector_output: &mut plotted_sector_bytes,
+            sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            table_generator: &mut table_generator,
+        }))
         .unwrap();
 
         (plotted_sector, plotted_sector_bytes)

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -126,6 +126,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
             sector_metadata_output: &mut plotted_sector_metadata_bytes,
+            downloading_semaphore: black_box(None),
+            encoding_semaphore: black_box(None),
             table_generator: &mut table_generator,
         }))
         .unwrap();

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -38,7 +38,6 @@ schnorrkel = "0.9.1"
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.106"
 static_assertions = "1.1.0"
-std-semaphore = "0.1.0"
 ss58-registry = "1.43.0"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding" }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -9,7 +9,7 @@ use clap::{Parser, ValueHint};
 use ss58::parse_ss58_reward_address;
 use std::fs;
 use std::net::SocketAddr;
-use std::num::NonZeroU8;
+use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::PathBuf;
 use std::str::FromStr;
 use subspace_core_primitives::PublicKey;
@@ -91,6 +91,15 @@ struct FarmingArgs {
     /// one specified endpoint. Format: 127.0.0.1:8080
     #[arg(long, alias = "metrics-endpoint")]
     metrics_endpoints: Vec<SocketAddr>,
+    /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
+    /// the plotting process, increasing beyond 2 makes practical sense due to limited networking
+    /// concurrency and will likely result in slower plotting overall
+    #[arg(long, default_value = "2")]
+    sector_downloading_concurrency: NonZeroUsize,
+    /// Defines how many sectors farmer will encode concurrently, should generally never be set to
+    /// more than 1 because it will most likely result in slower plotting overall
+    #[arg(long, default_value = "1")]
+    sector_encoding_concurrency: NonZeroUsize,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
     /// compute-intensive operations during proving), defaults to number of CPU cores available in
     /// the system

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -27,7 +27,7 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting;
 use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetter, PieceGetterRetryPolicy, PlottedSector,
+    plot_sector, PieceGetter, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
 };
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_proof_of_space::Table;
@@ -214,19 +214,21 @@ where
 
             let plotting_fn = move || {
                 tokio::task::block_in_place(move || {
-                    let plot_sector_fut = plot_sector::<_, PosTable>(
-                        &public_key,
+                    let plot_sector_fut = plot_sector::<PosTable, _>(PlotSectorOptions {
+                        public_key: &public_key,
                         sector_index,
-                        &piece_getter,
-                        PieceGetterRetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
-                        &farmer_app_info.protocol_info,
-                        &kzg,
-                        &erasure_coding,
+                        piece_getter: &piece_getter,
+                        piece_getter_retry_policy: PieceGetterRetryPolicy::Limited(
+                            PIECE_GETTER_RETRY_NUMBER.get(),
+                        ),
+                        farmer_protocol_info: &farmer_app_info.protocol_info,
+                        kzg: &kzg,
+                        erasure_coding: &erasure_coding,
                         pieces_in_sector,
-                        &mut sector,
-                        &mut sector_metadata,
-                        &mut table_generator,
-                    );
+                        sector_output: &mut sector,
+                        sector_metadata_output: &mut sector_metadata,
+                        table_generator: &mut table_generator,
+                    });
 
                     Handle::current()
                         .block_on(plot_sector_fut)

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -39,7 +39,9 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy, PlottedSector};
+use subspace_farmer_components::plotting::{
+    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
+};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_runtime_primitives::opaque::Block;
@@ -256,19 +258,19 @@ where
         min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
     };
 
-    let plotted_sector = plot_sector::<_, PosTable>(
-        &public_key,
+    let plotted_sector = plot_sector::<PosTable, _>(PlotSectorOptions {
+        public_key: &public_key,
         sector_index,
-        &archived_segment.pieces,
-        PieceGetterRetryPolicy::default(),
-        &farmer_protocol_info,
-        &kzg,
+        piece_getter: &archived_segment.pieces,
+        piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
+        farmer_protocol_info: &farmer_protocol_info,
+        kzg: &kzg,
         erasure_coding,
         pieces_in_sector,
-        &mut sector,
-        &mut sector_metadata,
-        &mut table_generator,
-    )
+        sector_output: &mut sector,
+        sector_metadata_output: &mut sector_metadata,
+        table_generator: &mut table_generator,
+    })
     .await
     .expect("Plotting one sector in memory must not fail");
 

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -269,6 +269,8 @@ where
         pieces_in_sector,
         sector_output: &mut sector,
         sector_metadata_output: &mut sector_metadata,
+        downloading_semaphore: None,
+        encoding_semaphore: None,
         table_generator: &mut table_generator,
     })
     .await


### PR DESCRIPTION
This is the first of two steps to improve plotting performance. While encoding one sector at a time in parallel is the most performance way, we can still do async I/O in the meantime. This PR allows to download second sector while we're encoding the first one, cutting total plotting time in case more than one farm is used. Generally the same should be used for single-farm setup as well, but it is a bit more difficult and will be implemented later.

The defaults are optimal, but still exposed to users via CLI in case they want to tinker with it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
