### PR TITLE
Fix piece cache sync restart by storing pieces in lower piece index offsets

### DIFF
--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -9,7 +9,7 @@ use futures::channel::oneshot;
 use futures::stream::{FuturesOrdered, FuturesUnordered};
 use futures::{select, FutureExt, StreamExt};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::num::NonZeroU16;
 use std::sync::Arc;
 use std::{fmt, mem};
@@ -42,7 +42,7 @@ struct Handlers {
 #[derive(Debug, Clone)]
 struct DiskPieceCacheState {
     stored_pieces: HashMap<RecordKey, Offset>,
-    free_offsets: Vec<Offset>,
+    free_offsets: VecDeque<Offset>,
     backend: DiskPieceCache,
 }
 
@@ -178,7 +178,7 @@ where
                     };
 
                     // Making offset as unoccupied and remove corresponding key from heap
-                    cache.free_offsets.push(offset);
+                    cache.free_offsets.push_front(offset);
                     match cache.backend.read_piece_index(offset) {
                         Ok(Some(piece_index)) => {
                             worker_state.heap.remove(KeyWrapper(piece_index));
@@ -227,7 +227,7 @@ where
             free_offsets.push(state.free_offsets);
         }
         stored_pieces.resize(new_caches.len(), HashMap::default());
-        free_offsets.resize(new_caches.len(), Vec::default());
+        free_offsets.resize(new_caches.len(), VecDeque::default());
 
         debug!("Collecting pieces that were in the cache before");
 
@@ -253,7 +253,7 @@ where
                                         );
                                     }
                                     None => {
-                                        free_offsets.push(offset);
+                                        free_offsets.push_back(offset);
                                     }
                                 }
 
@@ -356,7 +356,7 @@ where
                 .stored_pieces
                 .extract_if(|key, _offset| piece_indices_to_store.remove(key).is_none())
                 .for_each(|(_piece_index, offset)| {
-                    state.free_offsets.push(offset);
+                    state.free_offsets.push_front(offset);
                 });
         });
 
@@ -422,7 +422,7 @@ where
             // populated first
             sorted_caches.sort_by_key(|(_, cache)| cache.stored_pieces.len());
             if !sorted_caches.into_iter().any(|(disk_farm_index, cache)| {
-                let Some(offset) = cache.free_offsets.pop() else {
+                let Some(offset) = cache.free_offsets.pop_front() else {
                     return false;
                 };
 
@@ -702,7 +702,7 @@ where
                 // populated first
                 sorted_caches.sort_by_key(|(_, cache)| cache.stored_pieces.len());
                 for (disk_farm_index, cache) in sorted_caches {
-                    let Some(offset) = cache.free_offsets.pop() else {
+                    let Some(offset) = cache.free_offsets.pop_front() else {
                         // Not this disk farm
                         continue;
                     };


### PR DESCRIPTION
After https://github.com/subspace/subspace/pull/2479 piece cache is a bit broken. The reason for this is that farmer is "popping" offsets where pieces should be stored, meaning it will store pieces in the offsets towards the end of the cache, but initialization will stop reading contents once it sees a free spot, making piece cache "not see" stored pieces unless piece cache is full.

The solution is to store pieces in the beginning of the cache, which is also good for farm resizing.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
