### PR TITLE
Configurable dynamic cost of storage enablement

### DIFF
--- a/crates/pallet-runtime-configs/src/benchmarking.rs
+++ b/crates/pallet-runtime-configs/src/benchmarking.rs
@@ -16,6 +16,14 @@ mod benchmarks {
     }
 
     #[benchmark]
+    fn set_enable_dynamic_cost_of_storage() {
+        #[extrinsic_call]
+        _(RawOrigin::Root, true);
+
+        assert!(Pallet::<T>::enable_dynamic_cost_of_storage());
+    }
+
+    #[benchmark]
     fn set_enable_balance_transfers() {
         #[extrinsic_call]
         _(RawOrigin::Root, true);

--- a/crates/pallet-runtime-configs/src/benchmarking.rs
+++ b/crates/pallet-runtime-configs/src/benchmarking.rs
@@ -30,4 +30,12 @@ mod benchmarks {
 
         assert!(Pallet::<T>::enable_balance_transfers());
     }
+
+    #[benchmark]
+    fn set_enable_non_root_calls() {
+        #[extrinsic_call]
+        _(RawOrigin::Root, true);
+
+        assert!(Pallet::<T>::enable_non_root_calls());
+    }
 }

--- a/crates/pallet-runtime-configs/src/lib.rs
+++ b/crates/pallet-runtime-configs/src/lib.rs
@@ -48,6 +48,11 @@ mod pallet {
     #[pallet::getter(fn enable_balance_transfers)]
     pub type EnableBalanceTransfers<T> = StorageValue<_, bool, ValueQuery>;
 
+    /// Whether to enable calls from non-root account.
+    #[pallet::storage]
+    #[pallet::getter(fn enable_non_root_calls)]
+    pub type EnableNonRootCalls<T> = StorageValue<_, bool, ValueQuery>;
+
     #[pallet::storage]
     pub type ConfirmationDepthK<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 
@@ -65,6 +70,8 @@ mod pallet {
         pub enable_dynamic_cost_of_storage: bool,
         /// Whether to enable balance transfers
         pub enable_balance_transfers: bool,
+        /// Whether to enable calls from non-root account
+        pub enable_non_root_calls: bool,
         /// Confirmation depth k to use in the archiving process
         pub confirmation_depth_k: BlockNumberFor<T>,
     }
@@ -76,6 +83,7 @@ mod pallet {
                 enable_domains: false,
                 enable_dynamic_cost_of_storage: false,
                 enable_balance_transfers: false,
+                enable_non_root_calls: false,
                 confirmation_depth_k: BlockNumberFor::<T>::from(100u32),
             }
         }
@@ -88,6 +96,7 @@ mod pallet {
                 enable_domains,
                 enable_dynamic_cost_of_storage,
                 enable_balance_transfers,
+                enable_non_root_calls,
                 confirmation_depth_k,
             } = self;
 
@@ -99,6 +108,7 @@ mod pallet {
             <EnableDomains<T>>::put(enable_domains);
             <EnableDynamicCostOfStorage<T>>::put(enable_dynamic_cost_of_storage);
             <EnableBalanceTransfers<T>>::put(enable_balance_transfers);
+            <EnableNonRootCalls<T>>::put(enable_non_root_calls);
             <ConfirmationDepthK<T>>::put(confirmation_depth_k);
         }
     }
@@ -140,6 +150,20 @@ mod pallet {
             ensure_root(origin)?;
 
             EnableBalanceTransfers::<T>::put(enable_balance_transfers);
+
+            Ok(())
+        }
+
+        /// Enable or disable calls from non-root users.
+        #[pallet::call_index(3)]
+        #[pallet::weight(<T as Config>::WeightInfo::set_enable_non_root_calls())]
+        pub fn set_enable_non_root_calls(
+            origin: OriginFor<T>,
+            enable_non_root_calls: bool,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+
+            EnableNonRootCalls::<T>::put(enable_non_root_calls);
 
             Ok(())
         }

--- a/crates/pallet-runtime-configs/src/weights.rs
+++ b/crates/pallet-runtime-configs/src/weights.rs
@@ -32,6 +32,7 @@ pub trait WeightInfo {
 	fn set_enable_domains() -> Weight;
 	fn set_enable_dynamic_cost_of_storage() -> Weight;
 	fn set_enable_balance_transfers() -> Weight;
+	fn set_enable_non_root_calls() -> Weight;
 }
 
 /// Weights for pallet_runtime_configs using the Substrate node and recommended hardware.
@@ -67,6 +68,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(5_890_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	/// Storage: `RuntimeConfigs::EnableNonRootCalls` (r:0 w:1)
+	/// Proof: `RuntimeConfigs::EnableNonRootCalls` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	fn set_enable_non_root_calls() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 5_726_000 picoseconds.
+		Weight::from_parts(5_890_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -94,6 +105,16 @@ impl WeightInfo for () {
 	/// Storage: `RuntimeConfigs::EnableBalanceTransfers` (r:0 w:1)
 	/// Proof: `RuntimeConfigs::EnableBalanceTransfers` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
 	fn set_enable_balance_transfers() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 5_726_000 picoseconds.
+		Weight::from_parts(5_890_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `RuntimeConfigs::EnableNonRootCalls` (r:0 w:1)
+	/// Proof: `RuntimeConfigs::EnableNonRootCalls` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	fn set_enable_non_root_calls() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/crates/pallet-runtime-configs/src/weights.rs
+++ b/crates/pallet-runtime-configs/src/weights.rs
@@ -30,6 +30,7 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_runtime_configs.
 pub trait WeightInfo {
 	fn set_enable_domains() -> Weight;
+	fn set_enable_dynamic_cost_of_storage() -> Weight;
 	fn set_enable_balance_transfers() -> Weight;
 }
 
@@ -44,6 +45,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Estimated: `0`
 		// Minimum execution time: 5_640_000 picoseconds.
 		Weight::from_parts(5_782_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `RuntimeConfigs::EnableDynamicCostOfStorage` (r:0 w:1)
+	/// Proof: `RuntimeConfigs::EnableDynamicCostOfStorage` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	fn set_enable_dynamic_cost_of_storage() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 5_726_000 picoseconds.
+		Weight::from_parts(5_890_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `RuntimeConfigs::EnableBalanceTransfers` (r:0 w:1)
@@ -68,6 +79,16 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_640_000 picoseconds.
 		Weight::from_parts(5_782_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `RuntimeConfigs::EnableDynamicCostOfStorage` (r:0 w:1)
+	/// Proof: `RuntimeConfigs::EnableDynamicCostOfStorage` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
+	fn set_enable_dynamic_cost_of_storage() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 5_726_000 picoseconds.
+		Weight::from_parts(5_890_000, 0)
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `RuntimeConfigs::EnableBalanceTransfers` (r:0 w:1)

--- a/crates/pallet-subspace/src/benchmarking.rs
+++ b/crates/pallet-subspace/src/benchmarking.rs
@@ -135,14 +135,6 @@ mod benchmarks {
     }
 
     #[benchmark]
-    fn enable_storage_access() {
-        #[extrinsic_call]
-        _(RawOrigin::Root);
-
-        assert!(Pallet::<T>::is_storage_access_enabled());
-    }
-
-    #[benchmark]
     fn enable_authoring_by_anyone() {
         #[extrinsic_call]
         _(RawOrigin::Root);

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -282,8 +282,6 @@ pub mod pallet {
     {
         /// When rewards should be enabled.
         pub enable_rewards_at: EnableRewardsAt<BlockNumberFor<T>>,
-        /// Whether storage access should be enabled.
-        pub enable_storage_access: bool,
         /// Who can author blocks at genesis.
         pub allow_authoring_by: AllowAuthoringBy,
         /// Number of iterations for proof of time per slot
@@ -324,7 +322,6 @@ pub mod pallet {
                     // Nothing to do in this case
                 }
             }
-            IsStorageAccessEnabled::<T>::put(self.enable_storage_access);
             match &self.allow_authoring_by {
                 AllowAuthoringBy::Anyone => {
                     AllowAuthoringByAnyone::<T>::put(true);
@@ -490,11 +487,6 @@ pub mod pallet {
     #[pallet::storage]
     pub type BlockRandomness<T> = StorageValue<_, Randomness>;
 
-    /// Enable storage access for all users.
-    #[pallet::storage]
-    #[pallet::getter(fn is_storage_access_enabled)]
-    pub(super) type IsStorageAccessEnabled<T> = StorageValue<_, bool, ValueQuery>;
-
     /// Allow block authoring by anyone or just root.
     #[pallet::storage]
     pub(super) type AllowAuthoringByAnyone<T> = StorageValue<_, bool, ValueQuery>;
@@ -604,17 +596,6 @@ pub mod pallet {
 
         /// Enable storage access for all users.
         #[pallet::call_index(5)]
-        #[pallet::weight(<T as Config>::WeightInfo::enable_storage_access())]
-        pub fn enable_storage_access(origin: OriginFor<T>) -> DispatchResult {
-            ensure_root(origin)?;
-
-            IsStorageAccessEnabled::<T>::put(true);
-
-            Ok(())
-        }
-
-        /// Enable storage access for all users.
-        #[pallet::call_index(6)]
         #[pallet::weight(<T as Config>::WeightInfo::enable_authoring_by_anyone())]
         pub fn enable_authoring_by_anyone(origin: OriginFor<T>) -> DispatchResult {
             ensure_root(origin)?;

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -297,7 +297,6 @@ pub fn new_test_ext(pot_extension: PotExtension) -> TestExternalities {
 
     pallet_subspace::GenesisConfig::<Test> {
         enable_rewards_at: EnableRewardsAt::Height(Some(1)),
-        enable_storage_access: true,
         allow_authoring_by: AllowAuthoringBy::Anyone,
         pot_slot_iterations: NonZeroU32::new(100_000).unwrap(),
         phantom: PhantomData,

--- a/crates/pallet-subspace/src/weights.rs
+++ b/crates/pallet-subspace/src/weights.rs
@@ -36,7 +36,6 @@ pub trait WeightInfo {
 	fn enable_solution_range_adjustment() -> Weight;
 	fn vote() -> Weight;
 	fn enable_rewards() -> Weight;
-	fn enable_storage_access() -> Weight;
 	fn enable_authoring_by_anyone() -> Weight;
 }
 
@@ -117,16 +116,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 6_000_000 picoseconds.
 		Weight::from_parts(6_000_000, 1533)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	/// Storage: Subspace IsStorageAccessEnabled (r:0 w:1)
-	/// Proof Skipped: Subspace IsStorageAccessEnabled (max_values: Some(1), max_size: None, mode: Measured)
-	fn enable_storage_access() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 2_000_000 picoseconds.
-		Weight::from_parts(3_000_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: Subspace RootPlotPublicKey (r:1 w:0)
@@ -222,16 +211,6 @@ impl WeightInfo for () {
 		// Minimum execution time: 6_000_000 picoseconds.
 		Weight::from_parts(6_000_000, 1533)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
-	}
-	/// Storage: Subspace IsStorageAccessEnabled (r:0 w:1)
-	/// Proof Skipped: Subspace IsStorageAccessEnabled (max_values: Some(1), max_size: None, mode: Measured)
-	fn enable_storage_access() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 2_000_000 picoseconds.
-		Weight::from_parts(3_000_000, 0)
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: Subspace RootPlotPublicKey (r:1 w:0)

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -108,6 +108,9 @@ mod pallet {
 
         type FindBlockRewardAddress: FindBlockRewardAddress<Self::AccountId>;
 
+        /// Whether dynamic cost of storage should be used
+        type DynamicCostOfStorage: Get<bool>;
+
         type WeightInfo: WeightInfo;
     }
 
@@ -313,6 +316,10 @@ where
     /// return the next `transaction_byte_fee` value for validating extrinsic to be
     /// included in the next block
     pub fn transaction_byte_fee() -> BalanceOf<T> {
+        if !T::DynamicCostOfStorage::get() {
+            return BalanceOf::<T>::from(1);
+        }
+
         if IsDuringBlockExecution::<T>::get() {
             TransactionByteFee::<T>::get().current
         } else {

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -132,12 +132,12 @@ fn get_account_id_from_seed(seed: &'static str) -> AccountId32 {
 /// Additional subspace specific genesis parameters.
 struct GenesisParams {
     enable_rewards_at: EnableRewardsAt<BlockNumber>,
-    enable_storage_access: bool,
     allow_authoring_by: AllowAuthoringBy,
     pot_slot_iterations: NonZeroU32,
     enable_domains: bool,
     enable_dynamic_cost_of_storage: bool,
     enable_balance_transfers: bool,
+    enable_non_root_calls: bool,
     confirmation_depth_k: u32,
 }
 
@@ -181,12 +181,12 @@ pub fn dev_config() -> Result<ConsensusChainSpec<subspace_runtime::RuntimeGenesi
                 vec![],
                 GenesisParams {
                     enable_rewards_at: EnableRewardsAt::Manually,
-                    enable_storage_access: true,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
+                    enable_non_root_calls: true,
                     confirmation_depth_k: 5,
                 },
                 GenesisDomainParams {
@@ -224,12 +224,12 @@ fn subspace_genesis_config(
 ) -> subspace_runtime::RuntimeGenesisConfig {
     let GenesisParams {
         enable_rewards_at,
-        enable_storage_access,
         allow_authoring_by,
         pot_slot_iterations,
         enable_domains,
         enable_dynamic_cost_of_storage,
         enable_balance_transfers,
+        enable_non_root_calls,
         confirmation_depth_k,
     } = genesis_params;
 
@@ -243,7 +243,6 @@ fn subspace_genesis_config(
         },
         subspace: SubspaceConfig {
             enable_rewards_at,
-            enable_storage_access,
             allow_authoring_by,
             pot_slot_iterations,
             phantom: PhantomData,
@@ -253,6 +252,7 @@ fn subspace_genesis_config(
             enable_domains,
             enable_dynamic_cost_of_storage,
             enable_balance_transfers,
+            enable_non_root_calls,
             confirmation_depth_k,
         },
         domains: DomainsConfig {

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -136,6 +136,7 @@ struct GenesisParams {
     allow_authoring_by: AllowAuthoringBy,
     pot_slot_iterations: NonZeroU32,
     enable_domains: bool,
+    enable_dynamic_cost_of_storage: bool,
     enable_balance_transfers: bool,
     confirmation_depth_k: u32,
 }
@@ -184,6 +185,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<subspace_runtime::RuntimeGenesi
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
+                    enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
                     confirmation_depth_k: 5,
                 },
@@ -226,6 +228,7 @@ fn subspace_genesis_config(
         allow_authoring_by,
         pot_slot_iterations,
         enable_domains,
+        enable_dynamic_cost_of_storage,
         enable_balance_transfers,
         confirmation_depth_k,
     } = genesis_params;
@@ -248,6 +251,7 @@ fn subspace_genesis_config(
         vesting: VestingConfig { vesting },
         runtime_configs: RuntimeConfigsConfig {
             enable_domains,
+            enable_dynamic_cost_of_storage,
             enable_balance_transfers,
             confirmation_depth_k,
         },

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -82,9 +82,6 @@ substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/su
 
 [features]
 default = []
-do-not-enforce-cost-of-storage = [
-    "subspace-runtime/do-not-enforce-cost-of-storage"
-]
 runtime-benchmarks = [
     "domain-service/runtime-benchmarks",
     "evm-domain-runtime/runtime-benchmarks",

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -175,7 +175,7 @@ pub fn gemini_3g_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, 
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
-                    enable_non_root_calls: true,
+                    enable_non_root_calls: false,
                     confirmation_depth_k: 100, // TODO: Proper value here
                 },
                 GenesisDomainParams {
@@ -284,7 +284,7 @@ pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfi
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
-                    enable_non_root_calls: true,
+                    enable_non_root_calls: false,
                     confirmation_depth_k: 100, // TODO: Proper value here
                 },
                 GenesisDomainParams {

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -93,12 +93,12 @@ const TOKEN_GRANTS: &[(&str, u128)] = &[
 /// Additional subspace specific genesis parameters.
 struct GenesisParams {
     enable_rewards_at: EnableRewardsAt<BlockNumber>,
-    enable_storage_access: bool,
     allow_authoring_by: AllowAuthoringBy,
     pot_slot_iterations: NonZeroU32,
     enable_domains: bool,
     enable_dynamic_cost_of_storage: bool,
     enable_balance_transfers: bool,
+    enable_non_root_calls: bool,
     confirmation_depth_k: u32,
 }
 
@@ -164,7 +164,6 @@ pub fn gemini_3g_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, 
                 vesting_schedules,
                 GenesisParams {
                     enable_rewards_at: EnableRewardsAt::Manually,
-                    enable_storage_access: true,
                     allow_authoring_by: AllowAuthoringBy::RootFarmer(
                         FarmerPublicKey::unchecked_from(hex_literal::hex!(
                             "8aecbcf0b404590ddddc01ebacb205a562d12fdb5c2aa6a4035c1a20f23c9515"
@@ -176,6 +175,7 @@ pub fn gemini_3g_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, 
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
+                    enable_non_root_calls: true,
                     confirmation_depth_k: 100, // TODO: Proper value here
                 },
                 GenesisDomainParams {
@@ -279,12 +279,12 @@ pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfi
                 vesting_schedules,
                 GenesisParams {
                     enable_rewards_at: EnableRewardsAt::Manually,
-                    enable_storage_access: true,
                     allow_authoring_by: AllowAuthoringBy::FirstFarmer,
                     pot_slot_iterations: NonZeroU32::new(150_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
+                    enable_non_root_calls: true,
                     confirmation_depth_k: 100, // TODO: Proper value here
                 },
                 GenesisDomainParams {
@@ -346,12 +346,12 @@ pub fn dev_config() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, String> 
                 vec![],
                 GenesisParams {
                     enable_rewards_at: EnableRewardsAt::Manually,
-                    enable_storage_access: true,
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
                     enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
+                    enable_non_root_calls: true,
                     confirmation_depth_k: 5,
                 },
                 GenesisDomainParams {
@@ -396,12 +396,12 @@ fn subspace_genesis_config(
 ) -> RuntimeGenesisConfig {
     let GenesisParams {
         enable_rewards_at,
-        enable_storage_access,
         allow_authoring_by,
         pot_slot_iterations,
         enable_domains,
         enable_dynamic_cost_of_storage,
         enable_balance_transfers,
+        enable_non_root_calls,
         confirmation_depth_k,
     } = genesis_params;
 
@@ -434,7 +434,6 @@ fn subspace_genesis_config(
         },
         subspace: SubspaceConfig {
             enable_rewards_at,
-            enable_storage_access,
             allow_authoring_by,
             pot_slot_iterations,
             phantom: PhantomData,
@@ -444,6 +443,7 @@ fn subspace_genesis_config(
             enable_domains,
             enable_dynamic_cost_of_storage,
             enable_balance_transfers,
+            enable_non_root_calls,
             confirmation_depth_k,
         },
         domains: DomainsConfig {

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -97,6 +97,7 @@ struct GenesisParams {
     allow_authoring_by: AllowAuthoringBy,
     pot_slot_iterations: NonZeroU32,
     enable_domains: bool,
+    enable_dynamic_cost_of_storage: bool,
     enable_balance_transfers: bool,
     confirmation_depth_k: u32,
 }
@@ -173,6 +174,7 @@ pub fn gemini_3g_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, 
                     // About 1s on 6.0 GHz Raptor Lake CPU (14900K)
                     pot_slot_iterations: NonZeroU32::new(200_032_000).expect("Not zero; qed"),
                     enable_domains: true,
+                    enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
                     confirmation_depth_k: 100, // TODO: Proper value here
                 },
@@ -281,6 +283,7 @@ pub fn devnet_config_compiled() -> Result<ConsensusChainSpec<RuntimeGenesisConfi
                     allow_authoring_by: AllowAuthoringBy::FirstFarmer,
                     pot_slot_iterations: NonZeroU32::new(150_000_000).expect("Not zero; qed"),
                     enable_domains: true,
+                    enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
                     confirmation_depth_k: 100, // TODO: Proper value here
                 },
@@ -347,6 +350,7 @@ pub fn dev_config() -> Result<ConsensusChainSpec<RuntimeGenesisConfig>, String> 
                     allow_authoring_by: AllowAuthoringBy::Anyone,
                     pot_slot_iterations: NonZeroU32::new(100_000_000).expect("Not zero; qed"),
                     enable_domains: true,
+                    enable_dynamic_cost_of_storage: false,
                     enable_balance_transfers: true,
                     confirmation_depth_k: 5,
                 },
@@ -396,6 +400,7 @@ fn subspace_genesis_config(
         allow_authoring_by,
         pot_slot_iterations,
         enable_domains,
+        enable_dynamic_cost_of_storage,
         enable_balance_transfers,
         confirmation_depth_k,
     } = genesis_params;
@@ -437,6 +442,7 @@ fn subspace_genesis_config(
         vesting: VestingConfig { vesting },
         runtime_configs: RuntimeConfigsConfig {
             enable_domains,
+            enable_dynamic_cost_of_storage,
             enable_balance_transfers,
             confirmation_depth_k,
         },

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -132,4 +132,3 @@ runtime-benchmarks = [
     "pallet-utility/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
 ]
-do-not-enforce-cost-of-storage = []

--- a/crates/subspace-runtime/src/fees.rs
+++ b/crates/subspace-runtime/src/fees.rs
@@ -1,4 +1,4 @@
-use crate::{Balances, Runtime, RuntimeCall, RuntimeConfigs, TransactionFees};
+use crate::{Balances, Runtime, RuntimeCall, TransactionFees};
 use codec::Encode;
 use frame_support::traits::{Currency, ExistenceRequirement, Get, Imbalance, WithdrawReasons};
 use pallet_balances::NegativeImbalance;
@@ -10,11 +10,7 @@ pub struct TransactionByteFee;
 
 impl Get<Balance> for TransactionByteFee {
     fn get() -> Balance {
-        if RuntimeConfigs::enable_dynamic_cost_of_storage() {
-            TransactionFees::transaction_byte_fee()
-        } else {
-            1
-        }
+        TransactionFees::transaction_byte_fee()
     }
 }
 

--- a/crates/subspace-runtime/src/fees.rs
+++ b/crates/subspace-runtime/src/fees.rs
@@ -1,4 +1,4 @@
-use crate::{Balances, Runtime, RuntimeCall, TransactionFees};
+use crate::{Balances, Runtime, RuntimeCall, RuntimeConfigs, TransactionFees};
 use codec::Encode;
 use frame_support::traits::{Currency, ExistenceRequirement, Get, Imbalance, WithdrawReasons};
 use pallet_balances::NegativeImbalance;
@@ -10,10 +10,10 @@ pub struct TransactionByteFee;
 
 impl Get<Balance> for TransactionByteFee {
     fn get() -> Balance {
-        if cfg!(feature = "do-not-enforce-cost-of-storage") {
-            1
-        } else {
+        if RuntimeConfigs::enable_dynamic_cost_of_storage() {
             TransactionFees::transaction_byte_fee()
+        } else {
+            1
         }
     }
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -420,31 +420,13 @@ impl pallet_balances::Config for Runtime {
 parameter_types! {
     pub const StorageFeesEscrowBlockReward: (u64, u64) = STORAGE_FEES_ESCROW_BLOCK_REWARD;
     pub const StorageFeesEscrowBlockTax: (u64, u64) = STORAGE_FEES_ESCROW_BLOCK_TAX;
-}
-
-pub struct CreditSupply;
-
-impl Get<Balance> for CreditSupply {
-    fn get() -> Balance {
-        Balances::total_issuance()
-    }
-}
-
-pub struct TotalSpacePledged;
-
-impl Get<u128> for TotalSpacePledged {
-    fn get() -> u128 {
+    pub CreditSupply: Balance = Balances::total_issuance();
+    pub TotalSpacePledged: u128 = {
         let sectors = solution_range_to_sectors(Subspace::solution_ranges().current);
         sectors as u128 * MAX_PIECES_IN_SECTOR as u128 * Piece::SIZE as u128
-    }
-}
-
-pub struct BlockchainHistorySize;
-
-impl Get<u128> for BlockchainHistorySize {
-    fn get() -> u128 {
-        u128::from(Subspace::archived_history_size())
-    }
+    };
+    pub BlockchainHistorySize: u128 = u128::from(Subspace::archived_history_size());
+    pub DynamicCostOfStorage: bool = RuntimeConfigs::enable_dynamic_cost_of_storage();
 }
 
 impl pallet_transaction_fees::Config for Runtime {
@@ -457,6 +439,7 @@ impl pallet_transaction_fees::Config for Runtime {
     type BlockchainHistorySize = BlockchainHistorySize;
     type Currency = Balances;
     type FindBlockRewardAddress = Subspace;
+    type DynamicCostOfStorage = DynamicCostOfStorage;
     type WeightInfo = ();
 }
 

--- a/crates/subspace-runtime/src/signed_extensions.rs
+++ b/crates/subspace-runtime/src/signed_extensions.rs
@@ -1,4 +1,4 @@
-use crate::{Runtime, RuntimeCall, RuntimeConfigs, Subspace, Sudo};
+use crate::{Runtime, RuntimeCall, RuntimeConfigs, Sudo};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::traits::{DispatchInfoOf, SignedExtension};
@@ -28,7 +28,7 @@ impl SignedExtension for CheckStorageAccess {
         _info: &DispatchInfoOf<Self::Call>,
         _len: usize,
     ) -> TransactionValidity {
-        if Subspace::is_storage_access_enabled() || Some(who) == Sudo::key().as_ref() {
+        if RuntimeConfigs::enable_non_root_calls() || Some(who) == Sudo::key().as_ref() {
             Ok(ValidTransaction::default())
         } else {
             InvalidTransaction::BadSigner.into()

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -114,7 +114,6 @@ fn create_genesis_config(
         },
         subspace: SubspaceConfig {
             enable_rewards_at: EnableRewardsAt::Manually,
-            enable_storage_access: false,
             allow_authoring_by: AllowAuthoringBy::Anyone,
             pot_slot_iterations: NonZeroU32::new(50_000_000).expect("Not zero; qed"),
             phantom: PhantomData,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -64,8 +64,8 @@ use sp_messenger::messages::{
     ExtractedStateRootsFromProof, MessageId,
 };
 use sp_runtime::traits::{
-    AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Convert, DispatchInfoOf,
-    NumberFor, PostDispatchInfoOf, Zero,
+    AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConstBool, Convert,
+    DispatchInfoOf, NumberFor, PostDispatchInfoOf, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -401,6 +401,7 @@ impl pallet_transaction_fees::Config for Runtime {
     type BlockchainHistorySize = BlockchainHistorySize;
     type Currency = Balances;
     type FindBlockRewardAddress = Subspace;
+    type DynamicCostOfStorage = ConstBool<{ !cfg!(feature = "do-not-enforce-cost-of-storage") }>;
     type WeightInfo = ();
 }
 
@@ -408,11 +409,7 @@ pub struct TransactionByteFee;
 
 impl Get<Balance> for TransactionByteFee {
     fn get() -> Balance {
-        if cfg!(feature = "do-not-enforce-cost-of-storage") {
-            1
-        } else {
-            TransactionFees::transaction_byte_fee()
-        }
+        TransactionFees::transaction_byte_fee()
     }
 }
 


### PR DESCRIPTION
I basically replaced `do-not-enforce-cost-of-storage` feature (left as is in test infra though) with runtime configuration that is initialized in chain spec and can be changed later.

I also moved and renamed non-root calls enablement from `pallet-subspace` to `pallet-runtime-configs` and set it to `false` in production networks so we can seed the history first under sudo user before transitioning to normal operation.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
