### PR TITLE
Domain bootstrap nodes

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -50,6 +50,7 @@ use sp_runtime::{Digest, DigestItem, OpaqueExtrinsic, Percent};
 use sp_runtime_interface::pass_by;
 use sp_runtime_interface::pass_by::PassBy;
 use sp_std::collections::btree_set::BTreeSet;
+use sp_std::fmt::{Display, Formatter};
 use sp_std::vec::Vec;
 use sp_weights::Weight;
 use subspace_core_primitives::crypto::blake3_hash;
@@ -167,6 +168,12 @@ impl DomainId {
     /// Converts the inner integer to little-endian bytes.
     pub fn to_le_bytes(&self) -> [u8; 4] {
         self.0.to_le_bytes()
+    }
+}
+
+impl Display for DomainId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/crates/subspace-node/src/chain_spec_utils.rs
+++ b/crates/subspace-node/src/chain_spec_utils.rs
@@ -1,5 +1,7 @@
 use frame_support::traits::Get;
 use sc_service::Properties;
+use serde_json::map::Map;
+use serde_json::Value;
 use sp_core::crypto::AccountId32;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::IdentifyAccount;
@@ -18,6 +20,11 @@ pub(crate) fn chain_spec_properties() -> Properties {
     );
     properties.insert("tokenDecimals".to_string(), DECIMAL_PLACES.into());
     properties.insert("tokenSymbol".to_string(), "tSSC".into());
+    let domains_bootstrap_nodes = Map::<String, Value>::new();
+    properties.insert(
+        "domainsBootstrapNodes".to_string(),
+        domains_bootstrap_nodes.into(),
+    );
 
     properties
 }


### PR DESCRIPTION
Adds `domainsBootstrapNodes` property to the chain spec and picks the bootnodes for the given domain if there are no bootnodes passed through cmdline

The chainspec property for `domain 0` will be:
```
...
"domainsBootstrapNodes": {
	"0": [
		...
	]
}
...
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
