### PR TITLE
Connection limits improvements

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -52,7 +52,7 @@ const GOSSIPSUB_PROTOCOL_PREFIX: &str = "subspace/gossipsub";
 /// It must be set for large plots.
 const SWARM_MAX_NEGOTIATING_INBOUND_STREAMS: usize = 100000;
 /// How long will connection be allowed to be open without any usage
-const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(3);
 /// The default maximum established incoming connection number for the swarm.
 const SWARM_MAX_ESTABLISHED_INCOMING_CONNECTIONS: u32 = 100;
 /// The default maximum established incoming connection number for the swarm.

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -570,10 +570,7 @@ where
     // Create final structs
     let (command_sender, command_receiver) = mpsc::channel(1);
 
-    let rate_limiter = RateLimiter::new(
-        max_established_outgoing_connections,
-        max_pending_outgoing_connections,
-    );
+    let rate_limiter = RateLimiter::new();
 
     let shared = Arc::new(Shared::new(local_peer_id, command_sender, rate_limiter));
     let shared_weak = Arc::downgrade(&shared);


### PR DESCRIPTION
Largely fixes https://github.com/subspace/subspace/issues/2398 by switching from few connections (3) and large timeouts (10s) to many connections (restores scaling of permits that was essentially useless due to connections limit) and smaller timeouts (3s).

I tested even lower timeout (1s) locally and it still worked, but since scaling depends on actual outgoing connections I decided to keep a bit higher number for now.

I was testing this with piece cache sync and out of multiple runs I had 0 missing pieces. In some cases process was CPU-limited (piece verification is not free when there are many of them arriving each second).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
