### PR TITLE
Introduce bundle longevity

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -20,7 +20,7 @@ use sp_domains::{
     dummy_opaque_bundle, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
     OperatorPublicKey, RuntimeType,
 };
-use sp_runtime::traits::{BlockNumberProvider, CheckedAdd, One, Zero};
+use sp_runtime::traits::{CheckedAdd, One, Zero};
 
 const SEED: u32 = 0;
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -91,9 +91,8 @@ pub trait BlockSlot<T: frame_system::Config> {
     // Return the future slot of the given `block_number`
     fn future_slot(block_number: BlockNumberFor<T>) -> Option<sp_consensus_slots::Slot>;
 
-    // Return the latest block number whose slot is less than the given `to_check` slot,
-    // return zero if no such block found.
-    fn slot_produced_after(to_check: sp_consensus_slots::Slot) -> BlockNumberFor<T>;
+    // Return the latest block number whose slot is less than the given `to_check` slot
+    fn slot_produced_after(to_check: sp_consensus_slots::Slot) -> Option<BlockNumberFor<T>>;
 }
 
 pub type ExecutionReceiptOf<T> = ExecutionReceipt<
@@ -1624,7 +1623,8 @@ impl<T: Config> Pallet<T> {
         }
 
         // Check if the bundle is built too long time ago and beyond `T::BundleLongevity` number of consensus blocks.
-        let produced_after_block_number = T::BlockSlot::slot_produced_after(slot_number.into());
+        let produced_after_block_number = T::BlockSlot::slot_produced_after(slot_number.into())
+            .ok_or(BundleError::SlotInThePast)?;
         let produced_after_block_hash = if produced_after_block_number == current_block_number {
             // The hash of the current block is only available in the next block thus use the parent hash here
             frame_system::Pallet::<T>::parent_hash()

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -223,8 +223,8 @@ impl BlockSlot<Test> for DummyBlockSlot {
         Some(0u64.into())
     }
 
-    fn slot_produced_after(_slot: sp_consensus_slots::Slot) -> BlockNumberFor<Test> {
-        0u64
+    fn slot_produced_after(_slot: sp_consensus_slots::Slot) -> Option<BlockNumberFor<Test>> {
+        Some(0u64)
     }
 }
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -186,6 +186,7 @@ parameter_types! {
     pub const DomainChainByteFee: Balance = 1;
     pub const MaxInitialDomainAccounts: u32 = 5;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
+    pub const BundleLongevity: u32 = 5;
 }
 
 pub struct MockRandomness;
@@ -217,13 +218,13 @@ impl StorageFee<Balance> for DummyStorageFee {
 
 pub struct DummyBlockSlot;
 
-impl BlockSlot for DummyBlockSlot {
-    fn current_slot() -> sp_consensus_slots::Slot {
-        0u64.into()
+impl BlockSlot<Test> for DummyBlockSlot {
+    fn future_slot(_block_number: BlockNumberFor<Test>) -> Option<sp_consensus_slots::Slot> {
+        Some(0u64.into())
     }
 
-    fn future_slot() -> sp_consensus_slots::Slot {
-        0u64.into()
+    fn slot_produced_after(_slot: sp_consensus_slots::Slot) -> BlockNumberFor<Test> {
+        0u64
     }
 }
 
@@ -309,6 +310,7 @@ impl pallet_domains::Config for Test {
     type DomainsTransfersTracker = MockDomainsTransfersTracker;
     type MaxInitialDomainAccounts = MaxInitialDomainAccounts;
     type MinInitialDomainAccountBalance = MinInitialDomainAccountBalance;
+    type BundleLongevity = BundleLongevity;
 }
 
 pub struct ExtrinsicStorageFees;

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -244,7 +244,7 @@ pub mod pallet {
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
 
-        /// How many block slot to keep
+        /// Maximum number of block number to block slot mappings to keep (oldest pruned first).
         #[pallet::constant]
         type BlockSlotCount: Get<u32>;
     }
@@ -381,6 +381,7 @@ pub mod pallet {
     #[pallet::getter(fn current_slot)]
     pub type CurrentSlot<T> = StorageValue<_, Slot, ValueQuery>;
 
+    /// Bounded mapping from block number to slot
     #[pallet::storage]
     #[pallet::getter(fn block_slots)]
     pub type BlockSlots<T: Config> =

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -176,6 +176,7 @@ parameter_types! {
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
     pub const ShouldAdjustSolutionRange: bool = false;
+    pub const BlockSlotCount: u32 = 6;
 }
 
 impl Config for Test {
@@ -195,6 +196,7 @@ impl Config for Test {
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type EraChangeTrigger = NormalEraChange;
+    type BlockSlotCount = BlockSlotCount;
 
     type HandleEquivocation = EquivocationHandler<OffencesSubspace, ReportLongevity>;
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -319,6 +319,7 @@ parameter_types! {
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
+    pub const BlockSlotCount: u32 = 6;
 }
 
 pub struct ConfirmationDepthK;
@@ -594,6 +595,7 @@ parameter_types! {
     pub const DomainsPalletId: PalletId = PalletId(*b"domains_");
     pub const MaxInitialDomainAccounts: u32 = 10;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
+    pub const BundleLongevity: u32 = 5;
 }
 
 // Minimum operator stake must be >= minimum nominator stake since operator is also a nominator.

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -2936,7 +2936,7 @@ async fn stale_and_in_future_bundle_should_be_rejected() {
     .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
     .await;
 
-    produce_blocks!(ferdie, alice, 1).await.unwrap();
+    produce_blocks!(ferdie, alice, 10).await.unwrap();
     let bundle_to_tx = |opaque_bundle| {
         subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
             pallet_domains::Call::submit_bundle { opaque_bundle }.into(),
@@ -2969,21 +2969,23 @@ async fn stale_and_in_future_bundle_should_be_rejected() {
         )
     };
 
-    let (_, bundle1) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
-    let (_, bundle2) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
     ferdie.clear_tx_pool().await.unwrap();
 
-    // Produce one block that only included `bundle1`
-    produce_block_with!(
-        ferdie.produce_block_with_extrinsics(vec![bundle_to_tx(bundle1)]),
-        alice
-    )
-    .await
-    .unwrap();
+    // Bundle is valid and can submit to tx pool for 5 consensus blocks
+    for _ in 0..5 {
+        ferdie
+            .submit_transaction(bundle_to_tx(bundle.clone()))
+            .await
+            .unwrap();
 
-    // `bundle2` will be rejected because its PoT is stale
+        ferdie.produce_block_with_extrinsics(vec![]).await.unwrap();
+        ferdie.clear_tx_pool().await.unwrap();
+    }
+
+    // Bundle will be rejected because its PoT is stale now
     match ferdie
-        .submit_transaction(bundle_to_tx(bundle2))
+        .submit_transaction(bundle_to_tx(bundle))
         .await
         .unwrap_err()
     {
@@ -2992,6 +2994,20 @@ async fn stale_and_in_future_bundle_should_be_rejected() {
         }
         e => panic!("Unexpected error: {e}"),
     }
+
+    // Produce a bundle with slot newer than the consensus block slot but less its the future slot
+    let slot = ferdie.produce_slot();
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    produce_block_with!(
+        ferdie.produce_block_with_slot_at(
+            slot,
+            ferdie.client.info().best_hash,
+            Some(vec![bundle_to_tx(bundle)])
+        ),
+        alice
+    )
+    .await
+    .unwrap();
 
     // Bundle with unknow PoT and in future slot will be rejected before entring the tx pool
     let (valid_slot, valid_pot) = ferdie.produce_slot();

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -271,6 +271,7 @@ parameter_types! {
         HistorySize::new(NonZeroU64::new(10).unwrap()),
     );
     pub const MinSectorLifetime: HistorySize = HistorySize::new(NonZeroU64::new(4).unwrap());
+    pub const BlockSlotCount: u32 = 6;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -290,6 +291,7 @@ impl pallet_subspace::Config for Runtime {
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
+    type BlockSlotCount = BlockSlotCount;
 
     type HandleEquivocation = pallet_subspace::equivocation::EquivocationHandler<
         OffencesSubspace,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -642,6 +642,10 @@ parameter_types! {
 // keep enough block slot for bundle validation
 const_assert!(BlockSlotCount::get() >= 2 && BlockSlotCount::get() > BundleLongevity::get());
 
+// `BlockHashCount` must greater than `BlockSlotCount` because we need to use the block number found
+// with `BlockSlotCount` to get the block hash.
+const_assert!(BlockHashCount::get() > BlockSlotCount::get());
+
 // Minimum operator stake must be >= minimum nominator stake since operator is also a nominator.
 const_assert!(MinOperatorStake::get() >= MinNominatorStake::get());
 
@@ -655,14 +659,14 @@ impl pallet_domains::BlockSlot<Runtime> for BlockSlot {
             .map(|slot| *slot + Slot::from(BlockAuthoringDelay::get()))
     }
 
-    fn slot_produced_after(to_check: sp_consensus_slots::Slot) -> BlockNumber {
+    fn slot_produced_after(to_check: sp_consensus_slots::Slot) -> Option<BlockNumber> {
         let block_slots = Subspace::block_slots();
         for (block_number, slot) in block_slots.into_iter().rev() {
             if to_check > slot {
-                return block_number;
+                return Some(block_number);
             }
         }
-        Zero::zero()
+        None
     }
 }
 


### PR DESCRIPTION
This PR introduces bundle longevity, for bundle produced from the last 5 consensus blocks won't be considered stale (in main bundle produced before the parent block will be considered as stale), this should ideally fix the issue mentioned at https://github.com/subspace/subspace/pull/2516#issuecomment-1933848405 and slow domain block production in 3h.

This PR also introduces an additional storage item `BlockSlots` to `pallet-subspace` to keep track of the slot of the last 6 blocks, it can be used to replace the `CurrentSlot` and the `current_slot` and `parent_slot` fields in `ParentVoteVerificationData`, but more mitigation code will be required for keeping compatible with 3h, which will be done in a separate PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
