### PR TITLE
NUMA support improvements

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -17,7 +17,7 @@ pub use crate::single_disk_farm::plotting::PlottingError;
 use crate::single_disk_farm::plotting::{
     plotting, plotting_scheduler, PlottingOptions, PlottingSchedulerOptions,
 };
-use crate::thread_pool_manager::ThreadPoolManager;
+use crate::thread_pool_manager::PlottingThreadPoolManager;
 use crate::utils::{tokio_rayon_spawn_handler, AsyncJoinOnDrop};
 use crate::KNOWN_PEERS_CACHE_SIZE;
 use async_lock::RwLock;
@@ -288,10 +288,7 @@ pub struct SingleDiskFarmOptions<NC, PG> {
     /// compute-intensive operations during proving)
     pub farming_thread_pool_size: usize,
     /// Thread pool manager used for plotting
-    pub plotting_thread_pool_manager: ThreadPoolManager,
-    /// Thread pool manager used for replotting, typically smaller pool than for plotting to not
-    /// affect farming as much
-    pub replotting_thread_pool_manager: ThreadPoolManager,
+    pub plotting_thread_pool_manager: PlottingThreadPoolManager,
     /// Notification for plotter to start, can be used to delay plotting until some initialization
     /// has happened externally
     pub plotting_delay: Option<oneshot::Receiver<()>>,
@@ -626,7 +623,6 @@ impl SingleDiskFarm {
             downloading_semaphore,
             farming_thread_pool_size,
             plotting_thread_pool_manager,
-            replotting_thread_pool_manager,
             plotting_delay,
             farm_during_initial_plotting,
         } = options;
@@ -931,7 +927,6 @@ impl SingleDiskFarm {
                     sectors_to_plot_receiver,
                     downloading_semaphore,
                     plotting_thread_pool_manager,
-                    replotting_thread_pool_manager,
                     stop_receiver: &mut stop_receiver.resubscribe(),
                 };
 


### PR DESCRIPTION
Plotting and replotting can happen at the same time in case multiple farms are present. With recent changes it became possible for both plotting and replotting to use the same CPU cores, which this PR primarily fixes.

The first commit also improves CPU core distribution between thread pools in case thread pool size was not specified explicitly.

Fixes https://github.com/subspace/subspace/issues/2385

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
