### PR TITLE
Subspace node refactoring (part 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12009,6 +12009,7 @@ dependencies = [
  "domain-runtime-primitives",
  "domain-service",
  "evm-domain-runtime",
+ "fdlimit",
  "fp-evm",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -12016,7 +12017,6 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
- "log",
  "mimalloc",
  "parity-scale-codec",
  "sc-chain-spec",
@@ -12031,7 +12031,6 @@ dependencies = [
  "sc-storage-monitor",
  "sc-subspace-chain-specs",
  "sc-telemetry",
- "sc-tracing",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
@@ -12052,8 +12051,11 @@ dependencies = [
  "subspace-runtime-primitives",
  "subspace-service",
  "substrate-build-script-utils",
+ "supports-color",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -58,7 +58,7 @@ tempfile = "3.8.0"
 thiserror = "1.0.48"
 tokio = { version = "1.34.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 ulid = { version = "1.0.0", features = ["serde"] }
 zeroize = "1.6.0"
 

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -29,6 +29,7 @@ domain-eth-service = { version = "0.1.0", path = "../../domains/client/eth-servi
 domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 evm-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/evm" }
+fdlimit = "0.3.0"
 fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1c667eb43c3d087ac66dc9ed0aa44128373f5b0a" }
 frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", default-features = false }
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", default-features = false }
@@ -36,7 +37,6 @@ frame-support = { version = "4.0.0-dev", git = "https://github.com/subspace/polk
 futures = "0.3.29"
 hex = "0.4.3"
 hex-literal = "0.4.1"
-log = "0.4.20"
 mimalloc = "0.1.39"
 parity-scale-codec = "3.6.5"
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
@@ -50,7 +50,6 @@ sc-subspace-chain-specs = { version = "0.1.0", path = "../sc-subspace-chain-spec
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", default-features = false }
 sc-storage-monitor = { version = "0.1.0", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5", default-features = false }
 sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
-sc-tracing = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
 sc-utils = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }
@@ -71,8 +70,11 @@ subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-spac
 subspace-runtime = { version = "0.1.0", path = "../subspace-runtime" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 subspace-service = { version = "0.1.0", path = "../subspace-service" }
+supports-color = "2.0.0"
 thiserror = "1.0.48"
 tokio = { version = "1.34.0", features = ["macros"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [build-dependencies]
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -72,7 +72,7 @@ subspace-runtime = { version = "0.1.0", path = "../subspace-runtime" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 subspace-service = { version = "0.1.0", path = "../subspace-service" }
 thiserror = "1.0.48"
-tokio = "1.34.0"
+tokio = { version = "1.34.0", features = ["macros"] }
 
 [build-dependencies]
 substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "0831dfc3c54b10ab46e82acf98603b4af1a47bd5" }

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -30,7 +30,6 @@ use domain_runtime_primitives::opaque::Block as DomainBlock;
 use evm_domain_runtime::ExecutorDispatch as EVMDomainExecutorDispatch;
 use frame_benchmarking_cli::BenchmarkCmd;
 use futures::future::TryFutureExt;
-use log::warn;
 use sc_cli::{ChainSpec, SubstrateCli};
 use sc_executor::NativeExecutionDispatch;
 use sc_service::{Configuration, PartialComponents};
@@ -39,6 +38,7 @@ use sp_io::SubstrateHostFunctions;
 use sp_wasm_interface::ExtendedHostFunctions;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_runtime::{Block, ExecutorDispatch, RuntimeApi};
+use tracing::warn;
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;


### PR DESCRIPTION
Builds on top of https://github.com/subspace/subspace/pull/2405 and stops using Substrate runner and CLI for starting the node.

This means we are no longer required to use `RunCmd` and can replace it with our own CLI options as long as we can generate `Configuration` for `subspace-service` from it, which opens the door for consensus side of https://github.com/subspace/subspace/issues/1727, though there might be one more PR that moves things around before getting to that.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
