### PR TITLE
Farmer plot cache

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -632,6 +632,10 @@ where
                 .iter()
                 .map(|single_disk_farm| single_disk_farm.piece_cache())
                 .collect(),
+            single_disk_farms
+                .iter()
+                .map(|single_disk_farm| single_disk_farm.plot_cache())
+                .collect(),
         )
         .await;
     drop(farmer_cache);

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -51,7 +51,7 @@ struct DiskPieceCacheState {
 #[derive(Debug)]
 enum WorkerCommand {
     ReplaceBackingCaches {
-        new_caches: Vec<DiskPieceCache>,
+        new_piece_caches: Vec<DiskPieceCache>,
         acknowledgement: oneshot::Sender<()>,
     },
     ForgetKey {
@@ -102,11 +102,11 @@ where
             .expect("Always set during worker instantiation");
 
         if let Some(WorkerCommand::ReplaceBackingCaches {
-            new_caches,
+            new_piece_caches,
             acknowledgement,
         }) = worker_receiver.recv().await
         {
-            self.initialize(&piece_getter, &mut worker_state, new_caches)
+            self.initialize(&piece_getter, &mut worker_state, new_piece_caches)
                 .await;
             // Doesn't matter if receiver is still waiting for acknowledgement
             let _ = acknowledgement.send(());
@@ -163,10 +163,10 @@ where
     {
         match command {
             WorkerCommand::ReplaceBackingCaches {
-                new_caches,
+                new_piece_caches,
                 acknowledgement,
             } => {
-                self.initialize(piece_getter, worker_state, new_caches)
+                self.initialize(piece_getter, worker_state, new_piece_caches)
                     .await;
                 // Doesn't matter if receiver is still waiting for acknowledgement
                 let _ = acknowledgement.send(());
@@ -215,23 +215,23 @@ where
         &self,
         piece_getter: &PG,
         worker_state: &mut CacheWorkerState,
-        new_caches: Vec<DiskPieceCache>,
+        new_piece_caches: Vec<DiskPieceCache>,
     ) where
         PG: PieceGetter,
     {
         info!("Initializing piece cache");
         // Pull old cache state since it will be replaced with a new one and reuse its allocations
         let cache_state = mem::take(&mut *self.caches.write());
-        let mut stored_pieces = Vec::with_capacity(new_caches.len());
-        let mut free_offsets = Vec::with_capacity(new_caches.len());
+        let mut stored_pieces = Vec::with_capacity(new_piece_caches.len());
+        let mut free_offsets = Vec::with_capacity(new_piece_caches.len());
         for mut state in cache_state {
             state.stored_pieces.clear();
             stored_pieces.push(state.stored_pieces);
             state.free_offsets.clear();
             free_offsets.push(state.free_offsets);
         }
-        stored_pieces.resize(new_caches.len(), HashMap::default());
-        free_offsets.resize(new_caches.len(), VecDeque::default());
+        stored_pieces.resize(new_piece_caches.len(), HashMap::default());
+        free_offsets.resize(new_piece_caches.len(), VecDeque::default());
 
         debug!("Collecting pieces that were in the cache before");
 
@@ -239,7 +239,7 @@ where
         let maybe_caches_futures = stored_pieces
             .into_iter()
             .zip(free_offsets)
-            .zip(new_caches)
+            .zip(new_piece_caches)
             .enumerate()
             .map(
                 |(index, ((mut stored_pieces, mut free_offsets), new_cache))| {
@@ -760,8 +760,8 @@ where
 #[derive(Debug, Clone)]
 pub struct FarmerCache {
     peer_id: PeerId,
-    /// Individual disk caches where pieces are stored
-    caches: Arc<RwLock<Vec<DiskPieceCacheState>>>,
+    /// Individual dedicated piece caches
+    piece_caches: Arc<RwLock<Vec<DiskPieceCacheState>>>,
     handlers: Arc<Handlers>,
     // We do not want to increase capacity unnecessarily on clone
     worker_sender: Arc<mpsc::Sender<WorkerCommand>>,
@@ -782,7 +782,7 @@ impl FarmerCache {
 
         let instance = Self {
             peer_id,
-            caches: Arc::clone(&caches),
+            piece_caches: Arc::clone(&caches),
             handlers: Arc::clone(&handlers),
             worker_sender: Arc::new(worker_sender),
         };
@@ -801,11 +801,11 @@ impl FarmerCache {
     pub async fn get_piece(&self, key: RecordKey) -> Option<Piece> {
         let maybe_piece_fut = tokio::task::spawn_blocking({
             let key = key.clone();
-            let caches = Arc::clone(&self.caches);
+            let piece_caches = Arc::clone(&self.piece_caches);
             let worker_sender = Arc::clone(&self.worker_sender);
 
             move || {
-                for (disk_farm_index, cache) in caches.read().iter().enumerate() {
+                for (disk_farm_index, cache) in piece_caches.read().iter().enumerate() {
                     let Some(&offset) = cache.stored_pieces.get(&key) else {
                         continue;
                     };
@@ -850,13 +850,13 @@ impl FarmerCache {
     /// to identify when cache initialization has finished
     pub async fn replace_backing_caches(
         &self,
-        new_caches: Vec<DiskPieceCache>,
+        new_piece_caches: Vec<DiskPieceCache>,
     ) -> oneshot::Receiver<()> {
         let (sender, receiver) = oneshot::channel();
         if let Err(error) = self
             .worker_sender
             .send(WorkerCommand::ReplaceBackingCaches {
-                new_caches,
+                new_piece_caches,
                 acknowledgement: sender,
             })
             .await
@@ -876,8 +876,8 @@ impl FarmerCache {
 impl LocalRecordProvider for FarmerCache {
     fn record(&self, key: &RecordKey) -> Option<ProviderRecord> {
         // It is okay to take read lock here, writes locks are very infrequent and very short
-        for cache in self.caches.read().iter() {
-            if cache.stored_pieces.contains_key(key) {
+        for piece_cache in self.piece_caches.read().iter() {
+            if piece_cache.stored_pieces.contains_key(key) {
                 // Note: We store our own provider records locally without local addresses
                 // to avoid redundant storage and outdated addresses. Instead these are
                 // acquired on demand when returning a `ProviderRecord` for the local node.

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -192,10 +192,13 @@ async fn basic() {
             tokio::spawn(farmer_cache_worker.run(piece_getter.clone()));
 
         let initialized_fut = farmer_cache
-            .replace_backing_caches(vec![
-                DiskPieceCache::open(path1.as_ref(), 1).unwrap(),
-                DiskPieceCache::open(path2.as_ref(), 1).unwrap(),
-            ])
+            .replace_backing_caches(
+                vec![
+                    DiskPieceCache::open(path1.as_ref(), 1).unwrap(),
+                    DiskPieceCache::open(path2.as_ref(), 1).unwrap(),
+                ],
+                vec![],
+            )
             .await;
 
         // Wait for piece cache to be initialized
@@ -375,10 +378,13 @@ async fn basic() {
 
         // Reopen with the same backing caches
         let initialized_fut = farmer_cache
-            .replace_backing_caches(vec![
-                DiskPieceCache::open(path1.as_ref(), 1).unwrap(),
-                DiskPieceCache::open(path2.as_ref(), 1).unwrap(),
-            ])
+            .replace_backing_caches(
+                vec![
+                    DiskPieceCache::open(path1.as_ref(), 1).unwrap(),
+                    DiskPieceCache::open(path2.as_ref(), 1).unwrap(),
+                ],
+                vec![],
+            )
             .await;
         drop(farmer_cache);
 

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -56,12 +56,9 @@ pub struct DiskPieceCache {
 }
 
 impl DiskPieceCache {
-    pub(super) const FILE_NAME: &'static str = "piece_cache.bin";
+    pub(crate) const FILE_NAME: &'static str = "piece_cache.bin";
 
-    pub(in super::super) fn open(
-        directory: &Path,
-        capacity: u32,
-    ) -> Result<Self, DiskPieceCacheError> {
+    pub(crate) fn open(directory: &Path, capacity: u32) -> Result<Self, DiskPieceCacheError> {
         if capacity == 0 {
             return Err(DiskPieceCacheError::ZeroCapacity);
         }
@@ -91,7 +88,7 @@ impl DiskPieceCache {
         })
     }
 
-    pub(super) const fn element_size() -> u32 {
+    pub(crate) const fn element_size() -> u32 {
         (PieceIndex::SIZE + Piece::SIZE + mem::size_of::<Blake3Hash>()) as u32
     }
 

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -103,6 +103,7 @@ impl DiskPieceCache {
         let mut element = vec![0; Self::element_size() as usize];
         let mut early_exit = false;
 
+        // TODO: Parallelize or read in larger batches
         (0..self.inner.num_elements).map(move |offset| {
             if early_exit {
                 return (Offset(offset), None);

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache/tests.rs
@@ -1,5 +1,4 @@
-use crate::single_disk_farm::piece_cache::{DiskPieceCache, Offset};
-use crate::single_disk_farm::DiskPieceCacheError;
+use crate::single_disk_farm::piece_cache::{DiskPieceCache, DiskPieceCacheError, Offset};
 use rand::prelude::*;
 use std::assert_matches::assert_matches;
 use subspace_core_primitives::{Piece, PieceIndex};

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -1,0 +1,160 @@
+use crate::single_disk_farm::plot_cache::{DiskPlotCache, MaybePieceStoredResult};
+use rand::prelude::*;
+use std::assert_matches::assert_matches;
+use std::num::NonZeroU64;
+use std::sync::Arc;
+use subspace_core_primitives::{HistorySize, Piece, PieceIndex, Record, SectorIndex};
+use subspace_farmer_components::file_ext::FileExt;
+use subspace_farmer_components::sector::{SectorMetadata, SectorMetadataChecksummed};
+use subspace_networking::libp2p::kad::RecordKey;
+use subspace_networking::utils::multihash::ToMultihash;
+use tempfile::tempfile;
+
+const FAKE_SECTOR_SIZE: usize = 2 * 1024 * 1024;
+const TARGET_SECTOR_COUNT: SectorIndex = 5;
+
+#[test]
+fn basic() {
+    let dummy_sector_metadata = SectorMetadataChecksummed::from(SectorMetadata {
+        sector_index: 0,
+        pieces_in_sector: 0,
+        s_bucket_sizes: Box::new([0u16; Record::NUM_S_BUCKETS]),
+        history_size: HistorySize::new(NonZeroU64::MIN),
+    });
+
+    let file = Arc::new(tempfile().unwrap());
+    file.preallocate(FAKE_SECTOR_SIZE as u64 * u64::from(TARGET_SECTOR_COUNT))
+        .unwrap();
+
+    let piece_index_0 = PieceIndex::from(0);
+    let piece_index_1 = PieceIndex::from(1);
+    let piece_index_2 = PieceIndex::from(2);
+    let piece_0 = {
+        let mut piece = Piece::default();
+        thread_rng().fill(piece.as_mut());
+        piece
+    };
+    let piece_1 = {
+        let mut piece = Piece::default();
+        thread_rng().fill(piece.as_mut());
+        piece
+    };
+    let piece_2 = {
+        let mut piece = Piece::default();
+        thread_rng().fill(piece.as_mut());
+        piece
+    };
+    let record_key_0 = RecordKey::from(piece_index_0.to_multihash());
+    let record_key_1 = RecordKey::from(piece_index_1.to_multihash());
+    let record_key_2 = RecordKey::from(piece_index_2.to_multihash());
+
+    let sectors_metadata = Arc::default();
+
+    let disk_plot_cache = DiskPlotCache::new(
+        &file,
+        &sectors_metadata,
+        TARGET_SECTOR_COUNT,
+        FAKE_SECTOR_SIZE,
+    );
+
+    // Initially empty
+    assert_matches!(disk_plot_cache.read_piece(&record_key_0), None);
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_0),
+        MaybePieceStoredResult::Vacant
+    );
+
+    // Can't store pieces when all sectors are plotted
+    sectors_metadata.write_blocking().resize(
+        usize::from(TARGET_SECTOR_COUNT),
+        dummy_sector_metadata.clone(),
+    );
+    assert!(!disk_plot_cache
+        .try_store_piece(piece_index_0, &piece_0)
+        .unwrap());
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_0),
+        MaybePieceStoredResult::No
+    );
+
+    // Clear plotted sectors and reopen
+    sectors_metadata.write_blocking().clear();
+    let disk_plot_cache = DiskPlotCache::new(
+        &file,
+        &sectors_metadata,
+        TARGET_SECTOR_COUNT,
+        FAKE_SECTOR_SIZE,
+    );
+
+    // Successfully stores piece if not all sectors are plotted
+    assert!(disk_plot_cache
+        .try_store_piece(piece_index_0, &piece_0)
+        .unwrap());
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_0),
+        MaybePieceStoredResult::Yes
+    );
+    assert!(disk_plot_cache.read_piece(&record_key_0).unwrap() == piece_0);
+
+    // Store two more pieces and make sure they can be read
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_1),
+        MaybePieceStoredResult::Vacant
+    );
+    assert!(disk_plot_cache
+        .try_store_piece(piece_index_1, &piece_1)
+        .unwrap());
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_1),
+        MaybePieceStoredResult::Yes
+    );
+    assert!(disk_plot_cache.read_piece(&record_key_1).unwrap() == piece_1);
+
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_2),
+        MaybePieceStoredResult::Vacant
+    );
+    assert!(disk_plot_cache
+        .try_store_piece(piece_index_2, &piece_2)
+        .unwrap());
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_2),
+        MaybePieceStoredResult::Yes
+    );
+    assert!(disk_plot_cache.read_piece(&record_key_2).unwrap() == piece_2);
+
+    // Write almost all sectors even without updating metadata, this will result in internal piece
+    // read error due to checksum mismatch and eviction of the piece from cache
+    file.write_all_at(
+        &vec![0; usize::from(TARGET_SECTOR_COUNT - 1) * FAKE_SECTOR_SIZE],
+        0,
+    )
+    .unwrap();
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_2),
+        MaybePieceStoredResult::Yes
+    );
+    assert_matches!(disk_plot_cache.read_piece(&record_key_2), None);
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_2),
+        MaybePieceStoredResult::Vacant
+    );
+
+    // Updating metadata will immediately evict piece
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_1),
+        MaybePieceStoredResult::Yes
+    );
+    sectors_metadata
+        .write_blocking()
+        .resize(usize::from(TARGET_SECTOR_COUNT - 1), dummy_sector_metadata);
+    assert_matches!(
+        disk_plot_cache.is_piece_maybe_stored(&record_key_1),
+        MaybePieceStoredResult::No
+    );
+
+    // Closing file will render cache unusable
+    assert!(disk_plot_cache.read_piece(&record_key_0).unwrap() == piece_0);
+    drop(file);
+    assert_matches!(disk_plot_cache.read_piece(&record_key_0), None);
+}


### PR DESCRIPTION
Previously farmer only had piece cache as it supposed to for DSN, however, as described in https://github.com/subspace/subspace/issues/2399 we have a temporary additional space that we can exploit to cache even more pieces, helping both with plotting performance and with retrieval from DSN.

First two commits here are doing some cleanup/refactoring, the last commit implements plot cache. Since logic of plot cache contained in `FarmerCache` is quite trivial, no new `FarmerCache`-specific tests were added at this time, but `DiskPlotCache` itself has corresponding tests added to make sure lower-level component behaves as expected.

I also tested manually locally with dev chain and will do extra tests with Gemini 3h farmer client before merging for extra confidence.
UPD: Tested, seems to work fine on 3h as well.

Resolves https://github.com/subspace/subspace/issues/2399

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
