### PR TITLE
Restore connected-peers tests in subspace-networking crate.

### DIFF
--- a/crates/subspace-networking/src/protocols/connected_peers.rs
+++ b/crates/subspace-networking/src/protocols/connected_peers.rs
@@ -24,7 +24,6 @@
 
 mod handler;
 
-#[cfg(not(windows))] // TODO: Restore tests on windows after changing the waiting algorithm
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
This PR restores `connected-peers` protocol tests on windows platform following this comment: https://github.com/subspace/subspace/pull/2074#issuecomment-1826328386

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
