### PR TITLE
Change default CLI values for blocks and state pruning to and make in valid value for state pruning non-representable

### DIFF
--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -3,17 +3,19 @@ use crate::{chain_spec, derive_pot_external_entropy, Error};
 use clap::Parser;
 use sc_chain_spec::GenericChainSpec;
 use sc_cli::{
-    generate_node_name, Cors, NodeKeyParams, NodeKeyType, PruningParams, RpcMethods,
-    TelemetryParams, TransactionPoolParams, RPC_DEFAULT_PORT,
+    generate_node_name, Cors, NodeKeyParams, NodeKeyType, RpcMethods, TelemetryParams,
+    TransactionPoolParams, RPC_DEFAULT_PORT,
 };
 use sc_informant::OutputFormat;
 use sc_network::config::{MultiaddrWithPeerId, NonReservedPeerMode, SetConfig};
-use sc_service::Configuration;
+use sc_service::{BlocksPruning, Configuration, PruningMode};
 use sc_storage_monitor::StorageMonitorParams;
 use sc_telemetry::TelemetryEndpoints;
 use std::collections::HashSet;
+use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
+use std::str::FromStr;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_service::config::{
@@ -161,6 +163,121 @@ struct DsnOptions {
     dsn_external_addresses: Vec<Multiaddr>,
 }
 
+/// This mode specifies when the block's state (ie, storage) should be pruned (ie, removed) from
+/// the database.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum StatePruningMode {
+    /// Keep the data of all blocks.
+    Archive,
+    /// Keep only the data of finalized blocks.
+    ArchiveCanonical,
+}
+
+impl FromStr for StatePruningMode {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "archive" => Ok(Self::Archive),
+            "archive-canonical" => Ok(Self::ArchiveCanonical),
+            _ => Err("Invalid state pruning mode specified".to_string()),
+        }
+    }
+}
+
+impl fmt::Display for StatePruningMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Archive => "archive",
+            Self::ArchiveCanonical => "archive-canonical",
+        })
+    }
+}
+
+/// This mode specifies when the block's body (including justifications) should be pruned (ie,
+/// removed) from the database.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum BlocksPruningMode {
+    /// Keep the data of all blocks.
+    Archive,
+    /// Keep only the data of finalized blocks.
+    ArchiveCanonical,
+    /// Keep the data of the last number of finalized blocks.
+    Number(u32),
+}
+
+impl FromStr for BlocksPruningMode {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "archive" => Ok(Self::Archive),
+            "archive-canonical" => Ok(Self::ArchiveCanonical),
+            n => n
+                .parse()
+                .map_err(|_| "Invalid block pruning mode specified".to_string())
+                .map(Self::Number),
+        }
+    }
+}
+
+impl fmt::Display for BlocksPruningMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Archive => f.write_str("archive"),
+            Self::ArchiveCanonical => f.write_str("archive-canonical"),
+            Self::Number(n) => f.write_str(n.to_string().as_str()),
+        }
+    }
+}
+
+/// Parameters to define the pruning mode
+#[derive(Debug, Clone, Parser)]
+struct PruningOptions {
+    /// Specify the state pruning mode.
+    ///
+    /// This mode specifies when the block's state (ie, storage) should be pruned (ie, removed)
+    /// from the database.
+    /// This setting can only be set on the first creation of the database. Every subsequent run
+    /// will load the pruning mode from the database and will error if the stored mode doesn't
+    /// match this CLI value. It is fine to drop this CLI flag for subsequent runs.
+    /// Possible values:
+    ///  - archive: Keep the state of all blocks.
+    ///  - archive-canonical: Keep only the state of finalized blocks.
+    #[arg(long, default_value_t = StatePruningMode::ArchiveCanonical)]
+    state_pruning: StatePruningMode,
+
+    /// Specify the blocks pruning mode.
+    ///
+    /// This mode specifies when the block's body (including justifications)
+    /// should be pruned (ie, removed) from the database.
+    /// Possible values:
+    ///  - archive Keep all blocks.
+    ///  - archive-canonical Keep only finalized blocks.
+    ///  - number: Keep the last `number` of finalized blocks.
+    #[arg(long, default_value_t = BlocksPruningMode::Number(256))]
+    blocks_pruning: BlocksPruningMode,
+}
+
+impl PruningOptions {
+    /// Get the pruning value from the parameters
+    fn state_pruning(&self) -> PruningMode {
+        match self.state_pruning {
+            StatePruningMode::Archive => PruningMode::ArchiveAll,
+            StatePruningMode::ArchiveCanonical => PruningMode::ArchiveCanonical,
+        }
+    }
+
+    /// Get the block pruning value from the parameters
+    fn blocks_pruning(&self) -> BlocksPruning {
+        match self.blocks_pruning {
+            BlocksPruningMode::Archive => BlocksPruning::KeepAll,
+            BlocksPruningMode::ArchiveCanonical => BlocksPruning::KeepFinalized,
+            BlocksPruningMode::Number(n) => BlocksPruning::Some(n),
+        }
+    }
+}
+
 /// Options for timekeeper
 #[derive(Debug, Parser)]
 struct TimekeeperOptions {
@@ -249,7 +366,7 @@ pub(super) struct ConsensusChainOptions {
 
     /// Options for chain database pruning
     #[clap(flatten)]
-    pruning_params: PruningParams,
+    pruning_params: PruningOptions,
 
     /// Options for Substrate networking
     #[clap(flatten)]
@@ -431,8 +548,8 @@ pub(super) fn create_consensus_chain_configuration(
             allow_private_ips: network_options.allow_private_ips,
             force_synced,
         },
-        state_pruning: pruning_params.state_pruning()?,
-        blocks_pruning: pruning_params.blocks_pruning()?,
+        state_pruning: pruning_params.state_pruning(),
+        blocks_pruning: pruning_params.blocks_pruning(),
         rpc_options: SubstrateRpcConfiguration {
             listen_on: rpc_options.rpc_listen_on,
             max_connections: rpc_options.rpc_max_connections,

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -83,7 +83,7 @@ pub struct SubstrateConfiguration {
     /// Network configuration
     pub network: SubstrateNetworkConfiguration,
     /// State pruning settings
-    pub state_pruning: Option<PruningMode>,
+    pub state_pruning: PruningMode,
     /// Number of blocks to keep in the db.
     ///
     /// NOTE: only finalized blocks are subject for removal!
@@ -159,7 +159,7 @@ impl From<SubstrateConfiguration> for Configuration {
             data_path: configuration.base_path.clone(),
             // Substrate's default
             trie_cache_maximum_size: Some(64 * 1024 * 1024),
-            state_pruning: configuration.state_pruning,
+            state_pruning: Some(configuration.state_pruning),
             blocks_pruning: configuration.blocks_pruning,
             wasm_method: Default::default(),
             wasm_runtime_overrides: None,

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -47,8 +47,6 @@ If you're connected directly without any router, then again nothing needs to be 
 .\NODE_FILE_NAME.exe run `
 --base-path PATH_TO_NODE `
 --chain gemini-3h `
---blocks-pruning 256 `
---state-pruning archive-canonical `
 --farmer `
 --name "INSERT_YOUR_ID"
 ```
@@ -99,8 +97,6 @@ If you're connected directly without any router, then again nothing needs to be 
 ./NODE_FILE_NAME run \
   --base-path PATH_TO_NODE \
   --chain gemini-3h \
-  --blocks-pruning 256 \
-  --state-pruning archive-canonical \
   --farmer \
   --name "INSERT_YOUR_ID"
 ```
@@ -154,8 +150,6 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ./NODE_FILE_NAME run \
   --base-path PATH_TO_NODE \
   --chain gemini-3h \
-  --blocks-pruning 256 \
-  --state-pruning archive-canonical \
   --farmer \
   --name "INSERT_YOUR_ID"
 ```
@@ -219,8 +213,6 @@ services:
       "run",
       "--chain", "gemini-3h",
       "--base-path", "/var/subspace",
-      "--blocks-pruning", "256",
-      "--state-pruning", "archive-canonical",
       "--listen-on", "/ip4/0.0.0.0/tcp/30333",
       "--dsn-listen-on", "/ip4/0.0.0.0/udp/30433/quic-v1",
       "--dsn-listen-on", "/ip4/0.0.0.0/tcp/30433",


### PR DESCRIPTION
Subspace doesn't support state pruning the same way as many other Substrate chains because of the need to query state of older blocks for archiving, hence default state pruning of Substrate of 256 blocks is broken for Subspace (impossible to restart node after this).

Once user rightfully pointed this out and I decided to change the defaults accordingly. Instead of archive-canonical/256 for blocks and state pruning we now have 256/archive-canonical instead. Also state pruning in blocks is no longer specifiable.

This will be improved once we can prune things programmatically (see https://github.com/paritytech/polkadot-sdk/issues/1570).

As the result of these changes, some CLI options no longer need to be specified explicitly by farmers.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
