### PR TITLE
Remove extra boxing around `Unpin` requirement and fix fused future usage

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::net::SocketAddr;
 use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::PathBuf;
+use std::pin::pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
@@ -598,7 +599,7 @@ where
     // event handlers
     drop(readers_and_pieces);
 
-    let farm_fut = run_future_in_dedicated_thread(
+    let farm_fut = pin!(run_future_in_dedicated_thread(
         Box::pin(async move {
             while let Some(result) = single_disk_farms_stream.next().await {
                 let id = result?;
@@ -608,26 +609,24 @@ where
             anyhow::Ok(())
         }),
         "farmer-farm".to_string(),
-    )?;
-    let mut farm_fut = Box::pin(farm_fut).fuse();
+    )?);
 
-    let networking_fut = run_future_in_dedicated_thread(
+    let networking_fut = pin!(run_future_in_dedicated_thread(
         Box::pin(async move { node_runner.run().await }),
         "farmer-networking".to_string(),
-    )?;
-    let mut networking_fut = Box::pin(networking_fut).fuse();
+    )?);
 
     futures::select!(
         // Signal future
         _ = signal.fuse() => {},
 
         // Farm future
-        result = farm_fut => {
+        result = farm_fut.fuse() => {
             result??;
         },
 
         // Node runner future
-        _ = networking_fut => {
+        _ = networking_fut.fuse() => {
             info!("Node runner exited.")
         },
     );

--- a/crates/subspace-networking/examples/metrics.rs
+++ b/crates/subspace-networking/examples/metrics.rs
@@ -114,23 +114,21 @@ async fn get_peer(peer_id: PeerId, node: Node) {
 
 #[cfg(unix)]
 pub(crate) async fn shutdown_signal() {
+    use std::pin::pin;
+
     futures::future::select(
-        Box::pin(
-            signal::unix::signal(signal::unix::SignalKind::interrupt())
-                .expect("Setting signal handlers must never fail")
-                .recv()
-                .map(|_| {
-                    tracing::info!("Received SIGINT, shutting down farmer...");
-                }),
-        ),
-        Box::pin(
-            signal::unix::signal(signal::unix::SignalKind::terminate())
-                .expect("Setting signal handlers must never fail")
-                .recv()
-                .map(|_| {
-                    tracing::info!("Received SIGTERM, shutting down farmer...");
-                }),
-        ),
+        pin!(signal::unix::signal(signal::unix::SignalKind::interrupt())
+            .expect("Setting signal handlers must never fail")
+            .recv()
+            .map(|_| {
+                tracing::info!("Received SIGINT, shutting down farmer...");
+            }),),
+        pin!(signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("Setting signal handlers must never fail")
+            .recv()
+            .map(|_| {
+                tracing::info!("Received SIGTERM, shutting down farmer...");
+            }),),
     )
     .await;
 }

--- a/crates/subspace-networking/src/behavior/tests.rs
+++ b/crates/subspace-networking/src/behavior/tests.rs
@@ -230,7 +230,7 @@ async fn test_async_handler_works_with_pending_internal_future() {
 
     let (node_2, mut node_runner_2) = crate::construct(config_2).unwrap();
 
-    let bootstrap_fut = Box::pin({
+    tokio::spawn({
         let node = node_2.clone();
 
         async move {
@@ -238,10 +238,6 @@ async fn test_async_handler_works_with_pending_internal_future() {
 
             pending::<()>().await;
         }
-    });
-
-    tokio::spawn(async move {
-        bootstrap_fut.await;
     });
 
     tokio::spawn(async move {

--- a/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
+++ b/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
@@ -12,6 +12,7 @@ use sp_core::twox_256;
 use sp_messenger::messages::ChainId;
 use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
 use std::collections::{BTreeMap, HashSet};
+use std::pin::pin;
 use std::sync::Arc;
 
 const LOG_TARGET: &str = "cross_chain_gossip_worker";
@@ -123,16 +124,15 @@ fn topic<Block: BlockT>() -> Block::Hash {
 impl<Block: BlockT, Network> GossipWorker<Block, Network> {
     /// Starts the Gossip message worker.
     pub async fn run(mut self) {
-        let mut incoming_cross_chain_messages = Box::pin(
-            self.gossip_engine
-                .lock()
-                .messages_for(topic::<Block>())
-                .filter_map(|notification| async move {
-                    Message::decode(&mut &notification.message[..])
-                        .ok()
-                        .map(|msg| (notification.sender, msg))
-                }),
-        );
+        let mut incoming_cross_chain_messages = pin!(self
+            .gossip_engine
+            .lock()
+            .messages_for(topic::<Block>())
+            .filter_map(|notification| async move {
+                Message::decode(&mut &notification.message[..])
+                    .ok()
+                    .map(|msg| (notification.sender, msg))
+            }));
 
         loop {
             let engine = self.gossip_engine.clone();

--- a/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
+++ b/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
@@ -12,6 +12,7 @@ use sp_core::twox_256;
 use sp_messenger::messages::ChainId;
 use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
 use std::collections::{BTreeMap, HashSet};
+use std::future::poll_fn;
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -124,7 +125,7 @@ fn topic<Block: BlockT>() -> Block::Hash {
 impl<Block: BlockT, Network> GossipWorker<Block, Network> {
     /// Starts the Gossip message worker.
     pub async fn run(mut self) {
-        let mut incoming_cross_chain_messages = pin!(self
+        let incoming_cross_chain_messages = pin!(self
             .gossip_engine
             .lock()
             .messages_for(topic::<Block>())
@@ -133,27 +134,26 @@ impl<Block: BlockT, Network> GossipWorker<Block, Network> {
                     .ok()
                     .map(|msg| (notification.sender, msg))
             }));
+        let mut incoming_cross_chain_messages = incoming_cross_chain_messages.fuse();
 
         loop {
             let engine = self.gossip_engine.clone();
-            let gossip_engine = futures::future::poll_fn(|cx| engine.lock().poll_unpin(cx));
+            let mut gossip_engine = poll_fn(|cx| engine.lock().poll_unpin(cx)).fuse();
 
             futures::select! {
-                cross_chain_message = incoming_cross_chain_messages.next().fuse() => {
+                cross_chain_message = incoming_cross_chain_messages.next() => {
                     if let Some((maybe_peer, msg)) = cross_chain_message {
                         tracing::debug!(target: LOG_TARGET, "Incoming cross chain message for chain from Network: {:?}", msg.chain_id);
                         self.handle_cross_chain_message(msg, maybe_peer);
                     }
                 },
 
-                cross_chain_message = self.gossip_msg_stream.next().fuse() => {
-                    if let Some(msg) = cross_chain_message {
-                        tracing::debug!(target: LOG_TARGET, "Incoming cross chain message for chain from Relayer: {:?}", msg.chain_id);
-                        self.handle_cross_chain_message(msg, None);
-                    }
+                msg = self.gossip_msg_stream.select_next_some() => {
+                    tracing::debug!(target: LOG_TARGET, "Incoming cross chain message for chain from Relayer: {:?}", msg.chain_id);
+                    self.handle_cross_chain_message(msg, None);
                 }
 
-                _ = gossip_engine.fuse() => {
+                _ = gossip_engine => {
                     tracing::error!(target: LOG_TARGET, "Gossip engine has terminated.");
                     return;
                 }

--- a/domains/client/domain-operator/src/domain_worker_starter.rs
+++ b/domains/client/domain-operator/src/domain_worker_starter.rs
@@ -36,6 +36,7 @@ use sp_domains_fraud_proof::FraudProofApi;
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::NumberFor;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
+use std::pin::pin;
 use std::sync::Arc;
 use subspace_runtime_primitives::Balance;
 use tracing::{info, Instrument};
@@ -138,8 +139,8 @@ pub(super) async fn start_worker<
                     .boxed()
             }
         };
-        let mut new_slot_notification_stream = Box::pin(new_slot_notification_stream);
-        let mut acknowledgement_sender_stream = Box::pin(acknowledgement_sender_stream);
+        let mut new_slot_notification_stream = pin!(new_slot_notification_stream);
+        let mut acknowledgement_sender_stream = pin!(acknowledgement_sender_stream);
         loop {
             tokio::select! {
                 // Ensure any new slot/block import must handle first before the `acknowledgement_sender_stream`


### PR DESCRIPTION
I was removing extra boxing and noticed incorrect fused future usage in gossip code.

Fused futures are futures that have `.terminated()` method on them for the purposes of not being called again in `select!` (for example). 

By calling `.fuse()` in a loop it does literally nothing since termination status is not preserved across loop iterations. Futures and streams should be fused before entering the loop. Not all uses were incorrect, but the issue was still there.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
