### PR TITLE
Fix sending duplicate proofs

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -405,8 +405,7 @@ where
                                     slot = %slot_number,
                                     %sector_index,
                                     %public_key,
-                                    "Solution receiver is closed, likely because farmer was too \
-                                    slow"
+                                    "Solution receiver is closed, likely because farmer was too slow"
                                 );
                             }
                         }


### PR DESCRIPTION
I noticed a while ago that my farmer is not able to produce blocks, I thought it might be related to plotting or the fact that disks are slow. Now that we have https://github.com/subspace/subspace/pull/2202 I was able to confirm that both auditing and proving are within acceptable range.

Once I enabled debug logs it became clear that for many slots/challenges farmer is actually auditing and then also proving twice, which I also noticed in node's logs and it looked suspicious.

This PR allows me to farm (finally, after a week of plotting!).

The first commit is the fix, the second would have also prevented it and is more of a cleanup.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
