### PR TITLE
Downgrade annoying domain logs and add slow log for domain block derivation

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1285,6 +1285,7 @@ mod pallet {
                             BundleError::Receipt(BlockTreeError::InFutureReceipt)
                             | BundleError::Receipt(BlockTreeError::StaleReceipt)
                             | BundleError::Receipt(BlockTreeError::NewBranchReceipt)
+                            | BundleError::Receipt(BlockTreeError::UnavailableConsensusBlockHash)
                             | BundleError::Receipt(BlockTreeError::BuiltOnUnknownConsensusBlock) => {
                                 log::debug!(
                                     target: "runtime::domains",

--- a/domains/client/domain-operator/src/bundle_processor.rs
+++ b/domains/client/domain-operator/src/bundle_processor.rs
@@ -26,7 +26,9 @@ use std::time::Instant;
 // The slow log threshold for consensus block preprocessing
 const SLOW_PREPROCESS_MILLIS: u64 = 500;
 
-// The slow log threshold for domain block execution: `reference_duration_ms * 1.2 + 200ms`
+// The slow log threshold for domain block execution: `reference_duration_ms * 1.2 + 200ms`,
+// where `reference_duration_ms * 0.2` as buffer of the slow extrinsic execution (i.e. slower
+// machine than the reference machine) and 200ms as buffer of the rest of the processing.
 fn slow_domain_block_execution_threshold(reference_duration_ms: u64) -> u64 {
     reference_duration_ms + (reference_duration_ms / 5) + 200
 }

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -150,6 +150,7 @@ where
             domain_confirmation_depth: params.domain_confirmation_depth,
             block_import: params.block_import,
             import_notification_sinks: Default::default(),
+            consensus_network_sync_oracle: params.consensus_network_sync_oracle.clone(),
         };
 
         let receipts_checker = ReceiptsChecker {

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -237,6 +237,7 @@ async fn test_processing_empty_consensus_block() {
         domain_confirmation_depth: 256u32,
         block_import: SharedBlockImport::new(alice.client.clone()),
         import_notification_sinks: Default::default(),
+        consensus_network_sync_oracle: ferdie.sync_service.clone(),
     };
 
     let domain_genesis_hash = alice.client.info().best_hash;

--- a/domains/client/relayer/src/worker.rs
+++ b/domains/client/relayer/src/worker.rs
@@ -158,14 +158,14 @@ where
     while let Some(block) = chain_block_import.next().await {
         // if the client is in major sync, wait until sync is complete
         if sync_oracle.is_major_syncing() {
-            tracing::info!(target: LOG_TARGET, "Client is in major sync. Skipping...");
+            tracing::debug!(target: LOG_TARGET, "Client is in major sync. Skipping...");
             continue;
         }
 
         let relay_block_until = match block.header.number().checked_sub(&relay_confirmation_depth) {
             None => {
                 // not enough confirmed blocks.
-                tracing::info!(
+                tracing::debug!(
                     target: LOG_TARGET,
                     "Not enough confirmed blocks for domain: {:?}. Skipping...",
                     chain_id
@@ -183,7 +183,7 @@ where
                 .collect();
 
         for (number, hash) in blocks_to_process {
-            tracing::info!(
+            tracing::debug!(
                 target: LOG_TARGET,
                 "Checking messages to be submitted from chain: {chain_id:?} at block: ({number:?}, {hash:?})",
             );
@@ -193,7 +193,7 @@ where
             // mark this block processed and continue to next one.
             if !can_relay_message_from_block(chain_id, number)? {
                 Relayer::store_relayed_block(&client, chain_id, number, hash)?;
-                tracing::info!(
+                tracing::debug!(
                     target: LOG_TARGET,
                     "Chain({chain_id:?}) messages in the Block ({number:?}, {hash:?}) cannot be relayed. Skipping...",
                 );
@@ -201,7 +201,7 @@ where
                 match message_processor(&client, hash) {
                     Ok(_) => {
                         Relayer::store_relayed_block(&client, chain_id, number, hash)?;
-                        tracing::info!(
+                        tracing::debug!(
                             target: LOG_TARGET,
                             "Messages from {chain_id:?} at block({number:?}, {hash:?}) are processed."
                         )
@@ -209,7 +209,7 @@ where
                     Err(err) => {
                         match err {
                             Error::DomainNonConfirmedOnConsensusChain => {
-                                tracing::info!(
+                                tracing::debug!(
                                     target: LOG_TARGET,
                                     "Waiting for Domain[{chain_id:?}] block({number:?}, {hash:?}) to be confirmed on Consensus chain."
                                 )

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -435,7 +435,7 @@ where
             COnRuntimeUpgrade,
         >::apply_extrinsic(uxt);
         // TODO: Critical!!! https://github.com/paritytech/substrate/pull/10922#issuecomment-1068997467
-        log::info!(
+        log::debug!(
             target: "domain::runtime::executive",
             "[apply_extrinsic] after: {:?}",
             {

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -219,5 +219,9 @@ sp_api::decl_runtime_apis! {
 
         /// Return the block digest
         fn block_digest() -> Digest;
+
+        /// Return the consumed weight of the block
+        #[api_version(2)]
+        fn block_weight() -> Weight;
     }
 }

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -843,6 +843,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[api_version(2)]
     impl domain_runtime_primitives::DomainCoreApi<Block> for Runtime {
         fn extract_signer(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
@@ -962,6 +963,10 @@ impl_runtime_apis! {
 
         fn block_digest() -> Digest {
             System::digest()
+        }
+
+        fn block_weight() -> Weight {
+            System::block_weight().total()
         }
     }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -833,6 +833,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[api_version(2)]
     impl domain_runtime_primitives::DomainCoreApi<Block> for Runtime {
         fn extract_signer(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
@@ -950,6 +951,10 @@ impl_runtime_apis! {
 
         fn block_digest() -> Digest {
             System::digest()
+        }
+
+        fn block_weight() -> Weight {
+            System::block_weight().total()
         }
     }
 


### PR DESCRIPTION
This PR includes changes of:
- Downgrade the relayer log from `info` to `debug`
    - Most of the relayer log are expected, only the error log is keep
- Downgrade the `apply_extrinsic` log to `debug`, **NOTE:** this requires a domain runtime upgrade to take effect since the log is inside the domain runtime
- Use `NetworkInitialSync` as the domain block origin when the consensus chain is in major sync
    - This is used to avoid printing `✨ Imported #xx` when the chain is in major sync
    - This log is provided by upstream and will print for every notification from `import_notification_stream`, using `NetworkInitialSync` will avoid sending notification to this stream
    - There are 2 consumers in our usage, the relayer and the `frontier-mapping-sync-worker`, both should be fine with this change cc @vedhavyas 
- Add a slow log for domain block derivation, which will print if the derivation take longer than 2500ms (2000ms for domain block execution and 500ms for the consensus block preprocessing)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
