### PR TITLE
Move `known_addresses.bin` of the node into `network` directory

### DIFF
--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -84,13 +84,25 @@ pub(crate) fn create_dsn_instance(
     let metrics = enable_metrics.then(|| Metrics::new(&mut metric_registry));
 
     let networking_parameters_registry = {
+        // TODO: Make `base_path` point to `network` once we can clean up below migration code
         let path = dsn_config.base_path;
+        let network_path = path.join("network");
 
         // TODO: Remove this in the future after enough upgrade time that this no longer exist
         if path.join("known_addresses_db").is_dir() {
             let _ = fs::remove_file(path.join("known_addresses_db"));
         }
-        let file_path = path.join("known_addresses.bin");
+        if !network_path.is_dir() {
+            fs::create_dir(&network_path)
+                .map_err(|error| DsnConfigurationError::CreationError(CreationError::Io(error)))?;
+        }
+        if path.join("known_addresses.bin").is_dir() {
+            let _ = fs::rename(
+                path.join("known_addresses.bin"),
+                network_path.join("known_addresses.bin"),
+            );
+        }
+        let file_path = network_path.join("known_addresses.bin");
 
         KnownPeersManager::new(KnownPeersManagerConfig {
             path: Some(file_path.into_boxed_path()),


### PR DESCRIPTION
This makes sense given the fact that there is already `network` directory. I also tend to point both node and farmer to the same location during testing, in which case node's and farmer's known addresses files end up being the same and updated by both node and farmer concurrently.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
