### PR TITLE
fix docker instructions for farmer docs

### DIFF
--- a/docs/farming.md
+++ b/docs/farming.md
@@ -227,7 +227,6 @@ services:
       "--rpc-listen-on", "0.0.0.0:9944",
       "--rpc-cors", "all",
       "--rpc-methods", "unsafe",
-      "--rpc-external",
       "--farmer",
 # Replace `INSERT_YOUR_ID` with your node ID (will be shown in telemetry)
       "--name", "INSERT_YOUR_ID"


### PR DESCRIPTION
- update the docs to remove unsupported flag that prevents subspace node from starting

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
