### PR TITLE
Use the Prometheus Registry behind Mutex to share mutable references

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -406,7 +406,7 @@ where
     let _prometheus_worker = if metrics_endpoints_are_specified {
         let prometheus_task = start_prometheus_metrics_server(
             metrics_endpoints,
-            RegistryAdapter::Libp2p(prometheus_metrics_registry),
+            RegistryAdapter::Libp2p(Arc::new(Mutex::new(prometheus_metrics_registry))),
         )?;
 
         let join_handle = tokio::spawn(prometheus_task);

--- a/crates/subspace-networking/examples/metrics.rs
+++ b/crates/subspace-networking/examples/metrics.rs
@@ -32,7 +32,7 @@ async fn main() {
 
     match start_prometheus_metrics_server(
         vec![prometheus_metrics_server_address],
-        RegistryAdapter::Libp2p(metric_registry),
+        RegistryAdapter::Libp2p(Arc::new(Mutex::new(metric_registry))),
     ) {
         Err(err) => {
             error!(

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -7,6 +7,7 @@ use futures::{select, FutureExt};
 use libp2p::identity::ed25519::Keypair;
 use libp2p::kad::Mode;
 use libp2p::{identity, Multiaddr, PeerId};
+use parking_lot::Mutex;
 use prometheus_client::registry::Registry;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -221,7 +222,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .then(|| {
                     start_prometheus_metrics_server(
                         metrics_endpoints,
-                        RegistryAdapter::Libp2p(metrics_registry),
+                        RegistryAdapter::Libp2p(Arc::new(Mutex::new(metrics_registry))),
                     )
                 })
                 .transpose()?;

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -1,5 +1,6 @@
 use crate::dsn::DsnConfig;
 use crate::sync_from_dsn::DsnSyncPieceGetter;
+use parking_lot::Mutex;
 use prometheus_client::registry::Registry;
 use sc_chain_spec::ChainSpec;
 use sc_network::config::{
@@ -224,7 +225,7 @@ pub enum SubspaceNetworking {
         /// Bootstrap nodes used (that can be also sent to the farmer over RPC)
         bootstrap_nodes: Vec<Multiaddr>,
         /// DSN metrics registry
-        metrics_registry: Option<Registry>,
+        metrics_registry: Option<Arc<Mutex<Registry>>>,
     },
     /// Networking must be instantiated internally
     Create {


### PR DESCRIPTION
## Description
This PR modifies Prometheus registry usage to be behind `Arc<Mutex`. This allows clients like Pulsar to use one registry for both `Farmer` and `Node` instance.

I considered having simply `Option<&mut Registry>` but since we eventually use `Arc<Mutex` for `RegistryAdapter` and the mutable reference will need to be around longer (since it is running in background task), it's better to have `Arc<Mutex` at Registry and remove it from `RegistryAdapter`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
