### PR TITLE
Make the instantiate_domain call permissioned

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -288,6 +288,10 @@ mod pallet {
 
         /// Randomness source.
         type Randomness: RandomnessT<Self::Hash, BlockNumberFor<Self>>;
+
+        /// The sudo account id
+        #[pallet::constant]
+        type SudoId: Get<Self::AccountId>;
     }
 
     #[pallet::pallet]
@@ -1044,7 +1048,9 @@ mod pallet {
             origin: OriginFor<T>,
             domain_config: DomainConfig<T::AccountId>,
         ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
+            ensure_root(origin)?;
+
+            let who = T::SudoId::get();
 
             let created_at = frame_system::Pallet::<T>::current_block_number();
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -239,6 +239,7 @@ impl pallet_domains::Config for Test {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type MaxNominators = MaxNominators;
     type Randomness = MockRandomness;
+    type SudoId = ();
 }
 
 impl domain_pallet_executive::Config for Test {
@@ -476,7 +477,7 @@ pub(crate) fn register_genesis_domain(creator: u64, operator_ids: Vec<OperatorId
             + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
     );
     crate::Pallet::<Test>::instantiate_domain(
-        RawOrigin::Signed(creator).into(),
+        RawOrigin::Root.into(),
         DomainConfig {
             domain_name: "evm-domain".to_owned(),
             runtime_id: 0,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -605,6 +605,7 @@ parameter_types! {
     pub const MaxPendingStakingOperation: u32 = 100;
     // TODO: reset `MaxNominators` back to `100` once the gemini-3g chain spec is created
     pub const MaxNominators: u32 = 0;
+    pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
 }
 
 impl pallet_domains::Config for Runtime {
@@ -632,6 +633,7 @@ impl pallet_domains::Config for Runtime {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type MaxNominators = MaxNominators;
     type Randomness = Subspace;
+    type SudoId = SudoId;
 }
 
 pub struct StakingOnReward;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -637,6 +637,7 @@ parameter_types! {
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 100;
     pub const MaxNominators: u32 = 100;
+    pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
 }
 
 impl pallet_domains::Config for Runtime {
@@ -664,6 +665,7 @@ impl pallet_domains::Config for Runtime {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type MaxNominators = MaxNominators;
     type Randomness = Subspace;
+    type SudoId = SudoId;
 }
 
 parameter_types! {


### PR DESCRIPTION
This PR makes the `instantiate_domain` call permissioned and only allows the sudo account to instantiate domain.

cc @vedhavyas @jfrank-summit 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
