### PR TITLE
Fraud proof: Invalid Bundle, `true` and `false`, for inherent extrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,7 @@ dependencies = [
  "futures-timer",
  "pallet-balances",
  "pallet-domains",
+ "pallet-timestamp",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-cli",

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1287,7 +1287,7 @@ mod pallet {
             match call {
                 Call::submit_bundle { opaque_bundle } => {
                     if let Err(e) = Self::validate_bundle(opaque_bundle) {
-                        log::info!(
+                        log::error!(
                             target: "runtime::domains",
                             "Bad bundle {:?}, error: {e:?}", opaque_bundle.domain_id(),
                         );
@@ -1309,7 +1309,7 @@ mod pallet {
                 }
                 Call::submit_fraud_proof { fraud_proof } => {
                     if let Err(e) = Self::validate_fraud_proof(fraud_proof) {
-                        log::debug!(
+                        log::error!(
                             target: "runtime::domains",
                             "Bad fraud proof {:?}, error: {e:?}", fraud_proof.domain_id(),
                         );

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1287,7 +1287,7 @@ mod pallet {
             match call {
                 Call::submit_bundle { opaque_bundle } => {
                     if let Err(e) = Self::validate_bundle(opaque_bundle) {
-                        log::debug!(
+                        log::info!(
                             target: "runtime::domains",
                             "Bad bundle {:?}, error: {e:?}", opaque_bundle.domain_id(),
                         );

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -321,6 +321,12 @@ pub enum VerificationError<DomainHash> {
         error("The target valid bundle not found from the target bad receipt")
     )]
     TargetValidBundleNotFound,
+    /// Failed to check if a given extrinsic is inherent or not.
+    #[cfg_attr(
+        feature = "thiserror",
+        error("Failed to check if a given extrinsic is inherent or not")
+    )]
+    FailedToCheckInherentExtrinsic,
 }
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -92,6 +92,12 @@ pub enum FraudProofVerificationInfoRequest {
         /// Extrinsic for which we need to check the range
         opaque_extrinsic: OpaqueExtrinsic,
     },
+    /// Request to check if particular extrinsic is an inherent extrinsic
+    InherentExtrinsicCheck {
+        domain_id: DomainId,
+        /// Extrinsic for which we need to if it is inherent or not.
+        opaque_extrinsic: OpaqueExtrinsic,
+    },
 }
 
 impl PassBy for FraudProofVerificationInfoRequest {
@@ -120,8 +126,10 @@ pub enum FraudProofVerificationInfoResponse {
     DomainRuntimeCode(Vec<u8>),
     /// Encoded domain set_code extrinsic if there is a runtime upgrade at given consensus block hash.
     DomainSetCodeExtrinsic(SetCodeExtrinsic),
-    /// if particular extrinsic is in range for (domain, bundle) pair at given domain block
+    /// If particular extrinsic is in range for (domain, bundle) pair at given domain block
     TxRangeCheck(bool),
+    /// If the particular extrinsic provided is either inherent or not.
+    InherentExtrinsicCheck(bool),
 }
 
 impl FraudProofVerificationInfoResponse {
@@ -167,6 +175,15 @@ impl FraudProofVerificationInfoResponse {
     pub fn into_bundle_body(self) -> Option<Vec<OpaqueExtrinsic>> {
         match self {
             Self::DomainBundleBody(bb) => Some(bb),
+            _ => None,
+        }
+    }
+
+    pub fn into_inherent_extrinsic_check(self) -> Option<bool> {
+        match self {
+            FraudProofVerificationInfoResponse::InherentExtrinsicCheck(is_inherent) => {
+                Some(is_inherent)
+            }
             _ => None,
         }
     }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -805,6 +805,7 @@ pub enum BundleValidity<Hash> {
     Invalid(InvalidBundleType),
     // The valid bundle's hash of `Vec<(tx_signer, tx_hash)>` of all domain extrinsic being
     // included in the bundle.
+    // TODO remove this and use host function to fetch above mentioned data
     Valid(Hash),
 }
 
@@ -812,6 +813,7 @@ pub enum BundleValidity<Hash> {
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct InboxedBundle<Hash> {
     pub bundle: BundleValidity<Hash>,
+    // TODO remove this as the root is already present in the `ExecutionInbox` storage
     pub extrinsics_root: Hash,
 }
 

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -46,6 +46,7 @@ evm-domain-test-runtime = { version = "0.1.0", path = "../../test/runtime/evm" }
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 pallet-balances = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 pallet-domains = { version = "0.1.0", path = "../../../crates/pallet-domains" }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1", default-features = false }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1", default-features = false }
 sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -10,7 +10,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::traits::CodeExecutor;
 use sp_domain_digests::AsPredigest;
 use sp_domains::proof_provider_and_verifier::StorageProofProvider;
-use sp_domains::{DomainId, DomainsApi};
+use sp_domains::{DomainId, DomainsApi, HeaderHashingFor};
 use sp_domains_fraud_proof::execution_prover::ExecutionProver;
 use sp_domains_fraud_proof::fraud_proof::{
     ExecutionPhase, ExtrinsicDigest, FraudProof, InvalidBundlesFraudProof,
@@ -38,6 +38,8 @@ pub enum FraudProofError {
     InvalidBundleExtrinsic { bundle_index: usize },
     #[error("Fail to generate the proof of inclusion")]
     FailToGenerateProofOfInclusion,
+    #[error("Missing extrinsics in the Consesnsus block")]
+    MissingConsensusExtrinsics,
 }
 
 pub struct FraudProofGenerator<Block, CBlock, Client, CClient, Backend, E> {
@@ -149,7 +151,7 @@ where
     pub(crate) fn generate_invalid_bundle_field_proof<PCB>(
         &self,
         domain_id: DomainId,
-        _local_receipt: &ExecutionReceiptFor<Block, CBlock>,
+        local_receipt: &ExecutionReceiptFor<Block, CBlock>,
         mismatch_type: BundleMismatchType,
         bundle_index: u32,
         bad_receipt_hash: Block::Hash,
@@ -157,36 +159,53 @@ where
     where
         PCB: BlockT,
     {
-        match mismatch_type {
-            // TODO: Generate a proper proof once fields are in place
-            BundleMismatchType::TrueInvalid(invalid_type) => {
-                Ok(FraudProof::InvalidBundles(InvalidBundlesFraudProof::new(
-                    bad_receipt_hash,
-                    domain_id,
-                    bundle_index,
-                    invalid_type,
-                    StorageProof::empty(),
-                    true,
-                )))
+        let consensus_block_hash = local_receipt.consensus_block_hash;
+        let consensus_extrinsics = self
+            .consensus_client
+            .block_body(consensus_block_hash)?
+            .ok_or(FraudProofError::MissingConsensusExtrinsics)?;
+
+        let bundles = self
+            .consensus_client
+            .runtime_api()
+            .extract_successful_bundles(consensus_block_hash, domain_id, consensus_extrinsics)?;
+
+        let bundle = bundles
+            .get(bundle_index as usize)
+            .ok_or(FraudProofError::MissingBundle {
+                bundle_index: bundle_index as usize,
+            })?;
+
+        let (invalid_type, is_true_invalid) = match mismatch_type {
+            BundleMismatchType::TrueInvalid(invalid_type) => (invalid_type, true),
+            BundleMismatchType::FalseInvalid(invalid_type) => (invalid_type, false),
+            BundleMismatchType::Valid => {
+                return Err(sp_blockchain::Error::Application(
+                    "Unexpected bundle mismatch type, this should not happen"
+                        .to_string()
+                        .into(),
+                )
+                .into())
             }
-            // TODO: Generate a proper proof once fields are in place
-            BundleMismatchType::FalseInvalid(invalid_type) => {
-                Ok(FraudProof::InvalidBundles(InvalidBundlesFraudProof::new(
-                    bad_receipt_hash,
-                    domain_id,
-                    bundle_index,
-                    invalid_type,
-                    StorageProof::empty(),
-                    false,
-                )))
-            }
-            BundleMismatchType::Valid => Err(sp_blockchain::Error::Application(
-                "Unexpected bundle mismatch type, this should not happen"
-                    .to_string()
-                    .into(),
-            )
-            .into()),
-        }
+        };
+
+        let extrinsic_index = invalid_type.extrinsic_index();
+        let encoded_extrinsics: Vec<_> = bundle.extrinsics.iter().map(Encode::encode).collect();
+        let extrinsic_inclusion_proof = StorageProofProvider::<
+            LayoutV1<HeaderHashingFor<Block::Header>>,
+        >::generate_enumerated_proof_of_inclusion(
+            encoded_extrinsics.as_slice(), extrinsic_index
+        )
+        .ok_or(FraudProofError::FailToGenerateProofOfInclusion)?;
+
+        Ok(FraudProof::InvalidBundles(InvalidBundlesFraudProof::new(
+            bad_receipt_hash,
+            domain_id,
+            bundle_index,
+            invalid_type,
+            extrinsic_inclusion_proof,
+            is_true_invalid,
+        )))
     }
 
     pub(crate) fn generate_invalid_domain_extrinsics_root_proof<PCB>(

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -15,7 +15,7 @@ use sp_domains_fraud_proof::execution_prover::ExecutionProver;
 use sp_domains_fraud_proof::fraud_proof::{
     ExecutionPhase, ExtrinsicDigest, FraudProof, InvalidBundlesFraudProof,
     InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof, InvalidStateTransitionProof,
-    InvalidTotalRewardsProof, ProofDataPerInvalidBundleType, ValidBundleDigest,
+    InvalidTotalRewardsProof, ValidBundleDigest,
 };
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, HashingFor, Header as HeaderT, NumberFor};
 use sp_runtime::{Digest, DigestItem};
@@ -159,27 +159,25 @@ where
     {
         match mismatch_type {
             // TODO: Generate a proper proof once fields are in place
-            BundleMismatchType::TrueInvalid(_invalid_type) => {
+            BundleMismatchType::TrueInvalid(invalid_type) => {
                 Ok(FraudProof::InvalidBundles(InvalidBundlesFraudProof::new(
                     bad_receipt_hash,
                     domain_id,
                     bundle_index,
-                    0,
-                    vec![],
+                    invalid_type,
+                    StorageProof::empty(),
                     true,
-                    ProofDataPerInvalidBundleType::OutOfRangeTx,
                 )))
             }
             // TODO: Generate a proper proof once fields are in place
-            BundleMismatchType::FalseInvalid(_invalid_type) => {
+            BundleMismatchType::FalseInvalid(invalid_type) => {
                 Ok(FraudProof::InvalidBundles(InvalidBundlesFraudProof::new(
                     bad_receipt_hash,
                     domain_id,
                     bundle_index,
-                    0,
-                    vec![],
+                    invalid_type,
+                    StorageProof::empty(),
                     false,
-                    ProofDataPerInvalidBundleType::OutOfRangeTx,
                 )))
             }
             BundleMismatchType::Valid => Err(sp_blockchain::Error::Application(


### PR DESCRIPTION
This PR adds fraud proof verification for Invalid bundles for both `true` and `false` variants for Inherent extrinsics.

Closes: #2133

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
