### PR TITLE
Check if the state is available before trying to relay messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,6 +2617,7 @@ dependencies = [
  "futures",
  "parity-scale-codec",
  "sc-client-api",
+ "sc-state-db",
  "sc-utils",
  "sp-api",
  "sp-blockchain",

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -450,6 +450,10 @@ fn main() -> Result<(), Error> {
                         })?
                         .unwrap_or_default();
 
+                let consensus_state_pruning_mode = consensus_chain_config
+                    .state_pruning
+                    .clone()
+                    .unwrap_or_default();
                 let consensus_chain_node = {
                     let span = sc_tracing::tracing::info_span!(
                         sc_tracing::logging::PREFIX_LOG_SPAN,
@@ -608,6 +612,7 @@ fn main() -> Result<(), Error> {
                         let relayer_worker =
                             domain_client_message_relayer::worker::relay_consensus_chain_messages(
                                 consensus_chain_node.client.clone(),
+                                consensus_state_pruning_mode,
                                 consensus_chain_node.sync_service.clone(),
                                 xdm_gossip_worker_builder.gossip_msg_sink(),
                             );

--- a/domains/client/relayer/Cargo.toml
+++ b/domains/client/relayer/Cargo.toml
@@ -17,6 +17,7 @@ cross-domain-message-gossip = { path = "../../client/cross-domain-message-gossip
 futures = "0.3.29"
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
+sc-state-db = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }
 sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "892bf8e938c6bd2b893d3827d1093cd81baa59a1" }

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -371,6 +371,7 @@ where
         })?;
 
     let is_authority = domain_config.role.is_authority();
+    let domain_state_pruning = domain_config.state_pruning.clone().unwrap_or_default();
     domain_config.rpc_id_provider = provider.rpc_id();
     let rpc_builder = {
         let deps = crate::rpc::FullDeps {
@@ -467,6 +468,7 @@ where
         let relayer_worker = domain_client_message_relayer::worker::relay_domain_messages(
             consensus_client.clone(),
             client.clone(),
+            domain_state_pruning,
             // domain relayer will use consensus chain sync oracle instead of domain sync orcle
             // since domain sync oracle will always return `synced` due to force sync being set.
             consensus_network_sync_oracle,


### PR DESCRIPTION
So far relayer made an assumption that the nodes are run with archival or archival-canonical. This is not the case anymore since node run with default pruning, 256, blocks, state will not be available for the relayer by the time it completes the sync from the other nodes and as result we see the issue mentioned in #2257 

This PR makes relayer tries to relay messages from the blocks that have the state available and if not move to next block with available state.

Closes: #2257 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
