### PR TITLE
Fast node restart after upgrade

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -783,6 +783,7 @@ where
         None,
         Box::pin({
             let sync_service = sync_service.clone();
+            let sync_target_block_number = Arc::clone(&sync_target_block_number);
 
             async move {
                 loop {
@@ -832,6 +833,7 @@ where
             node.clone(),
             Arc::clone(&client),
             import_queue_service,
+            sync_target_block_number,
             sync_mode,
             subspace_link.kzg().clone(),
         );


### PR DESCRIPTION
During upgrade nodes are just a few blocks behind the tip. Yes, DSN sync should and will work quickly, but it is actually unnecessary to trigger it if node is not far from the tip anyway.

This massively improves upgrade user experience since node will start and become synced very quickly.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
