### PR TITLE
Fix operator incompatible with gemini-3g

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,7 +2520,6 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-timestamp",
- "sp-trie",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "tracing",

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -521,6 +521,9 @@ where
         return Err(InvalidBundleEquivocationError::MismatchedOperatorAndDomain);
     }
 
+    // TODO: `consensus_block_hash` is an default/empty value because this field is skipped
+    // during encode/decode due to incompatible with Gemini-3g, thus the verificaion will fail.
+    // This should be fix on new network when the field is not skipped.
     let consensus_block_hash = header_1.header.proof_of_election.consensus_block_hash;
     let domain_id = header_1.header.proof_of_election.domain_id;
     let operator_id = header_1.header.proof_of_election.operator_id;

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -544,6 +544,9 @@ pub struct ProofOfElection<CHash> {
     /// Operator index in the OperatorRegistry.
     pub operator_id: OperatorId,
     /// Consensus block hash at which proof of election was derived.
+    // TODO: skipping encode/decode this field becasue it is mismatch with the struct
+    // on the Gemini-3g runtime, remove `#[codec(skip)]` before new network
+    #[codec(skip)]
     pub consensus_block_hash: CHash,
 }
 

--- a/domains/client/block-preprocessor/Cargo.toml
+++ b/domains/client/block-preprocessor/Cargo.toml
@@ -28,7 +28,6 @@ sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
-sp-trie = { version = "22.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
 tracing = "0.1.37"

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -29,12 +29,11 @@ use sp_blockchain::HeaderBackend;
 use sp_core::H256;
 use sp_domains::extrinsics::deduplicate_and_shuffle_extrinsics;
 use sp_domains::{
-    DomainId, DomainsApi, ExecutionReceipt, ExtrinsicDigest, HeaderHashingFor, InboxedBundle,
-    InvalidBundleType, OpaqueBundle, OpaqueBundles, ReceiptValidity,
+    DomainId, DomainsApi, ExecutionReceipt, HeaderHashingFor, InboxedBundle, InvalidBundleType,
+    OpaqueBundle, OpaqueBundles, ReceiptValidity,
 };
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
-use sp_trie::LayoutV1;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -231,9 +230,16 @@ where
                         .map(|(signer, tx)| {
                             (
                                 signer.clone(),
-                                ExtrinsicDigest::new::<LayoutV1<HeaderHashingFor<Block::Header>>>(
-                                    tx.encode(),
-                                ),
+                                HeaderHashingFor::<Block::Header>::hash_of(tx),
+                                // TODO: enable before the new network
+                                // NOTE: we should using the `ExtrinsicDigest` to calculate the `bundle_digest`
+                                // to keep consistency with the `domain_block_extrinsic_root` fraud proof, but
+                                // this is incompatible with Gemini-3g network because operators who have this
+                                // change will produce a different ER than those who don't have, cause the ER
+                                // derivation become non-deterministic.
+                                // ExtrinsicDigest::new::<LayoutV1<HeaderHashingFor<Block::Header>>>(
+                                //     tx.encode(),
+                                // ),
                             )
                         })
                         .collect();

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1471,7 +1471,11 @@ async fn test_invalid_domain_block_hash_proof_creation() {
         .is_none());
 }
 
+// Disable because the `bundle_digest` value used in the ER is inconsistent with the value
+// used in the fraud proof, the fix is not deploy due to incompatible with the Gemini-3g
+// TODO: enable once the fix is deployed
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_invalid_domain_extrinsics_root_proof_creation() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -1604,7 +1608,12 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
         .is_none());
 }
 
+// Disable because the `ProofOfElection::consensus_block_hash` is skipped during encode/decode
+// due to incompatible with Gemini-3g, thus it is the empty value in the fraud proof and will
+// failed when used to get the required runtime state during verification.
+// TODO: enable once the field is not skipped.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_bundle_equivocation_fraud_proof() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 


### PR DESCRIPTION
close #2211 close #2214

This PR fixes the incompatible of operator in the main branch with Gemini-3g by:
- Skip encode/decode the `ProofOfElection::consensus_block_hash` field
    - This field is new and unknown to the Gemini-3g runtime, thus can't encode/decode properly cross runtime API boundary
    - This also disable the verification of the bundle equivocation proof since the field is skipped during encode/decode and is a default/empty value in the proof
- Revert the valid `bundle_digest` calculation change in block-preprocessor
    - This change will cause the operator to generate a different ER than the operator who without this change, thus causes the ER derivation to become non-deterministic and fail to submit with the `UnknownParentBlockReceipt` error

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
