### PR TITLE
Record encoding concurrency

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -465,6 +465,7 @@ pub fn create_signed_vote(
             downloading_semaphore: None,
             encoding_semaphore: None,
             table_generator: &mut table_generator,
+            abort_early: &Default::default(),
         }))
         .unwrap();
 

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3.29"
 hex = "0.4.3"
 libc = "0.2.152"
 parity-scale-codec = "3.6.9"
+parking_lot = "0.12.1"
 rand = "0.8.5"
 rayon = "1.8.1"
 schnorrkel = "0.11.4"
@@ -45,7 +46,6 @@ winapi = "0.3.9"
 [dev-dependencies]
 criterion = "0.5.1"
 futures = "0.3.29"
-parking_lot = "0.12.1"
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -129,6 +129,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             table_generator: &mut table_generator,
+            abort_early: &Default::default(),
         }))
         .unwrap();
 

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -80,6 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 downloading_semaphore: black_box(None),
                 encoding_semaphore: black_box(None),
                 table_generator: black_box(&mut table_generator),
+                abort_early: &Default::default(),
             }))
             .unwrap();
         })

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -136,6 +136,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             table_generator: &mut table_generator,
+            abort_early: &Default::default(),
         }))
         .unwrap();
 

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -129,6 +129,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             table_generator: &mut table_generator,
+            abort_early: &Default::default(),
         }))
         .unwrap();
 

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -935,7 +935,7 @@ impl SingleDiskFarm {
                     sectors_to_plot_receiver,
                     downloading_semaphore,
                     plotting_thread_pool_manager,
-                    stop_receiver: &mut stop_receiver.resubscribe(),
+                    stop_receiver: stop_receiver.resubscribe(),
                 };
 
                 let plotting_fut = async {

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -38,7 +38,7 @@ use std::error::Error;
 use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::{Seek, SeekFrom};
-use std::num::NonZeroU8;
+use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -277,6 +277,8 @@ pub struct SingleDiskFarmOptions<NC, PG> {
     /// Semaphore for part of the plotting when farmer downloads new sector, allows to limit memory
     /// usage of the plotting process, permit will be held until the end of the plotting process
     pub downloading_semaphore: Arc<Semaphore>,
+    /// Defines how many record farmer will encode in a single sector concurrently
+    pub record_encoding_concurrency: NonZeroUsize,
     /// Whether to farm during initial plotting
     pub farm_during_initial_plotting: bool,
     /// Thread pool size used for farming (mostly for blocking I/O, but also for some
@@ -609,6 +611,7 @@ impl SingleDiskFarm {
             erasure_coding,
             cache_percentage,
             downloading_semaphore,
+            record_encoding_concurrency,
             farming_thread_pool_size,
             plotting_thread_pool_manager,
             plotting_delay,
@@ -934,6 +937,7 @@ impl SingleDiskFarm {
                     modifying_sector_index,
                     sectors_to_plot_receiver,
                     downloading_semaphore,
+                    record_encoding_concurrency,
                     plotting_thread_pool_manager,
                     stop_receiver: stop_receiver.resubscribe(),
                 };

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -12,12 +12,12 @@ use lru::LruCache;
 use parity_scale_codec::{Decode, Encode};
 use std::collections::HashMap;
 use std::fs::File;
-use std::io;
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use std::{io, slice};
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{
     Blake3Hash, HistorySize, PieceOffset, PublicKey, SectorId, SectorIndex, SegmentHeader,
@@ -397,7 +397,8 @@ where
                             pieces_in_sector,
                             sector_output: &mut sector,
                             sector_metadata_output: &mut sector_metadata,
-                            table_generator: &mut table_generator,
+                            // TODO: Multiple table generators
+                            table_generators: slice::from_mut(&mut table_generator),
                             abort_early: &abort_early,
                         },
                     )?;

--- a/crates/subspace-proof-of-space/benches/pos.rs
+++ b/crates/subspace-proof-of-space/benches/pos.rs
@@ -40,9 +40,31 @@ fn pos_bench<PosTable>(
     #[cfg(feature = "parallel")]
     {
         let mut generator_instance = PosTable::generator();
-        group.bench_function("table/parallel", |b| {
+        group.bench_function("table/parallel/1x", |b| {
             b.iter(|| {
                 generator_instance.generate_parallel(black_box(&seed));
+            });
+        });
+
+        let mut generator_instances = [
+            PosTable::generator(),
+            PosTable::generator(),
+            PosTable::generator(),
+            PosTable::generator(),
+            PosTable::generator(),
+            PosTable::generator(),
+            PosTable::generator(),
+            PosTable::generator(),
+        ];
+        group.bench_function("table/parallel/8x", |b| {
+            b.iter(|| {
+                rayon::scope(|scope| {
+                    for g in &mut generator_instances {
+                        scope.spawn(|_scope| {
+                            g.generate_parallel(black_box(&seed));
+                        });
+                    }
+                });
             });
         });
     }

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -246,6 +246,7 @@ where
         downloading_semaphore: None,
         encoding_semaphore: None,
         table_generator: &mut table_generator,
+        abort_early: &Default::default(),
     })
     .await
     .expect("Plotting one sector in memory must not fail");


### PR DESCRIPTION
This leverages scalability introduced in https://github.com/subspace/subspace/pull/2526 and allows to improve CPU usage and plotting speed as the result.

The idea here is that there are both parallel and sequential parts of the table generation, so by generating a few tables at a time we can overlap sequential parts with parallel parts and improve CPU utilization. While generating tables for all records requires a lot of RAM, generating tables for only a few records at a time is not too bad.

`--record-encoding-concurrency` option was added to override default behavior (one record for each 2 cores, but not more than 8 in parallel, which according to my testing with P-cores, E-cores and P+E cores seems to result in peak performance). To get old behavior and lower RAM usage `--record-encoding-concurrency 1` can be used.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
