### PR TITLE
add delay mechanism for trivy scan job

### DIFF
--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -10,7 +10,38 @@ on:
     types: [trivy-scan-dispatch]
 
 jobs:
+  wait-for-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image-available: ${{ steps.check-image.outputs.available }}
+    steps:
+      - name: Check Docker image availability with retry
+        run: |
+          image="ghcr.io/${{ github.repository_owner }}/${{ github.event.client_payload.image }}:${{ github.event.client_payload.sha }}"
+          timeout=900 # Timeout in seconds (15 minutes)
+          interval=300 # Interval between retries in seconds (5 minutes)
+          retry_limit=5 # Number of retries
+          attempt=0
+
+          while ! docker pull $image; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -gt "$retry_limit" ]; then
+              echo "Image $image is not available after $retry_limit attempts."
+              echo "::set-output name=available::false"
+              exit 1
+            fi
+
+            echo "Attempt $attempt: Waiting for $image to be available. Retrying in $interval seconds..."
+            sleep $interval
+          done
+
+          echo "$image is now available."
+          echo "::set-output name=available::true"
+        shell: bash
+
   trivy_scan_image:
+    needs: wait-for-image
+    if: needs.wait-for-image.outputs.image-available == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR fixes the trivy scanning workflow, to wait for docker images to be available in github container registry after they are built. The current problem is that when the dispatch event is triggered and trivy runs the scan, the container building jobs have not completed from the `Snapshot build` workflow, so there are no docker images available in the container registry. A job is added to check if docker images are available first, and when they are the trivy scan container jobs are executed.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
