### PR TITLE
chore: avoid unnecessary call to `is_synced`

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -553,14 +553,14 @@ where
             info!("Node is not synced yet, pausing plotting until sync status changes");
 
             loop {
-                if node_sync_status.is_synced() {
-                    info!("Node is synced, resuming plotting");
-                    continue 'outer;
-                }
-
                 match node_sync_status_change_notifications.next().await {
                     Some(new_node_sync_status) => {
                         node_sync_status = new_node_sync_status;
+
+                        if node_sync_status.is_synced() {
+                            info!("Node is synced, resuming plotting");
+                            continue 'outer;
+                        }
                     }
                     None => {
                         // Subscription ended, nothing left to do


### PR DESCRIPTION
Only call `is_synced` again after `node_sync_status` is updated since last `is_synced` returns `false`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
