### PR TITLE
Proving benchmark in subspace-farmer

### DIFF
--- a/crates/subspace-core-primitives/benches/kzg.rs
+++ b/crates/subspace-core-primitives/benches/kzg.rs
@@ -16,41 +16,48 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("commit", |b| {
+    {
         let polynomial = kzg.poly(&values).unwrap();
-        b.iter(|| {
-            kzg.commit(black_box(&polynomial)).unwrap();
-        })
-    });
+
+        c.bench_function("commit", |b| {
+            b.iter(|| {
+                kzg.commit(black_box(&polynomial)).unwrap();
+            })
+        });
+    }
 
     let num_values = values.len();
 
-    c.bench_function("create-witness", |b| {
+    {
         let polynomial = kzg.poly(&values).unwrap();
 
-        b.iter(|| {
-            kzg.create_witness(black_box(&polynomial), black_box(num_values), black_box(0))
-                .unwrap();
-        })
-    });
+        c.bench_function("create-witness", |b| {
+            b.iter(|| {
+                kzg.create_witness(black_box(&polynomial), black_box(num_values), black_box(0))
+                    .unwrap();
+            })
+        });
+    }
 
-    c.bench_function("verify", |b| {
+    {
         let polynomial = kzg.poly(&values).unwrap();
         let commitment = kzg.commit(&polynomial).unwrap();
         let index = 0;
         let witness = kzg.create_witness(&polynomial, num_values, index).unwrap();
         let value = values.first().unwrap();
 
-        b.iter(|| {
-            kzg.verify(
-                black_box(&commitment),
-                black_box(num_values),
-                black_box(index),
-                black_box(value),
-                black_box(&witness),
-            );
-        })
-    });
+        c.bench_function("verify", |b| {
+            b.iter(|| {
+                kzg.verify(
+                    black_box(&commitment),
+                    black_box(num_values),
+                    black_box(index),
+                    black_box(value),
+                    black_box(&witness),
+                );
+            })
+        });
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -19,8 +19,9 @@ use subspace_rpc_primitives::SlotInfo;
 /// Arguments for benchmark
 #[derive(Debug, Subcommand)]
 pub(crate) enum BenchmarkArgs {
-    /// Audit benchmark
+    /// Auditing benchmark
     Audit {
+        /// Number of samples to collect for benchmarking purposes
         #[arg(long, default_value_t = 10)]
         sample_size: usize,
         /// Disk farm to audit
@@ -31,6 +32,23 @@ pub(crate) enum BenchmarkArgs {
         /// Optional filter for benchmarks, must correspond to a part of benchmark name in order for benchmark to run
         filter: Option<String>,
     },
+    /// Proving benchmark
+    Prove {
+        /// Number of samples to collect for benchmarking purposes
+        #[arg(long, default_value_t = 10)]
+        sample_size: usize,
+        /// Disk farm to prove
+        ///
+        /// Example:
+        ///   /path/to/directory
+        disk_farm: PathBuf,
+        /// Optional filter for benchmarks, must correspond to a part of benchmark name in order for benchmark to run
+        filter: Option<String>,
+        /// Limit number of sectors audited to specified number, this limits amount of memory used by benchmark (normal
+        /// farming process doesn't use this much RAM)
+        #[arg(long)]
+        limit_sector_count: Option<usize>,
+    },
 }
 
 pub(crate) fn benchmark(benchmark_args: BenchmarkArgs) -> anyhow::Result<()> {
@@ -40,6 +58,12 @@ pub(crate) fn benchmark(benchmark_args: BenchmarkArgs) -> anyhow::Result<()> {
             disk_farm,
             filter,
         } => audit(sample_size, disk_farm, filter),
+        BenchmarkArgs::Prove {
+            sample_size,
+            disk_farm,
+            filter,
+            limit_sector_count,
+        } => prove(sample_size, disk_farm, filter, limit_sector_count),
     }
 }
 
@@ -88,10 +112,9 @@ fn audit(sample_size: usize, disk_farm: PathBuf, filter: Option<String>) -> anyh
                 .read(true)
                 .open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
+            let plot_audit = PlotAudit::new(&plot);
 
             group.bench_function("plot/single", |b| {
-                let plot_audit = PlotAudit::new(&plot);
-
                 b.iter_batched(
                     rand::random,
                     |global_challenge| {
@@ -122,10 +145,9 @@ fn audit(sample_size: usize, disk_farm: PathBuf, filter: Option<String>) -> anyh
         {
             let plot = RayonFiles::open(&disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
+            let plot_audit = PlotAudit::new(&plot);
 
             group.bench_function("plot/rayon", |b| {
-                let plot_audit = PlotAudit::new(&plot);
-
                 b.iter_batched(
                     rand::random,
                     |global_challenge| {
@@ -148,6 +170,146 @@ fn audit(sample_size: usize, disk_farm: PathBuf, filter: Option<String>) -> anyh
                         };
 
                         black_box(plot_audit.audit(black_box(options)))
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+        }
+    }
+
+    criterion.final_summary();
+
+    Ok(())
+}
+
+fn prove(
+    sample_size: usize,
+    disk_farm: PathBuf,
+    filter: Option<String>,
+    limit_sector_count: Option<usize>,
+) -> anyhow::Result<()> {
+    let (single_disk_farm_info, disk_farm) = match SingleDiskFarm::collect_summary(disk_farm) {
+        SingleDiskFarmSummary::Found { info, directory } => (info, directory),
+        SingleDiskFarmSummary::NotFound { directory } => {
+            return Err(anyhow!(
+                "No single disk farm info found, make sure {} is a valid path to the farm and \
+                process have permissions to access it",
+                directory.display()
+            ));
+        }
+        SingleDiskFarmSummary::Error { directory, error } => {
+            return Err(anyhow!(
+                "Failed to open single disk farm info, make sure {} is a valid path to the farm \
+                and process have permissions to access it: {error}",
+                directory.display()
+            ));
+        }
+    };
+
+    let kzg = Kzg::new(embedded_kzg_settings());
+    let erasure_coding = ErasureCoding::new(
+        NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize)
+            .expect("Not zero; qed"),
+    )
+    .map_err(|error| anyhow::anyhow!(error))?;
+    let table_generator = Mutex::new(PosTable::generator());
+
+    let mut sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
+        .map_err(|error| anyhow::anyhow!("Failed to read sectors metadata: {error}"))?;
+    if let Some(limit_sector_count) = limit_sector_count {
+        sectors_metadata.truncate(limit_sector_count);
+    };
+
+    let mut criterion = Criterion::default().sample_size(sample_size);
+    if let Some(filter) = filter {
+        criterion = criterion.with_filter(filter);
+    }
+    {
+        let mut group = criterion.benchmark_group("prove");
+        {
+            let plot = OpenOptions::new()
+                .read(true)
+                .open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
+                .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
+            let plot_audit = PlotAudit::new(&plot);
+            let options = PlotAuditOptions::<PosTable> {
+                public_key: single_disk_farm_info.public_key(),
+                reward_address: single_disk_farm_info.public_key(),
+                slot_info: SlotInfo {
+                    slot_number: 0,
+                    global_challenge: rand::random(),
+                    // Solution is guaranteed to be found
+                    solution_range: SolutionRange::MAX,
+                    // Solution is guaranteed to be found
+                    voting_solution_range: SolutionRange::MAX,
+                },
+                sectors_metadata: &sectors_metadata,
+                kzg: &kzg,
+                erasure_coding: &erasure_coding,
+                maybe_sector_being_modified: None,
+                table_generator: &table_generator,
+            };
+
+            let mut audit_results = plot_audit.audit(options);
+
+            group.bench_function("plot/single", |b| {
+                b.iter_batched(
+                    || {
+                        if let Some(result) = audit_results.pop() {
+                            return result;
+                        }
+
+                        audit_results = plot_audit.audit(options);
+
+                        audit_results.pop().unwrap()
+                    },
+                    |(_sector_index, mut provable_solutions)| {
+                        while (provable_solutions.next()).is_none() {
+                            // Try to create one solution and exit
+                        }
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+        }
+        {
+            let plot = RayonFiles::open(&disk_farm.join(SingleDiskFarm::PLOT_FILE))
+                .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
+            let plot_audit = PlotAudit::new(&plot);
+            let options = PlotAuditOptions::<PosTable> {
+                public_key: single_disk_farm_info.public_key(),
+                reward_address: single_disk_farm_info.public_key(),
+                slot_info: SlotInfo {
+                    slot_number: 0,
+                    global_challenge: rand::random(),
+                    // Solution is guaranteed to be found
+                    solution_range: SolutionRange::MAX,
+                    // Solution is guaranteed to be found
+                    voting_solution_range: SolutionRange::MAX,
+                },
+                sectors_metadata: &sectors_metadata,
+                kzg: &kzg,
+                erasure_coding: &erasure_coding,
+                maybe_sector_being_modified: None,
+                table_generator: &table_generator,
+            };
+            let mut audit_results = plot_audit.audit(options);
+
+            group.bench_function("plot/rayon", |b| {
+                b.iter_batched(
+                    || {
+                        if let Some(result) = audit_results.pop() {
+                            return result;
+                        }
+
+                        audit_results = plot_audit.audit(options);
+
+                        audit_results.pop().unwrap()
+                    },
+                    |(_sector_index, mut provable_solutions)| {
+                        while (provable_solutions.next()).is_none() {
+                            // Try to create one solution and exit
+                        }
                     },
                     BatchSize::SmallInput,
                 )

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -79,6 +79,7 @@ where
 }
 
 /// Plot audit options
+#[derive(Debug)]
 pub struct PlotAuditOptions<'a, PosTable>
 where
     PosTable: Table,
@@ -101,6 +102,17 @@ where
     /// Proof of space table generator
     pub table_generator: &'a Mutex<PosTable::Generator>,
 }
+
+impl<'a, PosTable> Clone for PlotAuditOptions<'a, PosTable>
+where
+    PosTable: Table,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, PosTable> Copy for PlotAuditOptions<'a, PosTable> where PosTable: Table {}
 
 /// Plot auditing implementation
 pub struct PlotAudit<Plot>(Plot)

--- a/crates/subspace-farmer/src/single_disk_farm/farming/rayon_files.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming/rayon_files.rs
@@ -12,12 +12,7 @@ pub struct RayonFiles {
 
 impl ReadAtSync for RayonFiles {
     fn read_at(&self, buf: &mut [u8], offset: usize) -> io::Result<()> {
-        let thread_index = rayon::current_thread_index().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "Reads must be called from rayon worker thread",
-            )
-        })?;
+        let thread_index = rayon::current_thread_index().unwrap_or_default();
         let file = self.files.get(thread_index).ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "No files entry for this rayon thread")
         })?;

--- a/crates/subspace-proof-of-time/benches/pot-compare-cpu-cores.rs
+++ b/crates/subspace-proof-of-time/benches/pot-compare-cpu-cores.rs
@@ -12,10 +12,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let cpu_cores = core_affinity::get_core_ids().expect("Must be able to get CPU cores");
     for cpu_core in cpu_cores {
+        if !core_affinity::set_for_current(cpu_core) {
+            panic!("Failed to set CPU affinity");
+        }
+
         c.bench_function(&format!("prove/cpu-{}", cpu_core.id), move |b| {
-            if !core_affinity::set_for_current(cpu_core) {
-                panic!("Failed to set CPU affinity");
-            }
             b.iter(|| {
                 black_box(prove(black_box(seed), black_box(pot_iterations))).unwrap();
             })


### PR DESCRIPTION
Complements https://github.com/subspace/subspace/pull/2124

First commit allows benchmark filtering, for example it is possible to skip single auditing benchmark and just run rayon:
```
subspace-farmer benchmark audit /path/to/farm rayon
```

Second commit implements proving benchmark:
```
subspace-farmer benchmark prove /path/to/farm rayon
```

It will use quite a lot of memory on large farms, so `--limit-sector-count` CLI option can be used to effectively "truncate" the plot to that number of sectors and ignore the rest as far as benchmark is concerned.

I also noticed that while `bench_function()`'s contents is not timed, it is apparently running on every single iteration, so I fixed up a few places where this was used in lat commit.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
