### PR TITLE
Implement an abstraction that opens file for auditing multiple times, once for every auditing rayon thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6408,15 +6408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap2"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11519,7 +11510,6 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "lru 0.11.1",
- "memmap2 0.9.0",
  "mimalloc",
  "monoio",
  "parity-scale-codec",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -58,8 +58,5 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 zeroize = "1.6.0"
 
-[target.'cfg(windows)'.dependencies]
-memmap2 = "0.9.0"
-
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 monoio = { version = "0.1.10-beta.1", features = ["sync"] }

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -1,5 +1,6 @@
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod monoio;
+pub mod rayon_files;
 pub mod sync_fallback;
 
 use crate::node_client;

--- a/crates/subspace-farmer/src/single_disk_farm/farming/rayon_files.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming/rayon_files.rs
@@ -1,0 +1,53 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
+use subspace_farmer_components::ReadAtSync;
+
+/// Wrapper data structure for multiple files to be used with [`rayon`] thread pool, where the same
+/// file is opened multiple times, once for each thread.
+pub struct RayonFiles {
+    files: Vec<File>,
+}
+
+impl ReadAtSync for RayonFiles {
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        let thread_index = rayon::current_thread_index().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "Reads must be called from rayon worker thread",
+            )
+        })?;
+        let file = self.files.get(thread_index).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "No files entry for this rayon thread")
+        })?;
+
+        file.read_at(buf, offset)
+    }
+}
+
+impl ReadAtSync for &RayonFiles {
+    fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
+        (*self).read_at(buf, offset)
+    }
+}
+
+impl RayonFiles {
+    /// Open file at specified as many times as there is number of threads in current [`rayon`]
+    /// thread pool.
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let files = (0..rayon::current_num_threads())
+            .map(|_| {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .advise_random_access()
+                    .open(path)?;
+                file.advise_random_access()?;
+
+                Ok::<_, io::Error>(file)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { files })
+    }
+}


### PR DESCRIPTION
This seems to be a tiny bit faster on Linux, but more importantly, it is faster than even memory-mapped I/O on Windows.

Specifically numbers I shared on [Rust Internals](https://internals.rust-lang.org/t/introduce-write-at-write-all-at-read-at-read-exact-at-on-windows/19649/17?u=nazar-pc) are:
* 936 ms for single file with `seek_read` (+handling of partial reads identically to `read_exact_at` in std)
* 245 ms for single file with memory-mapped I/O
* 190 ms with file openes many times, once for each thead in thread pool using `seek_read`

Will ask come community members to bench it as well.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
