### PR TITLE
Improve network connectivity

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -193,7 +193,7 @@ struct DsnArgs {
     #[arg(long, default_value_t = 100)]
     pending_out_connections: u32,
     /// Defines target total (in and out) connection number that should be maintained.
-    #[arg(long, default_value_t = 25)]
+    #[arg(long, default_value_t = 15)]
     target_connections: u32,
     /// Known external addresses
     #[arg(long, alias = "external-address")]

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -182,13 +182,19 @@ pub(super) fn configure_dsn(
         max_pending_outgoing_connections: pending_out_connections,
         max_established_incoming_connections: in_connections,
         max_pending_incoming_connections: pending_in_connections,
-        general_target_connections: target_connections,
-        // maintain permanent connections between farmers
-        special_connected_peers_handler: Some(Arc::new(PeerInfo::is_farmer)),
-        // other (non-farmer) connections
+        // Non-farmer connections
         general_connected_peers_handler: Some(Arc::new(|peer_info| {
             !PeerInfo::is_farmer(peer_info)
         })),
+        // Proactively maintain permanent connections with farmers
+        special_connected_peers_handler: Some(Arc::new(PeerInfo::is_farmer)),
+        // Do not have any target for general peers
+        general_connected_peers_target: 0,
+        special_connected_peers_target: target_connections,
+        // Allow up to quarter of incoming connections to be maintained
+        general_connected_peers_limit: in_connections / 4,
+        // Allow to maintain some extra farmer connections beyond direct interest too
+        special_connected_peers_limit: target_connections + in_connections / 4,
         bootstrap_addresses: bootstrap_nodes,
         kademlia_mode: KademliaMode::Dynamic {
             initial_mode: Mode::Client,

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -163,9 +163,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 max_established_outgoing_connections: out_peers,
                 max_pending_incoming_connections: pending_in_peers,
                 max_pending_outgoing_connections: pending_out_peers,
-                // we don't maintain permanent connections with any peer
-                general_connected_peers_handler: None,
-                special_connected_peers_handler: None,
+                // Maintain proactive connections with all peers
+                general_connected_peers_handler: Some(Arc::new(|_| true)),
+                // Maintain some number of persistent connections
+                general_connected_peers_target: in_peers / 8,
+                // Allow some more persistent connections from other peers
+                general_connected_peers_limit: in_peers / 4,
                 bootstrap_addresses: bootstrap_nodes,
                 kademlia_mode: KademliaMode::Static(Mode::Server),
                 external_addresses,

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -373,9 +373,7 @@ where
             general_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
             bootstrap_addresses: Vec::new(),
-            kademlia_mode: KademliaMode::Dynamic {
-                initial_mode: Mode::Client,
-            },
+            kademlia_mode: KademliaMode::Static(Mode::Client),
             external_addresses: Vec::new(),
             enable_autonat: true,
             disable_bootstrap_on_start: false,

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -59,8 +59,8 @@ const PEER_INFO_PROTOCOL_NAME: &str = "/subspace/peer-info/1.0.0";
 const GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "general-connected-peers";
 const SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET: &str = "special-connected-peers";
 
-// Defines max_negotiating_inbound_streams constant for the swarm.
-// It must be set for large plots.
+/// Defines max_negotiating_inbound_streams constant for the swarm.
+/// It must be set for large plots.
 const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 /// The default maximum established incoming connection number for the swarm.
 const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 100;
@@ -70,12 +70,10 @@ const SWARM_MAX_ESTABLISHED_OUTGOING_CONNECTIONS: u32 = 100;
 const SWARM_MAX_PENDING_INCOMING_CONNECTIONS: u32 = 80;
 /// The default maximum pending incoming connection number for the swarm.
 const SWARM_MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 80;
-// The default maximum connection number to be maintained for the swarm.
-const SWARM_TARGET_CONNECTION_NUMBER: u32 = 25;
 const KADEMLIA_QUERY_TIMEOUT: Duration = Duration::from_secs(40);
 const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: Option<u32> = Some(3);
 // TODO: Consider moving this constant to configuration or removing `Toggle` wrapper when we find a
-// use-case for gossipsub protocol.
+//  use-case for gossipsub protocol.
 const ENABLE_GOSSIP_PROTOCOL: bool = false;
 
 const TEMPORARY_BANS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(10_000).expect("Not zero; qed");
@@ -236,15 +234,23 @@ pub struct Config<LocalRecordProvider> {
     /// Specifies a source for peer information. None disables the protocol.
     pub peer_info_provider: Option<PeerInfoProvider>,
     /// Defines whether we maintain a persistent connection for common peers.
-    /// None disables the protocol.
+    /// `None` (the default) disables the protocol.
     pub general_connected_peers_handler: Option<ConnectedPeersHandler>,
     /// Defines whether we maintain a persistent connection for special peers.
-    /// None disables the protocol.
+    /// `None` (the default) disables the protocol.
     pub special_connected_peers_handler: Option<ConnectedPeersHandler>,
-    /// Defines target total (in and out) connection number that should be maintained for general peers.
-    pub general_target_connections: u32,
-    /// Defines target total (in and out) connection number that should be maintained for special peers.
-    pub special_target_connections: u32,
+    /// Defines target total (in and out) connection number that should be maintained for general
+    /// peers (defaults to 0).
+    pub general_connected_peers_target: u32,
+    /// Defines target total (in and out) connection number that should be maintained for special
+    /// peers (defaults to 0).
+    pub special_connected_peers_target: u32,
+    /// Defines max total (in and out) connection number that should be maintained for general
+    /// peers (defaults to 0, will be automatically raised if set lower than target).
+    pub general_connected_peers_limit: u32,
+    /// Defines max total (in and out) connection number that should be maintained for special
+    /// peers (defaults to 0, will be automatically raised if set lower than target).
+    pub special_connected_peers_limit: u32,
     /// Addresses to bootstrap Kademlia network
     pub bootstrap_addresses: Vec<Multiaddr>,
     /// Kademlia mode. The default value is set to Static(Client). The peer won't add its address
@@ -367,11 +373,13 @@ where
             metrics: None,
             protocol_version,
             peer_info_provider,
-            // we don't need to keep additional connections by default
+            // Don't need to keep additional connections by default
             general_connected_peers_handler: None,
             special_connected_peers_handler: None,
-            general_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
-            special_target_connections: SWARM_TARGET_CONNECTION_NUMBER,
+            general_connected_peers_target: 0,
+            special_connected_peers_target: 0,
+            general_connected_peers_limit: 0,
+            special_connected_peers_limit: 0,
             bootstrap_addresses: Vec::new(),
             kademlia_mode: KademliaMode::Static(Mode::Client),
             external_addresses: Vec::new(),
@@ -434,8 +442,10 @@ where
         peer_info_provider,
         general_connected_peers_handler: general_connection_decision_handler,
         special_connected_peers_handler: special_connection_decision_handler,
-        general_target_connections,
-        special_target_connections,
+        general_connected_peers_target,
+        special_connected_peers_target,
+        general_connected_peers_limit,
+        special_connected_peers_limit,
         bootstrap_addresses,
         kademlia_mode,
         external_addresses,
@@ -490,14 +500,18 @@ where
         general_connected_peers_config: general_connection_decision_handler.as_ref().map(|_| {
             ConnectedPeersConfig {
                 log_target: GENERAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
-                target_connected_peers: general_target_connections,
+                target_connected_peers: general_connected_peers_target,
+                max_connected_peers: general_connected_peers_limit
+                    .max(general_connected_peers_target),
                 ..ConnectedPeersConfig::default()
             }
         }),
         special_connected_peers_config: special_connection_decision_handler.as_ref().map(|_| {
             ConnectedPeersConfig {
                 log_target: SPECIAL_CONNECTED_PEERS_PROTOCOL_LOG_TARGET,
-                target_connected_peers: special_target_connections,
+                target_connected_peers: special_connected_peers_target,
+                max_connected_peers: special_connected_peers_limit
+                    .max(special_connected_peers_target),
                 ..ConnectedPeersConfig::default()
             }
         }),

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -259,7 +259,7 @@ pub struct Cli {
     pub dsn_pending_out_connections: u32,
 
     /// Defines target total (in and out) connection number for DSN that should be maintained.
-    #[arg(long, default_value_t = 25)]
+    #[arg(long, default_value_t = 15)]
     pub dsn_target_connections: u32,
 
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -186,9 +186,7 @@ where
         general_connected_peers_handler: Some(Arc::new(|_| true)),
         bootstrap_addresses: dsn_config.bootstrap_nodes,
         external_addresses: dsn_config.external_addresses,
-        kademlia_mode: KademliaMode::Dynamic {
-            initial_mode: Mode::Client,
-        },
+        kademlia_mode: KademliaMode::Static(Mode::Client),
         metrics,
         disable_bootstrap_on_start: dsn_config.disable_bootstrap_on_start,
 

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -179,11 +179,13 @@ where
         max_established_outgoing_connections: dsn_config.max_out_connections,
         max_pending_incoming_connections: dsn_config.max_pending_in_connections,
         max_pending_outgoing_connections: dsn_config.max_pending_out_connections,
-        general_target_connections: dsn_config.target_connections,
-        special_target_connections: 0,
-        reserved_peers: dsn_config.reserved_peers,
-        // maintain permanent connections with any peer
+        // Maintain proactive connections with all peers
         general_connected_peers_handler: Some(Arc::new(|_| true)),
+        general_connected_peers_target: dsn_config.target_connections,
+        // Allow to maintain some extra general connections beyond direct interest too
+        general_connected_peers_limit: dsn_config.target_connections
+            + dsn_config.max_in_connections / 4,
+        reserved_peers: dsn_config.reserved_peers,
         bootstrap_addresses: dsn_config.bootstrap_nodes,
         external_addresses: dsn_config.external_addresses,
         kademlia_mode: KademliaMode::Static(Mode::Client),


### PR DESCRIPTION
First commit here reverts https://github.com/subspace/subspace/pull/2221 as unnecessary and a bit harmful.

Second commit changes connected peers implementation to separate target and limit.

Node will try to maintain target number of connected peers (which was decreased to 15 for both node and farmer), while allowing some more connections to be maintained on top of that as a function of incoming connections limit.

Default numbers for target number of connected peers were set to 0 just like handlers are set to `None`.

Third commit allows bootstrap node to maintain some active connections rather than allowing all connections to potentially drop and bring bootstrap node offline.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
