### PR TITLE
Modify domain public key console output format

### DIFF
--- a/crates/subspace-node/src/commands/domain_key.rs
+++ b/crates/subspace-node/src/commands/domain_key.rs
@@ -62,7 +62,7 @@ pub fn create_domain_key(options: CreateDomainKeyOptions) -> Result<(), Error> {
     store_key_in_keystore(path, &phrase, password)?;
 
     info!("Successfully generated and imported keypair!");
-    info!("Public key: {}", hex::encode(public_key.0));
+    info!("Public key: 0x{}", hex::encode(public_key.0));
     info!("Seed: \"{}\"", phrase.expose_secret());
     if has_password {
         info!("Password: as specified in CLI options");


### PR DESCRIPTION
Following [the discussion](https://subspacenetwork.slack.com/archives/C04MKMFNE48/p1707406602938309), this PR modifies the operator public key output format to be supported by PolkadotJS/Astral without any further modifications.  

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
