### PR TITLE
BugFix: Fix invalid state transition fraud proof generation

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -363,7 +363,7 @@ impl FraudProofHostFunctions for MockDomainFraudProofExtension {
         &self,
         _pre_state_root: H256,
         _encoded_proof: Vec<u8>,
-        _verifying_method: &str,
+        _execution_method: &str,
         _call_data: &[u8],
         _domain_runtime_code: Vec<u8>,
     ) -> Option<Vec<u8>> {

--- a/crates/sp-domains-fraud-proof/src/execution_prover.rs
+++ b/crates/sp-domains-fraud-proof/src/execution_prover.rs
@@ -57,7 +57,7 @@ where
             .runtime_code()
             .map_err(sp_blockchain::Error::RuntimeCode)?;
 
-        // TODO: avoid using the String API specified by `proving_method()`
+        // TODO: avoid using the String API specified by `execution_method()`
         // https://github.com/paritytech/substrate/discussions/11095
         if let Some((delta, post_delta_root)) = delta_changes {
             let delta_backend = create_delta_backend(trie_backend, delta, post_delta_root);
@@ -65,7 +65,7 @@ where
                 &delta_backend,
                 &mut Default::default(),
                 &*self.executor,
-                execution_phase.proving_method(),
+                execution_phase.execution_method(),
                 call_data,
                 &runtime_code,
                 &mut Default::default(),
@@ -77,7 +77,7 @@ where
                 trie_backend,
                 &mut Default::default(),
                 &*self.executor,
-                execution_phase.proving_method(),
+                execution_phase.execution_method(),
                 call_data,
                 &runtime_code,
                 &mut Default::default(),
@@ -114,7 +114,7 @@ where
             proof,
             &mut Default::default(),
             &*self.executor,
-            execution_phase.verifying_method(),
+            execution_phase.execution_method(),
             call_data,
             &runtime_code,
         )

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -37,7 +37,7 @@ impl ExecutionPhase {
             // TODO: Replace `DomainCoreApi_initialize_block_with_post_state_root` with `Core_initalize_block`
             // Should be a same issue with https://github.com/paritytech/substrate/pull/10922#issuecomment-1068997467
             Self::InitializeBlock => "DomainCoreApi_initialize_block_with_post_state_root",
-            Self::ApplyExtrinsic { .. } => "BlockBuilder_apply_extrinsic",
+            Self::ApplyExtrinsic { .. } => "DomainCoreApi_apply_extrinsic_with_post_state_root",
             Self::FinalizeBlock => "BlockBuilder_finalize_block",
         }
     }

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -32,23 +32,10 @@ pub enum ExecutionPhase {
 
 impl ExecutionPhase {
     /// Returns the method for generating the proof.
-    pub fn proving_method(&self) -> &'static str {
+    pub fn execution_method(&self) -> &'static str {
         match self {
             // TODO: Replace `DomainCoreApi_initialize_block_with_post_state_root` with `Core_initalize_block`
             // Should be a same issue with https://github.com/paritytech/substrate/pull/10922#issuecomment-1068997467
-            Self::InitializeBlock => "DomainCoreApi_initialize_block_with_post_state_root",
-            Self::ApplyExtrinsic { .. } => "DomainCoreApi_apply_extrinsic_with_post_state_root",
-            Self::FinalizeBlock => "BlockBuilder_finalize_block",
-        }
-    }
-
-    /// Returns the method for verifying the proof.
-    ///
-    /// The difference with [`Self::proving_method`] is that the return value of verifying method
-    /// must contain the post state root info so that it can be used to compare whether the
-    /// result of execution reported in [`FraudProof`] is expected or not.
-    pub fn verifying_method(&self) -> &'static str {
-        match self {
             Self::InitializeBlock => "DomainCoreApi_initialize_block_with_post_state_root",
             Self::ApplyExtrinsic { .. } => "DomainCoreApi_apply_extrinsic_with_post_state_root",
             Self::FinalizeBlock => "BlockBuilder_finalize_block",

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -56,7 +56,7 @@ pub trait FraudProofHostFunctions: Send + Sync {
         pre_state_root: H256,
         // TODO: implement `PassBy` for `sp_trie::StorageProof` in upstream to pass it directly here
         encoded_proof: Vec<u8>,
-        verifying_method: &str,
+        execution_method: &str,
         call_data: &[u8],
         domain_runtime_code: Vec<u8>,
     ) -> Option<Vec<u8>>;
@@ -467,7 +467,7 @@ where
         &self,
         pre_state_root: H256,
         encoded_proof: Vec<u8>,
-        verifying_method: &str,
+        execution_method: &str,
         call_data: &[u8],
         domain_runtime_code: Vec<u8>,
     ) -> Option<Vec<u8>> {
@@ -486,7 +486,7 @@ where
             proof,
             &mut Default::default(),
             self.executor.as_ref(),
-            verifying_method,
+            execution_method,
             call_data,
             &runtime_code,
         )

--- a/crates/sp-domains-fraud-proof/src/runtime_interface.rs
+++ b/crates/sp-domains-fraud-proof/src/runtime_interface.rs
@@ -40,7 +40,7 @@ pub trait FraudProofRuntimeInterface {
         &mut self,
         pre_state_root: H256,
         encoded_proof: Vec<u8>,
-        verifying_method: &str,
+        execution_method: &str,
         call_data: &[u8],
         domain_runtime_code: Vec<u8>,
     ) -> Option<Vec<u8>> {
@@ -49,7 +49,7 @@ pub trait FraudProofRuntimeInterface {
             .execution_proof_check(
                 pre_state_root,
                 encoded_proof,
-                verifying_method,
+                execution_method,
                 call_data,
                 domain_runtime_code,
             )

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -228,7 +228,7 @@ where
     let execution_result = fraud_proof_runtime_interface::execution_proof_check(
         pre_state_root,
         proof.encode(),
-        execution_phase.verifying_method(),
+        execution_phase.execution_method(),
         call_data.as_ref(),
         domain_runtime_code,
     )

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -813,7 +813,7 @@ async fn test_finalize_block_proof_creation_and_verification_should_work() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_false_invalid_state_transition_proof_is_rejected() {
+async fn test_bad_invalid_state_transition_proof_is_rejected() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
     let mut builder = sc_cli::LoggerBuilder::new("");
@@ -865,7 +865,7 @@ async fn test_false_invalid_state_transition_proof_is_rejected() {
 
     // We get the receipt of target bundle
     let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
-    let valid_receipt = bundle.unwrap().sealed_header.header.receipt;
+    let valid_receipt = bundle.unwrap().into_receipt();
     assert_eq!(valid_receipt.execution_trace.len(), 4);
     let valid_receipt_hash = valid_receipt.hash::<BlakeTwo256>();
 


### PR DESCRIPTION
# Description
This PR fixes invalid state transition fraud proof generation by using same method for both proving and verifying. It also adds test to check that `incorrect` InvalidStateTransitionFraudProof is rejected during the submission.

## Context
The invalid state transition fraud proof code currently executes different runtime apis during generation and verification of the storage proof.

For generation of the storage proof the runtime api is used as follows:
```rust
fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
       Executive::apply_extrinsic(extrinsic)
 }
```

For verification the runtime api is used as follows:
```rust
fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
        let _ = Executive::apply_extrinsic(extrinsic);
        Executive::storage_root()
}
```

The verification api calculates the storage root in addition to applying the extrinsic. The calculation of storage root by substrate reads some additional key prefixes while doing the insertion and removal, but since those prefixes were not recorded during the storage proof generation, the proof does not contain that. 

This results in `TrieError::IncompleteDatabase` error which on substrate side is only logged as warning since it is happening during wasm to host call and the original state root is returned.

```
Trie error: Database missing expected key: 0x7ece2630ee26ee436307bb21be9255e0fd8c6175b02087d501e7255c0d311844
```

To remedy this we need to use same runtime api for generation and verification which results in all required nodes recorded in storage proof and eliminates this issue.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
