### PR TITLE
Piece getter for DSN sync

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -54,10 +54,8 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector_sync;
-use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions,
-};
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions};
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
 use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_verification::is_within_solution_range;

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -14,13 +14,11 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_plot_sync;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
-};
+use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -8,11 +8,9 @@ use subspace_core_primitives::crypto::kzg;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{HistorySize, PublicKey, Record, RecordedHistorySegment};
 use subspace_erasure_coding::ErasureCoding;
-use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions,
-};
+use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions};
 use subspace_farmer_components::sector::sector_size;
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -19,13 +19,11 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_plot_sync;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
-};
+use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::{Table, TableGenerator};
 

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -15,14 +15,12 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
-};
+use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
 use subspace_farmer_components::reading::read_piece;
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::{FarmerProtocolInfo, ReadAt, ReadAtSync};
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy, ReadAt, ReadAtSync};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 

--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -1,4 +1,4 @@
-use crate::plotting::{PieceGetter, PieceGetterRetryPolicy};
+use crate::{PieceGetter, PieceGetterRetryPolicy};
 use futures::stream::FuturesOrdered;
 use futures::StreamExt;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, mem};
 use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
-use subspace_farmer_components::plotting::{PieceGetter, PieceGetterRetryPolicy};
+use subspace_farmer_components::{PieceGetter, PieceGetterRetryPolicy};
 use subspace_networking::libp2p::kad::{ProviderRecord, RecordKey};
 use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::multihash::ToMultihash;

--- a/crates/subspace-farmer/src/piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/piece_cache/tests.rs
@@ -15,8 +15,7 @@ use std::time::Duration;
 use subspace_core_primitives::{
     HistorySize, LastArchivedBlock, Piece, PieceIndex, SegmentHeader, SegmentIndex,
 };
-use subspace_farmer_components::plotting::{PieceGetter, PieceGetterRetryPolicy};
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter, PieceGetterRetryPolicy};
 use subspace_networking::libp2p::identity;
 use subspace_networking::libp2p::kad::RecordKey;
 use subspace_networking::utils::multihash::ToMultihash;

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -53,9 +53,9 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
-use subspace_farmer_components::plotting::{PieceGetter, PlottedSector};
+use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::{sector_size, SectorMetadata, SectorMetadataChecksummed};
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_networking::KnownPeersManager;
 use subspace_proof_of_space::Table;
 use subspace_rpc_primitives::{FarmerAppInfo, SolutionResponse};

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -26,12 +26,12 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::FileExt;
-use subspace_farmer_components::plotting;
 use subspace_farmer_components::plotting::{
     download_sector, encode_sector, DownloadSectorOptions, DownloadedSector, EncodeSectorOptions,
-    PieceGetter, PieceGetterRetryPolicy, PlottedSector,
+    PlottedSector,
 };
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
+use subspace_farmer_components::{plotting, PieceGetter, PieceGetterRetryPolicy};
 use subspace_proof_of_space::Table;
 use thiserror::Error;
 use tokio::runtime::Handle;

--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::error::Error;
 use std::sync::Arc;
 use subspace_core_primitives::{Piece, PieceIndex};
-use subspace_farmer_components::plotting::{PieceGetter, PieceGetterRetryPolicy};
+use subspace_farmer_components::{PieceGetter, PieceGetterRetryPolicy};
 use subspace_networking::libp2p::kad::RecordKey;
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator, RetryPolicy};

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -208,6 +208,7 @@ fn main() -> Result<(), Error> {
                 // Domain node needs slots notifications for bundle production.
                 force_new_slot_notifications: true,
                 subspace_networking: SubspaceNetworking::Create { config: dsn_config },
+                dsn_piece_getter: None,
                 sync_from_dsn: true,
                 is_timekeeper: false,
                 timekeeper_cpu_cores: Default::default(),

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 use libp2p::PeerId;
 use std::collections::HashSet;
 use std::error::Error;
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use subspace_core_primitives::{Piece, PieceIndex};
@@ -61,6 +62,12 @@ impl PieceValidator for NoPieceValidator {
 pub struct PieceProvider<PV> {
     node: Node,
     piece_validator: Option<PV>,
+}
+
+impl<PV> fmt::Debug for PieceProvider<PV> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("PieceProvider").finish_non_exhaustive()
+    }
 }
 
 impl<PV> PieceProvider<PV>

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -530,6 +530,7 @@ pub(super) fn create_consensus_chain_configuration(
             // Domain node needs slots notifications for bundle production.
             force_new_slot_notifications: domains_enabled,
             subspace_networking: SubspaceNetworking::Create { config: dsn_config },
+            dsn_piece_getter: None,
             sync_from_dsn,
             is_timekeeper: timekeeper_options.timekeeper,
             timekeeper_cpu_cores: timekeeper_options.timekeeper_cpu_cores,

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -1,4 +1,5 @@
 use crate::dsn::DsnConfig;
+use crate::sync_from_dsn::DsnSyncPieceGetter;
 use prometheus_client::registry::Registry;
 use sc_chain_spec::ChainSpec;
 use sc_network::config::{
@@ -242,6 +243,8 @@ pub struct SubspaceConfiguration {
     pub force_new_slot_notifications: bool,
     /// Subspace networking (DSN).
     pub subspace_networking: SubspaceNetworking,
+    /// DSN piece getter
+    pub dsn_piece_getter: Option<Arc<dyn DsnSyncPieceGetter + Send + Sync + 'static>>,
     /// Enables DSN-sync on startup.
     pub sync_from_dsn: bool,
     /// Is this node a Timekeeper

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -846,14 +846,16 @@ where
 
     network_wrapper.set(network_service.clone());
     if config.sync_from_dsn {
-        let piece_provider = PieceProvider::new(
-            node.clone(),
-            Some(SegmentCommitmentPieceValidator::new(
+        let dsn_sync_piece_getter = config.dsn_piece_getter.unwrap_or_else(|| {
+            Arc::new(PieceProvider::new(
                 node.clone(),
-                subspace_link.kzg().clone(),
-                segment_headers_store.clone(),
-            )),
-        );
+                Some(SegmentCommitmentPieceValidator::new(
+                    node.clone(),
+                    subspace_link.kzg().clone(),
+                    segment_headers_store.clone(),
+                )),
+            ))
+        });
 
         let (observer, worker) = sync_from_dsn::create_observer_and_worker(
             segment_headers_store.clone(),
@@ -863,7 +865,7 @@ where
             import_queue_service,
             sync_target_block_number,
             pause_sync,
-            piece_provider,
+            dsn_sync_piece_getter,
         );
         task_manager
             .spawn_handle()

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::sync_from_dsn::segment_header_downloader::SegmentHeaderDownloader;
+use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use sc_client_api::{AuxStore, BlockBackend, HeaderBackend};
@@ -26,15 +27,56 @@ use sp_consensus::BlockOrigin;
 use sp_runtime::generic::SignedBlock;
 use sp_runtime::traits::{Block as BlockT, Header, NumberFor, One};
 use sp_runtime::Saturating;
+use std::error::Error;
 use std::num::NonZeroU16;
+use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
 use subspace_core_primitives::{
-    ArchivedHistorySegment, BlockNumber, Piece, RecordedHistorySegment, SegmentIndex,
+    ArchivedHistorySegment, BlockNumber, Piece, PieceIndex, RecordedHistorySegment, SegmentIndex,
 };
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator, RetryPolicy};
 use tokio::sync::Semaphore;
 use tracing::warn;
+
+/// Trait representing a way to get pieces for DSN sync purposes
+#[async_trait]
+pub trait DsnSyncPieceGetter {
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
+}
+
+#[async_trait]
+impl<T> DsnSyncPieceGetter for Arc<T>
+where
+    T: DsnSyncPieceGetter + Send + Sync,
+{
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+        self.as_ref().get_piece(piece_index).await
+    }
+}
+
+#[async_trait]
+impl<PV> DsnSyncPieceGetter for PieceProvider<PV>
+where
+    PV: PieceValidator,
+{
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+        self.get_piece_from_dsn_cache(
+            piece_index,
+            RetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
+        )
+        .await
+    }
+}
 
 /// Get piece retry attempts number.
 const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(7).expect("Not zero; qed");
@@ -48,11 +90,11 @@ const WAIT_FOR_BLOCKS_TO_IMPORT: Duration = Duration::from_secs(1);
 /// Starts the process of importing blocks.
 ///
 /// Returns number of downloaded blocks.
-pub async fn import_blocks_from_dsn<Block, AS, Client, PV, IQS>(
+pub(super) async fn import_blocks_from_dsn<Block, AS, Client, PG, IQS>(
     segment_headers_store: &SegmentHeadersStore<AS>,
     segment_header_downloader: &SegmentHeaderDownloader<'_>,
     client: &Client,
-    piece_provider: &PieceProvider<PV>,
+    piece_getter: &PG,
     import_queue_service: &mut IQS,
     last_processed_segment_index: &mut SegmentIndex,
     last_processed_block_number: &mut <Block::Header as Header>::Number,
@@ -61,7 +103,7 @@ where
     Block: BlockT,
     AS: AuxStore + Send + Sync + 'static,
     Client: HeaderBackend<Block> + BlockBackend<Block> + Send + Sync + 'static,
-    PV: PieceValidator,
+    PG: DsnSyncPieceGetter,
     IQS: ImportQueueService<Block> + ?Sized,
 {
     {
@@ -135,7 +177,7 @@ where
         }
 
         let blocks =
-            download_and_reconstruct_blocks(segment_index, piece_provider, &mut reconstructor)
+            download_and_reconstruct_blocks(segment_index, piece_getter, &mut reconstructor)
                 .await?;
 
         let mut blocks_to_import = Vec::with_capacity(QUEUED_BLOCKS_LIMIT as usize);
@@ -242,13 +284,13 @@ where
     Ok(downloaded_blocks)
 }
 
-async fn download_and_reconstruct_blocks<PV>(
+async fn download_and_reconstruct_blocks<PG>(
     segment_index: SegmentIndex,
-    piece_provider: &PieceProvider<PV>,
+    piece_getter: &PG,
     reconstructor: &mut Reconstructor,
 ) -> Result<Vec<(BlockNumber, Vec<u8>)>, sc_service::Error>
 where
-    PV: PieceValidator,
+    PG: DsnSyncPieceGetter,
 {
     debug!(%segment_index, "Retrieving pieces of the segment");
 
@@ -279,13 +321,7 @@ where
                         }
                     }
                 };
-                let maybe_piece = match piece_provider
-                    .get_piece_from_dsn_cache(
-                        piece_index,
-                        RetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
-                    )
-                    .await
-                {
+                let maybe_piece = match piece_getter.get_piece(piece_index).await {
                     Ok(maybe_piece) => maybe_piece,
                     Err(error) => {
                         trace!(

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -28,6 +28,7 @@ use sp_runtime::generic::SignedBlock;
 use sp_runtime::traits::{Block as BlockT, Header, NumberFor, One};
 use sp_runtime::Saturating;
 use std::error::Error;
+use std::fmt;
 use std::num::NonZeroU16;
 use std::sync::Arc;
 use std::time::Duration;
@@ -41,7 +42,7 @@ use tracing::warn;
 
 /// Trait representing a way to get pieces for DSN sync purposes
 #[async_trait]
-pub trait DsnSyncPieceGetter {
+pub trait DsnSyncPieceGetter: fmt::Debug {
     async fn get_piece(
         &self,
         piece_index: PieceIndex,
@@ -51,7 +52,7 @@ pub trait DsnSyncPieceGetter {
 #[async_trait]
 impl<T> DsnSyncPieceGetter for Arc<T>
 where
-    T: DsnSyncPieceGetter + Send + Sync,
+    T: DsnSyncPieceGetter + Send + Sync + ?Sized,
 {
     async fn get_piece(
         &self,

--- a/crates/subspace-service/src/sync_from_dsn/piece_validator.rs
+++ b/crates/subspace-service/src/sync_from_dsn/piece_validator.rs
@@ -9,21 +9,21 @@ use subspace_networking::utils::piece_provider::PieceValidator;
 use subspace_networking::Node;
 use tracing::{error, warn};
 
-pub struct SegmentCommitmentPieceValidator<'a, AS> {
-    dsn_node: &'a Node,
-    kzg: &'a Kzg,
-    segment_headers_store: &'a SegmentHeadersStore<AS>,
+pub(crate) struct SegmentCommitmentPieceValidator<AS> {
+    dsn_node: Node,
+    kzg: Kzg,
+    segment_headers_store: SegmentHeadersStore<AS>,
 }
 
-impl<'a, AS> SegmentCommitmentPieceValidator<'a, AS>
+impl<AS> SegmentCommitmentPieceValidator<AS>
 where
     AS: AuxStore + Send + Sync + 'static,
 {
     /// Segment headers must be in order from 0 to the last one that exists
-    pub fn new(
-        dsn_node: &'a Node,
-        kzg: &'a Kzg,
-        segment_headers_store: &'a SegmentHeadersStore<AS>,
+    pub(crate) fn new(
+        dsn_node: Node,
+        kzg: Kzg,
+        segment_headers_store: SegmentHeadersStore<AS>,
     ) -> Self {
         Self {
             dsn_node,
@@ -34,7 +34,7 @@ where
 }
 
 #[async_trait]
-impl<'a, AS> PieceValidator for SegmentCommitmentPieceValidator<'a, AS>
+impl<AS> PieceValidator for SegmentCommitmentPieceValidator<AS>
 where
     AS: AuxStore + Send + Sync + 'static,
 {

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -39,10 +39,8 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector_sync;
-use subspace_farmer_components::plotting::{
-    plot_sector, PieceGetterRetryPolicy, PlotSectorOptions, PlottedSector,
-};
-use subspace_farmer_components::FarmerProtocolInfo;
+use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_service::{FullClient, NewFull};


### PR DESCRIPTION
This introduces a new trait for getting pieces for the purposes of DSN sync. The idea behind this change is such that Pulsar and Space Acres can take advantage of piece cache and plots during DSN sync rather than pulling already retrieved pieces from the network again.

This is especially useful because DSN sync and piece cache sync happen in parallel and with https://github.com/subspace/subspace/issues/2399 cache will become even bigger. We can leverage all that to make sync experience better.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
