### PR TITLE
Introduce `operator_id` cli arg that replaces `operator` arg.

### DIFF
--- a/crates/sp-domains/src/bundle_producer_election.rs
+++ b/crates/sp-domains/src/bundle_producer_election.rs
@@ -54,6 +54,9 @@ pub fn is_below_threshold(vrf_output: &VrfOutput, threshold: u128) -> bool {
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct BundleProducerElectionParams<Balance> {
+    // TODO: current operators is not required anymore.
+    //  This is not removed right now in order to not break runtime api with new version
+    //  marking a todo to remove it before next network.
     pub current_operators: Vec<OperatorId>,
     pub total_domain_stake: Balance,
     pub bundle_slot_probability: (u64, u64),

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -29,7 +29,7 @@ use sc_service::{BasePath, Configuration};
 use sp_blockchain::HeaderBackend;
 use sp_domain_digests::AsPredigest;
 use sp_domains::storage::RawGenesis;
-use sp_domains::DomainId;
+use sp_domains::{DomainId, OperatorId};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::Header;
 use sp_runtime::{BuildStorage, DigestItem};
@@ -64,6 +64,10 @@ fn parse_domain_id(s: &str) -> std::result::Result<DomainId, ParseIntError> {
     s.parse::<u32>().map(Into::into)
 }
 
+fn parse_operator_id(s: &str) -> std::result::Result<OperatorId, ParseIntError> {
+    s.parse::<u64>().map(Into::into)
+}
+
 #[derive(Debug, Parser)]
 pub struct DomainCli {
     /// Run a domain node.
@@ -73,9 +77,9 @@ pub struct DomainCli {
     #[clap(long, value_parser = parse_domain_id)]
     pub domain_id: DomainId,
 
-    /// Run the node as an Operator
-    #[arg(long, conflicts_with = "validator")]
-    pub operator: bool,
+    /// Use provider operator id to submit bundles.
+    #[arg(long, value_parser = parse_operator_id)]
+    pub operator_id: Option<OperatorId>,
 
     /// Additional args for domain.
     #[clap(raw = true)]
@@ -214,9 +218,13 @@ impl CliConfiguration<Self> for DomainCli {
         self.run.chain_id(is_dev)
     }
 
-    fn role(&self, is_dev: bool) -> Result<sc_service::Role> {
-        // is authority when operator is enabled or in dev mode
-        let is_authority = self.operator || self.run.validator || is_dev;
+    fn role(&self, _is_dev: bool) -> Result<sc_service::Role> {
+        if self.run.validator {
+            log::warn!("use `--operator-id` argument to run as operator")
+        }
+
+        // is authority when operator_id is passed.
+        let is_authority = self.operator_id.is_some();
 
         Ok(if is_authority {
             Role::Authority

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -65,7 +65,7 @@ fn parse_domain_id(s: &str) -> std::result::Result<DomainId, ParseIntError> {
 }
 
 fn parse_operator_id(s: &str) -> std::result::Result<OperatorId, ParseIntError> {
-    s.parse::<u64>().map(Into::into)
+    s.parse::<u64>().map(OperatorId::from)
 }
 
 #[derive(Debug, Parser)]
@@ -220,7 +220,9 @@ impl CliConfiguration<Self> for DomainCli {
 
     fn role(&self, _is_dev: bool) -> Result<sc_service::Role> {
         if self.run.validator {
-            log::warn!("use `--operator-id` argument to run as operator")
+            return Err(sc_cli::Error::Input(
+                "use `--operator-id` argument to run as operator".to_string(),
+            ));
         }
 
         // is authority when operator_id is passed.

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -138,6 +138,7 @@ impl DomainInstanceStarter {
                     domain_message_receiver,
                     provider: eth_provider,
                     skip_empty_bundle_production: true,
+                    maybe_operator_id: domain_cli.operator_id,
                 };
 
                 let mut domain_node = domain_service::new_full::<

--- a/domains/client/domain-operator/src/bundle_producer_election_solver.rs
+++ b/domains/client/domain-operator/src/bundle_producer_election_solver.rs
@@ -113,6 +113,9 @@ where
                         return Ok(None);
                     }
                 }
+            } else {
+                log::warn!("Operator[{operator_id}] is not registered on the Runtime",);
+                return Ok(None);
             }
         }
 

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -9,8 +9,8 @@ use sp_api::{NumberFor, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HashAndNumber, HeaderBackend};
 use sp_domains::{
-    Bundle, BundleProducerElectionApi, DomainId, DomainsApi, OperatorPublicKey, OperatorSignature,
-    SealedBundleHeader,
+    Bundle, BundleProducerElectionApi, DomainId, DomainsApi, OperatorId, OperatorPublicKey,
+    OperatorSignature, SealedBundleHeader,
 };
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Zero};
@@ -34,6 +34,7 @@ where
     CBlock: BlockT,
 {
     domain_id: DomainId,
+    maybe_operator_id: Option<OperatorId>,
     consensus_client: Arc<CClient>,
     client: Arc<Client>,
     bundle_sender: Arc<BundleSender<Block, CBlock>>,
@@ -52,6 +53,7 @@ where
     fn clone(&self) -> Self {
         Self {
             domain_id: self.domain_id,
+            maybe_operator_id: self.maybe_operator_id,
             consensus_client: self.consensus_client.clone(),
             client: self.client.clone(),
             bundle_sender: self.bundle_sender.clone(),
@@ -79,6 +81,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         domain_id: DomainId,
+        maybe_operator_id: Option<OperatorId>,
         consensus_client: Arc<CClient>,
         client: Arc<Client>,
         domain_bundle_proposer: DomainBundleProposer<
@@ -98,6 +101,7 @@ where
         );
         Self {
             domain_id,
+            maybe_operator_id,
             consensus_client,
             client,
             bundle_sender,
@@ -146,6 +150,7 @@ where
                 slot,
                 consensus_block_info.hash,
                 self.domain_id,
+                self.maybe_operator_id,
                 global_randomness,
             )?
         {

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -119,7 +119,7 @@ pub(super) async fn start_worker<
         );
 
     if let Some(operator_id) = maybe_operator_id {
-        info!("🧑‍🌾 Running as Operator[{operator_id:?}]...");
+        info!("👷 Running as Operator[{operator_id}]...");
         let bundler_fn = {
             let span = span.clone();
             move |consensus_block_info: sp_blockchain::HashAndNumber<CBlock>, slot_info| {

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -31,7 +31,7 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_core::traits::{CodeExecutor, SpawnEssentialNamed};
 use sp_core::H256;
-use sp_domains::{BundleProducerElectionApi, DomainsApi};
+use sp_domains::{BundleProducerElectionApi, DomainsApi, OperatorId};
 use sp_domains_fraud_proof::FraudProofApi;
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
@@ -57,7 +57,7 @@ pub(super) async fn start_worker<
     spawn_essential: Box<dyn SpawnEssentialNamed>,
     consensus_client: Arc<CClient>,
     consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
-    is_authority: bool,
+    maybe_operator_id: Option<OperatorId>,
     bundle_producer: DomainBundleProducer<Block, CBlock, Client, CClient, TransactionPool>,
     bundle_processor: BundleProcessor<Block, CBlock, Client, CClient, Backend, E>,
     operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS, ASS>,
@@ -118,27 +118,8 @@ pub(super) async fn start_worker<
             consensus_block_import_throttling_buffer_size,
         );
 
-    if !is_authority {
-        info!("🧑‍ Running as Full node...");
-        drop(new_slot_notification_stream);
-        drop(acknowledgement_sender_stream);
-        while let Some(maybe_block_info) = throttled_block_import_notification_stream.next().await {
-            if let Some(block_info) = maybe_block_info {
-                if let Err(error) = bundle_processor
-                    .clone()
-                    .process_bundles((block_info.hash, block_info.number, block_info.is_new_best))
-                    .instrument(span.clone())
-                    .await
-                {
-                    tracing::error!(?error, "Failed to process consensus block");
-                    // Bring down the service as bundles processor is an essential task.
-                    // TODO: more graceful shutdown.
-                    break;
-                }
-            }
-        }
-    } else {
-        info!("🧑‍🌾 Running as Operator...");
+    if let Some(operator_id) = maybe_operator_id {
+        info!("🧑‍🌾 Running as Operator[{operator_id:?}]...");
         let bundler_fn = {
             let span = span.clone();
             move |consensus_block_info: sp_blockchain::HashAndNumber<CBlock>, slot_info| {
@@ -212,6 +193,25 @@ pub(super) async fn start_worker<
                             "Failed to send acknowledgement"
                         );
                     }
+                }
+            }
+        }
+    } else {
+        info!("🧑‍ Running as Full node...");
+        drop(new_slot_notification_stream);
+        drop(acknowledgement_sender_stream);
+        while let Some(maybe_block_info) = throttled_block_import_notification_stream.next().await {
+            if let Some(block_info) = maybe_block_info {
+                if let Err(error) = bundle_processor
+                    .clone()
+                    .process_bundles((block_info.hash, block_info.number, block_info.is_new_best))
+                    .instrument(span.clone())
+                    .await
+                {
+                    tracing::error!(?error, "Failed to process consensus block");
+                    // Bring down the service as bundles processor is an essential task.
+                    // TODO: more graceful shutdown.
+                    break;
                 }
             }
         }

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -90,7 +90,7 @@ use sp_blockchain::HeaderBackend;
 use sp_consensus::SyncOracle;
 use sp_consensus_slots::Slot;
 use sp_domain_digests::AsPredigest;
-use sp_domains::{Bundle, DomainId, ExecutionReceipt};
+use sp_domains::{Bundle, DomainId, ExecutionReceipt, OperatorId};
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_runtime::DigestItem;
@@ -169,7 +169,7 @@ pub struct OperatorParams<
     pub transaction_pool: Arc<TransactionPool>,
     pub backend: Arc<Backend>,
     pub code_executor: Arc<E>,
-    pub is_authority: bool,
+    pub maybe_operator_id: Option<OperatorId>,
     pub keystore: KeystorePtr,
     pub bundle_sender: Arc<BundleSender<Block, CBlock>>,
     pub operator_streams: OperatorStreams<CBlock, IBNS, CIBNS, NSNS, ASS>,

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -126,6 +126,7 @@ where
 
         let bundle_producer = DomainBundleProducer::new(
             params.domain_id,
+            params.maybe_operator_id,
             params.consensus_client.clone(),
             params.client.clone(),
             domain_bundle_proposer,
@@ -179,7 +180,7 @@ where
                 spawn_essential.clone(),
                 params.consensus_client.clone(),
                 params.consensus_offchain_tx_pool_factory.clone(),
-                params.is_authority,
+                params.maybe_operator_id,
                 bundle_producer,
                 bundle_processor.clone(),
                 params.operator_streams,

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -28,7 +28,7 @@ use sp_consensus::SyncOracle;
 use sp_consensus_slots::Slot;
 use sp_core::traits::SpawnEssentialNamed;
 use sp_core::{Decode, Encode};
-use sp_domains::{BundleProducerElectionApi, DomainId, DomainsApi};
+use sp_domains::{BundleProducerElectionApi, DomainId, DomainsApi, OperatorId};
 use sp_domains_fraud_proof::FraudProofApi;
 use sp_messenger::messages::ChainId;
 use sp_messenger::{MessengerApi, RelayerApi};
@@ -223,6 +223,7 @@ where
     pub domain_id: DomainId,
     pub domain_config: ServiceConfiguration,
     pub domain_created_at: NumberFor<CBlock>,
+    pub maybe_operator_id: Option<OperatorId>,
     pub consensus_client: Arc<CClient>,
     pub consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
     pub consensus_network_sync_oracle: Arc<dyn SyncOracle + Send + Sync>,
@@ -324,6 +325,7 @@ where
 {
     let DomainParams {
         domain_id,
+        maybe_operator_id,
         mut domain_config,
         domain_created_at,
         consensus_client,
@@ -450,7 +452,7 @@ where
             transaction_pool: transaction_pool.clone(),
             backend: backend.clone(),
             code_executor: code_executor.clone(),
-            is_authority,
+            maybe_operator_id,
             keystore: params.keystore_container.keystore(),
             bundle_sender: Arc::new(bundle_sender),
             operator_streams,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -221,6 +221,11 @@ where
             .xdm_gossip_worker_builder()
             .gossip_msg_sink();
 
+        let mut maybe_operator_id = None;
+        if role.is_authority() {
+            maybe_operator_id = Some(0)
+        }
+
         let domain_params = domain_service::DomainParams {
             domain_id,
             domain_config,
@@ -235,6 +240,7 @@ where
             domain_message_receiver,
             provider: DefaultProvider,
             skip_empty_bundle_production,
+            maybe_operator_id,
         };
 
         let domain_node = domain_service::new_full::<

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -221,10 +221,7 @@ where
             .xdm_gossip_worker_builder()
             .gossip_msg_sink();
 
-        let mut maybe_operator_id = None;
-        if role.is_authority() {
-            maybe_operator_id = Some(0)
-        }
+        let maybe_operator_id = role.is_authority().then_some(0);
 
         let domain_params = domain_service::DomainParams {
             domain_id,


### PR DESCRIPTION
This change is breaking latest release and all operators when running their operator should pass their operator_id through CLI. Any operator passing `validator` arg will be errored out to run the node with `operator_id`.

@EmilFattakhov we should update the operator documentation removing usage of `operator` argument with `operator-id` argument passing their operator id.

I'm not fully happy with this change yet. Right now, `Operator` service is also running receipt checker, fraud proof generator, bundle processor, and domain block importer along with Bundle Proposer and Bundle Producer. Ideally, these should be seperated out to two processes, where if `operator_id` is passed, only Bundle Proposer and Producer should run while all the full nodes and operator nodes should run the rest of the processes. This refactor is more intense and should be handled in the later PRs.
cc: @NingLin-P 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
