### PR TITLE
Migrate multiple operators to single operator storage for signing key

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -111,7 +111,7 @@ pub type DomainHashingFor<T> = <<T as Config>::DomainHeader as Header>::Hashing;
 pub type ReceiptHashFor<T> = <<T as Config>::DomainHeader as Header>::Hash;
 
 /// The current storage version.
-const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 #[frame_support::pallet]
 mod pallet {
@@ -358,11 +358,9 @@ mod pallet {
         StorageMap<_, Identity, OperatorId, T::AccountId, OptionQuery>;
 
     /// Indexes operator signing key against OperatorId.
-    // TODO: remove BTreeSet with single operatorId before next network
-    //  since there are multiple operators registered with same signing key in gemini-3g
     #[pallet::storage]
     pub(super) type OperatorSigningKey<T: Config> =
-        StorageMap<_, Identity, OperatorPublicKey, BTreeSet<OperatorId>, OptionQuery>;
+        StorageMap<_, Identity, OperatorPublicKey, OperatorId, OptionQuery>;
 
     #[pallet::storage]
     pub(super) type DomainStakingSummary<T: Config> =

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -195,7 +195,7 @@ pub(crate) fn do_register_operator<T: Config>(
             status: OperatorStatus::Registered,
         };
         Operators::<T>::insert(operator_id, operator);
-        OperatorSigningKey::<T>::append(signing_key, operator_id);
+        OperatorSigningKey::<T>::insert(signing_key, operator_id);
         // update stake summary to include new operator for next epoch
         domain_stake_summary.next_operators.insert(operator_id);
         // update pending transfers

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -273,13 +273,7 @@ fn unlock_operator<T: Config>(operator_id: OperatorId) -> Result<(), Error> {
         OperatorIdOwner::<T>::remove(operator_id);
 
         // remove operator signing key
-        let maybe_operator_ids = OperatorSigningKey::<T>::take(operator.signing_key.clone());
-        if let Some(mut operator_ids) = maybe_operator_ids {
-            operator_ids.remove(&operator_id);
-            if !operator_ids.is_empty() {
-                OperatorSigningKey::<T>::insert(operator.signing_key, operator_ids)
-            }
-        }
+        OperatorSigningKey::<T>::remove(operator.signing_key.clone());
 
         // remove nominator count for this operator.
         NominatorCount::<T>::remove(operator_id);
@@ -902,7 +896,7 @@ mod tests {
             // unlock operator
             assert_eq!(
                 OperatorSigningKey::<Test>::get(pair.public()),
-                Some(BTreeSet::from([operator_id]))
+                Some(operator_id)
             );
             let unlock_at = 100 + crate::tests::StakeWithdrawalLockingPeriod::get();
             assert!(do_unlock_pending_withdrawals::<Test>(domain_id, unlock_at).is_ok());

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -731,7 +731,18 @@ pub type VersionCheckedMigrateDomainsV1ToV2<T> = VersionedMigration<
     <T as frame_system::Config>::DbWeight,
 >;
 
-pub type Migrations = VersionCheckedMigrateDomainsV1ToV2<Runtime>;
+pub type VersionCheckedMigrateDomainsV2ToV3<T> = VersionedMigration<
+    2,
+    3,
+    pallet_domains::migrations::VersionUncheckedMigrateV2ToV3<T>,
+    pallet_domains::Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;
+
+pub type Migrations = (
+    VersionCheckedMigrateDomainsV1ToV2<Runtime>,
+    VersionCheckedMigrateDomainsV2ToV3<Runtime>,
+);
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<


### PR DESCRIPTION
This PR migrates from holding multiple operators to single operator.

Checking the Gemini-3g state, there are no signing keys attached to multiple operators anymore.
This migration is tested locally

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
