### PR TITLE
More scalable Proof of Space

### DIFF
--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -43,6 +43,4 @@ std = [
 ]
 parallel = [
     "dep:rayon",
-    # Parallel implementation requires std due to usage of channels to achieve highest performance
-    "std",
 ]

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -787,18 +787,18 @@ where
         let mut t_n = t_n.into_iter().flatten().collect::<Vec<_>>();
         t_n.par_sort_unstable();
 
-        let mut ys = vec![Default::default(); t_n.len()];
-        let mut positions = vec![Default::default(); t_n.len()];
-        let mut metadatas = vec![Default::default(); t_n.len()];
+        let mut ys = Vec::with_capacity(t_n.len());
+        let mut positions = Vec::with_capacity(t_n.len());
+        let mut metadatas = Vec::with_capacity(t_n.len());
 
-        // Going in parallel saves a bit of time
-        t_n.into_par_iter()
-            .zip(ys.par_iter_mut().zip(&mut positions).zip(&mut metadatas))
-            .for_each(|(input, output)| {
-                *output.0 .0 = input.0;
-                *output.0 .1 = input.1;
-                *output.1 = input.2;
-            });
+        for (y, [left_position, right_position], metadata) in t_n {
+            ys.push(y);
+            positions.push([left_position, right_position]);
+            // Last table doesn't have metadata
+            if metadata_size_bits(K, TABLE_NUMBER) > 0 {
+                metadatas.push(metadata);
+            }
+        }
 
         Self::Other {
             ys,

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -16,10 +16,10 @@ use core::mem;
 use core::simd::num::SimdUint;
 use core::simd::Simd;
 #[cfg(any(feature = "parallel", test))]
+use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(any(feature = "parallel", test))]
 use rayon::prelude::*;
 use seq_macro::seq;
-#[cfg(any(feature = "parallel", test))]
-use std::sync::mpsc;
 use subspace_core_primitives::crypto::{blake3_hash, blake3_hash_list};
 
 pub(super) const COMPUTE_F1_SIMD_FACTOR: usize = 8;
@@ -759,42 +759,32 @@ where
         // Iteration stopped, but we did not store the last bucket yet
         buckets.push(bucket);
 
-        let (entries_sender, entries_receiver) = mpsc::sync_channel(1);
+        let counter = AtomicUsize::new(0);
 
-        let t_n_handle = std::thread::spawn(move || {
-            let num_values = 1 << K;
-            let mut t_n = Vec::with_capacity(num_values);
+        let t_n = rayon::broadcast(|_ctx| {
+            let mut entries = Vec::new();
+            let mut rmap_scratch = Vec::new();
 
-            while let Ok(entries) = entries_receiver.recv() {
-                t_n.extend(entries);
+            loop {
+                let offset = counter.fetch_add(1, Ordering::Relaxed);
+                if offset >= buckets.len() - 1 {
+                    break;
+                }
+
+                match_and_compute_fn::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(
+                    last_table,
+                    buckets[offset],
+                    buckets[offset + 1],
+                    &mut rmap_scratch,
+                    left_targets,
+                    &mut entries,
+                );
             }
 
-            t_n
+            entries
         });
 
-        buckets
-            .par_windows(2)
-            .fold(
-                || (Vec::new(), Vec::new()),
-                |(mut entries, mut rmap_scratch), buckets| {
-                    match_and_compute_fn::<K, TABLE_NUMBER, PARENT_TABLE_NUMBER>(
-                        last_table,
-                        buckets[0],
-                        buckets[1],
-                        &mut rmap_scratch,
-                        left_targets,
-                        &mut entries,
-                    );
-                    (entries, rmap_scratch)
-                },
-            )
-            .for_each(move |(entries, _rmap_scratch)| {
-                entries_sender
-                    .send(entries)
-                    .expect("Receiver is waiting until sender is exhausted; qed");
-            });
-
-        let mut t_n = t_n_handle.join().expect("Not joining itself; qed");
+        let mut t_n = t_n.into_iter().flatten().collect::<Vec<_>>();
         t_n.par_sort_unstable();
 
         let mut ys = vec![Default::default(); t_n.len()];


### PR DESCRIPTION
This one is a bit counter-intuitive.

Before/after:
```
chia/table/parallel     time:   [108.23 ms 109.01 ms 109.63 ms]
chia/table/parallel     time:   [119.45 ms 123.55 ms 127.52 ms]
```

Limited to 4 efficiency cores before/after:
```
chia/table/parallel     time:   [487.01 ms 489.29 ms 492.04 ms]
chia/table/parallel     time:   [531.40 ms 536.19 ms 541.15 ms]
```

So you might be wondering, why on Earth would I send a PR that makes things slower?

2 parallel benches before/after:
```
chia/table/parallel     time:   [189.94 ms 192.78 ms 195.86 ms]
chia/table/parallel     time:   [178.51 ms 185.22 ms 191.66 ms]
```

4 parallel benches before/after:
```
chia/table/parallel     time:   [451.34 ms 458.56 ms 465.66 ms]
chia/table/parallel     time:   [334.04 ms 338.05 ms 342.08 ms]
```

As you can see, old code is significantly slower with concurrency 2 or 4, new version improves performance down to 85ms per table when 4 tables are constructed concurrently. This is because updated implementation is doing strictly less work for each table, such that when other tables are processed concurrently they have more resources available to them, but every individual table generation is a bit slower.

With the performance level achieved already for single table creation scalability that improves plotting speeds seems much more important.

I plan to submit changes later that will increase default concurrency on farmer to take advantage of these improvements and maybe introduce optimizations of similar nature (and hopefully https://github.com/supranational/blst/pull/203) to push plotting performance further than it ever was. It should also help to further reduce replotting impact on normal usage of the computer.

Please let me know if you think this tradeoff is not worth it or have any other concerns.

P.S. As a bonus parallel PoSpace is now supported in no-std environment, not that I expect anyone to take advantage of that :upside_down_face: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
