### PR TITLE
Use strings rather than raw bytes for chain specs

### DIFF
--- a/crates/sc-subspace-chain-specs/src/lib.rs
+++ b/crates/sc-subspace-chain-specs/src/lib.rs
@@ -23,9 +23,9 @@ pub use utils::SerializableChainSpec;
 use sc_chain_spec::NoExtension;
 
 /// Devnet chain spec
-pub const DEVNET_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-devnet.json");
+pub const DEVNET_CHAIN_SPEC: &str = include_str!("../res/chain-spec-raw-devnet.json");
 /// Gemini 3g chain spec
-pub const GEMINI_3G_CHAIN_SPEC: &[u8] = include_bytes!("../res/chain-spec-raw-gemini-3g.json");
+pub const GEMINI_3G_CHAIN_SPEC: &str = include_str!("../res/chain-spec-raw-gemini-3g.json");
 
 /// Specialized `ChainSpec` for the consensus runtime.
 pub type ConsensusChainSpec<GenesisConfig> = SerializableChainSpec<GenesisConfig>;

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -206,11 +206,11 @@ pub fn gemini_3g_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, 
 }
 
 pub fn gemini_3g_config() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, String> {
-    ConsensusChainSpec::from_json_bytes(GEMINI_3G_CHAIN_SPEC)
+    ConsensusChainSpec::from_json_bytes(GEMINI_3G_CHAIN_SPEC.as_bytes())
 }
 
 pub fn devnet_config() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, String> {
-    ConsensusChainSpec::from_json_bytes(DEVNET_CHAIN_SPEC)
+    ConsensusChainSpec::from_json_bytes(DEVNET_CHAIN_SPEC.as_bytes())
 }
 
 pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, String> {


### PR DESCRIPTION
I always find it odd when JSON is stored as bytes rather than strings.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
