### PR TITLE
Ensure final state root matches the last trace element in ER

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -434,7 +434,7 @@ pub(crate) fn create_dummy_receipt(
         consensus_block_number: block_number,
         consensus_block_hash,
         inboxed_bundles,
-        final_state_root: Default::default(),
+        final_state_root: *execution_trace.last().unwrap_or(&Default::default()),
         execution_trace,
         execution_trace_root,
         block_fees: Default::default(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1159,6 +1159,7 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
                 .unwrap()
                 .into()
         };
+        receipt.final_state_root = *receipt.execution_trace.last().unwrap();
         opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
             .pair()
             .sign(opaque_bundle.sealed_header.pre_hash().as_ref())


### PR DESCRIPTION
We missed doing this check earlier. There is a discussion on removing the execution traces completely, this change should fix the issue until we have a quorum on such discussion


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
