### PR TITLE
image dispatched from snapshot workflow for trivy image scan

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: trivy-scan-dispatch
-          client-payload: '{"sha": "${{ github.sha }}"}'
+          client-payload: '{"sha": "${{ github.sha }}", "image": "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"}'
 
   executables:
     strategy:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: trivy-scan-dispatch
-          client-payload: '{"sha": "${{ github.sha }}", "image": "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}"}'
+          client-payload: '{"image": "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}"}'
 
   executables:
     strategy:

--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -12,18 +12,12 @@ on:
 jobs:
   wait-for-image:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image:
-          - farmer
-          - node
-          - bootstrap-node
     outputs:
       image-available: ${{ steps.check-image.outputs.available }}
     steps:
       - name: Check Docker image availability with retry
         run: |
-          image="${{ github.event.client_payload.image }}:sha-${{ github.event.client_payload.sha }}"
+          image="${{ github.event.client_payload.image }}"
           timeout=900 # Timeout in seconds (15 minutes)
           interval=300 # Interval between retries in seconds (5 minutes)
           retry_limit=5 # Number of retries
@@ -57,7 +51,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # @v0.16.1
         with:
-          image-ref: ${{ github.event.client_payload.image }}:sha-${{ github.event.client_payload.sha }}
+          image-ref: ${{ github.event.client_payload.image }}
           format: "sarif"
           output: "trivy-results.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -12,12 +12,18 @@ on:
 jobs:
   wait-for-image:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - farmer
+          - node
+          - bootstrap-node
     outputs:
       image-available: ${{ steps.check-image.outputs.available }}
     steps:
       - name: Check Docker image availability with retry
         run: |
-          image="ghcr.io/${{ github.repository_owner }}/${{ github.event.client_payload.image }}:${{ github.event.client_payload.sha }}"
+          image="${{ github.event.client_payload.image }}:sha-${{ github.event.client_payload.sha }}"
           timeout=900 # Timeout in seconds (15 minutes)
           interval=300 # Interval between retries in seconds (5 minutes)
           retry_limit=5 # Number of retries
@@ -43,12 +49,6 @@ jobs:
     needs: wait-for-image
     if: needs.wait-for-image.outputs.image-available == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image:
-          - farmer
-          - node
-          - bootstrap-node
 
     steps:
       - name: Checkout code
@@ -57,7 +57,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # @v0.16.1
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.event.client_payload.sha }}
+          image-ref: ${{ github.event.client_payload.image }}:sha-${{ github.event.client_payload.sha }}
           format: "sarif"
           output: "trivy-results.sarif"
           exit-code: "1"


### PR DESCRIPTION
This fixes the missing image for the `wait-for-image` job in trivy scan.
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
