### PR TITLE
Introduce new versioned `execution_proof_check`

### DIFF
--- a/crates/sp-domains-fraud-proof/src/runtime_interface.rs
+++ b/crates/sp-domains-fraud-proof/src/runtime_interface.rs
@@ -37,6 +37,30 @@ pub trait FraudProofRuntimeInterface {
     }
 
     /// Check the execution proof
+    // TODO: remove before the new network
+    #[version(1)]
+    fn execution_proof_check(
+        &mut self,
+        pre_state_root: H256,
+        encoded_proof: Vec<u8>,
+        execution_method: &str,
+        call_data: &[u8],
+        domain_runtime_code: Vec<u8>,
+    ) -> Option<Vec<u8>> {
+        self.extension::<FraudProofExtension>()
+            .expect("No `FraudProofExtension` associated for the current context!")
+            .execution_proof_check(
+                (Default::default(), Default::default()),
+                pre_state_root,
+                encoded_proof,
+                execution_method,
+                call_data,
+                domain_runtime_code,
+            )
+    }
+
+    /// Check the execution proof with also included domain block id.
+    #[version(2)]
     fn execution_proof_check(
         &mut self,
         domain_block_id: (BlockNumber, H256),


### PR DESCRIPTION
Adds a versioned `execution_proof_check` due to recently introduced change as part of the https://github.com/subspace/subspace/pull/2508

Tested locally

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
