### PR TITLE
Make `submit_fraud_proof` dispatch class `Operational`

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -969,7 +969,7 @@ mod pallet {
 
         #[pallet::call_index(1)]
         // TODO: proper weight
-        #[pallet::weight((Weight::from_all(10_000), Pays::No))]
+        #[pallet::weight((Weight::from_all(10_000), DispatchClass::Operational, Pays::No))]
         pub fn submit_fraud_proof(
             origin: OriginFor<T>,
             fraud_proof: Box<FraudProof<BlockNumberFor<T>, T::Hash, T::DomainHeader>>,


### PR DESCRIPTION
## Description
This PR makes `submit_fraud_proof`'s dispatch class `Operational`

Fixes #2522


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
