### PR TITLE
Downloading/encoding concurrency

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -461,7 +461,7 @@ pub fn create_signed_vote(
             sector_index,
             piece_getter: archived_history_segment,
             piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
-            farmer_protocol_info: &farmer_protocol_info,
+            farmer_protocol_info,
             kzg,
             erasure_coding,
             pieces_in_sector,

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -122,7 +122,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             sector_index,
             piece_getter: &archived_history_segment,
             piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
-            farmer_protocol_info: &farmer_protocol_info,
+            farmer_protocol_info,
             kzg: &kzg,
             erasure_coding: &erasure_coding,
             pieces_in_sector,

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -73,7 +73,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 sector_index: black_box(sector_index),
                 piece_getter: black_box(&archived_history_segment),
                 piece_getter_retry_policy: black_box(PieceGetterRetryPolicy::default()),
-                farmer_protocol_info: black_box(&farmer_protocol_info),
+                farmer_protocol_info: black_box(farmer_protocol_info),
                 kzg: black_box(&kzg),
                 erasure_coding: black_box(&erasure_coding),
                 pieces_in_sector: black_box(pieces_in_sector),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -129,7 +129,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             sector_index,
             piece_getter: &archived_history_segment,
             piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
-            farmer_protocol_info: &farmer_protocol_info,
+            farmer_protocol_info,
             kzg,
             erasure_coding,
             pieces_in_sector,

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -122,7 +122,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             sector_index,
             piece_getter: &archived_history_segment,
             piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
-            farmer_protocol_info: &farmer_protocol_info,
+            farmer_protocol_info,
             kzg: &kzg,
             erasure_coding: &erasure_coding,
             pieces_in_sector,

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -203,6 +203,8 @@ where
 
 /// Plot a single sector.
 ///
+/// This is a convenient wrapper around [`download_sector`] and [`encode_sector`] functions.
+///
 /// NOTE: Even though this function is async, it has blocking code inside and must be running in a
 /// separate thread in order to prevent blocking an executor.
 pub async fn plot_sector<PosTable, PG>(
@@ -228,6 +230,209 @@ where
         table_generator,
     } = options;
 
+    let download_sector_fut = download_sector(DownloadSectorOptions {
+        public_key,
+        sector_index,
+        piece_getter,
+        piece_getter_retry_policy,
+        farmer_protocol_info,
+        kzg,
+        pieces_in_sector,
+        downloading_semaphore,
+    });
+
+    encode_sector(
+        download_sector_fut.await?,
+        EncodeSectorOptions::<PosTable> {
+            sector_index,
+            erasure_coding,
+            pieces_in_sector,
+            sector_output,
+            sector_metadata_output,
+            encoding_semaphore,
+            table_generator,
+        },
+    )
+    .await
+}
+
+/// Opaque sector downloaded and ready for encoding
+pub struct DownloadedSector<'a> {
+    sector_id: SectorId,
+    piece_indices: Vec<PieceIndex>,
+    raw_sector: RawSector,
+    farmer_protocol_info: &'a FarmerProtocolInfo,
+    downloading_permit: Option<SemaphorePermit<'a>>,
+}
+
+/// Options for sector downloading
+pub struct DownloadSectorOptions<'a, PG> {
+    /// Public key corresponding to sector
+    pub public_key: &'a PublicKey,
+    /// Sector index
+    pub sector_index: SectorIndex,
+    /// Getter for pieces of archival history
+    pub piece_getter: &'a PG,
+    /// Retry policy for piece getter
+    pub piece_getter_retry_policy: PieceGetterRetryPolicy,
+    /// Farmer protocol info
+    pub farmer_protocol_info: &'a FarmerProtocolInfo,
+    /// KZG instance
+    pub kzg: &'a Kzg,
+    /// How many pieces should sector contain
+    pub pieces_in_sector: u16,
+    /// Semaphore for part of the plotting when farmer downloads new sector, allows to limit memory
+    /// usage of the plotting process, permit will be held until the end of the plotting process
+    pub downloading_semaphore: Option<&'a Semaphore>,
+}
+
+/// Download sector for plotting.
+///
+/// This will identify necessary pieces and download them from DSN, after which they can be encoded
+/// and written to the plot.
+pub async fn download_sector<PG>(
+    options: DownloadSectorOptions<'_, PG>,
+) -> Result<DownloadedSector<'_>, PlottingError>
+where
+    PG: PieceGetter,
+{
+    let DownloadSectorOptions {
+        public_key,
+        sector_index,
+        piece_getter,
+        piece_getter_retry_policy,
+        farmer_protocol_info,
+        kzg,
+        pieces_in_sector,
+        downloading_semaphore,
+    } = options;
+
+    let downloading_permit = match downloading_semaphore {
+        Some(downloading_semaphore) => Some(downloading_semaphore.acquire().await?),
+        None => None,
+    };
+
+    let sector_id = SectorId::new(public_key.hash(), sector_index);
+
+    let piece_indices = (PieceOffset::ZERO..)
+        .take(pieces_in_sector.into())
+        .map(|piece_offset| {
+            sector_id.derive_piece_index(
+                piece_offset,
+                farmer_protocol_info.history_size,
+                farmer_protocol_info.max_pieces_in_sector,
+                farmer_protocol_info.recent_segments,
+                farmer_protocol_info.recent_history_fraction,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    // TODO: Downloading and encoding below can happen in parallel, but a bit tricky to implement
+    //  due to sync/async pairing
+
+    let raw_sector = Mutex::new(RawSector::new(pieces_in_sector));
+
+    {
+        // This list will be mutated, replacing pieces we have already processed with `None`
+        let incremental_piece_indices =
+            Mutex::new(piece_indices.iter().copied().map(Some).collect::<Vec<_>>());
+
+        retry(default_backoff(), || async {
+            let mut raw_sector = raw_sector.lock().await;
+            let mut incremental_piece_indices = incremental_piece_indices.lock().await;
+
+            if let Err(error) = download_sector_internal(
+                &mut raw_sector,
+                piece_getter,
+                piece_getter_retry_policy,
+                kzg,
+                &mut incremental_piece_indices,
+            )
+            .await
+            {
+                let retrieved_pieces = incremental_piece_indices
+                    .iter()
+                    .filter(|maybe_piece_index| maybe_piece_index.is_none())
+                    .count();
+                warn!(
+                    %sector_index,
+                    %error,
+                    %pieces_in_sector,
+                    %retrieved_pieces,
+                    "Sector plotting attempt failed, will retry later"
+                );
+
+                return Err(BackoffError::transient(error));
+            }
+
+            debug!(%sector_index, "Sector downloaded successfully");
+
+            Ok(())
+        })
+        .await?;
+    }
+
+    Ok(DownloadedSector {
+        sector_id,
+        piece_indices,
+        raw_sector: raw_sector.into_inner(),
+        farmer_protocol_info,
+        downloading_permit,
+    })
+}
+
+/// Options for encoding a sector.
+///
+/// Sector output and sector metadata output should be either empty (in which case they'll be
+/// resized to correct size automatically) or correctly sized from the beginning or else error will
+/// be returned.
+pub struct EncodeSectorOptions<'a, PosTable>
+where
+    PosTable: Table,
+{
+    /// Sector index
+    pub sector_index: SectorIndex,
+    /// Erasure coding instance
+    pub erasure_coding: &'a ErasureCoding,
+    /// How many pieces should sector contain
+    pub pieces_in_sector: u16,
+    /// Where plotted sector should be written, vector must either be empty (in which case it'll be
+    /// resized to correct size automatically) or correctly sized from the beginning
+    pub sector_output: &'a mut Vec<u8>,
+    /// Where plotted sector metadata should be written, vector must either be empty (in which case
+    /// it'll be resized to correct size automatically) or correctly sized from the beginning
+    pub sector_metadata_output: &'a mut Vec<u8>,
+    /// Semaphore for part of the plotting when farmer encodes downloaded sector, should typically
+    /// allow one permit at a time for efficient CPU utilization
+    pub encoding_semaphore: Option<&'a Semaphore>,
+    /// Proof of space table generator
+    pub table_generator: &'a mut PosTable::Generator,
+}
+
+pub async fn encode_sector<PosTable>(
+    downloaded_sector: DownloadedSector<'_>,
+    encoding_options: EncodeSectorOptions<'_, PosTable>,
+) -> Result<PlottedSector, PlottingError>
+where
+    PosTable: Table,
+{
+    let DownloadedSector {
+        sector_id,
+        piece_indices,
+        mut raw_sector,
+        farmer_protocol_info,
+        downloading_permit: _downloading_permit,
+    } = downloaded_sector;
+    let EncodeSectorOptions {
+        sector_index,
+        erasure_coding,
+        pieces_in_sector,
+        sector_output,
+        sector_metadata_output,
+        encoding_semaphore,
+        table_generator,
+    } = encoding_options;
+
     if erasure_coding.max_shards() < Record::NUM_S_BUCKETS {
         return Err(PlottingError::InvalidErasureCodingInstance);
     }
@@ -249,23 +454,6 @@ where
             expected: SectorMetadataChecksummed::encoded_size(),
         });
     }
-
-    let download_sector_fut = download_sector(DownloadSectorOptions {
-        public_key,
-        sector_index,
-        piece_getter,
-        piece_getter_retry_policy,
-        farmer_protocol_info,
-        kzg,
-        pieces_in_sector,
-        downloading_semaphore,
-    });
-    let DownloadedSector {
-        sector_id,
-        piece_indices,
-        mut raw_sector,
-        downloading_permit: _downloading_permit,
-    } = download_sector_fut.await?;
 
     let _encoding_permit = match encoding_semaphore {
         Some(encoding_semaphore) => Some(encoding_semaphore.acquire().await?),
@@ -442,129 +630,6 @@ where
         sector_index,
         sector_metadata,
         piece_indexes: piece_indices,
-    })
-}
-
-/// Opaque sector downloaded and ready for encoding
-pub struct DownloadedSector<'a> {
-    sector_id: SectorId,
-    piece_indices: Vec<PieceIndex>,
-    raw_sector: RawSector,
-    downloading_permit: Option<SemaphorePermit<'a>>,
-}
-
-/// Options for sector downloading
-pub struct DownloadSectorOptions<'a, PG> {
-    /// Public key corresponding to sector
-    pub public_key: &'a PublicKey,
-    /// Sector index
-    pub sector_index: SectorIndex,
-    /// Getter for pieces of archival history
-    pub piece_getter: &'a PG,
-    /// Retry policy for piece getter
-    pub piece_getter_retry_policy: PieceGetterRetryPolicy,
-    /// Farmer protocol info
-    pub farmer_protocol_info: &'a FarmerProtocolInfo,
-    /// KZG instance
-    pub kzg: &'a Kzg,
-    /// How many pieces should sector contain
-    pub pieces_in_sector: u16,
-    /// Semaphore for part of the plotting when farmer downloads new sector, allows to limit memory
-    /// usage of the plotting process, permit will be held until the end of the plotting process
-    pub downloading_semaphore: Option<&'a Semaphore>,
-}
-
-/// Download sector for plotting.
-///
-/// This will identify necessary pieces and download them from DSN, after which they can be encoded
-/// and written to the plot.
-pub async fn download_sector<PG>(
-    options: DownloadSectorOptions<'_, PG>,
-) -> Result<DownloadedSector<'_>, PlottingError>
-where
-    PG: PieceGetter,
-{
-    let DownloadSectorOptions {
-        public_key,
-        sector_index,
-        piece_getter,
-        piece_getter_retry_policy,
-        farmer_protocol_info,
-        kzg,
-        pieces_in_sector,
-        downloading_semaphore,
-    } = options;
-
-    let downloading_permit = match downloading_semaphore {
-        Some(downloading_semaphore) => Some(downloading_semaphore.acquire().await?),
-        None => None,
-    };
-
-    let sector_id = SectorId::new(public_key.hash(), sector_index);
-
-    let piece_indices = (PieceOffset::ZERO..)
-        .take(pieces_in_sector.into())
-        .map(|piece_offset| {
-            sector_id.derive_piece_index(
-                piece_offset,
-                farmer_protocol_info.history_size,
-                farmer_protocol_info.max_pieces_in_sector,
-                farmer_protocol_info.recent_segments,
-                farmer_protocol_info.recent_history_fraction,
-            )
-        })
-        .collect::<Vec<_>>();
-
-    // TODO: Downloading and encoding below can happen in parallel, but a bit tricky to implement
-    //  due to sync/async pairing
-
-    let raw_sector = Mutex::new(RawSector::new(pieces_in_sector));
-
-    {
-        // This list will be mutated, replacing pieces we have already processed with `None`
-        let incremental_piece_indices =
-            Mutex::new(piece_indices.iter().copied().map(Some).collect::<Vec<_>>());
-
-        retry(default_backoff(), || async {
-            let mut raw_sector = raw_sector.lock().await;
-            let mut incremental_piece_indices = incremental_piece_indices.lock().await;
-
-            if let Err(error) = download_sector_internal(
-                &mut raw_sector,
-                piece_getter,
-                piece_getter_retry_policy,
-                kzg,
-                &mut incremental_piece_indices,
-            )
-            .await
-            {
-                let retrieved_pieces = incremental_piece_indices
-                    .iter()
-                    .filter(|maybe_piece_index| maybe_piece_index.is_none())
-                    .count();
-                warn!(
-                    %sector_index,
-                    %error,
-                    %pieces_in_sector,
-                    %retrieved_pieces,
-                    "Sector plotting attempt failed, will retry later"
-                );
-
-                return Err(BackoffError::transient(error));
-            }
-
-            debug!(%sector_index, "Sector downloaded successfully");
-
-            Ok(())
-        })
-        .await?;
-    }
-
-    Ok(DownloadedSector {
-        sector_id,
-        piece_indices,
-        raw_sector: raw_sector.into_inner(),
-        downloading_permit,
     })
 }
 

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -222,10 +222,10 @@ where
             piece_getter_retry_policy: PieceGetterRetryPolicy::Limited(
                 PIECE_GETTER_RETRY_NUMBER.get(),
             ),
-            farmer_protocol_info: &farmer_app_info.protocol_info,
+            farmer_protocol_info: farmer_app_info.protocol_info,
             kzg: &kzg,
             pieces_in_sector,
-            downloading_semaphore: Some(&downloading_semaphore),
+            downloading_semaphore: Some(Arc::clone(&downloading_semaphore)),
         });
         let downloaded_sector = downloaded_sector_fut.await?;
 

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -259,7 +259,7 @@ where
         sector_index,
         piece_getter: &archived_segment.pieces,
         piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
-        farmer_protocol_info: &farmer_protocol_info,
+        farmer_protocol_info,
         kzg: &kzg,
         erasure_coding,
         pieces_in_sector,


### PR DESCRIPTION
This PR aims to resolve https://github.com/subspace/subspace/issues/2027 by allowing next sector to be downloaded while the previous sector is being encoded.

All commits before the last one are just refactoring to enable necessary capabilities.

There are a few way to implement this, I decided to simply spawn background task and keep it in a variable to look into later.

As byproduct of refactoring `subspace-farmer-components` has become more flexible, but at the same time previous simple API is still present for convenience.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
