### PR TITLE
Optimized farmer piece getter

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -8,7 +8,6 @@ use anyhow::anyhow;
 use backoff::ExponentialBackoff;
 use bytesize::ByteSize;
 use clap::{Parser, ValueHint};
-use futures::channel::oneshot;
 use futures::stream::{FuturesOrdered, FuturesUnordered};
 use futures::{FutureExt, StreamExt};
 use parking_lot::Mutex;
@@ -576,13 +575,9 @@ where
         .map(|farming_thread_pool_size| farming_thread_pool_size.get())
         .unwrap_or_else(recommended_number_of_farming_threads);
 
-    let mut plotting_delay_senders = Vec::with_capacity(disk_farms.len());
-
     for (disk_farm_index, disk_farm) in disk_farms.into_iter().enumerate() {
         debug!(url = %node_rpc_url, %disk_farm_index, "Connecting to node RPC");
         let node_client = NodeRpcClient::new(&node_rpc_url).await?;
-        let (plotting_delay_sender, plotting_delay_receiver) = oneshot::channel();
-        plotting_delay_senders.push(plotting_delay_sender);
 
         let single_disk_farm_fut = SingleDiskFarm::new::<_, _, PosTable>(
             SingleDiskFarmOptions {
@@ -601,7 +596,6 @@ where
                 farm_during_initial_plotting,
                 farming_thread_pool_size,
                 plotting_thread_pool_manager: plotting_thread_pool_manager.clone(),
-                plotting_delay: Some(plotting_delay_receiver),
                 disable_farm_locking,
             },
             disk_farm_index,
@@ -645,29 +639,22 @@ where
         single_disk_farms.push(single_disk_farm);
     }
 
-    let cache_acknowledgement_receiver = farmer_cache
-        .replace_backing_caches(
-            single_disk_farms
-                .iter()
-                .map(|single_disk_farm| single_disk_farm.piece_cache())
-                .collect(),
-            single_disk_farms
-                .iter()
-                .map(|single_disk_farm| single_disk_farm.plot_cache())
-                .collect(),
-        )
-        .await;
+    // Acknowledgement is not necessary
+    drop(
+        farmer_cache
+            .replace_backing_caches(
+                single_disk_farms
+                    .iter()
+                    .map(|single_disk_farm| single_disk_farm.piece_cache())
+                    .collect(),
+                single_disk_farms
+                    .iter()
+                    .map(|single_disk_farm| single_disk_farm.plot_cache())
+                    .collect(),
+            )
+            .await,
+    );
     drop(farmer_cache);
-
-    // Wait for cache initialization before starting plotting
-    tokio::spawn(async move {
-        if cache_acknowledgement_receiver.await.is_ok() {
-            for plotting_delay_sender in plotting_delay_senders {
-                // Doesn't matter if receiver is gone
-                let _ = plotting_delay_sender.send(());
-            }
-        }
-    });
 
     // Store piece readers so we can reference them later
     let piece_readers = single_disk_farms

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -288,9 +288,6 @@ pub struct SingleDiskFarmOptions<NC, PG> {
     pub farming_thread_pool_size: usize,
     /// Thread pool manager used for plotting
     pub plotting_thread_pool_manager: PlottingThreadPoolManager,
-    /// Notification for plotter to start, can be used to delay plotting until some initialization
-    /// has happened externally
-    pub plotting_delay: Option<oneshot::Receiver<()>>,
     /// Disable farm locking, for example if file system doesn't support it
     pub disable_farm_locking: bool,
 }
@@ -619,7 +616,6 @@ impl SingleDiskFarm {
             record_encoding_concurrency,
             farming_thread_pool_size,
             plotting_thread_pool_manager,
-            plotting_delay,
             farm_during_initial_plotting,
             disable_farm_locking,
         } = options;
@@ -964,13 +960,6 @@ impl SingleDiskFarm {
                     if start_receiver.recv().await.is_err() {
                         // Dropped before starting
                         return Ok(());
-                    }
-
-                    if let Some(plotting_delay) = plotting_delay {
-                        if plotting_delay.await.is_err() {
-                            // Dropped before resolving
-                            return Ok(());
-                        }
                     }
 
                     plotting::<_, _, PosTable>(plotting_options).await


### PR DESCRIPTION
This builds on top of a few previous PRs and makes farmer's piece getter more efficient.

It is now possible to do node sync, piece cache sync and plotting all at the same time on Space Acres and due to sorting of pieces to be downloaded in piece cache sync, node and piece cache sync will have a significant overlap of pieces that they downloading, making the whole process faster than before.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
