### PR TITLE
Farmer caching tweaks

### DIFF
--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -30,7 +30,14 @@ impl OpenOptionsExt for OpenOptions {
     #[cfg(windows)]
     fn advise_random_access(&mut self) -> &mut Self {
         use std::os::windows::fs::OpenOptionsExt;
-        self.custom_flags(winapi::um::winbase::FILE_FLAG_RANDOM_ACCESS)
+        // `FILE_FLAG_WRITE_THROUGH` below is a bit of a hack, especially in `advise_random_access`,
+        // but it helps with memory usage and feels like should be default. Since `.custom_flags()`
+        // overrides previous value, we need to set bitwise OR of two flags rather that two flags
+        // separately.
+        self.custom_flags(
+            winapi::um::winbase::FILE_FLAG_RANDOM_ACCESS
+                | winapi::um::winbase::FILE_FLAG_WRITE_THROUGH,
+        )
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -886,10 +886,18 @@ impl FarmerCache {
 
         let should_store_fut = tokio::task::spawn_blocking({
             let plot_caches = Arc::clone(&self.plot_caches);
+            let piece_caches = Arc::clone(&self.piece_caches);
             let next_plot_cache = Arc::clone(&self.next_plot_cache);
             let piece = piece.clone();
 
             move || {
+                for cache in piece_caches.read().iter() {
+                    if cache.stored_pieces.contains_key(&key) {
+                        // Already stored in normal piece cache, no need to store it again
+                        return;
+                    }
+                }
+
                 let plot_caches = plot_caches.read();
                 let plot_caches_len = plot_caches.len();
 

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -20,9 +20,7 @@ use std::{io, thread};
 use thread_priority::{set_current_thread_priority, ThreadPriority};
 use tokio::runtime::Handle;
 use tokio::task;
-use tracing::debug;
-#[cfg(feature = "numa")]
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// It doesn't make a lot of sense to have a huge number of farming threads, 32 is plenty
 const MAX_DEFAULT_FARMING_THREADS: usize = 32;


### PR DESCRIPTION
A few things I discovered that should be beneficial.

The first commit reduces memory usage on Windows, second simply skips unnecessary caching of pieces that are already in piece cache in the plot cache. Third commit has a special case for Windows to avoid very large farms where piece cache is large enough as is.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
