### PR TITLE
Networking tweaks

### DIFF
--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -15,11 +15,12 @@ use crate::protocols::request_response::request_response_factory::{
 use crate::protocols::reserved_peers::{
     Behaviour as ReservedPeersBehaviour, Config as ReservedPeersConfig, Event as ReservedPeersEvent,
 };
+use crate::protocols::subspace_connection_limits::Behaviour as ConnectionLimitsBehaviour;
 use crate::PeerInfoProvider;
 use derive_more::From;
 use libp2p::allow_block_list::{Behaviour as AllowBlockListBehaviour, BlockedPeers};
 use libp2p::autonat::{Behaviour as Autonat, Config as AutonatConfig, Event as AutonatEvent};
-use libp2p::connection_limits::{Behaviour as ConnectionLimitsBehaviour, ConnectionLimits};
+use libp2p::connection_limits::ConnectionLimits;
 use libp2p::gossipsub::{
     Behaviour as Gossipsub, Config as GossipsubConfig, Event as GossipsubEvent, MessageAuthenticity,
 };

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -47,7 +47,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 use tokio::time::Sleep;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 // Defines a batch size for peer addresses from Kademlia buckets.
 const KADEMLIA_PEERS_ADDRESSES_BATCH_SIZE: usize = 20;
@@ -605,13 +605,13 @@ where
                 trace!(%address, "External address candidate");
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {
-                info!(%address, "Confirmed external address");
+                debug!(%address, "Confirmed external address");
 
                 let connected_peers = self.swarm.connected_peers().copied().collect::<Vec<_>>();
                 self.swarm.behaviour_mut().identify.push(connected_peers);
             }
             SwarmEvent::ExternalAddrExpired { address } => {
-                info!(%address, "External address expired");
+                debug!(%address, "External address expired");
 
                 let connected_peers = self.swarm.connected_peers().copied().collect::<Vec<_>>();
                 self.swarm.behaviour_mut().identify.push(connected_peers);
@@ -1188,7 +1188,7 @@ where
         }
 
         if let AutonatEvent::StatusChanged { old, new } = event {
-            info!(?old, ?new, "Public address status changed.");
+            debug!(?old, ?new, "Public address status changed.");
 
             // TODO: Remove block once https://github.com/libp2p/rust-libp2p/issues/4863 is resolved
             if let (NatStatus::Public(old_address), NatStatus::Private) = (old, new) {

--- a/crates/subspace-networking/src/protocols.rs
+++ b/crates/subspace-networking/src/protocols.rs
@@ -2,3 +2,4 @@ pub(crate) mod connected_peers;
 pub mod peer_info;
 pub mod request_response;
 pub(crate) mod reserved_peers;
+pub(crate) mod subspace_connection_limits;

--- a/crates/subspace-networking/src/protocols/subspace_connection_limits.rs
+++ b/crates/subspace-networking/src/protocols/subspace_connection_limits.rs
@@ -14,7 +14,11 @@ use std::task::{Context, Poll};
 // TODO: Upstream these capabilities
 pub(crate) struct Behaviour {
     inner: ConnectionLimitsBehaviour,
+    /// For every peer ID store both their expected IP addresses as well as number of incoming connection attempts
+    /// allowed before this allow list entry no longer has an effect
     incoming_allow_list: HashMap<PeerId, (HashSet<IpAddr>, usize)>,
+    /// For every peer ID store number of outgoing connection attempts allowed before this allow list entry no longer
+    /// has an effect
     outgoing_allow_list: HashMap<PeerId, usize>,
 }
 
@@ -64,37 +68,6 @@ impl Behaviour {
             }
         } else {
             self.incoming_allow_list.remove(peer);
-        }
-    }
-
-    /// Add to allow list some attempts of outgoing connections from specified peer ID that will bypass global limits
-    // TODO: Not using for now, but will be helpful upstream
-    #[allow(dead_code)]
-    pub(crate) fn add_to_outgoing_allow_list(&mut self, peer: PeerId, attempts: usize) {
-        self.outgoing_allow_list
-            .entry(peer)
-            .and_modify(|entry| *entry = entry.saturating_add(attempts))
-            .or_insert(attempts);
-    }
-
-    /// Remove some (or all) attempts of outgoing connections from specified peer ID
-    // TODO: Not using for now, but will be helpful upstream
-    #[allow(dead_code)]
-    pub(crate) fn remove_from_outgoing_allow_list(
-        &mut self,
-        peer: &PeerId,
-        remove_attempts: Option<usize>,
-    ) {
-        if let Some(remove_attempts) = remove_attempts {
-            if let Some(attempts) = self.outgoing_allow_list.get_mut(peer) {
-                *attempts = attempts.saturating_sub(remove_attempts);
-
-                if *attempts == 0 {
-                    self.outgoing_allow_list.remove(peer);
-                }
-            }
-        } else {
-            self.outgoing_allow_list.remove(peer);
         }
     }
 }

--- a/crates/subspace-networking/src/protocols/subspace_connection_limits.rs
+++ b/crates/subspace-networking/src/protocols/subspace_connection_limits.rs
@@ -1,0 +1,200 @@
+use libp2p::connection_limits::{Behaviour as ConnectionLimitsBehaviour, ConnectionLimits};
+use libp2p::core::Endpoint;
+use libp2p::multiaddr::Protocol;
+use libp2p::swarm::{
+    ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
+    THandlerOutEvent, ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
+use std::collections::HashMap;
+use std::task::{Context, Poll};
+
+// TODO: Upstream these capabilities
+pub(crate) struct Behaviour {
+    inner: ConnectionLimitsBehaviour,
+    incoming_allow_list: HashMap<PeerId, usize>,
+    outgoing_allow_list: HashMap<PeerId, usize>,
+}
+
+impl Behaviour {
+    pub(crate) fn new(limits: ConnectionLimits) -> Self {
+        Self {
+            inner: ConnectionLimitsBehaviour::new(limits),
+            incoming_allow_list: HashMap::default(),
+            outgoing_allow_list: HashMap::default(),
+        }
+    }
+
+    /// Add to allow list some attempts of incoming connections from specified peer ID that will bypass global limits
+    pub(crate) fn add_to_incoming_allow_list(&mut self, peer: PeerId, attempts: usize) {
+        self.incoming_allow_list
+            .entry(peer)
+            .and_modify(|entry| *entry = entry.saturating_add(attempts))
+            .or_insert(attempts);
+    }
+
+    /// Remove some (or all) attempts of incoming connections from specified peer ID
+    pub(crate) fn remove_from_incoming_allow_list(
+        &mut self,
+        peer: &PeerId,
+        remove_attempts: Option<usize>,
+    ) {
+        if let Some(remove_attempts) = remove_attempts {
+            if let Some(attempts) = self.incoming_allow_list.get_mut(peer) {
+                *attempts = attempts.saturating_sub(remove_attempts);
+
+                if *attempts == 0 {
+                    self.incoming_allow_list.remove(peer);
+                }
+            }
+        } else {
+            self.incoming_allow_list.remove(peer);
+        }
+    }
+
+    /// Add to allow list some attempts of outgoing connections from specified peer ID that will bypass global limits
+    // TODO: Not using for now, but will be helpful upstream
+    #[allow(dead_code)]
+    pub(crate) fn add_to_outgoing_allow_list(&mut self, peer: PeerId, attempts: usize) {
+        self.outgoing_allow_list
+            .entry(peer)
+            .and_modify(|entry| *entry = entry.saturating_add(attempts))
+            .or_insert(attempts);
+    }
+
+    /// Remove some (or all) attempts of outgoing connections from specified peer ID
+    // TODO: Not using for now, but will be helpful upstream
+    #[allow(dead_code)]
+    pub(crate) fn remove_from_outgoing_allow_list(
+        &mut self,
+        peer: &PeerId,
+        remove_attempts: Option<usize>,
+    ) {
+        if let Some(remove_attempts) = remove_attempts {
+            if let Some(attempts) = self.outgoing_allow_list.get_mut(peer) {
+                *attempts = attempts.saturating_sub(remove_attempts);
+
+                if *attempts == 0 {
+                    self.outgoing_allow_list.remove(peer);
+                }
+            }
+        } else {
+            self.outgoing_allow_list.remove(peer);
+        }
+    }
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = <ConnectionLimitsBehaviour as NetworkBehaviour>::ConnectionHandler;
+    type ToSwarm = <ConnectionLimitsBehaviour as NetworkBehaviour>::ToSwarm;
+
+    fn handle_pending_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<(), ConnectionDenied> {
+        if let Some(peer) = remote_addr.iter().find_map(|protocol| {
+            if let Protocol::P2p(peer) = protocol {
+                Some(peer)
+            } else {
+                None
+            }
+        }) {
+            if self.incoming_allow_list.contains_key(&peer) {
+                return Ok(());
+            }
+        }
+
+        self.inner
+            .handle_pending_inbound_connection(connection_id, local_addr, remote_addr)
+    }
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        if let Some(attempts) = self.incoming_allow_list.get_mut(&peer) {
+            *attempts -= 1;
+
+            if *attempts == 0 {
+                self.incoming_allow_list.remove(&peer);
+            }
+
+            return Ok(Self::ConnectionHandler {});
+        }
+
+        self.inner.handle_established_inbound_connection(
+            connection_id,
+            peer,
+            local_addr,
+            remote_addr,
+        )
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        maybe_peer: Option<PeerId>,
+        addresses: &[Multiaddr],
+        effective_role: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        if let Some(peer) = &maybe_peer {
+            if self.incoming_allow_list.contains_key(peer) {
+                return Ok(Vec::new());
+            }
+        }
+
+        self.inner.handle_pending_outbound_connection(
+            connection_id,
+            maybe_peer,
+            addresses,
+            effective_role,
+        )
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        addr: &Multiaddr,
+        role_override: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        if let Some(attempts) = self.outgoing_allow_list.get_mut(&peer) {
+            *attempts -= 1;
+
+            if *attempts == 0 {
+                self.outgoing_allow_list.remove(&peer);
+            }
+
+            return Ok(Self::ConnectionHandler {});
+        }
+
+        self.inner
+            .handle_established_outbound_connection(connection_id, peer, addr, role_override)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        self.inner.on_swarm_event(event)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        id: PeerId,
+        connection_id: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        self.inner
+            .on_connection_handler_event(id, connection_id, event)
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        self.inner.poll(cx)
+    }
+}


### PR DESCRIPTION
First of all I decided to downgrade messages related to address status changes to debug level since users do not really care about them.

Then as discussed temporarily disable temporary bans for dial errors.

Lastly connection limits behaviour wrapper was added to allow adding exceptions for bypassing limits. It is written in a way that should be upstreamable.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
