### PR TITLE
Several minor fraud proof fixes

### DIFF
--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -72,9 +72,13 @@ where
     .map(|resp| resp.into_domain_set_code_extrinsic())
     .ok_or(VerificationError::FailedToDeriveDomainSetCodeExtrinsic)?;
 
+    let bad_receipt_valid_bundle_digests = bad_receipt.valid_bundle_digests();
+    if valid_bundle_digests.len() != bad_receipt_valid_bundle_digests.len() {
+        return Err(VerificationError::InvalidBundleDigest);
+    }
+
     let mut bundle_extrinsics_digests = Vec::new();
-    for (bad_receipt_valid_bundle_digest, bundle_digest) in bad_receipt
-        .valid_bundle_digests()
+    for (bad_receipt_valid_bundle_digest, bundle_digest) in bad_receipt_valid_bundle_digests
         .into_iter()
         .zip(valid_bundle_digests)
     {

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -312,6 +312,11 @@ where
     let bad_receipt_hashes_key = (BAD_RECEIPT_HASHES, bad_receipt_number).encode();
     let mut bad_receipt_hashes: Vec<Block::Hash> =
         load_decode(backend, bad_receipt_hashes_key.as_slice())?.unwrap_or_default();
+    // Return early if the bad ER is already tracked
+    if bad_receipt_hashes.contains(&bad_receipt_hash) {
+        return Ok(());
+    }
+
     bad_receipt_hashes.push(bad_receipt_hash);
 
     let mut to_insert = vec![


### PR DESCRIPTION
This PR fixes several minor fraud proof issues:

**`#1`** Currently, the operator will return early if the consensus block doesn't contain any bundle, this will cause issues:
- if the consensus block contains fraud proof, we need to remove the targetted badER info from the aux storage, otherwise the operator node will keep trying to generate/submit fraud proof for the already pruned bad ER
- if there are bad ER found previously and not pruned by any fraud proof yet, the operator should retry to generate/submit fraud proof, otherwise if the operator fails to submit bundle due to bad ER not being pruned and the incoming consensus block will still be empty (if the malicious operator also not submit new bundle), thus the operator enter a dead loop and the domain is paused

This issue is fixed by processing/submitting fraud proof even for empty consensus blocks.

**`#2`** A consensus block may contain multiple duplicate bad ER, the operator will store the bad ER hash multiple times while only store the mismatch info once, it will cause the bad ER tracking being polluted after the mismatch info is removed while there is still the bad ER hash left in the aux storage.

This issue is fixed by deduplicating the bad ER before checking/storing them.

**`#3`** The length of `InvalidExtrinsicsRootProof::valid_bundle_digests` is not checked within the verification, while we are using the `zip` (which is short circuit) to check this field:
https://github.com/subspace/subspace/blob/7ee4687c10180cfa4d3a52da809e09d53a0887de/crates/sp-domains-fraud-proof/src/verification.rs#L76-L79

An invalid `InvalidExtrinsicsRootProof` that contains only the prefix of the `bad_receipt.valid_bundle_digests` can pass this check and result in a different `extrinsics_root` thus passing the whole fraud proof verification and prune the valid ER. cc @vedhavyas 

This issue is fixed by adding a check to ensure the length of `InvalidExtrinsicsRootProof::valid_bundle_digests` is the same as `bad_receipt.valid_bundle_digests`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
