### PR TITLE
Handle farmer panics nicely

### DIFF
--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -106,6 +106,8 @@ where
     let (result_tx, result_rx) = oneshot::channel();
     let handle = Handle::current();
     let join_handle = thread::Builder::new().name(thread_name).spawn(move || {
+        let _tokio_handle_guard = handle.enter();
+
         let result = match handle.block_on(futures::future::select(future, drop_rx)) {
             Either::Left((result, _)) => result,
             Either::Right(_) => {

--- a/crates/subspace-farmer/src/utils/tests.rs
+++ b/crates/subspace-farmer/src/utils/tests.rs
@@ -1,5 +1,6 @@
 use crate::utils::run_future_in_dedicated_thread;
 use std::future;
+use tokio::sync::oneshot;
 
 #[tokio::test]
 async fn run_future_in_dedicated_thread_ready() {
@@ -24,4 +25,31 @@ async fn run_future_in_dedicated_thread_cancellation() {
         )
         .unwrap(),
     );
+}
+
+#[test]
+fn run_future_in_dedicated_thread_tokio_on_drop() {
+    struct S;
+
+    impl Drop for S {
+        fn drop(&mut self) {
+            // This will panic only if called from non-tokio thread
+            tokio::task::spawn_blocking(|| {
+                // Nothing
+            });
+        }
+    }
+
+    let (_sender, receiver) = oneshot::channel::<()>();
+
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        drop(run_future_in_dedicated_thread(
+            Box::pin(async {
+                let s = S;
+                let _ = receiver.await;
+                drop(s);
+            }),
+            "tokio_on_drop".to_string(),
+        ));
+    });
 }


### PR DESCRIPTION
I noticed that when panics happen inside of farmer, the whole process kept running, which was confusing. This PR first fixes a small edge-case bug in `JoinOnDrop` implementation and then ensures that farmer exits when panics do happen.

Review with whitespace changes ignored, the diff is small here.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
