### PR TITLE
Update Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,6 +189,8 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/cache-cargo-install-action@1b76958d032c4d048c599f9fdfa48abe804d6319 # v1.2.2
         with:
+          # TODO: Remove when cargo-nextest 0.9.68+ is out and has crates compatible with latest nightly in lock file
+          locked: false
           tool: cargo-nextest
 
       - name: cargo nextest run --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,15 +31,15 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.5.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129d4c88e98860e1758c5de288d1632b07970a16d59bdf7b8d66053d582bb71f"
+checksum = "d223b13fd481fc0d1f83bb12659ae774d9e3601814c68a0bc539731698cca743"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.7",
+ "ahash 0.8.10",
  "base64 0.21.7",
  "bitflags 2.4.2",
  "brotli",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43428f3bf11dee6d166b00ec2df4e3aa8cc1606aaa0b7433c146852e2f4e03b"
+checksum = "43a6556ddebb638c2358714d853257ed226ece6023ef9364f23f0c70737ea984"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -154,7 +154,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.7",
+ "ahash 0.8.10",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.12",
  "once_cell",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.12",
@@ -2151,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2469,7 +2469,6 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "substrate-test-runtime-client",
  "tracing",
 ]
 
@@ -2657,7 +2656,6 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-runtime",
- "sp-std",
  "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
@@ -2851,7 +2849,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -4369,7 +4367,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -4378,7 +4376,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.10",
 ]
 
 [[package]]
@@ -4387,7 +4385,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.10",
  "allocator-api2",
 ]
 
@@ -5721,7 +5719,7 @@ source = "git+https://github.com/subspace/rust-libp2p?rev=d6339da35589d86bae6ecb
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "futures",
  "libp2p-core 0.41.1",
  "libp2p-identity 0.2.8",
@@ -6524,7 +6522,7 @@ dependencies = [
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "c2-chacha",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "either",
  "hashlink",
  "lioness",
@@ -7081,44 +7079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "pallet-authorship"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
-dependencies = [
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-babe"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authorship",
- "pallet-session",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
@@ -7308,7 +7268,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "subspace-core-primitives",
 ]
 
@@ -7352,7 +7311,6 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
  "sp-trie",
 ]
 
@@ -7387,7 +7345,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "subspace-core-primitives",
 ]
 
@@ -7430,28 +7387,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-session"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
-dependencies = [
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
 ]
 
 [[package]]
@@ -9516,7 +9451,7 @@ name = "sc-network-gossip"
 version = "0.10.0-dev"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.10",
  "futures",
  "futures-timer",
  "libp2p 0.51.4",
@@ -10067,7 +10002,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772575a524feeb803e5b0fcbc6dd9f367e579488197c94c6e4023aad2305774d"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.10",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -10081,7 +10016,7 @@ dependencies = [
  "aead",
  "arrayref",
  "arrayvec",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "getrandom_or_panic",
  "merlin",
  "rand_core 0.6.4",
@@ -10446,7 +10381,7 @@ dependencies = [
  "aes-gcm",
  "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "ring 0.17.7",
  "rustc_version",
@@ -10637,25 +10572,6 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp",
-]
-
-[[package]]
-name = "sp-consensus-babe"
-version = "0.10.0-dev"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-core",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -10944,7 +10860,6 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
- "sp-std",
 ]
 
 [[package]]
@@ -11053,7 +10968,6 @@ dependencies = [
  "sp-domains",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-std",
  "sp-trie",
 ]
 
@@ -11073,7 +10987,6 @@ dependencies = [
  "sp-messenger",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std",
 ]
 
 [[package]]
@@ -11122,7 +11035,6 @@ name = "sp-objects"
 version = "0.1.0"
 dependencies = [
  "sp-api",
- "sp-std",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
 ]
@@ -11268,7 +11180,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
 dependencies = [
  "aes-gcm",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
@@ -11317,7 +11229,6 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std",
 ]
 
 [[package]]
@@ -11374,7 +11285,7 @@ name = "sp-trie"
 version = "22.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.10",
  "hash-db",
  "lazy_static",
  "memory-db",
@@ -12007,7 +11918,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
  "subspace-core-primitives",
 ]
 
@@ -12305,65 +12215,6 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
-]
-
-[[package]]
-name = "substrate-test-runtime"
-version = "2.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
-dependencies = [
- "array-bytes 6.2.2",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-rpc-runtime-api",
- "log",
- "pallet-babe",
- "pallet-balances",
- "pallet-timestamp",
- "parity-scale-codec",
- "sc-service",
- "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-externalities",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-keyring",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-std",
- "sp-transaction-pool",
- "sp-trie",
- "sp-version",
- "substrate-wasm-builder",
- "trie-db",
-]
-
-[[package]]
-name = "substrate-test-runtime-client"
-version = "2.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=d6b500960579d73c43fc4ef550b703acfa61c4c8#d6b500960579d73c43fc4ef550b703acfa61c4c8"
-dependencies = [
- "futures",
- "sc-block-builder",
- "sc-client-api",
- "sc-consensus",
- "sp-api",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-runtime",
- "substrate-test-client",
- "substrate-test-runtime",
 ]
 
 [[package]]
@@ -13935,7 +13786,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG RUSTC_VERSION=nightly-2024-01-19
+ARG RUSTC_VERSION=nightly-2024-02-29
 ARG PROFILE=production
 ARG RUSTFLAGS
 # Workaround for https://github.com/rust-lang/cargo/issues/10583

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -1,11 +1,14 @@
 //! Benchmarking for `pallet-domains`.
 
+extern crate alloc;
+
 use super::*;
-use crate::alloc::borrow::ToOwned;
 use crate::domain_registry::DomainConfig;
 use crate::staking::{do_reward_operators, OperatorConfig, OperatorStatus};
 use crate::staking_epoch::{do_finalize_domain_current_epoch, do_finalize_domain_epoch_staking};
 use crate::{DomainBlockNumberFor, Pallet as Domains};
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
 use frame_support::traits::fungible::Mutate;
@@ -17,7 +20,7 @@ use sp_domains::{
     dummy_opaque_bundle, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
     OperatorPublicKey, RuntimeType,
 };
-use sp_runtime::traits::{BlockNumberProvider, CheckedAdd, One, SaturatedConversion, Zero};
+use sp_runtime::traits::{BlockNumberProvider, CheckedAdd, One, Zero};
 
 const SEED: u32 = 0;
 

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -1,10 +1,15 @@
 //! Domain block tree
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::{
     BalanceOf, BlockTree, BlockTreeNodes, Config, ConsensusBlockHash, DomainBlockNumberFor,
     DomainHashingFor, ExecutionInbox, ExecutionReceiptOf, HeadReceiptExtended, HeadReceiptNumber,
     InboxedBundleAuthor, LatestConfirmedDomainBlock, Pallet, ReceiptHashFor,
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use frame_support::{ensure, PalletError};
 use scale_info::TypeInfo;
@@ -17,7 +22,6 @@ use sp_domains::{
 use sp_runtime::traits::{BlockNumberProvider, CheckedSub, One, Saturating, Zero};
 use sp_std::cmp::Ordering;
 use sp_std::collections::btree_map::BTreeMap;
-use sp_std::vec::Vec;
 
 /// Block tree specific errors
 #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
@@ -511,7 +515,6 @@ mod tests {
     use frame_support::{assert_err, assert_ok};
     use sp_core::H256;
     use sp_domains::{BundleDigest, InboxedBundle, InvalidBundleType};
-    use sp_runtime::traits::BlockNumberProvider;
 
     #[test]
     fn test_genesis_receipt() {

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -1,5 +1,8 @@
 //! Domain registry for domains
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::block_tree::import_genesis_receipt;
 use crate::pallet::{DomainStakingSummary, NextEVMChainId};
 use crate::runtime_registry::DomainRuntimeInfo;
@@ -8,7 +11,10 @@ use crate::{
     BalanceOf, Config, DomainHashingFor, DomainRegistry, ExecutionReceiptOf, HoldIdentifier,
     NextDomainId, RuntimeRegistry,
 };
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use domain_runtime_primitives::MultiAccountId;
 use frame_support::traits::fungible::{Inspect, Mutate, MutateHold};
@@ -26,7 +32,6 @@ use sp_runtime::traits::{CheckedAdd, Zero};
 use sp_runtime::DigestItem;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
-use sp_std::vec::Vec;
 
 /// Domain registry specific errors
 #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
@@ -299,7 +304,6 @@ pub(crate) fn do_update_domain_allow_list<T: Config>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pallet::{DomainRegistry, NextDomainId, RuntimeRegistry};
     use crate::runtime_registry::RuntimeObject;
     use crate::tests::{new_test_ext, Test};
     use domain_runtime_primitives::{AccountId20, AccountId20Converter};
@@ -308,7 +312,6 @@ mod tests {
     use hex_literal::hex;
     use sp_domains::storage::RawGenesis;
     use sp_runtime::traits::Convert;
-    use sp_std::collections::btree_set::BTreeSet;
     use sp_std::vec;
     use sp_version::RuntimeVersion;
     use subspace_runtime_primitives::SSC;

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -36,6 +36,11 @@ extern crate alloc;
 
 use crate::block_tree::verify_execution_receipt;
 use crate::staking::OperatorStatus;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+use alloc::collections::btree_map::BTreeMap;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use frame_support::pallet_prelude::StorageVersion;
@@ -64,9 +69,6 @@ use sp_domains_fraud_proof::verification::{
 };
 use sp_runtime::traits::{Hash, Header, One, Zero};
 use sp_runtime::{RuntimeAppPublic, SaturatedConversion, Saturating};
-use sp_std::boxed::Box;
-use sp_std::collections::btree_map::BTreeMap;
-use sp_std::vec::Vec;
 pub use staking::OperatorConfig;
 use subspace_core_primitives::{BlockHash, SlotNumber, U256};
 use subspace_runtime_primitives::Balance;
@@ -153,7 +155,10 @@ mod pallet {
         BalanceOf, BlockSlot, DomainBlockNumberFor, ElectionVerificationParams, HoldIdentifier,
         NominatorId, OpaqueBundleOf, ReceiptHashFor, STORAGE_VERSION,
     };
+    #[cfg(not(feature = "std"))]
     use alloc::string::String;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use codec::FullCodec;
     use domain_runtime_primitives::EVMChainId;
     use frame_support::pallet_prelude::*;
@@ -181,7 +186,6 @@ mod pallet {
     use sp_std::collections::btree_set::BTreeSet;
     use sp_std::fmt::Debug;
     use sp_std::vec;
-    use sp_std::vec::Vec;
     use subspace_core_primitives::U256;
     use subspace_runtime_primitives::StorageFee;
 
@@ -609,7 +613,7 @@ mod pallet {
         InvalidExtrinsicRoot,
         /// This bundle duplicated with an already submitted bundle
         DuplicatedBundle,
-        /// Invalid proof of time in the proof of election  
+        /// Invalid proof of time in the proof of election
         InvalidProofOfTime,
         /// The bundle is built on a slot in the future
         SlotInTheFuture,

--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -1,8 +1,14 @@
 //! Runtime registry for domains
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::pallet::{NextRuntimeId, RuntimeRegistry, ScheduledRuntimeUpgrades};
 use crate::{BalanceOf, Config, Event};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use domain_runtime_primitives::{AccountId20, EVMChainId, MultiAccountId, TryConvertBack};
 use frame_support::PalletError;
@@ -15,7 +21,6 @@ use sp_domains::{DomainId, DomainsDigestItem, RuntimeId, RuntimeType};
 use sp_runtime::traits::{CheckedAdd, Get, Zero};
 use sp_runtime::DigestItem;
 use sp_std::vec;
-use sp_std::vec::Vec;
 use sp_version::RuntimeVersion;
 
 /// Runtime specific errors

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1,5 +1,8 @@
 //! Staking for domains
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::bundle_storage_fund::{self, deposit_reserve_for_storage_fund};
 use crate::pallet::{
     Deposits, DomainRegistry, DomainStakingSummary, NextOperatorId, NominatorCount,
@@ -23,7 +26,6 @@ use sp_runtime::{Perbill, Percent, Saturating};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::collections::vec_deque::VecDeque;
-use sp_std::iter::Iterator;
 use sp_std::vec::IntoIter;
 
 /// A nominators deposit.
@@ -1264,6 +1266,7 @@ pub(crate) mod tests {
 
     type Balances = pallet_balances::Pallet<Test>;
     type Domains = crate::Pallet<Test>;
+
     const STORAGE_FEE_RESERVE: Perbill = Perbill::from_percent(20);
 
     pub(crate) fn register_operator(

--- a/crates/pallet-feeds/Cargo.toml
+++ b/crates/pallet-feeds/Cargo.toml
@@ -18,7 +18,6 @@ frame-support = { version = "4.0.0-dev", default-features = false, git = "https:
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
@@ -28,13 +27,12 @@ sp-io = { version = "23.0.0", default-features = false, git = "https://github.co
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "frame-support/std",
-  "frame-system/std",
-  "scale-info/std",
-  "sp-core/std",
-  "sp-runtime/std",
-  "sp-std/std",
-  "subspace-core-primitives/std",
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "scale-info/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "subspace-core-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-feeds/src/feed_processor.rs
+++ b/crates/pallet-feeds/src/feed_processor.rs
@@ -15,11 +15,16 @@
 
 //! Defines FeedProcessor and its types
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::CallObject;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Compact, CompactLen, Decode, Encode};
 use sp_runtime::{DispatchError, DispatchResult};
-use sp_std::vec;
-use sp_std::vec::Vec;
 use subspace_core_primitives::Blake3Hash;
 
 /// Holds the offset to some portion of data within/or the object

--- a/crates/pallet-feeds/src/lib.rs
+++ b/crates/pallet-feeds/src/lib.rs
@@ -19,10 +19,15 @@
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_debug_implementations)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::mem;
 pub use pallet::*;
-use sp_std::vec;
-use sp_std::vec::Vec;
 use subspace_core_primitives::{crypto, Blake3Hash};
 
 pub mod feed_processor;
@@ -38,7 +43,6 @@ mod pallet {
     use frame_system::pallet_prelude::*;
     use sp_runtime::traits::{CheckedAdd, Hash, One, StaticLookup};
     use sp_runtime::ArithmeticError;
-    use sp_std::prelude::*;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -119,7 +123,7 @@ mod pallet {
 
     /// `pallet-feeds` events
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::generate_deposit(pub (super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// New object was added.
         ObjectSubmitted {

--- a/crates/pallet-grandpa-finality-verifier/src/chain.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/chain.rs
@@ -1,5 +1,10 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::grandpa::GrandpaJustification;
 use crate::{Config, EncodedBlockHash, EncodedBlockNumber, Error};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::Decode;
 use frame_support::Parameter;
 use num_traits::AsPrimitive;
@@ -10,7 +15,6 @@ use sp_runtime::traits::{
 };
 use sp_std::hash::Hash;
 use sp_std::str::FromStr;
-use sp_std::vec::Vec;
 
 pub(crate) type OpaqueExtrinsic = Vec<u8>;
 pub type SignedBlock<Header> = generic::SignedBlock<generic::Block<Header, OpaqueExtrinsic>>;

--- a/crates/pallet-grandpa-finality-verifier/src/grandpa.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/grandpa.rs
@@ -13,7 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 // GRANDPA verification is mostly taken from Parity's bridges https://github.com/paritytech/parity-bridges-common/tree/master/primitives/header-chain
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use finality_grandpa::voter_set::VoterSet;
 use scale_info::TypeInfo;
@@ -26,7 +31,6 @@ use sp_runtime::traits::Header as HeaderT;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::prelude::*;
-use sp_std::vec::Vec;
 
 /// A GRANDPA Justification is a proof that a given header was finalized
 /// at a certain height and with a certain set of authorities.

--- a/crates/pallet-grandpa-finality-verifier/src/lib.rs
+++ b/crates/pallet-grandpa-finality-verifier/src/lib.rs
@@ -29,19 +29,22 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-mod grandpa;
-
 pub mod chain;
+mod grandpa;
 #[cfg(test)]
 mod tests;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_consensus_grandpa::SetId;
 use sp_std::fmt::Debug;
-use sp_std::vec::Vec;
 
 // Re-export in crate namespace for `construct_runtime!`
 pub use pallet::*;

--- a/crates/pallet-object-store/Cargo.toml
+++ b/crates/pallet-object-store/Cargo.toml
@@ -19,7 +19,6 @@ frame-system = { version = "4.0.0-dev", default-features = false, git = "https:/
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.20", default-features = false }
 scale-info = { version = "2.7.0", default-features = false, features = ["derive"] }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [dev-dependencies]
@@ -30,13 +29,12 @@ sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-s
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "frame-support/std",
-  "frame-system/std",
-  "hex/std",
-  "log/std",
-  "scale-info/std",
-  "sp-std/std",
-  "subspace-core-primitives/std",
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "hex/std",
+    "log/std",
+    "scale-info/std",
+    "subspace-core-primitives/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-object-store/src/lib.rs
+++ b/crates/pallet-object-store/src/lib.rs
@@ -32,7 +32,6 @@ mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
     use log::debug;
-    use sp_std::prelude::*;
     use subspace_core_primitives::{crypto, Blake3Hash};
 
     #[pallet::config]
@@ -47,7 +46,7 @@ mod pallet {
 
     /// `pallet-object-store` events
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::generate_deposit(pub (super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// New object was added.
         ObjectSubmitted {

--- a/crates/pallet-subspace/src/benchmarking.rs
+++ b/crates/pallet-subspace/src/benchmarking.rs
@@ -1,5 +1,8 @@
 //! Benchmarking for `pallet-subspace`.
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use frame_benchmarking::v2::*;
 
 #[benchmarks]
@@ -9,6 +12,8 @@ mod benchmarks {
         NextSolutionRangeOverride, Pallet, SegmentCommitment, ShouldAdjustSolutionRange,
         SolutionRanges,
     };
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use frame_benchmarking::v2::*;
     use frame_system::pallet_prelude::*;
     use frame_system::{Pallet as System, RawOrigin};
@@ -19,7 +24,6 @@ mod benchmarks {
     use sp_core::Get;
     use sp_runtime::traits::{Block, Header};
     use sp_std::boxed::Box;
-    use sp_std::vec::Vec;
     use subspace_core_primitives::{
         ArchivedBlockProgress, Blake3Hash, LastArchivedBlock, PotOutput, SegmentHeader,
         SegmentIndex, Solution, SolutionRange,

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(array_chunks, assert_matches, const_option, let_chains, portable_simd)]
 #![warn(unused_must_use, unsafe_code, unused_variables, unused_must_use)]
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 pub mod equivocation;
@@ -32,6 +33,7 @@ mod benchmarking;
 
 pub mod weights;
 
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::num::NonZeroU64;
@@ -340,7 +342,7 @@ pub mod pallet {
 
     /// Events type.
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::generate_deposit(pub (super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// Segment header was stored in blockchain history.
         SegmentHeaderStored { segment_header: SegmentHeader },
@@ -519,7 +521,7 @@ pub mod pallet {
         /// call it (validated in `ValidateUnsigned`), as such if the block author is defined it
         /// will be defined as the equivocation reporter.
         #[pallet::call_index(0)]
-        #[pallet::weight((<T as Config>::WeightInfo::report_equivocation(), DispatchClass::Operational))]
+        #[pallet::weight((< T as Config >::WeightInfo::report_equivocation(), DispatchClass::Operational))]
         // Suppression because the custom syntax will also generate an enum and we need enum to have
         // boxed value.
         #[allow(clippy::boxed_local)]
@@ -535,7 +537,7 @@ pub mod pallet {
         /// Submit new segment header to the blockchain. This is an inherent extrinsic and part of
         /// the Subspace consensus logic.
         #[pallet::call_index(1)]
-        #[pallet::weight((<T as Config>::WeightInfo::store_segment_headers(segment_headers.len() as u32), DispatchClass::Mandatory, Pays::No))]
+        #[pallet::weight((< T as Config >::WeightInfo::store_segment_headers(segment_headers.len() as u32), DispatchClass::Mandatory, Pays::No))]
         pub fn store_segment_headers(
             origin: OriginFor<T>,
             segment_headers: Vec<SegmentHeader>,
@@ -547,7 +549,7 @@ pub mod pallet {
         /// Enable solution range adjustment after every era.
         /// Note: No effect on the solution range for the current era
         #[pallet::call_index(2)]
-        #[pallet::weight(<T as Config>::WeightInfo::enable_solution_range_adjustment())]
+        #[pallet::weight(< T as Config >::WeightInfo::enable_solution_range_adjustment())]
         pub fn enable_solution_range_adjustment(
             origin: OriginFor<T>,
             solution_range_override: Option<u64>,
@@ -569,7 +571,7 @@ pub mod pallet {
 
         /// Farmer vote, currently only used for extra rewards to farmers.
         #[pallet::call_index(3)]
-        #[pallet::weight((<T as Config>::WeightInfo::vote(), DispatchClass::Operational, Pays::No))]
+        #[pallet::weight((< T as Config >::WeightInfo::vote(), DispatchClass::Operational, Pays::No))]
         // Suppression because the custom syntax will also generate an enum and we need enum to have
         // boxed value.
         #[allow(clippy::boxed_local)]
@@ -584,7 +586,7 @@ pub mod pallet {
 
         /// Enable rewards for blocks and votes at specified block height.
         #[pallet::call_index(4)]
-        #[pallet::weight(<T as Config>::WeightInfo::enable_rewards())]
+        #[pallet::weight(< T as Config >::WeightInfo::enable_rewards())]
         pub fn enable_rewards_at(
             origin: OriginFor<T>,
             enable_rewards_at: EnableRewardsAt<BlockNumberFor<T>>,
@@ -596,7 +598,7 @@ pub mod pallet {
 
         /// Enable storage access for all users.
         #[pallet::call_index(5)]
-        #[pallet::weight(<T as Config>::WeightInfo::enable_authoring_by_anyone())]
+        #[pallet::weight(< T as Config >::WeightInfo::enable_authoring_by_anyone())]
         pub fn enable_authoring_by_anyone(origin: OriginFor<T>) -> DispatchResult {
             ensure_root(origin)?;
 

--- a/crates/sp-consensus-subspace/src/inherents.rs
+++ b/crates/sp-consensus-subspace/src/inherents.rs
@@ -16,11 +16,14 @@
 
 //! Inherents for Subspace consensus
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use sp_consensus_slots::Slot;
 use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
-use sp_std::result::Result;
-use sp_std::vec::Vec;
 use subspace_core_primitives::SegmentHeader;
 
 /// The Subspace inherent identifier.

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -30,7 +30,10 @@ mod tests;
 
 use crate::digests::{CompatibleDigestItem, PreDigest};
 use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_consensus_slots::{Slot, SlotDuration};
@@ -42,7 +45,6 @@ use sp_runtime::{ConsensusEngineId, Justification};
 use sp_runtime_interface::pass_by::PassBy;
 use sp_runtime_interface::{pass_by, runtime_interface};
 use sp_std::num::NonZeroU32;
-use sp_std::vec::Vec;
 #[cfg(feature = "std")]
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::{

--- a/crates/sp-consensus-subspace/src/offence.rs
+++ b/crates/sp-consensus-subspace/src/offence.rs
@@ -25,9 +25,13 @@
 //!
 //! [sp_staking::offence]: https://docs.substrate.io/rustdocs/latest/sp_staking/offence/index.html
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_std::vec::Vec;
 
 /// The kind of an offence, is a byte string representing some kind identifier
 /// e.g. `b"sub:equivocation"`

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -1,4 +1,9 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::verification::InvalidBundleEquivocationError;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
@@ -11,7 +16,6 @@ use sp_domains::{
 };
 use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
 use sp_runtime::{Digest, DigestItem};
-use sp_std::vec::Vec;
 use sp_trie::StorageProof;
 use subspace_runtime_primitives::Balance;
 
@@ -242,10 +246,10 @@ pub enum VerificationError<DomainHash> {
     InitializeBlockOrApplyExtrinsicDecode(codec::Error),
     /// Failed to decode the storage root produced by verifying `initialize_block` or `apply_extrinsic`.
     #[cfg_attr(
-        feature = "thiserror",
-        error(
-            "Failed to decode the storage root from verifying `initialize_block` and `apply_extrinsic`: {0}"
-        )
+    feature = "thiserror",
+    error(
+    "Failed to decode the storage root from verifying `initialize_block` and `apply_extrinsic`: {0}"
+    )
     )]
     StorageRootDecode(codec::Error),
     /// Failed to decode the header produced by `finalize_block`.
@@ -350,8 +354,8 @@ pub enum VerificationError<DomainHash> {
     BundleNotFound,
     /// Invalid bundle entry in bad receipt was expected to be valid but instead found invalid entry
     #[cfg_attr(
-        feature = "thiserror",
-        error("Unexpected bundle entry at {bundle_index} in bad receipt found: {targeted_entry_bundle:?} with fraud proof's type of proof: {fraud_proof_invalid_type_of_proof:?}")
+    feature = "thiserror",
+    error("Unexpected bundle entry at {bundle_index} in bad receipt found: {targeted_entry_bundle:?} with fraud proof's type of proof: {fraud_proof_invalid_type_of_proof:?}")
     )]
     UnexpectedTargetedBundleEntry {
         bundle_index: u32,

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -1,7 +1,12 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::{
     FraudProofVerificationInfoRequest, FraudProofVerificationInfoResponse, SetCodeExtrinsic,
     StorageKeyRequest,
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use domain_block_preprocessor::inherents::extract_domain_runtime_upgrade_code;
 use domain_block_preprocessor::stateless_runtime::StatelessRuntime;
@@ -22,7 +27,6 @@ use sp_externalities::Extensions;
 use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT, NumberFor};
 use sp_runtime::OpaqueExtrinsic;
 use sp_state_machine::{create_proof_check_backend, Error, OverlayedChanges, StateMachine};
-use sp_std::vec::Vec;
 use sp_trie::StorageProof;
 use std::borrow::Cow;
 use std::marker::PhantomData;

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -26,14 +26,17 @@ pub mod fraud_proof;
 mod host_functions;
 mod runtime_interface;
 #[cfg(test)]
-mod tests;
-
-#[cfg(test)]
 pub mod test_ethereum_tx;
-
+#[cfg(test)]
+mod tests;
 pub mod verification;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::fraud_proof::FraudProof;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 pub use host_functions::{
@@ -50,7 +53,6 @@ use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 use sp_runtime::OpaqueExtrinsic;
 use sp_runtime_interface::pass_by;
 use sp_runtime_interface::pass_by::PassBy;
-use sp_std::vec::Vec;
 use sp_trie::StorageProof;
 use subspace_core_primitives::Randomness;
 use subspace_runtime_primitives::Balance;

--- a/crates/sp-domains-fraud-proof/src/runtime_interface.rs
+++ b/crates/sp-domains-fraud-proof/src/runtime_interface.rs
@@ -1,6 +1,11 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[cfg(feature = "std")]
 use crate::FraudProofExtension;
 use crate::{FraudProofVerificationInfoRequest, FraudProofVerificationInfoResponse};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use domain_runtime_primitives::BlockNumber;
 use sp_core::H256;
 use sp_domains::DomainId;
@@ -8,7 +13,6 @@ use sp_domains::DomainId;
 use sp_externalities::ExternalitiesExt;
 use sp_runtime::OpaqueExtrinsic;
 use sp_runtime_interface::runtime_interface;
-use sp_std::vec::Vec;
 
 /// Domain fraud proof related runtime interface
 #[runtime_interface]

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::fraud_proof::{
     InvalidBundlesFraudProof, InvalidExtrinsicsRootProof, InvalidStateTransitionProof,
     InvalidTransfersProof, ValidBundleProof, VerificationError,
@@ -7,6 +10,8 @@ use crate::{
     fraud_proof_runtime_interface, FraudProofVerificationInfoRequest,
     FraudProofVerificationInfoResponse, SetCodeExtrinsic, StorageKeyRequest,
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use domain_runtime_primitives::BlockNumber;
 use hash_db::Hasher;
@@ -26,7 +31,6 @@ use sp_runtime::traits::{
     Block as BlockT, Hash, Header as HeaderT, NumberFor, UniqueSaturatedInto,
 };
 use sp_runtime::{OpaqueExtrinsic, RuntimeAppPublic, SaturatedConversion};
-use sp_std::vec::Vec;
 use sp_trie::{LayoutV1, StorageProof};
 use subspace_core_primitives::Randomness;
 use trie_db::node::Value;

--- a/crates/sp-domains/src/core_api.rs
+++ b/crates/sp-domains/src/core_api.rs
@@ -1,11 +1,15 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::{BlockFees, Transfers};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use domain_runtime_primitives::{
     opaque, Balance, CheckExtrinsicsValidityError, DecodeExtrinsicError,
 };
 use sp_runtime::generic::Era;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use sp_runtime::Digest;
-use sp_std::vec::Vec;
 use sp_weights::Weight;
 use subspace_core_primitives::U256;
 use subspace_runtime_primitives::Moment;

--- a/crates/sp-domains/src/extrinsics.rs
+++ b/crates/sp-domains/src/extrinsics.rs
@@ -1,4 +1,9 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use domain_runtime_primitives::opaque::AccountId;
 use hash_db::Hasher;
 use rand::seq::SliceRandom;
@@ -8,7 +13,6 @@ use sp_state_machine::trace;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::vec_deque::VecDeque;
 use sp_std::fmt::Debug;
-use sp_std::vec::Vec;
 use subspace_core_primitives::Randomness;
 
 pub fn extrinsics_shuffling_seed<Hashing>(block_randomness: Randomness) -> Hashing::Out

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -27,10 +27,14 @@ pub mod storage;
 mod tests;
 pub mod valued_trie;
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use crate::storage::{RawGenesis, StorageKey};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use bundle_producer_election::{BundleProducerElectionParams, ProofOfElectionError};
 use core::num::ParseIntError;
 use core::ops::{Add, Sub};
@@ -58,7 +62,6 @@ use sp_runtime_interface::pass_by::PassBy;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::fmt::{Display, Formatter};
-use sp_std::vec::Vec;
 use sp_trie::TrieLayout;
 use sp_version::RuntimeVersion;
 use sp_weights::Weight;

--- a/crates/sp-domains/src/merkle_tree.rs
+++ b/crates/sp-domains/src/merkle_tree.rs
@@ -1,11 +1,15 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::OperatorPublicKey;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use blake2::digest::FixedOutput;
 use blake2::{Blake2b, Digest};
 use parity_scale_codec::{Decode, Encode};
 use rs_merkle::Hasher;
 use scale_info::TypeInfo;
 use sp_runtime::traits::{BlakeTwo256, Hash};
-use sp_std::vec::Vec;
 use subspace_core_primitives::Blake3Hash;
 
 /// Merkle tree using [`Blake2b256Algorithm`].

--- a/crates/sp-domains/src/proof_provider_and_verifier.rs
+++ b/crates/sp-domains/src/proof_provider_and_verifier.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use frame_support::PalletError;
 use hash_db::Hasher;
 #[cfg(feature = "std")]
@@ -11,7 +16,6 @@ use sp_state_machine::prove_read;
 use sp_state_machine::TrieBackendBuilder;
 use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
-use sp_std::vec::Vec;
 use sp_trie::{read_trie_value, LayoutV1, StorageProof};
 #[cfg(feature = "std")]
 use trie_db::{DBValue, TrieDBMutBuilder, TrieLayout, TrieMut};

--- a/crates/sp-domains/src/storage.rs
+++ b/crates/sp-domains/src/storage.rs
@@ -1,4 +1,9 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::{evm_chain_id_storage_key, self_domain_id_storage_key, DomainId};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use domain_runtime_primitives::EVMChainId;
 use hash_db::Hasher;
 use parity_scale_codec::{Codec, Decode, Encode};
@@ -9,7 +14,6 @@ use sp_core::storage::{Storage, StorageChild};
 use sp_runtime::StateVersion;
 use sp_state_machine::{Backend, TrieBackend, TrieBackendBuilder};
 use sp_std::collections::btree_map::BTreeMap;
-use sp_std::vec::Vec;
 use sp_trie::{empty_trie_root, LayoutV0, MemoryDB};
 
 /// Create a new empty instance of in-memory backend.

--- a/crates/sp-domains/src/valued_trie.rs
+++ b/crates/sp-domains/src/valued_trie.rs
@@ -1,7 +1,11 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use hash_db::Hasher;
 use parity_scale_codec::{Compact, Encode};
 use sp_std::cmp::max;
-use sp_std::vec::Vec;
 use trie_db::node::Value;
 use trie_db::{
     nibble_ops, ChildReference, NibbleSlice, NodeCodec, ProcessEncodedNode, TrieHash, TrieLayout,
@@ -60,10 +64,10 @@ where
         for (k, v) in iter_input {
             single = false;
             let common_depth = nibble_ops::biggest_depth(&previous_value.0, &k);
-            // 0 is a reserved value : could use option
+            // 0 is a reserved value: could use option
             let depth_item = common_depth;
             if common_depth == previous_value.0.len() * nibble_ops::NIBBLE_PER_BYTE {
-                // the new key include the previous one : branch value case
+                // the new key include the previous one: branch value case
                 // just stored value at branch depth
                 depth_queue.set_cache_value(common_depth, Some(previous_value.1));
             } else if depth_item >= last_depth {
@@ -301,7 +305,7 @@ mod test {
                     &exts,
                     i as u32,
                 )
-                .unwrap();
+                    .unwrap();
 
             assert_eq!(
                 StorageProofVerifier::<BlakeTwo256>::get_bare_value(

--- a/crates/sp-objects/Cargo.toml
+++ b/crates/sp-objects/Cargo.toml
@@ -14,15 +14,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 subspace-runtime-primitives = { version = "0.1.0", default-features = false, path = "../subspace-runtime-primitives" }
 
 [features]
 default = ["std"]
 std = [
-	"sp-api/std",
-	"sp-std/std",
-	"subspace-core-primitives/std",
-	"subspace-runtime-primitives/std",
+    "sp-api/std",
+    "subspace-core-primitives/std",
+    "subspace-runtime-primitives/std",
 ]

--- a/crates/sp-objects/src/lib.rs
+++ b/crates/sp-objects/src/lib.rs
@@ -16,8 +16,14 @@
 //! Primitives for Objects.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+// TODO: Suppression because of https://github.com/paritytech/polkadot-sdk/issues/3533
+#![allow(clippy::multiple_bound_locations)]
 
-use sp_std::vec::Vec;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_runtime_primitives::Hash;
 

--- a/crates/sp-subspace-mmr/Cargo.toml
+++ b/crates/sp-subspace-mmr/Cargo.toml
@@ -25,7 +25,6 @@ sp-externalities = { version = "0.19.0", default-features = false, git = "https:
 sp-mmr-primitives = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 
 [features]
 default = ["std"]
@@ -39,5 +38,4 @@ std = [
     "sp-mmr-primitives/std",
     "sp-runtime/std",
     "sp-runtime-interface/std",
-    "sp-std/std",
 ]

--- a/crates/sp-subspace-mmr/src/runtime_interface.rs
+++ b/crates/sp-subspace-mmr/src/runtime_interface.rs
@@ -1,5 +1,10 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[cfg(feature = "std")]
 use crate::host_functions::SubspaceMmrExtension;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_core::H256;
@@ -7,7 +12,6 @@ use sp_core::H256;
 use sp_externalities::ExternalitiesExt;
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime_interface::runtime_interface;
-use sp_std::vec::Vec;
 
 /// MMR related runtime interface
 #[runtime_interface]

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -21,8 +21,11 @@ use crate::archiver::incremental_record_commitments::{
     update_record_commitments, IncrementalRecordCommitmentsState,
 };
 use alloc::collections::VecDeque;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::num::NonZeroUsize;
@@ -202,8 +205,8 @@ pub enum ArchiverInstantiationError {
     InvalidLastArchivedBlock(BlockNumber),
     /// Invalid block, its size is smaller than already archived number of bytes
     #[cfg_attr(
-        feature = "thiserror",
-        error("Invalid block, its size {block_bytes} bytes is smaller than already archived {archived_block_bytes} bytes")
+    feature = "thiserror",
+    error("Invalid block, its size {block_bytes} bytes is smaller than already archived {archived_block_bytes} bytes")
     )]
     InvalidBlockSmallSize {
         /// Full block size

--- a/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
+++ b/crates/subspace-archiving/src/archiver/incremental_record_commitments.rs
@@ -1,6 +1,8 @@
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use crate::archiver::Segment;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 use parity_scale_codec::{Encode, Output};

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -1,6 +1,9 @@
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 #[cfg(feature = "parallel")]

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -1,7 +1,10 @@
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use crate::archiver::{Segment, SegmentItem};
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::mem;
 use core::num::NonZeroUsize;
@@ -40,8 +43,8 @@ pub enum ReconstructorError {
     SegmentDecoding(parity_scale_codec::Error),
     /// Incorrect segment order, each next segment must have monotonically increasing segment index
     #[cfg_attr(
-        feature = "thiserror",
-        error("Incorrect segment order, expected index {expected_segment_index}, actual {actual_segment_index}")
+    feature = "thiserror",
+    error("Incorrect segment order, expected index {expected_segment_index}, actual {actual_segment_index}")
     )]
     IncorrectSegmentOrder {
         expected_segment_index: SegmentIndex,

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -15,14 +15,18 @@
 
 //! Various cryptographic utilities used across Subspace Network.
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 pub mod kzg;
 
 use crate::Blake3Hash;
 use ::kzg::Fr;
+#[cfg(not(feature = "std"))]
 use alloc::format;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};

--- a/crates/subspace-core-primitives/src/crypto/kzg.rs
+++ b/crates/subspace-core-primitives/src/crypto/kzg.rs
@@ -8,8 +8,10 @@ extern crate alloc;
 use crate::crypto::Scalar;
 use alloc::collections::btree_map::Entry;
 use alloc::collections::BTreeMap;
+#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
 use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::mem;
 use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -39,16 +39,19 @@ mod serde;
 #[cfg(test)]
 mod tests;
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use crate::crypto::{blake3_hash, blake3_hash_list, blake3_hash_with_key, Scalar};
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::convert::AsRef;
 use core::fmt;
-use core::iter::Iterator;
 use core::num::{NonZeroU64, NonZeroU8};
 use core::simd::Simd;
 use core::str::FromStr;
@@ -1074,7 +1077,7 @@ impl<T: Clone> NonEmptyVec<T> {
 
     /// Creates the Vec with the entry.
     pub fn new_with_entry(entry: T) -> Self {
-        Self(alloc::vec![entry])
+        Self(vec![entry])
     }
 
     /// Returns the number of entries.

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -21,8 +21,11 @@
 //! * for global objects in the global history of the blockchain
 
 #[cfg(not(feature = "std"))]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
+
 use crate::{Blake3Hash, PieceIndex};
+#[cfg(not(feature = "std"))]
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -9,9 +9,13 @@ use crate::segments::{ArchivedHistorySegment, SegmentIndex};
 use crate::RecordedHistorySegment;
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::array::TryFromSliceError;
 use core::iter::Step;
@@ -732,6 +736,7 @@ impl From<Piece> for Vec<u8> {
         piece.0.to_vec()
     }
 }
+
 impl TryFrom<&[u8]> for Piece {
     type Error = TryFromSliceError;
 

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -1,6 +1,8 @@
 use crate::crypto::kzg::Commitment;
 use crate::pieces::{FlatPieces, Piece, PieceIndex, RawRecord};
+#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::array::TryFromSliceError;
 use core::iter::Step;

--- a/crates/subspace-erasure-coding/src/lib.rs
+++ b/crates/subspace-erasure-coding/src/lib.rs
@@ -5,8 +5,10 @@ mod tests;
 
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 use kzg::{FFTSettings, PolyRecover, DAS, FFTG1, G1};

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -50,10 +50,10 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     pub(crate) autonat: AutonatWrapperConfig,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct GeneralConnectedPeersInstance;
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct SpecialConnectedPeersInstance;
+// #[derive(Debug, Clone, Copy)]
+// pub(crate) struct GeneralConnectedPeersInstance;
+// #[derive(Debug, Clone, Copy)]
+// pub(crate) struct SpecialConnectedPeersInstance;
 
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "Event")]

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -341,6 +341,7 @@ impl KnownPeersManager {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(path)?;
 
         let known_addresses_size = Self::known_addresses_size(cache_size);

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -36,7 +36,6 @@ use prometheus_client::registry::Registry;
 use std::borrow::Cow;
 use std::iter::Empty;
 use std::num::NonZeroUsize;
-use std::string::ToString;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, io, iter};
@@ -144,7 +143,7 @@ where
     LocalRecordProvider: self::LocalRecordProvider,
 {
     type RecordsIter<'a> = Empty<Cow<'a, Record>> where Self: 'a;
-    type ProvidedIter<'a> =  Empty<Cow<'a, ProviderRecord>> where Self: 'a;
+    type ProvidedIter<'a> = Empty<Cow<'a, ProviderRecord>> where Self: 'a;
 
     fn get(&self, _key: &RecordKey) -> Option<Cow<'_, Record>> {
         // Not supported

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -28,7 +28,7 @@ use libp2p::kad::{
 use libp2p::metrics::{Metrics, Recorder};
 use libp2p::multiaddr::Protocol;
 use libp2p::swarm::{DialError, SwarmEvent};
-use libp2p::{futures, Multiaddr, PeerId, Swarm, TransportError};
+use libp2p::{Multiaddr, PeerId, Swarm, TransportError};
 use nohash_hasher::IntMap;
 use parking_lot::Mutex;
 use std::collections::hash_map::Entry;

--- a/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
+++ b/crates/subspace-networking/src/protocols/reserved_peers/tests.rs
@@ -11,9 +11,6 @@ use libp2p_swarm_test::SwarmExt;
 use std::time::Duration;
 use tokio::time::sleep;
 
-#[derive(Debug, Clone)]
-struct ReservedPeersInstance;
-
 const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(1);
 
 #[tokio::test()]

--- a/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
+++ b/crates/subspace-networking/src/utils/unique_record_binary_heap.rs
@@ -45,8 +45,6 @@ where
     RecordKey: From<K>,
     K: Clone,
 {
-    // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12154
-    #[allow(clippy::unconditional_recursion)]
     fn eq(&self, other: &Self) -> bool {
         self.peer_distance().eq(&other.peer_distance())
     }

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -2,13 +2,16 @@
 mod tests;
 pub(super) mod types;
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use crate::chiapos::constants::{PARAM_B, PARAM_BC, PARAM_C, PARAM_EXT, PARAM_M};
 use crate::chiapos::table::types::{Metadata, Position, X, Y};
 use crate::chiapos::utils::EvaluatableUsize;
 use crate::chiapos::Seed;
+#[cfg(not(feature = "std"))]
 use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
 use chacha20::{ChaCha8, Key, Nonce};

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests;
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use crate::chiapos::table::types::{Metadata, Position, X, Y};
@@ -11,6 +12,7 @@ use crate::chiapos::table::{
 };
 use crate::chiapos::utils::EvaluatableUsize;
 use crate::chiapos::{Challenge, Quality, Seed};
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::mem;
 use sha2::{Digest, Sha256};

--- a/crates/subspace-proof-of-time/src/aes.rs
+++ b/crates/subspace-proof-of-time/src/aes.rs
@@ -4,6 +4,7 @@
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use aes::cipher::generic_array::GenericArray;
@@ -77,7 +78,6 @@ pub(crate) fn verify_sequential(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use subspace_core_primitives::{PotKey, PotOutput, PotSeed};
 
     const SEED: [u8; 16] = [
         0xd6, 0x66, 0xcc, 0xd8, 0xd5, 0x93, 0xc2, 0x3d, 0xa8, 0xdb, 0x6b, 0x5b, 0x14, 0x13, 0xb1,
@@ -115,7 +115,7 @@ mod tests {
             seed,
             key,
             &*checkpoints,
-            checkpoint_iterations
+            checkpoint_iterations,
         ));
 
         // Decryption of invalid cipher text fails.
@@ -125,7 +125,7 @@ mod tests {
             seed,
             key,
             &*checkpoints_1,
-            checkpoint_iterations
+            checkpoint_iterations,
         ));
 
         // Decryption with wrong number of iterations fails.
@@ -133,13 +133,13 @@ mod tests {
             seed,
             key,
             &*checkpoints,
-            checkpoint_iterations + 2
+            checkpoint_iterations + 2,
         ));
         assert!(!verify_sequential(
             seed,
             key,
             &*checkpoints,
-            checkpoint_iterations - 2
+            checkpoint_iterations - 2,
         ));
 
         // Decryption with wrong seed fails.
@@ -147,7 +147,7 @@ mod tests {
             PotSeed::from(SEED_1),
             key,
             &*checkpoints,
-            checkpoint_iterations
+            checkpoint_iterations,
         ));
 
         // Decryption with wrong key fails.
@@ -155,7 +155,7 @@ mod tests {
             seed,
             PotKey::from(KEY_1),
             &*checkpoints,
-            checkpoint_iterations
+            checkpoint_iterations,
         ));
     }
 }

--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -22,7 +22,6 @@ pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, 
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-io = { version = "23.0.0", default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../subspace-core-primitives" }
 
 [features]
@@ -31,7 +30,6 @@ std = [
     "pallet-transaction-payment/std",
     "sp-core/std",
     "sp-runtime/std",
-    "sp-std/std",
     "subspace-core-primitives/std",
 ]
 testing = [

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -18,11 +18,15 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use sp_core::parameter_types;
 use sp_runtime::traits::{Bounded, IdentifyAccount, Verify};
 use sp_runtime::{FixedPointNumber, MultiSignature, Perquintill};
-use sp_std::vec::Vec;
 pub use subspace_core_primitives::BlockNumber;
 
 /// Minimum desired number of replicas of the blockchain to be stored by the network,

--- a/crates/subspace-runtime/src/domains.rs
+++ b/crates/subspace-runtime/src/domains.rs
@@ -1,9 +1,13 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::{Balance, Block, Domains, RuntimeCall, UncheckedExtrinsic};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use sp_domains::DomainId;
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
-use sp_std::vec::Vec;
 
 pub(crate) fn extract_successful_bundles(
     domain_id: DomainId,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -830,6 +830,12 @@ mod benches {
     );
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+impl frame_system_benchmarking::Config for Runtime {}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl frame_benchmarking::baseline::Config for Runtime {}
+
 impl_runtime_apis! {
     impl sp_api::Core<Block> for Runtime {
         fn version() -> RuntimeVersion {
@@ -1291,9 +1297,6 @@ impl_runtime_apis! {
 
             use frame_system_benchmarking::Pallet as SystemBench;
             use baseline::Pallet as BaselineBench;
-
-            impl frame_system_benchmarking::Config for Runtime {}
-            impl baseline::Config for Runtime {}
 
             use frame_support::traits::WhitelistedStorageKeys;
             let whitelist: Vec<TrackedStorageKey> = AllPalletsWithSystem::whitelisted_storage_keys();

--- a/domains/client/block-builder/Cargo.toml
+++ b/domains/client/block-builder/Cargo.toml
@@ -23,6 +23,3 @@ sp-inherents = { version = "4.0.0-dev", git = "https://github.com/subspace/polka
 sp-runtime = { version = "24.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-state-machine = { version = "0.28.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 tracing = "0.1.40"
-
-[dev-dependencies]
-substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -328,49 +328,49 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use sp_blockchain::HeaderBackend;
-    use sp_core::Blake2Hasher;
-    use sp_state_machine::Backend;
-    // TODO: Remove `substrate_test_runtime_client` dependency for faster build time
-    use std::collections::VecDeque;
-    use substrate_test_runtime_client::{DefaultTestClientBuilderExt, TestClientBuilderExt};
-
-    // TODO: Unlock this test, it got broken in https://github.com/subspace/subspace/pull/1548 and
-    //  doesn't run on Windows at all
-    #[test]
-    #[ignore]
-    fn block_building_storage_proof_does_not_include_runtime_by_default() {
-        let (client, backend) =
-            substrate_test_runtime_client::TestClientBuilder::new().build_with_backend();
-
-        let block = BlockBuilder::new(
-            &client,
-            client.info().best_hash,
-            client.info().best_number,
-            RecordProof::Yes,
-            Default::default(),
-            &*backend,
-            VecDeque::new(),
-            Default::default(),
-        )
-        .unwrap()
-        .build()
-        .unwrap();
-
-        let proof = block.proof.expect("Proof is build on request");
-
-        let backend = sp_state_machine::create_proof_check_backend::<Blake2Hasher>(
-            block.storage_changes.transaction_storage_root,
-            proof,
-        )
-        .unwrap();
-
-        assert!(backend
-            .storage(sp_core::storage::well_known_keys::CODE)
-            .unwrap_err()
-            .contains("Database missing expected key"));
-    }
-}
+// TODO: Unlock this test, it got broken in https://github.com/subspace/subspace/pull/1548 and
+//  doesn't run on Windows at all, also needs to not use substrate_test_runtime_client
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use sp_blockchain::HeaderBackend;
+//     use sp_core::Blake2Hasher;
+//     use sp_state_machine::Backend;
+//     // TODO: Remove `substrate_test_runtime_client` dependency for faster build time
+//     use std::collections::VecDeque;
+//     use substrate_test_runtime_client::{DefaultTestClientBuilderExt, TestClientBuilderExt};
+//
+//     #[test]
+//     #[ignore]
+//     fn block_building_storage_proof_does_not_include_runtime_by_default() {
+//         let (client, backend) =
+//             substrate_test_runtime_client::TestClientBuilder::new().build_with_backend();
+//
+//         let block = BlockBuilder::new(
+//             &client,
+//             client.info().best_hash,
+//             client.info().best_number,
+//             RecordProof::Yes,
+//             Default::default(),
+//             &*backend,
+//             VecDeque::new(),
+//             Default::default(),
+//         )
+//         .unwrap()
+//         .build()
+//         .unwrap();
+//
+//         let proof = block.proof.expect("Proof is build on request");
+//
+//         let backend = sp_state_machine::create_proof_check_backend::<Blake2Hasher>(
+//             block.storage_changes.transaction_storage_root,
+//             proof,
+//         )
+//         .unwrap();
+//
+//         assert!(backend
+//             .storage(sp_core::storage::well_known_keys::CODE)
+//             .unwrap_err()
+//             .contains("Database missing expected key"));
+//     }
+// }

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -235,7 +235,7 @@ mod tests {
     use parking_lot::Mutex;
     use sp_core::hash::H256;
     use std::collections::HashMap;
-    use subspace_runtime_primitives::{Balance, BlockNumber, Hash};
+    use subspace_runtime_primitives::{Balance, Hash};
     use subspace_test_runtime::Block as CBlock;
 
     type ExecutionReceipt =

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -968,8 +968,7 @@ where
 mod tests {
     use super::*;
     use domain_test_service::evm_domain_test_runtime::Block;
-    use sp_core::{sp_std, H256};
-    use sp_domains::{ExecutionReceipt, InboxedBundle, InvalidBundleType};
+    use sp_domains::{InboxedBundle, InvalidBundleType};
     use subspace_test_runtime::Block as CBlock;
 
     fn create_test_execution_receipt(
@@ -988,7 +987,7 @@ mod tests {
             consensus_block_number: Zero::zero(),
             inboxed_bundles,
             final_state_root: Default::default(),
-            execution_trace: sp_std::vec![],
+            execution_trace: vec![],
             execution_trace_root: Default::default(),
             block_fees: Default::default(),
             transfers: Default::default(),

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -17,7 +17,6 @@ use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, NumberFor, Zero};
 use sp_runtime::RuntimeAppPublic;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
-use std::convert::{AsRef, Into};
 use std::sync::Arc;
 use subspace_runtime_primitives::Balance;
 use tracing::info;

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -25,13 +25,14 @@
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
-
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
 mod tests;
-
 pub mod weights;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 use codec::{Codec, Encode};
 use frame_support::dispatch::{
@@ -82,13 +83,14 @@ type BlockHashOf<T> = <BlockOf<T> as BlockT>::Hash;
 mod pallet {
     use crate::weights::WeightInfo;
     use crate::{BalanceOf, ExtrinsicStorageFees};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use frame_support::pallet_prelude::*;
     use frame_support::traits::fungible::Mutate;
     use frame_support::weights::WeightToFee;
     use frame_system::pallet_prelude::*;
     use frame_system::SetCode;
     use sp_executive::{InherentError, InherentType, INHERENT_IDENTIFIER};
-    use sp_std::vec::Vec;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -25,7 +25,6 @@ sp-domains = { version = "0.1.0", default-features = false, path = "../../../cra
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
 sp-mmr-primitives = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 
 [dev-dependencies]
@@ -48,7 +47,6 @@ std = [
     "sp-messenger/std",
     "sp-mmr-primitives/std",
     "sp-runtime/std",
-    "sp-std/std",
     "sp-trie/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -20,18 +20,18 @@
 #![warn(rust_2018_idioms, missing_debug_implementations)]
 #![feature(let_chains)]
 
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+mod fees;
+mod messages;
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
 mod tests;
-
-#[cfg(feature = "runtime-benchmarks")]
-mod benchmarking;
-
 pub mod weights;
 
-mod fees;
-mod messages;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 use codec::{Decode, Encode};
 use frame_support::traits::fungible::Inspect;
@@ -102,6 +102,10 @@ mod pallet {
         BalanceOf, Channel, ChannelId, ChannelState, FeeModel, Nonce, OutboxMessageResult,
         StateRootOf, ValidatedRelayMessage, U256,
     };
+    #[cfg(not(feature = "std"))]
+    use alloc::boxed::Box;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use frame_support::pallet_prelude::*;
     use frame_support::traits::fungible::Mutate;
     use frame_support::weights::WeightToFee;
@@ -116,8 +120,6 @@ mod pallet {
     use sp_messenger::{MmrProofVerifier, OnXDMRewards, StorageKeys};
     use sp_mmr_primitives::EncodableOpaqueLeaf;
     use sp_runtime::ArithmeticError;
-    use sp_std::boxed::Box;
-    use sp_std::vec::Vec;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -1,7 +1,12 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::{
     BalanceOf, BlockMessages as BlockMessagesStore, ChannelId, Channels, Config, Error, Event,
     InboxResponses, Nonce, Outbox, OutboxMessageResult, Pallet,
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use scale_info::TypeInfo;
@@ -12,7 +17,6 @@ use sp_messenger::messages::{
 };
 use sp_runtime::traits::Get;
 use sp_runtime::{ArithmeticError, DispatchError, DispatchResult};
-use sp_std::vec::Vec;
 
 /// Set of messages to be relayed by a given relayer.
 #[derive(Default, Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]

--- a/domains/pallets/transporter/src/benchmarking.rs
+++ b/domains/pallets/transporter/src/benchmarking.rs
@@ -1,9 +1,11 @@
 //! Benchmarking for `pallet-transporter`.
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use super::*;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
-use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use sp_messenger::endpoint::{
     Endpoint, EndpointHandler as EndpointHandlerT, EndpointRequest, Sender,

--- a/domains/pallets/transporter/src/lib.rs
+++ b/domains/pallets/transporter/src/lib.rs
@@ -19,6 +19,17 @@
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, missing_debug_implementations)]
 
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+pub mod weights;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use codec::{Decode, Encode};
 use domain_runtime_primitives::{MultiAccountId, TryConvertBack};
 use frame_support::dispatch::DispatchResult;
@@ -31,16 +42,6 @@ use sp_messenger::endpoint::EndpointResponse;
 use sp_messenger::messages::ChainId;
 use sp_runtime::traits::{CheckedAdd, CheckedSub, Get};
 use sp_std::vec;
-
-#[cfg(test)]
-mod mock;
-#[cfg(test)]
-mod tests;
-
-#[cfg(feature = "runtime-benchmarks")]
-mod benchmarking;
-
-pub mod weights;
 
 /// Location that either sends or receives transfers between chains.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
@@ -74,6 +75,8 @@ type MessageIdOf<T> = <<T as Config>::Sender as sp_messenger::endpoint::Sender<
 mod pallet {
     use crate::weights::WeightInfo;
     use crate::{BalanceOf, Location, MessageIdOf, MultiAccountId, Transfer, TryConvertBack};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use codec::{Decode, Encode};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::{Currency, ExistenceRequirement, WithdrawReasons};
@@ -87,7 +90,6 @@ mod pallet {
     use sp_messenger::messages::ChainId;
     use sp_runtime::traits::Convert;
     use sp_std::vec;
-    use sp_std::vec::Vec;
 
     #[pallet::config]
     pub trait Config: frame_system::Config {

--- a/domains/primitives/block-fees/src/lib.rs
+++ b/domains/primitives/block-fees/src/lib.rs
@@ -4,7 +4,6 @@
 use codec::{Decode, Encode};
 use domain_runtime_primitives::Balance;
 use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
-use sp_std::result::Result;
 
 /// Block-fees inherent identifier.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"blockfee";

--- a/domains/primitives/executive/Cargo.toml
+++ b/domains/primitives/executive/Cargo.toml
@@ -17,7 +17,6 @@ include = [
 async-trait = { version = "0.1.77", optional = true }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 
 [features]
 default = ["std"]
@@ -25,5 +24,4 @@ std = [
     "async-trait",
     "codec/std",
     "sp-inherents/std",
-    "sp-std/std",
 ]

--- a/domains/primitives/executive/src/lib.rs
+++ b/domains/primitives/executive/src/lib.rs
@@ -1,13 +1,15 @@
 //! Inherents for Executive pallet
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use sp_inherents::{Error, InherentData};
 use sp_inherents::{InherentIdentifier, IsFatalError};
-#[cfg(feature = "std")]
-use sp_std::result::Result;
-use sp_std::vec::Vec;
 
 /// Executive inherent identifier.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"executve";

--- a/domains/primitives/messenger-host-functions/Cargo.toml
+++ b/domains/primitives/messenger-host-functions/Cargo.toml
@@ -26,7 +26,6 @@ sp-externalities = { version = "0.19.0", default-features = false, git = "https:
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime-interface = { version = "17.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 
 [features]
 default = ["std"]
@@ -43,7 +42,6 @@ std = [
     "sp-messenger/std",
     "sp-runtime/std",
     "sp-runtime-interface/std",
-    "sp-std/std",
 ]
 
 runtime-benchmarks = []

--- a/domains/primitives/messenger-host-functions/src/lib.rs
+++ b/domains/primitives/messenger-host-functions/src/lib.rs
@@ -17,22 +17,24 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
-use scale_info::TypeInfo;
-use sp_domains::DomainId;
-use sp_messenger::messages::{ChainId, MessageId};
-use sp_runtime_interface::pass_by;
-use sp_runtime_interface::pass_by::PassBy;
-
 #[cfg(feature = "std")]
 mod host_functions;
 mod runtime_interface;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+use codec::{Decode, Encode};
 #[cfg(feature = "std")]
 pub use host_functions::{MessengerApi, MessengerExtension, MessengerHostFunctionsImpl};
 pub use runtime_interface::messenger_runtime_interface::get_storage_key;
 #[cfg(feature = "std")]
 pub use runtime_interface::messenger_runtime_interface::HostFunctions;
+use scale_info::TypeInfo;
+use sp_domains::DomainId;
+use sp_messenger::messages::{ChainId, MessageId};
+use sp_runtime_interface::pass_by;
+use sp_runtime_interface::pass_by::PassBy;
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub enum StorageKeyRequest {

--- a/domains/primitives/messenger-host-functions/src/runtime_interface.rs
+++ b/domains/primitives/messenger-host-functions/src/runtime_interface.rs
@@ -1,10 +1,11 @@
 #[cfg(feature = "std")]
 use crate::host_functions::MessengerExtension;
 use crate::StorageKeyRequest;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use sp_externalities::ExternalitiesExt;
 use sp_runtime_interface::runtime_interface;
-use sp_std::vec::Vec;
 
 /// Messenger related runtime interface
 #[runtime_interface]

--- a/domains/primitives/messenger/Cargo.toml
+++ b/domains/primitives/messenger/Cargo.toml
@@ -25,7 +25,6 @@ sp-core = { version = "21.0.0", default-features = false, git = "https://github.
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
 sp-mmr-primitives = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-trie = { version = "22.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 
 [features]
@@ -42,7 +41,6 @@ std = [
     "sp-domains/std",
     "sp-mmr-primitives/std",
     "sp-runtime/std",
-    "sp-std/std",
     "sp-trie/std"
 ]
 

--- a/domains/primitives/messenger/src/endpoint.rs
+++ b/domains/primitives/messenger/src/endpoint.rs
@@ -1,11 +1,15 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use frame_support::weights::Weight;
 use frame_support::Parameter;
 use scale_info::TypeInfo;
 use sp_domains::ChainId;
 use sp_runtime::traits::Member;
-use sp_runtime::{sp_std, DispatchError, DispatchResult};
-use sp_std::vec::Vec;
+use sp_runtime::{DispatchError, DispatchResult};
 
 /// Represents a particular endpoint in a given Execution environment.
 pub type EndpointId = u64;

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -20,11 +20,15 @@
 pub mod endpoint;
 pub mod messages;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use messages::{BlockMessagesWithStorageKey, CrossDomainMessage, MessageId};
 use sp_domains::{ChainId, DomainId};
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof};
-use sp_std::vec::Vec;
 
 /// Trait to handle XDM rewards.
 pub trait OnXDMRewards<Balance> {

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -1,11 +1,15 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use crate::endpoint::{Endpoint, EndpointRequest, EndpointResponse};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 pub use sp_domains::ChainId;
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
 use sp_runtime::app_crypto::sp_core::U256;
-use sp_runtime::{sp_std, DispatchError};
-use sp_std::vec::Vec;
+use sp_runtime::DispatchError;
 use sp_trie::StorageProof;
 
 /// Channel identity.

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -21,7 +21,6 @@ serde = { version = "1.0.195", default-features = false, features = ["alloc", "d
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-core = { version = "21.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 sp-runtime = { version = "24.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
-sp-std = { version = "8.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
 subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace-core-primitives", default-features = false }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 sp-weights = { version = "20.0.0", default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "d6b500960579d73c43fc4ef550b703acfa61c4c8" }
@@ -38,7 +37,6 @@ std = [
     "sp-api/std",
     "sp-core/std",
     "sp-runtime/std",
-    "sp-std/std",
     "sp-weights/std",
     "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -17,9 +17,13 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 pub use fp_account::AccountId20;
 use frame_support::dispatch::{DispatchClass, PerDispatchClass};
 use frame_support::weights::constants::{BlockExecutionWeight, ExtrinsicBaseWeight};
@@ -31,7 +35,6 @@ use sp_runtime::generic::UncheckedExtrinsic;
 use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
 use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_runtime::{MultiAddress, MultiSignature, Perbill};
-use sp_std::vec::Vec;
 use sp_weights::Weight;
 use subspace_runtime_primitives::SHANNON;
 
@@ -207,10 +210,11 @@ pub const CHECK_EXTRINSICS_AND_DO_PRE_DISPATCH_METHOD_NAME: &str =
 /// to even the core data structures.
 pub mod opaque {
     use crate::BlockNumber;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
     use sp_runtime::generic;
     use sp_runtime::traits::BlakeTwo256;
     pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
-    use sp_std::vec::Vec;
 
     /// Opaque block header type.
     pub type Header = generic::Header<BlockNumber, BlakeTwo256>;

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -8,8 +8,11 @@ mod precompiles;
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
+use alloc::format;
 use codec::{Decode, Encode};
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
@@ -804,6 +807,12 @@ fn check_transaction_and_do_pre_dispatch_inner(
     }
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+impl frame_system_benchmarking::Config for Runtime {}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl frame_benchmarking::baseline::Config for Runtime {}
+
 impl_runtime_apis! {
     impl sp_api::Core<Block> for Runtime {
         fn version() -> RuntimeVersion {
@@ -999,7 +1008,7 @@ impl_runtime_apis! {
         ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
             UncheckedExtrinsic::decode(&mut encoded.as_slice())
-                .map_err(|err| DecodeExtrinsicError(alloc::format!("{}", err)))
+                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
         }
 
         fn extrinsic_era(
@@ -1294,9 +1303,6 @@ impl_runtime_apis! {
             use frame_system_benchmarking::Pallet as SystemBench;
             use frame_support::traits::WhitelistedStorageKeys;
             use baseline::Pallet as BaselineBench;
-
-            impl frame_system_benchmarking::Config for Runtime {}
-            impl baseline::Config for Runtime {}
 
             let whitelist: Vec<TrackedStorageKey> = AllPalletsWithSystem::whitelisted_storage_keys();
 

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -140,8 +140,6 @@ where
     let (engine, sync_service, block_announce_config) = SyncingEngine::new(
         Roles::from(&config.role),
         client.clone(),
-        // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12148
-        #[allow(clippy::useless_asref)]
         config
             .prometheus_config
             .as_ref()
@@ -201,8 +199,6 @@ where
         genesis_hash,
         protocol_id,
         fork_id: config.chain_spec.fork_id().map(ToOwned::to_owned),
-        // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12148
-        #[allow(clippy::useless_asref)]
         metrics_registry: config
             .prometheus_config
             .as_ref()
@@ -225,8 +221,6 @@ where
             transaction_pool,
             client.clone(),
         )),
-        // TODO: False-positive in clippy: https://github.com/rust-lang/rust-clippy/issues/12148
-        #[allow(clippy::useless_asref)]
         config
             .prometheus_config
             .as_ref()

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -8,8 +8,11 @@ mod precompiles;
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
+use alloc::format;
 use codec::{Decode, Encode};
 pub use domain_runtime_primitives::opaque::Header;
 use domain_runtime_primitives::{
@@ -974,7 +977,7 @@ impl_runtime_apis! {
         ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
             let encoded = opaque_extrinsic.encode();
             UncheckedExtrinsic::decode(&mut encoded.as_slice())
-                .map_err(|err| DecodeExtrinsicError(alloc::format!("{}", err)))
+                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
         }
 
         fn extrinsic_era(

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -12,7 +12,6 @@ use domain_runtime_primitives::Balance;
 use domain_service::providers::DefaultProvider;
 use domain_service::FullClient;
 use domain_test_primitives::OnchainStateApi;
-use evm_domain_test_runtime;
 use evm_domain_test_runtime::AccountId as AccountId20;
 use fp_rpc::EthereumRuntimeRPCApi;
 use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};

--- a/orml/vesting/src/mock.rs
+++ b/orml/vesting/src/mock.rs
@@ -5,7 +5,7 @@
 use super::*;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU32, ConstU64, EnsureOrigin, Everything},
+	traits::{ConstU64, Everything},
 };
 use frame_system::RawOrigin;
 use sp_core::H256;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-01-19"
+channel = "nightly-2024-02-29"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"

--- a/shared/subspace-metrics/Cargo.toml
+++ b/shared/subspace-metrics/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 ]
 
 [dependencies]
-actix-web = "4.4.1"
+actix-web = "4.5.1"
 prometheus = { version = "0.13.0", default-features = false }
 prometheus-client = "0.22.0"
 tracing = "0.1.40"


### PR DESCRIPTION
This updates Rust version and fixes a bunch of related lints (latest nightly REALLY doesn't like when the same type is imported more than once even indirectly).

This also fixes https://github.com/subspace/subspace/issues/2575 by simply commenting-out already ignored test `block_building_storage_proof_does_not_include_runtime_by_default`.

Latest nightly also changed some features that required bumping versions of a few crated and removing `--locked` from `cargo-nextest` because its latest release still relies on non-fixed versions of dependencies and the only way to get newer compatible ones is to ignore lock file for now.

In some places where the same type was imported more than once due to `sp-std` I have replaced `sp-std` with `alloc` completely. But there are still places where `sp-std` is used and I didn't want to do bigger refactoring/cleanup.

The changes in this PR are simple and mechanical, no logic changes anywhere.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
