### PR TITLE
Add domain-genesis-storage CI workflow

### DIFF
--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -1,0 +1,49 @@
+# This action enabling building domain genesis storage used in registering new domain runtime, can be triggered manually or by release creation.
+#
+# Domain genesis storages are built for releases and for manually triggered runs, uploaded to artifacts and assets.
+name: Domain genesis storage snapshot build
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'domain-genesis-storage-snapshot-*'
+      - 'domain-genesis-storage-gemini-*'
+
+jobs:
+  domain-genesis-storage:
+    runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-22.04') }}
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Build node image
+        id: build
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # @v3.2.0
+        with:
+          file: Dockerfile-node
+          push: false
+
+      - name: Generate testnet domain genesis storages
+        run: |
+          docker run --rm -u root ${{ steps.build.outputs.digest }} domain build-genesis-storage --chain gemini-3h > domain-genesis-storage-gemini-3h
+          docker run --rm -u root ${{ steps.build.outputs.digest }} domain build-genesis-storage --chain devnet > domain-genesis-storage-devnet
+
+      - name: Upload domain genesis storages to artifacts
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
+        with:
+          name: domain-genesis-storage
+          path: |
+            domain-genesis-storage-gemini-3h
+            domain-genesis-storage-devnet
+          if-no-files-found: error
+
+      - name: Upload domain genesis storages to assets
+        uses: alexellis/upload-assets@259de5111cb56966d046ced998941e93f91d2c93 # @0.4.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["domain-genesis-storage-gemini-3h", "domain-genesis-storage-devnet"]'
+        # Only run for releases
+        if: github.event_name == 'push' && github.ref_type == 'tag'


### PR DESCRIPTION
This PR adds the domain-genesis-storage CI workflow.

It is mostly ported from [chain-spec-snapshot-build.yml](https://github.com/subspace/subspace/blob/main/.github/workflows/chain-spec-snapshot-build.yml) with some naming changes and it will run the following commands:
```
subspace-node domain build-genesis-storage --chain gemini-3h > domain-genesis-storage-gemini-3h
subspace-node domain build-genesis-storage --chain devnet > domain-genesis-storage-devnet
```

Similar to the chain spec workflow, it can be triggered by creating a new tag `domain-genesis-storage-snapshot-*` or `domain-genesis-storage-gemini-*`.

See https://github.com/subspace/subspace/actions/runs/7972872783 for the result.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
