### PR TITLE
Do not add observed addresses manually, we have autonat for this

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -593,7 +593,6 @@ where
             special_connection_decision_handler,
             bootstrap_addresses,
             kademlia_mode,
-            external_addresses,
             disable_bootstrap_on_start,
         });
 

--- a/crates/subspace-networking/src/utils.rs
+++ b/crates/subspace-networking/src/utils.rs
@@ -50,15 +50,6 @@ impl<T> Future for AsyncJoinOnDrop<T> {
     }
 }
 
-/// This test is successful only for global IP addresses.
-pub(crate) fn is_global_address(addr: &Multiaddr) -> bool {
-    match addr.iter().next() {
-        Some(Protocol::Ip4(ip)) => ip.is_global(),
-        Some(Protocol::Ip6(ip)) => ip.is_global(),
-        _ => false,
-    }
-}
-
 /// This test is successful only for global IP addresses and DNS names.
 pub(crate) fn is_global_address_or_dns(addr: &Multiaddr) -> bool {
     match addr.iter().next() {


### PR DESCRIPTION
`Identify` already fires candidates as events and `Autonat` already attempts to confirm candidates and add to addresses if confirmation is successful. The code we had there is unnecessary and potentially problematic.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
