### PR TITLE
Farmer refactoring

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -429,16 +429,16 @@ where
     ));
     let piece_provider = PieceProvider::new(node.clone(), validator.clone());
 
-    let piece_getter = Arc::new(FarmerPieceGetter::new(
+    let piece_getter = FarmerPieceGetter::new(
         piece_provider,
         farmer_cache.clone(),
         node_client.clone(),
         Arc::clone(&plotted_pieces),
-    ));
+    );
 
     let farmer_cache_worker_fut = run_future_in_dedicated_thread(
         {
-            let future = farmer_cache_worker.run(piece_getter.clone());
+            let future = farmer_cache_worker.run(piece_getter.downgrade());
 
             move || future
         },

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -83,7 +83,9 @@ impl<NC> FarmerCacheWorker<NC>
 where
     NC: NodeClient,
 {
-    /// Run the cache worker with provided piece getter
+    /// Run the cache worker with provided piece getter.
+    ///
+    /// NOTE: Piece getter must not depend on farmer cache in order to avoid reference cycles!
     pub async fn run<PG>(mut self, piece_getter: PG)
     where
         PG: PieceGetter,

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -65,10 +65,10 @@ struct CacheWorkerState {
     last_segment_index: SegmentIndex,
 }
 
-/// Cache worker used to drive the cache
+/// Farmer cache worker used to drive the farmer cache backend
 #[derive(Debug)]
-#[must_use = "Cache will not work unless its worker is running"]
-pub struct CacheWorker<NC>
+#[must_use = "Farmer cache will not work unless its worker is running"]
+pub struct FarmerCacheWorker<NC>
 where
     NC: fmt::Debug,
 {
@@ -79,7 +79,7 @@ where
     worker_receiver: Option<mpsc::Receiver<WorkerCommand>>,
 }
 
-impl<NC> CacheWorker<NC>
+impl<NC> FarmerCacheWorker<NC>
 where
     NC: NodeClient,
 {
@@ -754,9 +754,9 @@ where
     }
 }
 
-/// Piece cache that aggregates caches of multiple disks
+/// Farmer cache that aggregates different kinds of caches of multiple disks
 #[derive(Debug, Clone)]
-pub struct PieceCache {
+pub struct FarmerCache {
     peer_id: PeerId,
     /// Individual disk caches where pieces are stored
     caches: Arc<RwLock<Vec<DiskPieceCacheState>>>,
@@ -765,12 +765,12 @@ pub struct PieceCache {
     worker_sender: mpsc::Sender<WorkerCommand>,
 }
 
-impl PieceCache {
+impl FarmerCache {
     /// Create new piece cache instance and corresponding worker.
     ///
     /// NOTE: Returned future is async, but does blocking operations and should be running in
     /// dedicated thread.
-    pub fn new<NC>(node_client: NC, peer_id: PeerId) -> (Self, CacheWorker<NC>)
+    pub fn new<NC>(node_client: NC, peer_id: PeerId) -> (Self, FarmerCacheWorker<NC>)
     where
         NC: NodeClient,
     {
@@ -784,7 +784,7 @@ impl PieceCache {
             handlers: Arc::clone(&handlers),
             worker_sender,
         };
-        let worker = CacheWorker {
+        let worker = FarmerCacheWorker {
             peer_id,
             node_client,
             caches,
@@ -872,7 +872,7 @@ impl PieceCache {
     }
 }
 
-impl LocalRecordProvider for PieceCache {
+impl LocalRecordProvider for FarmerCache {
     fn record(&self, key: &RecordKey) -> Option<ProviderRecord> {
         // It is okay to take read lock here, writes locks are very infrequent and very short
         for cache in self.caches.read().iter() {

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -36,9 +36,9 @@
 //! are `target ± ½ * solution range` (while also handing overflow/underflow) when interpreted as
 //! 64-bit unsigned integers.
 
+pub mod farmer_cache;
 pub(crate) mod identity;
 pub mod node_client;
-pub mod piece_cache;
 pub mod reward_signing;
 pub mod single_disk_farm;
 pub mod thread_pool_manager;

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -48,7 +48,8 @@ struct Inner {
     num_elements: usize,
 }
 
-/// Piece cache stored on one disk
+/// Dedicated piece cache stored on one disk, is used both to accelerate DSN queries and to plot
+/// faster
 #[derive(Debug, Clone)]
 pub struct DiskPieceCache {
     inner: Arc<Inner>,
@@ -57,17 +58,7 @@ pub struct DiskPieceCache {
 impl DiskPieceCache {
     pub(super) const FILE_NAME: &'static str = "piece_cache.bin";
 
-    #[cfg(not(test))]
-    pub(super) fn open(directory: &Path, capacity: usize) -> Result<Self, DiskPieceCacheError> {
-        Self::open_internal(directory, capacity)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn open(directory: &Path, capacity: usize) -> Result<Self, DiskPieceCacheError> {
-        Self::open_internal(directory, capacity)
-    }
-
-    pub(super) fn open_internal(
+    pub(in super::super) fn open(
         directory: &Path,
         capacity: usize,
     ) -> Result<Self, DiskPieceCacheError> {

--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -1,4 +1,4 @@
-use crate::piece_cache::PieceCache;
+use crate::farmer_cache::FarmerCache;
 use crate::utils::plotted_pieces::PlottedPieces;
 use crate::NodeClient;
 use async_trait::async_trait;
@@ -16,7 +16,7 @@ const MAX_RANDOM_WALK_ROUNDS: usize = 15;
 
 pub struct FarmerPieceGetter<PV, NC> {
     piece_provider: PieceProvider<PV>,
-    piece_cache: PieceCache,
+    farmer_cache: FarmerCache,
     node_client: NC,
     plotted_pieces: Arc<Mutex<Option<PlottedPieces>>>,
 }
@@ -24,13 +24,13 @@ pub struct FarmerPieceGetter<PV, NC> {
 impl<PV, NC> FarmerPieceGetter<PV, NC> {
     pub fn new(
         piece_provider: PieceProvider<PV>,
-        piece_cache: PieceCache,
+        farmer_cache: FarmerCache,
         node_client: NC,
         plotted_pieces: Arc<Mutex<Option<PlottedPieces>>>,
     ) -> Self {
         Self {
             piece_provider,
-            piece_cache,
+            farmer_cache,
             node_client,
             plotted_pieces,
         }
@@ -57,9 +57,9 @@ where
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
         let key = RecordKey::from(piece_index.to_multihash());
 
-        trace!(%piece_index, "Getting piece from local cache");
-        if let Some(piece) = self.piece_cache.get_piece(key).await {
-            trace!(%piece_index, "Got piece from local cache successfully");
+        trace!(%piece_index, "Getting piece from farmer cache");
+        if let Some(piece) = self.farmer_cache.get_piece(key).await {
+            trace!(%piece_index, "Got piece from farmer cache successfully");
             return Ok(Some(piece));
         }
 

--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -4,7 +4,7 @@ use crate::NodeClient;
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::error::Error;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use subspace_core_primitives::{Piece, PieceIndex};
 use subspace_farmer_components::{PieceGetter, PieceGetterRetryPolicy};
 use subspace_networking::libp2p::kad::RecordKey;
@@ -14,11 +14,23 @@ use tracing::{debug, error, trace};
 
 const MAX_RANDOM_WALK_ROUNDS: usize = 15;
 
-pub struct FarmerPieceGetter<PV, NC> {
+struct Inner<PV, NC> {
     piece_provider: PieceProvider<PV>,
     farmer_cache: FarmerCache,
     node_client: NC,
     plotted_pieces: Arc<Mutex<Option<PlottedPieces>>>,
+}
+
+pub struct FarmerPieceGetter<PV, NC> {
+    inner: Arc<Inner<PV, NC>>,
+}
+
+impl<PV, NC> Clone for FarmerPieceGetter<PV, NC> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl<PV, NC> FarmerPieceGetter<PV, NC> {
@@ -29,10 +41,20 @@ impl<PV, NC> FarmerPieceGetter<PV, NC> {
         plotted_pieces: Arc<Mutex<Option<PlottedPieces>>>,
     ) -> Self {
         Self {
-            piece_provider,
-            farmer_cache,
-            node_client,
-            plotted_pieces,
+            inner: Arc::new(Inner {
+                piece_provider,
+                farmer_cache,
+                node_client,
+                plotted_pieces,
+            }),
+        }
+    }
+
+    /// Downgrade to [`WeakFarmerPieceGetter`] in order to break reference cycles with internally
+    /// used [`Arc`]
+    pub fn downgrade(&self) -> WeakFarmerPieceGetter<PV, NC> {
+        WeakFarmerPieceGetter {
+            inner: Arc::downgrade(&self.inner),
         }
     }
 
@@ -57,15 +79,17 @@ where
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
         let key = RecordKey::from(piece_index.to_multihash());
 
+        let inner = &self.inner;
+
         trace!(%piece_index, "Getting piece from farmer cache");
-        if let Some(piece) = self.farmer_cache.get_piece(key).await {
+        if let Some(piece) = inner.farmer_cache.get_piece(key).await {
             trace!(%piece_index, "Got piece from farmer cache successfully");
             return Ok(Some(piece));
         }
 
         // L2 piece acquisition
         trace!(%piece_index, "Getting piece from DSN L2 cache");
-        let maybe_piece = self
+        let maybe_piece = inner
             .piece_provider
             .get_piece_from_dsn_cache(piece_index, Self::convert_retry_policy(retry_policy))
             .await?;
@@ -77,7 +101,7 @@ where
 
         // Try node's RPC before reaching to L1 (archival storage on DSN)
         trace!(%piece_index, "Getting piece from node");
-        match self.node_client.piece(piece_index).await {
+        match inner.node_client.piece(piece_index).await {
             Ok(Some(piece)) => {
                 trace!(%piece_index, "Got piece from node successfully");
                 return Ok(Some(piece));
@@ -95,7 +119,7 @@ where
         }
 
         trace!(%piece_index, "Getting piece from local plot");
-        let maybe_read_piece_fut = self
+        let maybe_read_piece_fut = inner
             .plotted_pieces
             .lock()
             .as_ref()
@@ -111,7 +135,7 @@ where
         // L1 piece acquisition
         trace!(%piece_index, "Getting piece from DSN L1.");
 
-        let archival_storage_search_result = self
+        let archival_storage_search_result = inner
             .piece_provider
             .get_piece_from_archival_storage(piece_index, MAX_RANDOM_WALK_ROUNDS)
             .await;
@@ -127,5 +151,48 @@ where
             "Cannot acquire piece: all methods yielded empty result"
         );
         Ok(None)
+    }
+}
+
+/// Weak farmer piece getter, can be upgraded to [`FarmerPieceGetter`]
+#[derive(Debug)]
+pub struct WeakFarmerPieceGetter<PV, NC> {
+    inner: Weak<Inner<PV, NC>>,
+}
+
+impl<PV, NC> Clone for WeakFarmerPieceGetter<PV, NC> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl<PV, NC> PieceGetter for WeakFarmerPieceGetter<PV, NC>
+where
+    PV: PieceValidator + Send + 'static,
+    NC: NodeClient,
+{
+    async fn get_piece(
+        &self,
+        piece_index: PieceIndex,
+        retry_policy: PieceGetterRetryPolicy,
+    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+        let Some(piece_getter) = self.upgrade() else {
+            debug!("Farmer piece getter upgrade didn't succeed");
+            return Ok(None);
+        };
+
+        piece_getter.get_piece(piece_index, retry_policy).await
+    }
+}
+
+impl<PV, NC> WeakFarmerPieceGetter<PV, NC> {
+    /// Try to upgrade to [`FarmerPieceGetter`] if there is at least one other instance of it alive
+    pub fn upgrade(&self) -> Option<FarmerPieceGetter<PV, NC>> {
+        Some(FarmerPieceGetter {
+            inner: self.inner.upgrade()?,
+        })
     }
 }


### PR DESCRIPTION
Small refactoring around farmer cache, renames `PieceCache` into `FarmerCache` (that will be extended with plot cache in the future PRs) and `WeakFarmerPieceGetter` that allows to break unintentional reference cycles.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
