### PR TITLE
Downgrade `DuplicatedBundle` and `InvalidProofOfTime` bad bundle warning log to debug level

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1416,8 +1416,10 @@ mod pallet {
                             | BundleError::Receipt(BlockTreeError::NewBranchReceipt)
                             | BundleError::Receipt(BlockTreeError::UnavailableConsensusBlockHash)
                             | BundleError::Receipt(BlockTreeError::BuiltOnUnknownConsensusBlock)
+                            | BundleError::DuplicatedBundle
                             | BundleError::SlotInThePast
-                            | BundleError::SlotInTheFuture => {
+                            | BundleError::SlotInTheFuture
+                            | BundleError::InvalidProofOfTime => {
                                 log::debug!(
                                     target: "runtime::domains",
                                     "Bad bundle {:?}, error: {e:?}", opaque_bundle.domain_id(),


### PR DESCRIPTION
These warning logs are expected in some edge cases due to network delay and race conditions:
- `DuplicatedBundle`:
    -  after a bundle is included in a block and before the bundle is removed from tx pool, re-validation of the tx in pool is triggered and found the bundle is already included in the chain
    -  the node syncs a block from other peers and a bundle is included in the block, then the same bundle is broadcasted to the node again
- `InvalidProofOfTime`:
    - the node didn’t run a timekeeper, and the bundle is broadcasted to the node before the PoT.
    - the bundle is broadcasted to the node before it is fully synced

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
