### PR TITLE
fix container image sha format for trivy scanner

### DIFF
--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # @v0.16.1
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.event.client_payload.sha }}
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.event.client_payload.sha }}
           format: "sarif"
           output: "trivy-results.sarif"
           exit-code: "1"


### PR DESCRIPTION
This fixes the container sha format for the trivy container scanner argument input.

i.e `ghcr.io/subspace/node:sha-56cf1fb0c4ee40a1f354ea4b1219ade406073bcb`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
