### PR TITLE
Remove `--execution` argument from docs

### DIFF
--- a/crates/pallet-domains/src/weights.rs
+++ b/crates/pallet-domains/src/weights.rs
@@ -16,7 +16,6 @@
 // --repeat=20
 // --pallet=pallet_domains
 // --extrinsic=*
-// --execution=wasm
 // --wasm-execution=compiled
 // --heap-pages=4096
 // --output=./crates/pallet-domains/src/weights.rs

--- a/crates/pallet-subspace/src/weights.rs
+++ b/crates/pallet-subspace/src/weights.rs
@@ -16,7 +16,6 @@
 // --repeat=20
 // --pallet=pallet_subspace
 // --extrinsic=*
-// --execution=wasm
 // --wasm-execution=compiled
 // --heap-pages=4096
 // --output=./crates/pallet-subspace/src/weights.rs

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -45,7 +45,6 @@ If you're connected directly without any router, then again nothing needs to be 
 # Copy all of the lines below, they are all part of the same command
 .\NODE_FILE_NAME.exe `
 --chain gemini-3f `
---execution wasm `
 --blocks-pruning 256 `
 --state-pruning archive `
 --no-private-ipv4 `
@@ -97,7 +96,6 @@ If you're connected directly without any router, then again nothing needs to be 
 # Copy all of the lines below, they are all part of the same command
 ./NODE_FILE_NAME \
   --chain gemini-3f \
-  --execution wasm \
   --blocks-pruning 256 \
   --state-pruning archive \
   --no-private-ipv4 \
@@ -152,7 +150,6 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 # Copy all of the lines below, they are all part of the same command
 ./NODE_FILE_NAME \
   --chain gemini-3f \
-  --execution wasm \
   --blocks-pruning 256 \
   --state-pruning archive \
   --no-private-ipv4 \
@@ -218,7 +215,6 @@ services:
     command: [
       "--chain", "gemini-3f",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
       "--blocks-pruning", "256",
       "--state-pruning", "archive",
       "--port", "30333",

--- a/domains/pallets/executive/src/weights.rs
+++ b/domains/pallets/executive/src/weights.rs
@@ -17,7 +17,6 @@
 // --repeat=20
 // --pallet=domain-pallet-executive
 // --extrinsic=*
-// --execution=wasm
 // --wasm-execution=compiled
 // --heap-pages=4096
 // --output=./domains/pallets/executive/src/weights.rs

--- a/domains/pallets/messenger/src/weights.rs
+++ b/domains/pallets/messenger/src/weights.rs
@@ -16,7 +16,6 @@
 // --repeat=20
 // --pallet=pallet_messenger
 // --extrinsic=*
-// --execution=wasm
 // --wasm-execution=compiled
 // --heap-pages=4096
 // --output=./domains/pallets/messenger/src/weights.rs

--- a/domains/pallets/transporter/src/weights.rs
+++ b/domains/pallets/transporter/src/weights.rs
@@ -17,7 +17,6 @@
 // --repeat=20
 // --pallet=pallet_transporter
 // --extrinsic=*
-// --execution=wasm
 // --wasm-execution=compiled
 // --heap-pages=4096
 // --output=./domains/pallets/transporter/src/weights.rs

--- a/orml/vesting/src/weights.rs
+++ b/orml/vesting/src/weights.rs
@@ -12,7 +12,6 @@
 // --repeat=20
 // --pallet=orml_vesting
 // --extrinsic=*
-// --execution=wasm
 // --wasm-execution=compiled
 // --heap-pages=4096
 // --output=./vesting/src/weights.rs


### PR DESCRIPTION
The argument is not doing anything anymore, the only execution available right now is `wasm`, using this argument simply generates unnecessary warning.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
