### PR TITLE
Gemini 3g backport: farmer events

### DIFF
--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -2,6 +2,7 @@
     array_chunks,
     assert_matches,
     const_option,
+    exact_size_is_empty,
     hash_extract_if,
     impl_trait_in_assoc_type,
     int_roundings,

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -9,7 +9,7 @@ use crate::reward_signing::reward_signing;
 use crate::single_disk_farm::farming::rayon_files::RayonFiles;
 pub use crate::single_disk_farm::farming::FarmingError;
 use crate::single_disk_farm::farming::{
-    farming, slot_notification_forwarder, FarmingOptions, PlotAudit,
+    farming, slot_notification_forwarder, FarmingNotification, FarmingOptions, PlotAudit,
 };
 use crate::single_disk_farm::piece_cache::{DiskPieceCache, DiskPieceCacheError};
 use crate::single_disk_farm::piece_reader::PieceReader;
@@ -590,7 +590,7 @@ pub enum SectorExpirationDetails {
 /// Various sector updates
 #[derive(Debug, Clone, Encode, Decode)]
 pub enum SectorUpdate {
-    /// Sector is is being plotted
+    /// Sector is being plotted
     Plotting(SectorPlottingDetails),
     /// Sector expiration information updated
     Expiration(SectorExpirationDetails),
@@ -599,6 +599,7 @@ pub enum SectorUpdate {
 #[derive(Default, Debug)]
 struct Handlers {
     sector_update: Handler<(SectorIndex, SectorUpdate)>,
+    farming_notification: Handler<FarmingNotification>,
     solution: Handler<SolutionResponse>,
 }
 
@@ -1362,6 +1363,11 @@ impl SingleDiskFarm {
     /// Subscribe to sector updates
     pub fn on_sector_update(&self, callback: HandlerFn<(SectorIndex, SectorUpdate)>) -> HandlerId {
         self.handlers.sector_update.add(callback)
+    }
+
+    /// Subscribe to farming notifications
+    pub fn on_farming_notification(&self, callback: HandlerFn<FarmingNotification>) -> HandlerId {
+        self.handlers.farming_notification.add(callback)
     }
 
     /// Subscribe to new solution notification

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -560,8 +560,8 @@ pub enum SectorPlottingDetails {
     Encoded(Duration),
     /// Writing sector
     Writing,
-    /// Wrote sector
-    Wrote(Duration),
+    /// Written sector
+    Written(Duration),
     /// Finished plotting
     Finished {
         /// Information about plotted sector

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -6,11 +6,12 @@ use crate::single_disk_farm::Handlers;
 use async_lock::RwLock;
 use futures::channel::mpsc;
 use futures::StreamExt;
+use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use rayon::ThreadPoolBuildError;
 use std::io;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{PosSeed, PublicKey, SectorIndex, Solution, SolutionRange};
 use subspace_erasure_coding::ErasureCoding;
@@ -22,6 +23,45 @@ use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
 use tracing::{debug, error, info, trace, warn};
+
+/// Auditing details
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct AuditingDetails {
+    /// Number of sectors that were audited
+    pub sectors_count: SectorIndex,
+    /// Audit duration
+    pub duration: Duration,
+}
+
+/// Result of the proving
+#[derive(Debug, Clone, Encode, Decode)]
+pub enum ProvingResult {
+    /// Proved successfully and accepted by the node
+    Success,
+    /// Proving took too long
+    Timeout,
+    /// Managed to prove within time limit, but node rejected solution, likely due to timeout on its
+    /// end
+    Rejected,
+}
+
+/// Proving details
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct ProvingDetails {
+    /// Whether proving ended up being successful
+    pub result: ProvingResult,
+    /// Audit duration
+    pub duration: Duration,
+}
+
+/// Various farming notifications
+#[derive(Debug, Clone, Encode, Decode)]
+pub enum FarmingNotification {
+    /// Auditing
+    Auditing(AuditingDetails),
+    /// Proving
+    Proving(ProvingDetails),
+}
 
 /// Errors that happen during farming
 #[derive(Debug, Error)]
@@ -271,7 +311,18 @@ where
             a_solution_distance.cmp(&b_solution_distance)
         });
 
+        handlers
+            .farming_notification
+            .call_simple(&FarmingNotification::Auditing(AuditingDetails {
+                sectors_count: sectors_metadata.len() as SectorIndex,
+                duration: start.elapsed(),
+            }));
+
         'solutions_processing: for (sector_index, sector_solutions) in sectors_solutions {
+            if sector_solutions.is_empty() {
+                continue;
+            }
+            let mut start = Instant::now();
             for maybe_solution in sector_solutions {
                 let solution = match maybe_solution {
                     Ok(solution) => solution,
@@ -279,6 +330,7 @@ where
                         error!(%slot, %sector_index, %error, "Failed to prove");
                         // Do not error completely as disk corruption or other reasons why
                         // proving might fail
+                        start = Instant::now();
                         continue;
                     }
                 };
@@ -287,11 +339,18 @@ where
                 trace!(?solution, "Solution found");
 
                 if start.elapsed() >= farming_timeout {
+                    handlers
+                        .farming_notification
+                        .call_simple(&FarmingNotification::Proving(ProvingDetails {
+                            result: ProvingResult::Timeout,
+                            duration: start.elapsed(),
+                        }));
                     warn!(
                         %slot,
                         %sector_index,
                         "Proving for solution skipped due to farming time limit",
                     );
+
                     break 'solutions_processing;
                 }
 
@@ -303,6 +362,12 @@ where
                 handlers.solution.call_simple(&response);
 
                 if let Err(error) = node_client.submit_solution_response(response).await {
+                    handlers
+                        .farming_notification
+                        .call_simple(&FarmingNotification::Proving(ProvingDetails {
+                            result: ProvingResult::Rejected,
+                            duration: start.elapsed(),
+                        }));
                     warn!(
                         %slot,
                         %sector_index,
@@ -311,6 +376,14 @@ where
                     );
                     break 'solutions_processing;
                 }
+
+                handlers
+                    .farming_notification
+                    .call_simple(&FarmingNotification::Proving(ProvingDetails {
+                        result: ProvingResult::Success,
+                        duration: start.elapsed(),
+                    }));
+                start = Instant::now();
             }
         }
     }

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -1,6 +1,5 @@
 use crate::single_disk_farm::{
-    BackgroundTaskError, Handlers, PlotMetadataHeader, SectorExpirationDetails,
-    SectorPlottingDetails, SectorUpdate, RESERVED_PLOT_METADATA,
+    BackgroundTaskError, Handlers, PlotMetadataHeader, SectorUpdate, RESERVED_PLOT_METADATA,
 };
 use crate::thread_pool_manager::PlottingThreadPoolManager;
 use crate::utils::AsyncJoinOnDrop;
@@ -10,7 +9,7 @@ use atomic::Atomic;
 use futures::channel::{mpsc, oneshot};
 use futures::{select, FutureExt, SinkExt, StreamExt};
 use lru::LruCache;
-use parity_scale_codec::Encode;
+use parity_scale_codec::{Decode, Encode};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io;
@@ -45,6 +44,55 @@ const FARMER_APP_INFO_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 const ARCHIVED_SEGMENTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).expect("Not zero; qed");
 /// Get piece retry attempts number.
 const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(4).expect("Not zero; qed");
+
+/// Details about sector currently being plotted
+#[derive(Debug, Clone, Encode, Decode)]
+pub enum SectorPlottingDetails {
+    /// Starting plotting of a sector
+    Starting {
+        /// Progress so far in % (not including this sector)
+        progress: f32,
+        /// Whether sector is being replotted
+        replotting: bool,
+        /// Whether this is the last sector queued so far
+        last_queued: bool,
+    },
+    /// Downloading sector pieces
+    Downloading,
+    /// Downloaded sector pieces
+    Downloaded(Duration),
+    /// Encoding sector pieces
+    Encoding,
+    /// Encoded sector pieces
+    Encoded(Duration),
+    /// Writing sector
+    Writing,
+    /// Written sector
+    Written(Duration),
+    /// Finished plotting
+    Finished {
+        /// Information about plotted sector
+        plotted_sector: PlottedSector,
+        /// Information about old plotted sector that was replaced
+        old_plotted_sector: Option<PlottedSector>,
+        /// How much time it took to plot a sector
+        time: Duration,
+    },
+}
+
+/// Details about sector expiration
+#[derive(Debug, Clone, Encode, Decode)]
+pub enum SectorExpirationDetails {
+    /// Sector expiration became known
+    Determined {
+        /// Segment index at which sector expires
+        expires_at: SegmentIndex,
+    },
+    /// Sector will expire at the next segment index and should be replotted
+    AboutToExpire,
+    /// Sector already expired
+    Expired,
+}
 
 pub(super) struct SectorToPlot {
     sector_index: SectorIndex,

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -402,7 +402,7 @@ where
 
             handlers.sector_update.call_simple(&(
                 sector_index,
-                SectorUpdate::Plotting(SectorPlottingDetails::Wrote(start.elapsed())),
+                SectorUpdate::Plotting(SectorPlottingDetails::Written(start.elapsed())),
             ));
         }
 


### PR DESCRIPTION
Backports farmer events from https://github.com/subspace/subspace/pull/2457 into 3g, but not metrics because metrics server was never backported into 3g apparently.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
