### PR TITLE
Acknowledge segment headers in piece cache much faster

### DIFF
--- a/crates/subspace-farmer/src/piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/piece_cache/tests.rs
@@ -312,19 +312,23 @@ async fn basic() {
                 },
             };
 
-            archived_segment_headers_sender
-                .send(segment_header)
-                .await
-                .unwrap();
-
-            // Wait for acknowledgement
-            assert_eq!(
-                acknowledge_archived_segment_header_receiver
-                    .next()
+            // Send twice because acknowledgement arrives early, sending twice doesn't have side effects, but ensures
+            // things were processed fully
+            for _ in 0..=1 {
+                archived_segment_headers_sender
+                    .send(segment_header)
                     .await
-                    .unwrap(),
-                SegmentIndex::from(segment_index)
-            );
+                    .unwrap();
+
+                // Wait for acknowledgement
+                assert_eq!(
+                    acknowledge_archived_segment_header_receiver
+                        .next()
+                        .await
+                        .unwrap(),
+                    SegmentIndex::from(segment_index)
+                );
+            }
 
             current_segment_index.store(segment_index, Ordering::Release);
         }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -40,6 +40,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use std::{fs, io, mem};
 use subspace_core_primitives::crypto::blake3_hash;
 use subspace_core_primitives::crypto::kzg::Kzg;
@@ -63,12 +64,13 @@ use ulid::Ulid;
 
 // Refuse to compile on non-64-bit platforms, offsets may fail on those when converting from u64 to
 // usize depending on chain parameters
-const_assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u64>());
+const_assert!(mem::size_of::<usize>() >= mem::size_of::<u64>());
 
 /// Reserve 1M of space for plot metadata (for potential future expansion)
 const RESERVED_PLOT_METADATA: u64 = 1024 * 1024;
 /// Reserve 1M of space for farm info (for potential future expansion)
 const RESERVED_FARM_INFO: u64 = 1024 * 1024;
+const NEW_SEGMENT_PROCESSING_DELAY: Duration = Duration::from_secs(30);
 
 /// An identifier for single disk farm, can be used for in logs, thread names, etc.
 #[derive(
@@ -1038,6 +1040,7 @@ impl SingleDiskFarm {
             sectors_metadata: Arc::clone(&sectors_metadata),
             sectors_to_plot_sender,
             initial_plotting_finished: farming_delay_sender,
+            new_segment_processing_delay: NEW_SEGMENT_PROCESSING_DELAY,
         };
         tasks.push(Box::pin(plotting_scheduler(plotting_scheduler_options)));
 


### PR DESCRIPTION
When new segment of archived history is created, following was happening on all farmers:
* piece cache attempts to download and persist newly produced pieces (if necessary)
* replotting of expired sectors is starting

There is nothing inherently wrong with this, except piece cache is optimized for reads and not writes and due to replotting a lot of both internal and external overlapping requests to cache were made, that were all using `RwLock::read()` and preventing piece cache from persisting piece that needs `RwLock::write()`.

This had cascading effect:
* local block import is paused due to archived segment not being acknowledged yet
* pieces that fall into last segment during replotting can't be found locally while segment processing is still happening and is slow, so farmer needs to reach out to other farmers to get pieces it already has locally
* once segment is acknowledged by piece cache, a lot of farmers publish new block at around the same time all at once, causing high forking rate that even caused operator nodes that didn't handle this gracefully in the past to crash

We now download all potentially useful pieces from node right away and concurrently (it was done sequentially before) and acknowledge archived pieces quickly, while taking care of writing them to disk later when we can. This way block production can continue quickly.

I also added replotting delay in order to further ensure most farmers have already cached pieces locally by the time those pieces might be retrieved for replotting purposes.

This fixes large gaps in block production we observed when new segment header was produced that was slowly correcting itself over time.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
