### PR TITLE
Use polkadot's slow fee adjustment instead of constant fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11792,8 +11792,12 @@ dependencies = [
 name = "subspace-runtime-primitives"
 version = "0.1.0"
 dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-transaction-payment",
  "serde",
  "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
  "subspace-core-primitives",

--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -8,19 +8,23 @@ edition = "2021"
 homepage = "https://subspace.network"
 repository = "https://github.com/subspace/subspace"
 include = [
-	"/src",
-	"/Cargo.toml",
+    "/src",
+    "/Cargo.toml",
 ]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+frame-support = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
+frame-system = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
+pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 # TODO: Should, idealy, be optional, but `sp-runtime`'s `serde` feature is enabled unconditionally by something in
 #  Substrate and as the result our custom `Block` implementation has to derive `serde` traits essentially
 #  unconditionally or else it doesn't compile
 serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"] }
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
+sp-io = { version = "23.0.0", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
@@ -28,9 +32,15 @@ subspace-core-primitives = { version = "0.1.0", default-features = false, path =
 [features]
 default = ["std"]
 std = [
-	"serde/std",
-	"sp-core/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"subspace-core-primitives/std",
+    "pallet-transaction-payment/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "subspace-core-primitives/std",
+]
+testing = [
+    "frame-support",
+    "frame-system",
+    "sp-io"
 ]

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -69,6 +69,7 @@ substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subs
 [dev-dependencies]
 hex-literal = "0.4.1"
 sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
+subspace-runtime-primitives = { version = "0.1.0", features = ["testing"], path = "../subspace-runtime-primitives" }
 
 [features]
 default = ["std"]

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -90,7 +90,7 @@ use subspace_core_primitives::{
 };
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash, Moment, Nonce, Signature,
-    MIN_REPLICATION_FACTOR, SHANNON, SSC, STORAGE_FEES_ESCROW_BLOCK_REWARD,
+    SlowAdjustingFeeUpdate, MIN_REPLICATION_FACTOR, SHANNON, SSC, STORAGE_FEES_ESCROW_BLOCK_REWARD,
     STORAGE_FEES_ESCROW_BLOCK_TAX,
 };
 
@@ -487,7 +487,7 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = ConstU8<5>;
     type WeightToFee = IdentityFee<Balance>;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = ();
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
 }
 
 impl pallet_utility::Config for Runtime {
@@ -1223,5 +1223,16 @@ impl_runtime_apis! {
 
             Ok(batches)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Runtime, SubspaceBlockWeights as BlockWeights};
+    use subspace_runtime_primitives::tests_utils::FeeMultiplierUtils;
+
+    #[test]
+    fn multiplier_can_grow_from_zero() {
+        FeeMultiplierUtils::<Runtime, BlockWeights>::multiplier_can_grow_from_zero()
     }
 }

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -61,6 +61,9 @@ sp-version = { version = "22.0.0", default-features = false, git = "https://gith
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives", default-features = false }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 
+[dev-dependencies]
+subspace-runtime-primitives = { version = "0.1.0", features = ["testing"], path = "../../../crates/subspace-runtime-primitives" }
+
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1", optional = true }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -61,7 +61,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use subspace_runtime_primitives::{Moment, SHANNON};
+use subspace_runtime_primitives::{Moment, SlowAdjustingFeeUpdate, SHANNON};
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = EthereumSignature;
@@ -359,7 +359,7 @@ impl pallet_transaction_payment::Config for Runtime {
         pallet_transaction_payment::CurrencyAdapter<Balances, ActualPaidFeesHandler>;
     type WeightToFee = IdentityFee<Balance>;
     type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = ();
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
 }
 
@@ -1230,5 +1230,16 @@ impl_runtime_apis! {
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Runtime, RuntimeBlockWeights as BlockWeights};
+    use subspace_runtime_primitives::tests_utils::FeeMultiplierUtils;
+
+    #[test]
+    fn multiplier_can_grow_from_zero() {
+        FeeMultiplierUtils::<Runtime, BlockWeights>::multiplier_can_grow_from_zero()
     }
 }


### PR DESCRIPTION
Both Consensus and Evm runtimes are updated to use TagettedFeeAdjusment using the parameters defined on Polkadot relay chain.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
