### PR TITLE
Preparing domain for gemini-3g

### DIFF
--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -292,10 +292,10 @@ impl BuildGenesisStorageCmd {
         let is_dev = self.shared_params.is_dev();
         let chain_id = self.shared_params.chain_id(is_dev);
         let domain_genesis_config = match chain_id.as_str() {
-            "gemini-3g" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::Gemini).0,
-            "devnet" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::DevNet).0,
-            "dev" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::Dev).0,
-            "" | "local" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::Local).0,
+            "gemini-3g" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::Gemini),
+            "devnet" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::DevNet),
+            "dev" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::Dev),
+            "" | "local" => evm_chain_spec::get_testnet_genesis_by_spec_id(SpecId::Local),
             unknown_id => {
                 eprintln!(
                     "unknown chain {unknown_id:?}, expected gemini-3g, devnet, dev, or local",

--- a/crates/subspace-node/src/domain/evm_chain_spec.rs
+++ b/crates/subspace-node/src/domain/evm_chain_spec.rs
@@ -16,7 +16,7 @@
 
 //! EVM domain configurations.
 
-use crate::chain_spec_utils::{chain_spec_properties, get_public_key_from_seed};
+use crate::chain_spec_utils::chain_spec_properties;
 use evm_domain_runtime::{
     AccountId, BalancesConfig, EVMChainIdConfig, EVMConfig, Precompiles, RuntimeGenesisConfig,
     SudoConfig, SystemConfig, WASM_BINARY,
@@ -24,9 +24,7 @@ use evm_domain_runtime::{
 use hex_literal::hex;
 use sc_service::{ChainSpec as ChainSpecT, ChainType};
 use sc_subspace_chain_specs::ExecutionChainSpec;
-use sp_core::crypto::UncheckedFrom;
 use sp_domains::storage::RawGenesis;
-use sp_domains::OperatorPublicKey;
 use std::str::FromStr;
 use subspace_runtime_primitives::SSC;
 
@@ -138,14 +136,11 @@ pub fn devnet_config<F: Fn() -> RuntimeGenesisConfig + 'static + Send + Sync>(
 }
 
 pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
-    let constructor =
-        |spec_id: SpecId| -> RuntimeGenesisConfig { get_testnet_genesis_by_spec_id(spec_id).0 };
-
     let chain_spec = match spec_id {
-        "dev" => development_config(move || constructor(SpecId::Dev)),
-        "gemini-3g" => gemini_3g_config(move || constructor(SpecId::Gemini)),
-        "devnet" => devnet_config(move || constructor(SpecId::DevNet)),
-        "" | "local" => local_testnet_config(move || constructor(SpecId::Local)),
+        "dev" => development_config(move || get_testnet_genesis_by_spec_id(SpecId::Dev)),
+        "gemini-3g" => gemini_3g_config(move || get_testnet_genesis_by_spec_id(SpecId::Gemini)),
+        "devnet" => devnet_config(move || get_testnet_genesis_by_spec_id(SpecId::DevNet)),
+        "" | "local" => local_testnet_config(move || get_testnet_genesis_by_spec_id(SpecId::Local)),
         path => ChainSpec::from_json_file(std::path::PathBuf::from(path))?,
     };
     Ok(Box::new(chain_spec))
@@ -158,78 +153,48 @@ pub enum SpecId {
     Local,
 }
 
-pub struct GenesisDomainParams {
-    pub operator_signing_key: OperatorPublicKey,
-}
-
-pub fn get_testnet_genesis_by_spec_id(
-    spec_id: SpecId,
-) -> (RuntimeGenesisConfig, GenesisDomainParams) {
+pub fn get_testnet_genesis_by_spec_id(spec_id: SpecId) -> RuntimeGenesisConfig {
     match spec_id {
         SpecId::Dev => {
             let accounts = get_dev_accounts();
-            (
-                testnet_genesis(
-                    accounts.clone(),
-                    // Alith is Sudo
-                    Some(accounts[0]),
-                    1000,
-                ),
-                GenesisDomainParams {
-                    operator_signing_key: get_public_key_from_seed::<OperatorPublicKey>("Alice"),
-                },
+            testnet_genesis(
+                accounts.clone(),
+                // Alith is Sudo
+                Some(accounts[0]),
+                1000,
             )
         }
         SpecId::Gemini => {
             let sudo_account = AccountId::from_str("f31e60022e290708c17d6997c34de6a30d09438f")
                 .expect("Invalid Sudo account");
-            (
-                testnet_genesis(
-                    vec![
-                        // Sudo account
-                        sudo_account,
-                    ],
-                    Some(sudo_account),
-                    1002,
-                ),
-                GenesisDomainParams {
-                    operator_signing_key: OperatorPublicKey::unchecked_from(hex!(
-                        "aa3b05b4d649666723e099cf3bafc2f2c04160ebe0e16ddc82f72d6ed97c4b6b"
-                    )),
-                },
+            testnet_genesis(
+                vec![
+                    // Sudo account
+                    sudo_account,
+                ],
+                Some(sudo_account),
+                1002,
             )
         }
         SpecId::DevNet => {
             let sudo_account = AccountId::from_str("b66a91845249464309fad766fd0ece8144547736")
                 .expect("Invalid Sudo account");
-            (
-                testnet_genesis(
-                    vec![
-                        // Sudo account
-                        sudo_account,
-                    ],
-                    Some(sudo_account),
-                    1003,
-                ),
-                GenesisDomainParams {
-                    operator_signing_key: OperatorPublicKey::unchecked_from(hex!(
-                        "aa3b05b4d649666723e099cf3bafc2f2c04160ebe0e16ddc82f72d6ed97c4b6b"
-                    )),
-                },
+            testnet_genesis(
+                vec![
+                    // Sudo account
+                    sudo_account,
+                ],
+                Some(sudo_account),
+                1003,
             )
         }
         SpecId::Local => {
             let accounts = get_dev_accounts();
-            (
-                testnet_genesis(
-                    accounts.clone(),
-                    // Alith is sudo
-                    Some(accounts[0]),
-                    1001,
-                ),
-                GenesisDomainParams {
-                    operator_signing_key: get_public_key_from_seed::<OperatorPublicKey>("Alice"),
-                },
+            testnet_genesis(
+                accounts.clone(),
+                // Alith is sudo
+                Some(accounts[0]),
+                1001,
             )
         }
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -603,7 +603,8 @@ parameter_types! {
     pub const StakeEpochDuration: DomainNumber = 100;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 100;
-    pub const MaxNominators: u32 = 100;
+    // TODO: reset `MaxNominators` back to `100` once the gemini-3g chain spec is created
+    pub const MaxNominators: u32 = 0;
 }
 
 impl pallet_domains::Config for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 2,
+    spec_version: 0,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,


### PR DESCRIPTION
This PR aims to prepare the domain for gemini-3g, it include changes of:
- Set the genesis domain name to "nova" for gemini-3g
- Make the genesis domain permissioned, so it only allows the genesis operator to stake, this can be updated through the `pallet-domains::update_domain_operator_allow_list` call
- Temporarily set `MaxNominators` to 0, should reset it back to 100 once the gemini-3g chain spec is created
- Reset the consensus runtime version

cc @jfrank-summit 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
