### PR TITLE
Plot while syncing

### DIFF
--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -322,6 +322,7 @@ where
             FarmerAppInfo {
                 genesis_hash: self.genesis_hash,
                 dsn_bootstrap_nodes: self.dsn_bootstrap_nodes.clone(),
+                syncing: self.sync_oracle.is_major_syncing(),
                 farming_timeout: chain_constants
                     .slot_duration()
                     .as_duration()

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -64,8 +64,8 @@ use subspace_core_primitives::{
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_rpc_primitives::{
-    FarmerAppInfo, NodeSyncStatus, RewardSignatureResponse, RewardSigningInfo, SlotInfo,
-    SolutionResponse, MAX_SEGMENT_HEADERS_PER_REQUEST,
+    FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    MAX_SEGMENT_HEADERS_PER_REQUEST,
 };
 use tracing::{debug, error, warn};
 
@@ -73,7 +73,6 @@ use tracing::{debug, error, warn};
 /// the fact that channel sender exists
 const SOLUTION_SENDER_CHANNEL_CAPACITY: usize = 9;
 const REWARD_SIGNING_TIMEOUT: Duration = Duration::from_millis(500);
-const NODE_SYNC_STATUS_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Provides rpc methods for interacting with Subspace.
 #[rpc(client, server)]
@@ -111,14 +110,6 @@ pub trait SubspaceRpcApi {
         item = SegmentHeader,
     )]
     fn subscribe_archived_segment_header(&self);
-
-    /// Archived segment header subscription
-    #[subscription(
-        name = "subspace_subscribeNodeSyncStatusChange" => "subspace_node_sync_status_change",
-        unsubscribe = "subspace_unsubscribeNodeSyncStatusChange",
-        item = NodeSyncStatus,
-    )]
-    fn subscribe_node_sync_status_change(&self);
 
     #[method(name = "subspace_segmentHeaders")]
     async fn segment_headers(
@@ -643,61 +634,6 @@ where
 
         self.subscription_executor.spawn(
             "subspace-archived-segment-header-subscription",
-            Some("rpc"),
-            fut.boxed(),
-        );
-
-        Ok(())
-    }
-
-    fn subscribe_node_sync_status_change(&self, mut sink: SubscriptionSink) -> SubscriptionResult {
-        let sync_oracle = self.sync_oracle.clone();
-        let fut = async move {
-            let mut last_is_major_syncing = None;
-            loop {
-                let is_major_syncing = sync_oracle.is_major_syncing();
-
-                // Update subscriber if value has changed
-                if last_is_major_syncing != Some(is_major_syncing) {
-                    // In case change is detected, wait for another interval to confirm.
-                    // TODO: This is primarily because Substrate seems to lose peers for brief
-                    //  periods of time sometimes that needs to be investigated separately
-                    futures_timer::Delay::new(NODE_SYNC_STATUS_CHECK_INTERVAL).await;
-
-                    // If status returned back to what it was, ignore
-                    if last_is_major_syncing == Some(sync_oracle.is_major_syncing()) {
-                        futures_timer::Delay::new(NODE_SYNC_STATUS_CHECK_INTERVAL).await;
-                        continue;
-                    }
-
-                    // Otherwise save new status
-                    last_is_major_syncing.replace(is_major_syncing);
-
-                    let node_sync_status = if is_major_syncing {
-                        NodeSyncStatus::MajorSyncing
-                    } else {
-                        NodeSyncStatus::Synced
-                    };
-                    match sink.send(&node_sync_status) {
-                        Ok(true) => {
-                            // Success
-                        }
-                        Ok(false) => {
-                            // Subscription closed
-                            return;
-                        }
-                        Err(error) => {
-                            error!("Failed to serialize node sync status: {}", error);
-                        }
-                    }
-                }
-
-                futures_timer::Delay::new(NODE_SYNC_STATUS_CHECK_INTERVAL).await;
-            }
-        };
-
-        self.subscription_executor.spawn(
-            "subspace-node-sync-status-change-subscription",
             Some("rpc"),
             fut.boxed(),
         );

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -56,7 +56,7 @@ substrate-bip39 = "0.4.5"
 supports-color = "2.1.0"
 tempfile = "3.9.0"
 thiserror = "1.0.56"
-tokio = { version = "1.35.1", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
+tokio = { version = "1.35.1", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ulid = { version = "1.0.0", features = ["serde"] }

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -6,8 +6,7 @@ use std::fmt;
 use std::pin::Pin;
 use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
-    FarmerAppInfo, NodeSyncStatus, RewardSignatureResponse, RewardSigningInfo, SlotInfo,
-    SolutionResponse,
+    FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
 /// To become error type agnostic
@@ -45,11 +44,6 @@ pub trait NodeClient: Clone + fmt::Debug + Send + Sync + 'static {
     async fn subscribe_archived_segment_headers(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = SegmentHeader> + Send + 'static>>, Error>;
-
-    /// Subscribe to node sync status change
-    async fn subscribe_node_sync_status_change(
-        &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = NodeSyncStatus> + Send + 'static>>, Error>;
 
     /// Get segment headers for the segments
     async fn segment_headers(

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -9,8 +9,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
-    FarmerAppInfo, NodeSyncStatus, RewardSignatureResponse, RewardSigningInfo, SlotInfo,
-    SolutionResponse,
+    FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 use tokio::sync::Semaphore;
 
@@ -129,23 +128,6 @@ impl NodeClient for NodeRpcClient {
 
         Ok(Box::pin(subscription.filter_map(
             |archived_segment_header_result| async move { archived_segment_header_result.ok() },
-        )))
-    }
-
-    async fn subscribe_node_sync_status_change(
-        &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = NodeSyncStatus> + Send + 'static>>, RpcError> {
-        let subscription = self
-            .client
-            .subscribe(
-                "subspace_subscribeNodeSyncStatusChange",
-                rpc_params![],
-                "subspace_unsubscribeNodeSyncStatusChange",
-            )
-            .await?;
-
-        Ok(Box::pin(subscription.filter_map(
-            |node_sync_status_result| async move { node_sync_status_result.ok() },
         )))
     }
 

--- a/crates/subspace-farmer/src/piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/piece_cache/tests.rs
@@ -42,6 +42,7 @@ impl NodeClient for MockNodeClient {
         Ok(FarmerAppInfo {
             genesis_hash: [0; 32],
             dsn_bootstrap_nodes: Vec::new(),
+            syncing: false,
             farming_timeout: Duration::default(),
             protocol_info: FarmerProtocolInfo {
                 history_size: HistorySize::from(SegmentIndex::from(

--- a/crates/subspace-farmer/src/piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/piece_cache/tests.rs
@@ -21,8 +21,7 @@ use subspace_networking::libp2p::identity;
 use subspace_networking::libp2p::kad::RecordKey;
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_rpc_primitives::{
-    FarmerAppInfo, NodeSyncStatus, RewardSignatureResponse, RewardSigningInfo, SlotInfo,
-    SolutionResponse,
+    FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 use tempfile::tempdir;
 
@@ -97,12 +96,6 @@ impl NodeClient for MockNodeClient {
         // Allow to delay segment headers subscription in tests
         let stream = rx.await.unwrap();
         Ok(Box::pin(stream))
-    }
-
-    async fn subscribe_node_sync_status_change(
-        &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = NodeSyncStatus> + Send + 'static>>, Error> {
-        unimplemented!()
     }
 
     async fn segment_headers(

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -35,6 +35,8 @@ pub struct FarmerAppInfo {
     pub genesis_hash: [u8; 32],
     /// Bootstrap nodes for DSN
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
+    /// Whether node is syncing right now
+    pub syncing: bool,
     /// How much time farmer has to audit sectors and generate a solution
     pub farming_timeout: Duration,
     /// Protocol info for farmer

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -92,20 +92,3 @@ pub struct RewardSignatureResponse {
     /// Pre-header or vote hash signature.
     pub signature: Option<RewardSignature>,
 }
-
-/// Information about new slot that just arrived
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum NodeSyncStatus {
-    /// Node is fully synced
-    Synced,
-    /// Node is major syncing
-    MajorSyncing,
-}
-
-impl NodeSyncStatus {
-    /// Whether node is synced
-    pub fn is_synced(&self) -> bool {
-        matches!(self, Self::Synced)
-    }
-}


### PR DESCRIPTION
Builds on changes introduced in https://github.com/subspace/subspace/pull/2476 and resolves https://github.com/subspace/subspace/issues/2400 by only waiting for node to become aware of archival history, not to sync to the tip.

This means that piece cache sync and plotting can happen in parallel to node sync and reduce total amount of time farmer needs before they can start farming.

While the logic here is not perfect, I believe it is good enough for things to work reasonably well in practice, better than they did before.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
