### PR TITLE
Pause plotting, farming and piece reading while proving is happening to give it the highest chance of success

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -630,6 +630,7 @@ where
 
     let (single_disk_farms, plotting_delay_senders) = tokio::task::block_in_place(|| {
         let handle = Handle::current();
+        let global_mutex = Arc::default();
         let faster_read_sector_record_chunks_mode_barrier = &Barrier::new(disk_farms.len());
         let faster_read_sector_record_chunks_mode_concurrency = &Semaphore::new(1);
         let (plotting_delay_senders, plotting_delay_receivers) = (0..disk_farms.len())
@@ -665,6 +666,7 @@ where
                             farming_thread_pool_size,
                             plotting_thread_pool_manager: plotting_thread_pool_manager.clone(),
                             plotting_delay: Some(plotting_delay_receiver),
+                            global_mutex: Arc::clone(&global_mutex),
                             disable_farm_locking,
                             faster_read_sector_record_chunks_mode_barrier,
                             faster_read_sector_record_chunks_mode_concurrency,


### PR DESCRIPTION
Assuming that various farmer operations concurrently with proving impact proving success, this PR pauses them for the proving duration. Given the fact that proving happens rarely and for short period of time, this shouldn't be a big issue, but should improve proving success.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
