### PR TITLE
Piece cache improvements

### DIFF
--- a/crates/subspace-farmer/src/utils/piece_validator.rs
+++ b/crates/subspace-farmer/src/utils/piece_validator.rs
@@ -46,56 +46,65 @@ where
         piece_index: PieceIndex,
         piece: Piece,
     ) -> Option<Piece> {
-        if source_peer_id != self.dsn_node.id() {
-            let segment_index = piece_index.segment_index();
+        if source_peer_id == self.dsn_node.id() {
+            return Some(piece);
+        }
 
-            let maybe_segment_commitment = self
-                .segment_commitment_cache
-                .lock()
-                .get(&segment_index)
-                .copied();
-            let segment_commitment = match maybe_segment_commitment {
-                Some(segment_commitment) => segment_commitment,
-                None => {
-                    let segment_headers =
-                        match self.node_client.segment_headers(vec![segment_index]).await {
-                            Ok(segment_headers) => segment_headers,
-                            Err(error) => {
-                                error!(
-                                    %piece_index,
-                                    ?error,
-                                    "Failed tor retrieve segment headers from node"
-                                );
-                                return None;
-                            }
-                        };
+        let segment_index = piece_index.segment_index();
 
-                    let segment_commitment = match segment_headers.into_iter().next().flatten() {
-                        Some(segment_header) => segment_header.segment_commitment(),
-                        None => {
+        let maybe_segment_commitment = self
+            .segment_commitment_cache
+            .lock()
+            .get(&segment_index)
+            .copied();
+        let segment_commitment = match maybe_segment_commitment {
+            Some(segment_commitment) => segment_commitment,
+            None => {
+                let segment_headers =
+                    match self.node_client.segment_headers(vec![segment_index]).await {
+                        Ok(segment_headers) => segment_headers,
+                        Err(error) => {
                             error!(
                                 %piece_index,
-                                %segment_index,
-                                "Segment commitment for segment index wasn't found on node"
+                                ?error,
+                                "Failed tor retrieve segment headers from node"
                             );
                             return None;
                         }
                     };
 
-                    self.segment_commitment_cache
-                        .lock()
-                        .push(segment_index, segment_commitment);
+                let segment_commitment = match segment_headers.into_iter().next().flatten() {
+                    Some(segment_header) => segment_header.segment_commitment(),
+                    None => {
+                        error!(
+                            %piece_index,
+                            %segment_index,
+                            "Segment commitment for segment index wasn't found on node"
+                        );
+                        return None;
+                    }
+                };
 
-                    segment_commitment
-                }
-            };
+                self.segment_commitment_cache
+                    .lock()
+                    .push(segment_index, segment_commitment);
 
-            if !is_piece_valid(
-                &self.kzg,
-                &piece,
-                &segment_commitment,
-                piece_index.position(),
-            ) {
+                segment_commitment
+            }
+        };
+
+        let is_valid_fut = tokio::task::spawn_blocking({
+            let kzg = self.kzg.clone();
+
+            move || {
+                is_piece_valid(&kzg, &piece, &segment_commitment, piece_index.position())
+                    .then_some(piece)
+            }
+        });
+
+        match is_valid_fut.await.unwrap_or_default() {
+            Some(piece) => Some(piece),
+            None => {
                 warn!(
                     %piece_index,
                     %source_peer_id,
@@ -104,10 +113,8 @@ where
 
                 // We don't care about result here
                 let _ = self.dsn_node.ban_peer(source_peer_id).await;
-                return None;
+                None
             }
         }
-
-        Some(piece)
     }
 }

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -42,6 +42,7 @@ use std::pin::Pin;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
+use tokio::task::yield_now;
 use tokio::time::Sleep;
 use tracing::{debug, error, trace, warn};
 
@@ -295,6 +296,9 @@ where
                     self.handle_removed_address_event(event);
                 },
             }
+
+            // Allow to exit from busy loop during graceful shutdown
+            yield_now().await;
         }
     }
 


### PR DESCRIPTION
First of all I resolved TODO that accelerates partially populated piece cache initialization and reduces CPU usage.

Second, I noticed that under heavy load (achievable after https://github.com/subspace/subspace/pull/2477) it is possible that networking will get stuck in a busy loop. While not pretty, yielding to executor solves this problem and allows to interrupt networking operation when desired.

After that I tweaked drop order in the farmer (should be replicated in Pulsar and Space Acres) to drop networking last and avoid some of the annoying warnings that would be printed otherwise.

And at the end I noticed that piece verification is quite heavy in terms of compute and is done in async context, so I moved it into blocking task instead, that should accelerate piece downloading during DSN sync in node for example.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
