### PR TITLE
Remove `codegen-units = 1`, it only makes performance worse for plotting in our case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ panic = "unwind"
 [profile.production]
 inherits = "release"
 lto = "fat"
-codegen-units = 1
 
 # Reason: We need to patch substrate dependency of frontier to our fork
 # TODO: Remove if/when we are using upstream substrate instead of fork


### PR DESCRIPTION
After various experiments it was identified that this actually hurts performance, specifically proof of space performance becomes worse

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
