### PR TITLE
Report detailed cache sync progress via event handler

### DIFF
--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -376,14 +376,13 @@ where
             }
 
             downloaded_pieces_count += 1;
+            let progress = downloaded_pieces_count as f32 / pieces_to_download_total as f32 * 100.0;
             if downloaded_pieces_count % INTERMEDIATE_CACHE_UPDATE_INTERVAL == 0 {
-                let progress =
-                    downloaded_pieces_count as f32 / pieces_to_download_total as f32 * 100.0;
                 *self.caches.write() = caches.clone();
 
                 info!("Piece cache sync {progress:.2}% complete");
-                self.handlers.progress.call_simple(&progress);
             }
+            self.handlers.progress.call_simple(&progress);
         }
 
         *self.caches.write() = caches;


### PR DESCRIPTION
While we wouldn't want to print `info` level log message after every downloaded piece, it is not the reason to not fire an event.

This will be helpful for smooth progress bar in https://github.com/nazar-pc/space-acres

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
