### PR TITLE
Remove timestamp-based `slot_now` for equivocation check

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -508,18 +508,11 @@ where
         pot_verifier.clone(),
     )?;
 
-    let slot_duration = subspace_link.slot_duration();
     let sync_target_block_number = Arc::new(AtomicU32::new(0));
-    let verifier = SubspaceVerifier::<PosTable, _, _, _, _>::new(SubspaceVerifierOptions {
+    let verifier = SubspaceVerifier::<PosTable, _, _, _>::new(SubspaceVerifierOptions {
         client: client.clone(),
         kzg,
         select_chain: select_chain.clone(),
-        // TODO: Remove use current best slot known from PoT verifier in PoT case
-        slot_now: move || {
-            let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-
-            Slot::from_timestamp(*timestamp, slot_duration)
-        },
         telemetry: telemetry.as_ref().map(|x| x.handle()),
         offchain_tx_pool_factory: OffchainTransactionPoolFactory::new(transaction_pool.clone()),
         reward_signing_context: schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT),


### PR DESCRIPTION
With Proof of Time slots are not longer derived from timestamp, as such `slot_now` calculation was no longer correct.

Since we can't objectively know what "current" slot is until we have synced fully, we use sync target block and expected number of slots between blocks to estimate current slot.

There were already TODOs around this that are now resolved.

Substrate uses `slot_now` to check whether equivocation check should be performed or slot of the block that is being verified is too old to bother.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
