### PR TITLE
RFC: Handle large storage proofs.

### DIFF
--- a/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
+++ b/crates/subspace-fraud-proof/src/invalid_state_transition_proof.rs
@@ -13,7 +13,9 @@ use sc_client_api::backend;
 use sp_api::{ProvideRuntimeApi, StorageProof};
 use sp_core::traits::{CodeExecutor, RuntimeCode};
 use sp_core::H256;
-use sp_domains::fraud_proof::{ExecutionPhase, InvalidStateTransitionProof, VerificationError};
+use sp_domains::fraud_proof::{
+    ExecutionPhase, InvalidStateTransitionProof, StorageWitness, VerificationError,
+};
 use sp_domains::DomainsApi;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, HashingFor, Header as HeaderT, NumberFor};
 use sp_runtime::Digest;
@@ -283,6 +285,17 @@ where
                 Vec::new()
             }
             ExecutionPhase::FinalizeBlock { .. } => Vec::new(),
+        };
+
+        let proof = match proof {
+            StorageWitness::Proof(proof) => proof,
+            StorageWitness::SizeExceeded(_) => {
+                // TODO: idea is to recreate the storage proof locally,
+                // and verify that the proof size indeed exceeds the threshold
+                // and matches the summary. To be determined: if all the
+                // info is available to recreate the storage proof locally.
+                return Ok(());
+            }
         };
 
         let execution_result = sp_state_machine::execution_proof_check::<BlakeTwo256, _>(

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -16,7 +16,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_core::H256;
 use sp_domain_digests::AsPredigest;
 use sp_domains::fraud_proof::{
-    ExecutionPhase, FraudProof, InvalidStateTransitionProof, VerificationError,
+    ExecutionPhase, FraudProof, InvalidStateTransitionProof, StorageWitness, VerificationError,
 };
 use sp_domains::DomainId;
 use sp_runtime::generic::{Digest, DigestItem};
@@ -283,7 +283,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         consensus_parent_hash,
         pre_state_root: *parent_header.state_root(),
         post_state_root: intermediate_roots[0].into(),
-        proof: storage_proof,
+        proof: StorageWitness::Proof(storage_proof),
         execution_phase,
     };
     let fraud_proof = FraudProof::InvalidStateTransition(invalid_state_transition_proof);
@@ -340,7 +340,7 @@ async fn execution_proof_creation_and_verification_should_work() {
             consensus_parent_hash,
             pre_state_root: intermediate_roots[target_extrinsic_index].into(),
             post_state_root: intermediate_roots[target_extrinsic_index + 1].into(),
-            proof: storage_proof,
+            proof: StorageWitness::Proof(storage_proof),
             execution_phase,
         };
         let fraud_proof = FraudProof::InvalidStateTransition(invalid_state_transition_proof);
@@ -393,7 +393,7 @@ async fn execution_proof_creation_and_verification_should_work() {
         consensus_parent_hash,
         pre_state_root: intermediate_roots.last().unwrap().into(),
         post_state_root: post_execution_root,
-        proof: storage_proof,
+        proof: StorageWitness::Proof(storage_proof),
         execution_phase,
     };
     let fraud_proof = FraudProof::InvalidStateTransition(invalid_state_transition_proof);
@@ -570,7 +570,7 @@ async fn invalid_execution_proof_should_not_work() {
         consensus_parent_hash,
         pre_state_root: post_delta_root0,
         post_state_root: post_delta_root1,
-        proof: proof1,
+        proof: StorageWitness::Proof(proof1),
         execution_phase: execution_phase0.clone(),
     };
     let fraud_proof = FraudProof::InvalidStateTransition(invalid_state_transition_proof);
@@ -583,7 +583,7 @@ async fn invalid_execution_proof_should_not_work() {
         consensus_parent_hash,
         pre_state_root: post_delta_root0,
         post_state_root: post_delta_root1,
-        proof: proof0.clone(),
+        proof: StorageWitness::Proof(proof0.clone()),
         execution_phase: execution_phase1,
     };
     let fraud_proof = FraudProof::InvalidStateTransition(invalid_state_transition_proof);
@@ -596,7 +596,7 @@ async fn invalid_execution_proof_should_not_work() {
         consensus_parent_hash,
         pre_state_root: post_delta_root0,
         post_state_root: post_delta_root1,
-        proof: proof0,
+        proof: StorageWitness::Proof(proof0),
         execution_phase: execution_phase0,
     };
     let fraud_proof = FraudProof::InvalidStateTransition(invalid_state_transition_proof);

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -19,7 +19,7 @@ use sp_core::Pair;
 use sp_domain_digests::AsPredigest;
 use sp_domains::fraud_proof::{
     ExecutionPhase, FraudProof, InvalidExtrinsicsRootProof, InvalidStateTransitionProof,
-    InvalidTotalRewardsProof,
+    InvalidTotalRewardsProof, StorageWitness,
 };
 use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{Bundle, DomainId, DomainsApi};
@@ -1212,7 +1212,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
         consensus_parent_hash: parent_hash_ferdie,
         pre_state_root: *parent_header.state_root(),
         post_state_root: intermediate_roots[0].into(),
-        proof: storage_proof,
+        proof: StorageWitness::Proof(storage_proof),
         execution_phase,
     };
     let valid_fraud_proof =


### PR DESCRIPTION
1. When the storage proof in `InvalidStateTransitionProof` exceeds a threshold, a summary of the storage proof is included in the fraud proof instead of the full storage proof.
2. The verifier is expected to recreate the storage proof locally and verify that the summary is correct.

The PR is meant to get feedback on the approach/feasibility for now, will be opened for further review based on feedback.

Issue: https://github.com/subspace/subspace/issues/1596

### Code contributor checklist:
* [ ] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
