### PR TITLE
Remove duplicated extrinsic data from `ApplyExtrinsic` execution phase

### DIFF
--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -22,9 +22,8 @@ pub enum ExecutionPhase {
     InitializeBlock,
     /// Executes some extrinsic.
     ApplyExtrinsic {
-        proof_of_inclusion: StorageProof,
+        extrinsic_proof: StorageProof,
         mismatch_index: u32,
-        extrinsic: Vec<u8>,
     },
     /// Executes the `finalize_block` hook.
     FinalizeBlock,
@@ -142,9 +141,8 @@ impl ExecutionPhase {
                 new_header.encode()
             }
             ExecutionPhase::ApplyExtrinsic {
-                proof_of_inclusion,
+                extrinsic_proof: proof_of_inclusion,
                 mismatch_index,
-                extrinsic,
             } => {
                 // There is a trace root of the `initialize_block` in the head of the trace so we
                 // need to minus one to get the correct `extrinsic_index`
@@ -153,15 +151,13 @@ impl ExecutionPhase {
                     StorageProofVerifier::<DomainHeader::Hashing>::enumerated_storage_key(
                         extrinsic_index,
                     );
-                if !StorageProofVerifier::<DomainHeader::Hashing>::verify_storage_proof(
-                    proof_of_inclusion.clone(),
+
+                StorageProofVerifier::<DomainHeader::Hashing>::get_bare_value(
                     &bad_receipt.domain_block_extrinsic_root,
-                    extrinsic.clone(),
+                    proof_of_inclusion.clone(),
                     storage_key,
-                ) {
-                    return Err(VerificationError::InvalidApplyExtrinsicCallData);
-                }
-                extrinsic.clone()
+                )
+                .map_err(|_| VerificationError::InvalidApplyExtrinsicCallData)?
             }
             ExecutionPhase::FinalizeBlock => Vec::new(),
         })

--- a/crates/sp-domains/src/proof_provider_and_verifier.rs
+++ b/crates/sp-domains/src/proof_provider_and_verifier.rs
@@ -53,23 +53,6 @@ impl<H: Hasher> StorageProofVerifier<H> {
         Ok(val)
     }
 
-    /// Verifies the given storage proof and checks the expected_value matches the extracted value from the proof.
-    pub fn verify_storage_proof(
-        proof: StorageProof,
-        root: &H::Out,
-        expected_value: Vec<u8>,
-        storage_key: StorageKey,
-    ) -> bool
-    where
-        H: Hasher,
-    {
-        if let Ok(got_data) = StorageProofVerifier::<H>::get_bare_value(root, proof, storage_key) {
-            expected_value == got_data
-        } else {
-            false
-        }
-    }
-
     /// Constructs the storage key from a given enumerated index.
     pub fn enumerated_storage_key(index: u32) -> StorageKey {
         StorageKey(Compact(index).encode())

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -418,9 +418,8 @@ where
             )
             .ok_or(FraudProofError::FailToGenerateProofOfInclusion)?;
             ExecutionPhase::ApplyExtrinsic {
-                proof_of_inclusion,
+                extrinsic_proof: proof_of_inclusion,
                 mismatch_index: trace_mismatch_index,
-                extrinsic: target_extrinsic.clone(),
             }
         };
 


### PR DESCRIPTION
This is something that was left behind during our migration `proof_of_inclusion` proof to using Storage Proof.
The storage proof itself will carry the same extrinsic data that ApplyExtrinsic is holding. And we are also using this field to just check if the `bare_value` we get from the proof is matching the expected value which is redundant in this case.

There is one extra step this change will introduce, for a malicious fraud proof where the extrinsic index is wrong but still is a leaf of the tree, then it returns the incorrect extrinsic as expected and this will fail during the execution proof check.

In the main, this is short-circuited since we know which extrinsic to be expected but that is still possible to override where the extrinsic ApplyExtrinsic is carrying the same incorrect data proof returns. So nothing will change with this change of removing such field

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
