### PR TITLE
Account for DSN sync in `SubspaceSyncOracle`

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -813,7 +813,11 @@ where
         }),
     );
 
-    let sync_oracle = SubspaceSyncOracle::new(config.base.force_authoring, sync_service.clone());
+    let sync_oracle = SubspaceSyncOracle::new(
+        config.base.force_authoring,
+        Arc::clone(&pause_sync),
+        sync_service.clone(),
+    );
 
     let subspace_archiver = tokio::task::block_in_place(|| {
         create_subspace_archiver(


### PR DESCRIPTION
This is necessary for accuracy after Substrate upgrade in https://github.com/subspace/subspace/pull/2424 and usage of alternative sync pausing mechanism used by our fork.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
