### PR TITLE
 Add more logs for bootstrapping to subspace-networking crate.

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1033,11 +1033,13 @@ where
                 }
             }
             KademliaEvent::OutboundQueryProgressed {
-                step: ProgressStep { last, .. },
+                step: ProgressStep { last, count },
                 id,
                 result: QueryResult::Bootstrap(result),
-                ..
+                stats,
             } => {
+                debug!(?stats, %last, %count, ?id, ?result, "Bootstrap OutboundQueryProgressed step.");
+
                 let mut cancelled = false;
                 if let Some(QueryResultSender::Bootstrap { sender }) =
                     self.query_id_receivers.get_mut(&id)


### PR DESCRIPTION
The PR adds some logging on Kademlia bootstrapping.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
