### PR TITLE
Staking: Max nominators for each operator

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -288,6 +288,10 @@ mod pallet {
         #[pallet::constant]
         type MaxPendingStakingOperation: Get<u32>;
 
+        /// The maximum number of nominators for given operator.
+        #[pallet::constant]
+        type MaxNominators: Get<u32>;
+
         /// Randomness source.
         type Randomness: RandomnessT<Self::Hash, BlockNumberFor<Self>>;
     }
@@ -352,6 +356,16 @@ mod pallet {
         Nominator<T::Share>,
         OptionQuery,
     >;
+
+    /// Tracks the nominator count under given operator.
+    /// This storage is necessary since CountedStorageNMap does not support prefix key count, so
+    /// cannot use that storage type for `Nominators` storage.
+    /// Note: The count is incremented for new nominators and decremented when the nominator withdraws
+    /// all the stake.
+    /// Since Operator themselves are first nominator, they are not counted.
+    #[pallet::storage]
+    pub(super) type NominatorCount<T: Config> =
+        StorageMap<_, Identity, OperatorId, u32, ValueQuery>;
 
     /// Deposits initiated a nominator under this operator.
     /// Will be stored temporarily until the current epoch is complete.

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1,10 +1,10 @@
 //! Staking for domains
 
 use crate::pallet::{
-    DomainRegistry, DomainStakingSummary, NextOperatorId, Nominators, OperatorIdOwner, Operators,
-    PendingDeposits, PendingNominatorUnlocks, PendingOperatorDeregistrations,
-    PendingOperatorSwitches, PendingOperatorUnlocks, PendingSlashes, PendingStakingOperationCount,
-    PendingWithdrawals, PreferredOperator,
+    DomainRegistry, DomainStakingSummary, NextOperatorId, NominatorCount, Nominators,
+    OperatorIdOwner, Operators, PendingDeposits, PendingNominatorUnlocks,
+    PendingOperatorDeregistrations, PendingOperatorSwitches, PendingOperatorUnlocks,
+    PendingSlashes, PendingStakingOperationCount, PendingWithdrawals, PreferredOperator,
 };
 use crate::staking_epoch::{mint_funds, PendingNominatorUnlock, PendingOperatorSlashInfo};
 use crate::{BalanceOf, Config, Event, HoldIdentifier, NominatorId, Pallet};
@@ -213,19 +213,31 @@ pub(crate) fn do_nominate_operator<T: Config>(
         Error::TryDepositWithPendingWithdraw,
     );
 
-    let updated_total_deposit = match PendingDeposits::<T>::get(operator_id, nominator_id.clone()) {
-        None => amount,
-        Some(existing_deposit) => existing_deposit
-            .checked_add(&amount)
-            .ok_or(Error::BalanceOverflow)?,
-    };
+    let (updated_total_deposit, first_nomination) =
+        match PendingDeposits::<T>::get(operator_id, nominator_id.clone()) {
+            None => (amount, true),
+            Some(existing_deposit) => (
+                existing_deposit
+                    .checked_add(&amount)
+                    .ok_or(Error::BalanceOverflow)?,
+                false,
+            ),
+        };
 
-    // if not a nominator, then ensure amount >= operator's minimum nominator stake amount
+    // if not a nominator, then ensure
+    // - amount >= operator's minimum nominator stake amount.
+    // - if first nomination, then increment the nominator count.
     if !Nominators::<T>::contains_key(operator_id, nominator_id.clone()) {
         ensure!(
             updated_total_deposit >= operator.minimum_nominator_stake,
             Error::MinimumNominatorStake
         );
+
+        if first_nomination {
+            NominatorCount::<T>::mutate(operator_id, |count| {
+                *count += 1;
+            });
+        }
     }
 
     hold_pending_deposit::<T>(&nominator_id, operator_id, amount)?;
@@ -409,6 +421,11 @@ pub(crate) fn do_withdraw_stake<T: Config>(
                 }
 
                 PendingWithdrawals::<T>::insert(operator_id, nominator_id, withdraw);
+
+                // reduce nominator count if withdraw all
+                NominatorCount::<T>::mutate(operator_id, |count| {
+                    *count -= 1;
+                });
             }
             Withdraw::Some(withdraw_amount) => {
                 if withdraw_amount.is_zero() {
@@ -455,6 +472,10 @@ pub(crate) fn do_withdraw_stake<T: Config>(
                     // else withdraw the asked amount only
                 } else if nominator_remaining_amount < operator.minimum_nominator_stake {
                     PendingWithdrawals::<T>::insert(operator_id, nominator_id, Withdraw::All);
+                    // reduce nominator count if withdraw all
+                    NominatorCount::<T>::mutate(operator_id, |count| {
+                        *count -= 1;
+                    });
                 } else {
                     PendingWithdrawals::<T>::insert(operator_id, nominator_id, withdraw);
                 }
@@ -608,10 +629,10 @@ pub(crate) fn do_slash_operators<T: Config, Iter: Iterator<Item = OperatorId>>(
 pub(crate) mod tests {
     use crate::domain_registry::{DomainConfig, DomainObject};
     use crate::pallet::{
-        Config, DomainRegistry, DomainStakingSummary, NextOperatorId, OperatorIdOwner, Operators,
-        PendingDeposits, PendingNominatorUnlocks, PendingOperatorDeregistrations,
-        PendingOperatorSwitches, PendingSlashes, PendingStakingOperationCount, PendingUnlocks,
-        PendingWithdrawals, PreferredOperator,
+        Config, DomainRegistry, DomainStakingSummary, NextOperatorId, NominatorCount,
+        OperatorIdOwner, Operators, PendingDeposits, PendingNominatorUnlocks,
+        PendingOperatorDeregistrations, PendingOperatorSwitches, PendingSlashes,
+        PendingStakingOperationCount, PendingUnlocks, PendingWithdrawals, PreferredOperator,
     };
     use crate::staking::{
         do_nominate_operator, do_reward_operators, do_slash_operators, do_withdraw_stake,
@@ -701,11 +722,13 @@ pub(crate) mod tests {
         assert_ok!(res);
 
         let operator_id = 0;
+        let mut expected_nominator_count = 0;
         for nominator in nominators {
             if nominator.1 .1.is_zero() {
                 continue;
             }
 
+            expected_nominator_count += 1;
             let res = Domains::nominate_operator(
                 RuntimeOrigin::signed(nominator.0),
                 operator_id,
@@ -713,6 +736,9 @@ pub(crate) mod tests {
             );
             assert_ok!(res);
         }
+
+        let nominator_count = NominatorCount::<Test>::get(operator_id) as usize;
+        assert_eq!(nominator_count, expected_nominator_count);
 
         (operator_id, operator_config)
     }
@@ -802,7 +828,10 @@ pub(crate) mod tests {
             assert_err!(
                 res,
                 Error::<Test>::Staking(crate::staking::Error::InsufficientBalance)
-            )
+            );
+
+            let nominator_count = NominatorCount::<Test>::get(operator_id);
+            assert_eq!(nominator_count, 0);
         });
     }
 
@@ -850,6 +879,9 @@ pub(crate) mod tests {
             assert_ok!(res);
             let pending_deposit = PendingDeposits::<Test>::get(0, nominator_account).unwrap();
             assert_eq!(pending_deposit, nominator_stake + 40 * SSC);
+
+            let nominator_count = NominatorCount::<Test>::get(operator_id);
+            assert_eq!(nominator_count, 1);
         });
     }
 
@@ -1041,6 +1073,7 @@ pub(crate) mod tests {
         nominator_id: NominatorId<Test>,
         withdraws: WithdrawWithResult,
         expected_withdraw: Option<Withdraw<BalanceOf<Test>>>,
+        expected_nominator_count_reduced_by: u32,
     }
 
     fn withdraw_stake(params: WithdrawParams) {
@@ -1051,6 +1084,7 @@ pub(crate) mod tests {
             nominator_id,
             withdraws,
             expected_withdraw,
+            expected_nominator_count_reduced_by,
         } = params;
         let domain_id = DomainId::new(0);
         let operator_account = 0;
@@ -1088,6 +1122,7 @@ pub(crate) mod tests {
                 .unwrap();
             }
 
+            let nominator_count = NominatorCount::<Test>::get(operator_id);
             for (withdraw, expected_result) in withdraws {
                 let res = Domains::withdraw_stake(
                     RuntimeOrigin::signed(nominator_id),
@@ -1140,6 +1175,12 @@ pub(crate) mod tests {
                     previous_usable_balance + withdrew_amount
                 )
             }
+
+            let new_nominator_count = NominatorCount::<Test>::get(operator_id);
+            assert_eq!(
+                nominator_count - expected_nominator_count_reduced_by,
+                new_nominator_count
+            );
         });
     }
 
@@ -1152,6 +1193,7 @@ pub(crate) mod tests {
             nominator_id: 0,
             withdraws: vec![(Withdraw::All, Err(StakingError::MinimumOperatorStake))],
             expected_withdraw: None,
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1167,6 +1209,7 @@ pub(crate) mod tests {
                 Err(StakingError::MinimumOperatorStake),
             )],
             expected_withdraw: None,
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1182,6 +1225,7 @@ pub(crate) mod tests {
                 Err(StakingError::MinimumOperatorStake),
             )],
             expected_withdraw: None,
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1194,6 +1238,7 @@ pub(crate) mod tests {
             nominator_id: 0,
             withdraws: vec![(Withdraw::Some(64 * SSC), Ok(()))],
             expected_withdraw: Some(Withdraw::Some(64 * SSC)),
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1212,6 +1257,7 @@ pub(crate) mod tests {
                 ),
             ],
             expected_withdraw: Some(Withdraw::Some(60 * SSC)),
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1227,6 +1273,7 @@ pub(crate) mod tests {
                 (Withdraw::Some(4 * SSC), Ok(())),
             ],
             expected_withdraw: Some(Withdraw::Some(64 * SSC)),
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1239,6 +1286,7 @@ pub(crate) mod tests {
             nominator_id: 0,
             withdraws: vec![(Withdraw::Some(49 * SSC), Ok(()))],
             expected_withdraw: Some(Withdraw::Some(49 * SSC)),
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1251,6 +1299,7 @@ pub(crate) mod tests {
             nominator_id: 1,
             withdraws: vec![(Withdraw::Some(45 * SSC), Ok(()))],
             expected_withdraw: Some(Withdraw::All),
+            expected_nominator_count_reduced_by: 1,
         })
     }
 
@@ -1263,6 +1312,7 @@ pub(crate) mod tests {
             nominator_id: 1,
             withdraws: vec![(Withdraw::Some(45 * SSC), Ok(()))],
             expected_withdraw: Some(Withdraw::All),
+            expected_nominator_count_reduced_by: 1,
         })
     }
 
@@ -1275,6 +1325,7 @@ pub(crate) mod tests {
             nominator_id: 1,
             withdraws: vec![(Withdraw::Some(44 * SSC), Ok(()))],
             expected_withdraw: Some(Withdraw::Some(44 * SSC)),
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1290,6 +1341,7 @@ pub(crate) mod tests {
                 (Withdraw::Some(5 * SSC), Ok(())),
             ],
             expected_withdraw: Some(Withdraw::All),
+            expected_nominator_count_reduced_by: 1,
         })
     }
 
@@ -1302,6 +1354,7 @@ pub(crate) mod tests {
             nominator_id: 1,
             withdraws: vec![(Withdraw::All, Ok(()))],
             expected_withdraw: Some(Withdraw::All),
+            expected_nominator_count_reduced_by: 1,
         })
     }
 
@@ -1320,6 +1373,7 @@ pub(crate) mod tests {
                 ),
             ],
             expected_withdraw: Some(Withdraw::All),
+            expected_nominator_count_reduced_by: 1,
         })
     }
 
@@ -1332,6 +1386,7 @@ pub(crate) mod tests {
             nominator_id: 1,
             withdraws: vec![(Withdraw::Some(39 * SSC), Ok(()))],
             expected_withdraw: Some(Withdraw::Some(39 * SSC)),
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1344,6 +1399,7 @@ pub(crate) mod tests {
             nominator_id: 1,
             withdraws: vec![(Withdraw::Some(0), Ok(()))],
             expected_withdraw: None,
+            expected_nominator_count_reduced_by: 0,
         })
     }
 
@@ -1475,6 +1531,8 @@ pub(crate) mod tests {
                 PendingDeposits::<Test>::get(operator_id, nominator_account).unwrap();
             assert_eq!(pending_deposit, nominator_stake + additional_deposit);
 
+            let nominator_count = NominatorCount::<Test>::get(operator_id);
+
             // Withdraw will be rejected while there is pending deposit
             let res = Domains::withdraw_stake(
                 RuntimeOrigin::signed(nominator_account),
@@ -1484,7 +1542,10 @@ pub(crate) mod tests {
             assert_err!(
                 res,
                 Error::<Test>::Staking(crate::staking::Error::TryWithdrawWithPendingDeposit)
-            )
+            );
+
+            // count should remain same
+            assert_eq!(NominatorCount::<Test>::get(operator_id), nominator_count);
         });
     }
 
@@ -1545,6 +1606,8 @@ pub(crate) mod tests {
                 PendingWithdrawals::<Test>::get(operator_id, nominator_account).unwrap();
             assert_eq!(pending_withdrawal, Withdraw::Some(nominator_stake * 2 / 3));
 
+            let nominator_count = NominatorCount::<Test>::get(operator_id);
+
             // Deposit will be rejected while there is pending withdraw
             let res = Domains::nominate_operator(
                 RuntimeOrigin::signed(nominator_account),
@@ -1554,7 +1617,10 @@ pub(crate) mod tests {
             assert_err!(
                 res,
                 Error::<Test>::Staking(crate::staking::Error::TryDepositWithPendingWithdraw)
-            )
+            );
+
+            // count should remain same
+            assert_eq!(NominatorCount::<Test>::get(operator_id), nominator_count);
         });
     }
 

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -1,11 +1,10 @@
 //! Staking epoch transition for domain
 
 use crate::pallet::{
-    DomainStakingSummary, LastEpochStakingDistribution, NominatorCount, Nominators,
-    OperatorIdOwner, Operators, PendingDeposits, PendingNominatorUnlocks,
-    PendingOperatorDeregistrations, PendingOperatorSwitches, PendingOperatorUnlocks,
-    PendingSlashes, PendingStakingOperationCount, PendingUnlocks, PendingWithdrawals,
-    PreferredOperator,
+    DomainStakingSummary, LastEpochStakingDistribution, Nominators, OperatorIdOwner, Operators,
+    PendingDeposits, PendingNominatorUnlocks, PendingOperatorDeregistrations,
+    PendingOperatorSwitches, PendingOperatorUnlocks, PendingSlashes, PendingStakingOperationCount,
+    PendingUnlocks, PendingWithdrawals, PreferredOperator,
 };
 use crate::staking::{Error as TransitionError, Nominator, OperatorStatus, Withdraw};
 use crate::{
@@ -210,6 +209,7 @@ fn do_finalize_operator_deregistrations<T: Config>(
 
 #[cfg(any(not(feature = "runtime-benchmarks"), test))]
 fn unlock_operator<T: Config>(operator_id: OperatorId) -> Result<(), Error> {
+    use crate::pallet::NominatorCount;
     Operators::<T>::try_mutate_exists(operator_id, |maybe_operator| {
         // take the operator so this operator info is removed once we unlock the operator.
         let operator = maybe_operator

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -1,10 +1,11 @@
 //! Staking epoch transition for domain
 
 use crate::pallet::{
-    DomainStakingSummary, LastEpochStakingDistribution, Nominators, OperatorIdOwner, Operators,
-    PendingDeposits, PendingNominatorUnlocks, PendingOperatorDeregistrations,
-    PendingOperatorSwitches, PendingOperatorUnlocks, PendingSlashes, PendingStakingOperationCount,
-    PendingUnlocks, PendingWithdrawals, PreferredOperator,
+    DomainStakingSummary, LastEpochStakingDistribution, NominatorCount, Nominators,
+    OperatorIdOwner, Operators, PendingDeposits, PendingNominatorUnlocks,
+    PendingOperatorDeregistrations, PendingOperatorSwitches, PendingOperatorUnlocks,
+    PendingSlashes, PendingStakingOperationCount, PendingUnlocks, PendingWithdrawals,
+    PreferredOperator,
 };
 use crate::staking::{Error as TransitionError, Nominator, OperatorStatus, Withdraw};
 use crate::{
@@ -269,6 +270,9 @@ fn unlock_operator<T: Config>(operator_id: OperatorId) -> Result<(), Error> {
 
         // remove OperatorOwner Details
         OperatorIdOwner::<T>::remove(operator_id);
+
+        // remove nominator count for this operator.
+        NominatorCount::<T>::remove(operator_id);
 
         Ok(())
     })
@@ -742,8 +746,8 @@ pub struct PendingOperatorSlashInfo<NominatorId, Balance> {
 mod tests {
     use crate::domain_registry::{DomainConfig, DomainObject};
     use crate::pallet::{
-        DomainRegistry, DomainStakingSummary, LastEpochStakingDistribution, Nominators,
-        OperatorIdOwner, Operators, PendingDeposits, PendingOperatorSwitches,
+        DomainRegistry, DomainStakingSummary, LastEpochStakingDistribution, NominatorCount,
+        Nominators, OperatorIdOwner, Operators, PendingDeposits, PendingOperatorSwitches,
         PendingOperatorUnlocks, PendingUnlocks, PendingWithdrawals, PreferredOperator,
     };
     use crate::staking::tests::register_operator;
@@ -938,7 +942,8 @@ mod tests {
 
             assert_eq!(Operators::<Test>::get(operator_id), None);
             assert_eq!(OperatorIdOwner::<Test>::get(operator_id), None);
-            assert!(PendingOperatorUnlocks::<Test>::get().is_empty())
+            assert!(PendingOperatorUnlocks::<Test>::get().is_empty());
+            assert_eq!(NominatorCount::<Test>::get(operator_id), 0);
         });
     }
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -187,7 +187,7 @@ parameter_types! {
     pub TreasuryAccount: u64 = PalletId(*b"treasury").into_account_truncating();
     pub const BlockReward: Balance = 10 * SSC;
     pub const MaxPendingStakingOperation: u32 = 100;
-    pub const MaxNominators: u32 = 10;
+    pub const MaxNominators: u32 = 5;
 }
 
 pub struct MockRandomness;

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -187,6 +187,7 @@ parameter_types! {
     pub TreasuryAccount: u64 = PalletId(*b"treasury").into_account_truncating();
     pub const BlockReward: Balance = 10 * SSC;
     pub const MaxPendingStakingOperation: u32 = 100;
+    pub const MaxNominators: u32 = 10;
 }
 
 pub struct MockRandomness;
@@ -230,6 +231,7 @@ impl pallet_domains::Config for Test {
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
+    type MaxNominators = MaxNominators;
     type Randomness = MockRandomness;
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -616,6 +616,7 @@ parameter_types! {
     pub const StakeEpochDuration: DomainNumber = 100;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 100;
+    pub const MaxNominators: u32 = 100;
 }
 
 impl pallet_domains::Config for Runtime {
@@ -642,6 +643,7 @@ impl pallet_domains::Config for Runtime {
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
+    type MaxNominators = MaxNominators;
     type Randomness = Subspace;
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -640,6 +640,7 @@ parameter_types! {
     pub const StakeEpochDuration: DomainNumber = 5;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 100;
+    pub const MaxNominators: u32 = 100;
 }
 
 impl pallet_domains::Config for Runtime {
@@ -666,6 +667,7 @@ impl pallet_domains::Config for Runtime {
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
+    type MaxNominators = MaxNominators;
     type Randomness = Subspace;
 }
 


### PR DESCRIPTION
This PR introduces MaxNominators parameter to limit nominators per Operators.
Since we cannot use `CountedStorageNmap` to get the count with operatorId prefix, I introduced a new storage that tracks the nominator count for each operator. The count is tracked when there is a new nominator show intent to nominate or when a Nominator withdraws all the stake from an Operator.

If MaxNominators are set to `0`, which is a requirement for Stake wars, this will not allow any nominators for any operators and can be changed through a runtime upgrade.

cc: @jfrank-summit 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
