### PR TITLE
Domains: Set maximum Domain block weight 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,8 @@ dependencies = [
 name = "domain-runtime-primitives"
 version = "0.1.0"
 dependencies = [
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-api",

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -183,7 +183,7 @@ pub mod tests_utils {
             // if the min is too small, then this will not change, and we are doomed forever.
             // the block ref time is 1/100th bigger than target.
             Self::run_with_system_weight(
-                Self::target().set_ref_time(Self::target().ref_time() * 101 / 100),
+                Self::target().set_ref_time((Self::target().ref_time() / 100) * 101),
                 || {
                     let next = Self::runtime_multiplier_update(Self::min_multiplier());
                     assert!(

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -12,6 +12,8 @@ description = "Common primitives of subspace domain runtime"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
+frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 parity-scale-codec = { version = "3.6.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
@@ -25,13 +27,15 @@ sp-weights = { version = "20.0.0", default-features = false, git = "https://gith
 [features]
 default = ["std"]
 std = [
-	"parity-scale-codec/std",
-	"scale-info/std",
-	"sp-api/std",
-	"sp-core/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	"sp-weights/std",
-	"subspace-core-primitives/std",
-	"subspace-runtime-primitives/std",
+    "frame-support/std",
+    "frame-system/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "sp-weights/std",
+    "subspace-core-primitives/std",
+    "subspace-runtime-primitives/std",
 ]

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -17,6 +17,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use frame_support::dispatch::{DispatchClass, PerDispatchClass};
+use frame_system::limits::BlockLength;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::generic::{Era, UncheckedExtrinsic};
@@ -55,6 +57,24 @@ pub const SLOT_DURATION: u64 = 1000;
 
 /// The EVM chain Id type
 pub type EVMChainId = u64;
+
+/// Maximum block length for mandatory dispatch.
+pub const MAXIMUM_MANDATORY_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
+
+/// Maximum block length for operational and normal dispatches.
+pub const MAXIMUM_OPERATIONAL_AND_NORMAL_BLOCK_LENGTH: u32 = u32::MAX;
+
+/// Maximum block length for all dispatches.
+pub fn maximum_block_length() -> BlockLength {
+    BlockLength {
+        max: PerDispatchClass::new(|class| match class {
+            DispatchClass::Normal | DispatchClass::Operational => {
+                MAXIMUM_OPERATIONAL_AND_NORMAL_BLOCK_LENGTH
+            }
+            DispatchClass::Mandatory => MAXIMUM_MANDATORY_BLOCK_LENGTH,
+        }),
+    }
+}
 
 /// Extracts the signer from an unchecked extrinsic.
 ///

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -10,7 +10,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
 use domain_runtime_primitives::opaque::Header;
-pub use domain_runtime_primitives::{opaque, Balance, BlockNumber, Hash, Nonce};
+pub use domain_runtime_primitives::{
+    maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
+};
 use domain_runtime_primitives::{
     CheckExtrinsicsValidityError, MultiAccountId, TryConvertBack, SLOT_DURATION,
 };
@@ -209,7 +211,6 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_MILLISECS_PER_BLOCK * WEIGHT_REF_TIME_PER_MILLIS,
     u64::MAX,
 );
-pub const MAXIMUM_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
@@ -248,8 +249,7 @@ parameter_types! {
     //  The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
     // `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
     // the lazy contract deletion.
-    pub RuntimeBlockLength: BlockLength =
-        BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+    pub RuntimeBlockLength: BlockLength = maximum_block_length();
     pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())
         .for_class(DispatchClass::all(), |weights| {

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -11,7 +11,8 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use codec::{Decode, Encode};
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
-    maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
+    block_weights, maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
+    EXISTENTIAL_DEPOSIT, MAXIMUM_BLOCK_WEIGHT,
 };
 use domain_runtime_primitives::{
     CheckExtrinsicsValidityError, MultiAccountId, TryConvertBack, SLOT_DURATION,
@@ -24,10 +25,7 @@ use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, Imbalance, OnFinalize,
     OnUnbalanced,
 };
-use frame_support::weights::constants::{
-    BlockExecutionWeight, ExtrinsicBaseWeight, ParityDbWeight, WEIGHT_REF_TIME_PER_MILLIS,
-    WEIGHT_REF_TIME_PER_SECOND,
-};
+use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -66,7 +64,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use subspace_runtime_primitives::{Moment, SlowAdjustingFeeUpdate, SHANNON};
+use subspace_runtime_primitives::{Moment, SlowAdjustingFeeUpdate};
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = EthereumSignature;
@@ -195,23 +193,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     state_version: 0,
 };
 
-/// The existential deposit. Same with the one on primary chain.
-pub const EXISTENTIAL_DEPOSIT: Balance = 500 * SHANNON;
-
-/// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
-/// used to limit the maximal weight of a single extrinsic.
-const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
-
-/// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used by
-/// `Operational` extrinsics.
-const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2000ms of compute with a 6 second average block time.
-pub const WEIGHT_MILLISECS_PER_BLOCK: u64 = 2000;
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-    WEIGHT_MILLISECS_PER_BLOCK * WEIGHT_REF_TIME_PER_MILLIS,
-    u64::MAX,
-);
-
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
@@ -250,24 +231,7 @@ parameter_types! {
     // `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
     // the lazy contract deletion.
     pub RuntimeBlockLength: BlockLength = maximum_block_length();
-    pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
-        .base_block(BlockExecutionWeight::get())
-        .for_class(DispatchClass::all(), |weights| {
-            weights.base_extrinsic = ExtrinsicBaseWeight::get();
-        })
-        .for_class(DispatchClass::Normal, |weights| {
-            weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT);
-        })
-        .for_class(DispatchClass::Operational, |weights| {
-            weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT);
-            // Operational transactions have some extra reserved space, so that they
-            // are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
-            weights.reserved = Some(
-                MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT
-            );
-        })
-        .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
-        .build_or_panic();
+    pub RuntimeBlockWeights: BlockWeights = block_weights();
     pub const ExtrinsicsRootStateVersion: StateVersion = StateVersion::V1;
 }
 
@@ -500,8 +464,6 @@ impl FindAuthor<H160> for FindAuthorTruncated {
 
 /// Current approximation of the gas/s consumption considering
 /// EVM execution over compiled WASM (on 4.4Ghz CPU).
-/// Given the 500ms Weight, from which 75% only are used for transactions,
-/// the total EVM execution gas limit is: GAS_PER_SECOND * 0.500 * 0.75 ~= 15_000_000.
 pub const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
@@ -509,9 +471,9 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PER_SECOND);
 
 parameter_types! {
-    /// EVM gas limit
+    /// EVM block gas limit is set to maximum to allow all the transaction stored on Consensus chain.
     pub BlockGasLimit: U256 = U256::from(
-        NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS
+        MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS
     );
     pub PrecompilesValue: Precompiles = Precompiles::default();
     pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -10,10 +10,12 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode};
 pub use domain_runtime_primitives::opaque::Header;
+use domain_runtime_primitives::{
+    maximum_block_length, MultiAccountId, TryConvertBack, SLOT_DURATION,
+};
 pub use domain_runtime_primitives::{
     opaque, Balance, BlockNumber, CheckExtrinsicsValidityError, Hash, Nonce,
 };
-use domain_runtime_primitives::{MultiAccountId, TryConvertBack, SLOT_DURATION};
 use fp_account::EthereumSignature;
 use fp_self_contained::{CheckedSignature, SelfContainedCall};
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
@@ -209,7 +211,6 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_MILLISECS_PER_BLOCK * WEIGHT_REF_TIME_PER_MILLIS,
     u64::MAX,
 );
-pub const MAXIMUM_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
@@ -228,8 +229,7 @@ parameter_types! {
     //  The `RuntimeBlockLength` and `RuntimeBlockWeights` exist here because the
     // `DeletionWeightLimit` and `DeletionQueueDepth` depend on those to parameterize
     // the lazy contract deletion.
-    pub RuntimeBlockLength: BlockLength =
-        BlockLength::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+    pub RuntimeBlockLength: BlockLength = maximum_block_length();
     pub RuntimeBlockWeights: BlockWeights = BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())
         .for_class(DispatchClass::all(), |weights| {


### PR DESCRIPTION
Essentially makes the Domain block weight to the maximum and Block length to the maximum so that extrinsics do not fail at pre_dispatch with `ExhaustResources`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
