### PR TITLE
Fix sync deadlock

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -40,7 +40,6 @@ use domain_runtime_primitives::{BlockNumber as DomainNumber, Hash as DomainHash}
 pub use dsn::DsnConfig;
 use frame_system_rpc_runtime_api::AccountNonceApi;
 use futures::channel::oneshot;
-use futures::executor::block_on;
 use futures::FutureExt;
 use jsonrpsee::RpcModule;
 use pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi;
@@ -106,6 +105,7 @@ use subspace_proof_of_space::Table;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Hash, Nonce};
 use subspace_transaction_pool::{FullPool, PreValidateTransaction};
+use tokio::runtime::Handle;
 use tracing::{debug, error, info, Instrument};
 
 // There are multiple places where it is assumed that node is running on 64-bit system, refuse to
@@ -261,104 +261,110 @@ where
             let client = Arc::clone(&self.client);
             let pot_verifier = self.pot_verifier.clone();
 
-            Box::new(move |parent_hash, slot, proof_of_time, quick_verification| {
-                let parent_hash = {
-                    let mut converted_parent_hash = Block::Hash::default();
-                    converted_parent_hash.as_mut().copy_from_slice(&parent_hash);
-                    converted_parent_hash
-                };
+            Box::new(
+                move |parent_hash, slot, proof_of_time, quick_verification| {
+                    let parent_hash = {
+                        let mut converted_parent_hash = Block::Hash::default();
+                        converted_parent_hash.as_mut().copy_from_slice(&parent_hash);
+                        converted_parent_hash
+                    };
 
-                let parent_header = match client.header(parent_hash) {
-                    Ok(Some(parent_header)) => parent_header,
-                    Ok(None) => {
-                        error!(
-                            %parent_hash,
-                            "Header not found during proof of time verification"
-                        );
+                    let parent_header = match client.header(parent_hash) {
+                        Ok(Some(parent_header)) => parent_header,
+                        Ok(None) => {
+                            error!(
+                                %parent_hash,
+                                "Header not found during proof of time verification"
+                            );
 
+                            return false;
+                        }
+                        Err(error) => {
+                            error!(
+                                %error,
+                                %parent_hash,
+                                "Failed to retrieve header during proof of time verification"
+                            );
+
+                            return false;
+                        }
+                    };
+                    let parent_pre_digest = match extract_pre_digest(&parent_header) {
+                        Ok(parent_pre_digest) => parent_pre_digest,
+                        Err(error) => {
+                            error!(
+                                %error,
+                                %parent_hash,
+                                parent_number = %parent_header.number(),
+                                "Failed to extract pre-digest from parent header during proof of \
+                                time verification, this must never happen"
+                            );
+
+                            return false;
+                        }
+                    };
+
+                    let parent_slot = parent_pre_digest.slot();
+                    if slot <= *parent_slot {
                         return false;
                     }
-                    Err(error) => {
-                        error!(
-                            %error,
-                            %parent_hash,
-                            "Failed to retrieve header during proof of time verification"
-                        );
 
-                        return false;
+                    let pot_parameters = match client.runtime_api().pot_parameters(parent_hash) {
+                        Ok(pot_parameters) => pot_parameters,
+                        Err(error) => {
+                            debug!(
+                                %error,
+                                %parent_hash,
+                                parent_number = %parent_header.number(),
+                                "Failed to retrieve proof of time parameters during proof of time \
+                                verification"
+                            );
+
+                            return false;
+                        }
+                    };
+
+                    let pot_input = if parent_header.number().is_zero() {
+                        PotNextSlotInput {
+                            slot: parent_slot + Slot::from(1),
+                            slot_iterations: pot_parameters.slot_iterations(),
+                            seed: pot_verifier.genesis_seed(),
+                        }
+                    } else {
+                        let pot_info = parent_pre_digest.pot_info();
+
+                        PotNextSlotInput::derive(
+                            pot_parameters.slot_iterations(),
+                            parent_slot,
+                            pot_info.proof_of_time(),
+                            &pot_parameters.next_parameters_change(),
+                        )
+                    };
+
+                    // Ensure proof of time and future proof of time included in upcoming block are
+                    // valid
+
+                    if quick_verification {
+                        tokio::task::block_in_place(|| {
+                            Handle::current().block_on(pot_verifier.try_is_output_valid(
+                                pot_input,
+                                Slot::from(slot - u64::from(parent_slot)),
+                                proof_of_time,
+                                pot_parameters.next_parameters_change(),
+                            ))
+                        })
+                    } else {
+                        tokio::task::block_in_place(|| {
+                            Handle::current().block_on(pot_verifier.is_output_valid(
+                                pot_input,
+                                Slot::from(slot - u64::from(parent_slot)),
+                                proof_of_time,
+                                pot_parameters.next_parameters_change(),
+                            ))
+                        })
                     }
-                };
-                let parent_pre_digest = match extract_pre_digest(&parent_header) {
-                    Ok(parent_pre_digest) => parent_pre_digest,
-                    Err(error) => {
-                        error!(
-                            %error,
-                            %parent_hash,
-                            parent_number = %parent_header.number(),
-                            "Failed to extract pre-digest from parent header during proof of time \
-                            verification, this must never happen"
-                        );
-
-                        return false;
-                    }
-                };
-
-                let parent_slot = parent_pre_digest.slot();
-                if slot <= *parent_slot {
-                    return false;
-                }
-
-                let pot_parameters = match client.runtime_api().pot_parameters(parent_hash) {
-                    Ok(pot_parameters) => pot_parameters,
-                    Err(error) => {
-                        debug!(
-                            %error,
-                            %parent_hash,
-                            parent_number = %parent_header.number(),
-                            "Failed to retieve proof of time parameters during proof of time \
-                            verification"
-                        );
-
-                        return false;
-                    }
-                };
-
-                let pot_input = if parent_header.number().is_zero() {
-                    PotNextSlotInput {
-                        slot: parent_slot + Slot::from(1),
-                        slot_iterations: pot_parameters.slot_iterations(),
-                        seed: pot_verifier.genesis_seed(),
-                    }
-                } else {
-                    let pot_info = parent_pre_digest.pot_info();
-
-                    PotNextSlotInput::derive(
-                        pot_parameters.slot_iterations(),
-                        parent_slot,
-                        pot_info.proof_of_time(),
-                        &pot_parameters.next_parameters_change(),
-                    )
-                };
-
-                // Ensure proof of time and future proof of time included in upcoming block are
-                // valid
-
-                if quick_verification {
-                    block_on(pot_verifier.try_is_output_valid(
-                        pot_input,
-                        Slot::from(slot - u64::from(parent_slot)),
-                        proof_of_time,
-                        pot_parameters.next_parameters_change(),
-                    ))
-                } else {
-                    block_on(pot_verifier.is_output_valid(
-                        pot_input,
-                        Slot::from(slot - u64::from(parent_slot)),
-                        proof_of_time,
-                        pot_parameters.next_parameters_change(),
-                    ))
-                }
-            })
+                },
+            )
         }));
 
         exts.register(FraudProofExtension::new(Arc::new(


### PR DESCRIPTION
The issue observed was that `tokio::task::spawn_blocking` was blocking somehow. The only requirement in docs is that spawn function should eventually exit + obviously, should be called in tokio context.

What happened though is that while both of those were true and there were a lot of threads on the thread pool doing nothing, the function was still blocking.

I think what happened is that since even block execution threads have tokio context in Substrate (I honestly didn't expect them to), `futures::executor::block_on` under certain cicumstances was blocking tokio executor. I have no idea why tokio executor is necessary for something as simple as `tokio::task::spawn_blocking` to work, but here we go.

Second commit just simplifies a few things to use the future returned by `tokio::task::spawn_blocking` rather than additional one-shot channel + uses tokio's `block_on` even though it makes no difference there in practice.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
