### PR TITLE
Switch to upstream version of KZG library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,28 +1224,13 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.10"
-source = "git+https://github.com/subspace/blst.git?rev=017edf9d7b943813b9ba2804a9eda20607b48139#017edf9d7b943813b9ba2804a9eda20607b48139"
+version = "0.3.11"
+source = "git+https://github.com/supranational/blst.git#3f3457c04ec0bdf8de51b16a2092e349fdd9d8ef"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
  "zeroize",
-]
-
-[[package]]
-name = "blst_rust"
-version = "0.1.0"
-source = "git+https://github.com/subspace/rust-kzg?rev=1058cc8c8af8461b490dc212c41d7d506a746577#1058cc8c8af8461b490dc212c41d7d506a746577"
-dependencies = [
- "blst",
- "kzg",
- "libc",
- "num_cpus",
- "once_cell",
- "rand 0.8.5",
- "rayon",
- "smallvec",
 ]
 
 [[package]]
@@ -5221,7 +5206,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/subspace/rust-kzg?rev=1058cc8c8af8461b490dc212c41d7d506a746577#1058cc8c8af8461b490dc212c41d7d506a746577"
+source = "git+https://github.com/sifraitech/rust-kzg?rev=c34b73916af9b8a699a74bd0186f82f25e72861c#c34b73916af9b8a699a74bd0186f82f25e72861c"
 dependencies = [
  "blst",
  "sha2 0.10.7",
@@ -8775,6 +8760,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-kzg-blst"
+version = "0.1.0"
+source = "git+https://github.com/sifraitech/rust-kzg?rev=c34b73916af9b8a699a74bd0186f82f25e72861c#c34b73916af9b8a699a74bd0186f82f25e72861c"
+dependencies = [
+ "blst",
+ "hex",
+ "kzg",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "rand 0.8.5",
+ "rayon",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11481,7 +11482,6 @@ name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "blst_rust",
  "criterion",
  "derive_more",
  "hex",
@@ -11493,6 +11493,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
+ "rust-kzg-blst",
  "scale-info",
  "serde",
  "serde_arrays",
@@ -11507,10 +11508,10 @@ dependencies = [
 name = "subspace-erasure-coding"
 version = "0.1.0"
 dependencies = [
- "blst_rust",
  "criterion",
  "kzg",
  "rand 0.8.5",
+ "rust-kzg-blst",
  "subspace-core-primitives",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ blake2 = { opt-level = 3 }
 blake3 = { opt-level = 3 }
 blake2b_simd = { opt-level = 3 }
 blst = { opt-level = 3 }
-blst_rust = { opt-level = 3 }
+rust-kzg-blst = { opt-level = 3 }
 chacha20 = { opt-level = 3 }
 chacha20poly1305 = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,16 +17,14 @@ bench = false
 
 [dependencies]
 blake3 = { version = "1.4.1", default-features = false }
-# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_rust = { git = "https://github.com/subspace/rust-kzg", rev = "1058cc8c8af8461b490dc212c41d7d506a746577", default-features = false }
 derive_more = "0.99.17"
 hex = { version  = "0.4.3", default-features = false, features = ["alloc"] }
-# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-kzg = { git = "https://github.com/subspace/rust-kzg", rev = "1058cc8c8af8461b490dc212c41d7d506a746577", default-features = false }
+kzg = { git = "https://github.com/sifraitech/rust-kzg", rev = "c34b73916af9b8a699a74bd0186f82f25e72861c", default-features = false }
 num-traits = { version = "0.2.16", default-features = false }
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["derive", "max-encoded-len"] }
 parking_lot = { version = "0.12.1", optional = true }
 rayon = { version = "1.8.0", optional = true }
+rust-kzg-blst = { git = "https://github.com/sifraitech/rust-kzg", rev = "c34b73916af9b8a699a74bd0186f82f25e72861c", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.183", optional = true, features = ["alloc", "derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
@@ -54,7 +52,7 @@ embedded-kzg-settings = []
 # Enables some APIs and internal parallelism for KZG
 parallel = [
     "blake3/rayon",
-    "blst_rust/parallel",
+    "rust-kzg-blst/parallel",
     "dep:rayon",
 ]
 serde = [
@@ -65,7 +63,7 @@ serde = [
 ]
 std = [
     "blake3/std",
-    "blst_rust/std",
+    "rust-kzg-blst/std",
     "hex/std",
     "kzg/std",
     "num-traits/std",

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -20,15 +20,16 @@ extern crate alloc;
 pub mod kzg;
 
 use crate::Blake3Hash;
+use ::kzg::Fr;
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
-use blst_rust::types::fr::FsFr;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::mem;
 use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
 use parity_scale_codec::{Decode, Encode, EncodeLike, Input, MaxEncodedLen};
+use rust_kzg_blst::types::fr::FsFr;
 use scale_info::{Type, TypeInfo};
 
 /// BLAKE3 hashing of a single value.
@@ -204,18 +205,14 @@ impl TryFrom<[u8; Self::FULL_BYTES]> for Scalar {
 
     #[inline]
     fn try_from(value: [u8; Self::FULL_BYTES]) -> Result<Self, Self::Error> {
-        FsFr::from_scalar(value)
-            .map_err(|error_code| {
-                format!("Failed to create scalar from bytes with code: {error_code}")
-            })
-            .map(Scalar)
+        FsFr::from_bytes(&value).map(Scalar)
     }
 }
 
 impl From<&Scalar> for [u8; Scalar::FULL_BYTES] {
     #[inline]
     fn from(value: &Scalar) -> Self {
-        value.0.to_scalar()
+        value.0.to_bytes()
     }
 }
 

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -11,17 +11,17 @@ use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use blst_rust::types::fft_settings::FsFFTSettings;
-use blst_rust::types::g1::FsG1;
-use blst_rust::types::g2::FsG2;
-use blst_rust::types::kzg_settings::FsKZGSettings;
-use blst_rust::types::poly::FsPoly;
 use core::mem;
 use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
 use kzg::eip_4844::{BYTES_PER_G1, BYTES_PER_G2};
-use kzg::{FFTFr, FFTSettings, Fr, KZGSettings};
+use kzg::{FFTFr, FFTSettings, Fr, KZGSettings, G1, G2};
 #[cfg(feature = "std")]
 use parking_lot::Mutex;
+use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+use rust_kzg_blst::types::g1::FsG1;
+use rust_kzg_blst::types::g2::FsG2;
+use rust_kzg_blst::types::kzg_settings::FsKZGSettings;
+use rust_kzg_blst::types::poly::FsPoly;
 #[cfg(not(feature = "std"))]
 use spin::Mutex;
 use tracing::debug;
@@ -53,23 +53,11 @@ pub fn bytes_to_kzg_settings(
     let (secret_g1_bytes, secret_g2_bytes) = bytes.split_at(BYTES_PER_G1 * num_g1_powers);
     let secret_g1 = secret_g1_bytes
         .chunks_exact(BYTES_PER_G1)
-        .map(|bytes| {
-            FsG1::from_bytes(
-                bytes
-                    .try_into()
-                    .expect("Chunked into correct number of bytes above; qed"),
-            )
-        })
+        .map(FsG1::from_bytes)
         .collect::<Result<Vec<_>, _>>()?;
     let secret_g2 = secret_g2_bytes
         .chunks_exact(BYTES_PER_G2)
-        .map(|bytes| {
-            FsG2::from_bytes(
-                bytes
-                    .try_into()
-                    .expect("Chunked into correct number of bytes above; qed"),
-            )
-        })
+        .map(FsG2::from_bytes)
         .collect::<Result<Vec<_>, _>>()?;
 
     let fft_settings = FsFFTSettings::new(

--- a/crates/subspace-erasure-coding/Cargo.toml
+++ b/crates/subspace-erasure-coding/Cargo.toml
@@ -15,26 +15,23 @@ include = [
 bench = false
 
 [dependencies]
-# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_rust = { git = "https://github.com/subspace/rust-kzg", rev = "1058cc8c8af8461b490dc212c41d7d506a746577", default-features = false }
-# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-kzg = { git = "https://github.com/subspace/rust-kzg", rev = "1058cc8c8af8461b490dc212c41d7d506a746577", default-features = false }
+kzg = { git = "https://github.com/sifraitech/rust-kzg", rev = "c34b73916af9b8a699a74bd0186f82f25e72861c", default-features = false }
+rust-kzg-blst = { git = "https://github.com/sifraitech/rust-kzg", rev = "c34b73916af9b8a699a74bd0186f82f25e72861c", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
-# TODO: Switch to upstream `main` once https://github.com/sifraitech/rust-kzg/pull/204 is merged and blst has upstream no_std support
-blst_rust = { git = "https://github.com/subspace/rust-kzg", rev = "1058cc8c8af8461b490dc212c41d7d506a746577" }
+rust-kzg-blst = { git = "https://github.com/sifraitech/rust-kzg", rev = "c34b73916af9b8a699a74bd0186f82f25e72861c" }
 criterion = "0.5.1"
 rand = "0.8.5"
 
 [features]
 default = ["std", "parallel"]
 std = [
-    "blst_rust/std",
     "kzg/std",
+    "rust-kzg-blst/std",
     "subspace-core-primitives/std",
 ]
-parallel = ["blst_rust/parallel"]
+parallel = ["rust-kzg-blst/parallel"]
 
 [[bench]]
 name = "commitments"

--- a/crates/subspace-erasure-coding/benches/commitments.rs
+++ b/crates/subspace-erasure-coding/benches/commitments.rs
@@ -1,6 +1,6 @@
-use blst_rust::types::g1::FsG1;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use kzg::G1;
+use rust_kzg_blst::types::g1::FsG1;
 use std::num::NonZeroUsize;
 use subspace_core_primitives::crypto::kzg::Commitment;
 use subspace_core_primitives::ArchivedHistorySegment;

--- a/crates/subspace-erasure-coding/src/lib.rs
+++ b/crates/subspace-erasure-coding/src/lib.rs
@@ -8,11 +8,11 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use blst_rust::types::fft_settings::FsFFTSettings;
-use blst_rust::types::g1::FsG1;
-use blst_rust::types::poly::FsPoly;
 use core::num::NonZeroUsize;
 use kzg::{FFTSettings, PolyRecover, DAS, FFTG1, G1};
+use rust_kzg_blst::types::fft_settings::FsFFTSettings;
+use rust_kzg_blst::types::g1::FsG1;
+use rust_kzg_blst::types::poly::FsPoly;
 use subspace_core_primitives::crypto::kzg::{Commitment, Polynomial};
 use subspace_core_primitives::crypto::Scalar;
 

--- a/crates/subspace-erasure-coding/src/tests.rs
+++ b/crates/subspace-erasure-coding/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::ErasureCoding;
-use blst_rust::types::g1::FsG1;
 use kzg::G1;
+use rust_kzg_blst::types::g1::FsG1;
 use std::iter;
 use std::num::NonZeroUsize;
 use subspace_core_primitives::crypto::kzg::Commitment;


### PR DESCRIPTION
Upstream is finally `no_std`-compatible

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
