### PR TITLE
Double check the domain transaction validity before putting it into bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "sp-messenger",
  "sp-runtime",
  "sp-state-machine",
+ "sp-transaction-pool",
  "sp-trie",
  "sp-weights",
  "subspace-core-primitives",

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -31,6 +31,7 @@ sp-keystore = { version = "0.27.0", git = "https://github.com/subspace/polkadot-
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-weights = { version = "20.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -16,6 +16,7 @@ use sp_domains::{
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Zero};
 use sp_runtime::RuntimeAppPublic;
+use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::convert::{AsRef, Into};
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -101,7 +102,7 @@ where
     NumberFor<Block>: Into<NumberFor<CBlock>>,
     NumberFor<ParentChainBlock>: Into<NumberFor<Block>>,
     Client: HeaderBackend<Block> + BlockBackend<Block> + AuxStore + ProvideRuntimeApi<Block>,
-    Client::Api: BlockBuilder<Block> + DomainCoreApi<Block>,
+    Client::Api: BlockBuilder<Block> + DomainCoreApi<Block> + TaggedTransactionQueue<Block>,
     CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock>,
     CClient::Api: DomainsApi<CBlock, Block::Header> + BundleProducerElectionApi<CBlock, Balance>,
     ParentChain: ParentChainInterface<Block, ParentChainBlock> + Clone,

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -125,7 +125,7 @@ where
             // is finished, cause the bundle contains illegal tx accidentally and being considered as invalid
             // bundle and slashing on the honest operator.
             //
-            // NOTE: this check need tp keep aligned with how the illegal tx is detected in the block-preprocessor
+            // NOTE: this check need to be kept aligned with how the illegal tx is detected in the block-preprocessor
             // thus when https://github.com/subspace/subspace/issues/2184 is implemented, we also need to
             // perfome the check for bundle as a whole instead of checking tx one by one.
             let transaction_validity = self

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -35,6 +35,7 @@ use sp_core::H256;
 use sp_domains::{BundleProducerElectionApi, DomainsApi};
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
+use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
 use subspace_runtime_primitives::Balance;
 use tracing::{info, Instrument};
@@ -84,7 +85,8 @@ pub(super) async fn start_worker<
     Client::Api: DomainCoreApi<Block>
         + MessengerApi<Block, NumberFor<Block>>
         + BlockBuilder<Block>
-        + sp_api::ApiExt<Block>,
+        + sp_api::ApiExt<Block>
+        + TaggedTransactionQueue<Block>,
     CClient: HeaderBackend<CBlock>
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -19,6 +19,7 @@ use sp_core::H256;
 use sp_domains::{BundleProducerElectionApi, DomainsApi};
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
+use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use std::sync::Arc;
 use subspace_runtime_primitives::Balance;
 
@@ -74,7 +75,8 @@ where
     Client::Api: DomainCoreApi<Block>
         + MessengerApi<Block, NumberFor<Block>>
         + sp_block_builder::BlockBuilder<Block>
-        + sp_api::ApiExt<Block>,
+        + sp_api::ApiExt<Block>
+        + TaggedTransactionQueue<Block>,
     CClient: HeaderBackend<CBlock>
         + HeaderMetadata<CBlock, Error = sp_blockchain::Error>
         + BlockBackend<CBlock>


### PR DESCRIPTION
This PR fixes the race condition issue mentioned at https://github.com/subspace/subspace/issues/1731#issuecomment-1782839028.

Double check the transaction validity, because the tx pool are re-validate the transaction in pool asynchronously so there is a race condition that the operator imported a domain block and starts producing bundle immediately before the re-validation based on the latest block is finished, cause the bundle contains illegal tx accidentally and being considered as invalid bundle and slashing on the honest operator.

I tried to handle #2184 in this PR, but found that it required more work on the illegal tx fraud proof (which is under development by @ParthDesai ) so gave up.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
