### PR TITLE
Update benchmark example in subspace-networking crate.

### DIFF
--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -59,6 +59,8 @@ enum Command {
         retries: u16,
         #[arg(long, default_value_t = 1)]
         parallelism_level: u16,
+        #[arg(long, default_value_t = 1)]
+        repeat: u16,
     },
 }
 
@@ -92,8 +94,17 @@ async fn main() {
             start_with,
             retries,
             parallelism_level,
+            repeat,
         } => {
-            parallel_benchmark(node, max_pieces, start_with, retries, parallelism_level).await;
+            parallel_benchmark(
+                node,
+                max_pieces,
+                start_with,
+                retries,
+                parallelism_level,
+                repeat,
+            )
+            .await;
         }
     }
 
@@ -181,6 +192,7 @@ async fn parallel_benchmark(
     start_with: usize,
     retries: u16,
     parallelism_level: u16,
+    repeat: u16,
 ) {
     let start = Instant::now();
     let mut stats = PieceRequestStats::default();
@@ -195,6 +207,8 @@ async fn parallel_benchmark(
     let mut total_duration = Duration::default();
     let mut pure_total_duration = Duration::default();
     let mut pending_pieces = (start_with..(start_with + max_pieces))
+        .cycle()
+        .take(max_pieces * repeat as usize)
         .map(|i| {
             let piece_index = PieceIndex::from(i as u64);
             async move {


### PR DESCRIPTION
This PR adds “--repeat” parameter for `benchmark` example in `subspace-networking` crate that controls the repetition number of the "parallel" command. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
