### PR TITLE
Fix event description

### DIFF
--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -152,7 +152,7 @@ mod pallet {
             /// Amount of collected tips.
             tips: BalanceOf<T>,
         },
-        /// Fees burned due to equivocated block author.
+        /// Fees burned due to equivocated block author or rewards not enabled.
         #[codec(index = 1)]
         BurnedBlockFees {
             /// Amount of burned storage fees.


### PR DESCRIPTION
Seeing this event made me worried for a moment, but it was simply because rewards are not enabled yet

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
