### PR TITLE
Refactor farmer metrics

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1275,8 +1275,13 @@ impl SingleDiskFarm {
     }
 
     /// Number of sectors successfully plotted so far
-    pub async fn plotted_sectors_count(&self) -> usize {
-        self.sectors_metadata.read().await.len()
+    pub async fn plotted_sectors_count(&self) -> SectorIndex {
+        self.sectors_metadata
+            .read()
+            .await
+            .len()
+            .try_into()
+            .expect("Number of sectors never exceeds `SectorIndex` type; qed")
     }
 
     /// Read information about sectors plotted so far


### PR DESCRIPTION
This is a follow-up to https://github.com/subspace/subspace/pull/2525.

It combines newly introduced metrics into a single metrics that when summed will always result in the same total, but labels can be used to split it into not plotted/plotted/about to expire/expired sectors.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
