### PR TITLE
Remove ability to respond to segment headers DSN requests from node

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -707,7 +707,6 @@ where
             let (node, mut node_runner, dsn_metrics_registry) = create_dsn_instance(
                 dsn_protocol_version,
                 dsn_config.clone(),
-                segment_headers_store.clone(),
                 config.base.prometheus_config.is_some(),
             )?;
 


### PR DESCRIPTION
We only make requests to those peers that can be found in DSN, meaning only farmers. As such, supporting responses on the node side is unnecessary.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
