### PR TITLE
Use mimalloc allocator on all platforms for node and farmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,6 +5136,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libp2p"
 version = "0.51.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6425,6 +6435,15 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -11398,6 +11417,7 @@ dependencies = [
  "jsonrpsee",
  "lru 0.11.1",
  "memmap2 0.9.0",
+ "mimalloc",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "prometheus-client 0.21.2",
@@ -11558,6 +11578,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "log",
+ "mimalloc",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-cli",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.28"
 hex = { version = "0.4.3", features = ["serde"] }
 jsonrpsee = { version = "0.16.3", features = ["client"] }
 lru = "0.11.0"
+mimalloc = "0.1.39"
 parity-scale-codec = "3.6.5"
 parking_lot = "0.12.1"
 prometheus-client = "0.21.2"

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -21,6 +21,9 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 type PosTable = ChiaTable;
 
 fn available_parallelism() -> usize {

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3.28"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 log = "0.4.20"
+mimalloc = "0.1.39"
 parity-scale-codec = "3.6.5"
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "920fb277d5ea16a3b0918052c7555026a1ac2c6c" }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "920fb277d5ea16a3b0918052c7555026a1ac2c6c", default-features = false }

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -16,6 +16,9 @@
 
 //! Subspace node implementation.
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use cross_domain_message_gossip::GossipWorkerBuilder;
 use domain_client_operator::Bootstrapper;
 use domain_runtime_primitives::opaque::Block as DomainBlock;


### PR DESCRIPTION
I noticed that without jemalloc farmer is using ridiculous amounts of memory on Linux. It looks like it leaks memory, but this is just system allocator behaving badly, when application stops it goes release the expected memory just fine.

I thought about switching to jemalloc again, but the crate is not working on Windows and https://github.com/microsoft/mimalloc while working there should also be one of the highest performing allocators out there. Let's use it on both node and farmer.

I was running farmer over night with milalloc and it plotted ~100 sectors with current memory usage of ~2G (goes up and down depending on what app is doing), with system allocator farmer was using over 10G of RAM after plotting just a few sectors.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
