### PR TITLE
Do not advertize reserved peers as a protocol

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -54,7 +54,6 @@ pub type ConnectedPeersHandler = Arc<dyn Fn(&PeerInfo) -> bool + Send + Sync + '
 const DEFAULT_NETWORK_PROTOCOL_VERSION: &str = "dev";
 const KADEMLIA_PROTOCOL: &str = "/subspace/kad/0.1.0";
 const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
-const RESERVED_PEERS_PROTOCOL_NAME: &str = "/subspace/reserved-peers/1.0.0";
 const PEER_INFO_PROTOCOL_NAME: &str = "/subspace/peer-info/1.0.0";
 const GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "general-connected-peers";
 const SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "special-connected-peers";
@@ -482,7 +481,6 @@ where
         connection_limits,
         reserved_peers: ReservedPeersConfig {
             reserved_peers: reserved_peers.clone(),
-            protocol_name: RESERVED_PEERS_PROTOCOL_NAME,
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         },
         peer_info_config: PeerInfoConfig::new(PEER_INFO_PROTOCOL_NAME),

--- a/crates/subspace-networking/src/protocols/reserved_peers.rs
+++ b/crates/subspace-networking/src/protocols/reserved_peers.rs
@@ -66,8 +66,6 @@ pub struct Behaviour {
 /// Reserved peers protocol configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Protocol name.
-    pub protocol_name: &'static str,
     /// Predefined set of reserved peers with addresses.
     pub reserved_peers: Vec<Multiaddr>,
     /// Interval between new dialing attempts.

--- a/crates/subspace-networking/src/protocols/reserved_peers.rs
+++ b/crates/subspace-networking/src/protocols/reserved_peers.rs
@@ -133,12 +133,8 @@ impl Behaviour {
     }
 
     /// Create a connection handler for the reserved peers protocol.
-    #[inline]
     fn new_reserved_peers_handler(&self, peer_id: &PeerId) -> Handler {
-        Handler::new(
-            self.config.protocol_name,
-            self.reserved_peers_state.contains_key(peer_id),
-        )
+        Handler::new(self.reserved_peers_state.contains_key(peer_id))
     }
 
     fn wake(&self) {

--- a/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
+++ b/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
@@ -14,8 +14,6 @@ use tokio::time::sleep;
 #[derive(Debug, Clone)]
 struct ReservedPeersInstance;
 
-const PROTOCOL_NAME: &str = "/reserved-peers";
-
 const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(1);
 
 #[tokio::test()]
@@ -28,7 +26,6 @@ async fn test_connection_breaks_after_timeout_without_reservation() {
         identity1,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: Vec::new(),
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),
@@ -39,7 +36,6 @@ async fn test_connection_breaks_after_timeout_without_reservation() {
         identity2,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: Vec::new(),
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),
@@ -79,7 +75,6 @@ async fn test_connection_reservation() {
         identity1,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: vec![peer2_address.parse().unwrap()],
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),
@@ -89,7 +84,6 @@ async fn test_connection_reservation() {
         identity2,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: vec![peer1_address.parse().unwrap()],
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),
@@ -128,7 +122,6 @@ async fn test_connection_reservation_symmetry() {
         identity1,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: vec![peer2_address.parse().unwrap()],
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),
@@ -138,7 +131,6 @@ async fn test_connection_reservation_symmetry() {
         identity2,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: Vec::new(),
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),
@@ -178,7 +170,6 @@ async fn test_reserved_peers_dial_event() {
         identity1,
         connection_timeout,
         Behaviour::new(Config {
-            protocol_name: PROTOCOL_NAME,
             reserved_peers: vec![peer2_address.parse().unwrap()],
             dialing_interval: DIALING_INTERVAL_IN_SECS,
         }),


### PR DESCRIPTION
Similarly to connected peers I don't think there is a reason for this to be exposed publicly, we just need to return `KeepAlive::Yes`, we don't need any substreams because we will not send anything to the other side.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
