### PR TITLE
Refactor piece getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11643,6 +11643,7 @@ dependencies = [
  "async-lock 3.3.0",
  "async-trait",
  "atomic",
+ "backoff",
  "base58",
  "blake2 0.10.6",
  "blake3",

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -55,7 +55,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector_sync;
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions};
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
+use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_verification::is_within_solution_range;
@@ -455,7 +455,6 @@ pub fn create_signed_vote(
             public_key: &public_key,
             sector_index,
             piece_getter: archived_history_segment,
-            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
             farmer_protocol_info,
             kzg,
             erasure_coding,

--- a/crates/sp-lightclient/src/tests.rs
+++ b/crates/sp-lightclient/src/tests.rs
@@ -32,7 +32,7 @@ use subspace_core_primitives::{
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector;
-use subspace_farmer_components::plotting::{plot_sector, PieceGetterRetryPolicy};
+use subspace_farmer_components::plotting::plot_sector;
 use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::Table;
@@ -180,7 +180,6 @@ fn valid_header(
             &public_key,
             sector_index,
             &archived_segment.pieces,
-            PieceGetterRetryPolicy::default(),
             &farmer_parameters.farmer_protocol_info,
             kzg_instance(),
             erasure_coding_instance(),

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -18,7 +18,7 @@ use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, Plott
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
+use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 
@@ -119,7 +119,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             public_key,
             sector_index,
             piece_getter: &archived_history_segment,
-            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
             farmer_protocol_info,
             kzg: &kzg,
             erasure_coding: &erasure_coding,

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -10,7 +10,7 @@ use subspace_core_primitives::{HistorySize, PublicKey, Record, RecordedHistorySe
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions};
 use subspace_farmer_components::sector::sector_size;
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
+use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 
@@ -79,7 +79,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 public_key: black_box(&public_key),
                 sector_index: black_box(sector_index),
                 piece_getter: black_box(&archived_history_segment),
-                piece_getter_retry_policy: black_box(PieceGetterRetryPolicy::default()),
                 farmer_protocol_info: black_box(farmer_protocol_info),
                 kzg: black_box(&kzg),
                 erasure_coding: black_box(&erasure_coding),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -23,7 +23,7 @@ use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, Plott
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
+use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::{Table, TableGenerator};
 
@@ -126,7 +126,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             public_key,
             sector_index,
             piece_getter: &archived_history_segment,
-            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
             farmer_protocol_info,
             kzg,
             erasure_coding,

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -20,7 +20,7 @@ use subspace_farmer_components::reading::read_piece;
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy, ReadAt, ReadAtSync};
+use subspace_farmer_components::{FarmerProtocolInfo, ReadAt, ReadAtSync};
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::Table;
 
@@ -119,7 +119,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             public_key: &public_key,
             sector_index,
             piece_getter: &archived_history_segment,
-            piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
             farmer_protocol_info,
             kzg: &kzg,
             erasure_coding: &erasure_coding,

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -35,29 +35,12 @@ use subspace_core_primitives::{ArchivedHistorySegment, HistorySize, Piece, Piece
 
 use std::error::Error;
 
-/// Defines retry policy on error during piece acquiring.
-#[derive(PartialEq, Eq, Clone, Debug, Copy)]
-pub enum PieceGetterRetryPolicy {
-    /// Retry N times (including zero)
-    Limited(u16),
-    /// No restrictions on retries
-    Unlimited,
-}
-
-impl Default for PieceGetterRetryPolicy {
-    #[inline]
-    fn default() -> Self {
-        Self::Limited(0)
-    }
-}
-
 /// Trait representing a way to get pieces
 #[async_trait]
 pub trait PieceGetter {
     async fn get_piece(
         &self,
         piece_index: PieceIndex,
-        retry_policy: PieceGetterRetryPolicy,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
 }
 
@@ -69,9 +52,8 @@ where
     async fn get_piece(
         &self,
         piece_index: PieceIndex,
-        retry_policy: PieceGetterRetryPolicy,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
-        self.as_ref().get_piece(piece_index, retry_policy).await
+        self.as_ref().get_piece(piece_index).await
     }
 }
 
@@ -80,7 +62,6 @@ impl PieceGetter for ArchivedHistorySegment {
     async fn get_piece(
         &self,
         piece_index: PieceIndex,
-        _retry_policy: PieceGetterRetryPolicy,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
         Ok(self
             .get(usize::try_from(u64::from(piece_index))?)

--- a/crates/subspace-farmer-components/src/segment_reconstruction.rs
+++ b/crates/subspace-farmer-components/src/segment_reconstruction.rs
@@ -1,4 +1,4 @@
-use crate::{PieceGetter, PieceGetterRetryPolicy};
+use crate::PieceGetter;
 use futures::stream::FuturesOrdered;
 use futures::StreamExt;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -57,9 +57,7 @@ pub(crate) async fn recover_missing_piece<PG: PieceGetter>(
                 return None;
             }
 
-            let piece = piece_getter
-                .get_piece(piece_index, PieceGetterRetryPolicy::Limited(0))
-                .await;
+            let piece = piece_getter.get_piece(piece_index).await;
 
             match piece {
                 Ok(piece) => {

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.79"
 async-lock = "3.3.0"
 async-trait = "0.1.77"
 atomic = "0.5.3"
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base58 = "0.2.0"
 blake2 = "0.10.6"
 blake3 = { version = "1.5.0", default-features = false }

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use subspace_core_primitives::{
     HistorySize, LastArchivedBlock, Piece, PieceIndex, SegmentHeader, SegmentIndex,
 };
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter, PieceGetterRetryPolicy};
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_networking::libp2p::identity;
 use subspace_networking::libp2p::kad::RecordKey;
 use subspace_networking::utils::multihash::ToMultihash;
@@ -141,7 +141,6 @@ impl PieceGetter for MockPieceGetter {
     async fn get_piece(
         &self,
         piece_index: PieceIndex,
-        _retry_policy: PieceGetterRetryPolicy,
     ) -> Result<Option<Piece>, Box<dyn std::error::Error + Send + Sync + 'static>> {
         Ok(Some(
             self.pieces

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -13,7 +13,7 @@ use parity_scale_codec::{Decode, Encode};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io;
-use std::num::{NonZeroU16, NonZeroUsize};
+use std::num::NonZeroUsize;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -30,7 +30,7 @@ use subspace_farmer_components::plotting::{
     PlottedSector,
 };
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
-use subspace_farmer_components::{plotting, PieceGetter, PieceGetterRetryPolicy};
+use subspace_farmer_components::{plotting, PieceGetter};
 use subspace_proof_of_space::Table;
 use thiserror::Error;
 use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
@@ -40,8 +40,6 @@ use tracing::{debug, info, trace, warn, Instrument};
 const FARMER_APP_INFO_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 /// Size of the cache of archived segments for the purposes of faster sector expiration checks.
 const ARCHIVED_SEGMENTS_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).expect("Not zero; qed");
-/// Get piece retry attempts number.
-const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(7).expect("Not zero; qed");
 
 /// Details about sector currently being plotted
 #[derive(Debug, Clone, Encode, Decode)]
@@ -307,9 +305,6 @@ where
                     public_key: &public_key,
                     sector_index,
                     piece_getter,
-                    piece_getter_retry_policy: PieceGetterRetryPolicy::Limited(
-                        PIECE_GETTER_RETRY_NUMBER.get(),
-                    ),
                     farmer_protocol_info: farmer_app_info.protocol_info,
                     kzg,
                     pieces_in_sector,
@@ -351,9 +346,6 @@ where
                             public_key: &public_key,
                             sector_index,
                             piece_getter: &piece_getter,
-                            piece_getter_retry_policy: PieceGetterRetryPolicy::Limited(
-                                PIECE_GETTER_RETRY_NUMBER.get(),
-                            ),
                             farmer_protocol_info: farmer_app_info.protocol_info,
                             kzg: &kzg,
                             pieces_in_sector,

--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -91,7 +91,10 @@ where
         trace!(%piece_index, "Getting piece from DSN L2 cache");
         let maybe_piece = inner
             .piece_provider
-            .get_piece_from_dsn_cache(piece_index, Self::convert_retry_policy(retry_policy))
+            .get_piece_from_dsn_cache_with_retries(
+                piece_index,
+                Self::convert_retry_policy(retry_policy),
+            )
             .await?;
 
         if let Some(piece) = maybe_piece {

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -1,3 +1,5 @@
+use backoff::future::retry;
+use backoff::ExponentialBackoff;
 use clap::Parser;
 use futures::channel::oneshot;
 use futures::future::pending;
@@ -7,16 +9,75 @@ use libp2p::identity::Keypair;
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
 use parking_lot::Mutex;
+use std::error::Error;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use subspace_core_primitives::PieceIndex;
-use subspace_networking::utils::piece_provider::{NoPieceValidator, PieceProvider, RetryPolicy};
+use subspace_core_primitives::{Piece, PieceIndex};
+use subspace_networking::utils::piece_provider::{NoPieceValidator, PieceProvider, PieceValidator};
 use subspace_networking::{Config, Node, PieceByIndexRequestHandler};
 use tokio::sync::Semaphore;
-use tracing::{error, info, warn, Level};
+use tracing::{debug, error, info, trace, warn, Level};
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
+
+/// Defines initial duration between get_piece calls.
+const GET_PIECE_INITIAL_INTERVAL: Duration = Duration::from_secs(5);
+/// Defines max duration between get_piece calls.
+const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(40);
+
+/// Returns piece by its index from farmer's piece cache (L2).
+/// Uses retry policy for error handling.
+async fn get_piece_from_dsn_cache_with_retries<PV>(
+    piece_provider: &PieceProvider<PV>,
+    piece_index: PieceIndex,
+    max_retries: u32,
+) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>
+where
+    PV: PieceValidator,
+{
+    trace!(%piece_index, "Piece request.");
+
+    let backoff = ExponentialBackoff {
+        initial_interval: GET_PIECE_INITIAL_INTERVAL,
+        max_interval: GET_PIECE_MAX_INTERVAL,
+        // Try until we get a valid piece
+        max_elapsed_time: None,
+        multiplier: 1.75,
+        ..ExponentialBackoff::default()
+    };
+
+    let retries = AtomicU32::default();
+
+    retry(backoff, || async {
+        let current_attempt = retries.fetch_add(1, Ordering::Relaxed);
+
+        if let Some(piece) = piece_provider.get_piece_from_cache(piece_index).await {
+            trace!(%piece_index, current_attempt, "Got piece");
+            return Ok(Some(piece));
+        }
+
+        if current_attempt >= max_retries {
+            if max_retries > 0 {
+                debug!(
+                    %piece_index,
+                    current_attempt,
+                    max_retries,
+                    "Couldn't get a piece from DSN L2. No retries left."
+                );
+            }
+            return Ok(None);
+        }
+
+        trace!(%piece_index, current_attempt, "Couldn't get a piece from DSN L2. Retrying...");
+
+        Err(backoff::Error::transient(
+            "Couldn't get piece from DSN".into(),
+        ))
+    })
+    .await
+}
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -157,9 +218,9 @@ async fn simple_benchmark(node: Node, max_pieces: usize, start_with: usize, retr
     for i in start_with..(start_with + max_pieces) {
         let piece_index = PieceIndex::from(i as u64);
         let start = Instant::now();
-        let piece = piece_provider
-            .get_piece_from_dsn_cache_with_retries(piece_index, RetryPolicy::Limited(retries))
-            .await;
+        let piece =
+            get_piece_from_dsn_cache_with_retries(&piece_provider, piece_index, u32::from(retries))
+                .await;
         let end = Instant::now();
         let duration = end.duration_since(start);
         total_duration += duration;
@@ -220,12 +281,12 @@ async fn parallel_benchmark(
                     .await
                     .expect("Semaphore cannot be closed.");
                 let semaphore_acquired = Instant::now();
-                let maybe_piece = piece_provider
-                    .get_piece_from_dsn_cache_with_retries(
-                        piece_index,
-                        RetryPolicy::Limited(retries),
-                    )
-                    .await;
+                let maybe_piece = get_piece_from_dsn_cache_with_retries(
+                    piece_provider,
+                    piece_index,
+                    u32::from(retries),
+                )
+                .await;
 
                 let end = Instant::now();
                 let pure_duration = end.duration_since(semaphore_acquired);

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -117,6 +117,7 @@ struct PieceRequestStats {
     not_found: u32,
     error: u32,
 }
+
 impl PieceRequestStats {
     fn add_found(&mut self) {
         self.found += 1;
@@ -157,7 +158,7 @@ async fn simple_benchmark(node: Node, max_pieces: usize, start_with: usize, retr
         let piece_index = PieceIndex::from(i as u64);
         let start = Instant::now();
         let piece = piece_provider
-            .get_piece_from_dsn_cache(piece_index, RetryPolicy::Limited(retries))
+            .get_piece_from_dsn_cache_with_retries(piece_index, RetryPolicy::Limited(retries))
             .await;
         let end = Instant::now();
         let duration = end.duration_since(start);
@@ -220,7 +221,10 @@ async fn parallel_benchmark(
                     .expect("Semaphore cannot be closed.");
                 let semaphore_acquired = Instant::now();
                 let maybe_piece = piece_provider
-                    .get_piece_from_dsn_cache(piece_index, RetryPolicy::Limited(retries))
+                    .get_piece_from_dsn_cache_with_retries(
+                        piece_index,
+                        RetryPolicy::Limited(retries),
+                    )
                     .await;
 
                 let end = Instant::now();

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -82,8 +82,8 @@ where
         }
     }
 
-    // Get from piece cache (L2)
-    async fn get_piece_from_cache(&self, piece_index: PieceIndex) -> Option<Piece> {
+    /// Returns piece by its index from farmer's piece cache (L2)
+    pub async fn get_piece_from_cache(&self, piece_index: PieceIndex) -> Option<Piece> {
         let key = piece_index.to_multihash();
 
         let mut request_batch = self.node.get_requests_batch_handle().await;
@@ -129,7 +129,7 @@ where
 
     /// Returns piece by its index from farmer's piece cache (L2).
     /// Uses retry policy for error handling.
-    pub async fn get_piece_from_dsn_cache(
+    pub async fn get_piece_from_dsn_cache_with_retries(
         &self,
         piece_index: PieceIndex,
         retry_policy: RetryPolicy,

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -29,14 +29,13 @@ use sp_runtime::traits::{Block as BlockT, Header, NumberFor, One};
 use sp_runtime::Saturating;
 use std::error::Error;
 use std::fmt;
-use std::num::NonZeroU16;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
 use subspace_core_primitives::{
     ArchivedHistorySegment, BlockNumber, Piece, PieceIndex, RecordedHistorySegment, SegmentIndex,
 };
-use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator, RetryPolicy};
+use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
 use tokio::sync::Semaphore;
 use tracing::warn;
 
@@ -71,16 +70,9 @@ where
         &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
-        self.get_piece_from_dsn_cache_with_retries(
-            piece_index,
-            RetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
-        )
-        .await
+        Ok(self.get_piece_from_cache(piece_index).await)
     }
 }
-
-/// Get piece retry attempts number.
-const PIECE_GETTER_RETRY_NUMBER: NonZeroU16 = NonZeroU16::new(7).expect("Not zero; qed");
 
 /// How many blocks to queue before pausing and waiting for blocks to be imported, this is
 /// essentially used to ensure we use a bounded amount of RAM during sync process.

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -71,7 +71,7 @@ where
         &self,
         piece_index: PieceIndex,
     ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
-        self.get_piece_from_dsn_cache(
+        self.get_piece_from_dsn_cache_with_retries(
             piece_index,
             RetryPolicy::Limited(PIECE_GETTER_RETRY_NUMBER.get()),
         )

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -41,7 +41,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector_sync;
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
-use subspace_farmer_components::{FarmerProtocolInfo, PieceGetterRetryPolicy};
+use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_runtime_primitives::opaque::Block;
 use subspace_service::{FullClient, NewFull};
@@ -237,7 +237,6 @@ where
         public_key: &public_key,
         sector_index,
         piece_getter: &archived_segment.pieces,
-        piece_getter_retry_policy: PieceGetterRetryPolicy::default(),
         farmer_protocol_info,
         kzg: &kzg,
         erasure_coding,


### PR DESCRIPTION
This refactors piece getters in a way that will be helpful a bit later both for monorepo and Space Acres.

In `subspace-service` I have removed retries for piece getting completely because I am yet to see a single time when out of 256 pieces at least 128 wasn't available. For example I did two longer tests with 100/100 connections:
```
1000 pieces, parallelism 256 (100/100 connections):
2024-02-26T19:22:30.557179Z  INFO benchmark: Found: 885
2024-02-26T19:22:30.557181Z  WARN benchmark: Not found: 115

10000 pieces,  parallelism 1000 (100/100 connections):
2024-02-26T19:40:34.088795Z  INFO benchmark: Found: 8962
2024-02-26T19:40:34.088802Z  WARN benchmark: Not found: 1038
```

~10% of missing pieces missing that without retries we'll get all pieces necessary in at most 256 requests (all pieces in a segment) and with 7 retries (before this PR) we'll potentially waste a lot of time on pieces we can't get for some reason.

On farmer side I just refactored things in reusable way such that Space Acres can easily reuse it for DSN sync purposes on the node (by querying `get_piece_fast` method, benefiting from farmer caches).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
