### PR TITLE
Increase yamux buffers for subspace-networking.

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -87,6 +87,13 @@ const TEMPORARY_BANS_DEFAULT_BACKOFF_RANDOMIZATION_FACTOR: f64 = 0.1;
 const TEMPORARY_BANS_DEFAULT_BACKOFF_MULTIPLIER: f64 = 1.5;
 const TEMPORARY_BANS_DEFAULT_MAX_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
+/// Specific YAMUX settings for Subspace applications: additional buffer space for pieces.
+///
+/// 1MB of piece + original value (1 MB)
+const YAMUX_BUFFER_SIZE: usize = Piece::SIZE + 1024 * 1024;
+/// 1MB of piece + original value (256 KB)
+const YAMUX_RECEIVING_WINDOW: usize = Piece::SIZE + 256 * 1024;
+
 /// Max confidence for autonat protocol. Could affect Kademlia mode change.
 pub(crate) const AUTONAT_MAX_CONFIDENCE: usize = 3;
 
@@ -296,7 +303,10 @@ where
             .set_replication_interval(None);
 
         let mut yamux_config = YamuxConfig::default();
-        yamux_config.set_max_num_streams(YAMUX_MAX_STREAMS);
+        yamux_config
+            .set_max_num_streams(YAMUX_MAX_STREAMS)
+            .set_receive_window_size(YAMUX_RECEIVING_WINDOW as u32)
+            .set_max_buffer_size(YAMUX_BUFFER_SIZE);
 
         let gossipsub = ENABLE_GOSSIP_PROTOCOL.then(|| {
             GossipsubConfigBuilder::default()

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -72,9 +72,6 @@ const SWARM_MAX_PENDING_INCOMING_CONNECTIONS: u32 = 80;
 const SWARM_MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 80;
 // The default maximum connection number to be maintained for the swarm.
 const SWARM_TARGET_CONNECTION_NUMBER: u32 = 30;
-// Defines a replication factor for Kademlia on get_record operation.
-// "Good citizen" supports the network health.
-const YAMUX_MAX_STREAMS: usize = 256;
 const KADEMLIA_QUERY_TIMEOUT: Duration = Duration::from_secs(40);
 const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: Option<u32> = Some(3);
 // TODO: Consider moving this constant to configuration or removing `Toggle` wrapper when we find a
@@ -87,12 +84,16 @@ const TEMPORARY_BANS_DEFAULT_BACKOFF_RANDOMIZATION_FACTOR: f64 = 0.1;
 const TEMPORARY_BANS_DEFAULT_BACKOFF_MULTIPLIER: f64 = 1.5;
 const TEMPORARY_BANS_DEFAULT_MAX_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
-/// Specific YAMUX settings for Subspace applications: additional buffer space for pieces.
+/// Specific YAMUX settings for Subspace applications: additional buffer space for pieces and
+/// substream's limit.
 ///
-/// 1MB of piece + original value (1 MB)
-const YAMUX_BUFFER_SIZE: usize = Piece::SIZE + 1024 * 1024;
+/// Defines a replication factor for Kademlia on get_record operation.
+/// "Good citizen" supports the network health.
+const YAMUX_MAX_STREAMS: usize = 256;
 /// 1MB of piece + original value (256 KB)
 const YAMUX_RECEIVING_WINDOW: usize = Piece::SIZE + 256 * 1024;
+/// 1MB of piece + original value (1 MB)
+const YAMUX_BUFFER_SIZE: usize = Piece::SIZE + 1024 * 1024;
 
 /// Max confidence for autonat protocol. Could affect Kademlia mode change.
 pub(crate) const AUTONAT_MAX_CONFIDENCE: usize = 3;


### PR DESCRIPTION
This PR increases `yamux` buffers in the `subspace-networking` crate. The main reason for that is our network load pattern. We exchange relatively large objects (piece size = 1MB) and increased Yamux buffers improve the bandwidth consumption of our applications by at least 50% for the `benchmark` example. Relates to https://github.com/subspace/subspace/issues/2109

Similar adjustment will be required for QUIC protocol after `gemini-3g` release.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
