### PR TITLE
Cleaner farmer logs

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -672,7 +672,7 @@ where
                 "More than 256 plots are not supported, this is checked above already; qed",
             );
             let readers_and_pieces = Arc::clone(&readers_and_pieces);
-            let span = info_span!("farm", %disk_farm_index);
+            let span = info_span!("", %disk_farm_index);
 
             // Collect newly plotted pieces
             let on_plotted_sector_callback =

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/scrub.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/scrub.rs
@@ -8,7 +8,7 @@ pub(crate) fn scrub(disk_farms: &[PathBuf]) {
         .into_par_iter()
         .enumerate()
         .for_each(|(disk_farm_index, directory)| {
-            let span = info_span!("single_disk_farm", %disk_farm_index);
+            let span = info_span!("", %disk_farm_index);
             let _span_guard = span.enter();
             info!(
                 path = %directory.display(),

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -901,7 +901,7 @@ impl SingleDiskFarm {
             (Some(sender), Some(receiver))
         };
 
-        let span = info_span!("single_disk_farm", %disk_farm_index);
+        let span = info_span!("", %disk_farm_index);
 
         let plotting_join_handle = tokio::task::spawn_blocking({
             let sectors_metadata = Arc::clone(&sectors_metadata);


### PR DESCRIPTION
There was a suggestion in farmer chat to reduce length of log lines and this change reduces `single_disk_farm{disk_farm_index=0}` to just `{disk_farm_index=0}`. Not a lot, but it is a bit cleaner.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
