### PR TITLE
Benchmark for fast way to read record chunks

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -54,6 +54,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector_sync;
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions};
+use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::shim::ShimTable;
 use subspace_proof_of_space::{Table, TableGenerator};
@@ -481,9 +482,13 @@ pub fn create_signed_vote(
 
         let solution = audit_result
             .solution_candidates
-            .into_solutions(&reward_address, kzg, erasure_coding, |seed: &PosSeed| {
-                table_generator.generate_parallel(seed)
-            })
+            .into_solutions(
+                &reward_address,
+                kzg,
+                erasure_coding,
+                ReadSectorRecordChunksMode::ConcurrentChunks,
+                |seed: &PosSeed| table_generator.generate_parallel(seed),
+            )
             .unwrap()
             .next()
             .unwrap()

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -20,6 +20,7 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_plot_sync;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
+use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
@@ -176,9 +177,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         if !solution_candidates
             .clone()
-            .into_solutions(reward_address, kzg, erasure_coding, |seed: &PosSeed| {
-                table_generator.generate_parallel(seed)
-            })
+            .into_solutions(
+                reward_address,
+                kzg,
+                erasure_coding,
+                ReadSectorRecordChunksMode::ConcurrentChunks,
+                |seed: &PosSeed| table_generator.generate_parallel(seed),
+            )
             .unwrap()
             .is_empty()
         {
@@ -199,6 +204,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         black_box(reward_address),
                         black_box(kzg),
                         black_box(erasure_coding),
+                        black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                         black_box(|seed: &PosSeed| table_generator.lock().generate_parallel(seed)),
                     )
                     .unwrap()
@@ -266,6 +272,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                                     black_box(reward_address),
                                     black_box(kzg),
                                     black_box(erasure_coding),
+                                    black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                                     black_box(|seed: &PosSeed| {
                                         table_generator.lock().generate_parallel(seed)
                                     }),

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -16,7 +16,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
-use subspace_farmer_components::reading::read_piece;
+use subspace_farmer_components::reading::{read_piece, ReadSectorRecordChunksMode};
 use subspace_farmer_components::sector::{
     sector_size, SectorContentsMap, SectorMetadata, SectorMetadataChecksummed,
 };
@@ -159,6 +159,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&plotted_sector.sector_metadata),
                 black_box(&ReadAt::from_sync(&plotted_sector_bytes)),
                 black_box(&erasure_coding),
+                black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                 black_box(&mut *table_generator.lock()),
             )
             .now_or_never()
@@ -202,6 +203,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&plotted_sector.sector_metadata),
                         black_box(&ReadAt::from_sync(&sector)),
                         black_box(&erasure_coding),
+                        black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                         black_box(&mut *table_generator.lock()),
                     )
                     .now_or_never()

--- a/crates/subspace-farmer-components/src/proving.rs
+++ b/crates/subspace-farmer-components/src/proving.rs
@@ -1,5 +1,7 @@
 use crate::auditing::ChunkCandidate;
-use crate::reading::{read_record_metadata, read_sector_record_chunks, ReadingError};
+use crate::reading::{
+    read_record_metadata, read_sector_record_chunks, ReadSectorRecordChunksMode, ReadingError,
+};
 use crate::sector::{
     SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadataChecksummed,
 };
@@ -152,6 +154,7 @@ where
         reward_address: &'a RewardAddress,
         kzg: &'a Kzg,
         erasure_coding: &'a ErasureCoding,
+        mode: ReadSectorRecordChunksMode,
         table_generator: TableGenerator,
     ) -> Result<impl ProvableSolutions<Item = MaybeSolution<RewardAddress>> + 'a, ProvingError>
     where
@@ -169,6 +172,7 @@ where
             kzg,
             erasure_coding,
             self.chunk_candidates,
+            mode,
             table_generator,
         )
     }
@@ -195,6 +199,7 @@ where
     winning_chunks: VecDeque<WinningChunk>,
     count: usize,
     best_solution_distance: Option<SolutionRange>,
+    mode: ReadSectorRecordChunksMode,
     table_generator: TableGenerator,
 }
 
@@ -242,6 +247,7 @@ where
                 &self.sector_contents_map,
                 &pos_table,
                 &self.sector,
+                self.mode,
             );
             let sector_record_chunks = sector_record_chunks_fut
                 .now_or_never()
@@ -346,6 +352,7 @@ where
         kzg: &'a Kzg,
         erasure_coding: &'a ErasureCoding,
         chunk_candidates: VecDeque<ChunkCandidate>,
+        mode: ReadSectorRecordChunksMode,
         table_generator: TableGenerator,
     ) -> Result<Self, ProvingError> {
         if erasure_coding.max_shards() < Record::NUM_S_BUCKETS {
@@ -405,6 +412,7 @@ where
             winning_chunks,
             count,
             best_solution_distance,
+            mode,
             table_generator,
         })
     }

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -11,9 +11,7 @@ use std::io;
 use std::mem::ManuallyDrop;
 use std::simd::Simd;
 use subspace_core_primitives::crypto::{blake3_hash, Scalar};
-use subspace_core_primitives::{
-    Piece, PieceOffset, Record, RecordCommitment, RecordWitness, SBucket, SectorId,
-};
+use subspace_core_primitives::{Piece, PieceOffset, Record, SBucket, SectorId};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_proof_of_space::{Table, TableGenerator};
 use thiserror::Error;
@@ -88,17 +86,6 @@ impl ReadingError {
             ReadingError::ChecksumMismatch => false,
         }
     }
-}
-
-/// Record contained in the plot
-#[derive(Debug, Clone)]
-pub struct PlotRecord {
-    /// Record scalars
-    pub scalars: Box<[Scalar; Record::NUM_CHUNKS]>,
-    /// Record commitment
-    pub commitment: RecordCommitment,
-    /// Record witness
-    pub witness: RecordWitness,
 }
 
 /// Read sector record chunks, only plotted s-buckets are returned (in decoded form).

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -630,6 +630,7 @@ where
 
     let (single_disk_farms, plotting_delay_senders) = tokio::task::block_in_place(|| {
         let handle = Handle::current();
+        let faster_read_sector_record_chunks_mode_concurrency = &Semaphore::new(1);
         let (plotting_delay_senders, plotting_delay_receivers) = (0..disk_farms.len())
             .map(|_| oneshot::channel())
             .unzip::<_, _, Vec<_>, Vec<_>>();
@@ -664,6 +665,7 @@ where
                             plotting_thread_pool_manager: plotting_thread_pool_manager.clone(),
                             plotting_delay: Some(plotting_delay_receiver),
                             disable_farm_locking,
+                            faster_read_sector_record_chunks_mode_concurrency,
                         },
                         disk_farm_index,
                     );

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -50,7 +50,7 @@ use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
 use thread_priority::ThreadPriority;
 use tokio::runtime::Handle;
-use tokio::sync::Semaphore;
+use tokio::sync::{Barrier, Semaphore};
 use tracing::{debug, error, info, info_span, warn};
 use zeroize::Zeroizing;
 
@@ -630,6 +630,7 @@ where
 
     let (single_disk_farms, plotting_delay_senders) = tokio::task::block_in_place(|| {
         let handle = Handle::current();
+        let faster_read_sector_record_chunks_mode_barrier = &Barrier::new(disk_farms.len());
         let faster_read_sector_record_chunks_mode_concurrency = &Semaphore::new(1);
         let (plotting_delay_senders, plotting_delay_receivers) = (0..disk_farms.len())
             .map(|_| oneshot::channel())
@@ -665,6 +666,7 @@ where
                             plotting_thread_pool_manager: plotting_thread_pool_manager.clone(),
                             plotting_delay: Some(plotting_delay_receiver),
                             disable_farm_locking,
+                            faster_read_sector_record_chunks_mode_barrier,
                             faster_read_sector_record_chunks_mode_concurrency,
                         },
                         disk_farm_index,

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -8,7 +8,7 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 use parking_lot::Mutex;
-use rayon::{ThreadPool, ThreadPoolBuildError};
+use rayon::ThreadPool;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt, io};
@@ -118,9 +118,6 @@ pub enum FarmingError {
     /// I/O error occurred
     #[error("Farming I/O error: {0}")]
     Io(#[from] io::Error),
-    /// Failed to create thread pool
-    #[error("Failed to create thread pool: {0}")]
-    FailedToCreateThreadPool(#[from] ThreadPoolBuildError),
     /// Decoded farming error
     #[error("Decoded farming error {0}")]
     Decoded(DecodedFarmingError),
@@ -152,7 +149,6 @@ impl FarmingError {
             FarmingError::LowLevelAuditing(_) => "LowLevelAuditing",
             FarmingError::LowLevelProving(_) => "LowLevelProving",
             FarmingError::Io(_) => "Io",
-            FarmingError::FailedToCreateThreadPool(_) => "FailedToCreateThreadPool",
             FarmingError::Decoded(_) => "Decoded",
             FarmingError::SlotNotificationStreamEnded => "SlotNotificationStreamEnded",
         }
@@ -166,7 +162,6 @@ impl FarmingError {
             FarmingError::LowLevelAuditing(_) => true,
             FarmingError::LowLevelProving(error) => error.is_fatal(),
             FarmingError::Io(_) => true,
-            FarmingError::FailedToCreateThreadPool(_) => true,
             FarmingError::Decoded(error) => error.is_fatal,
             FarmingError::SlotNotificationStreamEnded => true,
         }

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -41,6 +41,7 @@ use subspace_core_primitives::{
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::auditing::audit_sector_sync;
 use subspace_farmer_components::plotting::{plot_sector, PlotSectorOptions, PlottedSector};
+use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_runtime_primitives::opaque::Block;
@@ -175,9 +176,13 @@ async fn start_farming<PosTable, Client>(
                 .unwrap()
                 .unwrap()
                 .solution_candidates
-                .into_solutions(&public_key, &kzg, &erasure_coding, |seed: &PosSeed| {
-                    table_generator.generate_parallel(seed)
-                })
+                .into_solutions(
+                    &public_key,
+                    &kzg,
+                    &erasure_coding,
+                    ReadSectorRecordChunksMode::ConcurrentChunks,
+                    |seed: &PosSeed| table_generator.generate_parallel(seed),
+                )
                 .unwrap()
                 .next()
                 .expect("With max solution range there must be a solution; qed")


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/2581 changed sector record chunks behavior on Windows to read the whole sector rather than individual chunks. Turns out it is not platform-specific and not one-size-fits-all.

This PR exposes two options in the API of `subspace-farmer-components` and implements a benchmark to pick the best one for each farm specifically, improving chances of proving in time.

Benchmark is primitive: simply tired both ways 3 times and picks whichever was the fastest all all. This is very naive, but quick and should be still representative of relative differences of both approaches relatively to each other.

Fixes https://github.com/subspace/subspace/issues/2591

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
