### PR TITLE
Default to dynamic Kademlia mode

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -373,7 +373,9 @@ where
             general_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             bootstrap_addresses: Vec::new(),
-            kademlia_mode: KademliaMode::Static(Mode::Client),
+            kademlia_mode: KademliaMode::Dynamic {
+                initial_mode: Mode::Client,
+            },
             external_addresses: Vec::new(),
             enable_autonat: true,
             disable_bootstrap_on_start: false,

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1334,10 +1334,7 @@ where
                                     }
                                 }
                                 Ok(false) => {
-                                    panic!(
-                                        "Logic error, topic subscription wasn't created, this must never \
-                            happen"
-                                    );
+                                    panic!("Logic error, topic subscription wasn't created, this must never happen");
                                 }
                                 Err(error) => {
                                     let _ = result_sender.send(Err(error));

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -186,7 +186,9 @@ where
         general_connected_peers_handler: Some(Arc::new(|_| true)),
         bootstrap_addresses: dsn_config.bootstrap_nodes,
         external_addresses: dsn_config.external_addresses,
-        kademlia_mode: KademliaMode::Static(Mode::Client),
+        kademlia_mode: KademliaMode::Dynamic {
+            initial_mode: Mode::Client,
+        },
         metrics,
         disable_bootstrap_on_start: dsn_config.disable_bootstrap_on_start,
 


### PR DESCRIPTION
Latest release fixed some issues, but it didn't fix issues of nodes connecting to other nodes. The problem there is that nodes were configured with `KademliaMode::Static(Mode:Client)`.

What does this mean? It means that no node on the network, regardless of whether it is node or farmer, will add node to its peers. Even nodes will not add other nodes. This explains and I believe fixes https://github.com/subspace/subspace/issues/2102.

There are likely other issues remaining, this should be helpful for the network already.

I also decided to make dynamic mode the default in general as I see no reason why that shouldn't be the case. Those with private addresses will not switch to server mode anyway and those that are public, but go offline will be handled by the logic we already have in the code eventually (temporary bans and eventual cleanups).

I'm investigating further, but with this we should already make a new snapshot.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
