### PR TITLE
Fraud proof: Invalid domain block hash

### DIFF
--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -31,9 +31,9 @@ subspace-runtime-primitives = { version = "0.1.0", default-features = false, pat
 [dev-dependencies]
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
+sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
-sp-externalities = { version = "0.19.0", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 
 [features]
 default = ["std"]

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -36,11 +36,12 @@ mod benchmarks {
         let (_, operator_id) =
             register_helper_operator::<T>(domain_id, T::Currency::minimum_balance());
 
-        let mut receipt = BlockTree::<T>::get::<_, T::DomainNumber>(domain_id, Zero::zero())
-            .first()
-            .and_then(DomainBlocks::<T>::get)
-            .expect("genesis receipt must exist")
-            .execution_receipt;
+        let mut receipt =
+            BlockTree::<T>::get::<_, DomainBlockNumberFor<T>>(domain_id, Zero::zero())
+                .first()
+                .and_then(DomainBlocks::<T>::get)
+                .expect("genesis receipt must exist")
+                .execution_receipt;
         for i in 1..=(block_tree_pruning_depth + 1) {
             let consensus_block_number = i.into();
             let domain_block_number = i.into();
@@ -243,7 +244,7 @@ mod benchmarks {
         assert_eq!(domain_obj.owner_account_id, creator);
         assert!(DomainStakingSummary::<T>::get(domain_id).is_some());
         assert_eq!(
-            BlockTree::<T>::get::<_, T::DomainNumber>(domain_id, Zero::zero()).len(),
+            BlockTree::<T>::get::<_, DomainBlockNumberFor<T>>(domain_id, Zero::zero()).len(),
             1
         );
         assert_eq!(NextDomainId::<T>::get(), domain_id + 1.into());

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -2,8 +2,8 @@
 
 use crate::pallet::StateRoots;
 use crate::{
-    BalanceOf, BlockTree, Config, ConsensusBlockHash, DomainBlockDescendants, DomainBlocks,
-    ExecutionInbox, ExecutionReceiptOf, HeadReceiptNumber, InboxedBundleAuthor,
+    BalanceOf, BlockTree, Config, ConsensusBlockHash, DomainBlockDescendants, DomainBlockNumberFor,
+    DomainBlocks, ExecutionInbox, ExecutionReceiptOf, HeadReceiptNumber, InboxedBundleAuthor,
 };
 use codec::{Decode, Encode};
 use frame_support::{ensure, PalletError};
@@ -219,7 +219,7 @@ pub(crate) fn verify_execution_receipt<T: Config>(
 }
 
 pub(crate) fn derive_domain_block_hash<T: Config>(
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
     extrinsics_root: T::DomainHash,
     state_root: T::DomainHash,
     parent_domain_block_hash: T::DomainHash,
@@ -246,7 +246,7 @@ pub(crate) struct ConfirmedDomainBlockInfo<DomainNumber, Balance> {
 }
 
 pub(crate) type ProcessExecutionReceiptResult<T> =
-    Result<Option<ConfirmedDomainBlockInfo<<T as Config>::DomainNumber, BalanceOf<T>>>, Error>;
+    Result<Option<ConfirmedDomainBlockInfo<DomainBlockNumberFor<T>, BalanceOf<T>>>, Error>;
 
 /// Process the execution receipt to add it to the block tree
 /// Returns the domain block number that was pruned, if any

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -11,7 +11,8 @@ use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{DomainId, ExecutionReceipt, OperatorId};
-use sp_runtime::traits::{BlockNumberProvider, CheckedSub, One, Saturating, Zero};
+use sp_runtime::traits::{BlockNumberProvider, CheckedSub, Header, One, Saturating, Zero};
+use sp_runtime::Digest;
 use sp_std::cmp::Ordering;
 use sp_std::vec::Vec;
 
@@ -215,6 +216,24 @@ pub(crate) fn verify_execution_receipt<T: Config>(
         }
         ReceiptType::Accepted(_) | ReceiptType::Stale => Ok(()),
     }
+}
+
+pub(crate) fn derive_domain_block_hash<T: Config>(
+    domain_block_number: T::DomainNumber,
+    extrinsics_root: T::DomainHash,
+    state_root: T::DomainHash,
+    parent_domain_block_hash: T::DomainHash,
+    digest: Digest,
+) -> T::DomainHash {
+    let domain_header = T::DomainHeader::new(
+        domain_block_number,
+        extrinsics_root,
+        state_root,
+        parent_domain_block_hash,
+        digest,
+    );
+
+    domain_header.hash()
 }
 
 /// Details of the confirmed domain block such as operators, rewards they would receive.

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -11,8 +11,7 @@ use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{DomainId, ExecutionReceipt, OperatorId};
-use sp_runtime::traits::{BlockNumberProvider, CheckedSub, Header, One, Saturating, Zero};
-use sp_runtime::Digest;
+use sp_runtime::traits::{BlockNumberProvider, CheckedSub, One, Saturating, Zero};
 use sp_std::cmp::Ordering;
 use sp_std::vec::Vec;
 
@@ -216,24 +215,6 @@ pub(crate) fn verify_execution_receipt<T: Config>(
         }
         ReceiptType::Accepted(_) | ReceiptType::Stale => Ok(()),
     }
-}
-
-pub(crate) fn derive_domain_block_hash<T: Config>(
-    domain_block_number: DomainBlockNumberFor<T>,
-    extrinsics_root: T::DomainHash,
-    state_root: T::DomainHash,
-    parent_domain_block_hash: T::DomainHash,
-    digest: Digest,
-) -> T::DomainHash {
-    let domain_header = T::DomainHeader::new(
-        domain_block_number,
-        extrinsics_root,
-        state_root,
-        parent_domain_block_hash,
-        digest,
-    );
-
-    domain_header.hash()
 }
 
 /// Details of the confirmed domain block such as operators, rewards they would receive.

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -1,6 +1,6 @@
 //! Domain registry for domains
 
-use crate::block_tree::{derive_domain_block_hash, import_genesis_receipt};
+use crate::block_tree::import_genesis_receipt;
 use crate::pallet::DomainStakingSummary;
 use crate::staking::StakingSummary;
 use crate::{
@@ -16,7 +16,10 @@ use frame_support::{ensure, PalletError};
 use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;
 use sp_core::Get;
-use sp_domains::{DomainId, DomainsDigestItem, OperatorAllowList, ReceiptHash, RuntimeId};
+use sp_domains::{
+    derive_domain_block_hash, DomainId, DomainsDigestItem, OperatorAllowList, ReceiptHash,
+    RuntimeId,
+};
 use sp_runtime::traits::{CheckedAdd, Zero};
 use sp_runtime::DigestItem;
 use sp_std::collections::btree_map::BTreeMap;
@@ -128,7 +131,7 @@ pub(crate) fn do_instantiate_domain<T: Config>(
         let state_version = runtime_obj.version.state_version();
         let raw_genesis = runtime_obj.into_complete_raw_genesis(domain_id);
         let state_root = raw_genesis.state_root::<DomainHashingFor<T>>(state_version);
-        let genesis_block_hash = derive_domain_block_hash::<T>(
+        let genesis_block_hash = derive_domain_block_hash::<T::DomainHeader>(
             Zero::zero(),
             sp_domains::EMPTY_EXTRINSIC_ROOT.into(),
             state_root,

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -4,7 +4,8 @@ use crate::block_tree::{derive_domain_block_hash, import_genesis_receipt};
 use crate::pallet::DomainStakingSummary;
 use crate::staking::StakingSummary;
 use crate::{
-    Config, DomainRegistry, ExecutionReceiptOf, HoldIdentifier, NextDomainId, RuntimeRegistry,
+    Config, DomainHashingFor, DomainRegistry, ExecutionReceiptOf, HoldIdentifier, NextDomainId,
+    RuntimeRegistry,
 };
 use alloc::string::String;
 use codec::{Decode, Encode};
@@ -126,7 +127,7 @@ pub(crate) fn do_instantiate_domain<T: Config>(
 
         let state_version = runtime_obj.version.state_version();
         let raw_genesis = runtime_obj.into_complete_raw_genesis(domain_id);
-        let state_root = raw_genesis.state_root::<T::DomainHashing>(state_version);
+        let state_root = raw_genesis.state_root::<DomainHashingFor<T>>(state_version);
         let genesis_block_hash = derive_domain_block_hash::<T>(
             Zero::zero(),
             sp_domains::EMPTY_EXTRINSIC_ROOT.into(),

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -1,6 +1,6 @@
 //! Domain registry for domains
 
-use crate::block_tree::import_genesis_receipt;
+use crate::block_tree::{derive_domain_block_hash, import_genesis_receipt};
 use crate::pallet::DomainStakingSummary;
 use crate::staking::StakingSummary;
 use crate::{
@@ -127,8 +127,19 @@ pub(crate) fn do_instantiate_domain<T: Config>(
         let state_version = runtime_obj.version.state_version();
         let raw_genesis = runtime_obj.into_complete_raw_genesis(domain_id);
         let state_root = raw_genesis.state_root::<T::DomainHashing>(state_version);
+        let genesis_block_hash = derive_domain_block_hash::<T>(
+            Zero::zero(),
+            sp_domains::EMPTY_EXTRINSIC_ROOT.into(),
+            state_root,
+            Default::default(),
+            Default::default(),
+        );
 
-        ExecutionReceiptOf::<T>::genesis(state_root)
+        ExecutionReceiptOf::<T>::genesis(
+            state_root,
+            sp_domains::EMPTY_EXTRINSIC_ROOT,
+            genesis_block_hash,
+        )
     };
     let genesis_receipt_hash = genesis_receipt.hash();
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -589,7 +589,7 @@ mod pallet {
         DescendantsOfFraudulentERNotPruned,
         /// Invalid fraud proof since total rewards are not mismatched.
         InvalidTotalRewardsFraudProof(sp_domains::verification::VerificationError),
-        /// Invalid fraud proof since domain block hash is not mismatched.
+        /// Invalid domain block hash fraud proof.
         InvalidDomainBlockHashFraudProof(sp_domains::verification::VerificationError),
         /// Invalid domain extrinsic fraud proof
         InvalidExtrinsicRootFraudProof(sp_domains::verification::VerificationError),
@@ -599,6 +599,8 @@ mod pallet {
         FailedToGetDomainTimestampExtrinsic,
         /// Received invalid Verification info from host function.
         ReceivedInvalidVerificationInfo,
+        /// Parent receipt not found.
+        ParentReceiptNotFound,
     }
 
     impl<T> From<FraudProofError> for Error<T> {
@@ -1532,7 +1534,7 @@ impl<T: Config> Pallet<T> {
             }) => {
                 let parent_receipt =
                     DomainBlocks::<T>::get(bad_receipt.parent_domain_block_receipt_hash)
-                        .ok_or(FraudProofError::BadReceiptNotFound)?
+                        .ok_or(FraudProofError::ParentReceiptNotFound)?
                         .execution_receipt;
                 verify_invalid_domain_block_hash_fraud_proof::<
                     T::Block,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -153,7 +153,7 @@ mod pallet {
     };
     use sp_runtime::traits::{
         AtLeast32BitUnsigned, BlockNumberProvider, Bounded, CheckEqual, CheckedAdd, Hash,
-        MaybeDisplay, One, SimpleBitOps, Zero,
+        Header as HeaderT, MaybeDisplay, One, SimpleBitOps, Zero,
     };
     use sp_runtime::SaturatedConversion;
     use sp_std::boxed::Box;
@@ -203,6 +203,13 @@ mod pallet {
 
         /// The domain hashing algorithm.
         type DomainHashing: Hash<Output = Self::DomainHash> + TypeInfo;
+
+        /// The domain header type.
+        type DomainHeader: HeaderT<
+            Number = Self::DomainNumber,
+            Hash = Self::DomainHash,
+            Hashing = Self::DomainHashing,
+        >;
 
         /// Same with `pallet_subspace::Config::ConfirmationDepthK`.
         #[pallet::constant]

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -8,7 +8,8 @@ use crate::pallet::{
 };
 use crate::staking::{Error as TransitionError, Nominator, OperatorStatus, Withdraw};
 use crate::{
-    BalanceOf, Config, ElectionVerificationParams, FungibleHoldId, HoldIdentifier, NominatorId,
+    BalanceOf, Config, DomainBlockNumberFor, ElectionVerificationParams, FungibleHoldId,
+    HoldIdentifier, NominatorId,
 };
 use codec::{Decode, Encode};
 use frame_support::traits::fungible::{InspectHold, Mutate, MutateHold};
@@ -37,7 +38,7 @@ pub enum Error {
 /// Returns true of the epoch indeed was finished.
 pub(crate) fn do_finalize_domain_current_epoch<T: Config>(
     domain_id: DomainId,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<EpochIndex, Error> {
     // Reset pending staking operation count to 0
     PendingStakingOperationCount::<T>::set(domain_id, 0);
@@ -62,7 +63,7 @@ pub(crate) fn do_finalize_domain_current_epoch<T: Config>(
 #[cfg(any(not(feature = "runtime-benchmarks"), test))]
 pub(crate) fn do_unlock_pending_withdrawals<T: Config>(
     domain_id: DomainId,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<(), Error> {
     if let Some(operator_ids) = PendingUnlocks::<T>::take((domain_id, domain_block_number)) {
         PendingOperatorUnlocks::<T>::try_mutate(|unlocking_operator_ids| {
@@ -181,7 +182,7 @@ fn switch_operator<T: Config>(operator_id: OperatorId) -> Result<(), TransitionE
 
 fn do_finalize_operator_deregistrations<T: Config>(
     domain_id: DomainId,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<(), Error> {
     let stake_withdrawal_locking_period = T::StakeWithdrawalLockingPeriod::get();
     let unlock_block_number = domain_block_number
@@ -293,7 +294,7 @@ fn release_pending_deposits<T: Config>(operator_id: OperatorId) -> Result<(), Tr
 #[cfg(any(not(feature = "runtime-benchmarks"), test))]
 fn unlock_nominator_withdrawals<T: Config>(
     operator_id: OperatorId,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<(), Error> {
     let pending_unlock_hold_id = T::HoldIdentifier::staking_pending_unlock(operator_id);
     match PendingNominatorUnlocks::<T>::take(operator_id, domain_block_number) {
@@ -334,7 +335,7 @@ pub struct PendingNominatorUnlock<NominatorId, Balance> {
 
 pub(crate) fn do_finalize_domain_staking<T: Config>(
     domain_id: DomainId,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<EpochIndex, Error> {
     DomainStakingSummary::<T>::try_mutate(domain_id, |maybe_stake_summary| {
         let stake_summary = maybe_stake_summary
@@ -377,7 +378,7 @@ pub(crate) fn do_finalize_domain_staking<T: Config>(
 
 fn finalize_operator_pending_transfers<T: Config>(
     operator_id: OperatorId,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<BalanceOf<T>, TransitionError> {
     Operators::<T>::try_mutate(operator_id, |maybe_operator| {
         let operator = maybe_operator
@@ -418,7 +419,7 @@ fn finalize_pending_withdrawals<T: Config>(
     operator_id: OperatorId,
     total_stake: &mut BalanceOf<T>,
     total_shares: &mut T::Share,
-    domain_block_number: T::DomainNumber,
+    domain_block_number: DomainBlockNumberFor<T>,
 ) -> Result<(), TransitionError> {
     let staked_hold_id = T::HoldIdentifier::staking_staked(operator_id);
     let pending_unlock_hold_id = T::HoldIdentifier::staking_pending_unlock(operator_id);
@@ -473,7 +474,7 @@ fn finalize_nominator_withdrawal<T: Config>(
     withdraw: Withdraw<BalanceOf<T>>,
     total_stake: &mut BalanceOf<T>,
     total_shares: &mut T::Share,
-    unlock_at: T::DomainNumber,
+    unlock_at: DomainBlockNumberFor<T>,
 ) -> Result<(), TransitionError> {
     let (withdrew_stake, withdrew_shares) = match withdraw {
         Withdraw::All => {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -211,6 +211,7 @@ impl pallet_domains::Config for Test {
     type DomainNumber = BlockNumber;
     type DomainHash = sp_core::H256;
     type DomainHashing = BlakeTwo256;
+    type DomainHeader = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -17,8 +17,8 @@ use sp_core::crypto::Pair;
 use sp_core::storage::{StateVersion, StorageKey};
 use sp_core::{Get, H256, U256};
 use sp_domains::fraud_proof::{
-    ExtrinsicDigest, FraudProof, InvalidExtrinsicsRootProof, InvalidTotalRewardsProof,
-    ValidBundleDigest,
+    ExtrinsicDigest, FraudProof, InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof,
+    InvalidTotalRewardsProof, ValidBundleDigest,
 };
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::storage::RawGenesis;
@@ -32,7 +32,7 @@ use sp_domains_fraud_proof::{
     FraudProofVerificationInfoResponse,
 };
 use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, Hash as HashT, IdentityLookup, Zero};
-use sp_runtime::{BuildStorage, OpaqueExtrinsic};
+use sp_runtime::{BuildStorage, Digest, OpaqueExtrinsic};
 use sp_state_machine::backend::AsTrieBackend;
 use sp_state_machine::{prove_read, Backend, TrieBackendBuilder};
 use sp_std::sync::Arc;
@@ -927,6 +927,62 @@ fn generate_invalid_domain_extrinsic_root_fraud_proof<T: Config + pallet_timesta
         bad_receipt_hash,
         valid_bundle_digests,
     })
+}
+
+#[test]
+fn test_invalid_domain_block_hash_fraud_proof() {
+    let creator = 0u64;
+    let operator_id = 1u64;
+    let head_domain_number = 10;
+    let mut ext = new_test_ext_with_extensions();
+    ext.execute_with(|| {
+        let domain_id = register_genesis_domain(creator, vec![operator_id]);
+        extend_block_tree(domain_id, operator_id, head_domain_number + 1);
+        assert_eq!(
+            HeadReceiptNumber::<Test>::get(domain_id),
+            head_domain_number
+        );
+
+        let bad_receipt_at = 8;
+        let mut domain_block = get_block_tree_node_at::<Test>(domain_id, bad_receipt_at).unwrap();
+
+        let bad_receipt_hash = domain_block.execution_receipt.hash();
+        let (fraud_proof, root) = generate_invalid_domain_block_hash_fraud_proof::<Test>(
+            domain_id,
+            bad_receipt_hash,
+            Digest::default(),
+        );
+        domain_block.execution_receipt.final_state_root = root;
+        domain_block.execution_receipt.domain_block_hash = H256::random();
+        DomainBlocks::<Test>::insert(bad_receipt_hash, domain_block);
+        assert_ok!(Domains::validate_fraud_proof(&fraud_proof),);
+    });
+}
+
+fn generate_invalid_domain_block_hash_fraud_proof<T: Config>(
+    domain_id: DomainId,
+    bad_receipt_hash: ReceiptHash,
+    digest: Digest,
+) -> (FraudProof<BlockNumberFor<T>, T::Hash>, T::Hash) {
+    let digest_storage_key = sp_domains::fraud_proof::system_digest_final_key();
+    let mut root = T::Hash::default();
+    let mut mdb = PrefixedMemoryDB::<T::Hashing>::default();
+    {
+        let mut trie = TrieDBMutBuilderV1::new(&mut mdb, &mut root).build();
+        trie.insert(&digest_storage_key, &digest.encode()).unwrap();
+    };
+
+    let backend = TrieBackendBuilder::new(mdb, root).build();
+    let (root, digest_storage_proof) =
+        storage_proof_for_key::<T, _>(backend, StorageKey(digest_storage_key));
+    (
+        FraudProof::InvalidDomainBlockHash(InvalidDomainBlockHashProof {
+            domain_id,
+            bad_receipt_hash,
+            digest_storage_proof,
+        }),
+        root,
+    )
 }
 
 #[test]

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -2,8 +2,9 @@ use crate::block_tree::DomainBlock;
 use crate::domain_registry::{DomainConfig, DomainObject};
 use crate::{
     self as pallet_domains, BalanceOf, BlockTree, BundleError, Config, ConsensusBlockHash,
-    DomainBlocks, DomainRegistry, ExecutionInbox, ExecutionReceiptOf, FraudProofError,
-    FungibleHoldId, HeadReceiptNumber, NextDomainId, Operator, OperatorStatus, Operators,
+    DomainBlockNumberFor, DomainBlocks, DomainRegistry, ExecutionInbox, ExecutionReceiptOf,
+    FraudProofError, FungibleHoldId, HeadReceiptNumber, NextDomainId, Operator, OperatorStatus,
+    Operators,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::dispatch::RawOrigin;
@@ -208,9 +209,7 @@ impl pallet_timestamp::Config for Test {
 
 impl pallet_domains::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type DomainNumber = BlockNumber;
     type DomainHash = sp_core::H256;
-    type DomainHashing = BlakeTwo256;
     type DomainHeader = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
@@ -490,8 +489,10 @@ pub(crate) fn extend_block_tree(
 #[allow(clippy::type_complexity)]
 pub(crate) fn get_block_tree_node_at<T: Config>(
     domain_id: DomainId,
-    block_number: T::DomainNumber,
-) -> Option<DomainBlock<BlockNumberFor<T>, T::Hash, T::DomainNumber, T::DomainHash, BalanceOf<T>>> {
+    block_number: DomainBlockNumberFor<T>,
+) -> Option<
+    DomainBlock<BlockNumberFor<T>, T::Hash, DomainBlockNumberFor<T>, T::DomainHash, BalanceOf<T>>,
+> {
     BlockTree::<T>::get(domain_id, block_number)
         .first()
         .and_then(DomainBlocks::<T>::get)

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -1,14 +1,18 @@
+use codec::Decode;
 use hash_db::Hasher;
+use sp_core::storage::StorageKey;
 use sp_core::H256;
 use sp_domains::fraud_proof::{ExtrinsicDigest, InvalidExtrinsicsRootProof};
 use sp_domains::valued_trie_root::valued_ordered_trie_root;
 use sp_domains::verification::{
-    deduplicate_and_shuffle_extrinsics, extrinsics_shuffling_seed, VerificationError,
+    deduplicate_and_shuffle_extrinsics, extrinsics_shuffling_seed, StorageProofVerifier,
+    VerificationError,
 };
 use sp_domains::ExecutionReceipt;
-use sp_runtime::traits::{BlakeTwo256, Block, Hash, NumberFor};
+use sp_runtime::generic::Digest;
+use sp_runtime::traits::{BlakeTwo256, Block, Hash, Header as HeaderT, NumberFor};
 use sp_std::vec::Vec;
-use sp_trie::LayoutV1;
+use sp_trie::{LayoutV1, StorageProof};
 use subspace_core_primitives::Randomness;
 use trie_db::node::Value;
 
@@ -80,6 +84,48 @@ where
     let extrinsics_root =
         valued_ordered_trie_root::<LayoutV1<BlakeTwo256>>(ordered_trie_node_values);
     if bad_receipt.domain_block_extrinsic_root == extrinsics_root {
+        return Err(VerificationError::InvalidProof);
+    }
+
+    Ok(())
+}
+
+pub fn verify_invalid_domain_block_hash_fraud_proof<CBlock, Balance, DomainHeader>(
+    bad_receipt: ExecutionReceipt<
+        NumberFor<CBlock>,
+        CBlock::Hash,
+        DomainHeader::Number,
+        DomainHeader::Hash,
+        Balance,
+    >,
+    digest_storage_proof: StorageProof,
+    parent_domain_block_hash: DomainHeader::Hash,
+) -> Result<(), VerificationError>
+where
+    CBlock: Block,
+    Balance: PartialEq + Decode,
+    DomainHeader: HeaderT,
+    DomainHeader::Hash: From<H256>,
+{
+    let state_root = bad_receipt.final_state_root;
+    let digest_storage_key = StorageKey(sp_domains::fraud_proof::system_digest_final_key());
+
+    let digest = StorageProofVerifier::<DomainHeader::Hashing>::verify_and_get_value::<Digest>(
+        &state_root,
+        digest_storage_proof,
+        digest_storage_key,
+    )
+    .map_err(|_| VerificationError::InvalidProof)?;
+
+    let derived_domain_block_hash = sp_domains::derive_domain_block_hash::<DomainHeader>(
+        bad_receipt.domain_block_number,
+        bad_receipt.domain_block_extrinsic_root.into(),
+        state_root,
+        parent_domain_block_hash,
+        digest,
+    );
+
+    if bad_receipt.domain_block_hash == derived_domain_block_hash {
         return Err(VerificationError::InvalidProof);
     }
 

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -491,6 +491,8 @@ impl InvalidTotalRewardsProof {
     }
 }
 
+//TODO: remove there key generations from here and instead use the fraud proof host function to fetch them
+
 /// This is a representation of actual Block Rewards storage in pallet-operator-rewards.
 /// Any change in key or value there should be changed here accordingly.
 pub fn operator_block_rewards_final_key() -> Vec<u8> {

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -242,6 +242,7 @@ pub enum FraudProof<Number, Hash> {
     ImproperTransactionSortition(ImproperTransactionSortitionProof),
     InvalidTotalRewards(InvalidTotalRewardsProof),
     InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof),
+    InvalidDomainBlockHash(InvalidDomainBlockHashProof),
     // Dummy fraud proof only used in test and benchmark
     #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
     Dummy {
@@ -265,6 +266,7 @@ impl<Number, Hash> FraudProof<Number, Hash> {
             FraudProof::InvalidTotalRewards(proof) => proof.domain_id(),
             FraudProof::InvalidBundles(proof) => proof.domain_id(),
             FraudProof::InvalidExtrinsicsRoot(proof) => proof.domain_id,
+            FraudProof::InvalidDomainBlockHash(proof) => proof.domain_id,
         }
     }
 
@@ -285,6 +287,7 @@ impl<Number, Hash> FraudProof<Number, Hash> {
             // TODO: Remove default value when invalid bundle proofs are fully expanded
             FraudProof::InvalidBundles(_) => Default::default(),
             FraudProof::InvalidExtrinsicsRoot(proof) => proof.bad_receipt_hash,
+            FraudProof::InvalidDomainBlockHash(proof) => proof.bad_receipt_hash,
         }
     }
 
@@ -417,6 +420,17 @@ pub struct InvalidTotalRewardsProof {
     pub storage_proof: StorageProof,
 }
 
+/// Represents an invalid domain block hash fraud proof.
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
+pub struct InvalidDomainBlockHashProof {
+    /// The id of the domain this fraud proof targeted
+    pub domain_id: DomainId,
+    /// Hash of the bad receipt this fraud proof targeted
+    pub bad_receipt_hash: ReceiptHash,
+    /// Digests storage proof that is used to derive Domain block hash.
+    pub digest_storage_proof: StorageProof,
+}
+
 /// Represents the extrinsic either as full data or hash of the data.
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
 pub enum ExtrinsicDigest {
@@ -482,4 +496,10 @@ impl InvalidTotalRewardsProof {
 pub fn operator_block_rewards_final_key() -> Vec<u8> {
     frame_support::storage::storage_prefix("OperatorRewards".as_ref(), "BlockRewards".as_ref())
         .to_vec()
+}
+
+/// Digest storage key in frame_system.
+/// Unfortunately, the digest storage is private and not possible to derive the key from it directly.
+pub fn system_digest_final_key() -> Vec<u8> {
+    frame_support::storage::storage_prefix("System".as_ref(), "Digest".as_ref()).to_vec()
 }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -45,9 +45,9 @@ use sp_core::sr25519::vrf::{VrfOutput, VrfProof};
 use sp_core::H256;
 use sp_runtime::generic::OpaqueDigestItemId;
 use sp_runtime::traits::{
-    BlakeTwo256, Block as BlockT, CheckedAdd, Hash as HashT, NumberFor, Zero,
+    BlakeTwo256, Block as BlockT, CheckedAdd, Hash as HashT, Header as HeaderT, NumberFor, Zero,
 };
-use sp_runtime::{DigestItem, OpaqueExtrinsic, Percent};
+use sp_runtime::{Digest, DigestItem, OpaqueExtrinsic, Percent};
 use sp_runtime_interface::pass_by;
 use sp_runtime_interface::pass_by::PassBy;
 use sp_std::collections::btree_set::BTreeSet;
@@ -811,6 +811,24 @@ pub const EMPTY_EXTRINSIC_ROOT: ExtrinsicsRoot = ExtrinsicsRoot {
 pub const ZERO_OPERATOR_SIGNING_KEY: sr25519::Public = sr25519::Public(hex!(
     "0000000000000000000000000000000000000000000000000000000000000000"
 ));
+
+pub fn derive_domain_block_hash<DomainHeader: HeaderT>(
+    domain_block_number: DomainHeader::Number,
+    extrinsics_root: DomainHeader::Hash,
+    state_root: DomainHeader::Hash,
+    parent_domain_block_hash: DomainHeader::Hash,
+    digest: Digest,
+) -> DomainHeader::Hash {
+    let domain_header = DomainHeader::new(
+        domain_block_number,
+        extrinsics_root,
+        state_root,
+        parent_domain_block_hash,
+        digest,
+    );
+
+    domain_header.hash()
+}
 
 sp_api::decl_runtime_apis! {
     /// API necessary for domains pallet.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -431,11 +431,15 @@ impl<
         BlakeTwo256::hash_of(self)
     }
 
-    pub fn genesis(genesis_state_root: DomainHash) -> Self {
+    pub fn genesis(
+        genesis_state_root: DomainHash,
+        genesis_extrinsic_root: H256,
+        genesis_domain_block_hash: DomainHash,
+    ) -> Self {
         ExecutionReceipt {
             domain_block_number: Zero::zero(),
-            domain_block_hash: Default::default(),
-            domain_block_extrinsic_root: Default::default(),
+            domain_block_hash: genesis_domain_block_hash,
+            domain_block_extrinsic_root: genesis_extrinsic_root,
             parent_domain_block_receipt_hash: Default::default(),
             consensus_block_hash: Default::default(),
             consensus_block_number: Zero::zero(),

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -620,9 +620,7 @@ parameter_types! {
 
 impl pallet_domains::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type DomainNumber = DomainNumber;
     type DomainHash = DomainHash;
-    type DomainHashing = BlakeTwo256;
     type DomainHeader = sp_runtime::generic::Header<DomainNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -623,6 +623,7 @@ impl pallet_domains::Config for Runtime {
     type DomainNumber = DomainNumber;
     type DomainHash = DomainHash;
     type DomainHashing = BlakeTwo256;
+    type DomainHeader = sp_runtime::generic::Header<DomainNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -254,6 +254,9 @@ pub(super) enum ReceiptMismatchInfo<CHash> {
     DomainExtrinsicsRoot {
         consensus_block_hash: CHash,
     },
+    DomainBlockHash {
+        consensus_block_hash: CHash,
+    },
     Bundles {
         mismatch_type: BundleMismatchType,
         bundle_index: u32,
@@ -285,6 +288,9 @@ impl<CHash: Clone> ReceiptMismatchInfo<CHash> {
                 ..
             } => consensus_block_hash.clone(),
             ReceiptMismatchInfo::DomainExtrinsicsRoot {
+                consensus_block_hash,
+            } => consensus_block_hash.clone(),
+            ReceiptMismatchInfo::DomainBlockHash {
                 consensus_block_hash,
             } => consensus_block_hash.clone(),
         }

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -812,6 +812,16 @@ where
                     },
                 ));
             }
+
+            if execution_receipt.domain_block_hash != local_receipt.domain_block_hash {
+                bad_receipts_to_write.push((
+                    execution_receipt.consensus_block_number,
+                    execution_receipt.hash(),
+                    ReceiptMismatchInfo::DomainBlockHash {
+                        consensus_block_hash,
+                    },
+                ));
+            }
         }
 
         let bad_receipts_to_delete = fraud_proofs
@@ -919,6 +929,18 @@ where
                     .map_err(|err| {
                         sp_blockchain::Error::Application(Box::from(format!(
                             "Failed to generate invalid block rewards fraud proof: {err}"
+                        )))
+                    })?,
+                ReceiptMismatchInfo::DomainBlockHash { .. } => self
+                    .fraud_proof_generator
+                    .generate_invalid_domain_block_hash_proof::<ParentChainBlock>(
+                        self.domain_id,
+                        &local_receipt,
+                        bad_receipt_hash,
+                    )
+                    .map_err(|err| {
+                        sp_blockchain::Error::Application(Box::from(format!(
+                            "Failed to generate invalid domain block hash fraud proof: {err}"
                         )))
                     })?,
                 ReceiptMismatchInfo::Bundles {

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -352,7 +352,11 @@ where
                     "Domain block header for #{genesis_hash:?} not found",
                 ))
             })?;
-            ExecutionReceipt::genesis(*genesis_header.state_root())
+            ExecutionReceipt::genesis(
+                *genesis_header.state_root(),
+                (*genesis_header.extrinsics_root()).into(),
+                genesis_hash,
+            )
         } else {
             crate::load_execution_receipt_by_domain_hash::<Block, CBlock, _>(
                 &*self.client,

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -9,6 +9,7 @@ use sc_client_api::{AuxStore, BlockBackend};
 use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HashAndNumber, HeaderBackend};
+use sp_core::H256;
 use sp_domains::{
     Bundle, BundleProducerElectionApi, DomainId, DomainsApi, OperatorPublicKey, OperatorSignature,
     SealedBundleHeader,
@@ -95,6 +96,7 @@ impl<Block, CBlock, ParentChainBlock, Client, CClient, ParentChain, TransactionP
     >
 where
     Block: BlockT,
+    Block::Hash: Into<H256>,
     CBlock: BlockT,
     ParentChainBlock: BlockT,
     NumberFor<Block>: Into<NumberFor<CBlock>>,

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -8,6 +8,7 @@ use sc_transaction_pool_api::InPoolTransaction;
 use sp_api::{HeaderT, NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
+use sp_core::H256;
 use sp_domains::{BundleHeader, ExecutionReceipt, ProofOfElection};
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Hash as HashT, One, Zero};
 use sp_weights::Weight;
@@ -53,6 +54,7 @@ impl<Block, Client, CBlock, CClient, TransactionPool>
 where
     Block: BlockT,
     CBlock: BlockT,
+    Block::Hash: Into<H256>,
     NumberFor<Block>: Into<NumberFor<CBlock>>,
     Client: HeaderBackend<Block> + BlockBackend<Block> + AuxStore + ProvideRuntimeApi<Block>,
     Client::Api: BlockBuilder<Block> + DomainCoreApi<Block>,
@@ -194,7 +196,12 @@ where
                     "Domain block header for #{genesis_hash:?} not found",
                 ))
             })?;
-            return Ok(ExecutionReceipt::genesis(*genesis_header.state_root()));
+
+            return Ok(ExecutionReceipt::genesis(
+                *genesis_header.state_root(),
+                (*genesis_header.extrinsics_root()).into(),
+                genesis_hash,
+            ));
         }
 
         // Get the domain block hash corresponding to `receipt_number` in the domain canonical chain

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1061,7 +1061,6 @@ async fn test_invalid_domain_block_hash_proof_creation() {
 
     // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let mut fraud_proof_submitted = false;
     while let Some(ready_tx_hash) = import_tx_stream.next().await {
         let ready_tx = ferdie
             .transaction_pool
@@ -1078,13 +1077,11 @@ async fn test_invalid_domain_block_hash_proof_creation() {
             if let FraudProof::InvalidDomainBlockHash(InvalidDomainBlockHashProof { .. }) =
                 *fraud_proof
             {
-                fraud_proof_submitted = true;
                 break;
             }
         }
     }
 
-    assert!(fraud_proof_submitted, "Fraud proof must be submitted");
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified on
     // on the runtime itself
     ferdie.produce_blocks(1).await.unwrap();

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -18,8 +18,8 @@ use sp_core::traits::FetchRuntimeCode;
 use sp_core::Pair;
 use sp_domain_digests::AsPredigest;
 use sp_domains::fraud_proof::{
-    ExecutionPhase, FraudProof, InvalidExtrinsicsRootProof, InvalidStateTransitionProof,
-    InvalidTotalRewardsProof,
+    ExecutionPhase, FraudProof, InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof,
+    InvalidStateTransitionProof, InvalidTotalRewardsProof,
 };
 use sp_domains::transaction::InvalidTransactionCode;
 use sp_domains::{Bundle, DomainId, DomainsApi};
@@ -968,6 +968,123 @@ async fn test_invalid_total_rewards_proof_creation() {
         }
     }
 
+    // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified on
+    // on the runtime itself
+    ferdie.produce_blocks(1).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_invalid_domain_block_hash_proof_creation() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
+
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Ferdie,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+    // Produce 1 consensus block to initialize genesis domain
+    ferdie.produce_block_with_slot(1.into()).await.unwrap();
+
+    // Run Alice (a evm domain authority node)
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Alice,
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .await;
+
+    let bundle_to_tx = |opaque_bundle| {
+        subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
+            pallet_domains::Call::submit_bundle { opaque_bundle }.into(),
+        )
+        .into()
+    };
+
+    produce_blocks!(ferdie, alice, 5).await.unwrap();
+
+    alice
+        .construct_and_send_extrinsic(pallet_balances::Call::transfer_allow_death {
+            dest: Bob.to_account_id(),
+            value: 1,
+        })
+        .await
+        .expect("Failed to send extrinsic");
+
+    // Produce a bundle that contains the previously sent extrinsic and record that bundle for later use
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let target_bundle = bundle.unwrap();
+    assert_eq!(target_bundle.extrinsics.len(), 1);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+
+    // Get a bundle from the txn pool and modify the receipt of the target bundle to an invalid one
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let original_submit_bundle_tx = bundle_to_tx(bundle.clone().unwrap());
+    let bad_submit_bundle_tx = {
+        let mut opaque_bundle = bundle.unwrap();
+        let receipt = &mut opaque_bundle.sealed_header.header.receipt;
+        receipt.domain_block_hash = Default::default();
+        opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
+            .pair()
+            .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
+            .into();
+        bundle_to_tx(opaque_bundle)
+    };
+
+    // Replace `original_submit_bundle_tx` with `bad_submit_bundle_tx` in the tx pool
+    ferdie
+        .prune_tx_from_pool(&original_submit_bundle_tx)
+        .await
+        .unwrap();
+    assert!(ferdie.get_bundle_from_tx_pool(slot.into()).is_none());
+
+    ferdie
+        .submit_transaction(bad_submit_bundle_tx)
+        .await
+        .unwrap();
+
+    // Produce a consensus block that contains the `bad_submit_bundle_tx`
+    let mut import_tx_stream = ferdie.transaction_pool.import_notification_stream();
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+
+    // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
+    // it will generate and submit a fraud proof
+    let mut fraud_proof_submitted = false;
+    while let Some(ready_tx_hash) = import_tx_stream.next().await {
+        let ready_tx = ferdie
+            .transaction_pool
+            .ready_transaction(&ready_tx_hash)
+            .unwrap();
+        let ext = subspace_test_runtime::UncheckedExtrinsic::decode(
+            &mut ready_tx.data.encode().as_slice(),
+        )
+        .unwrap();
+        if let subspace_test_runtime::RuntimeCall::Domains(
+            pallet_domains::Call::submit_fraud_proof { fraud_proof },
+        ) = ext.function
+        {
+            if let FraudProof::InvalidDomainBlockHash(InvalidDomainBlockHashProof { .. }) =
+                *fraud_proof
+            {
+                fraud_proof_submitted = true;
+                break;
+            }
+        }
+    }
+
+    assert!(fraud_proof_submitted, "Fraud proof must be submitted");
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified on
     // on the runtime itself
     ferdie.produce_blocks(1).await.unwrap();

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -647,6 +647,7 @@ impl pallet_domains::Config for Runtime {
     type DomainNumber = DomainNumber;
     type DomainHash = DomainHash;
     type DomainHashing = BlakeTwo256;
+    type DomainHeader = sp_runtime::generic::Header<DomainNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -644,9 +644,7 @@ parameter_types! {
 
 impl pallet_domains::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type DomainNumber = DomainNumber;
     type DomainHash = DomainHash;
-    type DomainHashing = BlakeTwo256;
     type DomainHeader = sp_runtime::generic::Header<DomainNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;


### PR DESCRIPTION
This PR add fraud proof for invalid domain block hash. The main reason this fraud proof case exists because we cannot derive domain block hash since consensus do not know the kind of digest logs exists for any given domain. For EVM domain, frontier brings its own digest logs and as result we do not know the content of those logs on consensus chain. 
Another reason this fraud proof exists is to enable customisation on different domain types to add their own digest logs rather than constraining them.

This PR also fixes the genesis domain block hash since that can be derived since digests logs are empty for genesis block.

Closes: #1889 
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
