### PR TITLE
Retry produce bundle with the same slot in the domain test

### DIFF
--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -140,6 +140,7 @@ where
             operator_keystore.clone(),
             // The malicious operator doesn't skip empty bundle
             false,
+            false,
         );
 
         let malicious_bundle_tamper =

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -148,6 +148,7 @@ where
                     domain_message_receiver,
                     provider: eth_provider,
                     skip_empty_bundle_production: true,
+                    skip_out_of_order_slot: false,
                     // Always set it to `None` to not running the normal bundle producer
                     maybe_operator_id: None,
                 };

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -483,6 +483,7 @@ where
                 domain_message_receiver,
                 provider: eth_provider,
                 skip_empty_bundle_production: true,
+                skip_out_of_order_slot: false,
                 maybe_operator_id: operator_id,
             };
 

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -7,6 +7,7 @@ use sc_client_api::{AuxStore, BlockBackend};
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::HeaderBackend;
+use sp_consensus_slots::Slot;
 use sp_domains::core_api::DomainCoreApi;
 use sp_domains::{
     Bundle, BundleProducerElectionApi, DomainId, DomainsApi, OperatorId, OperatorPublicKey,
@@ -41,6 +42,8 @@ where
     bundle_producer_election_solver: BundleProducerElectionSolver<Block, CBlock, CClient>,
     domain_bundle_proposer: DomainBundleProposer<Block, Client, CBlock, CClient, TransactionPool>,
     skip_empty_bundle_production: bool,
+    skip_out_of_order_slot: bool,
+    last_processed_slot: Option<Slot>,
 }
 
 impl<Block, CBlock, Client, CClient, TransactionPool> Clone
@@ -59,6 +62,8 @@ where
             bundle_producer_election_solver: self.bundle_producer_election_solver.clone(),
             domain_bundle_proposer: self.domain_bundle_proposer.clone(),
             skip_empty_bundle_production: self.skip_empty_bundle_production,
+            skip_out_of_order_slot: self.skip_out_of_order_slot,
+            last_processed_slot: None,
         }
     }
 }
@@ -92,6 +97,7 @@ where
         bundle_sender: Arc<BundleSender<Block, CBlock>>,
         keystore: KeystorePtr,
         skip_empty_bundle_production: bool,
+        skip_out_of_order_slot: bool,
     ) -> Self {
         let bundle_producer_election_solver = BundleProducerElectionSolver::<Block, CBlock, _>::new(
             keystore.clone(),
@@ -106,6 +112,8 @@ where
             bundle_producer_election_solver,
             domain_bundle_proposer,
             skip_empty_bundle_production,
+            skip_out_of_order_slot,
+            last_processed_slot: None,
         }
     }
 
@@ -131,7 +139,16 @@ where
             // already processed a block higher than the local best and submitted the receipt to
             // the parent chain, we ought to catch up with the consensus block processing before
             // producing new bundle.
-            !domain_best_number.is_zero() && domain_best_number <= head_receipt_number
+            let is_operator_lagging =
+                !domain_best_number.is_zero() && domain_best_number <= head_receipt_number;
+
+            let skip_out_of_order_slot = self.skip_out_of_order_slot
+                && self
+                    .last_processed_slot
+                    .map(|last_slot| last_slot >= slot)
+                    .unwrap_or(false);
+
+            is_operator_lagging || skip_out_of_order_slot
         };
 
         if should_skip_slot {
@@ -181,6 +198,8 @@ where
                 );
                 return Ok(None);
             }
+
+            self.last_processed_slot.replace(slot);
 
             info!("🔖 Producing bundle at slot {:?}", slot_info.slot);
 

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -41,6 +41,10 @@ where
     keystore: KeystorePtr,
     bundle_producer_election_solver: BundleProducerElectionSolver<Block, CBlock, CClient>,
     domain_bundle_proposer: DomainBundleProposer<Block, Client, CBlock, CClient, TransactionPool>,
+    // TODO: both `skip_empty_bundle_production` and `skip_out_of_order_slot` are only used in the
+    // tests, we should introduce a trait for `DomainBundleProducer` and use a wrapper of `DomainBundleProducer`
+    // in the test, both `skip_empty_bundle_production` and `skip_out_of_order_slot` should move into the wrapper
+    // to keep the production code clean.
     skip_empty_bundle_production: bool,
     skip_out_of_order_slot: bool,
     last_processed_slot: Option<Slot>,

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -176,6 +176,7 @@ pub struct OperatorParams<
     pub domain_confirmation_depth: NumberFor<Block>,
     pub block_import: SharedBlockImport<Block>,
     pub skip_empty_bundle_production: bool,
+    pub skip_out_of_order_slot: bool,
 }
 
 pub(crate) fn load_execution_receipt_by_domain_hash<Block, CBlock, Client>(

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -136,6 +136,7 @@ where
             params.bundle_sender,
             params.keystore.clone(),
             params.skip_empty_bundle_production,
+            params.skip_out_of_order_slot,
         );
 
         let fraud_proof_generator = FraudProofGenerator::new(

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -2965,6 +2965,7 @@ async fn stale_and_in_future_bundle_should_be_rejected() {
             Arc::new(bundle_sender),
             alice.operator.keystore.clone(),
             false,
+            false,
         )
     };
 
@@ -3881,6 +3882,7 @@ async fn test_bad_receipt_chain() {
             domain_bundle_proposer,
             Arc::new(bundle_sender),
             alice.operator.keystore.clone(),
+            false,
             false,
         )
     };

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -231,6 +231,7 @@ where
     pub domain_message_receiver: TracingUnboundedReceiver<ChainTxPoolMsg>,
     pub provider: Provider,
     pub skip_empty_bundle_production: bool,
+    pub skip_out_of_order_slot: bool,
 }
 
 /// Builds service for a domain full node.
@@ -328,6 +329,7 @@ where
         domain_message_receiver,
         provider,
         skip_empty_bundle_production,
+        skip_out_of_order_slot,
     } = domain_params;
 
     // TODO: Do we even need block announcement on domain node?
@@ -446,6 +448,7 @@ where
             domain_confirmation_depth,
             block_import,
             skip_empty_bundle_production,
+            skip_out_of_order_slot,
         },
     )
     .await?;

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -228,6 +228,7 @@ where
             domain_message_receiver,
             provider: DefaultProvider,
             skip_empty_bundle_production,
+            skip_out_of_order_slot: true,
             maybe_operator_id,
         };
 

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -529,8 +529,8 @@ impl MockConsensusNode {
         NewSlot,
         OpaqueBundle<NumberFor<Block>, Hash, DomainHeader, Balance>,
     ) {
+        let slot = self.produce_slot();
         for _ in 0..MAX_PRODUCE_BUNDLE_TRY {
-            let slot = self.produce_slot();
             if let Some(bundle) = self.notify_new_slot_and_wait_for_bundle(slot).await {
                 return (slot, bundle);
             }


### PR DESCRIPTION
In #2517, if a slot is notified and there is still no bundle submitted to the tx pool, we will use a new slot for retrying to produce the bundle, but the previous slot can still get handled by the operator and produce another bundle, and both bundle will contains the same ER with the same domain block number.

In the fraud proof tests, we usually will get a bundle from the tx pool and modify its ER to fraudulent then re-submit the bundle with the bad ER, but if another bundle is included in the block first then the bad bundle will be rejected with error `NewBranchReceipt`, this is what cause the CI test to fail.

This PR fixes the issue by using the same slot for retrying to produce bundle, and adding a field `skip_out_of_order_slot` (it is set to `false` in production thus no impact) for the operator to skip the repeat slot from the retrying, thus we can ensure only one bundle will be produced even with the retrying.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
