### PR TITLE
Split some methods from `NodeClient` into `NodeClientExt`

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -4,6 +4,7 @@ use prometheus_client::registry::Registry;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Weak};
+use subspace_farmer::node_client::NodeClientExt;
 use subspace_farmer::piece_cache::PieceCache;
 use subspace_farmer::utils::readers_and_pieces::ReadersAndPieces;
 use subspace_farmer::{NodeClient, NodeRpcClient, KNOWN_PEERS_CACHE_SIZE};

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -65,7 +65,11 @@ pub trait NodeClient: Clone + fmt::Debug + Send + Sync + 'static {
         &self,
         segment_index: SegmentIndex,
     ) -> Result<(), Error>;
+}
 
+/// Node Client extension methods that are not necessary for farmer as a library, but might be useful for an app
+#[async_trait]
+pub trait NodeClientExt: NodeClient {
     /// Get the last segment headers.
     async fn last_segment_headers(&self, limit: u64) -> Result<Vec<Option<SegmentHeader>>, Error>;
 }

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -1,4 +1,4 @@
-use crate::node_client::{Error as RpcError, Error, NodeClient};
+use crate::node_client::{Error as RpcError, Error, NodeClient, NodeClientExt};
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
@@ -188,7 +188,10 @@ impl NodeClient for NodeRpcClient {
             )
             .await?)
     }
+}
 
+#[async_trait]
+impl NodeClientExt for NodeRpcClient {
     async fn last_segment_headers(
         &self,
         limit: u64,


### PR DESCRIPTION
Not all methods are used by farmer as a library, yet users like Pulsar and Space Acres have to implement them even if they will end up not being used.

By refactoring extra methods into extension trait we reduce the amount of logic that needs to be implemented by those users.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
