### PR TITLE
Use storage proof to provide proof of inclusion for extrinsics

### DIFF
--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -178,7 +178,7 @@ where
     let state_root = bad_receipt.final_state_root;
     let digest_storage_key = StorageKey(sp_domains::fraud_proof::system_digest_final_key());
 
-    let digest = StorageProofVerifier::<DomainHeader::Hashing>::verify_and_get_value::<Digest>(
+    let digest = StorageProofVerifier::<DomainHeader::Hashing>::get_decoded_value::<Digest>(
         &state_root,
         digest_storage_proof,
         digest_storage_key,

--- a/crates/sp-domains/src/fraud_proof.rs
+++ b/crates/sp-domains/src/fraud_proof.rs
@@ -1,10 +1,9 @@
 use crate::verification::StorageProofVerifier;
 use crate::{DomainId, ExecutionReceipt, ReceiptHash, SealedBundleHeader};
 use hash_db::Hasher;
-use parity_scale_codec::{Compact, Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
-use sp_core::storage::StorageKey;
 use sp_core::H256;
 use sp_domain_digests::AsPredigest;
 use sp_runtime::traits::{
@@ -157,11 +156,15 @@ impl ExecutionPhase {
                 mismatch_index,
                 extrinsic,
             } => {
+                let storage_key =
+                    StorageProofVerifier::<DomainHeader::Hashing>::enumerated_storage_key(
+                        *mismatch_index,
+                    );
                 if !StorageProofVerifier::<DomainHeader::Hashing>::verify_storage_proof(
                     proof_of_inclusion.clone(),
                     &bad_receipt.domain_block_extrinsic_root.into(),
                     extrinsic.clone(),
-                    StorageKey(Compact(*mismatch_index).encode()),
+                    storage_key,
                 ) {
                     return Err(VerificationError::InvalidApplyExtrinsicCallData);
                 }

--- a/crates/sp-domains/src/valued_trie_root.rs
+++ b/crates/sp-domains/src/valued_trie_root.rs
@@ -296,9 +296,7 @@ where
 
         let backend = TrieBackendBuilder::new(db, root).build();
         let key = Compact(index).encode();
-        Some(StorageProof::new(
-            prove_read(backend, &[key]).ok()?.iter_nodes().cloned(),
-        ))
+        prove_read(backend, &[key]).ok()
     }
 }
 

--- a/crates/subspace-fraud-proof/src/tests.rs
+++ b/crates/subspace-fraud-proof/src/tests.rs
@@ -19,6 +19,7 @@ use sp_domain_digests::AsPredigest;
 use sp_domains::fraud_proof::{
     ExecutionPhase, FraudProof, InvalidStateTransitionProof, VerificationError,
 };
+use sp_domains::valued_trie_root::StorageProofProvider;
 use sp_domains::{DomainId, DomainsApi};
 use sp_runtime::generic::{Digest, DigestItem};
 use sp_runtime::traits::{BlakeTwo256, Header as HeaderT};
@@ -492,12 +493,11 @@ async fn execution_proof_creation_and_verification_should_work() {
         let post_delta_root = storage_changes.transaction_storage_root;
 
         let execution_phase = {
-            let proof_of_inclusion = sp_domains::valued_trie_root::generate_proof::<
+            let proof_of_inclusion = StorageProofProvider::<
                 LayoutV1<BlakeTwo256>,
-            >(
+            >::generate_enumerated_proof_of_inclusion(
                 encoded_test_txs.as_slice(), target_extrinsic_index as u32
-            )
-            .unwrap();
+            ).unwrap();
             ExecutionPhase::ApplyExtrinsic {
                 proof_of_inclusion,
                 mismatch_index: target_extrinsic_index as u32,
@@ -702,12 +702,11 @@ async fn invalid_execution_proof_should_not_work() {
         let post_delta_root = storage_changes.transaction_storage_root;
 
         let execution_phase = {
-            let proof_of_inclusion = sp_domains::valued_trie_root::generate_proof::<
+            let proof_of_inclusion = StorageProofProvider::<
                 LayoutV1<BlakeTwo256>,
-            >(
+            >::generate_enumerated_proof_of_inclusion(
                 encoded_test_txs.as_slice(), extrinsic_index as u32
-            )
-            .unwrap();
+            ).unwrap();
             ExecutionPhase::ApplyExtrinsic {
                 proof_of_inclusion,
                 mismatch_index: extrinsic_index as u32,

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -16,6 +16,7 @@ use sp_domains::fraud_proof::{
     InvalidTotalRewardsProof, MissingInvalidBundleEntryFraudProof,
     ValidAsInvalidBundleEntryFraudProof, ValidBundleDigest,
 };
+use sp_domains::valued_trie_root::StorageProofProvider;
 use sp_domains::{DomainId, DomainsApi};
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, HashingFor, Header as HeaderT, NumberFor};
 use sp_runtime::{Digest, DigestItem};
@@ -385,10 +386,11 @@ where
         )?;
 
         let execution_phase = {
-            let proof_of_inclusion = sp_domains::valued_trie_root::generate_proof::<
-                LayoutV1<BlakeTwo256>,
-            >(
-                encoded_extrinsics.as_slice(), extrinsic_index as u32
+            let proof_of_inclusion = StorageProofProvider::<
+                LayoutV1<<Block::Header as HeaderT>::Hashing>,
+            >::generate_enumerated_proof_of_inclusion(
+                encoded_extrinsics.as_slice(),
+                extrinsic_index as u32,
             )
             .ok_or(FraudProofError::FailToGenerateProofOfInclusion)?;
             ExecutionPhase::ApplyExtrinsic {

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -865,17 +865,20 @@ mod pallet {
                 .unwrap_or(extracted_state_roots.consensus_chain_state_root);
 
             // verify and decode the message
-            let msg = StorageProofVerifier::<T::Hashing>::verify_and_get_value::<
-                Message<BalanceOf<T>>,
-            >(&state_root, xdm.proof.message_proof.clone(), storage_key)
-            .map_err(|err| {
-                log::error!(
-                    target: "runtime::messenger",
-                    "Failed to verify storage proof: {:?}",
-                    err
-                );
-                TransactionValidityError::Invalid(InvalidTransaction::BadProof)
-            })?;
+            let msg =
+                StorageProofVerifier::<T::Hashing>::get_decoded_value::<Message<BalanceOf<T>>>(
+                    &state_root,
+                    xdm.proof.message_proof.clone(),
+                    storage_key,
+                )
+                .map_err(|err| {
+                    log::error!(
+                        target: "runtime::messenger",
+                        "Failed to verify storage proof: {:?}",
+                        err
+                    );
+                    TransactionValidityError::Invalid(InvalidTransaction::BadProof)
+                })?;
 
             Ok(msg)
         }

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -191,7 +191,7 @@ fn test_storage_proof_verification_invalid() {
         message_proof: storage_proof,
     };
     let res: Result<Channel<Balance>, VerificationError> =
-        StorageProofVerifier::<Blake2Hasher>::verify_and_get_value(
+        StorageProofVerifier::<Blake2Hasher>::get_decoded_value(
             &proof.consensus_chain_state_root,
             proof.message_proof,
             StorageKey(vec![]),
@@ -218,7 +218,7 @@ fn test_storage_proof_verification_missing_value() {
         message_proof: storage_proof,
     };
     let res: Result<Channel<Balance>, VerificationError> =
-        StorageProofVerifier::<Blake2Hasher>::verify_and_get_value(
+        StorageProofVerifier::<Blake2Hasher>::get_decoded_value(
             &proof.consensus_chain_state_root,
             proof.message_proof,
             storage_key,
@@ -247,7 +247,7 @@ fn test_storage_proof_verification() {
         message_proof: storage_proof,
     };
     let res: Result<Channel<Balance>, VerificationError> =
-        StorageProofVerifier::<Blake2Hasher>::verify_and_get_value(
+        StorageProofVerifier::<Blake2Hasher>::get_decoded_value(
             &proof.consensus_chain_state_root,
             proof.message_proof,
             storage_key,

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -295,7 +295,7 @@ impl<BlockNumber, BlockHash, StateRoot> CrossDomainMessage<BlockNumber, BlockHas
                 );
 
                 let domain_state_root =
-                    match StorageProofVerifier::<Hashing>::verify_and_get_value::<StateRoot>(
+                    match StorageProofVerifier::<Hashing>::get_decoded_value::<StateRoot>(
                         &consensus_chain_state_root.into(),
                         domain_state_root_proof,
                         domain_state_root_key,


### PR DESCRIPTION
Minor cleanup and structuring of storage proof provider and verifier and use StorageProof for proof of inclusion of extrinsic

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
