### PR TITLE
Update storages and types for Domains

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -159,8 +159,8 @@ mod pallet {
     use sp_core::H256;
     use sp_domains::bundle_producer_election::ProofOfElectionError;
     use sp_domains::{
-        BundleDigest, DomainId, EpochIndex, GenesisDomain, OperatorAllowList, OperatorId,
-        OperatorPublicKey, RuntimeId, RuntimeType,
+        BundleDigest, ConfirmedDomainBlock, DomainId, EpochIndex, GenesisDomain, OperatorAllowList,
+        OperatorId, OperatorPublicKey, RuntimeId, RuntimeType,
     };
     use sp_domains_fraud_proof::fraud_proof::FraudProof;
     use sp_domains_fraud_proof::InvalidTransactionCode;
@@ -495,11 +495,6 @@ mod pallet {
     pub(super) type HeadReceiptNumber<T: Config> =
         StorageMap<_, Identity, DomainId, DomainBlockNumberFor<T>, ValueQuery>;
 
-    /// The latest confirmed block number of each domain.
-    #[pallet::storage]
-    pub(super) type LatestConfirmedDomainBlockNumber<T: Config> =
-        StorageMap<_, Identity, DomainId, DomainBlockNumberFor<T>, ValueQuery>;
-
     /// Whether the head receipt have extended in the current consensus block
     ///
     /// Temporary storage only exist during block execution
@@ -570,6 +565,16 @@ mod pallet {
     #[pallet::storage]
     pub(super) type LastEpochStakingDistribution<T: Config> =
         StorageMap<_, Identity, DomainId, ElectionVerificationParams<BalanceOf<T>>, OptionQuery>;
+
+    /// Storage to hold all the domain's latest confirmed block.
+    #[pallet::storage]
+    pub(super) type LatestConfirmedDomainBlock<T: Config> = StorageMap<
+        _,
+        Identity,
+        DomainId,
+        ConfirmedDomainBlock<DomainBlockNumberFor<T>, T::DomainHash>,
+        OptionQuery,
+    >;
 
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
@@ -896,11 +901,6 @@ mod pallet {
                             ),
                         )
                         .map_err(Error::<T>::from)?;
-
-                        LatestConfirmedDomainBlockNumber::<T>::insert(
-                            domain_id,
-                            confirmed_block_info.domain_block_number,
-                        );
 
                         if confirmed_block_info.domain_block_number % T::StakeEpochDuration::get()
                             == Zero::zero()
@@ -1911,7 +1911,7 @@ impl<T: Config> Pallet<T> {
         domain_id: DomainId,
     ) -> Option<DomainBlockNumberFor<T>> {
         let oldest_nonconfirmed_er_number =
-            LatestConfirmedDomainBlockNumber::<T>::get(domain_id).saturating_add(One::one());
+            Self::latest_confirmed_domain_block_number(domain_id).saturating_add(One::one());
 
         if BlockTree::<T>::get(domain_id, oldest_nonconfirmed_er_number).is_some() {
             Some(oldest_nonconfirmed_er_number)
@@ -1922,6 +1922,14 @@ impl<T: Config> Pallet<T> {
             // - When using consensus block to derive the challenge period forward (unimplemented yet)
             None
         }
+    }
+
+    /// Returns the latest confirmed domain block number for a given domain
+    /// Zero block is always a default confirmed block.
+    pub fn latest_confirmed_domain_block_number(domain_id: DomainId) -> DomainBlockNumberFor<T> {
+        LatestConfirmedDomainBlock::<T>::get(domain_id)
+            .map(|block| block.block_number)
+            .unwrap_or_default()
     }
 
     /// Returns the domain block limit of the given domain.
@@ -1941,7 +1949,7 @@ impl<T: Config> Pallet<T> {
 
         // Start from the oldest non-confirmed ER to the head domain number
         let mut to_check =
-            LatestConfirmedDomainBlockNumber::<T>::get(domain_id).saturating_add(One::one());
+            Self::latest_confirmed_domain_block_number(domain_id).saturating_add(One::one());
         let head_number = HeadDomainNumber::<T>::get(domain_id);
 
         while to_check <= head_number {

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -481,8 +481,8 @@ mod tests {
     use crate::domain_registry::{DomainConfig, DomainObject};
     use crate::pallet::{
         Deposits, DomainRegistry, DomainStakingSummary, LastEpochStakingDistribution,
-        LatestConfirmedDomainBlockNumber, NominatorCount, OperatorIdOwner, OperatorSigningKey,
-        Operators, PendingOperatorSwitches, Withdrawals,
+        LatestConfirmedDomainBlock, NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators,
+        PendingOperatorSwitches, Withdrawals,
     };
     use crate::staking::tests::{register_operator, Share};
     use crate::staking::{
@@ -499,7 +499,7 @@ mod tests {
     use frame_support::traits::fungible::InspectHold;
     use frame_support::weights::Weight;
     use sp_core::{Pair, U256};
-    use sp_domains::{DomainId, OperatorAllowList, OperatorPair};
+    use sp_domains::{ConfirmedDomainBlock, DomainId, OperatorAllowList, OperatorPair};
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
     use std::collections::{BTreeMap, BTreeSet};
@@ -638,7 +638,16 @@ mod tests {
 
             // de-register operator
             let domain_block_number = 100;
-            LatestConfirmedDomainBlockNumber::<Test>::insert(domain_id, domain_block_number);
+            LatestConfirmedDomainBlock::<Test>::insert(
+                domain_id,
+                ConfirmedDomainBlock {
+                    block_number: domain_block_number,
+                    block_hash: Default::default(),
+                    parent_block_receipt_hash: Default::default(),
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                },
+            );
             do_deregister_operator::<Test>(operator_account, operator_id).unwrap();
 
             // finalize and add to pending operator unlocks
@@ -647,7 +656,16 @@ mod tests {
             // staking withdrawal is 5 blocks,
             // to unlock funds, confirmed block should be atleast 105
             let domain_block_number = 105;
-            LatestConfirmedDomainBlockNumber::<Test>::insert(domain_id, domain_block_number);
+            LatestConfirmedDomainBlock::<Test>::insert(
+                domain_id,
+                ConfirmedDomainBlock {
+                    block_number: domain_block_number,
+                    block_hash: Default::default(),
+                    parent_block_receipt_hash: Default::default(),
+                    state_root: Default::default(),
+                    extrinsics_root: Default::default(),
+                },
+            );
 
             assert_ok!(do_unlock_operator::<Test>(operator_id));
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -453,6 +453,7 @@ pub(crate) fn create_dummy_receipt(
         execution_trace,
         execution_trace_root,
         block_fees: Default::default(),
+        transfers: Default::default(),
     }
 }
 

--- a/crates/sp-domains-fraud-proof/src/bundle_equivocation.rs
+++ b/crates/sp-domains-fraud-proof/src/bundle_equivocation.rs
@@ -191,6 +191,7 @@ mod test {
                     execution_trace: vec![],
                     execution_trace_root: Default::default(),
                     block_fees: Default::default(),
+                    transfers: Default::default(),
                 },
                 estimated_bundle_weight: Default::default(),
                 bundle_extrinsics_root: Default::default(),

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -195,6 +195,57 @@ impl PassBy for DomainId {
     type PassBy = pass_by::Codec<Self>;
 }
 
+/// Identifier of a chain.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Encode,
+    Decode,
+    TypeInfo,
+    Serialize,
+    Deserialize,
+    MaxEncodedLen,
+)]
+pub enum ChainId {
+    Consensus,
+    Domain(DomainId),
+}
+
+impl ChainId {
+    #[inline]
+    pub fn consensus_chain_id() -> Self {
+        Self::Consensus
+    }
+
+    #[inline]
+    pub fn is_consensus_chain(&self) -> bool {
+        match self {
+            ChainId::Consensus => true,
+            ChainId::Domain(_) => false,
+        }
+    }
+}
+
+impl From<u32> for ChainId {
+    #[inline]
+    fn from(x: u32) -> Self {
+        Self::Domain(DomainId::new(x))
+    }
+}
+
+impl From<DomainId> for ChainId {
+    #[inline]
+    fn from(x: DomainId) -> Self {
+        Self::Domain(x)
+    }
+}
+
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct BundleHeader<Number, Hash, DomainHeader: HeaderT, Balance> {
     /// Proof of bundle producer election.
@@ -433,6 +484,8 @@ pub struct ExecutionReceipt<Number, Hash, DomainNumber, DomainHash, Balance> {
     /// Compute and Domain storage fees are shared across operators and Consensus
     /// storage fees are given to the consensus block author.
     pub block_fees: BlockFees<Balance>,
+    /// List of transfers from this Domain to other chains
+    pub transfers: BTreeMap<ChainId, Balance>,
 }
 
 impl<Number, Hash, DomainNumber, DomainHash, Balance>
@@ -510,6 +563,7 @@ impl<
             execution_trace: sp_std::vec![genesis_state_root],
             execution_trace_root: Default::default(),
             block_fees: Default::default(),
+            transfers: Default::default(),
         }
     }
 
@@ -546,6 +600,7 @@ impl<
             execution_trace,
             execution_trace_root,
             block_fees: Default::default(),
+            transfers: Default::default(),
         }
     }
 }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -36,7 +36,7 @@ use core::ops::{Add, Sub};
 use core::str::FromStr;
 use domain_runtime_primitives::BlockFees;
 use hexlit::hex;
-use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_application_crypto::sr25519;
@@ -608,6 +608,21 @@ impl<CHash: Default> ProofOfElection<CHash> {
             consensus_block_hash: Default::default(),
         }
     }
+}
+
+/// Type holding the block details of confirmed domain block.
+#[derive(TypeInfo, Encode, Decode, Debug, Clone, PartialEq, Eq)]
+pub struct ConfirmedDomainBlock<DomainBlockNumber: Codec, DomainHash: Codec> {
+    /// Block number of the confirmed domain block.
+    pub block_number: DomainBlockNumber,
+    /// Block hash of the confirmed domain block.
+    pub block_hash: DomainHash,
+    /// Parent block hash of the confirmed domain block.
+    pub parent_block_receipt_hash: DomainHash,
+    /// State root of the domain block.
+    pub state_root: DomainHash,
+    /// Extrinsic root of the domain block.
+    pub extrinsics_root: DomainHash,
 }
 
 /// Type that represents an operator allow list for Domains.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -477,8 +477,8 @@ impl sp_messenger::endpoint::DomainInfo<BlockNumber, Hash, Hash> for DomainInfo 
         Domains::domain_best_number(domain_id)
     }
 
-    fn domain_state_root(domain_id: DomainId, number: BlockNumber, hash: Hash) -> Option<Hash> {
-        Domains::domain_state_root(domain_id, number, hash)
+    fn domain_state_root(_domain_id: DomainId, _number: BlockNumber, _hash: Hash) -> Option<Hash> {
+        None
     }
 }
 
@@ -1061,8 +1061,8 @@ impl_runtime_apis! {
             Domains::domain_best_number(domain_id)
         }
 
-        fn domain_state_root(domain_id: DomainId, number: DomainNumber, hash: DomainHash) -> Option<DomainHash>{
-            Domains::domain_state_root(domain_id, number, hash)
+        fn domain_state_root(_domain_id: DomainId, _number: DomainNumber, _hash: DomainHash) -> Option<DomainHash>{
+            None
         }
 
         fn execution_receipt(receipt_hash: DomainHash) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>> {

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -254,6 +254,7 @@ mod tests {
             execution_trace: Default::default(),
             execution_trace_root: Default::default(),
             block_fees: Default::default(),
+            transfers: Default::default(),
         }
     }
 

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -396,6 +396,8 @@ where
             execution_trace: trace,
             execution_trace_root: sp_core::H256(trace_root),
             block_fees,
+            // TODO: Fetch transfers from the runtime
+            transfers: Default::default(),
         };
 
         Ok(DomainBlockResult {
@@ -973,6 +975,7 @@ mod tests {
             execution_trace: sp_std::vec![],
             execution_trace_root: Default::default(),
             block_fees: Default::default(),
+            transfers: Default::default(),
         }
     }
 

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -1,12 +1,12 @@
 use crate::endpoint::{Endpoint, EndpointRequest, EndpointResponse};
-use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
+use codec::{Decode, Encode, FullCodec};
 use frame_support::storage::generator::StorageMap;
 use frame_support::storage::storage_prefix;
 use frame_support::Identity;
 use scale_info::TypeInfo;
-use serde::{Deserialize, Serialize};
 use sp_core::storage::StorageKey;
 use sp_domains::proof_provider_and_verifier::StorageProofVerifier;
+pub use sp_domains::ChainId;
 use sp_domains::DomainId;
 use sp_runtime::app_crypto::sp_core::U256;
 use sp_runtime::{sp_std, DispatchError};
@@ -117,57 +117,6 @@ impl MessageWeightTag {
             ) => MessageWeightTag::EndpointResponse(endpoint),
             _ => MessageWeightTag::None,
         }
-    }
-}
-
-/// Identifier of a chain.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Hash,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Encode,
-    Decode,
-    TypeInfo,
-    Serialize,
-    Deserialize,
-    MaxEncodedLen,
-)]
-pub enum ChainId {
-    Consensus,
-    Domain(DomainId),
-}
-
-impl ChainId {
-    #[inline]
-    pub fn consensus_chain_id() -> Self {
-        Self::Consensus
-    }
-
-    #[inline]
-    pub fn is_consensus_chain(&self) -> bool {
-        match self {
-            ChainId::Consensus => true,
-            ChainId::Domain(_) => false,
-        }
-    }
-}
-
-impl From<u32> for ChainId {
-    #[inline]
-    fn from(x: u32) -> Self {
-        Self::Domain(DomainId::new(x))
-    }
-}
-
-impl From<DomainId> for ChainId {
-    #[inline]
-    fn from(x: DomainId) -> Self {
-        Self::Domain(x)
     }
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -532,8 +532,8 @@ impl sp_messenger::endpoint::DomainInfo<BlockNumber, Hash, Hash> for DomainInfo 
         Domains::domain_best_number(domain_id)
     }
 
-    fn domain_state_root(domain_id: DomainId, number: BlockNumber, hash: Hash) -> Option<Hash> {
-        Domains::domain_state_root(domain_id, number, hash)
+    fn domain_state_root(_domain_id: DomainId, _number: BlockNumber, _hash: Hash) -> Option<Hash> {
+        None
     }
 }
 
@@ -1253,8 +1253,8 @@ impl_runtime_apis! {
             Domains::domain_best_number(domain_id)
         }
 
-        fn domain_state_root(domain_id: DomainId, number: DomainNumber, hash: DomainHash) -> Option<DomainHash>{
-            Domains::domain_state_root(domain_id, number, hash)
+        fn domain_state_root(_domain_id: DomainId, _number: DomainNumber, _hash: DomainHash) -> Option<DomainHash>{
+            None
         }
 
         fn execution_receipt(receipt_hash: DomainHash) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>> {


### PR DESCRIPTION
This PR has collection of specific commits from #2508 and #2510 that updates the storages and types on Domains before we enable Nova on Gemini-3h.

TODOs are marked where necessary to fill the gaps in later PRs

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
