### PR TITLE
Remove custom LLVM version because latest Substrate doesn't need it, work around substrate-wasm-builder issue with newer LLVM

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,22 +66,12 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
-      # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
-      # LLVM 15.0.{3, 4, 5, 6} is not released for macOS thus install LLVM 15.0.2 explicitly as a
-      # temporary workaround, and remove once incompatible is fixed.
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
         with:
-          version: "15.0.2"
+          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
+          version: 15.0.7
         if: runner.os == 'macOS'
-
-      # TODO: on Linux and Windows, the consensus/domain runtime build is not compatible with LLVM 16,
-      # thus install LLVM 15 explicitly as a temporary workaround, and remove once incompatible is fixed.
-      - name: Install LLVM and Clang for Linux and Windows
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
-        with:
-          version: "15.0"
-        if: runner.os != 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
       - name: Install glibtoolize (macOS)
@@ -157,22 +147,12 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
-      # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
-      # LLVM 15.0.{3, 4, 5, 6} is not released for macOS thus install LLVM 15.0.2 explicitly as a
-      # temporary workaround, and remove once incompatible is fixed.
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
         with:
-          version: "15.0.2"
+          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
+          version: 15.0.7
         if: runner.os == 'macOS'
-
-      # TODO: on Linux and Windows, the consensus/domain runtime build is not compatible with LLVM 16,
-      # thus install LLVM 15 explicitly as a temporary workaround, and remove once incompatible is fixed.
-      - name: Install LLVM and Clang for Linux and Windows
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
-        with:
-          version: "15.0"
-        if: runner.os != 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
       - name: Install glibtoolize (macOS)

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -22,13 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
-      # TODO: on Linux and Windows, LLVM 16 is not compatible with the consensus/domain runtime build
-      # thus install LLVM 15 explicitly as a temporary workaround, and remove once it is fixed.
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
-        with:
-          version: "15.0"
-
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -135,22 +135,12 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
-      # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
-      # LLVM 15.0.{3, 4, 5, 6} is not released for macOS thus install LLVM 15.0.2 explicitly as a
-      # temporary workaround, and remove once incompatible is fixed.
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
+        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
         with:
-          version: "15.0.2"
+          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
+          version: 15.0.7
         if: runner.os == 'macOS'
-
-      # TODO: on Linux and Windows, the consensus/domain runtime build is not compatible with LLVM 16,
-      # thus install LLVM 15 explicitly as a temporary workaround, and remove once incompatible is fixed.
-      - name: Install LLVM and Clang for Linux and Windows
-        uses: KyleMayes/install-llvm-action@c135b3937686fd69c2651507aabc9925a8f9eee8 # v1.8.3
-        with:
-          version: "15.0"
-        if: runner.os != 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
       - name: Install glibtoolize (macOS)

--- a/crates/subspace-runtime/build.rs
+++ b/crates/subspace-runtime/build.rs
@@ -17,6 +17,8 @@
 fn main() {
     #[cfg(feature = "std")]
     {
+        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
+        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/runtime/evm/build.rs
+++ b/domains/runtime/evm/build.rs
@@ -1,6 +1,8 @@
 fn main() {
     #[cfg(feature = "std")]
     {
+        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
+        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/test/runtime/evm/build.rs
+++ b/domains/test/runtime/evm/build.rs
@@ -1,6 +1,8 @@
 fn main() {
     #[cfg(feature = "std")]
     {
+        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
+        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/test/subspace-test-runtime/build.rs
+++ b/test/subspace-test-runtime/build.rs
@@ -17,6 +17,8 @@
 fn main() {
     #[cfg(feature = "std")]
     {
+        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
+        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()


### PR DESCRIPTION
Finally a workaround for https://github.com/paritytech/polkadot-sdk/issues/3192, tested in a fork with GitHub's runners as well

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
