### PR TITLE
Use a wrapper with unbuffered I/O for farming on Windows

### DIFF
--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -14,7 +14,7 @@ pub trait OpenOptionsExt {
     /// NOTE: There are major alignment requirements described here:
     /// https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering#alignment-and-file-access-requirements
     #[cfg(windows)]
-    fn advise_random_unbuffered(&mut self) -> &mut Self;
+    fn advise_unbuffered(&mut self) -> &mut Self;
 
     /// Advise OS/file system that file will use sequential access and read-ahead behavior is
     /// desirable, only has impact on Windows, for other operating systems see [`FileExt`]
@@ -48,11 +48,10 @@ impl OpenOptionsExt for OpenOptions {
     }
 
     #[cfg(windows)]
-    fn advise_random_unbuffered(&mut self) -> &mut Self {
+    fn advise_unbuffered(&mut self) -> &mut Self {
         use std::os::windows::fs::OpenOptionsExt;
         self.custom_flags(
-            winapi::um::winbase::FILE_FLAG_RANDOM_ACCESS
-                | winapi::um::winbase::FILE_FLAG_WRITE_THROUGH
+            winapi::um::winbase::FILE_FLAG_WRITE_THROUGH
                 | winapi::um::winbase::FILE_FLAG_NO_BUFFERING,
         )
     }

--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -78,6 +78,9 @@ impl OpenOptionsExt for OpenOptions {
 /// Extension convenience trait that allows pre-allocating files, suggesting random access pattern
 /// and doing cross-platform exact reads/writes
 pub trait FileExt {
+    /// Get allocated file size
+    fn allocated_size(&self) -> Result<u64>;
+
     /// Make sure file has specified number of bytes allocated for it
     fn preallocate(&self, len: u64) -> Result<()>;
 
@@ -97,7 +100,15 @@ pub trait FileExt {
 }
 
 impl FileExt for File {
+    fn allocated_size(&self) -> Result<u64> {
+        fs4::FileExt::allocated_size(self)
+    }
+
     fn preallocate(&self, len: u64) -> Result<()> {
+        // TODO: Hack due to bugs on Windows: https://github.com/al8n/fs4-rs/issues/13
+        if fs4::FileExt::allocated_size(self)? == len {
+            return Ok(());
+        }
         fs4::FileExt::allocate(self, len)
     }
 

--- a/crates/subspace-farmer-components/src/file_ext.rs
+++ b/crates/subspace-farmer-components/src/file_ext.rs
@@ -9,6 +9,13 @@ pub trait OpenOptionsExt {
     /// undesirable, only has impact on Windows, for other operating systems see [`FileExt`]
     fn advise_random_access(&mut self) -> &mut Self;
 
+    /// Advise Windows to not use buffering for this file and that file access will be random.
+    ///
+    /// NOTE: There are major alignment requirements described here:
+    /// https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering#alignment-and-file-access-requirements
+    #[cfg(windows)]
+    fn advise_random_unbuffered(&mut self) -> &mut Self;
+
     /// Advise OS/file system that file will use sequential access and read-ahead behavior is
     /// desirable, only has impact on Windows, for other operating systems see [`FileExt`]
     fn advise_sequential_access(&mut self) -> &mut Self;
@@ -37,6 +44,16 @@ impl OpenOptionsExt for OpenOptions {
         self.custom_flags(
             winapi::um::winbase::FILE_FLAG_RANDOM_ACCESS
                 | winapi::um::winbase::FILE_FLAG_WRITE_THROUGH,
+        )
+    }
+
+    #[cfg(windows)]
+    fn advise_random_unbuffered(&mut self) -> &mut Self {
+        use std::os::windows::fs::OpenOptionsExt;
+        self.custom_flags(
+            winapi::um::winbase::FILE_FLAG_RANDOM_ACCESS
+                | winapi::um::winbase::FILE_FLAG_WRITE_THROUGH
+                | winapi::um::winbase::FILE_FLAG_NO_BUFFERING,
         )
     }
 

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -148,6 +148,7 @@ where
         )
         .collect::<Vec<_>>();
 
+    let sector_contents_map_size = SectorContentsMap::encoded_size(pieces_in_sector) as u64;
     match sector {
         ReadAt::Sync(sector) => {
             read_chunks_inputs.into_par_iter().flatten().try_for_each(
@@ -156,8 +157,7 @@ where
                     sector
                         .read_at(
                             &mut record_chunk,
-                            SectorContentsMap::encoded_size(pieces_in_sector) as u64
-                                + chunk_location * Scalar::FULL_BYTES as u64,
+                            sector_contents_map_size + chunk_location * Scalar::FULL_BYTES as u64,
                         )
                         .map_err(|error| ReadingError::FailedToReadChunk {
                             chunk_location,
@@ -198,8 +198,7 @@ where
                             &sector
                                 .read_at(
                                     vec![0; Scalar::FULL_BYTES],
-                                    SectorContentsMap::encoded_size(pieces_in_sector) as u64
-                                        + chunk_location * Scalar::FULL_BYTES as u64,
+                                    sector_contents_map_size + chunk_location * Scalar::FULL_BYTES as u64,
                                 )
                                 .await
                                 .map_err(|error| ReadingError::FailedToReadChunk {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -289,7 +289,7 @@ fn prove(
                 .open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
-            let options = PlotAuditOptions::<PosTable> {
+            let mut options = PlotAuditOptions::<PosTable> {
                 public_key: single_disk_farm_info.public_key(),
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
@@ -304,7 +304,7 @@ fn prove(
                 kzg: &kzg,
                 erasure_coding: &erasure_coding,
                 maybe_sector_being_modified: None,
-                table_generator: &table_generator,
+                table_generator: &Mutex::new(PosTable::generator()),
             };
 
             let mut audit_results = plot_audit.audit(options).unwrap();
@@ -316,12 +316,13 @@ fn prove(
                             return result;
                         }
 
+                        options.slot_info.global_challenge = rand::random();
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
                     |(_sector_index, mut provable_solutions)| {
-                        while (provable_solutions.next()).is_none() {
+                        while black_box(provable_solutions.next()).is_none() {
                             // Try to create one solution and exit
                         }
                     },
@@ -336,7 +337,7 @@ fn prove(
             )
             .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
-            let options = PlotAuditOptions::<PosTable> {
+            let mut options = PlotAuditOptions::<PosTable> {
                 public_key: single_disk_farm_info.public_key(),
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
@@ -362,12 +363,13 @@ fn prove(
                             return result;
                         }
 
+                        options.slot_info.global_challenge = rand::random();
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
                     |(_sector_index, mut provable_solutions)| {
-                        while (provable_solutions.next()).is_none() {
+                        while black_box(provable_solutions.next()).is_none() {
                             // Try to create one solution and exit
                         }
                     },
@@ -379,7 +381,7 @@ fn prove(
             let plot = RayonFiles::open(&disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
-            let options = PlotAuditOptions::<PosTable> {
+            let mut options = PlotAuditOptions::<PosTable> {
                 public_key: single_disk_farm_info.public_key(),
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
@@ -405,12 +407,13 @@ fn prove(
                             return result;
                         }
 
+                        options.slot_info.global_challenge = rand::random();
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
                     },
                     |(_sector_index, mut provable_solutions)| {
-                        while (provable_solutions.next()).is_none() {
+                        while black_box(provable_solutions.next()).is_none() {
                             // Try to create one solution and exit
                         }
                     },

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -9,6 +9,7 @@
     iter_collect_into,
     let_chains,
     never_type,
+    slice_flatten,
     trait_alias,
     try_blocks,
     type_alias_impl_trait,

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -1,4 +1,5 @@
 pub mod rayon_files;
+pub mod unbuffered_io_file_windows;
 
 use crate::node_client;
 use crate::node_client::NodeClient;

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -9,7 +9,7 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 use parking_lot::Mutex;
-use rayon::ThreadPoolBuildError;
+use rayon::{ThreadPool, ThreadPoolBuildError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, io};
@@ -23,7 +23,7 @@ use subspace_farmer_components::ReadAtSync;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
 use thiserror::Error;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn, Span};
 
 /// Auditing details
 #[derive(Debug, Copy, Clone, Encode, Decode)]
@@ -331,6 +331,7 @@ pub(super) struct FarmingOptions<NC, PlotAudit> {
     pub(super) handlers: Arc<Handlers>,
     pub(super) modifying_sector_index: Arc<RwLock<Option<SectorIndex>>>,
     pub(super) slot_info_notifications: mpsc::Receiver<SlotInfo>,
+    pub(super) thread_pool: ThreadPool,
 }
 
 /// Starts farming process.
@@ -356,6 +357,7 @@ where
         handlers,
         modifying_sector_index,
         mut slot_info_notifications,
+        thread_pool,
     } = farming_options;
 
     let farmer_app_info = node_client
@@ -367,6 +369,7 @@ where
     let farming_timeout = farmer_app_info.farming_timeout;
 
     let table_generator = Arc::new(Mutex::new(PosTable::generator()));
+    let span = Span::current();
 
     while let Some(slot_info) = slot_info_notifications.next().await {
         let result: Result<(), FarmingError> = try {
@@ -380,15 +383,19 @@ where
                 let modifying_sector_guard = modifying_sector_index.read().await;
                 let maybe_sector_being_modified = modifying_sector_guard.as_ref().copied();
 
-                plot_audit.audit(PlotAuditOptions::<PosTable> {
-                    public_key: &public_key,
-                    reward_address: &reward_address,
-                    slot_info,
-                    sectors_metadata: &sectors_metadata,
-                    kzg: &kzg,
-                    erasure_coding: &erasure_coding,
-                    maybe_sector_being_modified,
-                    table_generator: &table_generator,
+                thread_pool.install(|| {
+                    let _span_guard = span.enter();
+
+                    plot_audit.audit(PlotAuditOptions::<PosTable> {
+                        public_key: &public_key,
+                        reward_address: &reward_address,
+                        slot_info,
+                        sectors_metadata: &sectors_metadata,
+                        kzg: &kzg,
+                        erasure_coding: &erasure_coding,
+                        maybe_sector_being_modified,
+                        table_generator: &table_generator,
+                    })
                 })?
             };
 
@@ -401,6 +408,8 @@ where
                 a_solution_distance.cmp(&b_solution_distance)
             });
 
+            let mut sectors_solutions = sectors_solutions.into_iter();
+
             handlers
                 .farming_notification
                 .call_simple(&FarmingNotification::Auditing(AuditingDetails {
@@ -408,7 +417,13 @@ where
                     time: start.elapsed(),
                 }));
 
-            'solutions_processing: for (sector_index, sector_solutions) in sectors_solutions {
+            'solutions_processing: while let Some((sector_index, sector_solutions)) = thread_pool
+                .install(|| {
+                    let _span_guard = span.enter();
+
+                    sectors_solutions.next()
+                })
+            {
                 if sector_solutions.is_empty() {
                     continue;
                 }

--- a/crates/subspace-farmer/src/single_disk_farm/farming/unbuffered_io_file_windows.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming/unbuffered_io_file_windows.rs
@@ -25,13 +25,13 @@ impl ReadAtSync for UnbufferedIoFileWindows {
         // extra bytes at the beginning and the end that will be thrown away
         let bytes_to_read = buf.len();
         let offset_in_buffer = (offset % DISK_SECTOR_SIZE as u64) as usize;
-        buffer.resize(
-            (bytes_to_read + offset_in_buffer).div_ceil(DISK_SECTOR_SIZE),
-            [0; DISK_SECTOR_SIZE],
-        );
+        let desired_buffer_size = (bytes_to_read + offset_in_buffer).div_ceil(DISK_SECTOR_SIZE);
+        if buffer.len() < desired_buffer_size {
+            buffer.resize(desired_buffer_size, [0; DISK_SECTOR_SIZE]);
+        }
 
         self.file.read_at(
-            buffer.flatten_mut(),
+            buffer[..desired_buffer_size].flatten_mut(),
             offset / DISK_SECTOR_SIZE as u64 * DISK_SECTOR_SIZE as u64,
         )?;
 

--- a/crates/subspace-farmer/src/single_disk_farm/farming/unbuffered_io_file_windows.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming/unbuffered_io_file_windows.rs
@@ -1,0 +1,97 @@
+use parking_lot::Mutex;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+#[cfg(windows)]
+use subspace_farmer_components::file_ext::OpenOptionsExt;
+use subspace_farmer_components::ReadAtSync;
+
+/// 4096 is as a relatively safe size due to sector size on SSDs commonly being 512 or 4096 bytes
+pub const DISK_SECTOR_SIZE: usize = 4096;
+
+/// Wrapper data structure for unbuffered I/O on Windows.
+// TODO: Implement `FileExt` and use for all reads on Windows
+pub struct UnbufferedIoFileWindows {
+    file: File,
+    /// Scratch buffer of aligned memory for reads and writes
+    buffer: Mutex<Vec<[u8; DISK_SECTOR_SIZE]>>,
+}
+
+impl ReadAtSync for UnbufferedIoFileWindows {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
+        let mut buffer = self.buffer.lock();
+
+        // Make scratch buffer of a size that is necessary to read aligned memory, accounting for
+        // extra bytes at the beginning and the end that will be thrown away
+        let bytes_to_read = buf.len();
+        let offset_in_buffer = (offset % DISK_SECTOR_SIZE as u64) as usize;
+        buffer.resize(
+            (bytes_to_read + offset_in_buffer).div_ceil(DISK_SECTOR_SIZE),
+            [0; DISK_SECTOR_SIZE],
+        );
+
+        self.file.read_at(
+            buffer.flatten_mut(),
+            offset / DISK_SECTOR_SIZE as u64 * DISK_SECTOR_SIZE as u64,
+        )?;
+
+        buf.copy_from_slice(&buffer.flatten()[offset_in_buffer..][..bytes_to_read]);
+
+        Ok(())
+    }
+}
+
+impl ReadAtSync for &UnbufferedIoFileWindows {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
+        (*self).read_at(buf, offset)
+    }
+}
+
+impl UnbufferedIoFileWindows {
+    /// Open file at specified path for random unbuffered access on Windows.
+    ///
+    /// This abstraction is useless on other platforms and will just result in extra memory copies
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let mut open_options = OpenOptions::new();
+        #[cfg(windows)]
+        open_options.advise_random_unbuffered();
+        let file = open_options.read(true).open(path)?;
+
+        Ok(Self {
+            file,
+            buffer: Mutex::default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::single_disk_farm::farming::unbuffered_io_file_windows::UnbufferedIoFileWindows;
+    use rand::prelude::*;
+    use std::fs;
+    use subspace_farmer_components::ReadAtSync;
+    use tempfile::tempdir;
+
+    #[test]
+    fn basic() {
+        let tempdir = tempdir().unwrap();
+        let file_path = tempdir.as_ref().join("file.bin");
+        let mut data = vec![0u8; 4096 * 2];
+        thread_rng().fill(data.as_mut_slice());
+        fs::write(&file_path, &data).unwrap();
+
+        let file = UnbufferedIoFileWindows::open(&file_path).unwrap();
+
+        let mut buffer = Vec::new();
+        for (offset, size) in [(0_usize, 4096_usize), (0, 4000), (5, 50), (5, 4091)] {
+            buffer.resize(size, 0);
+            file.read_at(buffer.as_mut_slice(), offset as u64)
+                .unwrap_or_else(|error| panic!("Offset {offset}, size {size}: {error}"));
+            assert_eq!(
+                &data[offset..][..size],
+                buffer.as_slice(),
+                "Offset {offset}, size {size}"
+            );
+        }
+    }
+}

--- a/crates/subspace-farmer/src/single_disk_farm/farming/unbuffered_io_file_windows.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming/unbuffered_io_file_windows.rs
@@ -54,7 +54,7 @@ impl UnbufferedIoFileWindows {
     pub fn open(path: &Path) -> io::Result<Self> {
         let mut open_options = OpenOptions::new();
         #[cfg(windows)]
-        open_options.advise_random_unbuffered();
+        open_options.advise_unbuffered();
         let file = open_options.read(true).open(path)?;
 
         Ok(Self {


### PR DESCRIPTION
This PR makes farming on Windows use unbuffered I/O, which avoids memory usage issues, but also has annoying alignment requirements. Users are [testing this on the forum](https://forum.subspace.network/t/fake-display-of-high-ram-usage-or-ram-leak-on-windows-by-subspace-farmer/2354/45?u=nazar-pc) already.

Since reads we're doing during farming are tiny, I didn't implement fast path for cases where both read target and memory buffer into which read bytes are written are already aligned (it will not be a typical case for farming anyway), but that could be a hypothetical improvement.

Farming is a fairly limited in scope code path, so it was relatively easy to add there. We do have other places where reads are doing the old way though and I think there will be value of expanding there as well (left TODO about this). We can replace the whole `File` with this `UnbufferedIoFileWindows` for both reads and writes a bit later by implementing `FileExt` on it, but this PR should already be a huge improvement as is.

PR includes a few basic tests with aligned and unaligned reads that are cross-platform for convenience, but `UnbufferedIoFileWindows` only makes sense to use on Windows due to unnecessary copying on other platforms that do not suffer from memory usage bugs in the first place.

I also noticed a bit better auditing and proving performance with these changes (nothing to phone home about, but still), which are not very surprising.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
