### PR TITLE
Remove harcoded receipt hash in favor of Block::Hash

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -62,7 +62,7 @@ mod benchmarks {
                 .first()
                 .cloned()
                 .expect("parent receipt must exist");
-            receipt = ExecutionReceipt::dummy(
+            receipt = ExecutionReceipt::dummy::<DomainHashingFor<T>>(
                 consensus_block_number,
                 frame_system::Pallet::<T>::block_hash(consensus_block_number),
                 domain_block_number,

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -17,8 +17,7 @@ use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::{
-    derive_domain_block_hash, DomainId, DomainsDigestItem, OperatorAllowList, ReceiptHash,
-    RuntimeId,
+    derive_domain_block_hash, DomainId, DomainsDigestItem, OperatorAllowList, RuntimeId,
 };
 use sp_runtime::traits::{CheckedAdd, Zero};
 use sp_runtime::DigestItem;
@@ -62,7 +61,7 @@ pub struct DomainConfig<AccountId: Ord> {
 }
 
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct DomainObject<Number, AccountId: Ord> {
+pub struct DomainObject<Number, ReceiptHash, AccountId: Ord> {
     /// The address of the domain creator, used to validate updating the domain config.
     pub owner_account_id: AccountId,
     /// The consensus chain block number when the domain first instantiated.
@@ -145,7 +144,7 @@ pub(crate) fn do_instantiate_domain<T: Config>(
             genesis_block_hash,
         )
     };
-    let genesis_receipt_hash = genesis_receipt.hash();
+    let genesis_receipt_hash = genesis_receipt.hash::<DomainHashingFor<T>>();
 
     let domain_obj = DomainObject {
         owner_account_id: owner_account_id.clone(),

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -2,9 +2,9 @@ use crate::block_tree::BlockTreeNode;
 use crate::domain_registry::{DomainConfig, DomainObject};
 use crate::{
     self as pallet_domains, BalanceOf, BlockTree, BlockTreeNodes, BundleError, Config,
-    ConsensusBlockHash, DomainBlockNumberFor, DomainRegistry, ExecutionInbox, ExecutionReceiptOf,
-    FraudProofError, FungibleHoldId, HeadReceiptNumber, NextDomainId, Operator, OperatorStatus,
-    Operators,
+    ConsensusBlockHash, DomainBlockNumberFor, DomainHashingFor, DomainRegistry, ExecutionInbox,
+    ExecutionReceiptOf, FraudProofError, FungibleHoldId, HeadReceiptNumber, NextDomainId, Operator,
+    OperatorStatus, Operators, ReceiptHashFor,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use domain_runtime_primitives::opaque::Header as DomainHeader;
@@ -22,8 +22,8 @@ use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
     BundleHeader, DomainId, DomainsHoldIdentifier, ExecutionReceipt, InboxedBundle, OpaqueBundle,
-    OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, ReceiptHash, RuntimeType,
-    SealedBundleHeader, StakingHoldIdentifier,
+    OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, RuntimeType, SealedBundleHeader,
+    StakingHoldIdentifier,
 };
 use sp_domains_fraud_proof::fraud_proof::{
     ExtrinsicDigest, FraudProof, InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof,
@@ -528,7 +528,9 @@ pub(crate) fn extend_block_tree(
         receipt = create_dummy_receipt(
             block_number,
             H256::random(),
-            parent_block_tree_node.execution_receipt.hash(),
+            parent_block_tree_node
+                .execution_receipt
+                .hash::<DomainHashingFor<Test>>(),
             vec![bundle_extrinsics_root],
         );
     }
@@ -827,7 +829,7 @@ fn test_invalid_fraud_proof() {
         let bad_receipt_hash = get_block_tree_node_at::<Test>(domain_id, bad_receipt_at)
             .unwrap()
             .execution_receipt
-            .hash();
+            .hash::<DomainHashingFor<Test>>();
         let fraud_proof = FraudProof::dummy_fraud_proof(domain_id, bad_receipt_hash);
         assert_eq!(
             Domains::validate_fraud_proof(&fraud_proof),
@@ -861,7 +863,9 @@ fn test_invalid_total_rewards_fraud_proof() {
         let bad_receipt_at = 8;
         let mut domain_block = get_block_tree_node_at::<Test>(domain_id, bad_receipt_at).unwrap();
 
-        let bad_receipt_hash = domain_block.execution_receipt.hash();
+        let bad_receipt_hash = domain_block
+            .execution_receipt
+            .hash::<DomainHashingFor<Test>>();
         let (fraud_proof, root) = generate_invalid_total_rewards_fraud_proof::<Test>(
             domain_id,
             bad_receipt_hash,
@@ -879,7 +883,7 @@ type FraudProofFor<T> =
 
 fn generate_invalid_total_rewards_fraud_proof<T: Config>(
     domain_id: DomainId,
-    bad_receipt_hash: ReceiptHash,
+    bad_receipt_hash: ReceiptHashFor<T>,
     rewards: BalanceOf<T>,
 ) -> (FraudProofFor<T>, T::Hash) {
     let storage_key = sp_domains_fraud_proof::fraud_proof::operator_block_rewards_final_key();
@@ -943,7 +947,7 @@ fn test_invalid_domain_extrinsic_root_proof() {
         };
         bad_receipt.domain_block_extrinsic_root = H256::random();
 
-        let bad_receipt_hash = bad_receipt.hash();
+        let bad_receipt_hash = bad_receipt.hash::<DomainHashingFor<Test>>();
         let fraud_proof =
             generate_invalid_domain_extrinsic_root_fraud_proof::<Test>(domain_id, bad_receipt_hash);
         let (consensus_block_number, consensus_block_hash) = (
@@ -969,7 +973,7 @@ fn test_invalid_domain_extrinsic_root_proof() {
 
 fn generate_invalid_domain_extrinsic_root_fraud_proof<T: Config + pallet_timestamp::Config>(
     domain_id: DomainId,
-    bad_receipt_hash: ReceiptHash,
+    bad_receipt_hash: ReceiptHashFor<T>,
 ) -> FraudProof<BlockNumberFor<T>, T::Hash, T::DomainHeader> {
     let valid_bundle_digests = vec![ValidBundleDigest {
         bundle_index: 0,
@@ -1003,7 +1007,9 @@ fn test_invalid_domain_block_hash_fraud_proof() {
             generate_invalid_domain_block_hash_fraud_proof::<Test>(Digest::default());
         domain_block.execution_receipt.final_state_root = root;
         domain_block.execution_receipt.domain_block_hash = H256::random();
-        let bad_receipt_hash = domain_block.execution_receipt.hash();
+        let bad_receipt_hash = domain_block
+            .execution_receipt
+            .hash::<DomainHashingFor<Test>>();
         BlockTreeNodes::<Test>::insert(bad_receipt_hash, domain_block);
         let fraud_proof = FraudProof::InvalidDomainBlockHash(InvalidDomainBlockHashProof {
             domain_id,
@@ -1048,7 +1054,7 @@ fn test_basic_fraud_proof_processing() {
         let bad_receipt = get_block_tree_node_at::<Test>(domain_id, bad_receipt_at)
             .unwrap()
             .execution_receipt;
-        let bad_receipt_hash = bad_receipt.hash();
+        let bad_receipt_hash = bad_receipt.hash::<DomainHashingFor<Test>>();
         let fraud_proof = FraudProof::dummy_fraud_proof(domain_id, bad_receipt_hash);
         assert_ok!(Domains::submit_fraud_proof(
             RawOrigin::None.into(),
@@ -1117,7 +1123,7 @@ fn test_fraud_proof_prune_fraudulent_branch_of_receipt() {
                 }
                 er
             };
-            let bad_receipt_hash = bad_receipt.hash();
+            let bad_receipt_hash = bad_receipt.hash::<DomainHashingFor<Test>>();
             let bundle = create_dummy_bundle_with_receipts(
                 domain_id,
                 operator_id,

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -31,7 +31,7 @@ pub fn verify_invalid_domain_extrinsics_root_fraud_proof<CBlock, Balance, Hashin
         HeaderHashFor<DomainHeader>,
         Balance,
     >,
-    fraud_proof: &InvalidExtrinsicsRootProof,
+    fraud_proof: &InvalidExtrinsicsRootProof<HeaderHashFor<DomainHeader>>,
 ) -> Result<(), VerificationError>
 where
     CBlock: BlockT,
@@ -131,7 +131,7 @@ pub fn verify_valid_bundle_fraud_proof<CBlock, DomainNumber, DomainHash, Balance
         DomainHash,
         Balance,
     >,
-    fraud_proof: &ValidBundleProof,
+    fraud_proof: &ValidBundleProof<DomainHash>,
 ) -> Result<(), VerificationError>
 where
     CBlock: BlockT,
@@ -188,7 +188,7 @@ pub fn verify_invalid_state_transition_fraud_proof<CBlock, DomainHeader, Balance
         DomainHeader::Hash,
         Balance,
     >,
-    fraud_proof: &InvalidStateTransitionProof,
+    fraud_proof: &InvalidStateTransitionProof<HeaderHashFor<DomainHeader>>,
 ) -> Result<(), VerificationError>
 where
     CBlock: BlockT,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -64,7 +64,7 @@ use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainId, DomainInstanceData, DomainsHoldIdentifier, ExecutionReceipt, OperatorId,
-    OperatorPublicKey, ReceiptHash, StakingHoldIdentifier,
+    OperatorPublicKey, StakingHoldIdentifier,
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
@@ -1083,7 +1083,7 @@ impl_runtime_apis! {
             Domains::domain_state_root(domain_id, number, hash)
         }
 
-        fn execution_receipt(receipt_hash: ReceiptHash) -> Option<ExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainNumber, DomainHash, Balance>> {
+        fn execution_receipt(receipt_hash: DomainHash) -> Option<ExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainNumber, DomainHash, Balance>> {
             Domains::execution_receipt(receipt_hash)
         }
     }

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -8,7 +8,6 @@ use sc_client_api::{AuxStore, BlockBackend, ProofProvider};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::CodeExecutor;
-use sp_core::H256;
 use sp_domain_digests::AsPredigest;
 use sp_domains::proof_provider_and_verifier::StorageProofProvider;
 use sp_domains::{DomainId, DomainsApi};
@@ -108,7 +107,7 @@ where
         &self,
         domain_id: DomainId,
         local_receipt: &ExecutionReceiptFor<Block, CBlock>,
-        bad_receipt_hash: H256,
+        bad_receipt_hash: Block::Hash,
     ) -> Result<FraudProofFor<PCB, Block::Header>, FraudProofError>
     where
         PCB: BlockT,
@@ -129,7 +128,7 @@ where
         &self,
         domain_id: DomainId,
         local_receipt: &ExecutionReceiptFor<Block, CBlock>,
-        bad_receipt_hash: H256,
+        bad_receipt_hash: Block::Hash,
     ) -> Result<FraudProofFor<PCB, Block::Header>, FraudProofError>
     where
         PCB: BlockT,
@@ -154,7 +153,7 @@ where
         _local_receipt: &ExecutionReceiptFor<Block, CBlock>,
         mismatch_type: BundleMismatchType,
         bundle_index: u32,
-        _bad_receipt_hash: H256,
+        _bad_receipt_hash: Block::Hash,
     ) -> Result<FraudProofFor<PCB, Block::Header>, FraudProofError>
     where
         PCB: BlockT,
@@ -186,7 +185,7 @@ where
         &self,
         domain_id: DomainId,
         local_receipt: &ExecutionReceiptFor<Block, CBlock>,
-        bad_receipt_hash: H256,
+        bad_receipt_hash: Block::Hash,
     ) -> Result<FraudProofFor<PCB, Block::Header>, FraudProofError>
     where
         PCB: BlockT,
@@ -258,7 +257,7 @@ where
         domain_id: DomainId,
         local_trace_index: u32,
         local_receipt: &ExecutionReceiptFor<Block, CBlock>,
-        bad_receipt_hash: H256,
+        bad_receipt_hash: Block::Hash,
     ) -> Result<FraudProofFor<PCB, Block::Header>, FraudProofError>
     where
         PCB: BlockT,

--- a/domains/client/domain-operator/src/parent_chain.rs
+++ b/domains/client/domain-operator/src/parent_chain.rs
@@ -2,7 +2,7 @@ use crate::ExecutionReceiptFor;
 use sc_client_api::BlockBackend;
 use sp_api::{ApiError, HeaderT, NumberFor, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
-use sp_domains::{DomainBlockLimit, DomainId, DomainsApi, ReceiptHash};
+use sp_domains::{DomainBlockLimit, DomainId, DomainsApi};
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::Block as BlockT;
 use std::marker::PhantomData;
@@ -72,7 +72,7 @@ pub trait ParentChainInterface<Block: BlockT, ParentChainBlock: BlockT> {
     fn execution_receipt(
         &self,
         at: ParentChainBlock::Hash,
-        receipt_hash: ReceiptHash,
+        receipt_hash: Block::Hash,
     ) -> Result<Option<ExecutionReceiptFor<Block, ParentChainBlock>>, sp_api::ApiError>;
 }
 
@@ -219,7 +219,7 @@ where
     fn execution_receipt(
         &self,
         at: CBlock::Hash,
-        receipt_hash: ReceiptHash,
+        receipt_hash: Block::Hash,
     ) -> Result<Option<ExecutionReceiptFor<Block, CBlock>>, sp_api::ApiError> {
         self.consensus_client
             .runtime_api()

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -17,7 +17,7 @@ use sp_consensus::SyncOracle;
 use sp_core::traits::FetchRuntimeCode;
 use sp_core::{Pair, H256};
 use sp_domain_digests::AsPredigest;
-use sp_domains::{Bundle, BundleValidity, DomainId, DomainsApi};
+use sp_domains::{Bundle, BundleValidity, DomainId, DomainsApi, HeaderHashingFor};
 use sp_domains_fraud_proof::execution_prover::ExecutionProver;
 use sp_domains_fraud_proof::fraud_proof::{
     ExecutionPhase, FraudProof, InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof,
@@ -1328,7 +1328,10 @@ async fn test_valid_bundle_proof_generation_and_verification() {
         {
             if let FraudProof::ValidBundle(proof) = *fraud_proof {
                 // The fraud proof is targetting the `bad_receipt`
-                assert_eq!(proof.bad_receipt_hash, bad_receipt.hash());
+                assert_eq!(
+                    proof.bad_receipt_hash,
+                    bad_receipt.hash::<HeaderHashingFor<Header>>()
+                );
 
                 // If the fraud proof target a non-exist receipt then it is invalid
                 let mut bad_proof = proof.clone();
@@ -1448,7 +1451,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
 
     let good_invalid_state_transition_proof = InvalidStateTransitionProof {
         domain_id: DomainId::new(3u32),
-        bad_receipt_hash: bad_receipt.hash(),
+        bad_receipt_hash: bad_receipt.hash::<HeaderHashingFor<Header>>(),
         proof: storage_proof,
         execution_phase,
     };

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -57,7 +57,7 @@ use sp_core::{Hasher, OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainId, DomainInstanceData, DomainsHoldIdentifier, ExecutionReceipt, OpaqueBundle,
-    OpaqueBundles, OperatorId, OperatorPublicKey, ReceiptHash, StakingHoldIdentifier,
+    OpaqueBundles, OperatorId, OperatorPublicKey, StakingHoldIdentifier,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
@@ -1357,7 +1357,7 @@ impl_runtime_apis! {
             Domains::domain_state_root(domain_id, number, hash)
         }
 
-        fn execution_receipt(receipt_hash: ReceiptHash) -> Option<ExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainNumber, DomainHash, Balance>> {
+        fn execution_receipt(receipt_hash: DomainHash) -> Option<ExecutionReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainNumber, DomainHash, Balance>> {
             Domains::execution_receipt(receipt_hash)
         }
     }


### PR DESCRIPTION
Small refactoring to use Block::Hash instead of H256

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
