### PR TITLE
Runtime tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7477,7 +7477,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-weights",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -13,7 +13,7 @@ use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::BlockNumber as DomainBlockNumber;
 use frame_support::dispatch::{DispatchInfo, RawOrigin};
 use frame_support::traits::{ConstU16, ConstU32, ConstU64, Currency, Hooks, VariantCount};
-use frame_support::weights::constants::RocksDbWeight;
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::{IdentityFee, Weight};
 use frame_support::{assert_err, assert_ok, parameter_types, PalletId};
 use frame_system::mocking::MockUncheckedExtrinsic;
@@ -80,7 +80,7 @@ impl frame_system::Config for Test {
     type BaseCallFilter = frame_support::traits::Everything;
     type BlockWeights = ();
     type BlockLength = ();
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
     type RuntimeTask = RuntimeTask;

--- a/crates/pallet-domains/src/weights.rs
+++ b/crates/pallet-domains/src/weights.rs
@@ -26,7 +26,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_domains.
@@ -316,8 +316,8 @@ impl WeightInfo for () {
 		//  Estimated: `12367`
 		// Minimum execution time: 102_000_000 picoseconds.
 		Weight::from_parts(118_000_000, 12367)
-			.saturating_add(RocksDbWeight::get().reads(10_u64))
-			.saturating_add(RocksDbWeight::get().writes(12_u64))
+			.saturating_add(ParityDbWeight::get().reads(10_u64))
+			.saturating_add(ParityDbWeight::get().writes(12_u64))
 	}
 	/// Storage: Domains DomainStakingSummary (r:1 w:1)
 	/// Proof Skipped: Domains DomainStakingSummary (max_values: None, max_size: None, mode: Measured)
@@ -353,8 +353,8 @@ impl WeightInfo for () {
 		//  Estimated: `523490`
 		// Minimum execution time: 12_571_000_000 picoseconds.
 		Weight::from_parts(12_688_000_000, 523490)
-			.saturating_add(RocksDbWeight::get().reads(409_u64))
-			.saturating_add(RocksDbWeight::get().writes(406_u64))
+			.saturating_add(ParityDbWeight::get().reads(409_u64))
+			.saturating_add(ParityDbWeight::get().writes(406_u64))
 	}
 	/// Storage: Domains NextRuntimeId (r:1 w:1)
 	/// Proof Skipped: Domains NextRuntimeId (max_values: Some(1), max_size: None, mode: Measured)
@@ -366,8 +366,8 @@ impl WeightInfo for () {
 		//  Estimated: `1528`
 		// Minimum execution time: 14_372_000_000 picoseconds.
 		Weight::from_parts(14_986_000_000, 1528)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: Domains RuntimeRegistry (r:1 w:0)
 	/// Proof Skipped: Domains RuntimeRegistry (max_values: None, max_size: None, mode: Measured)
@@ -379,8 +379,8 @@ impl WeightInfo for () {
 		//  Estimated: `442147`
 		// Minimum execution time: 25_485_000_000 picoseconds.
 		Weight::from_parts(26_355_000_000, 442147)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: Domains RuntimeRegistry (r:1 w:0)
 	/// Proof Skipped: Domains RuntimeRegistry (max_values: None, max_size: None, mode: Measured)
@@ -408,8 +408,8 @@ impl WeightInfo for () {
 		//  Estimated: `442304`
 		// Minimum execution time: 228_000_000 picoseconds.
 		Weight::from_parts(247_000_000, 442304)
-			.saturating_add(RocksDbWeight::get().reads(7_u64))
-			.saturating_add(RocksDbWeight::get().writes(8_u64))
+			.saturating_add(ParityDbWeight::get().reads(7_u64))
+			.saturating_add(ParityDbWeight::get().writes(8_u64))
 	}
 	/// Storage: Domains PendingStakingOperationCount (r:1 w:1)
 	/// Proof Skipped: Domains PendingStakingOperationCount (max_values: None, max_size: None, mode: Measured)
@@ -433,8 +433,8 @@ impl WeightInfo for () {
 		//  Estimated: `6215`
 		// Minimum execution time: 66_000_000 picoseconds.
 		Weight::from_parts(70_000_000, 6215)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(8_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(8_u64))
 	}
 	/// Storage: Domains Operators (r:1 w:0)
 	/// Proof Skipped: Domains Operators (max_values: None, max_size: None, mode: Measured)
@@ -456,8 +456,8 @@ impl WeightInfo for () {
 		//  Estimated: `6215`
 		// Minimum execution time: 65_000_000 picoseconds.
 		Weight::from_parts(69_000_000, 6215)
-			.saturating_add(RocksDbWeight::get().reads(7_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(7_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: Domains OperatorIdOwner (r:1 w:0)
 	/// Proof Skipped: Domains OperatorIdOwner (max_values: None, max_size: None, mode: Measured)
@@ -475,8 +475,8 @@ impl WeightInfo for () {
 		//  Estimated: `6517`
 		// Minimum execution time: 35_000_000 picoseconds.
 		Weight::from_parts(38_000_000, 6517)
-			.saturating_add(RocksDbWeight::get().reads(6_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(6_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: Domains OperatorIdOwner (r:1 w:0)
 	/// Proof Skipped: Domains OperatorIdOwner (max_values: None, max_size: None, mode: Measured)
@@ -494,8 +494,8 @@ impl WeightInfo for () {
 		//  Estimated: `4008`
 		// Minimum execution time: 30_000_000 picoseconds.
 		Weight::from_parts(33_000_000, 4008)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: Domains PendingDeposits (r:1 w:0)
 	/// Proof Skipped: Domains PendingDeposits (max_values: None, max_size: None, mode: Measured)
@@ -517,8 +517,8 @@ impl WeightInfo for () {
 		//  Estimated: `4253`
 		// Minimum execution time: 36_000_000 picoseconds.
 		Weight::from_parts(38_000_000, 4253)
-			.saturating_add(RocksDbWeight::get().reads(7_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(7_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
 	/// Storage: Domains Nominators (r:1 w:0)
 	/// Proof Skipped: Domains Nominators (max_values: None, max_size: None, mode: Measured)
@@ -534,7 +534,7 @@ impl WeightInfo for () {
 		//  Estimated: `3979`
 		// Minimum execution time: 24_000_000 picoseconds.
 		Weight::from_parts(26_000_000, 3979)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 }

--- a/crates/pallet-offences-subspace/src/mock.rs
+++ b/crates/pallet-offences-subspace/src/mock.rs
@@ -22,7 +22,7 @@ use crate as pallet_offences_subspace;
 use crate::Config;
 use codec::Encode;
 use frame_support::traits::{ConstU32, ConstU64};
-use frame_support::weights::constants::RocksDbWeight;
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::Weight;
 use sp_consensus_subspace::offence::{self, Kind, OffenceDetails};
 use sp_consensus_subspace::FarmerPublicKey;
@@ -63,7 +63,7 @@ impl frame_system::Config for Runtime {
     type BaseCallFilter = frame_support::traits::Everything;
     type BlockWeights = ();
     type BlockLength = ();
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     type RuntimeOrigin = RuntimeOrigin;
     type Nonce = u64;
     type RuntimeCall = RuntimeCall;

--- a/crates/pallet-rewards/Cargo.toml
+++ b/crates/pallet-rewards/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/subspace/subspace"
 description = "Pallet for issuing rewards to block producers"
 readme = "README.md"
 include = [
-  "/src",
-  "/Cargo.toml",
-  "/README.md",
+    "/src",
+    "/Cargo.toml",
+    "/README.md",
 ]
 
 [package.metadata.docs.rs]
@@ -27,10 +27,10 @@ subspace-runtime-primitives = { version = "0.1.0", default-features = false, pat
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "frame-support/std",
-  "frame-system/std",
-  "scale-info/std",
-  "subspace-runtime-primitives/std",
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "scale-info/std",
+    "subspace-runtime-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-runtime-configs/Cargo.toml
+++ b/crates/pallet-runtime-configs/Cargo.toml
@@ -29,6 +29,7 @@ sp-std = { version = "8.0.0", default-features = false, git = "https://github.co
 default = ["std"]
 std = [
     "codec/std",
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "scale-info/std",

--- a/crates/pallet-runtime-configs/src/weights.rs
+++ b/crates/pallet-runtime-configs/src/weights.rs
@@ -24,7 +24,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_runtime_configs.
@@ -90,7 +90,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_640_000 picoseconds.
 		Weight::from_parts(5_782_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `RuntimeConfigs::EnableDynamicCostOfStorage` (r:0 w:1)
 	/// Proof: `RuntimeConfigs::EnableDynamicCostOfStorage` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
@@ -100,7 +100,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_726_000 picoseconds.
 		Weight::from_parts(5_890_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `RuntimeConfigs::EnableBalanceTransfers` (r:0 w:1)
 	/// Proof: `RuntimeConfigs::EnableBalanceTransfers` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
@@ -110,7 +110,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_726_000 picoseconds.
 		Weight::from_parts(5_890_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `RuntimeConfigs::EnableNonRootCalls` (r:0 w:1)
 	/// Proof: `RuntimeConfigs::EnableNonRootCalls` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
@@ -120,6 +120,6 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_726_000 picoseconds.
 		Weight::from_parts(5_890_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -38,7 +38,6 @@ pallet-offences-subspace = { version = "0.1.0", path = "../pallet-offences-subsp
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 sp-core = { version = "21.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-io = { version = "23.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-weights = { version = "20.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -36,8 +36,7 @@ use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::testing::{Digest, DigestItem, Header, TestXt};
 use sp_runtime::traits::{Block as BlockT, Header as _, IdentityLookup};
-use sp_runtime::{BuildStorage, Perbill};
-use sp_weights::Weight;
+use sp_runtime::BuildStorage;
 use std::marker::PhantomData;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::simd::Simd;
@@ -93,29 +92,23 @@ frame_support::construct_runtime!(
     }
 );
 
-parameter_types! {
-    pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(16);
-    pub BlockWeights: frame_system::limits::BlockWeights =
-        frame_system::limits::BlockWeights::simple_max(Weight::from_parts(1024, 0));
-}
-
 impl frame_system::Config for Test {
     type BaseCallFilter = frame_support::traits::Everything;
     type BlockWeights = ();
     type BlockLength = ();
     type DbWeight = ();
     type RuntimeOrigin = RuntimeOrigin;
-    type Nonce = u64;
     type RuntimeCall = RuntimeCall;
     type RuntimeTask = RuntimeTask;
+    type Nonce = u64;
     type Hash = H256;
-    type Version = ();
     type Hashing = sp_runtime::traits::BlakeTwo256;
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Block = Block;
     type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = ConstU64<250>;
+    type Version = ();
     type PalletInfo = PalletInfo;
     type AccountData = pallet_balances::AccountData<u128>;
     type OnNewAccount = ();

--- a/crates/pallet-subspace/src/weights.rs
+++ b/crates/pallet-subspace/src/weights.rs
@@ -26,7 +26,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_subspace.
@@ -151,8 +151,8 @@ impl WeightInfo for () {
 		//  Estimated: `10563`
 		// Minimum execution time: 22_000_000 picoseconds.
 		Weight::from_parts(23_000_000, 10563)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: Subspace SegmentCommitment (r:20 w:20)
 	/// Proof Skipped: Subspace SegmentCommitment (max_values: None, max_size: None, mode: Measured)
@@ -169,10 +169,10 @@ impl WeightInfo for () {
 		Weight::from_parts(20_123_871, 4060)
 			// Standard Error: 1_226_571
 			.saturating_add(Weight::from_parts(446_050_711, 0).saturating_mul(x.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(x.into())))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(x.into())))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads((1_u64).saturating_mul(x.into())))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().writes((1_u64).saturating_mul(x.into())))
 			.saturating_add(Weight::from_parts(0, 2475).saturating_mul(x.into()))
 	}
 	/// Storage: Subspace ShouldAdjustSolutionRange (r:1 w:1)
@@ -189,8 +189,8 @@ impl WeightInfo for () {
 		//  Estimated: `4647`
 		// Minimum execution time: 12_000_000 picoseconds.
 		Weight::from_parts(12_000_000, 4647)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: Subspace BlockList (r:1 w:0)
 	/// Proof Skipped: Subspace BlockList (max_values: None, max_size: None, mode: Measured)
@@ -200,7 +200,7 @@ impl WeightInfo for () {
 		//  Estimated: `3513`
 		// Minimum execution time: 1_288_000_000 picoseconds.
 		Weight::from_parts(1_297_000_000, 3513)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 	/// Storage: Subspace EnableRewards (r:1 w:1)
 	/// Proof Skipped: Subspace EnableRewards (max_values: Some(1), max_size: None, mode: Measured)
@@ -210,8 +210,8 @@ impl WeightInfo for () {
 		//  Estimated: `1533`
 		// Minimum execution time: 6_000_000 picoseconds.
 		Weight::from_parts(6_000_000, 1533)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: Subspace RootPlotPublicKey (r:1 w:0)
 	/// Proof Skipped: Subspace RootPlotPublicKey (max_values: Some(1), max_size: None, mode: Measured)
@@ -225,7 +225,7 @@ impl WeightInfo for () {
 		//  Estimated: `3114`
 		// Minimum execution time: 7_000_000 picoseconds.
 		Weight::from_parts(7_000_000, 3114)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -42,7 +42,7 @@ use frame_support::inherent::ProvideInherent;
 use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, ConstU8, Currency, Everything, Get, VariantCount,
 };
-use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
+use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -283,7 +283,7 @@ impl frame_system::Config for Runtime {
     /// Maximum number of block number to block hash mappings to keep (oldest pruned first).
     type BlockHashCount = ConstU32<250>;
     /// The weight of database operations that the runtime can invoke.
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     /// Version of the runtime.
     type Version = Version;
     /// Converts a module to the index of the module in `construct_runtime!`.

--- a/domains/pallets/executive/src/weights.rs
+++ b/domains/pallets/executive/src/weights.rs
@@ -27,7 +27,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for domain_pallet_executive.
@@ -65,7 +65,7 @@ impl WeightInfo for () {
 		//  Estimated: `1485`
 		// Minimum execution time: 14_298_000_000 picoseconds.
 		Weight::from_parts(14_475_000_000, 1485)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 }

--- a/domains/pallets/messenger/src/weights.rs
+++ b/domains/pallets/messenger/src/weights.rs
@@ -26,7 +26,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_messenger.
@@ -178,8 +178,8 @@ impl WeightInfo for () {
         //  Estimated: `15508`
         // Minimum execution time: 34_000_000 picoseconds.
         Weight::from_parts(34_000_000, 15508)
-            .saturating_add(RocksDbWeight::get().reads(6_u64))
-            .saturating_add(RocksDbWeight::get().writes(6_u64))
+            .saturating_add(ParityDbWeight::get().reads(6_u64))
+            .saturating_add(ParityDbWeight::get().writes(6_u64))
     }
     /// Storage: Messenger Channels (r:1 w:1)
     /// Proof Skipped: Messenger Channels (max_values: None, max_size: None, mode: Measured)
@@ -199,8 +199,8 @@ impl WeightInfo for () {
         //  Estimated: `16809`
         // Minimum execution time: 33_000_000 picoseconds.
         Weight::from_parts(34_000_000, 16809)
-            .saturating_add(RocksDbWeight::get().reads(6_u64))
-            .saturating_add(RocksDbWeight::get().writes(5_u64))
+            .saturating_add(ParityDbWeight::get().reads(6_u64))
+            .saturating_add(ParityDbWeight::get().writes(5_u64))
     }
     /// Storage: Messenger Channels (r:1 w:1)
     /// Proof Skipped: Messenger Channels (max_values: None, max_size: None, mode: Measured)
@@ -210,8 +210,8 @@ impl WeightInfo for () {
         //  Estimated: `3779`
         // Minimum execution time: 9_000_000 picoseconds.
         Weight::from_parts(9_000_000, 3779)
-            .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
+            .saturating_add(ParityDbWeight::get().reads(1_u64))
+            .saturating_add(ParityDbWeight::get().writes(1_u64))
     }
     /// Storage: Messenger Channels (r:1 w:1)
     /// Proof Skipped: Messenger Channels (max_values: None, max_size: None, mode: Measured)
@@ -221,8 +221,8 @@ impl WeightInfo for () {
         //  Estimated: `3779`
         // Minimum execution time: 9_000_000 picoseconds.
         Weight::from_parts(10_000_000, 3779)
-            .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
+            .saturating_add(ParityDbWeight::get().reads(1_u64))
+            .saturating_add(ParityDbWeight::get().writes(1_u64))
     }
     /// Storage: Messenger Inbox (r:1 w:1)
     /// Proof Skipped: Messenger Inbox (max_values: Some(1), max_size: None, mode: Measured)
@@ -244,8 +244,8 @@ impl WeightInfo for () {
         //  Estimated: `19279`
         // Minimum execution time: 31_000_000 picoseconds.
         Weight::from_parts(31_000_000, 19279)
-            .saturating_add(RocksDbWeight::get().reads(7_u64))
-            .saturating_add(RocksDbWeight::get().writes(6_u64))
+            .saturating_add(ParityDbWeight::get().reads(7_u64))
+            .saturating_add(ParityDbWeight::get().writes(6_u64))
     }
     /// Storage: Messenger OutboxResponses (r:1 w:1)
     /// Proof Skipped: Messenger OutboxResponses (max_values: Some(1), max_size: None, mode: Measured)
@@ -265,7 +265,7 @@ impl WeightInfo for () {
         //  Estimated: `17930`
         // Minimum execution time: 28_000_000 picoseconds.
         Weight::from_parts(29_000_000, 17930)
-            .saturating_add(RocksDbWeight::get().reads(6_u64))
-            .saturating_add(RocksDbWeight::get().writes(4_u64))
+            .saturating_add(ParityDbWeight::get().reads(6_u64))
+            .saturating_add(ParityDbWeight::get().writes(4_u64))
     }
 }

--- a/domains/pallets/transporter/src/weights.rs
+++ b/domains/pallets/transporter/src/weights.rs
@@ -27,7 +27,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_transporter.
@@ -119,8 +119,8 @@ impl WeightInfo for () {
 		//  Estimated: `25398`
 		// Minimum execution time: 59_000_000 picoseconds.
 		Weight::from_parts(60_000_000, 25398)
-			.saturating_add(RocksDbWeight::get().reads(8_u64))
-			.saturating_add(RocksDbWeight::get().writes(7_u64))
+			.saturating_add(ParityDbWeight::get().reads(8_u64))
+			.saturating_add(ParityDbWeight::get().writes(7_u64))
 	}
 	/// Storage: System Account (r:1 w:0)
 	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
@@ -130,7 +130,7 @@ impl WeightInfo for () {
 		//  Estimated: `3593`
 		// Minimum execution time: 9_000_000 picoseconds.
 		Weight::from_parts(10_000_000, 3593)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 	/// Storage: Transporter OutgoingTransfers (r:1 w:1)
 	/// Proof Skipped: Transporter OutgoingTransfers (max_values: None, max_size: None, mode: Measured)
@@ -142,7 +142,7 @@ impl WeightInfo for () {
 		//  Estimated: `7302`
 		// Minimum execution time: 15_000_000 picoseconds.
 		Weight::from_parts(16_000_000, 7302)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -81,6 +81,7 @@ std = [
     "fp-account/std",
     "fp-rpc/std",
     "fp-self-contained/std",
+    "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
     "frame-system-rpc-runtime-api/std",

--- a/frame-weight-template.hbs
+++ b/frame-weight-template.hbs
@@ -16,7 +16,7 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for {{pallet}}.
@@ -101,16 +101,16 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
 			{{/each}}
 			{{#if (ne benchmark.base_reads "0")}}
-			.saturating_add(RocksDbWeight::get().reads({{benchmark.base_reads}}_u64))
+			.saturating_add(ParityDbWeight::get().reads({{benchmark.base_reads}}_u64))
 			{{/if}}
 			{{#each benchmark.component_reads as |cr|}}
-			.saturating_add(RocksDbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
+			.saturating_add(ParityDbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
 			{{/each}}
 			{{#if (ne benchmark.base_writes "0")}}
-			.saturating_add(RocksDbWeight::get().writes({{benchmark.base_writes}}_u64))
+			.saturating_add(ParityDbWeight::get().writes({{benchmark.base_writes}}_u64))
 			{{/if}}
 			{{#each benchmark.component_writes as |cw|}}
-			.saturating_add(RocksDbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			.saturating_add(ParityDbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
 			{{/each}}
 			{{#each benchmark.component_calculated_proof_size as |cp|}}
 			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))

--- a/orml/vesting/src/default_weight.rs
+++ b/orml/vesting/src/default_weight.rs
@@ -4,7 +4,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
 
-use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+use frame_support::weights::{constants::ParityDbWeight as DbWeight, Weight};
 
 impl crate::WeightInfo for () {
 	fn vested_transfer() -> Weight {

--- a/orml/vesting/src/weights.rs
+++ b/orml/vesting/src/weights.rs
@@ -24,7 +24,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use sp_std::marker::PhantomData;
 
 /// Weight functions needed for orml_vesting.
@@ -38,21 +38,21 @@ pub trait WeightInfo {
 impl WeightInfo for () {
 	fn vested_transfer() -> Weight {
 		Weight::from_parts(69_000_000, 0)
-			.saturating_add(RocksDbWeight::get().reads(4 as u64))
-			.saturating_add(RocksDbWeight::get().writes(4 as u64))
+			.saturating_add(ParityDbWeight::get().reads(4 as u64))
+			.saturating_add(ParityDbWeight::get().writes(4 as u64))
 	}
 	fn claim(i: u32, ) -> Weight {
 		Weight::from_parts(31_747_000, 0)
 			// Standard Error: 4_000
 			.saturating_add(Weight::from_parts(63_000, 0).saturating_mul(i as u64))
-			.saturating_add(RocksDbWeight::get().reads(2 as u64))
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
+			.saturating_add(ParityDbWeight::get().reads(2 as u64))
+			.saturating_add(ParityDbWeight::get().writes(2 as u64))
 	}
 	fn update_vesting_schedules(i: u32, ) -> Weight {
 		Weight::from_parts(29_457_000, 0)
 			// Standard Error: 4_000
 			.saturating_add(Weight::from_parts(117_000, 0).saturating_mul(i as u64))
-			.saturating_add(RocksDbWeight::get().reads(2 as u64))
-			.saturating_add(RocksDbWeight::get().writes(3 as u64))
+			.saturating_add(ParityDbWeight::get().reads(2 as u64))
+			.saturating_add(ParityDbWeight::get().writes(3 as u64))
 	}
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -35,7 +35,7 @@ use frame_support::traits::{
     ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Currency, ExistenceRequirement, Get,
     Imbalance, VariantCount, WithdrawReasons,
 };
-use frame_support::weights::constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND};
+use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -233,7 +233,7 @@ impl frame_system::Config for Runtime {
     /// Maximum number of block number to block hash mappings to keep (oldest pruned first).
     type BlockHashCount = ConstU32<250>;
     /// The weight of database operations that the runtime can invoke.
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     /// Version of the runtime.
     type Version = Version;
     /// Converts a module to the index of the module in `construct_runtime!`.


### PR DESCRIPTION
Extracted some tweaks from https://github.com/subspace/subspace/pull/2515, most notably replacing RocksDb weights (that we don't use) with ParityDb weights (that we do use).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
