### PR TITLE
Restore removal of old addresses

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -733,34 +733,22 @@ where
             });
 
             if full_kademlia_support {
-                //TODO: Consider restoring obsolete address removal
-                // let old_addresses = kademlia
-                //     .kbucket(peer_id)
-                //     .and_then(|peers| {
-                //         let key = peer_id.into();
-                //         peers.iter().find_map(|peer| {
-                //             (peer.node.key == &key).then_some(
-                //                 peer.node
-                //                     .value
-                //                     .iter()
-                //                     .filter(|address| info.listen_addrs.contains(address))
-                //                     .cloned()
-                //                     .collect::<Vec<_>>(),
-                //             )
-                //         })
-                //     })
-                //     .unwrap_or_default();
-
-                // for old_address in old_addresses {
-                //     trace!(
-                //         %local_peer_id,
-                //         %peer_id,
-                //         %old_address,
-                //         "Removing old self-reported address from Kademlia DHT",
-                //     );
-                //
-                //     kademlia.remove_address(&peer_id, &old_address);
-                // }
+                let old_addresses = kademlia
+                    .kbucket(peer_id)
+                    .and_then(|peers| {
+                        let key = peer_id.into();
+                        peers.iter().find_map(|peer| {
+                            (peer.node.key == &key).then_some(
+                                peer.node
+                                    .value
+                                    .iter()
+                                    .filter(|address| !info.listen_addrs.contains(address))
+                                    .cloned()
+                                    .collect::<Vec<_>>(),
+                            )
+                        })
+                    })
+                    .unwrap_or_default();
 
                 for address in info.listen_addrs {
                     if !self.allow_non_global_addresses_in_dht
@@ -784,6 +772,17 @@ where
                     );
 
                     kademlia.add_address(&peer_id, address);
+                }
+
+                for old_address in old_addresses {
+                    trace!(
+                        %local_peer_id,
+                        %peer_id,
+                        %old_address,
+                        "Removing old self-reported address from Kademlia DHT",
+                    );
+
+                    kademlia.remove_address(&peer_id, &old_address);
                 }
             } else {
                 debug!(

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -733,6 +733,11 @@ where
             });
 
             if full_kademlia_support {
+                let received_address_strings = info
+                    .listen_addrs
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>();
                 let old_addresses = kademlia
                     .kbucket(peer_id)
                     .and_then(|peers| {
@@ -742,7 +747,14 @@ where
                                 peer.node
                                     .value
                                     .iter()
-                                    .filter(|address| !info.listen_addrs.contains(address))
+                                    .filter(|existing_address| {
+                                        let existing_address = existing_address.to_string();
+
+                                        !received_address_strings.iter().any(|received_address| {
+                                            received_address.starts_with(&existing_address)
+                                                || existing_address.starts_with(received_address)
+                                        })
+                                    })
                                     .cloned()
                                     .collect::<Vec<_>>(),
                             )


### PR DESCRIPTION
I was supposed to restore it before merging https://github.com/subspace/subspace/pull/2242.
Restored version has filtering condition flipped (that was a bug in the old version that had to be corrected).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
