### PR TITLE
Ensure the domain chain follow exactly the consensus chain's fork choice

### DIFF
--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -280,15 +280,11 @@ where
             bundles,
         } = preprocess_result;
 
-        // Although the domain block intuitively ought to use the same fork choice
-        // from the corresponding consensus block, it's fine to forcibly always use
-        // the longest chain for simplicity as we manually build the domain branches
-        // by following the consensus chain branches. Due to the possibility of domain
-        // branch transitioning to a lower fork caused by the change that a consensus block
-        // can possibility produce no domain block, it's important to note that now we
-        // need to ensure the consensus block built from the latest consensus block is the
-        // new best domain block after processing each imported consensus block.
-        let fork_choice = ForkChoiceStrategy::LongestChain;
+        // The fork choice of the domain chain should follow exactly as the consensus chain,
+        // so always use `Custom(false)` here to not set the domain block as new best block
+        // immediately, and if the domain block is indeed derive from the best consensus fork,
+        // it will be reset as the best domain block, see `BundleProcessor::process_bundles`.
+        let fork_choice = ForkChoiceStrategy::Custom(false);
         let inherent_data = get_inherent_data::<_, _, Block>(
             self.consensus_client.clone(),
             consensus_block_hash,

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -207,6 +207,14 @@ where
             .consensus_client
             .runtime_api()
             .head_receipt_number(consensus_chain_block_hash, self.domain_id)?;
+
+        // TODO: the `receipt_number` may not be the best domain block number if there
+        // is fraud proof submitted and bad ERs pruned, thus the ER may not the one that
+        // derive from the latest domain block, which may cause the lagging operator able
+        // to submit invalid bundle accidentally.
+        //
+        // We need to resolve `https://github.com/subspace/subspace/issues/1673` to fix it
+        // completely.
         let receipt_number = (head_receipt_number + One::one()).min(header_number);
 
         tracing::trace!(


### PR DESCRIPTION
In main we are using `ForkChoiceStrategy::LongestChain` when first importing the domain block and only reset the best domain fork later if we find the domain block is derived from the new best consensus block. 

This causes an issue that if the current best consensus block is fork A #n-a, and then a stale block with the same height in fork B #n-b is imported and derives a domain block which makes the domain fork B become the longest chain and hence the best fork. While the best consensus fork is A, the best domain fork is now B.

This PR fix the issue by replacing `ForkChoiceStrategy::LongestChain` with `ForkChoiceStrategy::Custom(false)`, thus whether the new domain block is the best block or not is totally control by the new consensus block, if it is the new best consensus block then the domain block will be reset to new best block in:
https://github.com/subspace/subspace/blob/e9af82fbe533af3f648d4c4773a00e3b04257850/domains/client/domain-operator/src/bundle_processor.rs#L221-L237

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
