### PR TITLE
Graceful farmer error handling

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -480,7 +480,8 @@ pub fn create_signed_vote(
             vote_solution_range,
             &plotted_sector_bytes,
             &plotted_sector.sector_metadata,
-        );
+        )
+        .unwrap();
 
         let Some(audit_result) = maybe_audit_result else {
             // Sector didn't have any solutions

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -151,14 +151,17 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
     group.bench_function("memory/sync", |b| {
         b.iter(|| async {
-            black_box(audit_plot_sync(
-                black_box(public_key),
-                black_box(global_challenge),
-                black_box(solution_range),
-                black_box(&plotted_sector_bytes),
-                black_box(slice::from_ref(&plotted_sector.sector_metadata)),
-                black_box(None),
-            ));
+            black_box(
+                audit_plot_sync(
+                    black_box(public_key),
+                    black_box(global_challenge),
+                    black_box(solution_range),
+                    black_box(&plotted_sector_bytes),
+                    black_box(slice::from_ref(&plotted_sector.sector_metadata)),
+                    black_box(None),
+                )
+                .unwrap(),
+            );
         })
     });
 
@@ -193,14 +196,17 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(sectors_count));
         group.bench_function("disk/sync", |b| {
             b.iter(|| {
-                black_box(audit_plot_sync(
-                    black_box(public_key),
-                    black_box(global_challenge),
-                    black_box(solution_range),
-                    black_box(&plot_file),
-                    black_box(&sectors_metadata),
-                    black_box(None),
-                ));
+                black_box(
+                    audit_plot_sync(
+                        black_box(public_key),
+                        black_box(global_challenge),
+                        black_box(solution_range),
+                        black_box(&plot_file),
+                        black_box(&sectors_metadata),
+                        black_box(None),
+                    )
+                    .unwrap(),
+                );
             });
         });
 

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -166,7 +166,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             &plotted_sector_bytes,
             slice::from_ref(&plotted_sector.sector_metadata),
             None,
-        );
+        )
+        .unwrap();
 
         let solution_candidates = match audit_results.into_iter().next() {
             Some(audit_result) => audit_result.solution_candidates,
@@ -249,7 +250,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 &plot_file,
                 &sectors_metadata,
                 None,
-            );
+            )
+            .unwrap();
             let solution_candidates = audit_results
                 .into_iter()
                 .map(|audit_result| audit_result.solution_candidates)

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -60,6 +60,20 @@ pub enum ProvingError {
     RecordReadingError(#[from] ReadingError),
 }
 
+impl ProvingError {
+    /// Whether this error is fatal and makes farm unusable
+    pub fn is_fatal(&self) -> bool {
+        match self {
+            ProvingError::InvalidErasureCodingInstance => true,
+            ProvingError::FailedToCreatePolynomialForRecord { .. } => false,
+            ProvingError::FailedToCreateChunkWitness { .. } => false,
+            ProvingError::FailedToDecodeSectorContentsMap(_) => false,
+            ProvingError::Io(_) => true,
+            ProvingError::RecordReadingError(error) => error.is_fatal(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct WinningChunk {
     /// Chunk offset within s-bucket

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -75,6 +75,21 @@ pub enum ReadingError {
     ChecksumMismatch,
 }
 
+impl ReadingError {
+    /// Whether this error is fatal and renders farm unusable
+    pub fn is_fatal(&self) -> bool {
+        match self {
+            ReadingError::FailedToReadChunk { .. } => false,
+            ReadingError::InvalidChunk { .. } => false,
+            ReadingError::FailedToErasureDecodeRecord { .. } => false,
+            ReadingError::WrongRecordSizeAfterDecoding { .. } => false,
+            ReadingError::FailedToDecodeSectorContentsMap(_) => false,
+            ReadingError::Io(_) => true,
+            ReadingError::ChecksumMismatch => false,
+        }
+    }
+}
+
 /// Record contained in the plot
 #[derive(Debug, Clone)]
 pub struct PlotRecord {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -250,7 +250,7 @@ fn prove(
                 table_generator: &table_generator,
             };
 
-            let mut audit_results = plot_audit.audit(options);
+            let mut audit_results = plot_audit.audit(options).unwrap();
 
             group.bench_function("plot/single", |b| {
                 b.iter_batched(
@@ -259,7 +259,7 @@ fn prove(
                             return result;
                         }
 
-                        audit_results = plot_audit.audit(options);
+                        audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
@@ -293,7 +293,7 @@ fn prove(
                 maybe_sector_being_modified: None,
                 table_generator: &table_generator,
             };
-            let mut audit_results = plot_audit.audit(options);
+            let mut audit_results = plot_audit.audit(options).unwrap();
 
             group.bench_function("plot/rayon", |b| {
                 b.iter_batched(
@@ -302,7 +302,7 @@ fn prove(
                             return result;
                         }
 
-                        audit_results = plot_audit.audit(options);
+                        audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -761,6 +761,9 @@ where
                                 proving_details.result,
                             );
                         }
+                        FarmingNotification::NonFatalError(error) => {
+                            farmer_metrics.note_farming_error(&single_disk_farm_id, error);
+                        }
                     }
                 }))
                 .detach();

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -6,7 +6,7 @@ use crate::single_disk_farm::Handlers;
 use async_lock::RwLock;
 use futures::channel::mpsc;
 use futures::StreamExt;
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 use parking_lot::Mutex;
 use rayon::ThreadPoolBuildError;
 use std::sync::Arc;
@@ -71,6 +71,23 @@ pub enum FarmingNotification {
     Auditing(AuditingDetails),
     /// Proving
     Proving(ProvingDetails),
+    /// Non-fatal farming error
+    NonFatalError(Arc<FarmingError>),
+}
+
+/// Special decoded farming error
+#[derive(Debug, Encode, Decode)]
+pub struct DecodedFarmingError {
+    /// String representation of an error
+    error: String,
+    /// Whether error is fatal
+    is_fatal: bool,
+}
+
+impl fmt::Display for DecodedFarmingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
 }
 
 /// Errors that happen during farming
@@ -100,6 +117,54 @@ pub enum FarmingError {
     /// Failed to create thread pool
     #[error("Failed to create thread pool: {0}")]
     FailedToCreateThreadPool(#[from] ThreadPoolBuildError),
+    /// Decoded farming error
+    #[error("Decoded farming error {0}")]
+    Decoded(DecodedFarmingError),
+}
+
+impl Encode for FarmingError {
+    fn encode_to<O: Output + ?Sized>(&self, dest: &mut O) {
+        let error = DecodedFarmingError {
+            error: self.to_string(),
+            is_fatal: self.is_fatal(),
+        };
+
+        error.encode_to(dest)
+    }
+}
+
+impl Decode for FarmingError {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        DecodedFarmingError::decode(input).map(FarmingError::Decoded)
+    }
+}
+
+impl FarmingError {
+    /// String variant of the error, primarily for monitoring purposes
+    pub fn str_variant(&self) -> &str {
+        match self {
+            FarmingError::FailedToSubscribeSlotInfo { .. } => "FailedToSubscribeSlotInfo",
+            FarmingError::FailedToGetFarmerInfo { .. } => "FailedToGetFarmerInfo",
+            FarmingError::LowLevelAuditing(_) => "LowLevelAuditing",
+            FarmingError::LowLevelProving(_) => "LowLevelProving",
+            FarmingError::Io(_) => "Io",
+            FarmingError::FailedToCreateThreadPool(_) => "FailedToCreateThreadPool",
+            FarmingError::Decoded(_) => "Decoded",
+        }
+    }
+
+    /// Whether this error is fatal and makes farm unusable
+    pub fn is_fatal(&self) -> bool {
+        match self {
+            FarmingError::FailedToSubscribeSlotInfo { .. } => true,
+            FarmingError::FailedToGetFarmerInfo { .. } => true,
+            FarmingError::LowLevelAuditing(_) => true,
+            FarmingError::LowLevelProving(error) => error.is_fatal(),
+            FarmingError::Io(_) => true,
+            FarmingError::FailedToCreateThreadPool(_) => true,
+            FarmingError::Decoded(error) => error.is_fatal,
+        }
+    }
 }
 
 pub(super) async fn slot_notification_forwarder<NC>(
@@ -298,110 +363,127 @@ where
     let table_generator = Arc::new(Mutex::new(PosTable::generator()));
 
     while let Some(slot_info) = slot_info_notifications.next().await {
-        let start = Instant::now();
-        let slot = slot_info.slot_number;
-        let sectors_metadata = sectors_metadata.read().await;
+        let result: Result<(), FarmingError> = try {
+            let start = Instant::now();
+            let slot = slot_info.slot_number;
+            let sectors_metadata = sectors_metadata.read().await;
 
-        debug!(%slot, sector_count = %sectors_metadata.len(), "Reading sectors");
+            debug!(%slot, sector_count = %sectors_metadata.len(), "Reading sectors");
 
-        let mut sectors_solutions = {
-            let modifying_sector_guard = modifying_sector_index.read().await;
-            let maybe_sector_being_modified = modifying_sector_guard.as_ref().copied();
+            let mut sectors_solutions = {
+                let modifying_sector_guard = modifying_sector_index.read().await;
+                let maybe_sector_being_modified = modifying_sector_guard.as_ref().copied();
 
-            let sectors_solutions = plot_audit.audit(PlotAuditOptions::<PosTable> {
-                public_key: &public_key,
-                reward_address: &reward_address,
-                slot_info,
-                sectors_metadata: &sectors_metadata,
-                kzg: &kzg,
-                erasure_coding: &erasure_coding,
-                maybe_sector_being_modified,
-                table_generator: &table_generator,
-            })?;
+                plot_audit.audit(PlotAuditOptions::<PosTable> {
+                    public_key: &public_key,
+                    reward_address: &reward_address,
+                    slot_info,
+                    sectors_metadata: &sectors_metadata,
+                    kzg: &kzg,
+                    erasure_coding: &erasure_coding,
+                    maybe_sector_being_modified,
+                    table_generator: &table_generator,
+                })?
+            };
 
-            sectors_solutions
+            sectors_solutions.sort_by(|a, b| {
+                let a_solution_distance =
+                    a.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
+                let b_solution_distance =
+                    b.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
+
+                a_solution_distance.cmp(&b_solution_distance)
+            });
+
+            handlers
+                .farming_notification
+                .call_simple(&FarmingNotification::Auditing(AuditingDetails {
+                    sectors_count: sectors_metadata.len() as SectorIndex,
+                    time: start.elapsed(),
+                }));
+
+            'solutions_processing: for (sector_index, sector_solutions) in sectors_solutions {
+                if sector_solutions.is_empty() {
+                    continue;
+                }
+                let mut start = Instant::now();
+                for maybe_solution in sector_solutions {
+                    let solution = match maybe_solution {
+                        Ok(solution) => solution,
+                        Err(error) => {
+                            error!(%slot, %sector_index, %error, "Failed to prove");
+                            // Do not error completely as disk corruption or other reasons why
+                            // proving might fail
+                            start = Instant::now();
+                            continue;
+                        }
+                    };
+
+                    debug!(%slot, %sector_index, "Solution found");
+                    trace!(?solution, "Solution found");
+
+                    if start.elapsed() >= farming_timeout {
+                        handlers
+                            .farming_notification
+                            .call_simple(&FarmingNotification::Proving(ProvingDetails {
+                                result: ProvingResult::Timeout,
+                                time: start.elapsed(),
+                            }));
+                        warn!(
+                            %slot,
+                            %sector_index,
+                            "Proving for solution skipped due to farming time limit",
+                        );
+
+                        break 'solutions_processing;
+                    }
+
+                    let response = SolutionResponse {
+                        slot_number: slot,
+                        solution,
+                    };
+
+                    handlers.solution.call_simple(&response);
+
+                    if let Err(error) = node_client.submit_solution_response(response).await {
+                        handlers
+                            .farming_notification
+                            .call_simple(&FarmingNotification::Proving(ProvingDetails {
+                                result: ProvingResult::Rejected,
+                                time: start.elapsed(),
+                            }));
+                        warn!(
+                            %slot,
+                            %sector_index,
+                            %error,
+                            "Failed to send solution to node, skipping further proving for this slot",
+                        );
+                        break 'solutions_processing;
+                    }
+
+                    handlers
+                        .farming_notification
+                        .call_simple(&FarmingNotification::Proving(ProvingDetails {
+                            result: ProvingResult::Success,
+                            time: start.elapsed(),
+                        }));
+                    start = Instant::now();
+                }
+            }
         };
 
-        sectors_solutions.sort_by(|a, b| {
-            let a_solution_distance = a.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
-            let b_solution_distance = b.1.best_solution_distance().unwrap_or(SolutionRange::MAX);
-
-            a_solution_distance.cmp(&b_solution_distance)
-        });
-
-        handlers
-            .farming_notification
-            .call_simple(&FarmingNotification::Auditing(AuditingDetails {
-                sectors_count: sectors_metadata.len() as SectorIndex,
-                time: start.elapsed(),
-            }));
-
-        'solutions_processing: for (sector_index, sector_solutions) in sectors_solutions {
-            if sector_solutions.is_empty() {
-                continue;
-            }
-            let mut start = Instant::now();
-            for maybe_solution in sector_solutions {
-                let solution = match maybe_solution {
-                    Ok(solution) => solution,
-                    Err(error) => {
-                        error!(%slot, %sector_index, %error, "Failed to prove");
-                        // Do not error completely as disk corruption or other reasons why
-                        // proving might fail
-                        start = Instant::now();
-                        continue;
-                    }
-                };
-
-                debug!(%slot, %sector_index, "Solution found");
-                trace!(?solution, "Solution found");
-
-                if start.elapsed() >= farming_timeout {
-                    handlers
-                        .farming_notification
-                        .call_simple(&FarmingNotification::Proving(ProvingDetails {
-                            result: ProvingResult::Timeout,
-                            time: start.elapsed(),
-                        }));
-                    warn!(
-                        %slot,
-                        %sector_index,
-                        "Proving for solution skipped due to farming time limit",
-                    );
-
-                    break 'solutions_processing;
-                }
-
-                let response = SolutionResponse {
-                    slot_number: slot,
-                    solution,
-                };
-
-                handlers.solution.call_simple(&response);
-
-                if let Err(error) = node_client.submit_solution_response(response).await {
-                    handlers
-                        .farming_notification
-                        .call_simple(&FarmingNotification::Proving(ProvingDetails {
-                            result: ProvingResult::Rejected,
-                            time: start.elapsed(),
-                        }));
-                    warn!(
-                        %slot,
-                        %sector_index,
-                        %error,
-                        "Failed to send solution to node, skipping further proving for this slot",
-                    );
-                    break 'solutions_processing;
-                }
+        if let Err(error) = result {
+            if error.is_fatal() {
+                return Err(error);
+            } else {
+                warn!(
+                    %error,
+                    "Non-fatal farming error"
+                );
 
                 handlers
                     .farming_notification
-                    .call_simple(&FarmingNotification::Proving(ProvingDetails {
-                        result: ProvingResult::Success,
-                        time: start.elapsed(),
-                    }));
-                start = Instant::now();
+                    .call_simple(&FarmingNotification::NonFatalError(Arc::new(error)));
             }
         }
     }

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -173,6 +173,7 @@ async fn start_farming<PosTable, Client>(
 
             let solution = audit_result
                 .unwrap()
+                .unwrap()
                 .solution_candidates
                 .into_solutions(&public_key, &kzg, &erasure_coding, |seed: &PosSeed| {
                     table_generator.generate_parallel(seed)


### PR DESCRIPTION
This brings a few important improvements to farmer experience:
* corrects broken sector metadata on farmer restart instead of crashing
* distinguishes fatal farming errors from non-fatal and tracks non-fatal errors as metrics instead of crashing the whole farmer

Space Acres will also use these these things to show warnings in UI.

Resolves https://github.com/subspace/subspace/issues/2464

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
