### PR TITLE
Fix RuntimeApiLight dispatch_call to correctly query RuntimeVersion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.3.11"
-source = "git+https://github.com/supranational/blst.git#3f3457c04ec0bdf8de51b16a2092e349fdd9d8ef"
+source = "git+https://github.com/supranational/blst.git#442e175b57d8f532416d2be934d008ba7c05faaa"
 dependencies = [
  "cc",
  "glob",
@@ -5194,12 +5194,12 @@ dependencies = [
  "libp2p-allow-block-list 0.2.0",
  "libp2p-autonat",
  "libp2p-connection-limits 0.2.1",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-dns 0.40.0",
  "libp2p-gossipsub",
  "libp2p-identify 0.43.0",
  "libp2p-identity 0.2.3",
- "libp2p-kad 0.44.5",
+ "libp2p-kad 0.44.4",
  "libp2p-mdns 0.44.0",
  "libp2p-metrics 0.13.1",
  "libp2p-noise 0.43.1",
@@ -5207,7 +5207,7 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-quic 0.9.2",
  "libp2p-request-response 0.25.1",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "libp2p-tcp 0.40.0",
  "libp2p-yamux 0.44.1",
  "multiaddr 0.18.0",
@@ -5232,9 +5232,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
 dependencies = [
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "void",
 ]
 
@@ -5248,10 +5248,10 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "libp2p-request-response 0.25.1",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5275,9 +5275,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
 dependencies = [
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "void",
 ]
 
@@ -5311,9 +5311,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.40.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
+checksum = "ef7dd7b09e71aac9271c60031d0e558966cdb3253ba0308ab369bb2de80630d0"
 dependencies = [
  "either",
  "fnv",
@@ -5359,7 +5359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4394c81c0c06d7b4a60f3face7e8e8a9b246840f98d2c80508d0721b032147"
 dependencies = [
  "futures",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "log",
  "parking_lot 0.12.1",
@@ -5384,9 +5384,9 @@ dependencies = [
  "getrandom 0.2.10",
  "hex_fmt",
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "prometheus-client 0.21.2",
  "quick-protobuf",
@@ -5432,9 +5432,9 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "lru 0.10.1",
  "quick-protobuf",
@@ -5510,9 +5510,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.44.5"
+version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c5c483b1e90e79409711f515c5bea5de9c4d772a245b1ac01a2233fbcb67fe"
+checksum = "fc125f83d8f75322c79e4ade74677d299b34aa5c9d9b5251c03ec28c683cb765"
 dependencies = [
  "arrayvec 0.7.4",
  "asynchronous-codec",
@@ -5522,12 +5522,11 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "quick-protobuf",
- "quick-protobuf-codec 0.2.0",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.7",
@@ -5568,9 +5567,9 @@ dependencies = [
  "data-encoding",
  "futures",
  "if-watch",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5601,13 +5600,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
 dependencies = [
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-gossipsub",
  "libp2p-identify 0.43.0",
  "libp2p-identity 0.2.3",
- "libp2p-kad 0.44.5",
+ "libp2p-kad 0.44.4",
  "libp2p-ping 0.43.0",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "once_cell",
  "prometheus-client 0.21.2",
 ]
@@ -5644,7 +5643,7 @@ dependencies = [
  "bytes",
  "curve25519-dalek 4.1.0",
  "futures",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "log",
  "multiaddr 0.18.0",
@@ -5687,9 +5686,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "rand 0.8.5",
  "void",
@@ -5704,7 +5703,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "log",
  "quick-protobuf",
@@ -5743,7 +5742,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "libp2p-tls 0.2.1",
  "log",
@@ -5781,9 +5780,9 @@ dependencies = [
  "async-trait",
  "futures",
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -5813,16 +5812,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.4"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0cf749abdc5ca1dce6296dc8ea0f012464dfcfd3ddd67ffc0cabd8241c4e1da"
+checksum = "28016944851bd73526d3c146aabf0fa9bbe27c558f080f9e5447da3a1772c01a"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
  "instant",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "libp2p-swarm-derive 0.33.0",
  "log",
@@ -5867,10 +5866,10 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "libp2p-plaintext",
- "libp2p-swarm 0.43.4",
+ "libp2p-swarm 0.43.3",
  "libp2p-tcp 0.40.0",
  "libp2p-yamux 0.44.1",
  "log",
@@ -5904,7 +5903,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "log",
  "socket2 0.5.4",
@@ -5938,7 +5937,7 @@ checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
 dependencies = [
  "futures",
  "futures-rustls 0.24.0",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "libp2p-identity 0.2.3",
  "rcgen 0.10.0",
  "ring 0.16.20",
@@ -6033,7 +6032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
 dependencies = [
  "futures",
- "libp2p-core 0.40.1",
+ "libp2p-core 0.40.0",
  "log",
  "thiserror",
  "yamux 0.12.0",
@@ -7523,9 +7522,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ab494af9e6e813c72170f0d3c1de1500990d62c97cc05cc7576f91aa402f"
+checksum = "ab512a34b3c2c5e465731cc7668edf79208bbe520be03484eeb05e63ed221735"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -10739,6 +10738,7 @@ dependencies = [
  "domain-block-preprocessor",
  "hash-db 0.16.0",
  "parity-scale-codec",
+ "sc-executor",
  "scale-info",
  "sp-api",
  "sp-blockchain",
@@ -12732,7 +12732,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/crates/sp-domains-fraud-proof/Cargo.toml
+++ b/crates/sp-domains-fraud-proof/Cargo.toml
@@ -15,6 +15,7 @@ codec = { package = "parity-scale-codec", version = "3.6.5", default-features = 
 hash-db = { version = "0.16.0", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 domain-block-preprocessor = { version = "0.1.0", default-features = false, path = "../../domains/client/block-preprocessor", optional = true }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9", default-features = false, optional = true }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9", optional = true }
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
@@ -34,6 +35,7 @@ std = [
     "hash-db/std",
     "scale-info/std",
     "domain-block-preprocessor",
+    "sc-executor",
     "sp-api/std",
     "sp-blockchain",
     "sp-core/std",

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -2,6 +2,7 @@ use crate::{FraudProofVerificationInfoRequest, FraudProofVerificationInfoRespons
 use codec::Encode;
 use domain_block_preprocessor::runtime_api::InherentExtrinsicConstructor;
 use domain_block_preprocessor::runtime_api_light::RuntimeApiLight;
+use sc_executor::RuntimeVersionOf;
 use sp_api::{BlockT, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::CodeExecutor;
@@ -61,7 +62,7 @@ where
     DomainBlock: BlockT,
     Client: HeaderBackend<Block> + ProvideRuntimeApi<Block>,
     Client::Api: DomainsApi<Block, NumberFor<DomainBlock>, DomainBlock::Hash>,
-    Executor: CodeExecutor,
+    Executor: CodeExecutor + RuntimeVersionOf,
 {
     fn get_block_randomness(&self, consensus_block_hash: H256) -> Option<Randomness> {
         let runtime_api = self.consensus_client.runtime_api();
@@ -106,7 +107,7 @@ where
     DomainBlock: BlockT,
     Client: HeaderBackend<Block> + ProvideRuntimeApi<Block>,
     Client::Api: DomainsApi<Block, NumberFor<DomainBlock>, DomainBlock::Hash>,
-    Executor: CodeExecutor,
+    Executor: CodeExecutor + RuntimeVersionOf,
 {
     fn get_fraud_proof_verification_info(
         &self,

--- a/crates/subspace-fraud-proof/Cargo.toml
+++ b/crates/subspace-fraud-proof/Cargo.toml
@@ -18,6 +18,7 @@ domain-block-preprocessor = { version = "0.1.0", path = "../../domains/client/bl
 futures = "0.3.28"
 hash-db = "0.16.0"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9", default-features = false }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }
 sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "74509ce016358e7f56ed2825fd75c324f8c22ef9" }

--- a/crates/subspace-fraud-proof/src/invalid_transaction_proof.rs
+++ b/crates/subspace-fraud-proof/src/invalid_transaction_proof.rs
@@ -7,6 +7,7 @@ use domain_block_preprocessor::runtime_api_light::RuntimeApiLight;
 use domain_runtime_primitives::opaque::Block;
 use domain_runtime_primitives::{DomainCoreApi, Hash};
 use sc_client_api::StorageProof;
+use sc_executor::RuntimeVersionOf;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::CodeExecutor;
@@ -53,7 +54,7 @@ fn create_runtime_api_light<Exec>(
     extrinsic: OpaqueExtrinsic,
 ) -> Result<RuntimeApiLight<Exec>, VerificationError>
 where
-    Exec: CodeExecutor,
+    Exec: CodeExecutor + RuntimeVersionOf,
 {
     let mut runtime_api_light = RuntimeApiLight::new(executor, wasm_bundle);
 
@@ -116,7 +117,7 @@ where
     CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + Send + Sync,
     CClient::Api: DomainsApi<CBlock, domain_runtime_primitives::BlockNumber, Hash>,
     VerifierClient: VerifierApi,
-    Exec: CodeExecutor + 'static,
+    Exec: CodeExecutor + RuntimeVersionOf + 'static,
 {
     /// Constructs a new instance of [`InvalidTransactionProofVerifier`].
     pub fn new(
@@ -237,7 +238,7 @@ where
     Client: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + Send + Sync,
     Client::Api: DomainsApi<CBlock, domain_runtime_primitives::BlockNumber, Hash>,
     VerifierClient: VerifierApi,
-    Exec: CodeExecutor + 'static,
+    Exec: CodeExecutor + RuntimeVersionOf + 'static,
 {
     fn verify_invalid_transaction_proof(
         &self,

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -115,9 +115,7 @@ fn generate_storage_proof_for_tx_validity(
         .unwrap()
 }
 
-// TODO: Enable this test when runtime_api_light is fixed
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn check_tx_validity_runtime_api_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -246,7 +246,7 @@ where
     Client: HeaderBackend<Block> + ProvideRuntimeApi<Block> + Send + Sync + 'static,
     Client::Api: SubspaceApi<Block, FarmerPublicKey>
         + DomainsApi<Block, NumberFor<DomainBlock>, DomainBlock::Hash>,
-    ExecutorDispatch: CodeExecutor,
+    ExecutorDispatch: CodeExecutor + sc_executor::RuntimeVersionOf,
 {
     fn extensions_for(
         &self,

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -200,7 +200,7 @@ where
     DomainBlock: BlockT,
     Client: HeaderBackend<Block> + ProvideRuntimeApi<Block> + 'static,
     Client::Api: DomainsApi<Block, NumberFor<DomainBlock>, DomainBlock::Hash>,
-    Executor: CodeExecutor,
+    Executor: CodeExecutor + sc_executor::RuntimeVersionOf,
 {
     fn extensions_for(
         &self,


### PR DESCRIPTION
## Description
This PR fix `RuntimeApiLight::dispatch_call` to correctly query `RuntimeVersion` from `executor`. This fix is imported from @NingLin-P's https://github.com/subspace/subspace/pull/1983 PR.

- First commit fixes `RuntimeApiLight`
- Second commit just enables the ignored test 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
