### PR TITLE
Graceful piece cache initialization shutdown

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -114,6 +114,7 @@ impl DiskPieceCache {
         let file = &self.inner.file;
         let mut element = vec![0; Self::element_size()];
 
+        // TODO: Stop early on first missing entry
         (0..self.inner.num_elements).map(move |offset| {
             match Self::read_piece_internal(file, offset, &mut element) {
                 Ok(maybe_piece_index) => (Offset(offset), maybe_piece_index),


### PR DESCRIPTION
In case piece cache is large, initialization takes a long time to read it. Since reading was a blocking operation, cancellation wasn't possible. By refactoring reading to yield to async runtime after each piece it is possible to abort quickly.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
