### PR TITLE
Reduce number of threads used by metrics server

### DIFF
--- a/shared/subspace-metrics/src/lib.rs
+++ b/shared/subspace-metrics/src/lib.rs
@@ -105,7 +105,9 @@ pub fn start_prometheus_metrics_server(
                 endpoint.set_port(0);
             });
 
-            let result = HttpServer::new(app_factory).bind(endpoints.as_slice());
+            let result = HttpServer::new(app_factory)
+                .workers(2)
+                .bind(endpoints.as_slice());
 
             match result {
                 Ok(server) => server,


### PR DESCRIPTION
By default as many threads as CPU cores are used, which is a ridiculous overkill for a metrics server. 2 threads should be plenty for a single HTTP endpoint queried a few times per minute.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
