### PR TITLE
Move executor dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11993,6 +11993,7 @@ dependencies = [
  "pallet-transporter",
  "pallet-utility",
  "parity-scale-codec",
+ "sc-executor",
  "scale-info",
  "sp-api",
  "sp-block-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,6 +3281,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
  "parity-scale-codec",
+ "sc-executor",
  "scale-info",
  "sp-api",
  "sp-block-builder",

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -34,9 +34,9 @@ use sp_core::traits::SpawnEssentialNamed;
 use sp_messenger::messages::ChainId;
 use subspace_malicious_operator::malicious_domain_instance_starter::DomainInstanceStarter;
 use subspace_node::domain::DomainCli;
-use subspace_node::{Cli, ExecutorDispatch};
+use subspace_node::Cli;
 use subspace_proof_of_space::chia::ChiaTable;
-use subspace_runtime::{Block, RuntimeApi};
+use subspace_runtime::{Block, ExecutorDispatch, RuntimeApi};
 use subspace_service::{DsnConfig, SubspaceConfiguration, SubspaceNetworking};
 
 type PosTable = ChiaTable;

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -21,8 +21,7 @@ use std::sync::Arc;
 use subspace_node::domain::{
     create_configuration, evm_chain_spec, AccountId20, DomainCli, EVMDomainExecutorDispatch,
 };
-use subspace_node::ExecutorDispatch as CExecutorDispatch;
-use subspace_runtime::RuntimeApi as CRuntimeApi;
+use subspace_runtime::{ExecutorDispatch as CExecutorDispatch, RuntimeApi as CRuntimeApi};
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_service::FullClient as CFullClient;
 

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -5,6 +5,7 @@ use domain_eth_service::provider::EthProvider;
 use domain_eth_service::DefaultEthConfig;
 use domain_runtime_primitives::opaque::Block as DomainBlock;
 use domain_service::{FullBackend, FullClient};
+use evm_domain_runtime::ExecutorDispatch as EVMDomainExecutorDispatch;
 use futures::StreamExt;
 use sc_cli::CliConfiguration;
 use sc_consensus_subspace::block_import::BlockImportingNotification;
@@ -18,9 +19,7 @@ use sp_core::traits::SpawnEssentialNamed;
 use sp_domains::{DomainInstanceData, RuntimeType};
 use sp_keystore::KeystorePtr;
 use std::sync::Arc;
-use subspace_node::domain::{
-    create_configuration, evm_chain_spec, AccountId20, DomainCli, EVMDomainExecutorDispatch,
-};
+use subspace_node::domain::{create_configuration, evm_chain_spec, AccountId20, DomainCli};
 use subspace_runtime::{ExecutorDispatch as CExecutorDispatch, RuntimeApi as CRuntimeApi};
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_service::FullClient as CFullClient;

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -22,6 +22,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use cross_domain_message_gossip::GossipWorkerBuilder;
 use domain_client_operator::Bootstrapper;
 use domain_runtime_primitives::opaque::Block as DomainBlock;
+use evm_domain_runtime::ExecutorDispatch as EVMDomainExecutorDispatch;
 use frame_benchmarking_cli::BenchmarkCmd;
 use futures::future::TryFutureExt;
 use log::warn;
@@ -37,9 +38,7 @@ use sp_core::traits::SpawnEssentialNamed;
 use sp_io::SubstrateHostFunctions;
 use sp_messenger::messages::ChainId;
 use sp_wasm_interface::ExtendedHostFunctions;
-use subspace_node::domain::{
-    DomainCli, DomainInstanceStarter, DomainSubcommand, EVMDomainExecutorDispatch,
-};
+use subspace_node::domain::{DomainCli, DomainInstanceStarter, DomainSubcommand};
 use subspace_node::{Cli, Subcommand};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_runtime::{Block, ExecutorDispatch, RuntimeApi};

--- a/crates/subspace-node/src/bin/subspace-node.rs
+++ b/crates/subspace-node/src/bin/subspace-node.rs
@@ -40,9 +40,9 @@ use sp_wasm_interface::ExtendedHostFunctions;
 use subspace_node::domain::{
     DomainCli, DomainInstanceStarter, DomainSubcommand, EVMDomainExecutorDispatch,
 };
-use subspace_node::{Cli, ExecutorDispatch, Subcommand};
+use subspace_node::{Cli, Subcommand};
 use subspace_proof_of_space::chia::ChiaTable;
-use subspace_runtime::{Block, RuntimeApi};
+use subspace_runtime::{Block, ExecutorDispatch, RuntimeApi};
 use subspace_service::{DsnConfig, SubspaceConfiguration, SubspaceNetworking};
 
 type PosTable = ChiaTable;

--- a/crates/subspace-node/src/domain.rs
+++ b/crates/subspace-node/src/domain.rs
@@ -21,22 +21,3 @@ pub mod evm_chain_spec;
 pub use self::cli::{DomainCli, Subcommand as DomainSubcommand};
 pub use self::domain_instance_starter::{create_configuration, DomainInstanceStarter};
 pub use evm_domain_runtime::AccountId as AccountId20;
-use sc_executor::NativeExecutionDispatch;
-
-/// EVM domain executor instance.
-pub struct EVMDomainExecutorDispatch;
-
-impl NativeExecutionDispatch for EVMDomainExecutorDispatch {
-    #[cfg(feature = "runtime-benchmarks")]
-    type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-    #[cfg(not(feature = "runtime-benchmarks"))]
-    type ExtendHostFunctions = ();
-
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        evm_domain_runtime::api::dispatch(method, data)
-    }
-
-    fn native_version() -> sc_executor::NativeVersion {
-        evm_domain_runtime::native_version()
-    }
-}

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -1,11 +1,12 @@
 use super::{evm_chain_spec, DomainCli};
-use crate::domain::{AccountId20, EVMDomainExecutorDispatch};
+use crate::domain::AccountId20;
 use cross_domain_message_gossip::{ChainTxPoolMsg, Message};
 use domain_client_operator::{BootstrapResult, OperatorStreams};
 use domain_eth_service::provider::EthProvider;
 use domain_eth_service::DefaultEthConfig;
 use domain_runtime_primitives::opaque::Block as DomainBlock;
 use domain_service::{FullBackend, FullClient};
+use evm_domain_runtime::ExecutorDispatch as EVMDomainExecutorDispatch;
 use futures::StreamExt;
 use sc_chain_spec::ChainSpec;
 use sc_cli::{CliConfiguration, Database, DefaultConfigurationValues, SubstrateCli};

--- a/crates/subspace-node/src/domain/domain_instance_starter.rs
+++ b/crates/subspace-node/src/domain/domain_instance_starter.rs
@@ -1,6 +1,5 @@
 use super::{evm_chain_spec, DomainCli};
 use crate::domain::{AccountId20, EVMDomainExecutorDispatch};
-use crate::ExecutorDispatch as CExecutorDispatch;
 use cross_domain_message_gossip::{ChainTxPoolMsg, Message};
 use domain_client_operator::{BootstrapResult, OperatorStreams};
 use domain_eth_service::provider::EthProvider;
@@ -19,7 +18,7 @@ use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_domains::{DomainInstanceData, RuntimeType};
 use std::sync::Arc;
-use subspace_runtime::RuntimeApi as CRuntimeApi;
+use subspace_runtime::{ExecutorDispatch as CExecutorDispatch, RuntimeApi as CRuntimeApi};
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_service::FullClient as CFullClient;
 

--- a/crates/subspace-node/src/lib.rs
+++ b/crates/subspace-node/src/lib.rs
@@ -22,7 +22,6 @@ pub mod domain;
 
 use clap::Parser;
 use sc_cli::{RunCmd, SubstrateCli};
-use sc_executor::NativeExecutionDispatch;
 use sc_service::ChainSpec;
 use sc_storage_monitor::StorageMonitorParams;
 use sc_subspace_chain_specs::ConsensusChainSpec;
@@ -32,33 +31,6 @@ use std::collections::HashSet;
 use std::io::Write;
 use std::{fs, io};
 use subspace_networking::libp2p::Multiaddr;
-
-/// Executor dispatch for subspace runtime
-pub struct ExecutorDispatch;
-
-impl NativeExecutionDispatch for ExecutorDispatch {
-    /// Only enable the benchmarking host functions when we actually want to benchmark.
-    #[cfg(feature = "runtime-benchmarks")]
-    type ExtendHostFunctions = (
-        frame_benchmarking::benchmarking::HostFunctions,
-        sp_consensus_subspace::consensus::HostFunctions,
-        sp_domains_fraud_proof::HostFunctions,
-    );
-    /// Otherwise we only use the default Substrate host functions.
-    #[cfg(not(feature = "runtime-benchmarks"))]
-    type ExtendHostFunctions = (
-        sp_consensus_subspace::consensus::HostFunctions,
-        sp_domains_fraud_proof::HostFunctions,
-    );
-
-    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-        subspace_runtime::api::dispatch(method, data)
-    }
-
-    fn native_version() -> sc_executor::NativeVersion {
-        subspace_runtime::native_version()
-    }
-}
 
 /// This `purge-chain` command used to remove both consensus chain and domain.
 #[derive(Debug, Clone, Parser)]

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -40,6 +40,7 @@ pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-fe
 pallet-transporter = { version = "0.1.0", path = "../../domains/pallets/transporter", default-features = false }
 pallet-utility = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", optional = true }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 sp-block-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", default-features = false, version = "4.0.0-dev" }
 sp-consensus-subspace = { version = "0.1.0", default-features = false, path = "../sp-consensus-subspace" }
@@ -95,6 +96,7 @@ std = [
     "pallet-transporter/std",
     "pallet-utility/std",
     "scale-info/std",
+    "sc-executor",
     "sp-api/std",
     "sp-block-builder/std",
     "sp-consensus-subspace/std",

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -119,6 +119,35 @@ pub fn native_version() -> NativeVersion {
     }
 }
 
+/// Executor dispatch for subspace runtime
+#[cfg(feature = "std")]
+pub struct ExecutorDispatch;
+
+#[cfg(feature = "std")]
+impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
+    /// Only enable the benchmarking host functions when we actually want to benchmark.
+    #[cfg(feature = "runtime-benchmarks")]
+    type ExtendHostFunctions = (
+        frame_benchmarking::benchmarking::HostFunctions,
+        sp_consensus_subspace::consensus::HostFunctions,
+        sp_domains_fraud_proof::HostFunctions,
+    );
+    /// Otherwise we only use the default Substrate host functions.
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type ExtendHostFunctions = (
+        sp_consensus_subspace::consensus::HostFunctions,
+        sp_domains_fraud_proof::HostFunctions,
+    );
+
+    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+        api::dispatch(method, data)
+    }
+
+    fn native_version() -> sc_executor::NativeVersion {
+        native_version()
+    }
+}
+
 // TODO: Many of below constants should probably be updatable but currently they are not
 
 /// Since Subspace is probabilistic this is the average expected block time that

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -45,6 +45,7 @@ pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, 
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 pallet-transporter = { version = "0.1.0", path = "../../pallets/transporter", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", optional = true }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
@@ -98,6 +99,7 @@ std = [
     "pallet-transaction-payment/std",
     "pallet-transporter/std",
     "scale-info/std",
+    "sc-executor",
     "sp-api/std",
     "sp-block-builder/std",
     "sp-core/std",

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -220,6 +220,26 @@ pub fn native_version() -> NativeVersion {
     }
 }
 
+/// EVM domain executor instance.
+#[cfg(feature = "std")]
+pub struct ExecutorDispatch;
+
+#[cfg(feature = "std")]
+impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
+    #[cfg(feature = "runtime-benchmarks")]
+    type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type ExtendHostFunctions = ();
+
+    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+        api::dispatch(method, data)
+    }
+
+    fn native_version() -> sc_executor::NativeVersion {
+        native_version()
+    }
+}
+
 parameter_types! {
     pub const Version: RuntimeVersion = VERSION;
     pub const BlockHashCount: BlockNumber = 2400;


### PR DESCRIPTION
I do find it a bit awkward that runtime now optionally depends on the client library, but otherwise if we want to reuse we have some not very nice options:
* make malicious domain operator, Pulsar, Space Acres depend on `subspace-node`
* move into `subspace-service` (which doesn't know about specific runtimes right now and I'd like to keep it that way)
* create a separate crate just for this (annoying)
* copy-paste it into other projects (I believe this is what is being done right now, which is fragile)

Just moving it into runtime it strictly 1:1 corresponds to made the most sense to me even though it is a bit awkward hierarchy-wise.

I didn't move test dispatches as I'm not sure we will not have custom ones there, but feel free to follow-up with moving those into test runtimes too.

@ParthDesai this will simplify Pulsar a tiny bit I think.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
