### PR TITLE
Improve block finalization by make it reliant on segment headers store

### DIFF
--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -43,6 +43,7 @@ use lru::LruCache;
 use parking_lot::Mutex;
 use sp_consensus_subspace::ChainConstants;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::SegmentHeader;
@@ -89,7 +90,8 @@ impl<Block: BlockT> SubspaceLink<Block> {
             block_importing_notification_sender,
             block_importing_notification_stream,
             segment_headers: Arc::new(Mutex::new(LruCache::new(
-                FINALIZATION_DEPTH_IN_SEGMENTS.saturating_add(1),
+                NonZeroUsize::new(u64::from(FINALIZATION_DEPTH_IN_SEGMENTS) as usize + 1)
+                    .expect("Not zero; qed"),
             ))),
             chain_constants,
             kzg,

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -69,6 +69,12 @@ impl SegmentIndex {
     /// Segment index 1.
     pub const ONE: SegmentIndex = SegmentIndex(1);
 
+    /// Create new instance
+    #[inline]
+    pub const fn new(n: u64) -> Self {
+        Self(n)
+    }
+
     /// Get the first piece index in this segment.
     pub fn first_piece_index(&self) -> PieceIndex {
         PieceIndex::from(self.0 * ArchivedHistorySegment::NUM_PIECES as u64)
@@ -108,6 +114,12 @@ impl SegmentIndex {
             });
 
         source_first_piece_indices
+    }
+
+    /// Checked integer subtraction. Computes `self - rhs`, returning `None` if overflow occurred.
+    #[inline]
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
     }
 }
 


### PR DESCRIPTION
Previously finalization depended on in-memory data structure, but since now we have persistent `SegmentHeadersStore` that is populated at the beginning of DSN sync, we can finalize blocks in a better way, ensuring necessary blocks are pruned quickly even if node restarts (which is especially true when we do daily software updates).

Related to both https://github.com/subspace/subspace/issues/1797 and https://github.com/subspace/subspace/issues/2114

Tested by syncing devnet successfully.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
