### PR TITLE
Make `SingleDiskFarm::total_sectors_count()` synchronous

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1278,7 +1278,7 @@ impl SingleDiskFarm {
     }
 
     /// Number of sectors in this farm
-    pub async fn total_sectors_count(&self) -> SectorIndex {
+    pub fn total_sectors_count(&self) -> SectorIndex {
         self.total_sectors_count
     }
 


### PR DESCRIPTION
Accidentally made it async due to copy-paste

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
