### PR TITLE
Auditing refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11461,6 +11461,8 @@ dependencies = [
  "hex",
  "libc",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "pin-project",
  "rand 0.8.5",
  "rayon",
  "schnorrkel",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -44,7 +44,7 @@ use std::marker::PhantomData;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::simd::Simd;
 use std::sync::{Once, OnceLock};
-use std::{iter, mem, slice};
+use std::{iter, mem};
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::crypto::Scalar;
@@ -55,7 +55,7 @@ use subspace_core_primitives::{
     Solution, SolutionRange, REWARD_SIGNING_CONTEXT,
 };
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::auditing::audit_plot_sync;
+use subspace_farmer_components::auditing::audit_sector_sync;
 use subspace_farmer_components::plotting::{
     plot_sector, PieceGetterRetryPolicy, PlotSectorOptions,
 };
@@ -479,16 +479,15 @@ pub fn create_signed_vote(
             .derive_global_randomness()
             .derive_global_challenge(slot.into());
 
-        let maybe_audit_result = audit_plot_sync(
+        let maybe_audit_result = audit_sector_sync(
             &public_key,
             &global_challenge,
             vote_solution_range,
             &plotted_sector_bytes,
-            slice::from_ref(&plotted_sector.sector_metadata),
-            None,
+            &plotted_sector.sector_metadata,
         );
 
-        let Some(audit_result) = maybe_audit_result.into_iter().next() else {
+        let Some(audit_result) = maybe_audit_result else {
             // Sector didn't have any solutions
             continue;
         };

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -480,7 +480,6 @@ pub fn create_signed_vote(
 
         let maybe_audit_result = audit_sector(
             &public_key,
-            sector_index,
             &global_challenge,
             vote_solution_range,
             &plotted_sector_bytes,

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -197,7 +197,6 @@ fn valid_header(
 
         let maybe_solution_candidates = audit_sector(
             &public_key,
-            sector_index,
             &global_challenge,
             SolutionRange::MAX,
             &plotted_sector_bytes,

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3.28"
 hex = "0.4.3"
 libc = "0.2.146"
 parity-scale-codec = "3.6.5"
+pin-project = "1.1.3"
 rand = "0.8.5"
 rayon = "1.8.0"
 schnorrkel = "0.9.1"
@@ -45,6 +46,7 @@ winapi = "0.3.9"
 [dev-dependencies]
 criterion = "0.5.1"
 futures = "0.3.28"
+parking_lot = "0.12.1"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -1,11 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
-use futures::FutureExt;
 use rand::prelude::*;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
-use std::{env, fs};
+use std::{env, fs, slice};
 use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -13,7 +12,7 @@ use subspace_core_primitives::{
     Blake3Hash, HistorySize, PublicKey, Record, RecordedHistorySegment, SectorId, SolutionRange,
 };
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::auditing::audit_sector;
+use subspace_farmer_components::auditing::audit_plot_sync;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{
     plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
@@ -21,7 +20,7 @@ use subspace_farmer_components::plotting::{
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::{FarmerProtocolInfo, ReadAt, ReadAtSync};
+use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 
@@ -150,17 +149,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("auditing");
     group.throughput(Throughput::Elements(1));
-    group.bench_function("memory", |b| {
-        b.iter(|| {
-            audit_sector(
+    group.bench_function("memory/sync", |b| {
+        b.iter(|| async {
+            black_box(audit_plot_sync(
                 black_box(public_key),
                 black_box(global_challenge),
                 black_box(solution_range),
-                black_box(ReadAt::from_sync(&plotted_sector_bytes)),
-                black_box(&plotted_sector.sector_metadata),
-            )
-            .now_or_never()
-            .unwrap();
+                black_box(&plotted_sector_bytes),
+                black_box(slice::from_ref(&plotted_sector.sector_metadata)),
+                black_box(None),
+            ));
         })
     });
 
@@ -188,23 +186,21 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 .unwrap();
         }
 
+        let sectors_metadata = (0..sectors_count)
+            .map(|_| plotted_sector.sector_metadata.clone())
+            .collect::<Vec<_>>();
+
         group.throughput(Throughput::Elements(sectors_count));
-        group.bench_function("disk", |b| {
+        group.bench_function("disk/sync", |b| {
             b.iter(|| {
-                for sector_index in 0..sectors_count as usize {
-                    let sector = plot_file.offset(sector_index * sector_size);
-                    black_box(
-                        audit_sector(
-                            black_box(public_key),
-                            black_box(global_challenge),
-                            black_box(solution_range),
-                            black_box(ReadAt::from_sync(sector)),
-                            black_box(&plotted_sector.sector_metadata),
-                        )
-                        .now_or_never()
-                        .unwrap(),
-                    );
-                }
+                black_box(audit_plot_sync(
+                    black_box(public_key),
+                    black_box(global_challenge),
+                    black_box(solution_range),
+                    black_box(&plot_file),
+                    black_box(&sectors_metadata),
+                    black_box(None),
+                ));
             });
         });
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -10,8 +10,7 @@ use subspace_archiving::archiver::Archiver;
 use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{
-    Blake3Hash, HistorySize, PublicKey, Record, RecordedHistorySegment, SectorId, SectorIndex,
-    SolutionRange,
+    Blake3Hash, HistorySize, PublicKey, Record, RecordedHistorySegment, SectorId, SolutionRange,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
@@ -155,7 +154,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             audit_sector(
                 black_box(&public_key),
-                black_box(sector_index),
                 black_box(&global_challenge),
                 black_box(solution_range),
                 black_box(&plotted_sector_bytes),
@@ -197,7 +195,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         let sector = plot_file.offset(sector_index * sector_size);
                         audit_sector(
                             black_box(&public_key),
-                            black_box(sector_index as SectorIndex),
                             black_box(&global_challenge),
                             black_box(solution_range),
                             black_box(&sector),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -159,7 +159,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let maybe_audit_result = audit_sector(
             &public_key,
-            sector_index,
             &global_challenge,
             solution_range,
             &plotted_sector_bytes,
@@ -190,7 +189,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     {
         let solution_candidates = audit_sector(
             &public_key,
-            sector_index,
             &global_challenge,
             solution_range,
             &plotted_sector_bytes,
@@ -252,7 +250,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .map(|sector| {
                 audit_sector(
                     &public_key,
-                    sector_index,
                     &global_challenge,
                     solution_range,
                     sector,

--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -3,6 +3,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::Result;
 
+/// Extension convenience trait that allows setting some file opening options in cross-platform way
 pub trait OpenOptionsExt {
     /// Advise OS/file system that file will use random access and read-ahead behavior is
     /// undesirable, only has impact on Windows, for other operating systems see [`FileExt`]

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -68,7 +68,8 @@ where
 /// thread pool
 pub trait ReadAtSync: Send + Sync {
     /// Get implementation of [`ReadAtSync`] that add specified offset to all attempted reads
-    fn offset(&self, offset: usize) -> ReadAtOffset<&Self>
+    // TODO: Should offset and reads be in u64?
+    fn offset(&self, offset: usize) -> ReadAtOffset<'_, Self>
     where
         Self: Sized,
     {
@@ -92,7 +93,7 @@ impl ReadAtSync for ! {
 /// concurrent async combinators
 pub trait ReadAtAsync {
     /// Get implementation of [`ReadAtAsync`] that add specified offset to all attempted reads
-    fn offset(&self, offset: usize) -> ReadAtOffset<&Self>
+    fn offset(&self, offset: usize) -> ReadAtOffset<'_, Self>
     where
         Self: Sized,
     {
@@ -168,12 +169,12 @@ impl ReadAtSync for &File {
 
 /// Reader with fixed offset added to all attempted reads
 #[derive(Debug, Copy, Clone)]
-pub struct ReadAtOffset<T> {
-    inner: T,
+pub struct ReadAtOffset<'a, T> {
+    inner: &'a T,
     offset: usize,
 }
 
-impl<T> ReadAtSync for ReadAtOffset<T>
+impl<T> ReadAtSync for ReadAtOffset<'_, T>
 where
     T: ReadAtSync,
 {
@@ -182,7 +183,7 @@ where
     }
 }
 
-impl<T> ReadAtSync for &ReadAtOffset<T>
+impl<T> ReadAtSync for &ReadAtOffset<'_, T>
 where
     T: ReadAtSync,
 {
@@ -191,7 +192,7 @@ where
     }
 }
 
-impl<T> ReadAtAsync for ReadAtOffset<T>
+impl<T> ReadAtAsync for ReadAtOffset<'_, T>
 where
     T: ReadAtAsync,
 {
@@ -200,7 +201,7 @@ where
     }
 }
 
-impl<T> ReadAtAsync for &ReadAtOffset<T>
+impl<T> ReadAtAsync for &ReadAtOffset<'_, T>
 where
     T: ReadAtAsync,
 {

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -4,6 +4,7 @@
     const_trait_impl,
     int_roundings,
     iter_collect_into,
+    never_type,
     new_uninit,
     portable_simd,
     slice_flatten,
@@ -26,12 +27,47 @@ use crate::file_ext::FileExt;
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
 use std::fs::File;
+use std::future::Future;
 use std::io;
 use subspace_core_primitives::HistorySize;
 
-/// Trait for reading data at specific offset
-pub trait ReadAt: Send + Sync {
-    /// Get implementation of [`ReadAt`] that add specified offset to all attempted reads
+/// Enum to encapsulate the selection between [`ReadAtSync`] and [`ReadAtAsync]` variants
+#[derive(Copy, Clone)]
+pub enum ReadAt<S, A>
+where
+    S: ReadAtSync,
+    A: ReadAtAsync,
+{
+    /// Sync variant
+    Sync(S),
+    /// Async variant
+    Async(A),
+}
+
+impl<S> ReadAt<S, !>
+where
+    S: ReadAtSync,
+{
+    /// Instantiate [`ReadAt`] from some [`ReadAtSync`] implementation
+    pub fn from_sync(value: S) -> Self {
+        Self::Sync(value)
+    }
+}
+
+impl<A> ReadAt<!, A>
+where
+    A: ReadAtAsync,
+{
+    /// Instantiate [`ReadAt`] from some [`ReadAtAsync`] implementation
+    pub fn from_async(value: A) -> Self {
+        Self::Async(value)
+    }
+}
+
+/// Sync version of [`ReadAt`], it is both [`Send`] and [`Sync`] and is supposed to be used with a
+/// thread pool
+pub trait ReadAtSync: Send + Sync {
+    /// Get implementation of [`ReadAtSync`] that add specified offset to all attempted reads
     fn offset(&self, offset: usize) -> ReadAtOffset<&Self>
     where
         Self: Sized,
@@ -46,7 +82,37 @@ pub trait ReadAt: Send + Sync {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()>;
 }
 
-impl ReadAt for [u8] {
+impl ReadAtSync for ! {
+    fn read_at(&self, _buf: &mut [u8], _offset: usize) -> io::Result<()> {
+        unreachable!("Is never called")
+    }
+}
+
+/// Async version of [`ReadAt`], it is neither [`Send`] nor [`Sync`] and is supposed to be used with
+/// concurrent async combinators
+pub trait ReadAtAsync {
+    /// Get implementation of [`ReadAtAsync`] that add specified offset to all attempted reads
+    fn offset(&self, offset: usize) -> ReadAtOffset<&Self>
+    where
+        Self: Sized,
+    {
+        ReadAtOffset {
+            inner: self,
+            offset,
+        }
+    }
+
+    /// Fill the buffer by reading bytes at a specific offset
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> impl Future<Output = io::Result<()>>;
+}
+
+impl ReadAtAsync for ! {
+    async fn read_at(&self, _buf: &mut [u8], _offset: usize) -> io::Result<()> {
+        unreachable!("Is never called")
+    }
+}
+
+impl ReadAtSync for [u8] {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         if buf.len() + offset > self.len() {
             return Err(io::Error::new(
@@ -61,7 +127,7 @@ impl ReadAt for [u8] {
     }
 }
 
-impl ReadAt for &[u8] {
+impl ReadAtSync for &[u8] {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         if buf.len() + offset > self.len() {
             return Err(io::Error::new(
@@ -76,25 +142,25 @@ impl ReadAt for &[u8] {
     }
 }
 
-impl ReadAt for Vec<u8> {
+impl ReadAtSync for Vec<u8> {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.as_slice().read_at(buf, offset)
     }
 }
 
-impl ReadAt for &Vec<u8> {
+impl ReadAtSync for &Vec<u8> {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.as_slice().read_at(buf, offset)
     }
 }
 
-impl ReadAt for File {
+impl ReadAtSync for File {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.read_exact_at(buf, offset as u64)
     }
 }
 
-impl ReadAt for &File {
+impl ReadAtSync for &File {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.read_exact_at(buf, offset as u64)
     }
@@ -107,21 +173,39 @@ pub struct ReadAtOffset<T> {
     offset: usize,
 }
 
-impl<T> ReadAt for ReadAtOffset<T>
+impl<T> ReadAtSync for ReadAtOffset<T>
 where
-    T: ReadAt,
+    T: ReadAtSync,
 {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.inner.read_at(buf, offset + self.offset)
     }
 }
 
-impl<T> ReadAt for &ReadAtOffset<T>
+impl<T> ReadAtSync for &ReadAtOffset<T>
 where
-    T: ReadAt,
+    T: ReadAtSync,
 {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
         self.inner.read_at(buf, offset + self.offset)
+    }
+}
+
+impl<T> ReadAtAsync for ReadAtOffset<T>
+where
+    T: ReadAtAsync,
+{
+    async fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        self.inner.read_at(buf, offset + self.offset).await
+    }
+}
+
+impl<T> ReadAtAsync for &ReadAtOffset<T>
+where
+    T: ReadAtAsync,
+{
+    async fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        self.inner.read_at(buf, offset + self.offset).await
     }
 }
 

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -10,7 +10,7 @@ use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::{
     ChunkWitness, PieceOffset, PosProof, PosSeed, PublicKey, Record, RecordCommitment,
-    RecordWitness, SBucket, SectorId, SectorIndex, Solution, SolutionRange,
+    RecordWitness, SBucket, SectorId, Solution, SolutionRange,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_proof_of_space::{Quality, Table};
@@ -77,7 +77,6 @@ where
     Sector: 'a,
 {
     public_key: &'a PublicKey,
-    sector_index: SectorIndex,
     sector_id: SectorId,
     s_bucket: SBucket,
     sector: Sector,
@@ -92,7 +91,6 @@ where
     fn clone(&self) -> Self {
         Self {
             public_key: self.public_key,
-            sector_index: self.sector_index,
             sector_id: self.sector_id,
             s_bucket: self.s_bucket,
             sector: self.sector.clone(),
@@ -108,7 +106,6 @@ where
 {
     pub(crate) fn new(
         public_key: &'a PublicKey,
-        sector_index: SectorIndex,
         sector_id: SectorId,
         s_bucket: SBucket,
         sector: Sector,
@@ -117,7 +114,6 @@ where
     ) -> Self {
         Self {
             public_key,
-            sector_index,
             sector_id,
             s_bucket,
             sector,
@@ -157,7 +153,6 @@ where
         SolutionsIterator::<'a, RewardAddress, Sector, PosTable, TableGenerator>::new(
             self.public_key,
             reward_address,
-            self.sector_index,
             self.sector_id,
             self.s_bucket,
             self.sector,
@@ -187,7 +182,6 @@ where
 {
     public_key: &'a PublicKey,
     reward_address: &'a RewardAddress,
-    sector_index: SectorIndex,
     sector_id: SectorId,
     s_bucket: SBucket,
     sector_metadata: &'a SectorMetadataChecksummed,
@@ -331,7 +325,7 @@ where
         Some(Ok(Solution {
             public_key: *self.public_key,
             reward_address: *self.reward_address,
-            sector_index: self.sector_index,
+            sector_index: self.sector_metadata.sector_index,
             history_size: self.sector_metadata.history_size,
             piece_offset,
             record_commitment: chunk_cache.record_commitment,
@@ -389,7 +383,6 @@ where
     fn new(
         public_key: &'a PublicKey,
         reward_address: &'a RewardAddress,
-        sector_index: SectorIndex,
         sector_id: SectorId,
         s_bucket: SBucket,
         sector: Sector,
@@ -450,7 +443,6 @@ where
         Ok(Self {
             public_key,
             reward_address,
-            sector_index,
             sector_id,
             s_bucket,
             sector_metadata,

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -3,9 +3,14 @@ use crate::reading::{read_record_metadata, read_sector_record_chunks, ReadingErr
 use crate::sector::{
     SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadataChecksummed,
 };
-use crate::ReadAt;
+use crate::{ReadAt, ReadAtAsync, ReadAtSync};
+use futures::Stream;
 use std::collections::VecDeque;
 use std::io;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::{
@@ -16,10 +21,21 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_proof_of_space::{Quality, Table};
 use thiserror::Error;
 
-/// Solutions that can be proven if necessary
-pub trait ProvableSolutions: ExactSizeIterator {
-    /// Best solution distance found, `None` in case iterator is empty
+/// Solutions that can be proven if necessary.
+///
+/// NOTE: Even though this implements async stream, it will do blocking proof os space table
+/// derivation and should be running on a dedicated thread.
+pub trait ProvableSolutions: Stream {
+    /// Best solution distance found, `None` in case there are no solutions
     fn best_solution_distance(&self) -> Option<SolutionRange>;
+
+    /// Returns the exact remaining number of solutions
+    fn len(&self) -> usize;
+
+    /// Returns `true` if there are no solutions
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Errors that happen during proving
@@ -70,7 +86,7 @@ struct WinningChunk {
     audit_chunks: VecDeque<AuditChunkCandidate>,
 }
 
-/// Container for solutions
+/// Container for solution candidates.
 #[derive(Debug)]
 pub struct SolutionCandidates<'a, Sector>
 where
@@ -100,15 +116,16 @@ where
     }
 }
 
-impl<'a, Sector> SolutionCandidates<'a, Sector>
+impl<'a, S, A> SolutionCandidates<'a, ReadAt<S, A>>
 where
-    Sector: ReadAt + 'a,
+    S: ReadAtSync + 'a,
+    A: ReadAtAsync + 'a,
 {
     pub(crate) fn new(
         public_key: &'a PublicKey,
         sector_id: SectorId,
         s_bucket: SBucket,
-        sector: Sector,
+        sector: ReadAt<S, A>,
         sector_metadata: &'a SectorMetadataChecksummed,
         chunk_candidates: VecDeque<ChunkCandidate>,
     ) -> Self {
@@ -135,33 +152,34 @@ where
         self.chunk_candidates.is_empty()
     }
 
-    pub fn into_solutions<RewardAddress, PosTable, TableGenerator>(
+    /// Turn solution candidates into actual solutions
+    pub async fn into_solutions<RewardAddress, PosTable, TableGenerator>(
         self,
         reward_address: &'a RewardAddress,
         kzg: &'a Kzg,
         erasure_coding: &'a ErasureCoding,
         table_generator: TableGenerator,
-    ) -> Result<
-        impl ProvableSolutions<Item = Result<Solution<PublicKey, RewardAddress>, ProvingError>> + 'a,
-        ProvingError,
-    >
+    ) -> Result<impl ProvableSolutions<Item = MaybeSolution<RewardAddress>> + 'a, ProvingError>
     where
         RewardAddress: Copy,
         PosTable: Table,
         TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
     {
-        SolutionsIterator::<'a, RewardAddress, Sector, PosTable, TableGenerator>::new(
-            self.public_key,
-            reward_address,
-            self.sector_id,
-            self.s_bucket,
-            self.sector,
-            self.sector_metadata,
-            kzg,
-            erasure_coding,
-            self.chunk_candidates,
-            table_generator,
-        )
+        let solutions_iterator_fut =
+            SolutionsIterator::<'a, RewardAddress>::new::<PosTable, TableGenerator, S, A>(
+                self.public_key,
+                reward_address,
+                self.sector_id,
+                self.s_bucket,
+                self.sector,
+                self.sector_metadata,
+                kzg,
+                erasure_coding,
+                self.chunk_candidates,
+                table_generator,
+            );
+
+        solutions_iterator_fut.await
     }
 }
 
@@ -174,7 +192,7 @@ struct ChunkCache {
     proof_of_space: PosProof,
 }
 
-struct SolutionsIterator<'a, RewardAddress, Sector, PosTable, TableGenerator>
+struct SolutionsIteratorState<'a, RewardAddress, PosTable, TableGenerator, Sector>
 where
     Sector: 'a,
     PosTable: Table,
@@ -191,207 +209,73 @@ where
     sector_contents_map: SectorContentsMap,
     sector: Sector,
     winning_chunks: VecDeque<WinningChunk>,
-    count: usize,
+    count: Arc<AtomicUsize>,
     chunk_cache: Option<ChunkCache>,
-    best_solution_distance: Option<SolutionRange>,
     table_generator: TableGenerator,
 }
 
-// TODO: This can be potentially parallelized with rayon
-impl<'a, RewardAddress, Sector, PosTable, TableGenerator> Iterator
-    for SolutionsIterator<'a, RewardAddress, Sector, PosTable, TableGenerator>
+type MaybeSolution<RewardAddress> = Result<Solution<PublicKey, RewardAddress>, ProvingError>;
+
+#[pin_project::pin_project]
+struct SolutionsIterator<'a, RewardAddress> {
+    #[pin]
+    stream: Pin<Box<dyn Stream<Item = MaybeSolution<RewardAddress>> + 'a>>,
+    count: Arc<AtomicUsize>,
+    best_solution_distance: Option<SolutionRange>,
+}
+
+impl<'a, RewardAddress> Stream for SolutionsIterator<'a, RewardAddress>
 where
     RewardAddress: Copy,
-    Sector: ReadAt + 'a,
-    PosTable: Table,
-    TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
 {
-    type Item = Result<Solution<PublicKey, RewardAddress>, ProvingError>;
+    type Item = MaybeSolution<RewardAddress>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let (chunk_offset, piece_offset, audit_chunk_offset) = {
-            let winning_chunk = self.winning_chunks.front_mut()?;
-
-            let audit_chunk = winning_chunk.audit_chunks.pop_front()?;
-            let chunk_offset = winning_chunk.chunk_offset;
-            let piece_offset = winning_chunk.piece_offset;
-
-            if winning_chunk.audit_chunks.is_empty() {
-                // When all audit chunk offsets are removed, the winning chunks entry itself can be removed
-                self.winning_chunks.pop_front();
-            }
-
-            (chunk_offset, piece_offset, audit_chunk.offset)
-        };
-
-        self.count -= 1;
-
-        let chunk_cache = 'outer: {
-            if let Some(chunk_cache) = &self.chunk_cache {
-                if chunk_cache.chunk_offset == chunk_offset {
-                    break 'outer chunk_cache;
-                }
-            }
-
-            // Derive PoSpace table
-            let pos_table = (self.table_generator)(
-                &self
-                    .sector_id
-                    .derive_evaluation_seed(piece_offset, self.sector_metadata.history_size),
-            );
-
-            let maybe_chunk_cache: Result<_, ProvingError> = try {
-                let sector_record_chunks = read_sector_record_chunks(
-                    piece_offset,
-                    self.sector_metadata.pieces_in_sector,
-                    &self.s_bucket_offsets,
-                    &self.sector_contents_map,
-                    &pos_table,
-                    &self.sector,
-                )?;
-
-                let chunk = sector_record_chunks
-                    .get(usize::from(self.s_bucket))
-                    .expect("Within s-bucket range; qed")
-                    .expect("Winning chunk was plotted; qed");
-
-                let source_chunks_polynomial = self
-                    .erasure_coding
-                    .recover_poly(sector_record_chunks.as_slice())
-                    .map_err(|error| ReadingError::FailedToErasureDecodeRecord {
-                        piece_offset,
-                        error,
-                    })?;
-                drop(sector_record_chunks);
-
-                // NOTE: We do not check plot consistency using checksum because it is more
-                // expensive and consensus will verify validity of the proof anyway
-                let record_metadata = read_record_metadata(
-                    piece_offset,
-                    self.sector_metadata.pieces_in_sector,
-                    &self.sector,
-                )?;
-
-                let proof_of_space = pos_table
-                    .find_quality(self.s_bucket.into())
-                    .expect(
-                        "Quality exists for this s-bucket, otherwise it wouldn't be a winning \
-                        chunk; qed",
-                    )
-                    .create_proof();
-
-                let chunk_witness = self
-                    .kzg
-                    .create_witness(
-                        &source_chunks_polynomial,
-                        Record::NUM_S_BUCKETS,
-                        self.s_bucket.into(),
-                    )
-                    .map_err(|error| ProvingError::FailedToCreateChunkWitness {
-                        piece_offset,
-                        chunk_offset,
-                        error,
-                    })?;
-
-                ChunkCache {
-                    chunk,
-                    chunk_offset,
-                    record_commitment: record_metadata.commitment,
-                    record_witness: record_metadata.witness,
-                    chunk_witness: ChunkWitness::from(chunk_witness),
-                    proof_of_space,
-                }
-            };
-
-            let chunk_cache = match maybe_chunk_cache {
-                Ok(chunk_cache) => chunk_cache,
-                Err(error) => {
-                    if let Some(winning_chunk) = self.winning_chunks.front() {
-                        if winning_chunk.chunk_offset == chunk_offset {
-                            // Subsequent attempts to generate solutions for this chunk offset will
-                            // fail too, remove it so save potential computation
-                            self.count -= winning_chunk.audit_chunks.len();
-                            self.winning_chunks.pop_front();
-                        }
-                    }
-
-                    return Some(Err(error));
-                }
-            };
-
-            self.chunk_cache.insert(chunk_cache)
-        };
-
-        Some(Ok(Solution {
-            public_key: *self.public_key,
-            reward_address: *self.reward_address,
-            sector_index: self.sector_metadata.sector_index,
-            history_size: self.sector_metadata.history_size,
-            piece_offset,
-            record_commitment: chunk_cache.record_commitment,
-            record_witness: chunk_cache.record_witness,
-            chunk: chunk_cache.chunk,
-            chunk_witness: chunk_cache.chunk_witness,
-            audit_chunk_offset,
-            proof_of_space: chunk_cache.proof_of_space,
-        }))
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().stream.poll_next(cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.count, Some(self.count))
-    }
-
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
-        self.count
+        let count = self.count.load(Ordering::Acquire);
+        (count, Some(count))
     }
 }
 
-impl<'a, RewardAddress, Sector, PosTable, TableGenerator> ExactSizeIterator
-    for SolutionsIterator<'a, RewardAddress, Sector, PosTable, TableGenerator>
+impl<'a, RewardAddress> ProvableSolutions for SolutionsIterator<'a, RewardAddress>
 where
     RewardAddress: Copy,
-    Sector: ReadAt + 'a,
-    PosTable: Table,
-    TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
-{
-}
-
-impl<'a, RewardAddress, Sector, PosTable, TableGenerator> ProvableSolutions
-    for SolutionsIterator<'a, RewardAddress, Sector, PosTable, TableGenerator>
-where
-    RewardAddress: Copy,
-    Sector: ReadAt + 'a,
-    PosTable: Table,
-    TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
 {
     fn best_solution_distance(&self) -> Option<SolutionRange> {
         self.best_solution_distance
     }
+
+    fn len(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
 }
 
-impl<'a, RewardAddress, Sector, PosTable, TableGenerator>
-    SolutionsIterator<'a, RewardAddress, Sector, PosTable, TableGenerator>
+impl<'a, RewardAddress> SolutionsIterator<'a, RewardAddress>
 where
-    Sector: ReadAt + 'a,
-    PosTable: Table,
-    TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
+    RewardAddress: Copy,
 {
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    async fn new<PosTable, TableGenerator, S, A>(
         public_key: &'a PublicKey,
         reward_address: &'a RewardAddress,
         sector_id: SectorId,
         s_bucket: SBucket,
-        sector: Sector,
+        sector: ReadAt<S, A>,
         sector_metadata: &'a SectorMetadataChecksummed,
         kzg: &'a Kzg,
         erasure_coding: &'a ErasureCoding,
         chunk_candidates: VecDeque<ChunkCandidate>,
         table_generator: TableGenerator,
-    ) -> Result<Self, ProvingError> {
+    ) -> Result<Self, ProvingError>
+    where
+        S: ReadAtSync + 'a,
+        A: ReadAtAsync + 'a,
+        PosTable: Table,
+        TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
+    {
         if erasure_coding.max_shards() < Record::NUM_S_BUCKETS {
             return Err(ProvingError::InvalidErasureCodingInstance);
         }
@@ -399,7 +283,15 @@ where
         let sector_contents_map = {
             let mut sector_contents_map_bytes =
                 vec![0; SectorContentsMap::encoded_size(sector_metadata.pieces_in_sector)];
-            sector.read_at(&mut sector_contents_map_bytes, 0)?;
+
+            match &sector {
+                ReadAt::Sync(sector) => {
+                    sector.read_at(&mut sector_contents_map_bytes, 0)?;
+                }
+                ReadAt::Async(sector) => {
+                    sector.read_at(&mut sector_contents_map_bytes, 0).await?;
+                }
+            }
 
             SectorContentsMap::from_bytes(
                 &sector_contents_map_bytes,
@@ -440,7 +332,9 @@ where
 
         let s_bucket_offsets = sector_metadata.s_bucket_offsets();
 
-        Ok(Self {
+        let count = Arc::new(AtomicUsize::new(count));
+
+        let state = SolutionsIteratorState {
             public_key,
             reward_address,
             sector_id,
@@ -452,10 +346,164 @@ where
             sector_contents_map,
             sector,
             winning_chunks,
-            count,
+            count: Arc::clone(&count),
             chunk_cache: None,
-            best_solution_distance,
             table_generator,
+        };
+
+        let stream = futures::stream::unfold(state, solutions_iterator_next);
+
+        Ok(Self {
+            stream: Box::pin(stream),
+            count,
+            best_solution_distance,
         })
     }
+}
+
+async fn solutions_iterator_next<'a, RewardAddress, PosTable, TableGenerator, S, A>(
+    mut state: SolutionsIteratorState<'a, RewardAddress, PosTable, TableGenerator, ReadAt<S, A>>,
+) -> Option<(
+    MaybeSolution<RewardAddress>,
+    SolutionsIteratorState<'a, RewardAddress, PosTable, TableGenerator, ReadAt<S, A>>,
+)>
+where
+    RewardAddress: Copy,
+    PosTable: Table,
+    TableGenerator: (FnMut(&PosSeed) -> PosTable) + 'a,
+    S: ReadAtSync + 'a,
+    A: ReadAtAsync + 'a,
+{
+    let (chunk_offset, piece_offset, audit_chunk_offset) = {
+        let winning_chunk = state.winning_chunks.front_mut()?;
+
+        let audit_chunk = winning_chunk.audit_chunks.pop_front()?;
+        let chunk_offset = winning_chunk.chunk_offset;
+        let piece_offset = winning_chunk.piece_offset;
+
+        if winning_chunk.audit_chunks.is_empty() {
+            // When all audit chunk offsets are removed, the winning chunks entry itself can be removed
+            state.winning_chunks.pop_front();
+        }
+
+        (chunk_offset, piece_offset, audit_chunk.offset)
+    };
+
+    state.count.fetch_sub(1, Ordering::SeqCst);
+
+    let chunk_cache = 'outer: {
+        if let Some(chunk_cache) = &state.chunk_cache {
+            if chunk_cache.chunk_offset == chunk_offset {
+                break 'outer chunk_cache;
+            }
+        }
+
+        // Derive PoSpace table
+        let pos_table = (state.table_generator)(
+            &state
+                .sector_id
+                .derive_evaluation_seed(piece_offset, state.sector_metadata.history_size),
+        );
+
+        let maybe_chunk_cache: Result<_, ProvingError> = try {
+            let sector_record_chunks_fut = read_sector_record_chunks(
+                piece_offset,
+                state.sector_metadata.pieces_in_sector,
+                &state.s_bucket_offsets,
+                &state.sector_contents_map,
+                &pos_table,
+                &state.sector,
+            );
+            let sector_record_chunks = sector_record_chunks_fut.await?;
+
+            let chunk = sector_record_chunks
+                .get(usize::from(state.s_bucket))
+                .expect("Within s-bucket range; qed")
+                .expect("Winning chunk was plotted; qed");
+
+            let source_chunks_polynomial = state
+                .erasure_coding
+                .recover_poly(sector_record_chunks.as_slice())
+                .map_err(|error| ReadingError::FailedToErasureDecodeRecord {
+                    piece_offset,
+                    error,
+                })?;
+            drop(sector_record_chunks);
+
+            // NOTE: We do not check plot consistency using checksum because it is more
+            // expensive and consensus will verify validity of the proof anyway
+            let record_metadata_fut = read_record_metadata(
+                piece_offset,
+                state.sector_metadata.pieces_in_sector,
+                &state.sector,
+            );
+            let record_metadata = record_metadata_fut.await?;
+
+            let proof_of_space = pos_table
+                .find_quality(state.s_bucket.into())
+                .expect(
+                    "Quality exists for this s-bucket, otherwise it wouldn't be a winning \
+                        chunk; qed",
+                )
+                .create_proof();
+
+            let chunk_witness = state
+                .kzg
+                .create_witness(
+                    &source_chunks_polynomial,
+                    Record::NUM_S_BUCKETS,
+                    state.s_bucket.into(),
+                )
+                .map_err(|error| ProvingError::FailedToCreateChunkWitness {
+                    piece_offset,
+                    chunk_offset,
+                    error,
+                })?;
+
+            ChunkCache {
+                chunk,
+                chunk_offset,
+                record_commitment: record_metadata.commitment,
+                record_witness: record_metadata.witness,
+                chunk_witness: ChunkWitness::from(chunk_witness),
+                proof_of_space,
+            }
+        };
+
+        let chunk_cache = match maybe_chunk_cache {
+            Ok(chunk_cache) => chunk_cache,
+            Err(error) => {
+                if let Some(winning_chunk) = state.winning_chunks.front() {
+                    if winning_chunk.chunk_offset == chunk_offset {
+                        // Subsequent attempts to generate solutions for this chunk offset will
+                        // fail too, remove it so save potential computation
+                        state
+                            .count
+                            .fetch_sub(winning_chunk.audit_chunks.len(), Ordering::SeqCst);
+                        state.winning_chunks.pop_front();
+                    }
+                }
+
+                return Some((Err(error), state));
+            }
+        };
+
+        state.chunk_cache.insert(chunk_cache)
+    };
+
+    let solution = Solution {
+        public_key: *state.public_key,
+        reward_address: *state.reward_address,
+        sector_index: state.sector_metadata.sector_index,
+        history_size: state.sector_metadata.history_size,
+        piece_offset,
+        record_commitment: chunk_cache.record_commitment,
+        record_witness: chunk_cache.record_witness,
+        chunk: chunk_cache.chunk,
+        chunk_witness: chunk_cache.chunk_witness,
+        audit_chunk_offset,
+        proof_of_space: chunk_cache.proof_of_space,
+    };
+
+    Some((Ok(solution), state))
 }

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -2,7 +2,9 @@ use crate::sector::{
     sector_record_chunks_size, RecordMetadata, SectorContentsMap, SectorContentsMapFromBytesError,
     SectorMetadataChecksummed,
 };
-use crate::ReadAt;
+use crate::{ReadAt, ReadAtAsync, ReadAtSync};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use parity_scale_codec::Decode;
 use rayon::prelude::*;
 use std::io;
@@ -84,22 +86,26 @@ pub struct PlotRecord {
     pub witness: RecordWitness,
 }
 
-/// Read sector record chunks, only plotted s-buckets are returned (in decoded form)
-pub fn read_sector_record_chunks<PosTable, Sector>(
+/// Read sector record chunks, only plotted s-buckets are returned (in decoded form).
+///
+/// NOTE: This is an async function, but it also does CPU-intensive operation internally, while it
+/// is not very long, make sure it is okay to do so in your context.
+pub async fn read_sector_record_chunks<PosTable, S, A>(
     piece_offset: PieceOffset,
     pieces_in_sector: u16,
     s_bucket_offsets: &[u32; Record::NUM_S_BUCKETS],
     sector_contents_map: &SectorContentsMap,
     pos_table: &PosTable,
-    sector: &Sector,
+    sector: &ReadAt<S, A>,
 ) -> Result<Box<[Option<Scalar>; Record::NUM_S_BUCKETS]>, ReadingError>
 where
     PosTable: Table,
-    Sector: ReadAt + ?Sized,
+    S: ReadAtSync,
+    A: ReadAtAsync,
 {
     let mut record_chunks = vec![None; Record::NUM_S_BUCKETS];
 
-    record_chunks
+    let read_chunks_inputs = record_chunks
         .par_iter_mut()
         .zip(sector_contents_map.par_iter_record_chunk_to_plot(piece_offset))
         .zip(
@@ -108,52 +114,118 @@ where
                 .map(SBucket::from)
                 .zip(s_bucket_offsets.par_iter()),
         )
-        .try_for_each(
+        .map(
             |((maybe_record_chunk, maybe_chunk_details), (s_bucket, &s_bucket_offset))| {
-                let (chunk_offset, encoded_chunk_used) = match maybe_chunk_details {
-                    Some(chunk_details) => chunk_details,
-                    None => {
-                        return Ok(());
-                    }
-                };
+                let (chunk_offset, encoded_chunk_used) = maybe_chunk_details?;
 
                 let chunk_location = chunk_offset + s_bucket_offset as usize;
 
-                let mut record_chunk = [0; Scalar::FULL_BYTES];
-                sector
-                    .read_at(
-                        &mut record_chunk,
-                        SectorContentsMap::encoded_size(pieces_in_sector)
-                            + chunk_location * Scalar::FULL_BYTES,
-                    )
-                    .map_err(|error| ReadingError::FailedToReadChunk {
-                        chunk_location,
-                        error,
-                    })?;
-
-                // Decode chunk if necessary
-                if encoded_chunk_used {
-                    let quality = pos_table
-                        .find_quality(s_bucket.into())
-                        .expect("encoded_chunk_used implies quality exists for this chunk; qed");
-
-                    record_chunk = Simd::to_array(
-                        Simd::from(record_chunk) ^ Simd::from(quality.create_proof().hash()),
-                    );
-                }
-
-                maybe_record_chunk.replace(Scalar::try_from(record_chunk).map_err(|error| {
-                    ReadingError::InvalidChunk {
-                        s_bucket,
-                        encoded_chunk_used,
-                        chunk_location,
-                        error,
-                    }
-                })?);
-
-                Ok::<_, ReadingError>(())
+                Some((
+                    maybe_record_chunk,
+                    chunk_location,
+                    encoded_chunk_used,
+                    s_bucket,
+                ))
             },
-        )?;
+        )
+        .collect::<Vec<_>>();
+
+    match sector {
+        ReadAt::Sync(sector) => {
+            read_chunks_inputs.into_par_iter().flatten().try_for_each(
+                |(maybe_record_chunk, chunk_location, encoded_chunk_used, s_bucket)| {
+                    let mut record_chunk = [0; Scalar::FULL_BYTES];
+                    sector
+                        .read_at(
+                            &mut record_chunk,
+                            SectorContentsMap::encoded_size(pieces_in_sector)
+                                + chunk_location * Scalar::FULL_BYTES,
+                        )
+                        .map_err(|error| ReadingError::FailedToReadChunk {
+                            chunk_location,
+                            error,
+                        })?;
+
+                    // Decode chunk if necessary
+                    if encoded_chunk_used {
+                        let quality = pos_table.find_quality(s_bucket.into()).expect(
+                            "encoded_chunk_used implies quality exists for this chunk; qed",
+                        );
+
+                        record_chunk = Simd::to_array(
+                            Simd::from(record_chunk) ^ Simd::from(quality.create_proof().hash()),
+                        );
+                    }
+
+                    maybe_record_chunk.replace(Scalar::try_from(record_chunk).map_err(
+                        |error| ReadingError::InvalidChunk {
+                            s_bucket,
+                            encoded_chunk_used,
+                            chunk_location,
+                            error,
+                        },
+                    )?);
+
+                    Ok::<_, ReadingError>(())
+                },
+            )?;
+        }
+        ReadAt::Async(sector) => {
+            let processing_chunks = read_chunks_inputs
+                .into_iter()
+                .flatten()
+                .map(
+                    |(maybe_record_chunk, chunk_location, encoded_chunk_used, s_bucket)| async move {
+                        let mut record_chunk = [0; Scalar::FULL_BYTES];
+                        sector
+                            .read_at(
+                                &mut record_chunk,
+                                SectorContentsMap::encoded_size(pieces_in_sector)
+                                    + chunk_location * Scalar::FULL_BYTES,
+                            )
+                            .await
+                            .map_err(|error| ReadingError::FailedToReadChunk {
+                                chunk_location,
+                                error,
+                            })?;
+
+                        // Decode chunk if necessary
+                        if encoded_chunk_used {
+                            let quality = pos_table.find_quality(s_bucket.into()).expect(
+                                "encoded_chunk_used implies quality exists for this chunk; qed",
+                            );
+
+                            record_chunk = Simd::to_array(
+                                Simd::from(record_chunk) ^ Simd::from(quality.create_proof().hash()),
+                            );
+                        }
+
+                        maybe_record_chunk.replace(Scalar::try_from(record_chunk).map_err(
+                            |error| ReadingError::InvalidChunk {
+                                s_bucket,
+                                encoded_chunk_used,
+                                chunk_location,
+                                error,
+                            },
+                        )?);
+
+                        Ok::<_, ReadingError>(())
+                    },
+                )
+                .collect::<FuturesUnordered<_>>()
+                .filter_map(|result| async move {
+                    match result {
+                        Ok(()) => None,
+                        Err(error) => Some(error),
+                    }
+                });
+
+            std::pin::pin!(processing_chunks)
+                .next()
+                .await
+                .map_or(Ok(()), Err)?;
+        }
+    }
 
     let mut record_chunks = ManuallyDrop::new(record_chunks);
 
@@ -223,13 +295,14 @@ pub fn recover_source_record_chunks(
 }
 
 /// Read metadata (commitment and witness) for record
-pub(crate) fn read_record_metadata<Sector>(
+pub(crate) async fn read_record_metadata<S, A>(
     piece_offset: PieceOffset,
     pieces_in_sector: u16,
-    sector: &Sector,
+    sector: &ReadAt<S, A>,
 ) -> Result<RecordMetadata, ReadingError>
 where
-    Sector: ReadAt + ?Sized,
+    S: ReadAtSync,
+    A: ReadAtAsync,
 {
     let sector_metadata_start = SectorContentsMap::encoded_size(pieces_in_sector)
         + sector_record_chunks_size(pieces_in_sector);
@@ -238,53 +311,72 @@ where
         sector_metadata_start + RecordMetadata::encoded_size() * usize::from(piece_offset);
 
     let mut record_metadata_bytes = [0; RecordMetadata::encoded_size()];
-    sector.read_at(&mut record_metadata_bytes, record_metadata_offset)?;
+    match sector {
+        ReadAt::Sync(sector) => {
+            sector.read_at(&mut record_metadata_bytes, record_metadata_offset)?;
+        }
+        ReadAt::Async(sector) => {
+            sector
+                .read_at(&mut record_metadata_bytes, record_metadata_offset)
+                .await?;
+        }
+    }
     let record_metadata = RecordMetadata::decode(&mut record_metadata_bytes.as_ref())
         .expect("Length is correct, contents doesn't have specific structure to it; qed");
 
     Ok(record_metadata)
 }
 
-/// Read piece from sector
-pub fn read_piece<PosTable, Sector>(
+/// Read piece from sector.
+///
+/// NOTE: Even though this function is async, proof of time table generation is expensive and should
+/// be done in a dedicated thread where blocking is allowed.
+pub async fn read_piece<PosTable, S, A>(
     piece_offset: PieceOffset,
     sector_id: &SectorId,
     sector_metadata: &SectorMetadataChecksummed,
-    sector: &Sector,
+    sector: &ReadAt<S, A>,
     erasure_coding: &ErasureCoding,
     table_generator: &mut PosTable::Generator,
 ) -> Result<Piece, ReadingError>
 where
     PosTable: Table,
-    Sector: ReadAt + ?Sized,
+    S: ReadAtSync,
+    A: ReadAtAsync,
 {
     let pieces_in_sector = sector_metadata.pieces_in_sector;
 
     let sector_contents_map = {
         let mut sector_contents_map_bytes =
             vec![0; SectorContentsMap::encoded_size(pieces_in_sector)];
-        sector.read_at(&mut sector_contents_map_bytes, 0)?;
+        match sector {
+            ReadAt::Sync(sector) => {
+                sector.read_at(&mut sector_contents_map_bytes, 0)?;
+            }
+            ReadAt::Async(sector) => {
+                sector.read_at(&mut sector_contents_map_bytes, 0).await?;
+            }
+        }
 
         SectorContentsMap::from_bytes(&sector_contents_map_bytes, pieces_in_sector)?
     };
 
-    // Restore source record scalars
-    let record_chunks = recover_source_record_chunks(
-        &*read_sector_record_chunks(
-            piece_offset,
-            pieces_in_sector,
-            &sector_metadata.s_bucket_offsets(),
-            &sector_contents_map,
-            &table_generator.generate(
-                &sector_id.derive_evaluation_seed(piece_offset, sector_metadata.history_size),
-            ),
-            sector,
-        )?,
+    let sector_record_chunks = read_sector_record_chunks(
         piece_offset,
-        erasure_coding,
-    )?;
+        pieces_in_sector,
+        &sector_metadata.s_bucket_offsets(),
+        &sector_contents_map,
+        &table_generator.generate(
+            &sector_id.derive_evaluation_seed(piece_offset, sector_metadata.history_size),
+        ),
+        sector,
+    )
+    .await?;
+    // Restore source record scalars
+    let record_chunks =
+        recover_source_record_chunks(&sector_record_chunks, piece_offset, erasure_coding)?;
 
-    let record_metadata = read_record_metadata(piece_offset, pieces_in_sector, sector)?;
+    let record_metadata = read_record_metadata(piece_offset, pieces_in_sector, sector).await?;
 
     let mut piece = Piece::default();
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -89,7 +89,7 @@ async fn audit(disk_farm: PathBuf, sample_size: usize) -> anyhow::Result<()> {
             b.iter_batched(
                 rand::random,
                 |global_challenge| {
-                    let options = PlotAuditOptions::<PosTable> {
+                    let options = PlotAuditOptions::<PosTable, _> {
                         public_key: single_disk_farm_info.public_key(),
                         reward_address: single_disk_farm_info.public_key(),
                         sector_size,
@@ -105,9 +105,9 @@ async fn audit(disk_farm: PathBuf, sample_size: usize) -> anyhow::Result<()> {
                         kzg: &kzg,
                         erasure_coding: &erasure_coding,
                         #[cfg(not(windows))]
-                        plot_file: &plot_file,
+                        plot: &plot_file,
                         #[cfg(windows)]
-                        plot_mmap: &plot_mmap,
+                        plot: &plot_mmap,
                         maybe_sector_being_modified: None,
                         table_generator: &table_generator,
                     };

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -6,6 +6,7 @@
     int_roundings,
     iter_collect_into,
     let_chains,
+    never_type,
     trait_alias,
     try_blocks,
     type_alias_impl_trait,

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1027,7 +1027,6 @@ impl SingleDiskFarm {
                                 public_key,
                                 reward_address,
                                 node_client,
-                                sector_size,
                                 plot_file: &plot_file,
                                 sectors_metadata,
                                 kzg,

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info, trace, warn};
 #[derive(Debug, Error)]
 pub enum FarmingError {
     /// Failed to subscribe to slot info notifications
-    #[error("Failed to substribe to slot info notifications: {error}")]
+    #[error("Failed to subscribe to slot info notifications: {error}")]
     FailedToSubscribeSlotInfo {
         /// Lower-level error
         error: node_client::Error,

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -282,25 +282,29 @@ where
     let mut sectors_solutions = sectors_metadata
         .par_iter()
         .zip(sectors)
-        .enumerate()
-        .filter_map(|(sector_index, (sector_metadata, sector))| {
-            let sector_index = sector_index as u16;
-            if maybe_sector_being_modified == Some(sector_index) {
+        .filter_map(|(sector_metadata, sector)| {
+            if maybe_sector_being_modified == Some(sector_metadata.sector_index) {
                 // Skip sector that is being modified right now
                 return None;
             }
-            trace!(slot = %slot_info.slot_number, %sector_index, "Auditing sector");
+            trace!(
+                slot = %slot_info.slot_number,
+                sector_index = %sector_metadata.sector_index,
+                "Auditing sector",
+            );
 
             let audit_results = audit_sector(
                 public_key,
-                sector_index,
                 &slot_info.global_challenge,
                 slot_info.voting_solution_range,
                 sector,
                 sector_metadata,
             )?;
 
-            Some((sector_index, audit_results.solution_candidates))
+            Some((
+                sector_metadata.sector_index,
+                audit_results.solution_candidates,
+            ))
         })
         .filter_map(|(sector_index, solution_candidates)| {
             let sector_solutions = match solution_candidates.into_solutions(

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -175,7 +175,6 @@ async fn start_farming<PosTable, Client>(
     });
 
     let (sector, plotted_sector, mut table_generator) = plotting_result_receiver.await.unwrap();
-    let sector_index = 0;
     let public_key = PublicKey::from(keypair.public.to_bytes());
 
     let mut new_slot_notification_stream = new_slot_notification_stream.subscribe();
@@ -191,7 +190,6 @@ async fn start_farming<PosTable, Client>(
                 .derive_global_challenge(new_slot_info.slot.into());
             let audit_result = audit_sector(
                 &public_key,
-                sector_index,
                 &global_challenge,
                 new_slot_info.solution_range,
                 &sector,

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -31,7 +31,6 @@ use sp_api::ProvideRuntimeApi;
 use sp_consensus_subspace::{FarmerPublicKey, FarmerSignature, SubspaceApi};
 use sp_core::{Decode, Encode};
 use std::num::{NonZeroU64, NonZeroUsize};
-use std::slice;
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::objects::BlockObjectMapping;
@@ -39,7 +38,7 @@ use subspace_core_primitives::{
     HistorySize, PosSeed, PublicKey, Record, SegmentIndex, Solution, REWARD_SIGNING_CONTEXT,
 };
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::auditing::audit_plot_sync;
+use subspace_farmer_components::auditing::audit_sector_sync;
 use subspace_farmer_components::plotting::{
     plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
 };
@@ -189,18 +188,15 @@ async fn start_farming<PosTable, Client>(
             let global_challenge = new_slot_info
                 .global_randomness
                 .derive_global_challenge(new_slot_info.slot.into());
-            let audit_result = audit_plot_sync(
+            let audit_result = audit_sector_sync(
                 &public_key,
                 &global_challenge,
                 new_slot_info.solution_range,
                 &sector,
-                slice::from_ref(&plotted_sector.sector_metadata),
-                None,
+                &plotted_sector.sector_metadata,
             );
 
             let solution = audit_result
-                .into_iter()
-                .next()
                 .unwrap()
                 .solution_candidates
                 .into_solutions(&public_key, &kzg, &erasure_coding, |seed: &PosSeed| {


### PR DESCRIPTION
This is a collection of refactoring steps towards properly async auditing.

The APIs exposed here should be sufficient, I have async implementation for Linux using https://github.com/DataDog/glommio that is based on `io_uring` and the complete audit is ~10% faster on NVMe SSD and ~10% slower on SATA SSD. In case of NVMe it is heavily CPU bound and `io_uring` allows it to spread wings a bit more using more parallelism. I'll also try https://github.com/bytedance/monoio before submitting PRs with those though.

There are some cleanups and smaller things here, but the biggest change is tricky and a bit awkward abstractions that allow us to use both synchronous and asynchronous APIs (and single threaded non-Send too!) for I/O that can be used later by implementations like I mentioned above.

In the end `audit_sector` is replaved with a pair of functions in order to be able to simplify API a bit as well as to take advantage of slightly different ways in which auditing is done in sync and async versions. I initially created `audit_plot` that can do both, but we don't really need such a universal function and it hurts API.

Review individual commits and ignore whitespace changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
