### PR TITLE
Set MIN_REPLICATION_FACTOR to proper value

### DIFF
--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -27,8 +27,7 @@ pub use subspace_core_primitives::BlockNumber;
 
 /// Minimum desired number of replicas of the blockchain to be stored by the network,
 /// impacts storage fees.
-// TODO: Proper value here
-pub const MIN_REPLICATION_FACTOR: u16 = 1;
+pub const MIN_REPLICATION_FACTOR: u16 = 50;
 /// How much (ratio) of storage fees escrow should be given to farmer each block as a reward.
 // TODO: Proper value here
 pub const STORAGE_FEES_ESCROW_BLOCK_REWARD: (u64, u64) = (1, 10000);


### PR DESCRIPTION
Setting minimum replication factor to 50 ensures that basically no piece is replicated fewer than 10 times, details: https://forum.subspace.network/t/calculating-fraction-of-missing-pieces/1967/4?u=dariolina

Part of #2332 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
