### PR TITLE
Fix AES-NI enablement by default, including when building container images

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,9 @@
-[target.'cfg(target_arch = "x64_64")']
+[target.'cfg(target_arch = "x86_64")']
 # Require AES-NI on x86-64 by default
-rustflags = "-C target-feature=+aes"
+rustflags = ["-C", "target-feature=+aes"]
 
 [target.'cfg(target_arch = "aarch64")']
 # TODO: Try to remove once https://github.com/paritytech/substrate/issues/11538 is resolved
 # TODO: AES flag is such that we have decent performance on ARMv8, remove once `aes` crate bumps MSRV to at least
 #  1.61: https://github.com/RustCrypto/block-ciphers/issues/373
-rustflags = "--cfg aes_armv8"
+rustflags = ["--cfg", "aes_armv8"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!/.cargo
 !/crates
 !/domains
 !/orml

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -91,7 +91,7 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
-            rustflags: "-C target-cpu=x86-64-v2"
+            rustflags: "-C target-cpu=x86-64-v2 -C target-feature=+aes"
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: aarch64-unknown-linux-gnu
             suffix: ubuntu-aarch64-${{ github.ref_name }}
@@ -115,7 +115,7 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || 'windows-2022') }}
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-v2-${{ github.ref_name }}
-            rustflags: "-C target-cpu=x86-64-v2"
+            rustflags: "-C target-cpu=x86-64-v2 -C target-feature=+aes"
     runs-on: ${{ matrix.build.os }}
     env:
       PRODUCTION_TARGET: target/${{ matrix.build.target }}/production

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -25,6 +25,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -25,6 +25,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -25,6 +25,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -25,6 +25,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -25,6 +25,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -25,6 +25,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -24,6 +24,7 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
+COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml


### PR DESCRIPTION
This is just :facepalm: 

It didn't affect official container images, but did impact if someone was building it manually and didn't specify `RUSTFLAGS` argument, also aarch64 container image wasn't using hardware instructions for AES because of this.

I also enabled AES feature explicitly for `x86-64-v2` builds because our PoT code already uses AES-NI unconditionally on x86-64 for timekeeper, but not for verifier and we will get lower performance if feature is not specified.

For our releases it made no difference

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
