### PR TITLE
Support wiping node data of old Gemini versions

### DIFF
--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -218,6 +218,8 @@ fn main() -> Result<(), Error> {
                     "subspace_gemini_3b",
                     "subspace_gemini_3c",
                     "subspace_gemini_3d",
+                    "subspace_gemini_3e",
+                    "subspace_gemini_3f",
                 ] {
                     let _ = std::fs::remove_dir_all(
                         base_dir.join("subspace-node").join("chains").join(chain),
@@ -366,7 +368,7 @@ fn main() -> Result<(), Error> {
                         cli.run
                             .base_path()?
                             .map(|base_path| base_path.path().to_path_buf()),
-                        // pass the domain-id manually for benchmark since this is 
+                        // pass the domain-id manually for benchmark since this is
                         // not possible through cli commands at this moment.
                         vec!["--domain-id".to_owned(), "0".to_owned()].into_iter(),
                     );


### PR DESCRIPTION
Something we should usually do before launching new network, one day we'll change how we store the files so this is not necessary.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
