### PR TITLE
Improve sync status detection

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -649,18 +649,19 @@ where
     fn subscribe_node_sync_status_change(&self, mut sink: SubscriptionSink) -> SubscriptionResult {
         let sync_oracle = self.sync_oracle.clone();
         let fut = async move {
-            let mut last_node_sync_status = None;
+            let mut last_is_major_syncing = None;
             loop {
-                let node_sync_status = if sync_oracle.is_major_syncing() {
-                    NodeSyncStatus::MajorSyncing
-                } else {
-                    NodeSyncStatus::Synced
-                };
+                let is_major_syncing = sync_oracle.is_major_syncing();
 
                 // Update subscriber if value has changed
-                if last_node_sync_status != Some(node_sync_status) {
-                    last_node_sync_status.replace(node_sync_status);
+                if last_is_major_syncing != Some(is_major_syncing) {
+                    last_is_major_syncing.replace(is_major_syncing);
 
+                    let node_sync_status = if is_major_syncing {
+                        NodeSyncStatus::MajorSyncing
+                    } else {
+                        NodeSyncStatus::Synced
+                    };
                     match sink.send(&node_sync_status) {
                         Ok(true) => {
                             // Success

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -655,6 +655,18 @@ where
 
                 // Update subscriber if value has changed
                 if last_is_major_syncing != Some(is_major_syncing) {
+                    // In case change is detected, wait for another interval to confirm.
+                    // TODO: This is primarily because Substrate seems to lose peers for brief
+                    //  periods of time sometimes that needs to be investigated separately
+                    futures_timer::Delay::new(NODE_SYNC_STATUS_CHECK_INTERVAL).await;
+
+                    // If status returned back to what it was, ignore
+                    if last_is_major_syncing == Some(sync_oracle.is_major_syncing()) {
+                        futures_timer::Delay::new(NODE_SYNC_STATUS_CHECK_INTERVAL).await;
+                        continue;
+                    }
+
+                    // Otherwise save new status
                     last_is_major_syncing.replace(is_major_syncing);
 
                     let node_sync_status = if is_major_syncing {


### PR DESCRIPTION
I do not have a good explanation why, but sometimes Substrate looses all peers for a brief period of time, which makes node switch into syncing state.

When adding logs around periodic check it looks like this, 6 queries with 1s interval:
```
SyncStatus { state: Idle, best_seen_block: None, num_peers: 8, num_connected_peers: 8, queued_blocks: 0, state_sync: None, warp_sync: None }
SyncStatus { state: Idle, best_seen_block: None, num_peers: 8, num_connected_peers: 8, queued_blocks: 0, state_sync: None, warp_sync: None }
SyncStatus { state: Idle, best_seen_block: None, num_peers: 0, num_connected_peers: 0, queued_blocks: 0, state_sync: None, warp_sync: None }
SyncStatus { state: Idle, best_seen_block: None, num_peers: 8, num_connected_peers: 8, queued_blocks: 0, state_sync: None, warp_sync: None }
SyncStatus { state: Idle, best_seen_block: None, num_peers: 8, num_connected_peers: 8, queued_blocks: 0, state_sync: None, warp_sync: None }
SyncStatus { state: Idle, best_seen_block: None, num_peers: 8, num_connected_peers: 8, queued_blocks: 0, state_sync: None, warp_sync: None }
```

On farmer it results in annoying:
```
2023-12-22T23:31:45.618650Z  INFO Farmer:single_disk_farm{disk_farm_index=0}: subspace_farmer::single_disk_farm::plotting: Node is not synced yet, pausing plotting until sync status changes
2023-12-22T23:31:46.615258Z  INFO Farmer:single_disk_farm{disk_farm_index=0}: subspace_farmer::single_disk_farm::plotting: Node is synced, resuming plotting
```

That many users ask about regularly.

This doesn't seem to be a huge issue right now, so I added a check to only report change in status if two queries return the same result 1 second apart. This should fix absolute majority of these undesired sync state transitions.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
