### PR TITLE
comment out consensus block hash on Proof of election.

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1494,7 +1494,7 @@ impl<T: Config> Pallet<T> {
         let (operator_stake, total_domain_stake) =
             Self::fetch_operator_stake_info(domain_id, &operator_id)?;
 
-        sp_domains::bundle_producer_election::check_proof_of_election(
+        sp_domains::bundle_producer_election::check_proof_of_election::<T::Hash>(
             &operator.signing_key,
             domain_config.bundle_slot_probability,
             proof_of_election,

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -521,7 +521,10 @@ where
         return Err(InvalidBundleEquivocationError::MismatchedOperatorAndDomain);
     }
 
-    let consensus_block_hash = header_1.header.proof_of_election.consensus_block_hash;
+    // TODO: enable before the new network
+    // Commented out due to mismatch of structure on Gemini-3g runtime and fails to decode/encode.
+    // let consensus_block_hash = header_1.header.proof_of_election.consensus_block_hash;
+    let consensus_block_hash: CBlock::Hash = Default::default();
     let domain_id = header_1.header.proof_of_election.domain_id;
     let operator_id = header_1.header.proof_of_election.operator_id;
 
@@ -540,7 +543,7 @@ where
     .ok_or(InvalidBundleEquivocationError::FailedToGetOperatorStake)?
     .saturated_into();
 
-    check_proof_of_election(
+    check_proof_of_election::<CBlock::Hash>(
         operator_signing_key,
         bundle_slot_probability,
         &header_1.header.proof_of_election,
@@ -549,7 +552,7 @@ where
     )
     .map_err(InvalidBundleEquivocationError::InvalidProofOfElection)?;
 
-    check_proof_of_election(
+    check_proof_of_election::<CBlock::Hash>(
         operator_signing_key,
         bundle_slot_probability,
         &header_2.header.proof_of_election,

--- a/crates/sp-domains/src/bundle_producer_election.rs
+++ b/crates/sp-domains/src/bundle_producer_election.rs
@@ -87,7 +87,7 @@ pub(crate) fn verify_vrf_signature(
 pub fn check_proof_of_election<CHash>(
     operator_signing_key: &OperatorPublicKey,
     bundle_slot_probability: (u64, u64),
-    proof_of_election: &ProofOfElection<CHash>,
+    proof_of_election: &ProofOfElection,
     operator_stake: StakeWeight,
     total_domain_stake: StakeWeight,
 ) -> Result<(), ProofOfElectionError> {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -185,7 +185,7 @@ impl PassBy for DomainId {
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct BundleHeader<Number, Hash, DomainHeader: HeaderT, Balance> {
     /// Proof of bundle producer election.
-    pub proof_of_election: ProofOfElection<Hash>,
+    pub proof_of_election: ProofOfElection,
     /// Execution receipt that should extend the receipt chain or add confirmations
     /// to the head receipt.
     pub receipt: ExecutionReceipt<
@@ -532,7 +532,7 @@ impl<
 }
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
-pub struct ProofOfElection<CHash> {
+pub struct ProofOfElection {
     /// Domain id.
     pub domain_id: DomainId,
     /// The slot number.
@@ -543,11 +543,13 @@ pub struct ProofOfElection<CHash> {
     pub vrf_signature: VrfSignature,
     /// Operator index in the OperatorRegistry.
     pub operator_id: OperatorId,
-    /// Consensus block hash at which proof of election was derived.
-    pub consensus_block_hash: CHash,
+    // /// Consensus block hash at which proof of election was derived.
+    // TODO: enable before the new network
+    // Commented out due to mismatch of structure on Gemini-3g runtime and fails to decode/encode.
+    // pub consensus_block_hash: CHash,
 }
 
-impl<CHash> ProofOfElection<CHash> {
+impl ProofOfElection {
     pub fn verify_vrf_signature(
         &self,
         operator_signing_key: &OperatorPublicKey,
@@ -571,7 +573,7 @@ impl<CHash> ProofOfElection<CHash> {
     }
 }
 
-impl<CHash: Default> ProofOfElection<CHash> {
+impl ProofOfElection {
     #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
     pub fn dummy(domain_id: DomainId, operator_id: OperatorId) -> Self {
         let output_bytes = sp_std::vec![0u8; VrfOutput::max_encoded_len()];
@@ -586,7 +588,6 @@ impl<CHash: Default> ProofOfElection<CHash> {
             global_randomness: Randomness::default(),
             vrf_signature,
             operator_id,
-            consensus_block_hash: Default::default(),
         }
     }
 }

--- a/domains/client/domain-operator/src/bundle_producer_election_solver.rs
+++ b/domains/client/domain-operator/src/bundle_producer_election_solver.rs
@@ -49,7 +49,7 @@ where
         consensus_block_hash: CBlock::Hash,
         domain_id: DomainId,
         global_randomness: Randomness,
-    ) -> sp_blockchain::Result<Option<(ProofOfElection<CBlock::Hash>, OperatorPublicKey)>> {
+    ) -> sp_blockchain::Result<Option<(ProofOfElection, OperatorPublicKey)>> {
         let BundleProducerElectionParams {
             current_operators,
             total_domain_stake,
@@ -94,7 +94,9 @@ where
                             global_randomness,
                             vrf_signature,
                             operator_id,
-                            consensus_block_hash,
+                            // TODO: enable before the new network
+                            // Commented out due to mismatch of structure on Gemini-3g runtime and fails to decode/encode.
+                            // consensus_block_hash,
                         };
                         return Ok(Some((proof_of_election, operator_signing_key)));
                     }

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -75,7 +75,7 @@ where
 
     pub(crate) async fn propose_bundle_at(
         &self,
-        proof_of_election: ProofOfElection<CBlock::Hash>,
+        proof_of_election: ProofOfElection,
         tx_range: U256,
     ) -> sp_blockchain::Result<ProposeBundleOutput<Block, CBlock>> {
         let parent_number = self.client.info().best_number;

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1604,7 +1604,9 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
         .is_none());
 }
 
+// TODO: enable the test once Proof of election's consensus hash is not skipped while encoding and decoding
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_bundle_equivocation_fraud_proof() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 


### PR DESCRIPTION
This will essentially make bundle equiovcation check invalid

We can bring this check back in the next network if proven impossible to add in Gemini-3g

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
