### PR TITLE
Fix the flaky domain tests

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1645,8 +1645,7 @@ impl<T: Config> Pallet<T> {
         let operator_stake = domain_stake_summary
             .current_operators
             .get(operator_id)
-            .ok_or(BundleError::BadOperator)
-            .unwrap();
+            .ok_or(BundleError::BadOperator)?;
         Ok((*operator_stake, domain_stake_summary.current_total_stake))
     }
 

--- a/crates/sp-domains-fraud-proof/src/tests.rs
+++ b/crates/sp-domains-fraud-proof/src/tests.rs
@@ -58,7 +58,7 @@ async fn check_tx_validity_runtime_api_should_work() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -137,6 +137,7 @@ impl DomainInstanceStarter {
                     gossip_message_sink,
                     domain_message_receiver,
                     provider: eth_provider,
+                    skip_empty_bundle_production: true,
                 };
 
                 let mut domain_node = domain_service::new_full::<

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -177,6 +177,7 @@ pub struct OperatorParams<
     pub operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS, ASS>,
     pub domain_confirmation_depth: NumberFor<Block>,
     pub block_import: SharedBlockImport<Block>,
+    pub skip_empty_bundle_production: bool,
 }
 
 pub(crate) fn load_execution_receipt_by_domain_hash<Block, CBlock, Client>(

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -131,6 +131,7 @@ where
             domain_bundle_proposer,
             params.bundle_sender,
             params.keystore.clone(),
+            params.skip_empty_bundle_production,
         );
 
         let fraud_proof_generator = FraudProofGenerator::new(

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -67,7 +67,7 @@ async fn test_domain_instance_bootstrapper() {
         .unwrap();
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -90,8 +90,6 @@ async fn test_domain_instance_bootstrapper() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(target_os = "windows", ignore)]
-// TODO: fix this on windows. https://github.com/subspace/subspace/actions/runs/6505907396/job/17683021699?pr=1974
 async fn test_domain_block_production() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -109,7 +107,7 @@ async fn test_domain_block_production() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -120,7 +118,6 @@ async fn test_domain_block_production() {
     for i in 0..50 {
         let (tx, slot) = if i % 2 == 0 {
             // Produce bundle and include it in the primary block hence produce a domain block
-            alice.send_system_remark().await;
             let (slot, _) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
             // `None` means collect tx from the tx pool
             (None, slot)
@@ -181,7 +178,6 @@ async fn test_domain_block_production() {
     assert_eq!(alice.client.info().best_hash, domain_block_hash);
 
     // Simply producing more block on fork C
-    alice.send_system_remark().await;
     for _ in 0..10 {
         let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
         let tx = subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
@@ -221,7 +217,7 @@ async fn test_processing_empty_consensus_block() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -377,7 +373,7 @@ async fn collected_receipts_should_be_on_the_same_branch_with_current_best_block
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -549,7 +545,7 @@ async fn test_domain_tx_propagate() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -623,7 +619,7 @@ async fn test_executor_full_node_catching_up() {
     }
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -675,7 +671,7 @@ async fn test_executor_inherent_timestamp_is_set() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -1378,7 +1374,7 @@ async fn fraud_proof_verification_in_tx_pool_should_work() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -1522,7 +1518,7 @@ async fn set_new_code_should_work() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -1593,7 +1589,7 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -1602,7 +1598,7 @@ async fn pallet_domains_unsigned_extrinsics_should_work() {
     .await;
 
     // Run Bob (a evm domain full node)
-    let mut bob = domain_test_service::DomainNodeBuilder::new(
+    let bob = domain_test_service::DomainNodeBuilder::new(
         tokio_handle,
         Bob,
         BasePath::new(directory.path().join("bob")),
@@ -1691,7 +1687,7 @@ async fn duplicated_and_stale_bundle_should_be_rejected() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -1762,7 +1758,7 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -2208,7 +2204,7 @@ async fn test_restart_domain_operator() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -2241,7 +2237,7 @@ async fn test_restart_domain_operator() {
     ferdie.set_next_slot(next_slot);
 
     // Restart Alice
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),
@@ -2340,7 +2336,7 @@ async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
     );
 
     // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
+    let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
         Alice,
         BasePath::new(directory.path().join("alice")),

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -229,6 +229,7 @@ where
     pub gossip_message_sink: GossipMessageSink,
     pub domain_message_receiver: TracingUnboundedReceiver<Vec<u8>>,
     pub provider: Provider,
+    pub skip_empty_bundle_production: bool,
 }
 
 /// Builds service for a domain full node.
@@ -330,6 +331,7 @@ where
         gossip_message_sink,
         domain_message_receiver,
         provider,
+        skip_empty_bundle_production,
     } = domain_params;
 
     // TODO: Do we even need block announcement on domain node?
@@ -452,6 +454,7 @@ where
             operator_streams,
             domain_confirmation_depth,
             block_import,
+            skip_empty_bundle_production,
         },
     )
     .await?;

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -167,6 +167,7 @@ where
         base_path: BasePath,
         domain_nodes: Vec<MultiaddrWithPeerId>,
         domain_nodes_exclusive: bool,
+        skip_empty_bundle_production: bool,
         role: Role,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> Self {
@@ -233,6 +234,7 @@ where
             gossip_message_sink: gossip_msg_sink,
             domain_message_receiver,
             provider: DefaultProvider,
+            skip_empty_bundle_production,
         };
 
         let domain_node = domain_service::new_full::<
@@ -387,6 +389,7 @@ pub struct DomainNodeBuilder {
     key: EcdsaKeyring,
     domain_nodes: Vec<MultiaddrWithPeerId>,
     domain_nodes_exclusive: bool,
+    skip_empty_bundle_production: bool,
     base_path: BasePath,
 }
 
@@ -406,6 +409,7 @@ impl DomainNodeBuilder {
             tokio_handle,
             domain_nodes: Vec::new(),
             domain_nodes_exclusive: false,
+            skip_empty_bundle_production: false,
             base_path,
         }
     }
@@ -427,6 +431,12 @@ impl DomainNodeBuilder {
         self
     }
 
+    /// Skip empty bundle production when there is no non-empty domain block need to confirm
+    pub fn skip_empty_bundle(mut self) -> Self {
+        self.skip_empty_bundle_production = true;
+        self
+    }
+
     /// Build a evm domain node
     pub async fn build_evm_node(
         self,
@@ -441,6 +451,7 @@ impl DomainNodeBuilder {
             self.base_path,
             self.domain_nodes,
             self.domain_nodes_exclusive,
+            self.skip_empty_bundle_production,
             role,
             mock_consensus_node,
         )

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -907,7 +907,6 @@ where
 macro_rules! produce_blocks {
     ($primary_node:ident, $operator_node:ident, $count: literal $(, $domain_node:ident)*) => {
         {
-            $operator_node.send_system_remark().await;
             async {
                 let domain_fut = {
                     let mut futs: Vec<std::pin::Pin<Box<dyn futures::Future<Output = ()>>>> = Vec::new();
@@ -929,7 +928,6 @@ macro_rules! produce_blocks {
 macro_rules! produce_block_with {
     ($primary_node_produce_block:expr, $operator_node:ident $(, $domain_node:ident)*) => {
         {
-            $operator_node.send_system_remark().await;
             async {
                 let domain_fut = {
                     let mut futs: Vec<std::pin::Pin<Box<dyn futures::Future<Output = ()>>>> = Vec::new();


### PR DESCRIPTION
This PR fix the flaky domain test `test_domain_block_production` and `duplicated_and_stale_bundle_should_be_rejected`.

The root cause is we call `alice.send_system_remark` to send domain extrinsic so that the operator won't skip producing an empty bundle. But this extrinsic may included in multiple bundles sometimes if the operator doesn't clean up its tx pool in time (this is done through a worker asynchronously), which will cause the bundle to be invalid and the operator to be slashed hence the operator's bundle will be rejected. So the expected number of domain block can't produced and cause the test stuck or failed at assert. The slash happens when the ER is confirmed and only these 2 tests produce such many domain block to confirm an ER hence trigger this issue.

Another case that caused the test to fail is that even with `alice.send_system_remark`, the operator can still skip producing bundle if the tx can't fall into the tx range.

This PR fixes the problem by allowing the operator to produce empty bundle in test (through a config flag), and a new test is added to cover the case when empty bundle production is disabled.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
