### PR TITLE
Lazily process bad ER after fraud proof is submitted

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -308,28 +308,30 @@ mod benchmarks {
         );
     }
 
-    #[benchmark]
-    fn switch_domain() {
-        let domain1_id = register_domain::<T>();
-        let domain2_id = register_domain::<T>();
+    // TODO: `switch_domain` is not supported currently due to incompatible with lazily slashing
+    // enable this test when `switch_domain` is ready
+    // #[benchmark]
+    // fn switch_domain() {
+    //     let domain1_id = register_domain::<T>();
+    //     let domain2_id = register_domain::<T>();
 
-        let (operator_owner, operator_id) =
-            register_helper_operator::<T>(domain1_id, T::Currency::minimum_balance());
+    //     let (operator_owner, operator_id) =
+    //         register_helper_operator::<T>(domain1_id, T::Currency::minimum_balance());
 
-        #[extrinsic_call]
-        _(
-            RawOrigin::Signed(operator_owner.clone()),
-            operator_id,
-            domain2_id,
-        );
+    //     #[extrinsic_call]
+    //     _(
+    //         RawOrigin::Signed(operator_owner.clone()),
+    //         operator_id,
+    //         domain2_id,
+    //     );
 
-        let operator = Operators::<T>::get(operator_id).expect("operator must exist");
-        assert_eq!(operator.next_domain_id, domain2_id);
+    //     let operator = Operators::<T>::get(operator_id).expect("operator must exist");
+    //     assert_eq!(operator.next_domain_id, domain2_id);
 
-        let pending_switch =
-            PendingOperatorSwitches::<T>::get(domain1_id).expect("pending switch must exist");
-        assert!(pending_switch.contains(&operator_id));
-    }
+    //     let pending_switch =
+    //         PendingOperatorSwitches::<T>::get(domain1_id).expect("pending switch must exist");
+    //     assert!(pending_switch.contains(&operator_id));
+    // }
 
     #[benchmark]
     fn deregister_operator() {

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -343,7 +343,7 @@ mod benchmarks {
 
         let operator = Operators::<T>::get(operator_id).expect("operator must exist");
         assert_eq!(
-            operator.status,
+            *operator.status::<T>(operator_id),
             OperatorStatus::Deregistered((domain_id, 0, DomainBlockNumberFor::<T>::zero()).into())
         );
     }

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -41,7 +41,6 @@ pub enum Error {
     BalanceOverflow,
     DomainTransfersTracking,
     InvalidDomainTransfers,
-    LatestSubmittedERFallback,
     OverwritingER,
 }
 
@@ -401,11 +400,8 @@ pub(crate) fn process_execution_receipt<T: Config>(
 
     // Update the `LatestSubmittedER` for the operator
     let key = (domain_id, submitter);
-    match receipt_block_number.cmp(&Pallet::<T>::latest_submitted_er(key)) {
-        Ordering::Equal => {}
-        Ordering::Greater => LatestSubmittedER::<T>::insert(key, receipt_block_number),
-        // The `LatestSubmittedER` should never fallback there must be something wrong
-        Ordering::Less => return Err(Error::LatestSubmittedERFallback),
+    if receipt_block_number > Pallet::<T>::latest_submitted_er(key) {
+        LatestSubmittedER::<T>::insert(key, receipt_block_number)
     }
 
     Ok(None)

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -582,6 +582,17 @@ mod pallet {
         OptionQuery,
     >;
 
+    /// The latest ER submitted by the operator for a given domain. It is used to determine if the operator
+    /// has submitted bad ER and is pending to slash.
+    ///
+    /// The storage item of a given `(domain_id, operator_id)` will be pruned after either:
+    /// - All the ERs submitted by the operator for this domain are confirmed and pruned
+    /// - All the bad ERs submitted by the operator for this domain are pruned and the operator is slashed
+    #[pallet::storage]
+    #[pallet::getter(fn latest_submitted_er)]
+    pub(super) type LatestSubmittedER<T: Config> =
+        StorageMap<_, Identity, (DomainId, OperatorId), DomainBlockNumberFor<T>, ValueQuery>;
+
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
         /// Can not find the operator for given operator id.

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -151,9 +151,8 @@ mod pallet {
     use crate::staking::do_reward_operators;
     use crate::staking::{
         do_deregister_operator, do_nominate_operator, do_register_operator, do_slash_operators,
-        do_switch_operator_domain, do_unlock_funds, do_unlock_operator, do_withdraw_stake, Deposit,
-        DomainEpoch, Error as StakingError, Operator, OperatorConfig, SharePrice, StakingSummary,
-        Withdrawal,
+        do_unlock_funds, do_unlock_operator, do_withdraw_stake, Deposit, DomainEpoch,
+        Error as StakingError, Operator, OperatorConfig, SharePrice, StakingSummary, Withdrawal,
     };
     use crate::staking_epoch::{do_finalize_domain_current_epoch, Error as StakingEpochError};
     use crate::weights::WeightInfo;
@@ -1182,26 +1181,6 @@ mod pallet {
                 .map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::DomainInstantiated { domain_id });
-
-            Ok(())
-        }
-
-        #[pallet::call_index(7)]
-        #[pallet::weight(T::WeightInfo::switch_domain())]
-        pub fn switch_domain(
-            origin: OriginFor<T>,
-            operator_id: OperatorId,
-            new_domain_id: DomainId,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-
-            let old_domain_id = do_switch_operator_domain::<T>(who, operator_id, new_domain_id)
-                .map_err(Error::<T>::from)?;
-
-            Self::deposit_event(Event::OperatorSwitchedDomain {
-                old_domain_id,
-                new_domain_id,
-            });
 
             Ok(())
         }

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -489,106 +489,103 @@ pub(crate) fn do_finalize_slashed_operators<T: Config>(
 #[cfg(test)]
 mod tests {
     use crate::bundle_storage_fund::STORAGE_FEE_RESERVE;
-    use crate::domain_registry::{DomainConfig, DomainObject};
     use crate::pallet::{
-        Deposits, DomainRegistry, DomainStakingSummary, LastEpochStakingDistribution,
-        LatestConfirmedDomainBlock, NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators,
-        PendingOperatorSwitches, Withdrawals,
+        Deposits, DomainStakingSummary, LastEpochStakingDistribution, LatestConfirmedDomainBlock,
+        NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators, Withdrawals,
     };
     use crate::staking::tests::{register_operator, Share};
     use crate::staking::{
         do_deregister_operator, do_nominate_operator, do_reward_operators, do_unlock_operator,
-        do_withdraw_stake, StakingSummary,
+        do_withdraw_stake,
     };
     use crate::staking_epoch::{
-        do_finalize_domain_current_epoch, do_finalize_switch_operator_domain,
-        operator_take_reward_tax_and_stake,
+        do_finalize_domain_current_epoch, operator_take_reward_tax_and_stake,
     };
-    use crate::tests::{new_test_ext, RuntimeOrigin, Test};
+    use crate::tests::{new_test_ext, Test};
     use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
     use frame_support::assert_ok;
     use frame_support::traits::fungible::InspectHold;
-    use frame_support::weights::Weight;
     use sp_core::{Pair, U256};
-    use sp_domains::{ConfirmedDomainBlock, DomainId, OperatorAllowList, OperatorPair};
+    use sp_domains::{ConfirmedDomainBlock, DomainId, OperatorPair};
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeMap;
     use subspace_runtime_primitives::SSC;
 
     type Balances = pallet_balances::Pallet<Test>;
-    type Domains = crate::Pallet<Test>;
 
-    #[test]
-    fn finalize_operator_domain_switch() {
-        let old_domain_id = DomainId::new(0);
-        let new_domain_id = DomainId::new(1);
-        let operator_account = 1;
-        let operator_free_balance = 200 * SSC;
-        let operator_stake = 100 * SSC;
-        let pair = OperatorPair::from_seed(&U256::from(0u32).into());
+    // TODO: `switch_domain` is not supported currently due to incompatible with lazily slashing
+    // enable this test when `switch_domain` is ready
+    // #[test]
+    // fn finalize_operator_domain_switch() {
+    //     let old_domain_id = DomainId::new(0);
+    //     let new_domain_id = DomainId::new(1);
+    //     let operator_account = 1;
+    //     let operator_free_balance = 200 * SSC;
+    //     let operator_stake = 100 * SSC;
+    //     let pair = OperatorPair::from_seed(&U256::from(0u32).into());
 
-        let mut ext = new_test_ext();
-        ext.execute_with(|| {
-            let (operator_id, _) = register_operator(
-                old_domain_id,
-                operator_account,
-                operator_free_balance,
-                operator_stake,
-                100 * SSC,
-                pair.public(),
-                BTreeMap::new(),
-            );
+    //     let mut ext = new_test_ext();
+    //     ext.execute_with(|| {
+    //         let (operator_id, _) = register_operator(
+    //             old_domain_id,
+    //             operator_account,
+    //             operator_free_balance,
+    //             operator_stake,
+    //             100 * SSC,
+    //             pair.public(),
+    //             BTreeMap::new(),
+    //         );
 
-            let domain_config = DomainConfig {
-                domain_name: String::from_utf8(vec![0; 1024]).unwrap(),
-                runtime_id: 0,
-                max_block_size: u32::MAX,
-                max_block_weight: Weight::MAX,
-                bundle_slot_probability: (0, 0),
-                target_bundles_per_block: 0,
-                operator_allow_list: OperatorAllowList::Anyone,
-                initial_balances: Default::default(),
-            };
+    //         let domain_config = DomainConfig {
+    //             domain_name: String::from_utf8(vec![0; 1024]).unwrap(),
+    //             runtime_id: 0,
+    //             max_block_size: u32::MAX,
+    //             max_block_weight: Weight::MAX,
+    //             bundle_slot_probability: (0, 0),
+    //             target_bundles_per_block: 0,
+    //             operator_allow_list: OperatorAllowList::Anyone,
+    //             initial_balances: Default::default(),
+    //         };
 
-            let domain_obj = DomainObject {
-                owner_account_id: 0,
-                created_at: 0,
-                genesis_receipt_hash: Default::default(),
-                domain_config,
-                domain_runtime_info: Default::default(),
-            };
+    //         let domain_obj = DomainObject {
+    //             owner_account_id: 0,
+    //             created_at: 0,
+    //             genesis_receipt_hash: Default::default(),
+    //             domain_config,
+    //             domain_runtime_info: Default::default(),
+    //         };
 
-            DomainRegistry::<Test>::insert(new_domain_id, domain_obj);
+    //         DomainRegistry::<Test>::insert(new_domain_id, domain_obj);
 
-            DomainStakingSummary::<Test>::insert(
-                new_domain_id,
-                StakingSummary {
-                    current_epoch_index: 0,
-                    current_total_stake: 0,
-                    current_operators: BTreeMap::new(),
-                    next_operators: BTreeSet::new(),
-                    current_epoch_rewards: BTreeMap::new(),
-                },
-            );
-            let res = Domains::switch_domain(
-                RuntimeOrigin::signed(operator_account),
-                operator_id,
-                new_domain_id,
-            );
-            assert_ok!(res);
+    //         DomainStakingSummary::<Test>::insert(
+    //             new_domain_id,
+    //             StakingSummary {
+    //                 current_epoch_index: 0,
+    //                 current_total_stake: 0,
+    //                 current_operators: BTreeMap::new(),
+    //                 next_operators: BTreeSet::new(),
+    //                 current_epoch_rewards: BTreeMap::new(),
+    //             },
+    //         );
+    //         let res = Domains::switch_domain(
+    //             RuntimeOrigin::signed(operator_account),
+    //             operator_id,
+    //             new_domain_id,
+    //         );
+    //         assert_ok!(res);
 
-            assert!(do_finalize_switch_operator_domain::<Test>(old_domain_id).is_ok());
+    //         assert!(do_finalize_switch_operator_domain::<Test>(old_domain_id).is_ok());
 
-            let operator = Operators::<Test>::get(operator_id).unwrap();
-            assert_eq!(operator.current_domain_id, new_domain_id);
-            assert_eq!(operator.next_domain_id, new_domain_id);
-            assert_eq!(PendingOperatorSwitches::<Test>::get(old_domain_id), None);
+    //         let operator = Operators::<Test>::get(operator_id).unwrap();
+    //         assert_eq!(operator.current_domain_id, new_domain_id);
+    //         assert_eq!(operator.next_domain_id, new_domain_id);
+    //         assert_eq!(PendingOperatorSwitches::<Test>::get(old_domain_id), None);
 
-            let domain_stake_summary = DomainStakingSummary::<Test>::get(new_domain_id).unwrap();
-            assert!(domain_stake_summary.next_operators.contains(&operator_id));
-        });
-    }
+    //         let domain_stake_summary = DomainStakingSummary::<Test>::get(new_domain_id).unwrap();
+    //         assert!(domain_stake_summary.next_operators.contains(&operator_id));
+    //     });
+    // }
 
     fn unlock_operator(
         nominators: Vec<(NominatorId<Test>, BalanceOf<Test>)>,

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     self as pallet_domains, BalanceOf, BlockSlot, BlockTree, BlockTreeNodes, BundleError, Config,
     ConsensusBlockHash, DomainBlockNumberFor, DomainHashingFor, DomainRegistry, ExecutionInbox,
     ExecutionReceiptOf, FraudProofError, FungibleHoldId, HeadReceiptNumber, NextDomainId,
-    OperatorStatus, Operators, ReceiptHashFor,
+    Operators, ReceiptHashFor,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::mem;
@@ -39,7 +39,7 @@ use sp_domains_fraud_proof::{
     FraudProofVerificationInfoResponse, SetCodeExtrinsic,
 };
 use sp_runtime::traits::{
-    AccountIdConversion, BlakeTwo256, BlockNumberProvider, Hash as HashT, IdentityLookup, One, Zero,
+    AccountIdConversion, BlakeTwo256, BlockNumberProvider, Hash as HashT, IdentityLookup, One,
 };
 use sp_runtime::{BuildStorage, Digest, OpaqueExtrinsic, Saturating};
 use sp_state_machine::backend::AsTrieBackend;
@@ -618,23 +618,7 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorI
 
     let pair = OperatorPair::from_seed(&U256::from(0u32).into());
     for operator_id in operator_ids {
-        Operators::<Test>::insert(
-            operator_id,
-            Operator {
-                signing_key: pair.public(),
-                current_domain_id: domain_id,
-                next_domain_id: domain_id,
-                minimum_nominator_stake: SSC,
-                nomination_tax: Default::default(),
-                current_total_stake: Zero::zero(),
-                current_epoch_rewards: Zero::zero(),
-                current_total_shares: Zero::zero(),
-                status: OperatorStatus::Registered,
-                deposits_in_epoch: Zero::zero(),
-                withdrawals_in_epoch: Zero::zero(),
-                total_storage_fee_deposit: Zero::zero(),
-            },
-        );
+        Operators::<Test>::insert(operator_id, Operator::dummy(domain_id, pair.public(), SSC));
     }
 
     domain_id

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1248,6 +1248,9 @@ sp_api::decl_runtime_apis! {
         /// Reture the consensus chain byte fee that will used to charge the domain transaction for consensus
         /// chain storage fee
         fn consensus_chain_byte_fee() -> Balance;
+
+        /// Return if the receipt is exist and pending to prune
+        fn is_bad_er_pending_to_prune(domain_id: DomainId, receipt_hash: HeaderHashFor<DomainHeader>) -> bool;
     }
 
     pub trait BundleProducerElectionApi<Balance: Encode + Decode> {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1104,6 +1104,13 @@ impl_runtime_apis! {
         fn consensus_chain_byte_fee() -> Balance {
             DOMAIN_STORAGE_FEE_MULTIPLIER * TransactionFees::transaction_byte_fee()
         }
+
+        fn is_bad_er_pending_to_prune(domain_id: DomainId, receipt_hash: DomainHash) -> bool {
+            Domains::execution_receipt(receipt_hash).map(
+                |er| Domains::is_bad_er_pending_to_prune(domain_id, er.domain_block_number)
+            )
+            .unwrap_or(false)
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -3924,61 +3924,75 @@ async fn test_bad_receipt_chain() {
     // Remove the fraud proof from tx pool
     ferdie.clear_tx_pool().await.unwrap();
 
-    // Produce a bundle with another bad ER that use previous bad ER as parent
-    let parent_bad_receipt_hash = bad_receipt_hash;
-    let slot = ferdie.produce_slot();
-    let bundle = bundle_producer
-        .produce_bundle(
-            0,
-            OperatorSlotInfo {
-                slot: slot.0,
-                proof_of_time: slot.1,
-            },
-        )
-        .await
-        .expect("produce bundle must success")
-        .expect("must win the challenge");
-    let (bad_receipt_hash, bad_submit_bundle_tx) = {
-        let mut opaque_bundle = bundle;
-        let receipt = &mut opaque_bundle.sealed_header.header.receipt;
-        receipt.parent_domain_block_receipt_hash = parent_bad_receipt_hash;
-        receipt.domain_block_hash = Default::default();
-        opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
-            .pair()
-            .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
-            .into();
-        (
-            opaque_bundle.receipt().hash::<BlakeTwo256>(),
-            bundle_to_tx(opaque_bundle),
-        )
-    };
-    ferdie
-        .submit_transaction(bad_submit_bundle_tx)
-        .await
-        .unwrap();
-
     // Wait for a fraud proof that target the first bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         matches!(
             fp,
             FraudProof::InvalidDomainBlockHash(InvalidDomainBlockHashProof { .. })
-        ) && fp.targeted_bad_receipt_hash() == Some(parent_bad_receipt_hash)
+        ) && fp.targeted_bad_receipt_hash() == Some(bad_receipt_hash)
     });
 
-    // Produce a consensus block that contains the bad receipt and it should
-    // be added to the consensus chain block tree
-    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
-        .await
-        .unwrap();
-    assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // Produce more bundle with bad ER that use previous bad ER as parent
+    let mut parent_bad_receipt_hash = bad_receipt_hash;
+    let mut bad_receipt_descendants = vec![];
+    for _ in 0..10 {
+        let slot = ferdie.produce_slot();
+        let bundle = bundle_producer
+            .produce_bundle(
+                0,
+                OperatorSlotInfo {
+                    slot: slot.0,
+                    proof_of_time: slot.1,
+                },
+            )
+            .await
+            .expect("produce bundle must success")
+            .expect("must win the challenge");
+        let (receipt_hash, bad_submit_bundle_tx) = {
+            let mut opaque_bundle = bundle;
+            let receipt = &mut opaque_bundle.sealed_header.header.receipt;
+            receipt.parent_domain_block_receipt_hash = parent_bad_receipt_hash;
+            receipt.domain_block_hash = Default::default();
+            opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
+                .pair()
+                .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
+                .into();
+            (
+                opaque_bundle.receipt().hash::<BlakeTwo256>(),
+                bundle_to_tx(opaque_bundle),
+            )
+        };
+        parent_bad_receipt_hash = receipt_hash;
+        bad_receipt_descendants.push(receipt_hash);
+        ferdie
+            .produce_block_with_slot_at(
+                slot,
+                ferdie.client.info().best_hash,
+                Some(vec![bad_submit_bundle_tx]),
+            )
+            .await
+            .unwrap();
+    }
+
+    // All bad ERs should be added to the consensus chain block tree
+    for receipt_hash in bad_receipt_descendants.iter().chain(&[bad_receipt_hash]) {
+        assert!(ferdie.does_receipt_exist(*receipt_hash).unwrap());
+    }
 
     // The fraud proof should be submitted
     let _ = wait_for_fraud_proof_fut.await;
 
-    // Both bad ER should be pruned
+    // The first bad ER should be pruned and its descendants are marked as pending to prune
     ferdie.produce_blocks(1).await.unwrap();
-    for er_hash in [parent_bad_receipt_hash, bad_receipt_hash] {
-        assert!(!ferdie.does_receipt_exist(er_hash).unwrap());
+    assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+
+    let ferdie_best_hash = ferdie.client.info().best_hash;
+    let runtime_api = ferdie.client.runtime_api();
+    for receipt_hash in bad_receipt_descendants {
+        assert!(ferdie.does_receipt_exist(receipt_hash).unwrap());
+        assert!(runtime_api
+            .is_bad_er_pending_to_prune(ferdie_best_hash, GENESIS_DOMAIN_ID, receipt_hash)
+            .unwrap());
     }
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1297,6 +1297,13 @@ impl_runtime_apis! {
         fn consensus_chain_byte_fee() -> Balance {
             DOMAIN_STORAGE_FEE_MULTIPLIER * TransactionFees::transaction_byte_fee()
         }
+
+        fn is_bad_er_pending_to_prune(domain_id: DomainId, receipt_hash: DomainHash) -> bool {
+            Domains::execution_receipt(receipt_hash).map(
+                |er| Domains::is_bad_er_pending_to_prune(domain_id, er.domain_block_number)
+            )
+            .unwrap_or(false)
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {


### PR DESCRIPTION
close #2538 

This PR implements #2538, it contains changes of:
- Process only the first bad ER `submit_fraud_proof` and lazily process other descendant bad ERs in `submit_bundle`
- Introduce a `PendingSlash` operator status and reject the bundle/staking request of the operator with such status
- Reject the fraud proof that targetting the bad ER that is already reported by a previous fraud proof and is under lazily processing (i.e. the descendant bad ER)
- Reject the `switch_domain` request if the operator has unconfirmed ER in the current domain
    - This is not mentioned in #2538 but is necessary, because the `LatestSubmittedER` that we used to determine the pending slash operator is indexed by `(domain_id, operator_id)` and can only check if the operator has submitted bad ER in the current domain, if the operator switch domain then we can't slash the operator for bad ER it submitted in the previous domain.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
