### PR TITLE
Drain notifications after DSN sync

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -256,10 +256,6 @@ where
     while let Some(reason) = notifications.next().await {
         let prev_sync_mode = sync_mode.swap(SyncMode::Paused, Ordering::AcqRel);
 
-        while notifications.try_next().is_ok() {
-            // Just drain extra messages if there are any
-        }
-
         info!(?reason, "Received notification to sync from DSN");
         // TODO: Maybe handle failed block imports, additional helpful logging
         if let Err(error) = import_blocks_from_dsn(
@@ -280,6 +276,10 @@ where
             initial_sync_mode.take().unwrap_or(prev_sync_mode),
             Ordering::Release,
         );
+
+        while notifications.try_next().is_ok() {
+            // Just drain extra messages if there are any
+        }
     }
 
     Ok(())


### PR DESCRIPTION
I noticed a while ago that often after DSN sync has finished it immediately starts again. The reason for that is that there might be notifications in-flights by the time DSN sync has finished.

For example when node starts, two triggers will happen: Substrate networking going online, then after bootstrapping has finished Subspace networking going online. When Subspace networking goes online we are already inside of DSN sync.

The solution here is to drain any remaining notifications after we are done with DSN sync in order to avoid triggering it unnecessarily. If sync is really necessary, it will be restarted later anyway.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
