### PR TITLE
Fix sync deadlock (take 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9501,7 +9501,6 @@ dependencies = [
 name = "sc-proof-of-time"
 version = "0.1.0"
 dependencies = [
- "async-lock",
  "atomic",
  "core_affinity",
  "derive_more",
@@ -9523,7 +9522,6 @@ dependencies = [
  "sp-runtime",
  "subspace-core-primitives",
  "subspace-proof-of-time",
- "tokio",
  "tracing",
 ]
 

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -324,16 +324,12 @@ where
             };
 
             // Ensure proof of time is valid according to parent block
-            if !self
-                .pot_verifier
-                .is_output_valid(
-                    pot_input,
-                    Slot::from(u64::from(slot) - u64::from(parent_slot)),
-                    proof_of_time,
-                    parent_pot_parameters.next_parameters_change(),
-                )
-                .await
-            {
+            if !self.pot_verifier.is_output_valid(
+                pot_input,
+                Slot::from(u64::from(slot) - u64::from(parent_slot)),
+                proof_of_time,
+                parent_pot_parameters.next_parameters_change(),
+            ) {
                 warn!(
                     target: "subspace",
                     "Proof of time is invalid, skipping block authoring at slot {slot:?}"
@@ -363,11 +359,11 @@ where
 
             for slot in *parent_future_slot + 1..=*future_slot {
                 let slot = Slot::from(slot);
-                let maybe_slot_checkpoints_fut = self.pot_verifier.get_checkpoints(
+                let maybe_slot_checkpoints = self.pot_verifier.get_checkpoints(
                     checkpoints_pot_input.slot_iterations,
                     checkpoints_pot_input.seed,
                 );
-                let Some(slot_checkpoints) = maybe_slot_checkpoints_fut.await else {
+                let Some(slot_checkpoints) = maybe_slot_checkpoints else {
                     warn!("Proving failed during block authoring");
                     return None;
                 };

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -11,7 +11,6 @@ include = [
 ]
 
 [dependencies]
-async-lock = "2.8.0"
 atomic = "0.5.3"
 core_affinity = "0.8.1"
 derive_more = "0.99.17"
@@ -33,5 +32,4 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time" }
 parking_lot = "0.12.1"
 rayon = "1.8.0"
-tokio = { version = "1.32.0", features = ["macros", "time"] }
 tracing = "0.1.37"

--- a/crates/sc-proof-of-time/src/verifier/tests.rs
+++ b/crates/sc-proof-of-time/src/verifier/tests.rs
@@ -9,8 +9,8 @@ const SEED: [u8; 16] = [
     0xd6, 0x66, 0xcc, 0xd8, 0xd5, 0x93, 0xc2, 0x3d, 0xa8, 0xdb, 0x6b, 0x5b, 0x14, 0x13, 0xb1, 0x3a,
 ];
 
-#[tokio::test]
-async fn test_basic() {
+#[test]
+fn test_basic() {
     let genesis_seed = PotSeed::from(SEED);
     let slot_iterations = NonZeroU32::new(512).unwrap();
     let checkpoints_1 = subspace_proof_of_time::prove(genesis_seed, slot_iterations).unwrap();
@@ -18,158 +18,114 @@ async fn test_basic() {
     let verifier = PotVerifier::new(genesis_seed, NonZeroUsize::new(1000).unwrap());
 
     // Expected to be valid
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations,
-                    seed: genesis_seed,
-                },
-                Slot::from(1),
-                checkpoints_1.output(),
-                None
-            )
-            .await
-    );
-    assert!(
-        verifier
-            .verify_checkpoints(genesis_seed, slot_iterations, &checkpoints_1)
-            .await
-    );
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations,
+            seed: genesis_seed,
+        },
+        Slot::from(1),
+        checkpoints_1.output(),
+        None
+    ));
+    assert!(verifier.verify_checkpoints(genesis_seed, slot_iterations, &checkpoints_1));
 
     // Invalid number of slots
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations,
-                    seed: genesis_seed,
-                },
-                Slot::from(2),
-                checkpoints_1.output(),
-                None
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations,
+            seed: genesis_seed,
+        },
+        Slot::from(2),
+        checkpoints_1.output(),
+        None
+    ));
     // Invalid seed
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations,
-                    seed: checkpoints_1.output().seed(),
-                },
-                Slot::from(1),
-                checkpoints_1.output(),
-                None
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations,
+            seed: checkpoints_1.output().seed(),
+        },
+        Slot::from(1),
+        checkpoints_1.output(),
+        None
+    ));
     // Invalid number of iterations
-    assert!(
-        !verifier
-            .verify_checkpoints(
-                genesis_seed,
-                slot_iterations
-                    .checked_mul(NonZeroU32::new(2).unwrap())
-                    .unwrap(),
-                &checkpoints_1
-            )
-            .await
-    );
+    assert!(!verifier.verify_checkpoints(
+        genesis_seed,
+        slot_iterations
+            .checked_mul(NonZeroU32::new(2).unwrap())
+            .unwrap(),
+        &checkpoints_1
+    ));
 
     let seed_1 = checkpoints_1.output().seed();
     let checkpoints_2 = subspace_proof_of_time::prove(seed_1, slot_iterations).unwrap();
 
     // Expected to be valid
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(2),
-                    slot_iterations,
-                    seed: seed_1,
-                },
-                Slot::from(1),
-                checkpoints_2.output(),
-                None
-            )
-            .await
-    );
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations,
-                    seed: genesis_seed,
-                },
-                Slot::from(2),
-                checkpoints_2.output(),
-                None
-            )
-            .await
-    );
-    assert!(
-        verifier
-            .verify_checkpoints(seed_1, slot_iterations, &checkpoints_2)
-            .await
-    );
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(2),
+            slot_iterations,
+            seed: seed_1,
+        },
+        Slot::from(1),
+        checkpoints_2.output(),
+        None
+    ));
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations,
+            seed: genesis_seed,
+        },
+        Slot::from(2),
+        checkpoints_2.output(),
+        None
+    ));
+    assert!(verifier.verify_checkpoints(seed_1, slot_iterations, &checkpoints_2));
 
     // Invalid number of slots
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations,
-                    seed: seed_1,
-                },
-                Slot::from(2),
-                checkpoints_2.output(),
-                None
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations,
+            seed: seed_1,
+        },
+        Slot::from(2),
+        checkpoints_2.output(),
+        None
+    ));
     // Invalid seed
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations,
-                    seed: seed_1,
-                },
-                Slot::from(2),
-                checkpoints_2.output(),
-                None
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations,
+            seed: seed_1,
+        },
+        Slot::from(2),
+        checkpoints_2.output(),
+        None
+    ));
     // Invalid number of iterations
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations: slot_iterations
-                        .checked_mul(NonZeroU32::new(2).unwrap())
-                        .unwrap(),
-                    seed: genesis_seed,
-                },
-                Slot::from(2),
-                checkpoints_2.output(),
-                None
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations: slot_iterations
+                .checked_mul(NonZeroU32::new(2).unwrap())
+                .unwrap(),
+            seed: genesis_seed,
+        },
+        Slot::from(2),
+        checkpoints_2.output(),
+        None
+    ));
 }
 
-#[tokio::test]
-async fn parameters_change() {
+#[test]
+fn parameters_change() {
     let genesis_seed = PotSeed::from(SEED);
     let slot_iterations_1 = NonZeroU32::new(512).unwrap();
     let entropy = [1; mem::size_of::<Blake3Hash>()];
@@ -186,114 +142,90 @@ async fn parameters_change() {
     let verifier = PotVerifier::new(genesis_seed, NonZeroUsize::new(1000).unwrap());
 
     // Changing parameters after first slot
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations: slot_iterations_1,
-                    seed: genesis_seed,
-                },
-                Slot::from(1),
-                checkpoints_1.output(),
-                Some(PotParametersChange {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_2,
-                    entropy,
-                })
-            )
-            .await
-    );
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations: slot_iterations_1,
+            seed: genesis_seed,
+        },
+        Slot::from(1),
+        checkpoints_1.output(),
+        Some(PotParametersChange {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_2,
+            entropy,
+        })
+    ));
     // Changing parameters in the middle
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations: slot_iterations_1,
-                    seed: genesis_seed,
-                },
-                Slot::from(3),
-                checkpoints_3.output(),
-                Some(PotParametersChange {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_2,
-                    entropy,
-                })
-            )
-            .await
-    );
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations: slot_iterations_1,
+            seed: genesis_seed,
+        },
+        Slot::from(3),
+        checkpoints_3.output(),
+        Some(PotParametersChange {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_2,
+            entropy,
+        })
+    ));
     // Changing parameters on last slot
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations: slot_iterations_1,
-                    seed: genesis_seed,
-                },
-                Slot::from(2),
-                checkpoints_2.output(),
-                Some(PotParametersChange {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_2,
-                    entropy,
-                })
-            )
-            .await
-    );
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations: slot_iterations_1,
+            seed: genesis_seed,
+        },
+        Slot::from(2),
+        checkpoints_2.output(),
+        Some(PotParametersChange {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_2,
+            entropy,
+        })
+    ));
     // Not changing parameters because changes apply to the very first slot that is verified
-    assert!(
-        verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_2,
-                    seed: checkpoints_1.output().seed_with_entropy(&entropy),
-                },
-                Slot::from(2),
-                checkpoints_3.output(),
-                Some(PotParametersChange {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_2,
-                    entropy,
-                })
-            )
-            .await
-    );
+    assert!(verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_2,
+            seed: checkpoints_1.output().seed_with_entropy(&entropy),
+        },
+        Slot::from(2),
+        checkpoints_3.output(),
+        Some(PotParametersChange {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_2,
+            entropy,
+        })
+    ));
 
     // Missing parameters change
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(1),
-                    slot_iterations: slot_iterations_1,
-                    seed: genesis_seed,
-                },
-                Slot::from(3),
-                checkpoints_3.output(),
-                None
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(1),
+            slot_iterations: slot_iterations_1,
+            seed: genesis_seed,
+        },
+        Slot::from(3),
+        checkpoints_3.output(),
+        None
+    ));
     // Invalid slot
-    assert!(
-        !verifier
-            .is_output_valid(
-                PotNextSlotInput {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_1,
-                    seed: genesis_seed,
-                },
-                Slot::from(3),
-                checkpoints_3.output(),
-                Some(PotParametersChange {
-                    slot: Slot::from(2),
-                    slot_iterations: slot_iterations_2,
-                    entropy,
-                })
-            )
-            .await
-    );
+    assert!(!verifier.is_output_valid(
+        PotNextSlotInput {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_1,
+            seed: genesis_seed,
+        },
+        Slot::from(3),
+        checkpoints_3.output(),
+        Some(PotParametersChange {
+            slot: Slot::from(2),
+            slot_iterations: slot_iterations_2,
+            entropy,
+        })
+    ));
 }

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -113,7 +113,7 @@ const_assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u64>());
 
 /// This is over 15 minutes of slots assuming there are no forks, should be both sufficient and not
 /// too large to handle
-const POT_VERIFIER_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(10_000).expect("Not zero; qed");
+const POT_VERIFIER_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(30_000).expect("Not zero; qed");
 const SYNC_TARGET_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Error type for Subspace service.

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -105,7 +105,6 @@ use subspace_proof_of_space::Table;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Hash, Nonce};
 use subspace_transaction_pool::{FullPool, PreValidateTransaction};
-use tokio::runtime::Handle;
 use tracing::{debug, error, info, Instrument};
 
 // There are multiple places where it is assumed that node is running on 64-bit system, refuse to
@@ -345,23 +344,19 @@ where
                     // valid
 
                     if quick_verification {
-                        tokio::task::block_in_place(|| {
-                            Handle::current().block_on(pot_verifier.try_is_output_valid(
-                                pot_input,
-                                Slot::from(slot - u64::from(parent_slot)),
-                                proof_of_time,
-                                pot_parameters.next_parameters_change(),
-                            ))
-                        })
+                        pot_verifier.try_is_output_valid(
+                            pot_input,
+                            Slot::from(slot - u64::from(parent_slot)),
+                            proof_of_time,
+                            pot_parameters.next_parameters_change(),
+                        )
                     } else {
-                        tokio::task::block_in_place(|| {
-                            Handle::current().block_on(pot_verifier.is_output_valid(
-                                pot_input,
-                                Slot::from(slot - u64::from(parent_slot)),
-                                proof_of_time,
-                                pot_parameters.next_parameters_change(),
-                            ))
-                        })
+                        pot_verifier.is_output_valid(
+                            pot_input,
+                            Slot::from(slot - u64::from(parent_slot)),
+                            proof_of_time,
+                            pot_parameters.next_parameters_change(),
+                        )
                     }
                 },
             )


### PR DESCRIPTION
This is a follow-up to https://github.com/subspace/subspace/pull/2115 that didn't fix the issue fully.

Some assumptions about `tokio::task::spawn_blocking` I had were incorrect and were in fact violated with parallel block verification when Substrate's sync was kicking in and queueing over 2000 blocks for import. Here is a good description of some of the assumptions: https://github.com/tokio-rs/tokio/discussions/3717

While we are often working in async context in Substrate, there is a bunch of blocking work happening there and turned out we don't really need async `PotVerifier` API in the end. As the result I simplified the code a bit, which makes things much easier to follow. Sync APIs can always be wrapped into async if really needed.

Second commit is a cherry on top until we remove LRU cache from `PotVerifier`. With how many blocks Substrate schedules and 6 slots on average between blocks the size of verifier cache was not enough to prevent involvement of proving. Increasing cache size 3x guarantees that things will follow happy path in most cases, while we will resolve it fully soon.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
