### PR TITLE
Change plot auditing to reduce amount of computation needed

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -99,15 +99,9 @@ struct VoteVerificationData {
     parent_slot: Slot,
 }
 
-/// Simple wrapper for chunk offset in a sector for readability purposes
-#[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo,
-)]
-struct AuditChunkOffset(u8);
-
 #[frame_support::pallet]
 pub mod pallet {
-    use super::{AuditChunkOffset, EraChangeTrigger, VoteVerificationData};
+    use super::{EraChangeTrigger, VoteVerificationData};
     use crate::equivocation::HandleEquivocation;
     use crate::weights::WeightInfo;
     use frame_support::pallet_prelude::*;
@@ -401,17 +395,8 @@ pub mod pallet {
 
     /// Parent block author information.
     #[pallet::storage]
-    pub(super) type ParentBlockAuthorInfo<T> = StorageValue<
-        _,
-        (
-            FarmerPublicKey,
-            SectorIndex,
-            PieceOffset,
-            Scalar,
-            AuditChunkOffset,
-            Slot,
-        ),
-    >;
+    pub(super) type ParentBlockAuthorInfo<T> =
+        StorageValue<_, (FarmerPublicKey, SectorIndex, PieceOffset, Scalar, Slot)>;
 
     /// Enable rewards since specified block number.
     #[pallet::storage]
@@ -426,7 +411,6 @@ pub mod pallet {
             SectorIndex,
             PieceOffset,
             Scalar,
-            AuditChunkOffset,
             Slot,
             T::AccountId,
         ),
@@ -437,14 +421,7 @@ pub mod pallet {
     pub(super) type ParentBlockVoters<T: Config> = StorageValue<
         _,
         BTreeMap<
-            (
-                FarmerPublicKey,
-                SectorIndex,
-                PieceOffset,
-                Scalar,
-                AuditChunkOffset,
-                Slot,
-            ),
+            (FarmerPublicKey, SectorIndex, PieceOffset, Scalar, Slot),
             (T::AccountId, FarmerSignature),
         >,
         ValueQuery,
@@ -455,14 +432,7 @@ pub mod pallet {
     pub(super) type CurrentBlockVoters<T: Config> = StorageValue<
         _,
         BTreeMap<
-            (
-                FarmerPublicKey,
-                SectorIndex,
-                PieceOffset,
-                Scalar,
-                AuditChunkOffset,
-                Slot,
-            ),
+            (FarmerPublicKey, SectorIndex, PieceOffset, Scalar, Slot),
             (T::AccountId, FarmerSignature),
         >,
     >;
@@ -805,12 +775,10 @@ impl<T: Config> Pallet<T> {
                 pre_digest.solution().sector_index,
                 pre_digest.solution().piece_offset,
                 pre_digest.solution().chunk,
-                AuditChunkOffset(pre_digest.solution().audit_chunk_offset),
                 pre_digest.slot(),
             );
             if ParentBlockVoters::<T>::get().contains_key(&key) {
-                let (public_key, _sector_index, _piece_offset, _chunk, _audit_chunk_offset, slot) =
-                    key;
+                let (public_key, _sector_index, _piece_offset, _chunk, slot) = key;
 
                 let offence = SubspaceEquivocationOffence {
                     slot,
@@ -827,28 +795,20 @@ impl<T: Config> Pallet<T> {
                     );
                 }
             } else {
-                let (public_key, sector_index, piece_offset, chunk, audit_chunk_offset, slot) = key;
+                let (public_key, sector_index, piece_offset, chunk, slot) = key;
 
                 CurrentBlockAuthorInfo::<T>::put((
                     public_key,
                     sector_index,
                     piece_offset,
                     chunk,
-                    audit_chunk_offset,
                     slot,
                     pre_digest.solution().reward_address.clone(),
                 ));
             }
         }
         CurrentBlockVoters::<T>::put(BTreeMap::<
-            (
-                FarmerPublicKey,
-                SectorIndex,
-                PieceOffset,
-                Scalar,
-                AuditChunkOffset,
-                Slot,
-            ),
+            (FarmerPublicKey, SectorIndex, PieceOffset, Scalar, Slot),
             (T::AccountId, FarmerSignature),
         >::default());
 
@@ -978,24 +938,10 @@ impl<T: Config> Pallet<T> {
             ));
         }
 
-        if let Some((
-            public_key,
-            sector_index,
-            piece_offset,
-            scalar,
-            audit_chunk_offset,
-            slot,
-            _reward_address,
-        )) = CurrentBlockAuthorInfo::<T>::take()
+        if let Some((public_key, sector_index, piece_offset, scalar, slot, _reward_address)) =
+            CurrentBlockAuthorInfo::<T>::take()
         {
-            ParentBlockAuthorInfo::<T>::put((
-                public_key,
-                sector_index,
-                piece_offset,
-                scalar,
-                audit_chunk_offset,
-                slot,
-            ));
+            ParentBlockAuthorInfo::<T>::put((public_key, sector_index, piece_offset, scalar, slot));
         }
 
         ParentVoteVerificationData::<T>::put(current_vote_verification_data::<T>(true));
@@ -1611,7 +1557,6 @@ fn check_vote<T: Config>(
         solution.sector_index,
         solution.piece_offset,
         solution.chunk,
-        AuditChunkOffset(solution.audit_chunk_offset),
         slot,
     );
     // Check that farmer didn't use solution from this vote yet in:
@@ -1622,23 +1567,8 @@ fn check_vote<T: Config>(
     let mut is_equivocating = ParentBlockAuthorInfo::<T>::get().as_ref() == Some(&key)
         || CurrentBlockAuthorInfo::<T>::get()
             .map(
-                |(
-                    public_key,
-                    sector_index,
-                    piece_offset,
-                    chunk,
-                    audit_chunk_offset,
-                    slot,
-                    _reward_address,
-                )| {
-                    (
-                        public_key,
-                        sector_index,
-                        piece_offset,
-                        chunk,
-                        audit_chunk_offset,
-                        slot,
-                    )
+                |(public_key, sector_index, piece_offset, chunk, slot, _reward_address)| {
+                    (public_key, sector_index, piece_offset, chunk, slot)
                 },
             )
             .as_ref()
@@ -1676,7 +1606,7 @@ fn check_vote<T: Config>(
             }
         });
 
-        let (public_key, _sector_index, _piece_offset, _chunk, _audit_chunk_offset, _slot) = key;
+        let (public_key, _sector_index, _piece_offset, _chunk, _slot) = key;
 
         return Err(CheckVoteError::Equivocated(SubspaceEquivocationOffence {
             slot,
@@ -1754,15 +1684,7 @@ fn check_segment_headers<T: Config>(
 impl<T: Config> subspace_runtime_primitives::FindBlockRewardAddress<T::AccountId> for Pallet<T> {
     fn find_block_reward_address() -> Option<T::AccountId> {
         CurrentBlockAuthorInfo::<T>::get().and_then(
-            |(
-                public_key,
-                _sector_index,
-                _piece_offset,
-                _chunk,
-                _audit_chunk_offset,
-                _slot,
-                reward_address,
-            )| {
+            |(public_key, _sector_index, _piece_offset, _chunk, _slot, reward_address)| {
                 // Equivocation might have happened in this block, if so - no reward for block
                 // author
                 if !BlockList::<T>::contains_key(public_key) {

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -23,7 +23,7 @@ use crate::mock::{
     SLOT_PROBABILITY,
 };
 use crate::{
-    pallet, AllowAuthoringByAnyone, AuditChunkOffset, BlockList, Call, CheckVoteError, Config,
+    pallet, AllowAuthoringByAnyone, BlockList, Call, CheckVoteError, Config,
     CurrentBlockAuthorInfo, CurrentBlockVoters, CurrentSlot, ParentBlockAuthorInfo,
     ParentBlockVoters, SegmentCommitment, SubspaceEquivocationOffence,
 };
@@ -1300,14 +1300,12 @@ fn vote_equivocation_current_block_plus_vote() {
             pallet::SolutionRanges::<Test>::get().voting_current,
         );
 
-        // Parent block author + sector index + chunk + audit chunk index + slot matches that of the
-        // vote
+        // Parent block author + sector index + chunk + slot matches that of the vote
         CurrentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             signed_vote.vote.solution().sector_index,
             signed_vote.vote.solution().piece_offset,
             signed_vote.vote.solution().chunk,
-            AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
             slot,
             reward_address,
         ));
@@ -1357,14 +1355,12 @@ fn vote_equivocation_parent_block_plus_vote() {
             pallet::SolutionRanges::<Test>::get().voting_current,
         );
 
-        // Parent block author + sector index + chunk + audit chunk index + slot matches that of the
-        // vote
+        // Parent block author + sector index + chunk + slot matches that of the vote
         ParentBlockAuthorInfo::<Test>::put((
             FarmerPublicKey::unchecked_from(keypair.public.to_bytes()),
             signed_vote.vote.solution().sector_index,
             signed_vote.vote.solution().piece_offset,
             signed_vote.vote.solution().chunk,
-            AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
             slot,
         ));
 
@@ -1432,7 +1428,6 @@ fn vote_equivocation_current_voters_duplicate() {
                     signed_vote.vote.solution().sector_index,
                     signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
-                    AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
                 ),
                 (reward_address, signed_vote.signature.clone()),
@@ -1454,7 +1449,6 @@ fn vote_equivocation_current_voters_duplicate() {
                     signed_vote.vote.solution().sector_index,
                     signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
-                    AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
                 ),
                 (reward_address, FarmerSignature::unchecked_from([0; 64])),
@@ -1518,7 +1512,6 @@ fn vote_equivocation_parent_voters_duplicate() {
                     signed_vote.vote.solution().sector_index,
                     signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
-                    AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
                 ),
                 (reward_address, signed_vote.signature.clone()),
@@ -1540,7 +1533,6 @@ fn vote_equivocation_parent_voters_duplicate() {
                     signed_vote.vote.solution().sector_index,
                     signed_vote.vote.solution().piece_offset,
                     signed_vote.vote.solution().chunk,
-                    AuditChunkOffset(signed_vote.vote.solution().audit_chunk_offset),
                     slot,
                 ),
                 (reward_address, FarmerSignature::unchecked_from([0; 64])),
@@ -1572,7 +1564,6 @@ fn enabling_block_rewards_works() {
             0,
             PieceOffset::ZERO,
             Scalar::default(),
-            AuditChunkOffset(0),
             Subspace::current_slot(),
             1,
         ));
@@ -1584,7 +1575,6 @@ fn enabling_block_rewards_works() {
                     0,
                     PieceOffset::ZERO,
                     Scalar::default(),
-                    AuditChunkOffset(0),
                     Subspace::current_slot(),
                 ),
                 (2, FarmerSignature::unchecked_from([0; 64])),

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -397,7 +397,6 @@ where
                                 record_witness: solution.record_witness,
                                 chunk: solution.chunk,
                                 chunk_witness: solution.chunk_witness,
-                                audit_chunk_offset: solution.audit_chunk_offset,
                                 proof_of_space: solution.proof_of_space,
                             };
 

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -709,7 +709,6 @@
 //                 record_witness: Default::default(),
 //                 chunk: Default::default(),
 //                 chunk_witness: Default::default(),
-//                 audit_chunk_offset: 0,
 //                 proof_of_space: Default::default(),
 //             },
 //             slot,

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -504,7 +504,6 @@ impl<RewardAddress> From<&Solution<FarmerPublicKey, RewardAddress>> for WrappedS
             record_witness: solution.record_witness,
             chunk: solution.chunk,
             chunk_witness: solution.chunk_witness,
-            audit_chunk_offset: solution.audit_chunk_offset,
             proof_of_space: solution.proof_of_space,
         })
     }

--- a/crates/sp-consensus-subspace/src/tests.rs
+++ b/crates/sp-consensus-subspace/src/tests.rs
@@ -29,7 +29,6 @@ fn test_is_equivocation_proof_valid() {
         record_witness: Default::default(),
         chunk: Default::default(),
         chunk_witness: Default::default(),
-        audit_chunk_offset: 0,
         proof_of_space: Default::default(),
     };
 

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -230,7 +230,6 @@ fn valid_header(
             record_witness: solution.record_witness,
             chunk: solution.chunk,
             chunk_witness: solution.chunk_witness,
-            audit_chunk_offset: solution.audit_chunk_offset,
             proof_of_space: solution.proof_of_space,
         };
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -614,8 +614,6 @@ pub struct Solution<PublicKey, RewardAddress> {
     pub chunk: Scalar,
     /// Witness for above chunk
     pub chunk_witness: ChunkWitness,
-    /// Audit chunk offset within above chunk
-    pub audit_chunk_offset: u8,
     /// Proof of space for piece offset
     pub proof_of_space: PosProof,
 }
@@ -640,7 +638,6 @@ impl<PublicKey, RewardAddressA> Solution<PublicKey, RewardAddressA> {
             record_witness,
             chunk,
             chunk_witness,
-            audit_chunk_offset,
             proof_of_space,
         } = self;
         Solution {
@@ -653,7 +650,6 @@ impl<PublicKey, RewardAddressA> Solution<PublicKey, RewardAddressA> {
             record_witness,
             chunk,
             chunk_witness,
-            audit_chunk_offset,
             proof_of_space,
         }
     }
@@ -672,13 +668,13 @@ impl<PublicKey, RewardAddress> Solution<PublicKey, RewardAddress> {
             record_witness: RecordWitness::default(),
             chunk: Scalar::default(),
             chunk_witness: ChunkWitness::default(),
-            audit_chunk_offset: 0,
             proof_of_space: PosProof::default(),
         }
     }
 }
 
 /// Bidirectional distance metric implemented on top of subtraction
+#[inline(always)]
 pub fn bidirectional_distance<T: WrappingSub + Ord>(a: &T, b: &T) -> T {
     let diff = a.wrapping_sub(b);
     let diff2 = b.wrapping_sub(a);


### PR DESCRIPTION
Updated auditing algorithm according to latest spec updates where instead of auditing each audit chunk of the s-bucket chunk we audit the whole s-bucket chunk at once, this makes auditing less CPU-intensive due to lower number of hashing and sorting involved. Also implementation is nicer to read.

Space pledged formula in runtime is updated accordingly as well.

This is a breaking change to consensus.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
