### PR TITLE
Staking: Protocol level Minimum Nominator stake

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -275,6 +275,10 @@ mod pallet {
         #[pallet::constant]
         type MinOperatorStake: Get<BalanceOf<Self>>;
 
+        /// Minimum nominator stake required to nominate and operator.
+        #[pallet::constant]
+        type MinNominatorStake: Get<BalanceOf<Self>>;
+
         /// Minimum number of blocks after which any finalized withdrawals are released to nominators.
         #[pallet::constant]
         type StakeWithdrawalLockingPeriod: Get<DomainBlockNumberFor<Self>>;

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -191,6 +191,7 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
     pub const MinOperatorStake: Balance = 100 * SSC;
+    pub const MinNominatorStake: Balance = SSC;
     pub const StakeWithdrawalLockingPeriod: DomainBlockNumber = 5;
     pub const StakeEpochDuration: DomainBlockNumber = 5;
     pub TreasuryAccount: u64 = PalletId(*b"treasury").into_account_truncating();
@@ -228,6 +229,7 @@ impl pallet_domains::Config for Test {
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;
     type MinOperatorStake = MinOperatorStake;
+    type MinNominatorStake = MinNominatorStake;
     type MaxDomainBlockSize = MaxDomainBlockSize;
     type MaxDomainBlockWeight = MaxDomainBlockWeight;
     type MaxBundlesPerBlock = MaxBundlesPerBlock;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -587,7 +587,12 @@ parameter_types! {
     pub const DomainTxRangeAdjustmentInterval: u64 = TX_RANGE_ADJUSTMENT_INTERVAL_BLOCKS;
     /// Runtime upgrade is delayed for 1 day at 6 sec block time.
     pub const DomainRuntimeUpgradeDelay: BlockNumber = 14_400;
-    pub MinOperatorStake: Balance = 100 * SSC;
+    /// Minimum operator stake to become an operator.
+    // TODO: this value should be properly updated before mainnet
+    pub const MinOperatorStake: Balance = 100 * SSC;
+    /// Minimum nominator stake to nominate and operator.
+    // TODO: this value should be properly updated before mainnet
+    pub const MinNominatorStake: Balance = SSC;
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
@@ -607,6 +612,9 @@ parameter_types! {
     pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
 }
 
+// Minimum operator stake must be >= minimum nominator stake since operator is also a nominator.
+const_assert!(MinOperatorStake::get() >= MinNominatorStake::get());
+
 impl pallet_domains::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = DomainHash;
@@ -619,6 +627,7 @@ impl pallet_domains::Config for Runtime {
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;
     type MinOperatorStake = MinOperatorStake;
+    type MinNominatorStake = MinNominatorStake;
     type MaxDomainBlockSize = MaxDomainBlockSize;
     type MaxDomainBlockWeight = MaxDomainBlockWeight;
     type MaxBundlesPerBlock = MaxBundlesPerBlock;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -626,6 +626,7 @@ parameter_types! {
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
     pub const DomainRuntimeUpgradeDelay: BlockNumber = 10;
     pub const MinOperatorStake: Balance = 100 * SSC;
+    pub const MinNominatorStake: Balance = SSC;
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
@@ -641,6 +642,9 @@ parameter_types! {
     pub const MaxNominators: u32 = 100;
     pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
 }
+
+// Minimum operator stake must be >= minimum nominator stake since operator is also a nominator.
+const_assert!(MinOperatorStake::get() >= MinNominatorStake::get());
 
 impl pallet_domains::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -668,6 +672,7 @@ impl pallet_domains::Config for Runtime {
     type MaxNominators = MaxNominators;
     type Randomness = Subspace;
     type SudoId = SudoId;
+    type MinNominatorStake = MinNominatorStake;
 }
 
 parameter_types! {


### PR DESCRIPTION
This PR introduces protocol level Minimum nominator stake. If an operator, while registering, set the minimum nominator stake to less then protocol defined value, then the registration fails.

For now I have set the minimum nominator to 1 SSC with a TODO to revisit this before mainnet

Closes: #2328

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
