### PR TITLE
Fix connected peers bombarding peers with connection attempts

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -514,6 +514,7 @@ where
                 peer_id,
                 endpoint,
                 num_established,
+                cause,
                 ..
             } => {
                 let shared = match self.shared_weak.upgrade() {
@@ -522,7 +523,10 @@ where
                         return;
                     }
                 };
-                debug!("Connection closed with peer {peer_id} [{num_established} from peer]");
+                debug!(
+                    ?cause,
+                    "Connection closed with peer {peer_id} [{num_established} from peer]"
+                );
 
                 // TODO: Workaround for https://github.com/libp2p/rust-libp2p/discussions/3418
                 {

--- a/crates/subspace-networking/src/protocols/connected_peers.rs
+++ b/crates/subspace-networking/src/protocols/connected_peers.rs
@@ -393,7 +393,7 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
                     .unwrap_or(false);
 
                 if known_connection_closed {
-                    trace!(%peer_id, ?connection_id, "Known connection closed.");
+                    trace!(%peer_id, ?connection_id, "Known connection closed");
                     self.known_peers.remove(&peer_id);
                     self.wake();
                 }
@@ -403,12 +403,17 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
                     let old_peer_decision = self.known_peers.remove(&peer_id);
 
                     if old_peer_decision.is_some() {
-                        trace!(%peer_id, ?old_peer_decision, ?connection_id, "Known peer disconnected.");
+                        trace!(
+                            %peer_id,
+                            ?old_peer_decision,
+                            ?connection_id,
+                            "Known peer disconnected"
+                        );
                         self.wake();
                     }
                 };
             }
-            FromSwarm::DialFailure(DialFailure { peer_id, .. }) => {
+            FromSwarm::DialFailure(DialFailure { peer_id, error, .. }) => {
                 if let Some(peer_id) = peer_id {
                     let other_connections = self
                         .known_peers
@@ -419,7 +424,12 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
                         let old_peer_decision = self.known_peers.remove(&peer_id);
 
                         if old_peer_decision.is_some() {
-                            debug!(%peer_id, ?old_peer_decision, "Dialing error to known peer.");
+                            debug!(
+                                %peer_id,
+                                ?old_peer_decision,
+                                ?error,
+                                "Dialing error to known peer"
+                            );
                         }
                     }
 
@@ -467,7 +477,7 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
                 ConnectionState::Connecting {
                     peer_address: address,
                 } => {
-                    debug!(%peer_id, "Dialing a new peer.");
+                    debug!(%peer_id, "Dialing a new peer");
 
                     let dial_opts = DialOpts::peer_id(*peer_id).addresses(vec![address.clone()]);
 
@@ -492,7 +502,7 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
 
                 // Request new peer addresses.
                 if self.peer_cache.is_empty() {
-                    trace!("Requesting new peers for connected-peers protocol....");
+                    trace!("Requesting new peers for connected-peers protocol...");
 
                     return Poll::Ready(ToSwarm::GenerateEvent(
                         Event::NewDialingCandidatesRequested(PhantomData),
@@ -525,7 +535,11 @@ impl<Instance: 'static + Send> NetworkBehaviour for Behaviour<Instance> {
 
                 let stats = self.gather_stats();
 
-                debug!(instance=%self.config.log_target, ?stats, "Connected peers protocol statistics.");
+                debug!(
+                    instance = %self.config.log_target,
+                    ?stats,
+                    "Connected peers protocol statistics",
+                );
             }
         }
 

--- a/crates/subspace-networking/src/protocols/peer_info/handler.rs
+++ b/crates/subspace-networking/src/protocols/peer_info/handler.rs
@@ -255,7 +255,7 @@ impl ConnectionHandler for Handler {
                 match error {
                     ConnectionHandlerUpgrErr::NegotiationFailed
                     | ConnectionHandlerUpgrErr::Apply(..) => {
-                        debug!("Peer-info protocol dial upgrade failed.");
+                        debug!(?error, "Peer-info protocol dial upgrade failed");
                     }
                     e => {
                         self.error = Some(PeerInfoError::Other { error: Box::new(e) });


### PR DESCRIPTION
The first commit is just some logging tweaks, some formatting and some to debug what is going on better.

The second commit fixes following thing I observed in logs (note the time difference between lines):
<details>

```
2023-11-08T05:26:25.324940Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325193Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325309Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325420Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325527Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325642Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325750Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325856Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.325963Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326071Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326180Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326285Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326402Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326514Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326620Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326727Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326833Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.326943Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327051Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327159Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327264Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327372Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327479Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327588Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327708Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327818Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.327943Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328050Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328155Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328263Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328370Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328477Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328593Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328705Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328812Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.328922Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329027Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329135Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329313Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329502Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329592Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329680Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329754Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329829Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329911Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.329986Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330049Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330112Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330185Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330261Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330343Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330414Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330480Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330550Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330633Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330702Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330765Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330827Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330886Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.330953Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331016Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331086Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331155Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331217Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331281Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331347Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331412Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331457Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331500Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331556Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331618Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331678Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331723Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331789Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331854Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331924Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.331980Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332045Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332105Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332161Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332229Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332293Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332354Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332411Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332474Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332540Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332603Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332677Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332746Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332819Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332884Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.332951Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333016Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333082Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333143Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333190Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333245Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333310Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333376Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333440Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333505Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333571Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333639Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333703Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333753Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333807Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333877Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.333945Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334012Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334081Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334198Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334267Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334332Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334436Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334663Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334792Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.334922Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335000Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335050Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335093Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335149Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335220Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335285Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335346Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335411Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335479Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335545Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335613Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335676Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335742Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335805Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335868Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335931Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.335997Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336043Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336090Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336154Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336217Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336273Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336319Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336379Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336436Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336479Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336534Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336600Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336662Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336732Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
2023-11-08T05:26:25.336802Z DEBUG tokio-runtime-worker subspace_networking::protocols::connected_peers: [Consensus] Dialing a new peer. peer_id=12D3KooWPZ44Ei67GAnvEzxL4nvaXdQVXYi2KCzzo8iYExY3t9Jd
```

</details>

Essentially the way `fn poll` was written the following happened:
* not enough peers, but there are some candidates to connect to
* add candidate to known peers as `ConnectionState::Connecting` (but waker wasn't called, so there was no guarantee it will ever actually dial that peer)
* on the next call dial will be attempted to the first known peer with `ConnectionState::Connecting`
* unless connection was established or failed, dial to the same peer will be initiated over and over and over again, while other known peers will be ignored

This change both fixes missing waker call and introduces `ConnectionState::ToConnect` that is used to indicate that connection should be initiated, but it didn't actually happen yet.

This doesn't fix networking issues I observe fully, but this seems like a clear bug that should be fixed anyway.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
