### PR TITLE
Add PoT proving benchmark that compares CPU cores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11717,6 +11717,7 @@ name = "subspace-proof-of-time"
 version = "0.1.0"
 dependencies = [
  "aes 0.8.3",
+ "core_affinity",
  "criterion",
  "rand 0.8.5",
  "subspace-core-primitives",

--- a/crates/subspace-proof-of-time/Cargo.toml
+++ b/crates/subspace-proof-of-time/Cargo.toml
@@ -20,11 +20,16 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 thiserror = { version = "1.0.48", optional = true }
 
 [dev-dependencies]
+core_affinity = "0.8.1"
 criterion = "0.5.1"
 rand = "0.8.5"
 
 [[bench]]
 name = "pot"
+harness = false
+
+[[bench]]
+name = "pot-compare-cpu-cores"
 harness = false
 
 [features]

--- a/crates/subspace-proof-of-time/benches/pot-compare-cpu-cores.rs
+++ b/crates/subspace-proof-of-time/benches/pot-compare-cpu-cores.rs
@@ -1,0 +1,27 @@
+use core::num::NonZeroU32;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{thread_rng, Rng};
+use subspace_core_primitives::PotSeed;
+use subspace_proof_of_time::prove;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut seed = PotSeed::default();
+    thread_rng().fill(seed.as_mut());
+    // About 1s on 6.0 GHz Raptor Lake CPU (14900K)
+    let pot_iterations = NonZeroU32::new(200_032_000).expect("Not zero; qed");
+
+    let cpu_cores = core_affinity::get_core_ids().expect("Must be able to get CPU cores");
+    for cpu_core in cpu_cores {
+        c.bench_function(&format!("prove/cpu-{}", cpu_core.id), move |b| {
+            if !core_affinity::set_for_current(cpu_core) {
+                panic!("Failed to set CPU affinity");
+            }
+            b.iter(|| {
+                black_box(prove(black_box(seed), black_box(pot_iterations))).unwrap();
+            })
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Not only processors have heterogeneous cores, some cores can boost higher than others. This new benchmark will go through all of them one by one to find the fastest.

Much more convenient than messing with `taskset` manually.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
