### PR TITLE
Subspace v2 network partition

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -334,7 +334,7 @@ where
                 .expect("Default config for gossipsub is always correct; qed")
         });
 
-        let protocol_version = format!("/subspace/{}", protocol_version);
+        let protocol_version = format!("/subspace-v2/{}", protocol_version);
         let identify = IdentifyConfig::new(protocol_version.clone(), keypair.public());
 
         let temporary_ban_backoff = ExponentialBackoff {

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -334,7 +334,7 @@ where
                 .expect("Default config for gossipsub is always correct; qed")
         });
 
-        let protocol_version = format!("/subspace-v2/{}", protocol_version);
+        let protocol_version = format!("/subspace/2/{}", protocol_version);
         let identify = IdentifyConfig::new(protocol_version.clone(), keypair.public());
 
         let temporary_ban_backoff = ExponentialBackoff {

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -706,6 +706,10 @@ where
 
             // Remove temporary ban if there was any
             self.temporary_bans.lock().remove(&peer_id);
+            // Forget about this peer until they upgrade
+            self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
+            self.networking_parameters_registry
+                .remove_all_known_peer_addresses(peer_id);
 
             if info.listen_addrs.len() > 30 {
                 debug!(

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -707,6 +707,7 @@ where
             // Remove temporary ban if there was any
             self.temporary_bans.lock().remove(&peer_id);
             // Forget about this peer until they upgrade
+            let _ = self.swarm.disconnect_peer_id(peer_id);
             self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
             self.networking_parameters_registry
                 .remove_all_known_peer_addresses(peer_id);

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -700,17 +700,17 @@ where
                 );
 
                 self.temporary_bans.lock().create_or_extend(&peer_id);
+                // Forget about this peer until they upgrade
+                let _ = self.swarm.disconnect_peer_id(peer_id);
+                self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
+                self.networking_parameters_registry
+                    .remove_all_known_peer_addresses(peer_id);
 
                 return;
             }
 
             // Remove temporary ban if there was any
             self.temporary_bans.lock().remove(&peer_id);
-            // Forget about this peer until they upgrade
-            let _ = self.swarm.disconnect_peer_id(peer_id);
-            self.swarm.behaviour_mut().kademlia.remove_peer(&peer_id);
-            self.networking_parameters_registry
-                .remove_all_known_peer_addresses(peer_id);
 
             if info.listen_addrs.len() > 30 {
                 debug!(

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -462,9 +462,6 @@ where
                     }
                 };
 
-                // Remove temporary ban if there was any
-                self.temporary_bans.lock().remove(&peer_id);
-
                 let shared = match self.shared_weak.upgrade() {
                     Some(shared) => shared,
                     None => {
@@ -690,21 +687,25 @@ where
         let local_peer_id = *self.swarm.local_peer_id();
 
         if let IdentifyEvent::Received { peer_id, mut info } = event {
-            debug!(?peer_id, protocols=?info.protocols, "IdentifyEvent::Received");
+            debug!(?peer_id, protocols = ?info.protocols, "IdentifyEvent::Received");
 
             // Check for network partition
             if info.protocol_version != self.protocol_version {
                 debug!(
                     %local_peer_id,
                     %peer_id,
-                    local_protocol_version=%self.protocol_version,
-                    peer_protocol_version=%info.protocol_version,
-                    "Peer has different protocol version. Peer was banned.",
+                    local_protocol_version = %self.protocol_version,
+                    peer_protocol_version = %info.protocol_version,
+                    "Peer has different protocol version, banning temporarily",
                 );
 
-                self.ban_peer(peer_id);
+                self.temporary_bans.lock().create_or_extend(&peer_id);
+
                 return;
             }
+
+            // Remove temporary ban if there was any
+            self.temporary_bans.lock().remove(&peer_id);
 
             if info.listen_addrs.len() > 30 {
                 debug!(


### PR DESCRIPTION
This will partition network participants that upgraded from those who did not. In order to allow those who didn't upgrade to join the network later after upgrade we replace permanent ban due to protocol version mismatch with temporary ban.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
