### PR TITLE
Add execution trace length mismatch detection

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -31,6 +31,7 @@ pub enum Error {
     MaxHeadDomainNumber,
     MissingDomainBlock,
     InvalidTraceRoot,
+    InvalidExecutionTrace,
     UnavailableConsensusBlockHash,
 }
 
@@ -178,6 +179,16 @@ pub(crate) fn verify_execution_receipt<T: Config>(
             Error::BadGenesisReceipt
         );
         return Ok(());
+    }
+
+    // Check if the ER has at least 2 trace root (for Initialization and Finalization of block at least)
+    if execution_trace.len() < 2 {
+        log::error!(
+            "Execution trace: {:?} and receipt: {:?}",
+            execution_trace,
+            execution_receipt
+        );
+        return Err(Error::InvalidExecutionTrace);
     }
 
     // Check if the ER is derived from the correct consensus block in the current chain
@@ -812,11 +823,32 @@ mod tests {
             );
 
             // Receipt with unknown parent receipt
-            let mut unknown_parent_receipt = next_receipt;
+            let mut unknown_parent_receipt = next_receipt.clone();
             unknown_parent_receipt.parent_domain_block_receipt_hash = H256::random();
             assert_err!(
                 verify_execution_receipt::<Test>(domain_id, &unknown_parent_receipt),
                 Error::UnknownParentBlockReceipt
+            );
+
+            // Receipt with execution_trace length less than two
+            let mut invalid_execution_trace_receipt = next_receipt;
+
+            // Receipt with only one element in execution trace vector
+            invalid_execution_trace_receipt.execution_trace = vec![invalid_execution_trace_receipt
+                .execution_trace
+                .first()
+                .cloned()
+                .expect("First element should be there; qed")];
+            assert_err!(
+                verify_execution_receipt::<Test>(domain_id, &invalid_execution_trace_receipt),
+                Error::InvalidExecutionTrace
+            );
+
+            // Receipt with zero element in execution trace vector
+            invalid_execution_trace_receipt.execution_trace = vec![];
+            assert_err!(
+                verify_execution_receipt::<Test>(domain_id, &invalid_execution_trace_receipt),
+                Error::InvalidExecutionTrace
             );
         });
     }
@@ -829,7 +861,24 @@ mod tests {
         let mut ext = new_test_ext_with_extensions();
         ext.execute_with(|| {
             let domain_id = register_genesis_domain(creator, vec![operator_id1, operator_id2]);
-            let next_receipt = extend_block_tree_from_zero(domain_id, operator_id1, 3);
+            let mut next_receipt = extend_block_tree_from_zero(domain_id, operator_id1, 3);
+            next_receipt.execution_trace.push(H256::random());
+
+            let mut trace = Vec::with_capacity(next_receipt.execution_trace.len());
+            for root in &next_receipt.execution_trace {
+                trace.push(
+                    root.encode()
+                        .try_into()
+                        .map_err(|_| Error::InvalidTraceRoot)
+                        .expect("H256 to Blake3Hash should be successful; qed"),
+                );
+            }
+            let new_execution_trace_root = MerkleTree::from_leaves(trace.as_slice())
+                .root()
+                .expect("Compute merkle root of trace should success")
+                .into();
+            next_receipt.execution_trace_root = new_execution_trace_root;
+            assert_ok!(verify_execution_receipt::<Test>(domain_id, &next_receipt));
 
             // Receipt with wrong value of `execution_trace_root`
             let mut invalid_receipt = next_receipt.clone();

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -183,11 +183,6 @@ pub(crate) fn verify_execution_receipt<T: Config>(
 
     // Check if the ER has at least 2 trace root (for Initialization and Finalization of block at least)
     if execution_trace.len() < 2 {
-        log::error!(
-            "Execution trace: {:?} and receipt: {:?}",
-            execution_trace,
-            execution_receipt
-        );
         return Err(Error::InvalidExecutionTrace);
     }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -309,8 +309,6 @@ pub enum VerificationError<DomainHash> {
     InvalidExecutionTrace,
     #[cfg_attr(feature = "thiserror", error("Invalid ApplyExtrinsic trace index"))]
     InvalidApplyExtrinsicTraceIndex,
-    #[cfg_attr(feature = "thiserror", error("Invalid shorter mismatch trace index"))]
-    InvalidShorterMismatchTraceIndex,
     #[cfg_attr(feature = "thiserror", error("Invalid longer mismatch trace index"))]
     InvalidLongerMismatchTraceIndex,
     #[cfg_attr(feature = "thiserror", error("Invalid ApplyExtrinsic call data"))]

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -15,6 +15,20 @@ use sp_std::vec::Vec;
 use sp_trie::StorageProof;
 use subspace_runtime_primitives::Balance;
 
+/// Mismatch type possible for ApplyExtrinsic execution phase
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub enum ApplyExtrinsicMismatch {
+    StateRoot(u32),
+    Shorter,
+}
+
+/// Mismatch type possible for FinalizBlock execution phase
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub enum FinalizeBlockMismatch {
+    StateRoot,
+    Longer(u32),
+}
+
 /// A phase of a block's execution, carrying necessary information needed for verifying the
 /// invalid state transition proof.
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
@@ -24,10 +38,10 @@ pub enum ExecutionPhase {
     /// Executes some extrinsic.
     ApplyExtrinsic {
         extrinsic_proof: StorageProof,
-        mismatch_index: u32,
+        mismatch: ApplyExtrinsicMismatch,
     },
     /// Executes the `finalize_block` hook.
-    FinalizeBlock,
+    FinalizeBlock { mismatch: FinalizeBlockMismatch },
 }
 
 impl ExecutionPhase {
@@ -38,10 +52,25 @@ impl ExecutionPhase {
             // Should be a same issue with https://github.com/paritytech/substrate/pull/10922#issuecomment-1068997467
             Self::InitializeBlock => "DomainCoreApi_initialize_block_with_post_state_root",
             Self::ApplyExtrinsic { .. } => "DomainCoreApi_apply_extrinsic_with_post_state_root",
-            Self::FinalizeBlock => "BlockBuilder_finalize_block",
+            Self::FinalizeBlock { .. } => "BlockBuilder_finalize_block",
         }
     }
 
+    /// Returns true if execution phase refers to mismatch between state roots
+    /// false otherwise.
+    pub fn is_state_root_mismatch(&self) -> bool {
+        matches!(
+            self,
+            ExecutionPhase::InitializeBlock
+                | ExecutionPhase::ApplyExtrinsic {
+                    mismatch: ApplyExtrinsicMismatch::StateRoot(_),
+                    extrinsic_proof: _,
+                }
+                | ExecutionPhase::FinalizeBlock {
+                    mismatch: FinalizeBlockMismatch::StateRoot,
+                }
+        )
+    }
     /// Returns the post state root for the given execution result.
     pub fn decode_execution_result<Header: HeaderT>(
         &self,
@@ -54,7 +83,7 @@ impl ExecutionPhase {
                 Header::Hash::decode(&mut encoded_storage_root.as_slice())
                     .map_err(VerificationError::StorageRootDecode)
             }
-            Self::FinalizeBlock => {
+            Self::FinalizeBlock { .. } => {
                 let new_header = Header::decode(&mut execution_result.as_slice())
                     .map_err(VerificationError::HeaderDecode)?;
                 Ok(*new_header.state_root())
@@ -80,7 +109,10 @@ impl ExecutionPhase {
                 bad_receipt_parent.final_state_root,
                 bad_receipt.execution_trace[0],
             ),
-            ExecutionPhase::ApplyExtrinsic { mismatch_index, .. } => {
+            ExecutionPhase::ApplyExtrinsic {
+                mismatch: ApplyExtrinsicMismatch::StateRoot(mismatch_index),
+                ..
+            } => {
                 if *mismatch_index == 0
                     || *mismatch_index >= bad_receipt.execution_trace.len() as u32 - 1
                 {
@@ -91,11 +123,36 @@ impl ExecutionPhase {
                     bad_receipt.execution_trace[*mismatch_index as usize],
                 )
             }
-            ExecutionPhase::FinalizeBlock => {
+            ExecutionPhase::ApplyExtrinsic {
+                mismatch: ApplyExtrinsicMismatch::Shorter,
+                ..
+            } => {
                 let mismatch_index = bad_receipt.execution_trace.len() - 1;
                 (
                     bad_receipt.execution_trace[mismatch_index - 1],
                     bad_receipt.execution_trace[mismatch_index],
+                )
+            }
+            ExecutionPhase::FinalizeBlock {
+                mismatch: FinalizeBlockMismatch::StateRoot,
+            } => {
+                let mismatch_index = bad_receipt.execution_trace.len() - 1;
+                (
+                    bad_receipt.execution_trace[mismatch_index - 1],
+                    bad_receipt.execution_trace[mismatch_index],
+                )
+            }
+            ExecutionPhase::FinalizeBlock {
+                mismatch: FinalizeBlockMismatch::Longer(mismatch_index),
+            } => {
+                if *mismatch_index == 0
+                    || *mismatch_index >= bad_receipt.execution_trace.len() as u32 - 1
+                {
+                    return Err(VerificationError::InvalidLongerMismatchTraceIndex);
+                }
+                (
+                    bad_receipt.execution_trace[(*mismatch_index - 1) as usize],
+                    bad_receipt.execution_trace[*mismatch_index as usize],
                 )
             }
         };
@@ -130,11 +187,18 @@ impl ExecutionPhase {
             }
             ExecutionPhase::ApplyExtrinsic {
                 extrinsic_proof: proof_of_inclusion,
-                mismatch_index,
+                mismatch,
             } => {
+                let mismatch_index = match mismatch {
+                    ApplyExtrinsicMismatch::StateRoot(mismatch_index) => *mismatch_index,
+                    ApplyExtrinsicMismatch::Shorter => (bad_receipt.execution_trace.len() - 1)
+                        .try_into()
+                        .expect("trace index should always fit into u32; qed"),
+                };
                 // There is a trace root of the `initialize_block` in the head of the trace so we
                 // need to minus one to get the correct `extrinsic_index`
-                let extrinsic_index = *mismatch_index - 1;
+                let extrinsic_index: u32 = mismatch_index - 1;
+
                 let storage_key =
                     StorageProofVerifier::<DomainHeader::Hashing>::enumerated_storage_key(
                         extrinsic_index,
@@ -147,7 +211,7 @@ impl ExecutionPhase {
                 )
                 .map_err(|_| VerificationError::InvalidApplyExtrinsicCallData)?
             }
-            ExecutionPhase::FinalizeBlock => Vec::new(),
+            ExecutionPhase::FinalizeBlock { .. } => Vec::new(),
         })
     }
 }
@@ -245,6 +309,10 @@ pub enum VerificationError<DomainHash> {
     InvalidExecutionTrace,
     #[cfg_attr(feature = "thiserror", error("Invalid ApplyExtrinsic trace index"))]
     InvalidApplyExtrinsicTraceIndex,
+    #[cfg_attr(feature = "thiserror", error("Invalid shorter mismatch trace index"))]
+    InvalidShorterMismatchTraceIndex,
+    #[cfg_attr(feature = "thiserror", error("Invalid longer mismatch trace index"))]
+    InvalidLongerMismatchTraceIndex,
     #[cfg_attr(feature = "thiserror", error("Invalid ApplyExtrinsic call data"))]
     InvalidApplyExtrinsicCallData,
     /// Invalid bundle digest
@@ -477,7 +545,9 @@ pub fn dummy_invalid_state_transition_proof<ReceiptHash: Default>(
         domain_id,
         bad_receipt_hash: ReceiptHash::default(),
         proof: StorageProof::empty(),
-        execution_phase: ExecutionPhase::FinalizeBlock,
+        execution_phase: ExecutionPhase::FinalizeBlock {
+            mismatch: FinalizeBlockMismatch::StateRoot,
+        },
     }
 }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -191,9 +191,9 @@ impl ExecutionPhase {
             } => {
                 let mismatch_index = match mismatch {
                     ApplyExtrinsicMismatch::StateRoot(mismatch_index) => *mismatch_index,
-                    ApplyExtrinsicMismatch::Shorter => (bad_receipt.execution_trace.len() - 1)
-                        .try_into()
-                        .expect("trace index should always fit into u32; qed"),
+                    ApplyExtrinsicMismatch::Shorter => {
+                        (bad_receipt.execution_trace.len() - 1) as u32
+                    }
                 };
                 // There is a trace root of the `initialize_block` in the head of the trace so we
                 // need to minus one to get the correct `extrinsic_index`

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -238,7 +238,14 @@ where
         .decode_execution_result::<DomainHeader>(execution_result)?
         .into();
 
-    if valid_post_state_root != post_state_root {
+    let is_mismatch = valid_post_state_root != post_state_root;
+
+    // If there is mismatch and execution phase indicate state root mismatch then the fraud proof is valid
+    // If there is no mismatch and execution phase indicate non state root mismatch (i.e the trace is either long or short) then
+    // the fraud proof is valid.
+    let is_valid = is_mismatch == execution_phase.is_state_root_mismatch();
+
+    if is_valid {
         Ok(())
     } else {
         Err(VerificationError::InvalidProof)

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -876,14 +876,14 @@ where
                 });
         }
 
-        if let Some(trace_mismatch_index) =
+        if let Some(trace_mismatch) =
             find_trace_mismatch(&local_receipt.execution_trace, &bad_receipt.execution_trace)
         {
             return self
                 .fraud_proof_generator
                 .generate_invalid_state_transition_proof(
                     self.domain_id,
-                    trace_mismatch_index,
+                    trace_mismatch,
                     &local_receipt,
                     bad_receipt_hash,
                 )

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -514,6 +514,8 @@ where
             }
             (TraceDiffType::Mismatch, mismatch_trace_index)
             | (TraceDiffType::Shorter, mismatch_trace_index) => {
+                // There is a trace root of the `initialize_block` in the head of the trace so we
+                // need to minus one to get the correct `extrinsic_index`
                 let extrinsic_index = mismatch_trace_index as usize - 1;
 
                 if extrinsic_index >= encoded_extrinsics.len() {

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -893,6 +893,7 @@ async fn test_bad_invalid_state_transition_proof_is_rejected() {
                 continue;
             }
 
+            // Abusing this method to generate every possible variant of ExecutionPhase
             let result_execution_phase = fraud_proof_generator.find_mismatched_execution_phase(
                 valid_receipt.domain_block_hash,
                 &valid_receipt.execution_trace,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1111,15 +1111,19 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     // Get a bundle from the txn pool and modify the receipt of the target bundle to an invalid one
     let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
     let original_submit_bundle_tx = bundle_to_tx(bundle.clone().unwrap());
-    let original_length;
+    let original_length = bundle
+        .as_ref()
+        .map(|opaque_bundle| {
+            opaque_bundle
+                .sealed_header
+                .header
+                .receipt
+                .execution_trace
+                .len()
+        })
+        .expect("Bundle should exists; qed");
     let (bad_receipt_hash, bad_submit_bundle_tx) = {
         let mut opaque_bundle = bundle.unwrap();
-        original_length = opaque_bundle
-            .sealed_header
-            .header
-            .receipt
-            .execution_trace
-            .len();
         let receipt = &mut opaque_bundle.sealed_header.header.receipt;
         assert_eq!(receipt.execution_trace.len(), 4);
 

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::domain_block_processor::{DomainBlockProcessor, PendingConsensusBlocks};
 use crate::domain_bundle_producer::DomainBundleProducer;
 use crate::domain_bundle_proposer::DomainBundleProposer;
-use crate::fraud_proof::FraudProofGenerator;
+use crate::fraud_proof::{FraudProofGenerator, TraceDiffType};
 use crate::tests::TxPoolError::InvalidTransaction as TxPoolInvalidTransaction;
 use crate::utils::OperatorSlotInfo;
 use codec::{Decode, Encode};
@@ -29,8 +29,8 @@ use sp_domains::{
     Bundle, BundleValidity, DomainsApi, HeaderHashingFor, InboxedBundle, InvalidBundleType,
 };
 use sp_domains_fraud_proof::fraud_proof::{
-    ExecutionPhase, FraudProof, InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof,
-    InvalidTotalRewardsProof,
+    ApplyExtrinsicMismatch, ExecutionPhase, FinalizeBlockMismatch, FraudProof,
+    InvalidDomainBlockHashProof, InvalidExtrinsicsRootProof, InvalidTotalRewardsProof,
 };
 use sp_domains_fraud_proof::InvalidTransactionCode;
 use sp_runtime::generic::{BlockId, DigestItem};
@@ -798,21 +798,6 @@ async fn test_executor_inherent_timestamp_is_set() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_initialize_block_proof_creation_and_verification_should_work() {
-    test_invalid_state_transition_proof_creation_and_verification(0).await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_apply_extrinsic_proof_creation_and_verification_should_work() {
-    test_invalid_state_transition_proof_creation_and_verification(2).await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_finalize_block_proof_creation_and_verification_should_work() {
-    test_invalid_state_transition_proof_creation_and_verification(3).await
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_bad_invalid_state_transition_proof_is_rejected() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -877,48 +862,108 @@ async fn test_bad_invalid_state_transition_proof_is_rejected() {
     // trace index 1 is the index of the state root after applying inherent timestamp extrinsic
     // trace index 2 is the index of the state root after applying above balance transfer extrinsic
     // trace index 3 is the index of the state root after applying BlockBuilder::finalize_block
-    for mismatch_index in 0..valid_receipt.execution_trace.len() {
-        let fraud_proof = fraud_proof_generator
-            .generate_invalid_state_transition_proof(
-                GENESIS_DOMAIN_ID,
-                mismatch_index.try_into().expect(
-                    "execution trace index should always be convertible into u32 from usize; qed",
-                ),
-                &valid_receipt,
-                valid_receipt_hash,
-            )
-            .unwrap();
+    for trace_diff_type in [
+        TraceDiffType::Shorter,
+        TraceDiffType::Longer,
+        TraceDiffType::Mismatch,
+    ] {
+        for mismatch_index in 0..valid_receipt.execution_trace.len() {
+            let fraud_proof_generation_response = fraud_proof_generator
+                .generate_invalid_state_transition_proof(
+                    GENESIS_DOMAIN_ID,
+                    (trace_diff_type, mismatch_index.try_into().expect(
+                        "execution trace index should always be convertible into u32 from usize; qed",
+                    )),
+                    &valid_receipt,
+                    valid_receipt_hash,
+                );
 
-        let submit_fraud_proof_extrinsic = subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
-            pallet_domains::Call::submit_fraud_proof {
-                fraud_proof: Box::new(fraud_proof),
+            // If we cannot generate fraud proof for particular (TraceDiffType, mismatch_index) combination
+            // then we move on to next combination.
+            if fraud_proof_generation_response.is_err() {
+                continue;
             }
-            .into(),
-        )
-        .into();
 
-        let response = ferdie
-            .submit_transaction(submit_fraud_proof_extrinsic)
-            .await;
+            let mut fraud_proof =
+                fraud_proof_generation_response.expect("already checked for error above; qed");
 
-        assert!(matches!(
-            response,
-            Err(PoolError::Pool(TxPoolInvalidTransaction(
-                InvalidTransaction::Custom(105)
-            )))
-        ));
+            let submit_fraud_proof_extrinsic =
+                subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
+                    pallet_domains::Call::submit_fraud_proof {
+                        fraud_proof: Box::new(fraud_proof),
+                    }
+                    .into(),
+                )
+                .into();
+
+            let response = ferdie
+                .submit_transaction(submit_fraud_proof_extrinsic)
+                .await;
+
+            assert!(matches!(
+                response,
+                Err(PoolError::Pool(TxPoolInvalidTransaction(
+                    InvalidTransaction::Custom(tx_code)
+                ))) if tx_code == InvalidTransactionCode::FraudProof as u8
+            ));
+
+            // To prevent receiving TemporarilyBanned error from the pool
+            ferdie.clear_tx_pool().await.unwrap();
+        }
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_initialize_block_proof_creation_and_verification_should_work() {
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Mismatch, 0).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_apply_extrinsic_proof_inherent_ext_creation_and_verification_should_work() {
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Mismatch, 1).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_apply_extrinsic_proof_normal_ext_creation_and_verification_should_work() {
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Mismatch, 2).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_finalize_block_proof_creation_and_verification_should_work() {
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Mismatch, 3).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_short_trace_for_inherent_apply_extrinsic_proof_creation_and_verification_should_work()
+{
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Shorter, 1).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_short_trace_for_normal_ext_apply_extrinsic_proof_creation_and_verification_should_work(
+) {
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Shorter, 2).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_long_trace_for_finalize_block_proof_creation_and_verification_should_work() {
+    // In case of TraceDiffType::Longer the bad ER always has two more elements. So, no effect of
+    // `mismatch_trace_index`
+    test_invalid_state_transition_proof_creation_and_verification(TraceDiffType::Longer, 0).await
 }
 
 /// This test will create and verify a invalid state transition proof that targets the receipt of
 /// a bundle that contains 2 extrinsic (including 1 inherent timestamp extrinsic), thus there are
 /// 4 trace roots in total, passing the `mismatch_trace_index` as:
-/// - 0 to test the `initialize_block` invalid state transition
-/// - 1 to test the `apply_extrinsic` invalid state transition with the inherent timestamp extrinsic
-/// - 2 to test the `apply_extrinsic` invalid state transition with regular domain extrinsic
-/// - 3 to test the `finalize_block` invalid state transition
+/// - 0 to test the `initialize_block` state transition
+/// - 1 to test the `apply_extrinsic` state transition with the inherent timestamp extrinsic
+/// - 2 to test the `apply_extrinsic` state transition with regular domain extrinsic
+/// - 3 to test the `finalize_block` state transition
+/// TraceDiffType can be passed as `TraceDiffType::Shorter`, `TraceDiffType::Longer`
+/// and `TraceDiffType::Mismatch`
 async fn test_invalid_state_transition_proof_creation_and_verification(
-    mismatch_trace_index: usize,
+    trace_diff_type: TraceDiffType,
+    mismatch_trace_index: u32,
 ) {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -972,12 +1017,36 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     // Get a bundle from the txn pool and modify the receipt of the target bundle to an invalid one
     let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
     let original_submit_bundle_tx = bundle_to_tx(bundle.clone().unwrap());
+    let original_length;
     let (bad_receipt_hash, bad_submit_bundle_tx) = {
         let mut opaque_bundle = bundle.unwrap();
+        original_length = opaque_bundle
+            .sealed_header
+            .header
+            .receipt
+            .execution_trace
+            .len();
         let receipt = &mut opaque_bundle.sealed_header.header.receipt;
         assert_eq!(receipt.execution_trace.len(), 4);
 
-        receipt.execution_trace[mismatch_trace_index] = Default::default();
+        match trace_diff_type {
+            TraceDiffType::Longer => {
+                receipt.execution_trace.push(Default::default());
+                receipt.execution_trace.push(Default::default());
+            }
+            TraceDiffType::Shorter => {
+                receipt.execution_trace = receipt
+                    .execution_trace
+                    .clone()
+                    .drain(..)
+                    .take((mismatch_trace_index + 1) as usize)
+                    .collect();
+            }
+            TraceDiffType::Mismatch => {
+                receipt.execution_trace[mismatch_trace_index as usize] = Default::default();
+            }
+        }
+
         receipt.execution_trace_root = {
             let trace: Vec<_> = receipt
                 .execution_trace
@@ -1014,21 +1083,45 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     // Wait for the fraud proof that target the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProof::InvalidStateTransition(proof) = fp {
-            match mismatch_trace_index {
-                0 => assert!(matches!(
-                    proof.execution_phase,
-                    ExecutionPhase::InitializeBlock
-                )),
-                // 1 for the inherent timestamp extrinsic, 2 for the above `transfer_allow_death` extrinsic
-                1 | 2 => assert!(matches!(
-                    proof.execution_phase,
-                    ExecutionPhase::ApplyExtrinsic { .. }
-                )),
-                3 => assert!(matches!(
-                    proof.execution_phase,
-                    ExecutionPhase::FinalizeBlock
-                )),
-                _ => unreachable!(),
+            match (trace_diff_type, mismatch_trace_index) {
+                (TraceDiffType::Mismatch, mismatch_trace_index) => match mismatch_trace_index {
+                    0 => assert!(matches!(
+                        proof.execution_phase,
+                        ExecutionPhase::InitializeBlock
+                    )),
+                    // 1 for the inherent timestamp extrinsic, 2 for the above `transfer_allow_death` extrinsic
+                    1 | 2 => assert!(matches!(
+                        proof.execution_phase,
+                        ExecutionPhase::ApplyExtrinsic {
+                            mismatch: ApplyExtrinsicMismatch::StateRoot(trace_index),
+                            ..
+                        } if trace_index == mismatch_trace_index
+                    )),
+                    3 => assert!(matches!(
+                        proof.execution_phase,
+                        ExecutionPhase::FinalizeBlock {
+                            mismatch: FinalizeBlockMismatch::StateRoot
+                        }
+                    )),
+                    _ => unreachable!(),
+                },
+                (TraceDiffType::Shorter, _) => {
+                    assert!(matches!(
+                        proof.execution_phase,
+                        ExecutionPhase::ApplyExtrinsic {
+                            mismatch: ApplyExtrinsicMismatch::Shorter,
+                            ..
+                        }
+                    ))
+                }
+                (TraceDiffType::Longer, _) => {
+                    assert!(matches!(
+                        proof.execution_phase,
+                        ExecutionPhase::FinalizeBlock {
+                            mismatch: FinalizeBlockMismatch::Longer(trace_index)
+                        } if trace_index as usize == original_length - 1
+                    ))
+                }
             }
             true
         } else {


### PR DESCRIPTION
# Description
This PR adds execution trace length mismatch detection in the invalid state transition fraud proof machinery. 

On generation side, `find_trace_mismatch` is modified to return additional data in regards to type of mismatch. `ApplyExtrinsic` and `FinalizeBlock` execution phase have additional field to indicate what type of mismatch it is.

On verification side, the `ExecutionPhase::pre_post_state_root` method is updated to handle different type of mismatch and fraud proof validity is determined based on whether the state transition is valid and the mismatch type.


Fixes #2303


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
