### PR TITLE
Add `--disable-bootstrap-on-start` flag for DSN apps.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -198,6 +198,9 @@ struct DsnArgs {
     /// Known external addresses
     #[arg(long, alias = "external-address")]
     external_addresses: Vec<Multiaddr>,
+    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
+    #[arg(long, default_value_t = false)]
+    disable_bootstrap_on_start: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -293,8 +296,9 @@ where
         replotting_thread_pool_size,
     } = farming_args;
 
-    // Override the `--enable_private_ips` flag with `--dev`
+    // Override flags with `--dev`
     dsn.enable_private_ips = dsn.enable_private_ips || dev;
+    dsn.disable_bootstrap_on_start = dsn.disable_bootstrap_on_start || dev;
 
     let _tmp_directory = if let Some(plot_size) = tmp {
         let tmp_directory = TempDir::new()?;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -42,6 +42,7 @@ pub(super) fn configure_dsn(
         pending_out_connections,
         target_connections,
         external_addresses,
+        disable_bootstrap_on_start,
     }: DsnArgs,
     weak_readers_and_pieces: Weak<Mutex<Option<ReadersAndPieces>>>,
     node_client: NodeRpcClient,
@@ -194,6 +195,7 @@ pub(super) fn configure_dsn(
         },
         external_addresses,
         metrics,
+        disable_bootstrap_on_start,
         ..default_config
     };
 

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -252,6 +252,8 @@ pub struct Config<LocalRecordProvider> {
     pub external_addresses: Vec<Multiaddr>,
     /// Enable autonat protocol. Helps detecting whether we're behind the firewall.
     pub enable_autonat: bool,
+    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
+    pub disable_bootstrap_on_start: bool,
 }
 
 impl<LocalRecordProvider> fmt::Debug for Config<LocalRecordProvider> {
@@ -370,6 +372,7 @@ where
             kademlia_mode: KademliaMode::Static(Mode::Client),
             external_addresses: Vec::new(),
             enable_autonat: true,
+            disable_bootstrap_on_start: false,
         }
     }
 }
@@ -433,6 +436,7 @@ where
         kademlia_mode,
         external_addresses,
         enable_autonat,
+        disable_bootstrap_on_start,
     } = config;
     let local_peer_id = peer_id(&keypair);
 
@@ -557,6 +561,7 @@ where
             bootstrap_addresses,
             kademlia_mode,
             external_addresses,
+            disable_bootstrap_on_start,
         });
 
     Ok((node, node_runner))

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -516,6 +516,9 @@ fn main() -> Result<(), Error> {
                             max_pending_out_connections: cli.dsn_pending_out_connections,
                             target_connections: cli.dsn_target_connections,
                             external_addresses: cli.dsn_external_addresses,
+                            // Override initial Kademlia bootstrapping  with --dev
+                            disable_bootstrap_on_start: cli.dsn_disable_bootstrap_on_start
+                                || cli.run.shared_params.dev,
                         }
                     };
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -267,6 +267,10 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     pub dsn_enable_private_ips: bool,
 
+    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
+    #[arg(long, default_value_t = false)]
+    pub dsn_disable_bootstrap_on_start: bool,
+
     /// Enables DSN-sync on startup.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub sync_from_dsn: bool,

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -69,6 +69,9 @@ pub struct DsnConfig {
 
     /// Known external addresses
     pub external_addresses: Vec<Multiaddr>,
+
+    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
+    pub disable_bootstrap_on_start: bool,
 }
 
 pub(crate) fn create_dsn_instance<AS>(
@@ -185,6 +188,7 @@ where
         external_addresses: dsn_config.external_addresses,
         kademlia_mode: KademliaMode::Static(Mode::Client),
         metrics,
+        disable_bootstrap_on_start: dsn_config.disable_bootstrap_on_start,
 
         ..default_networking_config
     };


### PR DESCRIPTION
This PR introduces the `--disable-bootstrap-on-start` flag for DSN for nodes and farmers. It disables the blocking Kademlia `boostrap()` call on start. This flag is auto-toggled with `--dev` flag.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
