### PR TITLE
Subspace node refactoring (part 10)

### DIFF
--- a/crates/subspace-node/src/cli.rs
+++ b/crates/subspace-node/src/cli.rs
@@ -58,7 +58,6 @@ pub enum Cli {
     Domain(crate::domain::cli::Subcommand),
 
     /// Sub-commands concerned with benchmarking.
-    #[cfg(feature = "runtime-benchmarks")]
     #[clap(subcommand)]
     Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 }

--- a/crates/subspace-node/src/cli.rs
+++ b/crates/subspace-node/src/cli.rs
@@ -29,10 +29,6 @@ pub enum Cli {
     /// Run blockchain node
     Run(RunOptions),
 
-    /// Key management cli utilities
-    #[clap(subcommand)]
-    Key(sc_cli::KeySubcommand),
-
     /// Build a chain specification.
     BuildSpec(sc_cli::BuildSpecCmd),
 

--- a/crates/subspace-node/src/cli.rs
+++ b/crates/subspace-node/src/cli.rs
@@ -15,72 +15,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::chain_spec;
-use crate::commands::RunOptions;
+use crate::commands::{RunOptions, WipeOptions};
 use clap::Parser;
 use sc_cli::SubstrateCli;
 use sc_service::ChainSpec;
 use sc_subspace_chain_specs::ConsensusChainSpec;
-use std::io::Write;
-use std::{fs, io};
-
-/// This `purge-chain` command used to remove both consensus chain and domain.
-#[derive(Debug, Clone, Parser)]
-#[group(skip)]
-pub struct PurgeChainCmd {
-    /// The base struct of the purge-chain command.
-    #[clap(flatten)]
-    pub base: sc_cli::PurgeChainCmd,
-}
-
-impl PurgeChainCmd {
-    /// Run the purge command
-    pub fn run(&self, consensus_chain_config: sc_service::Configuration) -> sc_cli::Result<()> {
-        let paths = vec![
-            consensus_chain_config.base_path.path().join("db"),
-            consensus_chain_config.base_path.path().join("domains"),
-            consensus_chain_config.base_path.path().join("network"),
-            // TODO: Following three are temporary workaround for wiping old chains, remove once enough time has passed
-            consensus_chain_config.base_path.path().join("chains"),
-            consensus_chain_config.base_path.path().join("domain-0"),
-            consensus_chain_config.base_path.path().join("domain-1"),
-        ];
-
-        if !self.base.yes {
-            println!("Following paths (if exist) are about to be removed:");
-            for path in &paths {
-                println!(" {}", path.display());
-            }
-            print!("Are you sure to remove? [y/N]: ");
-            io::stdout().flush().expect("failed to flush stdout");
-
-            let mut input = String::new();
-            io::stdin().read_line(&mut input)?;
-            let input = input.trim();
-
-            match input.chars().next() {
-                Some('y') | Some('Y') => {}
-                _ => {
-                    println!("Aborted");
-                    return Ok(());
-                }
-            }
-        }
-
-        for db_path in &paths {
-            match fs::remove_dir_all(db_path) {
-                Ok(_) => {
-                    println!("{:?} removed.", &db_path);
-                }
-                Err(ref err) if err.kind() == io::ErrorKind::NotFound => {
-                    eprintln!("{:?} did not exist already, skipping.", &db_path);
-                }
-                Err(err) => return Err(err.into()),
-            }
-        }
-
-        Ok(())
-    }
-}
 
 /// Commands for working with a node.
 #[derive(Debug, Parser)]
@@ -109,8 +48,8 @@ pub enum Cli {
     /// Import blocks.
     ImportBlocks(sc_cli::ImportBlocksCmd),
 
-    /// Remove the whole chain.
-    PurgeChain(PurgeChainCmd),
+    /// Remove all node's data
+    Wipe(WipeOptions),
 
     /// Revert the chain to a previous state.
     Revert(sc_cli::RevertCmd),

--- a/crates/subspace-node/src/commands.rs
+++ b/crates/subspace-node/src/commands.rs
@@ -1,3 +1,5 @@
 mod run;
+mod wipe;
 
 pub use run::{run, RunOptions};
+pub use wipe::{wipe, WipeOptions};

--- a/crates/subspace-node/src/commands.rs
+++ b/crates/subspace-node/src/commands.rs
@@ -1,5 +1,8 @@
+mod insert_domain_key;
 mod run;
+mod shared;
 mod wipe;
 
+pub use insert_domain_key::{insert_domain_key, InsertDomainKeyOptions};
 pub use run::{run, RunOptions};
 pub use wipe::{wipe, WipeOptions};

--- a/crates/subspace-node/src/commands/insert_domain_key.rs
+++ b/crates/subspace-node/src/commands/insert_domain_key.rs
@@ -1,0 +1,58 @@
+use crate::commands::shared::{init_logger, store_key_in_keystore, KeystoreOptions};
+use clap::Parser;
+use sc_cli::{Error, KeystoreParams};
+use sc_service::config::KeystoreConfig;
+use sp_domains::DomainId;
+use std::path::PathBuf;
+use tracing::info;
+
+/// Options for running a node
+#[derive(Debug, Parser)]
+pub struct InsertDomainKeyOptions {
+    /// Base path where to store node files
+    #[arg(long)]
+    base_path: PathBuf,
+    /// ID of the domain to store key for
+    #[arg(long, required = true)]
+    domain_id: DomainId,
+    /// Options for domain keystore
+    #[clap(flatten)]
+    keystore_options: KeystoreOptions<true>,
+}
+
+pub fn insert_domain_key(options: InsertDomainKeyOptions) -> Result<(), Error> {
+    init_logger();
+
+    let InsertDomainKeyOptions {
+        base_path,
+        domain_id,
+        keystore_options,
+    } = options;
+    let domain_path = base_path.join("domains").join(domain_id.to_string());
+
+    let keystore_params = KeystoreParams {
+        keystore_path: None,
+        password_interactive: keystore_options.keystore_password_interactive,
+        password: keystore_options.keystore_password,
+        password_filename: keystore_options.keystore_password_filename,
+    };
+
+    let keystore_config = keystore_params.keystore_config(&domain_path)?;
+
+    let Some(keystore_suri) = keystore_options.keystore_suri else {
+        unreachable!("--keystore-suri is set to required; qed");
+    };
+
+    let (path, password) = match &keystore_config {
+        KeystoreConfig::Path { path, password, .. } => (path.clone(), password.clone()),
+        KeystoreConfig::InMemory => {
+            unreachable!("Just constructed non-memory keystore config; qed");
+        }
+    };
+
+    store_key_in_keystore(path, password, &keystore_suri)?;
+
+    info!("Success");
+
+    Ok(())
+}

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -94,9 +94,6 @@ struct KeystoreOptions {
     /// Use interactive shell for entering the password used by the keystore.
     #[arg(long, conflicts_with_all = &["keystore_password", "keystore_password_filename"])]
     keystore_password_interactive: bool,
-    // TODO: Substrate has interactive password as well, but we run domain after consensus chain
-    //  reaches height of the domain registration, so interactive makes less sense here, but maybe
-    //  we will want to use some alternative
     /// Password used by the keystore. This allows appending an extra user-defined secret to the
     /// seed.
     #[arg(long, conflicts_with_all = &["keystore_password_interactive", "keystore_password_filename"])]

--- a/crates/subspace-node/src/commands/wipe.rs
+++ b/crates/subspace-node/src/commands/wipe.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use std::path::PathBuf;
+use std::{fs, io};
+use tracing::info;
+
+/// Options for running a node
+#[derive(Debug, Parser)]
+pub struct WipeOptions {
+    /// Base path where to store node files
+    base_path: PathBuf,
+}
+
+pub fn wipe(WipeOptions { base_path }: WipeOptions) -> Result<(), io::Error> {
+    let paths = [
+        base_path.join("db"),
+        base_path.join("domains"),
+        base_path.join("network"),
+        // TODO: Following three are temporary workaround for wiping old chains, remove once enough time has passed
+        base_path.join("chains"),
+        base_path.join("domain-0"),
+        base_path.join("domain-1"),
+    ];
+
+    for path in paths {
+        if path.exists() {
+            info!("Removing {}", path.display());
+            fs::remove_dir_all(path)?;
+        }
+    }
+
+    info!("Done");
+
+    Ok(())
+}

--- a/crates/subspace-node/src/commands/wipe.rs
+++ b/crates/subspace-node/src/commands/wipe.rs
@@ -1,3 +1,4 @@
+use crate::commands::shared::init_logger;
 use clap::Parser;
 use std::path::PathBuf;
 use std::{fs, io};
@@ -11,6 +12,8 @@ pub struct WipeOptions {
 }
 
 pub fn wipe(WipeOptions { base_path }: WipeOptions) -> Result<(), io::Error> {
+    init_logger();
+
     let paths = [
         base_path.join("db"),
         base_path.join("domains"),

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -89,8 +89,6 @@ impl DomainCli {
         let mut domain_config = SubstrateCli::create_configuration(self, self, tokio_handle)?;
 
         // Change default paths to Subspace structure
-        // TODO: Similar copy-paste exists in `DomainCli::create_domain_configuration()` and
-        //  `DomainInstanceStarter::start()` and should be de-duplicated
         let domain_base_path = base_path.join(self.domain_id.to_string());
         {
             domain_config.database = DatabaseSource::ParityDb {

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::commands::InsertDomainKeyOptions;
 use crate::domain::evm_chain_spec;
 use crate::domain::evm_chain_spec::SpecId;
 use clap::Parser;
@@ -43,6 +44,9 @@ use subspace_runtime::Block;
 #[derive(Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommand {
+    /// Insert key into domain's keystore
+    InsertKey(InsertDomainKeyOptions),
+
     /// Export the state of a given block into a chain spec.
     ExportState(sc_cli::ExportStateCmd),
 

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -127,7 +127,6 @@ fn main() -> Result<(), Error> {
         Cli::Run(run_options) => {
             commands::run(run_options)?;
         }
-        Cli::Key(cmd) => cmd.run(&SubspaceCliPlaceholder)?,
         Cli::BuildSpec(cmd) => {
             let runner = SubspaceCliPlaceholder.create_runner(&cmd)?;
             runner.sync_run(|config| cmd.run(config.chain_spec, config.network))?
@@ -315,6 +314,9 @@ fn main() -> Result<(), Error> {
             })?;
         }
         Cli::Domain(domain_cmd) => match domain_cmd {
+            DomainSubcommand::InsertKey(insert_domain_key_options) => {
+                commands::insert_domain_key(insert_domain_key_options)?;
+            }
             DomainSubcommand::Benchmark(cmd) => {
                 let runner = SubspaceCliPlaceholder.create_runner(&cmd)?;
                 runner.sync_run(|consensus_chain_config| {

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -347,7 +347,7 @@ fn main() -> Result<(), Error> {
                     );
                     let domain_config = domain_cli
                         .create_domain_configuration(
-                            &consensus_chain_config.base_path.path().join("domains"),
+                            consensus_chain_config.base_path.path(),
                             consensus_chain_config.tokio_handle,
                         )
                         .map_err(|error| {
@@ -380,7 +380,7 @@ fn main() -> Result<(), Error> {
                     let domain_cli = DomainCli::new(cmd.domain_args.clone().into_iter());
                     let domain_config = domain_cli
                         .create_domain_configuration(
-                            &consensus_chain_config.base_path.path().join("domains"),
+                            consensus_chain_config.base_path.path(),
                             consensus_chain_config.tokio_handle,
                         )
                         .map_err(|error| {

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -233,7 +233,6 @@ fn main() -> Result<(), Error> {
             let runner = SubspaceCliPlaceholder.create_runner(&cmd)?;
             runner.sync_run(|config| cmd.run::<Block>(&config))?;
         }
-        #[cfg(feature = "runtime-benchmarks")]
         Cli::Benchmark(cmd) => {
             let runner = SubspaceCliPlaceholder.create_runner(&cmd)?;
 
@@ -267,6 +266,12 @@ fn main() -> Result<(), Error> {
 
                         cmd.run(client)
                     }
+                    #[cfg(not(feature = "runtime-benchmarks"))]
+                    BenchmarkCmd::Storage(_) => Err(sc_cli::Error::Input(
+                        "Compile with --features=runtime-benchmarks to enable storage benchmarks."
+                            .into(),
+                    )),
+                    #[cfg(feature = "runtime-benchmarks")]
                     BenchmarkCmd::Storage(cmd) => {
                         let PartialComponents {
                             client, backend, ..

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -208,30 +208,8 @@ fn main() -> Result<(), Error> {
                 ))
             })?;
         }
-        Cli::PurgeChain(cmd) => {
-            // This is a compatibility layer to make sure we wipe old data from disks of our users
-            if let Some(base_dir) = dirs::data_local_dir() {
-                for chain in &[
-                    "subspace_gemini_2a",
-                    "subspace_gemini_3a",
-                    "subspace_gemini_3b",
-                    "subspace_gemini_3c",
-                    "subspace_gemini_3d",
-                    "subspace_gemini_3e",
-                    "subspace_gemini_3f",
-                    "subspace_gemini_3g",
-                ] {
-                    let _ = std::fs::remove_dir_all(
-                        base_dir.join("subspace-node").join("chains").join(chain),
-                    );
-                }
-                let _ = std::fs::remove_dir_all(base_dir.join("subspace-node").join("domain-0"));
-                let _ = std::fs::remove_dir_all(base_dir.join("subspace-node").join("domain-1"));
-            }
-
-            let runner = SubspaceCliPlaceholder.create_runner(&cmd.base)?;
-
-            runner.sync_run(|consensus_chain_config| cmd.run(consensus_chain_config))?;
+        Cli::Wipe(wipe_options) => {
+            commands::wipe(wipe_options).map_err(|error| Error::Other(error.to_string()))?;
         }
         Cli::Revert(cmd) => {
             let runner = SubspaceCliPlaceholder.create_runner(&cmd)?;

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -299,7 +299,7 @@ If you were running a node previously, and want to switch to a new snapshot, ple
 # Replace `FARMER_FILE_NAME` with the name of the node file you downloaded from releases
 ./FARMER_FILE_NAME wipe PATH_TO_FARM
 # Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases
-./NODE_FILE_NAME purge-chain --chain gemini-3g
+./NODE_FILE_NAME wipe PATH_TO_NODE
 ```
 Does not matter if the node/farmer executable is the previous one or from the new snapshot, both will work :)
 The reason we require this is, with every snapshot change, the network might get partitioned, and you may be on a different genesis than the current one.
@@ -323,7 +323,7 @@ Below are some helpful samples:
 - `./FARMER_FILE_NAME info PATH_TO_FARM`: show information about the farm at `PATH_TO_FARM`
 - `./FARMER_FILE_NAME scrub PATH_TO_FARM`: Scrub the farm to find and fix farm at `PATH_TO_FARM` corruption
 - `./FARMER_FILE_NAME wipe PATH_TO_FARM`: erases everything related to farmer if data were stored in `PATH_TO_FARM`
-- `./NODE_FILE_NAME purge-chain --base-path NODE_DATA_PATH --chain gemini-3g`: erases data related to the node if data were stored in `NODE_DATA_PATH`
+- `./NODE_FILE_NAME wipe PATH_TO_NODE`: erases data related to the node if data were stored in `PATH_TO_NODE`
 
 Examples:
 ```bash

--- a/domains/README.md
+++ b/domains/README.md
@@ -29,11 +29,10 @@ Backup the key. Take `Public key (hex)` of the Keypair. The public key is part o
 The above generated key is added to the Keystore so that Operator node can use to participate in Bundle production.
 The key is inserted using the following command:
 ```bash
-target/production/subspace-node key insert \
-      --suri "<Secret phrase>" --key-type oper --scheme sr25519 --keystore-path `{subspace-node-base-path}/domains/{domain-id}/keystore`
+target/production/subspace-node domain insert-key \
+      --base-path {subspace-node-base-path} --domain-id {domain-id} --keypair-suri {secret-phrase}
 ```
-The above command assumes `{subspace-node-base-path}` as the location of node data.
-`suri` is the secret phrase of the Operator key.
+The above command assumes `{subspace-node-base-path}` as the location of node data. `{domain-id}` is a domain for which to insert the key and `{secret-phrase}` is the secret phrase to use for keypair derivation.
 
 #### Register Operator:
 Operator needs to register to a domain they want to operate on using `register_operator`. Registration extrinsic requires Operator Config.


### PR DESCRIPTION
Builds on top of https://github.com/subspace/subspace/pull/2412 and resolves https://github.com/subspace/subspace/issues/1727 fully.

First this replaces `purge-chain` with `wipe` command:
```
subspace-node wipe /path/to/node
```

Second it removes `key` command (cc @DaMandal0rian in case you're using it for automation) because all the same stuff and a bit more can be done with subkey (see `docker run --rm -it parity/subkey --help`). Instead a single `domain insert-key` command was added instead, here is how you use it:
```
subspace-node domain insert-key --base-path /tmp/node --domain-id 0 --keystore-suri "//Alice"
```

In last commit I also fixed up benchmarking a bit.

This is all that is necessary in terms of basic key operations for most users.

There are still many awkward commands left in subspace-node that are using Substrate infra, but none of them should be needed by regular users and I expect that maybe Ning will upgrade malicious operator to have API similar to `subspace-node` (or better yet, integrates it in `subspace-node`, maybe as a conditionally compiled feature).

@EmilFattakhov @ImmaZoni @jim-counter FYI, this is one of the planned CLI changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
