### PR TITLE
Return `MandatoryValidation` error instead of `BadMandatory` if inherent tx is being validated

### DIFF
--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -914,7 +914,7 @@ impl_runtime_apis! {
             let dispatch_info = xt.get_dispatch_info();
 
             if dispatch_info.class == DispatchClass::Mandatory {
-                return Err(InvalidTransaction::BadMandatory.into());
+                return Err(InvalidTransaction::MandatoryValidation.into());
             }
 
             let encoded_len = uxt.encoded_size();

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -897,7 +897,7 @@ impl_runtime_apis! {
             let dispatch_info = xt.get_dispatch_info();
 
             if dispatch_info.class == DispatchClass::Mandatory {
-                return Err(InvalidTransaction::BadMandatory.into());
+                return Err(InvalidTransaction::MandatoryValidation.into());
             }
 
             let encoded_len = uxt.encoded_size();


### PR DESCRIPTION
# Description
This PR correctly returns `MandatoryValidation` error instead of `BadMandatory` if inherent tx is being validated. This correction is in line with `polkadot-sdk`'s `Executive::validate_block`.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
