### PR TITLE
Thread priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11683,6 +11683,7 @@ dependencies = [
  "supports-color",
  "tempfile",
  "thiserror",
+ "thread-priority",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -11716,6 +11717,7 @@ dependencies = [
  "subspace-proof-of-space",
  "subspace-verification",
  "thiserror",
+ "thread-priority",
  "tokio",
  "tracing",
  "winapi",
@@ -12545,6 +12547,20 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "thread-priority"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a617e9eeeb20448b01a8e2427fb80dfbc9c49d79a1de3b11f25731edbf547e3c"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9665,6 +9665,7 @@ dependencies = [
  "sp-runtime",
  "subspace-core-primitives",
  "subspace-proof-of-time",
+ "thread-priority",
  "tracing",
 ]
 
@@ -11717,7 +11718,6 @@ dependencies = [
  "subspace-proof-of-space",
  "subspace-verification",
  "thiserror",
- "thread-priority",
  "tokio",
  "tracing",
  "winapi",

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -17,6 +17,8 @@ derive_more = "0.99.17"
 futures = "0.3.29"
 lru = "0.12.1"
 parity-scale-codec = { version = "3.6.9", features = ["derive"] }
+parking_lot = "0.12.1"
+rayon = "1.8.1"
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
@@ -30,6 +32,5 @@ sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polka
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time" }
-parking_lot = "0.12.1"
-rayon = "1.8.1"
+thread-priority = "0.16.0"
 tracing = "0.1.40"

--- a/crates/sc-proof-of-time/src/source.rs
+++ b/crates/sc-proof-of-time/src/source.rs
@@ -28,6 +28,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::thread;
 use subspace_core_primitives::PotCheckpoints;
+use thread_priority::{set_current_thread_priority, ThreadPriority};
 use tracing::{debug, error, trace, warn};
 
 const LOCAL_PROOFS_CHANNEL_CAPACITY: usize = 10;
@@ -148,6 +149,14 @@ where
                                 core",
                             );
                         }
+                    }
+
+                    if let Err(error) = set_current_thread_priority(ThreadPriority::Max) {
+                        warn!(
+                            %error,
+                            "Failed to set thread priority, timekeeper performance may be \
+                            negatively impacted by other software running on this machine",
+                        );
                     }
 
                     if let Err(error) =

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -57,6 +57,7 @@ substrate-bip39 = "0.4.5"
 supports-color = "2.1.0"
 tempfile = "3.9.0"
 thiserror = "1.0.56"
+thread-priority = "0.16.0"
 tokio = { version = "1.35.1", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }


### PR DESCRIPTION
Yesterday during interview with a candidate I learned that it is possible to not only set process priority, but also thread priority.

This PR takes advantage of that for maximizing timekeeper thread priority and minimizing plotting thread priority (by default, can be changed with `--plotting-thread-priority` to `default` or `max`).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
