### PR TITLE
Add `force_staking_epoch_transition` call to pallet-domains

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -746,6 +746,10 @@ mod pallet {
             domain_id: DomainId,
             completed_epoch_index: EpochIndex,
         },
+        ForceDomainEpochTransition {
+            domain_id: DomainId,
+            completed_epoch_index: EpochIndex,
+        },
         FraudProofProcessed {
             domain_id: DomainId,
             new_head_receipt_number: Option<DomainBlockNumberFor<T>>,
@@ -1182,7 +1186,7 @@ mod pallet {
             )
             .map_err(Error::<T>::from)?;
 
-            Self::deposit_event(Event::DomainEpochCompleted {
+            Self::deposit_event(Event::ForceDomainEpochTransition {
                 domain_id,
                 completed_epoch_index,
             });


### PR DESCRIPTION
close #2215 

This PR adds the `force_staking_epoch_transition` call to pallet-domains, which will trigger epoch transition immediately for a given domain.

For regular epoch transition, it requires `StakeEpochDuration` number of domain blocks to trigger, we don't trigger epoch transition for every domain block mainly because we don't want to change the stake distribution frequently which will cause unstable bundle production (i.e. some node may use a stale stake distribution to produce illegal bundle or skip producing bundle). Besides that, it is okay to trigger epoch transition on an arbitrary domain block, since epoch transition just finalizes pending staking operation, and it is helpful to handle case mentioned at #2215.

cc @jfrank-summit 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
