### PR TITLE
Domains: Fix inconsistency between Block body and Trace roots

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -10,11 +10,12 @@ use crate::{
 use codec::{Decode, Encode, MaxEncodedLen};
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::BlockNumber as DomainBlockNumber;
-use frame_support::dispatch::RawOrigin;
+use frame_support::dispatch::{DispatchInfo, RawOrigin};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Currency, Hooks};
 use frame_support::weights::constants::RocksDbWeight;
-use frame_support::weights::Weight;
+use frame_support::weights::{IdentityFee, Weight};
 use frame_support::{assert_err, assert_ok, parameter_types, PalletId};
+use frame_system::mocking::MockUncheckedExtrinsic;
 use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;
 use sp_core::crypto::Pair;
@@ -72,6 +73,7 @@ frame_support::construct_runtime!(
 
 type BlockNumber = u64;
 type Hash = H256;
+type AccountId = u64;
 
 parameter_types! {
     pub const ExtrinsicsRootStateVersion: StateVersion = StateVersion::V0;
@@ -87,7 +89,7 @@ impl frame_system::Config for Test {
     type Nonce = u64;
     type Hash = Hash;
     type Hashing = BlakeTwo256;
-    type AccountId = u64;
+    type AccountId = AccountId;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Block = Block;
     type RuntimeEvent = RuntimeEvent;
@@ -244,9 +246,21 @@ impl pallet_domains::Config for Test {
     type SudoId = ();
 }
 
+pub struct ExtrinsicStorageFees;
+impl domain_pallet_executive::ExtrinsicStorageFees<Test> for ExtrinsicStorageFees {
+    fn extract_signer(_xt: MockUncheckedExtrinsic<Test>) -> (Option<AccountId>, DispatchInfo) {
+        (None, DispatchInfo::default())
+    }
+
+    fn on_storage_fees_charged(_charged_fees: Balance) {}
+}
+
 impl domain_pallet_executive::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
+    type Currency = Balances;
+    type LengthToFee = IdentityFee<Balance>;
+    type ExtrinsicStorageFees = ExtrinsicStorageFees;
 }
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -272,14 +272,13 @@ where
 
         let header = self.api.finalize_block(self.parent_hash)?;
 
-        // TODO: will be enabled in the next commit
-        // debug_assert_eq!(
-        //     header.extrinsics_root().clone(),
-        //     HashingFor::<Block>::ordered_trie_root(
-        //         self.extrinsics.iter().map(Encode::encode).collect(),
-        //         sp_core::storage::StateVersion::V1
-        //     ),
-        // );
+        debug_assert_eq!(
+            header.extrinsics_root().clone(),
+            HashingFor::<Block>::ordered_trie_root(
+                self.extrinsics.iter().map(Encode::encode).collect(),
+                sp_core::storage::StateVersion::V1
+            ),
+        );
 
         let proof = self.api.extract_proof();
 

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -272,13 +272,14 @@ where
 
         let header = self.api.finalize_block(self.parent_hash)?;
 
-        debug_assert_eq!(
-            header.extrinsics_root().clone(),
-            HashingFor::<Block>::ordered_trie_root(
-                self.extrinsics.iter().map(Encode::encode).collect(),
-                sp_core::storage::StateVersion::V1
-            ),
-        );
+        // TODO: will be enabled in the next commit
+        // debug_assert_eq!(
+        //     header.extrinsics_root().clone(),
+        //     HashingFor::<Block>::ordered_trie_root(
+        //         self.extrinsics.iter().map(Encode::encode).collect(),
+        //         sp_core::storage::StateVersion::V1
+        //     ),
+        // );
 
         let proof = self.api.extract_proof();
 

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1969,9 +1969,8 @@ async fn test_domain_block_builder_include_ext_with_failed_predispatch() {
     let bundle = bundle.unwrap();
     let er = bundle.sealed_header.header.receipt;
 
-    // TODO: will update this to 5 once the fix is done in next commit
-    assert_eq!(er.execution_trace.len(), 4);
-    assert_eq!(er.execution_trace[3], er.final_state_root);
+    assert_eq!(er.execution_trace.len(), 5);
+    assert_eq!(er.execution_trace[4], er.final_state_root);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -468,11 +468,11 @@ where
                 let encoded = uxt.encode();
                 let (maybe_signer, dispatch_info) =
                     ExecutiveConfig::ExtrinsicStorageFees::extract_signer(uxt);
-                // if this is not a normal extrinsic, then transaction should not execute
+                // if this is mandatory extrinsic, then transaction should not execute
                 // we should fail here.
-                if dispatch_info.class != DispatchClass::Normal {
+                if dispatch_info.class == DispatchClass::Mandatory {
                     return Err(TransactionValidityError::Invalid(
-                        InvalidTransaction::BadMandatory,
+                        InvalidTransaction::MandatoryValidation,
                     ));
                 }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -14,7 +14,7 @@ pub use domain_runtime_primitives::{opaque, Balance, BlockNumber, Hash, Nonce};
 use domain_runtime_primitives::{MultiAccountId, TryConvertBack, SLOT_DURATION};
 use fp_account::EthereumSignature;
 use fp_self_contained::{CheckedSignature, SelfContainedCall};
-use frame_support::dispatch::{DispatchClass, GetDispatchInfo};
+use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
 use frame_support::inherent::ProvideInherent;
 use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, Imbalance, OnFinalize,
@@ -109,11 +109,9 @@ pub type CheckedExtrinsic =
 /// Executive: handles dispatch to the various modules.
 pub type Executive = domain_pallet_executive::Executive<
     Runtime,
-    Block,
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    Runtime,
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
@@ -364,9 +362,26 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
 }
 
+pub struct ExtrinsicStorageFees;
+impl domain_pallet_executive::ExtrinsicStorageFees<Runtime> for ExtrinsicStorageFees {
+    fn extract_signer(xt: UncheckedExtrinsic) -> (Option<AccountId>, DispatchInfo) {
+        let dispatch_info = xt.get_dispatch_info();
+        let lookup = frame_system::ChainContext::<Runtime>::default();
+        let maybe_signer = extract_signer_inner(&xt, &lookup).and_then(|res| res.ok());
+        (maybe_signer, dispatch_info)
+    }
+
+    fn on_storage_fees_charged(charged_fees: Balance) {
+        OperatorRewards::note_operator_rewards(charged_fees)
+    }
+}
+
 impl domain_pallet_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = domain_pallet_executive::weights::SubstrateWeight<Runtime>;
+    type Currency = Balances;
+    type LengthToFee = <Runtime as pallet_transaction_payment::Config>::LengthToFee;
+    type ExtrinsicStorageFees = ExtrinsicStorageFees;
 }
 
 impl pallet_sudo::Config for Runtime {

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -14,7 +14,7 @@ pub use domain_runtime_primitives::{opaque, Balance, BlockNumber, Hash, Nonce};
 use domain_runtime_primitives::{MultiAccountId, TryConvertBack, SLOT_DURATION};
 use fp_account::EthereumSignature;
 use fp_self_contained::{CheckedSignature, SelfContainedCall};
-use frame_support::dispatch::{DispatchClass, GetDispatchInfo};
+use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
 use frame_support::inherent::ProvideInherent;
 use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, Imbalance, OnFinalize,
@@ -109,11 +109,9 @@ pub type CheckedExtrinsic =
 /// Executive: handles dispatch to the various modules.
 pub type Executive = domain_pallet_executive::Executive<
     Runtime,
-    Block,
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    Runtime,
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
@@ -362,9 +360,26 @@ impl pallet_transaction_payment::Config for Runtime {
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
 }
 
+pub struct ExtrinsicStorageFees;
+impl domain_pallet_executive::ExtrinsicStorageFees<Runtime> for ExtrinsicStorageFees {
+    fn extract_signer(xt: UncheckedExtrinsic) -> (Option<AccountId>, DispatchInfo) {
+        let dispatch_info = xt.get_dispatch_info();
+        let lookup = frame_system::ChainContext::<Runtime>::default();
+        let maybe_signer = extract_signer_inner(&xt, &lookup).and_then(|res| res.ok());
+        (maybe_signer, dispatch_info)
+    }
+
+    fn on_storage_fees_charged(charged_fees: Balance) {
+        OperatorRewards::note_operator_rewards(charged_fees)
+    }
+}
+
 impl domain_pallet_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = domain_pallet_executive::weights::SubstrateWeight<Runtime>;
+    type Currency = Balances;
+    type LengthToFee = <Runtime as pallet_transaction_payment::Config>::LengthToFee;
+    type ExtrinsicStorageFees = ExtrinsicStorageFees;
 }
 
 impl pallet_sudo::Config for Runtime {


### PR DESCRIPTION
This PR fixes inconsistency in domain block body and trace roots when an extrinsic fails at pre/post dispatch from the context of domain block.

Notes:
I recommend looking at tests in the first commit to understand why there would be an inconsistency.

We did consider leaving it as is and fix the domain_extrinsic_root but unfortunately, proving such fraud proof is unbounded as we cannot know how many such invalid extrinsics per domain block context exists though these extrinsics are valid per bundle context. 

Current approach reverts the extrinsic changes and notes the extrinsics into system to be consistent with trace roots. we also optimistacally charge extrinsic signer the storage fees for storing extrinsic and later would also need to charge storage fees for consensus chain. The latter is left as TODO and will be handled as part of Storage fee orcale PR.

Closes #2181
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
