### PR TITLE
XDM: Permissioned Channel - 2

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -832,6 +832,18 @@ pub enum StakingHoldIdentifier {
     Staked(OperatorId),
 }
 
+/// Channel identity.
+pub type ChannelId = sp_core::U256;
+
+/// Messenger specific hold identifier
+#[derive(
+    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
+)]
+pub enum MessengerHoldIdentifier {
+    /// Holds the current reserved balance for channel opening
+    Channel((ChainId, ChannelId)),
+}
+
 /// Domains specific Identifier for Balances holds.
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -60,8 +60,9 @@ use sp_core::crypto::{ByteArray, KeyTypeId};
 use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
-    DomainAllowlistUpdates, DomainId, DomainInstanceData, DomainsHoldIdentifier,
-    ExecutionReceiptFor, OpaqueBundle, OperatorId, OperatorPublicKey, StakingHoldIdentifier,
+    ChannelId, DomainAllowlistUpdates, DomainId, DomainInstanceData, DomainsHoldIdentifier,
+    ExecutionReceiptFor, MessengerHoldIdentifier, OpaqueBundle, OperatorId, OperatorPublicKey,
+    StakingHoldIdentifier,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
@@ -375,6 +376,7 @@ parameter_types! {
 )]
 pub enum HoldIdentifier {
     Domains(DomainsHoldIdentifier),
+    Messenger(MessengerHoldIdentifier),
 }
 
 impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
@@ -390,6 +392,12 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
 
     fn storage_fund_withdrawal(operator_id: OperatorId) -> Self {
         Self::Domains(DomainsHoldIdentifier::StorageFund(operator_id))
+    }
+}
+
+impl pallet_messenger::HoldIdentifier for HoldIdentifier {
+    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
     }
 }
 
@@ -516,6 +524,11 @@ impl sp_messenger::StorageKeys for StorageKeys {
     }
 }
 
+parameter_types! {
+    // TODO: update value
+    pub const ChannelReserveFee: Balance = 100 * SSC;
+}
+
 impl pallet_messenger::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
@@ -537,6 +550,8 @@ impl pallet_messenger::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;
     type DomainOwner = Domains;
+    type HoldIdentifier = HoldIdentifier;
+    type ChannelReserveFee = ChannelReserveFee;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -395,7 +395,7 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
     }
 }
 
-impl pallet_messenger::HoldIdentifier for HoldIdentifier {
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
     fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
         Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
     }

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -3356,17 +3356,15 @@ async fn test_cross_domains_messages_should_work() {
     // Open channel between the Consensus chain and EVM domains
     let fee_model = FeeModel { relay_fee: 1 };
     alice
-        .construct_and_send_extrinsic(pallet_sudo::Call::sudo {
-            call: Box::new(evm_domain_test_runtime::RuntimeCall::Messenger(
-                pallet_messenger::Call::initiate_channel {
-                    dst_chain_id: ChainId::Consensus,
-                    params: InitiateChannelParams {
-                        max_outgoing_messages: 100,
-                        fee_model,
-                    },
+        .construct_and_send_extrinsic(evm_domain_test_runtime::RuntimeCall::Messenger(
+            pallet_messenger::Call::initiate_channel {
+                dst_chain_id: ChainId::Consensus,
+                params: InitiateChannelParams {
+                    max_outgoing_messages: 100,
+                    fee_model,
                 },
-            )),
-        })
+            },
+        ))
         .await
         .expect("Failed to construct and send extrinsic");
     // Wait until channel open
@@ -3399,6 +3397,31 @@ async fn test_cross_domains_messages_should_work() {
 
         post_alice_free_balance < pre_alice_free_balance - transfer_amount
             && post_ferdie_free_balance == pre_ferdie_free_balance + transfer_amount
+    })
+    .await
+    .unwrap();
+
+    // close channel on consensus chain using sudo since
+    // channel is opened on domain
+    let channel_id = alice
+        .get_open_channel_for_chain(ChainId::Consensus)
+        .unwrap();
+    ferdie
+        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
+            call: Box::new(subspace_test_runtime::RuntimeCall::Messenger(
+                pallet_messenger::Call::close_channel {
+                    chain_id: ChainId::Domain(GENESIS_DOMAIN_ID),
+                    channel_id,
+                },
+            )),
+        })
+        .await
+        .expect("Failed to construct and send consensus chain to close channel");
+    // Wait until channel close
+    produce_blocks_until!(ferdie, alice, {
+        alice
+            .get_open_channel_for_chain(ChainId::Consensus)
+            .is_none()
     })
     .await
     .unwrap();

--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -1,7 +1,7 @@
 //! Benchmarking for `pallet-messenger`.
 
 use super::*;
-use crate::Pallet as Messenger;
+use crate::{CloseChannelBy, Pallet as Messenger};
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
 use frame_support::traits::Get;
@@ -58,7 +58,8 @@ mod benchmarks {
         let channel_id = NextChannelId::<T>::get(dst_chain_id);
         assert_ok!(Messenger::<T>::do_init_channel(
             dst_chain_id,
-            dummy_channel_params::<T>()
+            dummy_channel_params::<T>(),
+            None,
         ));
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
         assert_eq!(channel.state, ChannelState::Initiated);
@@ -80,7 +81,11 @@ mod benchmarks {
 
         #[block]
         {
-            assert_ok!(Messenger::<T>::do_close_channel(dst_chain_id, channel_id));
+            assert_ok!(Messenger::<T>::do_close_channel(
+                dst_chain_id,
+                channel_id,
+                CloseChannelBy::Sudo
+            ));
         }
 
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
@@ -217,7 +222,7 @@ mod benchmarks {
         params: InitiateChannelParams<BalanceOf<T>>,
     ) -> ChannelId {
         let channel_id = NextChannelId::<T>::get(dst_chain_id);
-        assert_ok!(Messenger::<T>::do_init_channel(dst_chain_id, params));
+        assert_ok!(Messenger::<T>::do_init_channel(dst_chain_id, params, None));
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
         assert_eq!(channel.state, ChannelState::Initiated);
 

--- a/domains/pallets/messenger/src/messages.rs
+++ b/domains/pallets/messenger/src/messages.rs
@@ -2,8 +2,8 @@
 extern crate alloc;
 
 use crate::{
-    BalanceOf, BlockMessages as BlockMessagesStore, ChannelId, Channels, Config, Error, Event,
-    InboxResponses, Nonce, Outbox, OutboxMessageResult, Pallet,
+    BalanceOf, BlockMessages as BlockMessagesStore, ChannelId, Channels, CloseChannelBy, Config,
+    Error, Event, InboxResponses, Nonce, Outbox, OutboxMessageResult, Pallet,
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -226,7 +226,9 @@ impl<T: Config> Pallet<T> {
                 if weight_tag != &MessageWeightTag::ProtocolChannelClose {
                     return Err(Error::<T>::WeightTagNotMatch.into());
                 }
-                Self::do_close_channel(chain_id, channel_id)
+                // closing of this channel is coming from the other chain
+                // so safe to close it as Sudo here
+                Self::do_close_channel(chain_id, channel_id, CloseChannelBy::Sudo)
             }
         }
     }

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -33,6 +33,10 @@ macro_rules! impl_runtime {
             BlakeTwo256, ConstU16, ConstU32, ConstU64, Convert, IdentityLookup,
         };
         use sp_runtime::BuildStorage;
+        use crate::HoldIdentifier;
+        use sp_domains::ChannelId;
+        use scale_info::TypeInfo;
+        use codec::MaxEncodedLen;
 
         type Block = frame_system::mocking::MockBlock<Runtime>;
 
@@ -83,6 +87,17 @@ macro_rules! impl_runtime {
 
         parameter_types! {
             pub SelfChainId: ChainId = $chain_id.into();
+            pub const ChannelReserveFee: Balance = 10;
+        }
+
+        #[derive(
+            PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
+        )]
+        pub struct MockHoldIdentifer((ChainId, ChannelId));
+        impl HoldIdentifier for MockHoldIdentifer{
+            fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
+                MockHoldIdentifer((dst_chain_id, channel_id))
+            }
         }
 
         impl crate::Config for $runtime {
@@ -97,6 +112,8 @@ macro_rules! impl_runtime {
             type MmrProofVerifier = ();
             type StorageKeys = ();
             type DomainOwner = ();
+            type ChannelReserveFee = ChannelReserveFee;
+            type HoldIdentifier = MockHoldIdentifer;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(
                 #[allow(unused_variables)] endpoint: &Endpoint,

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -1,13 +1,14 @@
 use crate::mock::chain_a::{
     new_test_ext as new_chain_a_ext, Messenger, Runtime, RuntimeEvent, RuntimeOrigin, System,
+    USER_ACCOUNT,
 };
 use crate::mock::{
     chain_a, chain_b, storage_proof_of_inbox_message_responses, storage_proof_of_outbox_messages,
     AccountId, Balance, TestExternalities,
 };
 use crate::{
-    ChainAllowlist, Channel, ChannelId, ChannelState, Channels, Error, FeeModel, Inbox,
-    InboxResponses, Nonce, Outbox, OutboxMessageResult, OutboxResponses, Pallet, U256,
+    ChainAllowlist, Channel, ChannelId, ChannelState, Channels, CloseChannelBy, Error, FeeModel,
+    Inbox, InboxResponses, Nonce, Outbox, OutboxMessageResult, OutboxResponses, Pallet, U256,
 };
 use frame_support::{assert_err, assert_ok};
 use pallet_transporter::Location;
@@ -33,7 +34,7 @@ fn create_channel(chain_id: ChainId, channel_id: ChannelId, fee_model: FeeModel<
     let list = BTreeSet::from([chain_id]);
     ChainAllowlist::<chain_a::Runtime>::put(list);
     assert_ok!(Messenger::initiate_channel(
-        RuntimeOrigin::root(),
+        RuntimeOrigin::signed(USER_ACCOUNT),
         chain_id,
         params,
     ));
@@ -202,7 +203,7 @@ fn test_storage_proof_verification_invalid() {
 
     let (_, storage_key, storage_proof) =
         crate::mock::storage_proof_of_channels::<Runtime>(t.as_backend(), chain_id, channel_id);
-    let res: Result<Channel<Balance>, VerificationError> =
+    let res: Result<Channel<Balance, AccountId>, VerificationError> =
         StorageProofVerifier::<Blake2Hasher>::get_decoded_value(
             &H256::zero(),
             storage_proof,
@@ -223,7 +224,7 @@ fn test_storage_proof_verification_missing_value() {
 
     let (state_root, _, storage_proof) =
         crate::mock::storage_proof_of_channels::<Runtime>(t.as_backend(), chain_id, U256::one());
-    let res: Result<Channel<Balance>, VerificationError> =
+    let res: Result<Channel<Balance, AccountId>, VerificationError> =
         StorageProofVerifier::<Blake2Hasher>::get_decoded_value(
             &state_root,
             storage_proof,
@@ -246,7 +247,7 @@ fn test_storage_proof_verification() {
 
     let (state_root, storage_key, storage_proof) =
         crate::mock::storage_proof_of_channels::<Runtime>(t.as_backend(), chain_id, channel_id);
-    let res: Result<Channel<Balance>, VerificationError> =
+    let res: Result<Channel<Balance, AccountId>, VerificationError> =
         StorageProofVerifier::<Blake2Hasher>::get_decoded_value(
             &state_root,
             storage_proof,
@@ -489,7 +490,7 @@ fn force_toggle_channel_state<Runtime: crate::Config>(
     let channel = Pallet::<Runtime>::channels(dst_chain_id, channel_id).unwrap_or_else(|| {
         let list = BTreeSet::from([dst_chain_id]);
         ChainAllowlist::<Runtime>::put(list);
-        Pallet::<Runtime>::do_init_channel(dst_chain_id, init_params).unwrap();
+        Pallet::<Runtime>::do_init_channel(dst_chain_id, init_params, None).unwrap();
         Pallet::<Runtime>::channels(dst_chain_id, channel_id).unwrap()
     });
 
@@ -502,7 +503,8 @@ fn force_toggle_channel_state<Runtime: crate::Config>(
     }
 
     if channel.state == ChannelState::Open {
-        Pallet::<Runtime>::do_close_channel(dst_chain_id, channel_id).unwrap();
+        Pallet::<Runtime>::do_close_channel(dst_chain_id, channel_id, CloseChannelBy::Sudo)
+            .unwrap();
     }
 }
 

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -6,14 +6,11 @@ use crate::endpoint::{Endpoint, EndpointRequest, EndpointResponse};
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-pub use sp_domains::ChainId;
+pub use sp_domains::{ChainId, ChannelId};
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
 use sp_runtime::app_crypto::sp_core::U256;
 use sp_runtime::DispatchError;
 use sp_trie::StorageProof;
-
-/// Channel identity.
-pub type ChannelId = U256;
 
 /// Nonce used as an identifier and ordering of messages within a channel.
 /// Nonce is always increasing.

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(variant_count)]
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -14,6 +15,7 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
     block_weights, maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
@@ -30,7 +32,7 @@ use frame_support::pallet_prelude::TypeInfo;
 use frame_support::traits::fungible::Credit;
 use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, Currency, Everything, FindAuthor, Imbalance, OnFinalize,
-    OnUnbalanced,
+    OnUnbalanced, VariantCount,
 };
 use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
@@ -316,6 +318,10 @@ impl OnUnbalanced<Credit<AccountId, Balances>> for DustRemovalHandler {
     }
 }
 
+parameter_types! {
+    pub const MaxHolds: u32 = 100;
+}
+
 impl pallet_balances::Config for Runtime {
     type RuntimeFreezeReason = RuntimeFreezeReason;
     type MaxLocks = MaxLocks;
@@ -331,8 +337,8 @@ impl pallet_balances::Config for Runtime {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type MaxFreezes = ();
-    type RuntimeHoldReason = ();
-    type MaxHolds = ();
+    type RuntimeHoldReason = HoldIdentifier;
+    type MaxHolds = MaxHolds;
 }
 
 parameter_types! {
@@ -463,7 +469,11 @@ pub enum HoldIdentifier {
     Messenger(MessengerHoldIdentifier),
 }
 
-impl pallet_messenger::HoldIdentifier for HoldIdentifier {
+impl VariantCount for HoldIdentifier {
+    const VARIANT_COUNT: u32 = mem::variant_count::<Self>() as u32;
+}
+
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
     fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
         Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
     }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -55,8 +55,8 @@ use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainAllowlistUpdates, DomainId, DomainInstanceData, DomainsHoldIdentifier,
-    ExecutionReceiptFor, OpaqueBundle, OpaqueBundles, OperatorId, OperatorPublicKey,
-    StakingHoldIdentifier,
+    ExecutionReceiptFor, MessengerHoldIdentifier, OpaqueBundle, OpaqueBundles, OperatorId,
+    OperatorPublicKey, StakingHoldIdentifier,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
@@ -315,6 +315,7 @@ impl pallet_timestamp::Config for Runtime {
 )]
 pub enum HoldIdentifier {
     Domains(DomainsHoldIdentifier),
+    Messenger(MessengerHoldIdentifier),
 }
 
 impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
@@ -330,6 +331,12 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
 
     fn storage_fund_withdrawal(operator_id: OperatorId) -> Self {
         Self::Domains(DomainsHoldIdentifier::StorageFund(operator_id))
+    }
+}
+
+impl pallet_messenger::HoldIdentifier for HoldIdentifier {
+    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
     }
 }
 
@@ -563,6 +570,10 @@ impl sp_messenger::StorageKeys for StorageKeys {
     }
 }
 
+parameter_types! {
+    pub const ChannelReserveFee: Balance = SSC;
+}
+
 impl pallet_messenger::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
@@ -584,6 +595,8 @@ impl pallet_messenger::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;
     type DomainOwner = Domains;
+    type HoldIdentifier = HoldIdentifier;
+    type ChannelReserveFee = ChannelReserveFee;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -334,7 +334,7 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
     }
 }
 
-impl pallet_messenger::HoldIdentifier for HoldIdentifier {
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
     fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
         Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
     }


### PR DESCRIPTION
This PR brings the following changes
- Opening a channel requires a signed extrinsic and `ChannelReserveFee` is put on hold for the duration of the channel for the owner on the chain intiating the channel openeing.
- Closing a channel from `src_chain` that initialised the channel requires either channel owner or Sudo. Either case, the `ChannelReserveFee` is unlocked once the channel is closed. Channel on the dst_chain will close as Sudo as this will be a relay message.

Closes: #2611

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
