### PR TITLE
Switch the checking order of the empty message and state root for XDM

### DIFF
--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -302,6 +302,19 @@ where
             return Err(Error::DomainNonConfirmedOnConsensusChain);
         }
 
+        // fetch messages to be relayed
+        let domain_api = domain_client.runtime_api();
+        let block_messages: BlockMessagesWithStorageKey = domain_api
+            .block_messages(confirmed_block_hash)
+            .map_err(|_| Error::FetchAssignedMessages)?;
+
+        let filtered_messages = Self::filter_messages(domain_client, block_messages)?;
+
+        // short circuit if the there are no messages to relay
+        if filtered_messages.outbox.is_empty() && filtered_messages.inbox_responses.is_empty() {
+            return Ok(());
+        }
+
         // verify if the state root is matching.
         let domain_number = *domain_block_header.number();
         if !consensus_chain_api
@@ -324,19 +337,6 @@ where
                 confirmed_block_hash
             );
             return Err(Error::DomainStateRootInvalid);
-        }
-
-        // fetch messages to be relayed
-        let domain_api = domain_client.runtime_api();
-        let block_messages: BlockMessagesWithStorageKey = domain_api
-            .block_messages(confirmed_block_hash)
-            .map_err(|_| Error::FetchAssignedMessages)?;
-
-        let filtered_messages = Self::filter_messages(domain_client, block_messages)?;
-
-        // short circuit if the there are no messages to relay
-        if filtered_messages.outbox.is_empty() && filtered_messages.inbox_responses.is_empty() {
-            return Ok(());
         }
 
         // generate domain proof that points to the state root of the domain block on Consensus chain.


### PR DESCRIPTION
The operator will stop producing empty bundle so the ER/state root of the last domain block won't be submitted which will cause the XDM state root check to fail when processing the last domain block, perform the empty message check before the state root check fix this issue because the whole function will early return if there is no message and the state root check is skipped

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
