### PR TITLE
Require force authoring for genesis farmer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,12 +66,22 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
+      # LLVM 15.0.{3, 4, 5, 6} is not released for macOS thus install LLVM 15.0.2 explicitly as a
+      # temporary workaround, and remove once incompatible is fixed.
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
         with:
-          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
-          version: 15.0.7
+          version: "15.0.2"
         if: runner.os == 'macOS'
+
+      # TODO: on Linux and Windows, the consensus/domain runtime build is not compatible with LLVM 16,
+      # thus install LLVM 15 explicitly as a temporary workaround, and remove once incompatible is fixed.
+      - name: Install LLVM and Clang for Linux and Windows
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        with:
+          version: "15.0"
+        if: runner.os != 'macOS'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
@@ -142,12 +152,22 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
+      # LLVM 15.0.{3, 4, 5, 6} is not released for macOS thus install LLVM 15.0.2 explicitly as a
+      # temporary workaround, and remove once incompatible is fixed.
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
         with:
-          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
-          version: 15.0.7
+          version: "15.0.2"
         if: runner.os == 'macOS'
+
+      # TODO: on Linux and Windows, the consensus/domain runtime build is not compatible with LLVM 16,
+      # thus install LLVM 15 explicitly as a temporary workaround, and remove once incompatible is fixed.
+      - name: Install LLVM and Clang for Linux and Windows
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        with:
+          version: "15.0"
+        if: runner.os != 'macOS'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
+      # TODO: on Linux and Windows, LLVM 16 is not compatible with the consensus/domain runtime build
+      # thus install LLVM 15 explicitly as a temporary workaround, and remove once it is fixed.
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        with:
+          version: "15.0"
+
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -135,12 +135,22 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
+      # LLVM 15.0.{3, 4, 5, 6} is not released for macOS thus install LLVM 15.0.2 explicitly as a
+      # temporary workaround, and remove once incompatible is fixed.
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
         with:
-          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
-          version: 15.0.7
+          version: "15.0.2"
         if: runner.os == 'macOS'
+
+      # TODO: on Linux and Windows, the consensus/domain runtime build is not compatible with LLVM 16,
+      # thus install LLVM 15 explicitly as a temporary workaround, and remove once incompatible is fixed.
+      - name: Install LLVM and Clang for Linux and Windows
+        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        with:
+          version: "15.0"
+        if: runner.os != 'macOS'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -257,6 +257,20 @@ where
             return;
         }
 
+        let maybe_root_plot_public_key = self
+            .client
+            .runtime_api()
+            .root_plot_public_key(self.client.info().best_hash)
+            .ok()
+            .flatten();
+        if maybe_root_plot_public_key.is_some() && !self.force_authoring {
+            debug!(
+                "Skipping farming slot {slot} due to root public key present and force authoring \
+                not enabled"
+            );
+            return;
+        }
+
         let proof_of_time = checkpoints.output();
         let global_randomness = proof_of_time.derive_global_randomness();
 


### PR DESCRIPTION
This will make node not send challenged to farmers before authoring is enabled for everyone, removing the need to specify `--farm-during-initial-plotting false`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
