### PR TITLE
Reorder the ER verification steps and downgrade log level for some common/expected errors in pallet-domains

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -158,7 +158,7 @@ pub(crate) fn verify_execution_receipt<T: Config>(
         ..
     } = execution_receipt;
 
-    // Checking if the incoming ER is expected regarding to its `domain_block_number`/freshness
+    // Checking if the incoming ER is expected regarding to its `domain_block_number` or freshness
     if let ReceiptType::Rejected(rejected_receipt_type) =
         execution_receipt_type::<T>(domain_id, execution_receipt)
     {

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1277,10 +1277,24 @@ mod pallet {
             match call {
                 Call::submit_bundle { opaque_bundle } => {
                     if let Err(e) = Self::validate_bundle(opaque_bundle) {
-                        log::error!(
-                            target: "runtime::domains",
-                            "Bad bundle {:?}, error: {e:?}", opaque_bundle.domain_id(),
-                        );
+                        match e {
+                            // These errors are common due to networking delay or chain re-org,
+                            // using a lower log level to avoid the noise.
+                            BundleError::Receipt(BlockTreeError::StaleReceipt)
+                            | BundleError::Receipt(BlockTreeError::NewBranchReceipt)
+                            | BundleError::Receipt(BlockTreeError::BuiltOnUnknownConsensusBlock) => {
+                                log::debug!(
+                                    target: "runtime::domains",
+                                    "Bad bundle {:?}, error: {e:?}", opaque_bundle.domain_id(),
+                                );
+                            }
+                            _ => {
+                                log::warn!(
+                                    target: "runtime::domains",
+                                    "Bad bundle {:?}, error: {e:?}", opaque_bundle.domain_id(),
+                                );
+                            }
+                        }
                         if let BundleError::Receipt(_) = e {
                             return InvalidTransactionCode::ExecutionReceipt.into();
                         } else {
@@ -1299,7 +1313,7 @@ mod pallet {
                 }
                 Call::submit_fraud_proof { fraud_proof } => {
                     if let Err(e) = Self::validate_fraud_proof(fraud_proof) {
-                        log::error!(
+                        log::warn!(
                             target: "runtime::domains",
                             "Bad fraud proof {:?}, error: {e:?}", fraud_proof.domain_id(),
                         );

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1280,7 +1280,8 @@ mod pallet {
                         match e {
                             // These errors are common due to networking delay or chain re-org,
                             // using a lower log level to avoid the noise.
-                            BundleError::Receipt(BlockTreeError::StaleReceipt)
+                            BundleError::Receipt(BlockTreeError::InFutureReceipt)
+                            | BundleError::Receipt(BlockTreeError::StaleReceipt)
                             | BundleError::Receipt(BlockTreeError::NewBranchReceipt)
                             | BundleError::Receipt(BlockTreeError::BuiltOnUnknownConsensusBlock) => {
                                 log::debug!(


### PR DESCRIPTION
This PR mainly brings 2 changes:
- Reorder the ER verification steps to bring short circuits for some common/expected errors
- Downgrade log level for some common/expected errors in `pallet-domains` to avoid noise and confusion

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
