### PR TITLE
Fraud proof: Derive set code extrinsic for Domain extrinsic root proof verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7205,6 +7205,7 @@ dependencies = [
 name = "pallet-domains"
 version = "0.1.0"
 dependencies = [
+ "domain-pallet-executive",
  "domain-runtime-primitives",
  "frame-benchmarking",
  "frame-support",

--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -29,6 +29,7 @@ subspace-core-primitives = { version = "0.1.0", default-features = false, path =
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [dev-dependencies]
+domain-pallet-executive = { version = "0.1.0", default-features = false, path = "../../domains/pallets/executive" }
 domain-runtime-primitives = { version = "0.1.0", default-features = false, path = "../../domains/primitives/runtime" }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -60,6 +60,7 @@ frame_support::construct_runtime!(
         Timestamp: pallet_timestamp,
         Balances: pallet_balances,
         Domains: pallet_domains,
+        DomainExecutive: domain_pallet_executive,
     }
 );
 
@@ -236,6 +237,11 @@ impl pallet_domains::Config for Test {
     type Randomness = MockRandomness;
 }
 
+impl domain_pallet_executive::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = ();
+}
+
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
     let t = frame_system::GenesisConfig::<Test>::default()
         .build_storage()
@@ -247,6 +253,7 @@ pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 pub(crate) struct MockDomainFraudProofExtension {
     block_randomness: Randomness,
     timestamp: Moment,
+    runtime_code: Vec<u8>,
 }
 
 impl FraudProofHostFunctions for MockDomainFraudProofExtension {
@@ -272,6 +279,17 @@ impl FraudProofHostFunctions for MockDomainFraudProofExtension {
             }
             FraudProofVerificationInfoRequest::DomainRuntimeCode(_) => {
                 FraudProofVerificationInfoResponse::DomainRuntimeCode(Default::default())
+            }
+            FraudProofVerificationInfoRequest::DomainSetCodeExtrinsic(_) => {
+                FraudProofVerificationInfoResponse::DomainSetCodeExtrinsic(Some(
+                    UncheckedExtrinsic::new_unsigned(
+                        domain_pallet_executive::Call::<Test>::set_code {
+                            code: self.runtime_code.clone(),
+                        }
+                        .into(),
+                    )
+                    .encode(),
+                ))
             }
         };
 
@@ -922,6 +940,7 @@ fn test_invalid_domain_extrinsic_root_proof() {
     let fraud_proof_ext = FraudProofExtension::new(Arc::new(MockDomainFraudProofExtension {
         block_randomness: Randomness::from([1u8; 32]),
         timestamp: 1000,
+        runtime_code: vec![1, 2, 3, 4],
     }));
     ext.register_extension(fraud_proof_ext);
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -30,7 +30,7 @@ use sp_domains::{
 };
 use sp_domains_fraud_proof::{
     FraudProofExtension, FraudProofHostFunctions, FraudProofVerificationInfoRequest,
-    FraudProofVerificationInfoResponse,
+    FraudProofVerificationInfoResponse, SetCodeExtrinsic,
 };
 use sp_runtime::traits::{AccountIdConversion, BlakeTwo256, Hash as HashT, IdentityLookup, Zero};
 use sp_runtime::{BuildStorage, Digest, OpaqueExtrinsic};
@@ -281,15 +281,17 @@ impl FraudProofHostFunctions for MockDomainFraudProofExtension {
                 FraudProofVerificationInfoResponse::DomainRuntimeCode(Default::default())
             }
             FraudProofVerificationInfoRequest::DomainSetCodeExtrinsic(_) => {
-                FraudProofVerificationInfoResponse::DomainSetCodeExtrinsic(Some(
-                    UncheckedExtrinsic::new_unsigned(
-                        domain_pallet_executive::Call::<Test>::set_code {
-                            code: self.runtime_code.clone(),
-                        }
-                        .into(),
-                    )
-                    .encode(),
-                ))
+                FraudProofVerificationInfoResponse::DomainSetCodeExtrinsic(
+                    SetCodeExtrinsic::EncodedExtrinsic(
+                        UncheckedExtrinsic::new_unsigned(
+                            domain_pallet_executive::Call::<Test>::set_code {
+                                code: self.runtime_code.clone(),
+                            }
+                            .into(),
+                        )
+                        .encode(),
+                    ),
+                )
             }
         };
 

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -1,6 +1,8 @@
-use crate::{FraudProofVerificationInfoRequest, FraudProofVerificationInfoResponse};
+use crate::{
+    FraudProofVerificationInfoRequest, FraudProofVerificationInfoResponse, SetCodeExtrinsic,
+};
 use codec::{Decode, Encode};
-use domain_block_preprocessor::inherents::maybe_runtime_upgrade;
+use domain_block_preprocessor::inherents::extract_domain_runtime_upgrade_code;
 use domain_block_preprocessor::runtime_api::{SetCodeConstructor, TimestampExtrinsicConstructor};
 use domain_block_preprocessor::runtime_api_light::RuntimeApiLight;
 use sc_executor::RuntimeVersionOf;
@@ -120,8 +122,8 @@ where
         &self,
         consensus_block_hash: H256,
         domain_id: DomainId,
-    ) -> Option<Option<Vec<u8>>> {
-        let maybe_upgraded_runtime = maybe_runtime_upgrade::<_, _, DomainBlock>(
+    ) -> Option<SetCodeExtrinsic> {
+        let maybe_upgraded_runtime = extract_domain_runtime_upgrade_code::<_, _, DomainBlock>(
             &self.consensus_client,
             consensus_block_hash.into(),
             domain_id,
@@ -142,9 +144,9 @@ where
                 upgraded_runtime,
             )
             .ok()
-            .map(|ext| Some(ext.encode()))
+            .map(|ext| SetCodeExtrinsic::EncodedExtrinsic(ext.encode()))
         } else {
-            Some(None)
+            Some(SetCodeExtrinsic::None)
         }
     }
 

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -1,6 +1,7 @@
 use crate::{FraudProofVerificationInfoRequest, FraudProofVerificationInfoResponse};
 use codec::{Decode, Encode};
-use domain_block_preprocessor::runtime_api::TimestampExtrinsicConstructor;
+use domain_block_preprocessor::inherents::maybe_runtime_upgrade;
+use domain_block_preprocessor::runtime_api::{SetCodeConstructor, TimestampExtrinsicConstructor};
 use domain_block_preprocessor::runtime_api_light::RuntimeApiLight;
 use sc_executor::RuntimeVersionOf;
 use sp_api::{BlockT, ProvideRuntimeApi};
@@ -98,11 +99,8 @@ where
         domain_id: DomainId,
     ) -> Option<Vec<u8>> {
         let runtime_api = self.consensus_client.runtime_api();
-        let consensus_block_hash = consensus_block_hash.into();
-        let runtime_code = runtime_api
-            .domain_runtime_code(consensus_block_hash, domain_id)
-            .ok()??;
-        let timestamp = runtime_api.timestamp(consensus_block_hash).ok()?;
+        let runtime_code = self.get_domain_runtime_code(consensus_block_hash, domain_id)?;
+        let timestamp = runtime_api.timestamp(consensus_block_hash.into()).ok()?;
 
         let domain_runtime_api_light =
             RuntimeApiLight::new(self.executor.clone(), runtime_code.into());
@@ -116,6 +114,38 @@ where
         )
         .ok()
         .map(|ext| ext.encode())
+    }
+
+    fn derive_domain_set_code_extrinsic(
+        &self,
+        consensus_block_hash: H256,
+        domain_id: DomainId,
+    ) -> Option<Option<Vec<u8>>> {
+        let maybe_upgraded_runtime = maybe_runtime_upgrade::<_, _, DomainBlock>(
+            &self.consensus_client,
+            consensus_block_hash.into(),
+            domain_id,
+        )
+        .ok()
+        .flatten();
+
+        if let Some(upgraded_runtime) = maybe_upgraded_runtime {
+            let runtime_code = self.get_domain_runtime_code(consensus_block_hash, domain_id)?;
+            let domain_runtime_api_light =
+                RuntimeApiLight::new(self.executor.clone(), runtime_code.into());
+
+            SetCodeConstructor::<DomainBlock>::construct_set_code_extrinsic(
+                &domain_runtime_api_light,
+                // We do not care about the domain hash since this is stateless call into
+                // domain runtime,
+                Default::default(),
+                upgraded_runtime,
+            )
+            .ok()
+            .map(|ext| Some(ext.encode()))
+        } else {
+            Some(None)
+        }
     }
 
     fn get_domain_runtime_code(
@@ -160,8 +190,8 @@ where
                 .map(|block_randomness| {
                     FraudProofVerificationInfoResponse::BlockRandomness(block_randomness)
                 }),
-            FraudProofVerificationInfoRequest::DomainTimestampExtrinsic(doman_id) => self
-                .derive_domain_timestamp_extrinsic(consensus_block_hash, doman_id)
+            FraudProofVerificationInfoRequest::DomainTimestampExtrinsic(domain_id) => self
+                .derive_domain_timestamp_extrinsic(consensus_block_hash, domain_id)
                 .map(|domain_timestamp_extrinsic| {
                     FraudProofVerificationInfoResponse::DomainTimestampExtrinsic(
                         domain_timestamp_extrinsic,
@@ -171,6 +201,13 @@ where
                 .get_domain_runtime_code(consensus_block_hash, domain_id)
                 .map(|domain_runtime_code| {
                     FraudProofVerificationInfoResponse::DomainRuntimeCode(domain_runtime_code)
+                }),
+            FraudProofVerificationInfoRequest::DomainSetCodeExtrinsic(domain_id) => self
+                .derive_domain_set_code_extrinsic(consensus_block_hash, domain_id)
+                .map(|maybe_domain_set_code_extrinsic| {
+                    FraudProofVerificationInfoResponse::DomainSetCodeExtrinsic(
+                        maybe_domain_set_code_extrinsic,
+                    )
                 }),
         }
     }

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -68,6 +68,20 @@ pub enum FraudProofVerificationInfoResponse {
 }
 
 impl FraudProofVerificationInfoResponse {
+    pub fn into_block_randomness(self) -> Option<Randomness> {
+        match self {
+            Self::BlockRandomness(randomness) => Some(randomness),
+            _ => None,
+        }
+    }
+
+    pub fn into_domain_timestamp_extrinsic(self) -> Option<Vec<u8>> {
+        match self {
+            Self::DomainTimestampExtrinsic(timestamp_extrinsic) => Some(timestamp_extrinsic),
+            _ => None,
+        }
+    }
+
     pub fn into_domain_runtime_code(self) -> Option<Vec<u8>> {
         match self {
             Self::DomainRuntimeCode(c) => Some(c),

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -54,6 +54,15 @@ impl PassBy for FraudProofVerificationInfoRequest {
     type PassBy = pass_by::Codec<Self>;
 }
 
+/// Type that maybe holds an encoded set_code extrinsic with upgraded runtime
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub enum SetCodeExtrinsic {
+    /// No runtime upgrade.
+    None,
+    /// Holds an encoded set_code extrinsic with an upgraded runtime.
+    EncodedExtrinsic(Vec<u8>),
+}
+
 /// Response holds required verification information for fraud proof from Host function.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub enum FraudProofVerificationInfoResponse {
@@ -64,7 +73,7 @@ pub enum FraudProofVerificationInfoResponse {
     /// The domain runtime code
     DomainRuntimeCode(Vec<u8>),
     /// Encoded domain set_code extrinsic if there is a runtime upgrade at given consensus block hash.
-    DomainSetCodeExtrinsic(Option<Vec<u8>>),
+    DomainSetCodeExtrinsic(SetCodeExtrinsic),
 }
 
 impl FraudProofVerificationInfoResponse {
@@ -89,12 +98,12 @@ impl FraudProofVerificationInfoResponse {
         }
     }
 
-    pub fn into_domain_set_code_extrinsic(self) -> Option<Vec<u8>> {
+    pub fn into_domain_set_code_extrinsic(self) -> SetCodeExtrinsic {
         match self {
             FraudProofVerificationInfoResponse::DomainSetCodeExtrinsic(
                 maybe_set_code_extrinsic,
             ) => maybe_set_code_extrinsic,
-            _ => None,
+            _ => SetCodeExtrinsic::None,
         }
     }
 }

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -46,6 +46,8 @@ pub enum FraudProofVerificationInfoRequest {
     DomainTimestampExtrinsic(DomainId),
     /// The domain runtime code
     DomainRuntimeCode(DomainId),
+    /// Domain set_code extrinsic if there is a runtime upgrade at a given consensus block hash.
+    DomainSetCodeExtrinsic(DomainId),
 }
 
 impl PassBy for FraudProofVerificationInfoRequest {
@@ -61,12 +63,23 @@ pub enum FraudProofVerificationInfoResponse {
     DomainTimestampExtrinsic(Vec<u8>),
     /// The domain runtime code
     DomainRuntimeCode(Vec<u8>),
+    /// Encoded domain set_code extrinsic if there is a runtime upgrade at given consensus block hash.
+    DomainSetCodeExtrinsic(Option<Vec<u8>>),
 }
 
 impl FraudProofVerificationInfoResponse {
     pub fn into_domain_runtime_code(self) -> Option<Vec<u8>> {
         match self {
             Self::DomainRuntimeCode(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    pub fn into_domain_set_code_extrinsic(self) -> Option<Vec<u8>> {
+        match self {
+            FraudProofVerificationInfoResponse::DomainSetCodeExtrinsic(
+                maybe_set_code_extrinsic,
+            ) => maybe_set_code_extrinsic,
             _ => None,
         }
     }

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -1,6 +1,6 @@
 use crate::{
     fraud_proof_runtime_interface, FraudProofVerificationInfoRequest,
-    FraudProofVerificationInfoResponse,
+    FraudProofVerificationInfoResponse, SetCodeExtrinsic,
 };
 use codec::{Decode, Encode};
 use hash_db::Hasher;
@@ -39,7 +39,7 @@ pub fn verify_invalid_domain_extrinsics_root_fraud_proof<
     fraud_proof: &InvalidExtrinsicsRootProof,
     block_randomness: Randomness,
     domain_timestamp_extrinsic: Vec<u8>,
-    maybe_domain_set_code_extrinsic: Option<Vec<u8>>,
+    maybe_domain_set_code_extrinsic: SetCodeExtrinsic,
 ) -> Result<(), sp_domains::verification::VerificationError>
 where
     CBlock: BlockT,
@@ -74,7 +74,9 @@ where
         Randomness::from(shuffling_seed.to_fixed_bytes()),
     );
 
-    if let Some(domain_set_code_extrinsic) = maybe_domain_set_code_extrinsic {
+    if let SetCodeExtrinsic::EncodedExtrinsic(domain_set_code_extrinsic) =
+        maybe_domain_set_code_extrinsic
+    {
         let domain_set_code_extrinsic =
             ExtrinsicDigest::new::<LayoutV1<DomainHashing>>(domain_set_code_extrinsic);
         ordered_extrinsics.push_front(domain_set_code_extrinsic);

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -87,7 +87,7 @@ where
         .any(|upgraded_runtime_id| upgraded_runtime_id == runtime_id))
 }
 
-fn maybe_runtime_upgrade<CClient, CBlock, Block>(
+pub fn maybe_runtime_upgrade<CClient, CBlock, Block>(
     consensus_client: &Arc<CClient>,
     consensus_block_hash: CBlock::Hash,
     domain_id: DomainId,

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -55,7 +55,7 @@ where
     Ok(inherent_data)
 }
 
-pub(crate) fn has_runtime_upgrade<CClient, CBlock, Block>(
+pub(crate) fn is_runtime_upgraded<CClient, CBlock, Block>(
     consensus_client: &Arc<CClient>,
     consensus_block_hash: CBlock::Hash,
     domain_id: DomainId,
@@ -87,7 +87,8 @@ where
         .any(|upgraded_runtime_id| upgraded_runtime_id == runtime_id))
 }
 
-pub fn maybe_runtime_upgrade<CClient, CBlock, Block>(
+/// Returns new upgraded runtime if upgraded did happen in the provided consensus block.
+pub fn extract_domain_runtime_upgrade_code<CClient, CBlock, Block>(
     consensus_client: &Arc<CClient>,
     consensus_block_hash: CBlock::Hash,
     domain_id: DomainId,
@@ -195,7 +196,7 @@ where
         let timestamp_provider =
             sp_timestamp::InherentDataProvider::new(InherentType::new(timestamp));
 
-        let maybe_runtime_upgrade_code = maybe_runtime_upgrade::<_, _, Block>(
+        let maybe_runtime_upgrade_code = extract_domain_runtime_upgrade_code::<_, _, Block>(
             &self.consensus_client,
             consensus_block_hash,
             self.domain_id,

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -16,7 +16,7 @@ pub mod runtime_api_full;
 pub mod runtime_api_light;
 pub mod xdm_verifier;
 
-use crate::inherents::has_runtime_upgrade;
+use crate::inherents::is_runtime_upgraded;
 use crate::runtime_api::{SetCodeConstructor, SignerExtractor, StateRootExtractor};
 use crate::xdm_verifier::is_valid_xdm;
 use codec::{Decode, Encode};
@@ -170,7 +170,7 @@ where
             .extract_successful_bundles(consensus_block_hash, self.domain_id, primary_extrinsics)?;
 
         if bundles.is_empty()
-            && !has_runtime_upgrade::<_, _, Block>(
+            && !is_runtime_upgraded::<_, _, Block>(
                 &self.consensus_client,
                 consensus_block_hash,
                 self.domain_id,


### PR DESCRIPTION
This PR derives the set code extrinsic if runtime was upgraded during the invalid domain extrinsic root fraud proof verification.

Closes: #1897

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
