### PR TITLE
Better farmer caching

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -383,9 +383,9 @@ where
     let farm_fut = run_future_in_dedicated_thread(
         Box::pin(async move {
             while let Some(result) = single_disk_farms_stream.next().await {
-                result?;
+                let id = result?;
 
-                info!("Farm exited successfully");
+                info!(%id, "Farm exited successfully");
             }
             anyhow::Ok(())
         }),

--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -284,6 +284,9 @@ where
                 });
         });
 
+        // Store whatever correct pieces are immediately available after restart
+        *self.caches.write() = caches.clone();
+
         debug!(
             count = %piece_indices_to_store.len(),
             "Identified piece indices that should be cached",

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1178,7 +1178,7 @@ impl SingleDiskFarm {
     }
 
     /// Run and wait for background threads to exit or return an error
-    pub async fn run(mut self) -> anyhow::Result<()> {
+    pub async fn run(mut self) -> anyhow::Result<SingleDiskFarmId> {
         if let Some(start_sender) = self.start_sender.take() {
             // Do not care if anyone is listening on the other side
             let _ = start_sender.send(());
@@ -1188,7 +1188,7 @@ impl SingleDiskFarm {
             result?;
         }
 
-        Ok(())
+        Ok(*self.id())
     }
 
     /// Wipe everything that belongs to this single disk farm


### PR DESCRIPTION
This PR introduces a few important quality of life improvements:
* plotting is delayed until piece cache is populated, this improves cache hit ratio
* piece cache sync is concurrent rather than sequential, making it much faster
* piece cache sync progress reporting is now logged such that user can see that something is happening (there is also a subscription for Pulsar to use)
* previously pieces that were cached before restart were not usable until cache sync is either finished or made a significant progres

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
