### PR TITLE
Update Rust to latest nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,10 +52,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: cargo fmt
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   cargo-clippy:
     strategy:
@@ -114,10 +111,8 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: cargo clippy
-        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d # @v1.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --locked --all-targets --features "runtime-benchmarks" -- -D warnings
+        run: |
+          cargo -Zgitoxide -Zgit clippy --locked --all-targets --features "runtime-benchmarks" -- -D warnings
 
   cargo-docs:
     runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || '"ubuntu-22.04"') }}
@@ -141,7 +136,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Check Documentation
-        run: cargo doc --locked --all --no-deps --lib
+        run: cargo -Zgitoxide -Zgit doc --locked --all --no-deps --lib
         env:
           RUSTDOCFLAGS: "-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links"
 
@@ -207,7 +202,5 @@ jobs:
           tool: cargo-nextest
 
       - name: cargo nextest run --locked
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
-        with:
-          command: nextest
-          args: run --locked
+        run: |
+          cargo -Zgitoxide -Zgit nextest run --locked

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Build the rust crate docs
       - name: Build Documentation
-        run: cargo doc --all --no-deps --lib
+        run: cargo -Zgitoxide -Zgit doc --all --no-deps --lib
         env:
           RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
 

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -201,25 +201,19 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build farmer (Linux and Windows)
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
-        with:
-          command: build
-          args: --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
+        run: |
+          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
         if: runner.os != 'macOS'
 
       # We build macOS without `numa` feature, primarily because of https://github.com/HadrienG2/hwlocality/issues/31
       - name: Build farmer (macOS)
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
-        with:
-          command: build
-          args: --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --no-default-features
+        run: |
+          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --no-default-features
         if: runner.os == 'macOS'
 
       - name: Build node
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1
-        with:
-          command: build
-          args: --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-node
+        run: |
+          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-node
 
       - name: Sign Application (macOS)
         run: |

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -41,7 +41,7 @@ COPY test /code/test
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -54,7 +54,7 @@ RUN \
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-9-multilib
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -41,7 +41,7 @@ COPY test /code/test
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -54,7 +54,7 @@ RUN \
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-9-multilib
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -43,7 +43,7 @@ COPY test /code/test
 ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -51,7 +51,7 @@ RUN \
         libc6-dev-arm64-cross
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2023-10-16
+ARG RUSTC_VERSION=nightly-2024-01-19
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -41,7 +41,7 @@ COPY test /code/test
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 RUN \
-    /root/.cargo/bin/cargo build \
+    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \
         --profile $PROFILE \

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1023,7 +1023,7 @@ fn test_invalid_domain_extrinsic_root_proof() {
         );
 
         let bad_receipt_at = 8;
-        let valid_bundle_digests = vec![ValidBundleDigest {
+        let valid_bundle_digests = [ValidBundleDigest {
             bundle_index: 0,
             bundle_digest: vec![(Some(vec![1, 2, 3]), ExtrinsicDigest::Data(vec![4, 5, 6]))],
         }];

--- a/crates/pallet-rewards/src/lib.rs
+++ b/crates/pallet-rewards/src/lib.rs
@@ -113,7 +113,7 @@ impl<T: Config> Pallet<T> {
         // Block author may equivocate, in which case they'll not be present here
         if let Some(block_author) = T::FindBlockRewardAddress::find_block_reward_address() {
             let reward = T::BlockReward::get();
-            T::Currency::deposit_creating(&block_author, reward);
+            let _imbalance = T::Currency::deposit_creating(&block_author, reward);
             T::OnReward::on_reward(block_author.clone(), reward);
 
             Self::deposit_event(Event::BlockReward {
@@ -127,7 +127,7 @@ impl<T: Config> Pallet<T> {
         let reward = T::VoteReward::get();
 
         for voter in T::FindVotingRewardAddresses::find_voting_reward_addresses() {
-            T::Currency::deposit_creating(&voter, reward);
+            let _imbalance = T::Currency::deposit_creating(&voter, reward);
             T::OnReward::on_reward(voter.clone(), reward);
 
             Self::deposit_event(Event::VoteReward { voter, reward });

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -264,7 +264,7 @@ where
             // Issue storage fees reward.
             let storage_fees_reward = storage_fees_escrow_reward + collected_storage_fees_reward;
             if !storage_fees_reward.is_zero() {
-                T::Currency::deposit_creating(&block_author, storage_fees_reward);
+                let _imbalance = T::Currency::deposit_creating(&block_author, storage_fees_reward);
                 Self::deposit_event(Event::<T>::StorageFeesReward {
                     who: block_author.clone(),
                     amount: storage_fees_reward,
@@ -273,7 +273,8 @@ where
 
             // Issue compute fees reward.
             if !collected_fees.compute.is_zero() {
-                T::Currency::deposit_creating(&block_author, collected_fees.compute);
+                let _imbalance =
+                    T::Currency::deposit_creating(&block_author, collected_fees.compute);
                 Self::deposit_event(Event::<T>::ComputeFeesReward {
                     who: block_author.clone(),
                     amount: collected_fees.compute,
@@ -282,7 +283,7 @@ where
 
             // Issue tips reward.
             if !collected_fees.tips.is_zero() {
-                T::Currency::deposit_creating(&block_author, collected_fees.tips);
+                let _imbalance = T::Currency::deposit_creating(&block_author, collected_fees.tips);
                 Self::deposit_event(Event::<T>::TipsReward {
                     who: block_author,
                     amount: collected_fees.tips,

--- a/crates/sp-domains/src/merkle_tree.rs
+++ b/crates/sp-domains/src/merkle_tree.rs
@@ -1,5 +1,4 @@
 use crate::OperatorPublicKey;
-use blake2::digest::typenum::U32;
 use blake2::digest::FixedOutput;
 use blake2::{Blake2b, Digest};
 use parity_scale_codec::{Decode, Encode};
@@ -27,12 +26,12 @@ pub struct Witness {
 }
 
 #[derive(Clone)]
-pub struct Blake2b256Algorithm(Blake2b<U32>);
+pub struct Blake2b256Algorithm;
 
 impl Default for Blake2b256Algorithm {
     #[inline]
     fn default() -> Self {
-        Self(Blake2b::new())
+        Self
     }
 }
 

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -276,7 +276,7 @@ fn archiver() {
 
     // Check archived bytes for block with index `2` in each archived segment
     {
-        let archived_segment = archived_segments.get(0).unwrap();
+        let archived_segment = archived_segments.first().unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
         assert_eq!(last_archived_block.partial_archived(), Some(108352733));
@@ -360,7 +360,7 @@ fn archiver() {
 
     // Archived segment should fit exactly into the last archived segment (rare case)
     {
-        let archived_segment = archived_segments.get(0).unwrap();
+        let archived_segment = archived_segments.first().unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 3);
         assert_eq!(last_archived_block.partial_archived(), None);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -231,11 +231,7 @@ impl FromStr for DiskFarm {
 
             match key {
                 "path" => {
-                    plot_directory.replace(
-                        PathBuf::try_from(value).map_err(|error| {
-                            format!("Failed to parse `path` \"{value}\": {error}")
-                        })?,
-                    );
+                    plot_directory.replace(PathBuf::from(value));
                 }
                 "size" => {
                     allocated_plotting_space.replace(

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
@@ -45,6 +45,8 @@ where
     RecordKey: From<K>,
     K: Clone,
 {
+    // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12154
+    #[allow(clippy::unconditional_recursion)]
     fn eq(&self, other: &Self) -> bool {
         self.peer_distance().eq(&other.peer_distance())
     }

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -13,7 +13,8 @@ use alloc::vec::Vec;
 use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
 use chacha20::{ChaCha8, Key, Nonce};
 use core::mem;
-use core::simd::{Simd, SimdUint};
+use core::simd::num::SimdUint;
+use core::simd::Simd;
 #[cfg(any(feature = "parallel", test))]
 use rayon::prelude::*;
 use seq_macro::seq;

--- a/domains/client/eth-service/src/rpc.rs
+++ b/domains/client/eth-service/src/rpc.rs
@@ -4,9 +4,8 @@ use fc_rpc::{
     Eth, EthApiServer, EthDevSigner, EthFilter, EthFilterApiServer, EthPubSub, EthPubSubApiServer,
     EthSigner, Net, NetApiServer, Web3, Web3ApiServer,
 };
-pub use fc_rpc::{EthBlockDataCacheTask, EthConfig, StorageOverride};
+pub use fc_rpc::{EthBlockDataCacheTask, EthConfig};
 pub use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
-pub use fc_storage::overrides_handle;
 use fc_storage::OverrideHandle;
 use fp_rpc::{ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi};
 use jsonrpsee::RpcModule;

--- a/domains/client/eth-service/src/service.rs
+++ b/domains/client/eth-service/src/service.rs
@@ -1,5 +1,3 @@
-pub use fc_consensus::FrontierBlockImport;
-pub use fc_db::kv::frontier_database_dir;
 use fc_mapping_sync::kv::MappingSyncWorker;
 use fc_mapping_sync::SyncStrategy;
 use fc_rpc::{EthTask, OverrideHandle};

--- a/domains/pallets/transporter/src/lib.rs
+++ b/domains/pallets/transporter/src/lib.rs
@@ -193,7 +193,7 @@ mod pallet {
             let sender = ensure_signed(origin)?;
 
             // burn transfer amount
-            T::Currency::withdraw(
+            let _imbalance = T::Currency::withdraw(
                 &sender,
                 amount,
                 WithdrawReasons::TRANSFER,
@@ -266,7 +266,7 @@ mod pallet {
             let account_id = T::AccountIdConverter::try_convert_back(req.receiver.account_id)
                 .ok_or(Error::<T>::InvalidAccountId)?;
 
-            T::Currency::deposit_creating(&account_id, req.amount);
+            let _imbalance = T::Currency::deposit_creating(&account_id, req.amount);
             frame_system::Pallet::<T>::deposit_event(Into::<<T as Config>::RuntimeEvent>::into(
                 Event::<T>::IncomingTransferSuccessful {
                     chain_id: src_chain_id,
@@ -314,7 +314,7 @@ mod pallet {
                     let account_id =
                         T::AccountIdConverter::try_convert_back(transfer.sender.account_id)
                             .ok_or(Error::<T>::InvalidAccountId)?;
-                    T::Currency::deposit_creating(&account_id, transfer.amount);
+                    let _imbalance = T::Currency::deposit_creating(&account_id, transfer.amount);
                     frame_system::Pallet::<T>::deposit_event(
                         Into::<<T as Config>::RuntimeEvent>::into(
                             Event::<T>::OutgoingTransferFailed {

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -153,6 +153,8 @@ where
     let (engine, sync_service, block_announce_config) = SyncingEngine::new(
         Roles::from(&config.role),
         client.clone(),
+        // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12148
+        #[allow(clippy::useless_asref)]
         config
             .prometheus_config
             .as_ref()
@@ -212,6 +214,8 @@ where
         genesis_hash,
         protocol_id,
         fork_id: config.chain_spec.fork_id().map(ToOwned::to_owned),
+        // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12148
+        #[allow(clippy::useless_asref)]
         metrics_registry: config
             .prometheus_config
             .as_ref()
@@ -234,6 +238,8 @@ where
             transaction_pool,
             client.clone(),
         )),
+        // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12148
+        #[allow(clippy::useless_asref)]
         config
             .prometheus_config
             .as_ref()

--- a/orml/vesting/src/tests.rs
+++ b/orml/vesting/src/tests.rs
@@ -164,7 +164,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
         ));
 
         assert_eq!(
-            PalletBalances::locks(BOB).get(0),
+            PalletBalances::locks(BOB).first(),
             Some(&BalanceLock {
                 id: VESTING_LOCK_ID,
                 amount: 17u64,
@@ -348,7 +348,7 @@ fn claim_for_works() {
         assert_ok!(Vesting::claim_for(RuntimeOrigin::signed(ALICE), BOB));
 
         assert_eq!(
-            PalletBalances::locks(BOB).get(0),
+            PalletBalances::locks(BOB).first(),
             Some(&BalanceLock {
                 id: VESTING_LOCK_ID,
                 amount: 20u64,
@@ -411,7 +411,7 @@ fn update_vesting_schedules_works() {
         // empty vesting schedules cleanup the storage and unlock the fund
         assert!(VestingSchedules::<Runtime>::contains_key(BOB));
         assert_eq!(
-            PalletBalances::locks(BOB).get(0),
+            PalletBalances::locks(BOB).first(),
             Some(&BalanceLock {
                 id: VESTING_LOCK_ID,
                 amount: 10u64,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-10-16"
+channel = "nightly-2024-01-19"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
Notably, [shallow clones](https://github.com/rust-lang/cargo/pull/13252#issuecomment-1889487362) are now a thing :tada: 

There are two clippy regressions that will land in released version of clippy next week, so we'll do another update then and clean up introduced suppressions.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
