### PR TITLE
Remove WASM_BUILD_CLEAN_TARGET as no longer necessary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,6 @@ env:
   # TODO: AES flag is such that we have decent performance on ARMv8, remove once `aes` crate bumps MSRV to at least
   #  1.61: https://github.com/RustCrypto/block-ciphers/issues/373
   RUSTFLAGS: -C strip=symbols -C opt-level=s --cfg aes_armv8
-  # Remove unnecessary WASM build artefacts
-  WASM_BUILD_CLEAN_TARGET: 1
 
 jobs:
   cargo-fmt:


### PR DESCRIPTION
This is provided by one of downstream patches in our fork of Substrate that I want to drop from newer versions. It was fixing large disk space usage that seems to not be an issue anymore. I've tested this with self-hosted runners and running test with GitHub's runners here: https://github.com/nazar-pc/subspace/actions/runs/7526853533

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
