### PR TITLE
Domains: Staking v1.1

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::alloc::borrow::ToOwned;
 use crate::domain_registry::DomainConfig;
-use crate::staking::{do_reward_operators, OperatorConfig, OperatorStatus, Withdraw};
+use crate::staking::{do_reward_operators, OperatorConfig, OperatorStatus};
 use crate::staking_epoch::{do_finalize_domain_current_epoch, do_finalize_domain_epoch_staking};
 use crate::Pallet as Domains;
 use frame_benchmarking::v2::*;
@@ -127,7 +127,7 @@ mod benchmarks {
             assert_ok!(Domains::<T>::withdraw_stake(
                 RawOrigin::Signed(nominator).into(),
                 operator_id,
-                Withdraw::Some(withdraw_amount.into()),
+                withdraw_amount.into(),
             ));
         }
         assert_eq!(
@@ -384,14 +384,14 @@ mod benchmarks {
         assert_ok!(Domains::<T>::withdraw_stake(
             RawOrigin::Signed(nominator.clone()).into(),
             operator_id,
-            Withdraw::Some(withdraw_amount.into()),
+            withdraw_amount.into(),
         ));
 
         #[extrinsic_call]
         _(
             RawOrigin::Signed(nominator.clone()),
             operator_id,
-            Withdraw::Some(withdraw_amount.into()),
+            withdraw_amount.into(),
         );
     }
 

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -134,10 +134,6 @@ mod benchmarks {
             PendingStakingOperationCount::<T>::get(domain_id) as u32,
             max_pending_staking_op
         );
-        assert_eq!(
-            PendingWithdrawals::<T>::iter_prefix_values(operator_id).count() as u32,
-            max_pending_staking_op
-        );
 
         #[block]
         {
@@ -149,10 +145,6 @@ mod benchmarks {
         }
 
         assert_eq!(PendingStakingOperationCount::<T>::get(domain_id), 0);
-        assert_eq!(
-            PendingWithdrawals::<T>::iter_prefix_values(operator_id).count(),
-            0
-        );
     }
 
     #[benchmark]
@@ -282,11 +274,6 @@ mod benchmarks {
         let staking_summary =
             DomainStakingSummary::<T>::get(domain_id).expect("staking summary must exist");
         assert!(staking_summary.next_operators.contains(&operator_id));
-
-        assert_eq!(
-            PendingDeposits::<T>::get(operator_id, operator_account),
-            Some(T::MinOperatorStake::get())
-        );
     }
 
     /// Benchmark `nominate_operator` extrinsic with the worst possible conditions:
@@ -315,11 +302,6 @@ mod benchmarks {
             RawOrigin::Signed(nominator.clone()),
             operator_id,
             minimum_nominator_stake,
-        );
-
-        assert_eq!(
-            PendingDeposits::<T>::get(operator_id, nominator),
-            Some(minimum_nominator_stake * 2u32.into())
         );
     }
 
@@ -411,11 +393,6 @@ mod benchmarks {
             RawOrigin::Signed(nominator.clone()),
             operator_id,
             Withdraw::Some(withdraw_amount.into()),
-        );
-
-        assert_eq!(
-            PendingWithdrawals::<T>::get(operator_id, nominator),
-            Some(Withdraw::Some(withdraw_amount * 2u32.into()))
         );
     }
 

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -127,7 +127,7 @@ mod benchmarks {
             assert_ok!(Domains::<T>::withdraw_stake(
                 RawOrigin::Signed(nominator).into(),
                 operator_id,
-                Withdraw::Some(withdraw_amount),
+                Withdraw::Some(withdraw_amount.into()),
             ));
         }
         assert_eq!(
@@ -403,14 +403,14 @@ mod benchmarks {
         assert_ok!(Domains::<T>::withdraw_stake(
             RawOrigin::Signed(nominator.clone()).into(),
             operator_id,
-            Withdraw::Some(withdraw_amount),
+            Withdraw::Some(withdraw_amount.into()),
         ));
 
         #[extrinsic_call]
         _(
             RawOrigin::Signed(nominator.clone()),
             operator_id,
-            Withdraw::Some(withdraw_amount),
+            Withdraw::Some(withdraw_amount.into()),
         );
 
         assert_eq!(

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::alloc::borrow::ToOwned;
 use crate::domain_registry::DomainConfig;
 use crate::staking::{do_reward_operators, OperatorConfig, OperatorStatus, Withdraw};
-use crate::staking_epoch::{do_finalize_domain_current_epoch, do_finalize_domain_staking};
+use crate::staking_epoch::{do_finalize_domain_current_epoch, do_finalize_domain_epoch_staking};
 use crate::Pallet as Domains;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
@@ -339,7 +339,10 @@ mod benchmarks {
         _(RawOrigin::Signed(operator_owner.clone()), operator_id);
 
         let operator = Operators::<T>::get(operator_id).expect("operator must exist");
-        assert_eq!(operator.status, OperatorStatus::Deregistered);
+        assert_eq!(
+            operator.status,
+            OperatorStatus::Deregistered((domain_id, 0).into())
+        );
 
         let pending_deregistration = PendingOperatorDeregistrations::<T>::get(domain_id)
             .expect("pending deregistration must exist");
@@ -367,7 +370,7 @@ mod benchmarks {
             operator_id,
             withdraw_amount * 3u32.into(),
         ));
-        do_finalize_domain_staking::<T>(domain_id, 1u32.into())
+        do_finalize_domain_epoch_staking::<T>(domain_id, 1u32.into())
             .expect("finalize domain staking should success");
 
         // Add reward to the operator

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -343,10 +343,6 @@ mod benchmarks {
             operator.status,
             OperatorStatus::Deregistered((domain_id, 0).into())
         );
-
-        let pending_deregistration = PendingOperatorDeregistrations::<T>::get(domain_id)
-            .expect("pending deregistration must exist");
-        assert!(pending_deregistration.contains(&operator_id));
     }
 
     /// Benchmark `withdraw_stake` extrinsic with the worst possible conditions:

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1273,7 +1273,7 @@ mod pallet {
         pub fn withdraw_stake(
             origin: OriginFor<T>,
             operator_id: OperatorId,
-            withdraw: Withdraw<BalanceOf<T>>,
+            withdraw: Withdraw<T::Share>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -134,8 +134,7 @@ mod pallet {
     use crate::staking::{
         do_deregister_operator, do_nominate_operator, do_register_operator, do_slash_operators,
         do_switch_operator_domain, do_unlock_funds, do_unlock_operator, do_withdraw_stake, Deposit,
-        DomainEpoch, Error as StakingError, Operator, OperatorConfig, StakingSummary, Withdraw,
-        Withdrawal,
+        DomainEpoch, Error as StakingError, Operator, OperatorConfig, StakingSummary, Withdrawal,
     };
     use crate::staking_epoch::{do_finalize_domain_current_epoch, Error as StakingEpochError};
     use crate::weights::WeightInfo;
@@ -1184,11 +1183,11 @@ mod pallet {
         pub fn withdraw_stake(
             origin: OriginFor<T>,
             operator_id: OperatorId,
-            withdraw: Withdraw<T::Share>,
+            shares: T::Share,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
 
-            do_withdraw_stake::<T>(operator_id, who.clone(), withdraw).map_err(Error::<T>::from)?;
+            do_withdraw_stake::<T>(operator_id, who.clone(), shares).map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::WithdrewStake {
                 operator_id,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -134,7 +134,8 @@ mod pallet {
     use crate::staking::{
         do_deregister_operator, do_nominate_operator, do_register_operator, do_slash_operators,
         do_switch_operator_domain, do_unlock_funds, do_unlock_operator, do_withdraw_stake, Deposit,
-        DomainEpoch, Error as StakingError, Operator, OperatorConfig, StakingSummary, Withdrawal,
+        DomainEpoch, Error as StakingError, Operator, OperatorConfig, SharePrice, StakingSummary,
+        Withdrawal,
     };
     use crate::staking_epoch::{do_finalize_domain_current_epoch, Error as StakingEpochError};
     use crate::weights::WeightInfo;
@@ -164,7 +165,7 @@ mod pallet {
         AtLeast32BitUnsigned, BlockNumberProvider, CheckEqual, CheckedAdd, Header as HeaderT,
         MaybeDisplay, One, SimpleBitOps, Zero,
     };
-    use sp_runtime::{Perbill, SaturatedConversion, Saturating};
+    use sp_runtime::{SaturatedConversion, Saturating};
     use sp_std::boxed::Box;
     use sp_std::collections::btree_map::BTreeMap;
     use sp_std::collections::btree_set::BTreeSet;
@@ -387,7 +388,7 @@ mod pallet {
     // TODO: currently unbounded storage.
     #[pallet::storage]
     pub type OperatorEpochSharePrice<T: Config> =
-        StorageDoubleMap<_, Identity, OperatorId, Identity, DomainEpoch, Perbill, OptionQuery>;
+        StorageDoubleMap<_, Identity, OperatorId, Identity, DomainEpoch, SharePrice, OptionQuery>;
 
     /// List of all deposits for given Operator.
     #[pallet::storage]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1197,7 +1197,9 @@ mod pallet {
             Ok(())
         }
 
-        /// Unlocks the nominator funds given the unlocking period is complete.
+        /// Unlocks the first withdrawal given the unlocking period is complete.
+        /// Even if rest of the withdrawals are out of unlocking period, nominator
+        /// should call this extrinsic to unlock each withdrawal
         #[pallet::call_index(10)]
         #[pallet::weight(Weight::from_all(10_000))]
         pub fn unlock_funds(origin: OriginFor<T>, operator_id: OperatorId) -> DispatchResult {

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -79,10 +79,7 @@ pub(crate) type FungibleHoldId<T> =
 pub(crate) type NominatorId<T> = <T as frame_system::Config>::AccountId;
 
 pub trait HoldIdentifier<T: Config> {
-    // TODO: remove pending deposit and unlock holds as they are not required anymore.
-    fn staking_pending_deposit(operator_id: OperatorId) -> FungibleHoldId<T>;
     fn staking_staked(operator_id: OperatorId) -> FungibleHoldId<T>;
-    fn staking_pending_unlock(operator_id: OperatorId) -> FungibleHoldId<T>;
     fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<T>;
 }
 
@@ -434,12 +431,6 @@ mod pallet {
     #[pallet::storage]
     pub(super) type NominatorCount<T: Config> =
         StorageMap<_, Identity, OperatorId, u32, ValueQuery>;
-
-    /// Operators who chose to deregister from a domain.
-    /// Stored here temporarily until domain epoch is complete.
-    #[pallet::storage]
-    pub(super) type PendingOperatorDeregistrations<T: Config> =
-        StorageMap<_, Identity, DomainId, BTreeSet<OperatorId>, OptionQuery>;
 
     /// A list operators who were slashed during the current epoch associated with the domain.
     /// When the epoch for a given domain is complete, operator total stake is moved to treasury and

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -349,7 +349,7 @@ pub(crate) fn do_convert_previous_epoch_deposits<T: Config>(
             OperatorEpochSharePrice::<T>::get(operator_id, effective_domain_epoch)
                 .ok_or(Error::MissingOperatorEpochSharePrice)?;
 
-        let new_shares = T::Share::from(epoch_share_price.saturating_reciprocal_mul_floor(amount));
+        let new_shares = T::Share::from(epoch_share_price.mul_floor(amount));
         deposit.known.shares = deposit
             .known
             .shares

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -421,7 +421,7 @@ mod tests {
     use crate::staking::tests::{register_operator, Share};
     use crate::staking::{
         do_deregister_operator, do_nominate_operator, do_reward_operators, do_unlock_operator,
-        do_withdraw_stake, StakingSummary, Withdraw,
+        do_withdraw_stake, StakingSummary,
     };
     use crate::staking_epoch::{
         do_finalize_domain_current_epoch, do_finalize_switch_operator_domain,
@@ -562,8 +562,7 @@ mod tests {
             }
 
             for (nominator_id, shares) in withdrawals {
-                do_withdraw_stake::<Test>(operator_id, nominator_id, Withdraw::Some(shares))
-                    .unwrap();
+                do_withdraw_stake::<Test>(operator_id, nominator_id, shares).unwrap();
             }
 
             if !rewards.is_zero() {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -538,8 +538,10 @@ pub(crate) fn register_genesis_domain(creator: u64, operator_ids: Vec<OperatorId
                 nomination_tax: Default::default(),
                 current_total_stake: Zero::zero(),
                 current_epoch_rewards: Zero::zero(),
-                total_shares: Zero::zero(),
+                current_total_shares: Zero::zero(),
                 status: OperatorStatus::Registered,
+                deposits_in_epoch: Zero::zero(),
+                withdrawals_in_epoch: Zero::zero(),
             },
         );
     }

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -147,21 +147,9 @@ pub enum HoldIdentifier {
 }
 
 impl pallet_domains::HoldIdentifier<Test> for HoldIdentifier {
-    fn staking_pending_deposit(operator_id: OperatorId) -> FungibleHoldId<Test> {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::PendingDeposit(operator_id),
-        ))
-    }
-
     fn staking_staked(operator_id: OperatorId) -> FungibleHoldId<Test> {
         Self::Domains(DomainsHoldIdentifier::Staking(
             StakingHoldIdentifier::Staked(operator_id),
-        ))
-    }
-
-    fn staking_pending_unlock(operator_id: OperatorId) -> FungibleHoldId<Test> {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::PendingUnlock(operator_id),
         ))
     }
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -658,12 +658,8 @@ pub type OperatorId = u64;
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
 pub enum StakingHoldIdentifier {
-    /// Holds all the pending deposits to an Operator.
-    PendingDeposit(OperatorId),
     /// Holds all the currently staked funds to an Operator.
     Staked(OperatorId),
-    /// Holds all the currently unlocking funds.
-    PendingUnlock(OperatorId),
 }
 
 /// Domains specific Identifier for Balances holds.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -408,21 +408,9 @@ pub enum HoldIdentifier {
 }
 
 impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn staking_pending_deposit(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::PendingDeposit(operator_id),
-        ))
-    }
-
     fn staking_staked(operator_id: OperatorId) -> Self {
         Self::Domains(DomainsHoldIdentifier::Staking(
             StakingHoldIdentifier::Staked(operator_id),
-        ))
-    }
-
-    fn staking_pending_unlock(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::PendingUnlock(operator_id),
         ))
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -322,21 +322,9 @@ pub enum HoldIdentifier {
 }
 
 impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn staking_pending_deposit(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::PendingDeposit(operator_id),
-        ))
-    }
-
     fn staking_staked(operator_id: OperatorId) -> Self {
         Self::Domains(DomainsHoldIdentifier::Staking(
             StakingHoldIdentifier::Staked(operator_id),
-        ))
-    }
-
-    fn staking_pending_unlock(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::PendingUnlock(operator_id),
         ))
     }
 


### PR DESCRIPTION
This PR introduces new Staking v1.1 changes. Please read and understand the new flow from the spec before proceeding to review.

### Some notes:
- The first 6 commits introduces the changes specific to v1.1. So recommend going through each commit
- The remaining commits handles edge cases through testing. Recommend understanding the tests and then looking at the changes made. There are some other changes made that either removes unnecessary abstractions or deprecated code.
- We still have pending operations and is tied to operator actions like
	- Registering operators 
	- Switching operator domains
	Since these actions are still part of the epoch transition and will need to be limited to avoid unbounded operator actions.
- I got rid different staking holding reasons to just one since it will complicate the code to work with them with no much benefit.
- I got rid of `Withdraw::Some()` and `Withdraw::All` since this was useful when withdraws were initiated in SSC and nominator cannot tell how much SSC they will get at the end of epoch incase they want to withdraw all. With the new flow, withdraw intention is done with shares and shares always remain same there by making the above type redundant.

### Whats next:
- Benchmarking

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
