### PR TITLE
Async parallel farms initialization

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -5,6 +5,7 @@ use crate::commands::farm::dsn::configure_dsn;
 use crate::commands::farm::metrics::{FarmerMetrics, SectorState};
 use crate::utils::shutdown_signal;
 use anyhow::anyhow;
+use async_lock::Mutex as AsyncMutex;
 use backoff::ExponentialBackoff;
 use bytesize::ByteSize;
 use clap::{Parser, ValueHint};
@@ -13,7 +14,6 @@ use futures::stream::{FuturesOrdered, FuturesUnordered};
 use futures::{FutureExt, StreamExt};
 use parking_lot::Mutex;
 use prometheus_client::registry::Registry;
-use rayon::prelude::*;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::PathBuf;
@@ -49,7 +49,6 @@ use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
 use thread_priority::ThreadPriority;
-use tokio::runtime::Handle;
 use tokio::sync::{Barrier, Semaphore};
 use tracing::{debug, error, info, info_span, warn};
 use zeroize::Zeroizing;
@@ -650,46 +649,58 @@ where
         .map(|farming_thread_pool_size| farming_thread_pool_size.get())
         .unwrap_or_else(recommended_number_of_farming_threads);
 
-    let (single_disk_farms, plotting_delay_senders) = tokio::task::block_in_place(|| {
-        let handle = Handle::current();
+    let (single_disk_farms, plotting_delay_senders) = {
+        let node_rpc_url = &node_rpc_url;
         let global_mutex = Arc::default();
-        let info_mutex = &Mutex::<()>::default();
-        let faster_read_sector_record_chunks_mode_barrier = &Barrier::new(disk_farms.len());
-        let faster_read_sector_record_chunks_mode_concurrency = &Semaphore::new(1);
+        let info_mutex = &AsyncMutex::new(());
+        let faster_read_sector_record_chunks_mode_barrier =
+            Arc::new(Barrier::new(disk_farms.len()));
+        let faster_read_sector_record_chunks_mode_concurrency = Arc::new(Semaphore::new(1));
         let (plotting_delay_senders, plotting_delay_receivers) = (0..disk_farms.len())
             .map(|_| oneshot::channel())
             .unzip::<_, _, Vec<_>, Vec<_>>();
 
-        let single_disk_farms = disk_farms
-            .into_par_iter()
+        let mut single_disk_farms = Vec::with_capacity(disk_farms.len());
+        let mut single_disk_farms_stream = disk_farms
+            .into_iter()
             .zip(plotting_delay_receivers)
             .enumerate()
-            .map(
-                move |(disk_farm_index, (disk_farm, plotting_delay_receiver))| {
-                    let _tokio_handle_guard = handle.enter();
+            .map(|(disk_farm_index, (disk_farm, plotting_delay_receiver))| {
+                let farmer_app_info = farmer_app_info.clone();
+                let kzg = kzg.clone();
+                let erasure_coding = erasure_coding.clone();
+                let piece_getter = piece_getter.clone();
+                let downloading_semaphore = Arc::clone(&downloading_semaphore);
+                let plotting_thread_pool_manager = plotting_thread_pool_manager.clone();
+                let global_mutex = Arc::clone(&global_mutex);
+                let faster_read_sector_record_chunks_mode_barrier =
+                    Arc::clone(&faster_read_sector_record_chunks_mode_barrier);
+                let faster_read_sector_record_chunks_mode_concurrency =
+                    Arc::clone(&faster_read_sector_record_chunks_mode_concurrency);
 
+                async move {
                     debug!(url = %node_rpc_url, %disk_farm_index, "Connecting to node RPC");
-                    let node_client = handle.block_on(NodeRpcClient::new(&node_rpc_url))?;
+                    let node_client = NodeRpcClient::new(node_rpc_url).await?;
 
                     let single_disk_farm_fut = SingleDiskFarm::new::<_, _, PosTable>(
                         SingleDiskFarmOptions {
                             directory: disk_farm.directory.clone(),
-                            farmer_app_info: farmer_app_info.clone(),
+                            farmer_app_info,
                             allocated_space: disk_farm.allocated_plotting_space,
                             max_pieces_in_sector,
                             node_client,
                             reward_address,
-                            kzg: kzg.clone(),
-                            erasure_coding: erasure_coding.clone(),
-                            piece_getter: piece_getter.clone(),
+                            kzg,
+                            erasure_coding,
+                            piece_getter,
                             cache_percentage,
-                            downloading_semaphore: Arc::clone(&downloading_semaphore),
+                            downloading_semaphore,
                             record_encoding_concurrency,
                             farm_during_initial_plotting,
                             farming_thread_pool_size,
-                            plotting_thread_pool_manager: plotting_thread_pool_manager.clone(),
+                            plotting_thread_pool_manager,
                             plotting_delay: Some(plotting_delay_receiver),
-                            global_mutex: Arc::clone(&global_mutex),
+                            global_mutex,
                             disable_farm_locking,
                             faster_read_sector_record_chunks_mode_barrier,
                             faster_read_sector_record_chunks_mode_concurrency,
@@ -697,7 +708,7 @@ where
                         disk_farm_index,
                     );
 
-                    let single_disk_farm = match handle.block_on(single_disk_farm_fut) {
+                    let single_disk_farm = match single_disk_farm_fut.await {
                         Ok(single_disk_farm) => single_disk_farm,
                         Err(SingleDiskFarmError::InsufficientAllocatedSpace {
                             min_space,
@@ -719,7 +730,7 @@ where
                     };
 
                     if !no_info {
-                        let _info_guard = info_mutex.lock();
+                        let _info_guard = info_mutex.lock().await;
 
                         let info = single_disk_farm.info();
                         println!("Single disk farm {disk_farm_index}:");
@@ -735,12 +746,16 @@ where
                     }
 
                     Ok(single_disk_farm)
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?;
+                }
+            })
+            .collect::<FuturesUnordered<_>>();
 
-        anyhow::Ok((single_disk_farms, plotting_delay_senders))
-    })?;
+        while let Some(single_disk_farm) = single_disk_farms_stream.next().await {
+            single_disk_farms.push(single_disk_farm?);
+        }
+
+        (single_disk_farms, plotting_delay_senders)
+    };
 
     {
         let handler_id = Arc::new(Mutex::new(None));

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -574,6 +574,25 @@ struct Handlers {
     solution: Handler<SolutionResponse>,
 }
 
+struct SingleDiskFarmInit {
+    identity: Identity,
+    single_disk_farm_info: SingleDiskFarmInfo,
+    single_disk_farm_info_lock: Option<SingleDiskFarmInfoLock>,
+    #[cfg(not(windows))]
+    plot_file: Arc<File>,
+    #[cfg(windows)]
+    plot_file: Arc<UnbufferedIoFileWindows>,
+    #[cfg(not(windows))]
+    metadata_file: File,
+    #[cfg(windows)]
+    metadata_file: UnbufferedIoFileWindows,
+    metadata_header: PlotMetadataHeader,
+    target_sector_count: u16,
+    sectors_metadata: Arc<AsyncRwLock<Vec<SectorMetadataChecksummed>>>,
+    piece_cache: DiskPieceCache,
+    plot_cache: DiskPlotCache,
+}
+
 /// Single disk farm abstraction is a container for everything necessary to plot/farm with a single
 /// disk.
 ///
@@ -626,17 +645,35 @@ impl SingleDiskFarm {
         PG: PieceGetter + Clone + Send + Sync + 'static,
         PosTable: Table,
     {
+        let span = info_span!("", %disk_farm_index);
+        let span_guard = span.enter();
+
+        let SingleDiskFarmInit {
+            identity,
+            single_disk_farm_info,
+            single_disk_farm_info_lock,
+            plot_file,
+            metadata_file,
+            metadata_header,
+            target_sector_count,
+            sectors_metadata,
+            piece_cache,
+            plot_cache,
+        } = Self::init(&options)?;
+
+        let public_key = *single_disk_farm_info.public_key();
+        let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
+        let sector_size = sector_size(pieces_in_sector);
+        let sector_metadata_size = SectorMetadataChecksummed::encoded_size();
+
         let SingleDiskFarmOptions {
             directory,
             farmer_app_info,
-            allocated_space,
-            max_pieces_in_sector,
             node_client,
             reward_address,
             piece_getter,
             kzg,
             erasure_coding,
-            cache_percentage,
             downloading_semaphore,
             record_encoding_concurrency,
             farming_thread_pool_size,
@@ -644,308 +681,10 @@ impl SingleDiskFarm {
             plotting_delay,
             farm_during_initial_plotting,
             global_mutex,
-            disable_farm_locking,
             faster_read_sector_record_chunks_mode_barrier,
             faster_read_sector_record_chunks_mode_concurrency,
+            ..
         } = options;
-        fs::create_dir_all(&directory)?;
-
-        let span = info_span!("", %disk_farm_index);
-        let span_guard = span.enter();
-
-        let identity = Identity::open_or_create(&directory)?;
-        let public_key = identity.public_key().to_bytes().into();
-
-        let single_disk_farm_info = match SingleDiskFarmInfo::load_from(&directory)? {
-            Some(mut single_disk_farm_info) => {
-                if &farmer_app_info.genesis_hash != single_disk_farm_info.genesis_hash() {
-                    return Err(SingleDiskFarmError::WrongChain {
-                        id: *single_disk_farm_info.id(),
-                        correct_chain: hex::encode(single_disk_farm_info.genesis_hash()),
-                        wrong_chain: hex::encode(farmer_app_info.genesis_hash),
-                    });
-                }
-
-                if &public_key != single_disk_farm_info.public_key() {
-                    return Err(SingleDiskFarmError::IdentityMismatch {
-                        id: *single_disk_farm_info.id(),
-                        correct_public_key: *single_disk_farm_info.public_key(),
-                        wrong_public_key: public_key,
-                    });
-                }
-
-                let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
-
-                if max_pieces_in_sector < pieces_in_sector {
-                    return Err(SingleDiskFarmError::InvalidPiecesInSector {
-                        id: *single_disk_farm_info.id(),
-                        max_supported: max_pieces_in_sector,
-                        initialized_with: pieces_in_sector,
-                    });
-                }
-
-                if max_pieces_in_sector > pieces_in_sector {
-                    info!(
-                        pieces_in_sector,
-                        max_pieces_in_sector,
-                        "Farm initialized with smaller number of pieces in sector, farm needs to \
-                        be re-created for increase"
-                    );
-                }
-
-                if allocated_space != single_disk_farm_info.allocated_space() {
-                    info!(
-                        old_space = %bytesize::to_string(single_disk_farm_info.allocated_space(), true),
-                        new_space = %bytesize::to_string(allocated_space, true),
-                        "Farm size has changed"
-                    );
-
-                    {
-                        let new_allocated_space = allocated_space;
-                        let SingleDiskFarmInfo::V0 {
-                            allocated_space, ..
-                        } = &mut single_disk_farm_info;
-                        *allocated_space = new_allocated_space;
-                    }
-
-                    single_disk_farm_info.store_to(&directory)?;
-                }
-
-                single_disk_farm_info
-            }
-            None => {
-                let single_disk_farm_info = SingleDiskFarmInfo::new(
-                    SingleDiskFarmId::new(),
-                    farmer_app_info.genesis_hash,
-                    public_key,
-                    max_pieces_in_sector,
-                    allocated_space,
-                );
-
-                single_disk_farm_info.store_to(&directory)?;
-
-                single_disk_farm_info
-            }
-        };
-
-        let single_disk_farm_info_lock = if disable_farm_locking {
-            None
-        } else {
-            Some(
-                SingleDiskFarmInfo::try_lock(&directory)
-                    .map_err(SingleDiskFarmError::LikelyAlreadyInUse)?,
-            )
-        };
-
-        let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
-        let sector_size = sector_size(pieces_in_sector);
-        let sector_metadata_size = SectorMetadataChecksummed::encoded_size();
-        let single_sector_overhead = (sector_size + sector_metadata_size) as u64;
-        // Fixed space usage regardless of plot size
-        let fixed_space_usage = RESERVED_PLOT_METADATA
-            + RESERVED_FARM_INFO
-            + Identity::file_size() as u64
-            + KnownPeersManager::file_size(KNOWN_PEERS_CACHE_SIZE) as u64;
-        // Calculate how many sectors can fit
-        let target_sector_count = {
-            let potentially_plottable_space = allocated_space.saturating_sub(fixed_space_usage)
-                / 100
-                * (100 - u64::from(cache_percentage.get()));
-            // Do the rounding to make sure we have exactly as much space as fits whole number of
-            // sectors, account for disk sector size just in case
-            (potentially_plottable_space - DISK_SECTOR_SIZE as u64) / single_sector_overhead
-        };
-
-        if target_sector_count == 0 {
-            let mut single_plot_with_cache_space =
-                single_sector_overhead.div_ceil(100 - u64::from(cache_percentage.get())) * 100;
-            // Cache must not be empty, ensure it contains at least one element even if
-            // percentage-wise it will use more space
-            if single_plot_with_cache_space - single_sector_overhead
-                < DiskPieceCache::element_size() as u64
-            {
-                single_plot_with_cache_space =
-                    single_sector_overhead + DiskPieceCache::element_size() as u64;
-            }
-
-            return Err(SingleDiskFarmError::InsufficientAllocatedSpace {
-                min_space: fixed_space_usage + single_plot_with_cache_space,
-                allocated_space,
-            });
-        }
-        let plot_file_size = target_sector_count * sector_size as u64;
-        // Align plot file size for disk sector size
-        let plot_file_size =
-            plot_file_size.div_ceil(DISK_SECTOR_SIZE as u64) * DISK_SECTOR_SIZE as u64;
-
-        // Remaining space will be used for caching purposes
-        let cache_capacity = {
-            let cache_space = allocated_space
-                - fixed_space_usage
-                - plot_file_size
-                - (sector_metadata_size as u64 * target_sector_count);
-            (cache_space / u64::from(DiskPieceCache::element_size())) as u32
-        };
-        let target_sector_count = match SectorIndex::try_from(target_sector_count) {
-            Ok(target_sector_count) if target_sector_count < SectorIndex::MAX => {
-                target_sector_count
-            }
-            _ => {
-                // We use this for both count and index, hence index must not reach actual `MAX`
-                // (consensus doesn't care about this, just farmer implementation detail)
-                let max_sectors = SectorIndex::MAX - 1;
-                return Err(SingleDiskFarmError::FarmTooLarge {
-                    allocated_space: target_sector_count * sector_size as u64,
-                    allocated_sectors: target_sector_count,
-                    max_space: max_sectors as u64 * sector_size as u64,
-                    max_sectors,
-                });
-            }
-        };
-
-        let metadata_file_path = directory.join(Self::METADATA_FILE);
-        #[cfg(not(windows))]
-        let mut metadata_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .advise_random_access()
-            .open(&metadata_file_path)?;
-
-        #[cfg(not(windows))]
-        metadata_file.advise_random_access()?;
-
-        #[cfg(windows)]
-        let mut metadata_file = UnbufferedIoFileWindows::open(&metadata_file_path)?;
-
-        let metadata_size = metadata_file.size()?;
-        let expected_metadata_size =
-            RESERVED_PLOT_METADATA + sector_metadata_size as u64 * u64::from(target_sector_count);
-        // Align plot file size for disk sector size
-        let expected_metadata_size =
-            expected_metadata_size.div_ceil(DISK_SECTOR_SIZE as u64) * DISK_SECTOR_SIZE as u64;
-        let metadata_header = if metadata_size == 0 {
-            let metadata_header = PlotMetadataHeader {
-                version: 0,
-                plotted_sector_count: 0,
-            };
-
-            metadata_file
-                .preallocate(expected_metadata_size)
-                .map_err(SingleDiskFarmError::CantPreallocateMetadataFile)?;
-            metadata_file.write_all_at(metadata_header.encode().as_slice(), 0)?;
-
-            metadata_header
-        } else {
-            if metadata_size != expected_metadata_size {
-                // Allocating the whole file (`set_len` below can create a sparse file, which will
-                // cause writes to fail later)
-                metadata_file
-                    .preallocate(expected_metadata_size)
-                    .map_err(SingleDiskFarmError::CantPreallocateMetadataFile)?;
-                // Truncating file (if necessary)
-                metadata_file.set_len(expected_metadata_size)?;
-            }
-
-            let mut metadata_header_bytes = vec![0; PlotMetadataHeader::encoded_size()];
-            metadata_file.read_exact_at(&mut metadata_header_bytes, 0)?;
-
-            let mut metadata_header =
-                PlotMetadataHeader::decode(&mut metadata_header_bytes.as_ref())
-                    .map_err(SingleDiskFarmError::FailedToDecodeMetadataHeader)?;
-
-            if metadata_header.version != Self::SUPPORTED_PLOT_VERSION {
-                return Err(SingleDiskFarmError::UnexpectedMetadataVersion(
-                    metadata_header.version,
-                ));
-            }
-
-            if metadata_header.plotted_sector_count > target_sector_count {
-                metadata_header.plotted_sector_count = target_sector_count;
-                metadata_file.write_all_at(&metadata_header.encode(), 0)?;
-            }
-
-            metadata_header
-        };
-
-        let sectors_metadata = {
-            let mut sectors_metadata =
-                Vec::<SectorMetadataChecksummed>::with_capacity(usize::from(target_sector_count));
-
-            let mut sector_metadata_bytes = vec![0; sector_metadata_size];
-            for sector_index in 0..metadata_header.plotted_sector_count {
-                let sector_offset =
-                    RESERVED_PLOT_METADATA + sector_metadata_size as u64 * u64::from(sector_index);
-                metadata_file.read_exact_at(&mut sector_metadata_bytes, sector_offset)?;
-
-                let sector_metadata =
-                    match SectorMetadataChecksummed::decode(&mut sector_metadata_bytes.as_ref()) {
-                        Ok(sector_metadata) => sector_metadata,
-                        Err(error) => {
-                            warn!(
-                                path = %metadata_file_path.display(),
-                                %error,
-                                %sector_index,
-                                "Failed to decode sector metadata, replacing with dummy expired \
-                                sector metadata"
-                            );
-
-                            let dummy_sector = SectorMetadataChecksummed::from(SectorMetadata {
-                                sector_index,
-                                pieces_in_sector,
-                                s_bucket_sizes: Box::new([0; Record::NUM_S_BUCKETS]),
-                                history_size: HistorySize::from(SegmentIndex::ZERO),
-                            });
-                            metadata_file.write_all_at(&dummy_sector.encode(), sector_offset)?;
-
-                            dummy_sector
-                        }
-                    };
-                sectors_metadata.push(sector_metadata);
-            }
-
-            Arc::new(AsyncRwLock::new(sectors_metadata))
-        };
-
-        #[cfg(not(windows))]
-        let mut plot_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .advise_random_access()
-            .open(directory.join(Self::PLOT_FILE))?;
-
-        #[cfg(not(windows))]
-        plot_file.advise_random_access()?;
-
-        #[cfg(windows)]
-        let mut plot_file = UnbufferedIoFileWindows::open(&directory.join(Self::PLOT_FILE))?;
-
-        if plot_file.size()? != plot_file_size {
-            // Allocating the whole file (`set_len` below can create a sparse file, which will cause
-            // writes to fail later)
-            plot_file
-                .preallocate(plot_file_size)
-                .map_err(SingleDiskFarmError::CantPreallocatePlotFile)?;
-            // Truncating file (if necessary)
-            plot_file.set_len(plot_file_size)?;
-
-            // TODO: Hack due to Windows bugs:
-            //  https://learn.microsoft.com/en-us/answers/questions/1608540/getfileinformationbyhandle-followed-by-read-with-f
-            if cfg!(windows) {
-                warn!("Farm was resized, farmer restart is needed for optimal performance!")
-            }
-        }
-
-        let plot_file = Arc::new(plot_file);
-
-        let piece_cache = DiskPieceCache::open(&directory, cache_capacity)?;
-        let plot_cache = DiskPlotCache::new(
-            &plot_file,
-            &sectors_metadata,
-            target_sector_count,
-            sector_size,
-        );
 
         let (error_sender, error_receiver) = oneshot::channel();
         let error_sender = Arc::new(Mutex::new(Some(error_sender)));
@@ -1282,6 +1021,332 @@ impl SingleDiskFarm {
         };
 
         Ok(farm)
+    }
+
+    fn init<NC, PG>(
+        options: &SingleDiskFarmOptions<'_, NC, PG>,
+    ) -> Result<SingleDiskFarmInit, SingleDiskFarmError> {
+        let SingleDiskFarmOptions {
+            directory,
+            farmer_app_info,
+            allocated_space,
+            max_pieces_in_sector,
+            cache_percentage,
+            disable_farm_locking,
+            ..
+        } = options;
+
+        let allocated_space = *allocated_space;
+        let max_pieces_in_sector = *max_pieces_in_sector;
+
+        fs::create_dir_all(directory)?;
+
+        let identity = Identity::open_or_create(directory)?;
+        let public_key = identity.public_key().to_bytes().into();
+
+        let single_disk_farm_info = match SingleDiskFarmInfo::load_from(directory)? {
+            Some(mut single_disk_farm_info) => {
+                if &farmer_app_info.genesis_hash != single_disk_farm_info.genesis_hash() {
+                    return Err(SingleDiskFarmError::WrongChain {
+                        id: *single_disk_farm_info.id(),
+                        correct_chain: hex::encode(single_disk_farm_info.genesis_hash()),
+                        wrong_chain: hex::encode(farmer_app_info.genesis_hash),
+                    });
+                }
+
+                if &public_key != single_disk_farm_info.public_key() {
+                    return Err(SingleDiskFarmError::IdentityMismatch {
+                        id: *single_disk_farm_info.id(),
+                        correct_public_key: *single_disk_farm_info.public_key(),
+                        wrong_public_key: public_key,
+                    });
+                }
+
+                let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
+
+                if max_pieces_in_sector < pieces_in_sector {
+                    return Err(SingleDiskFarmError::InvalidPiecesInSector {
+                        id: *single_disk_farm_info.id(),
+                        max_supported: max_pieces_in_sector,
+                        initialized_with: pieces_in_sector,
+                    });
+                }
+
+                if max_pieces_in_sector > pieces_in_sector {
+                    info!(
+                        pieces_in_sector,
+                        max_pieces_in_sector,
+                        "Farm initialized with smaller number of pieces in sector, farm needs to \
+                        be re-created for increase"
+                    );
+                }
+
+                if allocated_space != single_disk_farm_info.allocated_space() {
+                    info!(
+                        old_space = %bytesize::to_string(single_disk_farm_info.allocated_space(), true),
+                        new_space = %bytesize::to_string(allocated_space, true),
+                        "Farm size has changed"
+                    );
+
+                    {
+                        let new_allocated_space = allocated_space;
+                        let SingleDiskFarmInfo::V0 {
+                            allocated_space, ..
+                        } = &mut single_disk_farm_info;
+                        *allocated_space = new_allocated_space;
+                    }
+
+                    single_disk_farm_info.store_to(directory)?;
+                }
+
+                single_disk_farm_info
+            }
+            None => {
+                let single_disk_farm_info = SingleDiskFarmInfo::new(
+                    SingleDiskFarmId::new(),
+                    farmer_app_info.genesis_hash,
+                    public_key,
+                    max_pieces_in_sector,
+                    allocated_space,
+                );
+
+                single_disk_farm_info.store_to(directory)?;
+
+                single_disk_farm_info
+            }
+        };
+
+        let single_disk_farm_info_lock = if *disable_farm_locking {
+            None
+        } else {
+            Some(
+                SingleDiskFarmInfo::try_lock(directory)
+                    .map_err(SingleDiskFarmError::LikelyAlreadyInUse)?,
+            )
+        };
+
+        let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
+        let sector_size = sector_size(pieces_in_sector);
+        let sector_metadata_size = SectorMetadataChecksummed::encoded_size();
+        let single_sector_overhead = (sector_size + sector_metadata_size) as u64;
+        // Fixed space usage regardless of plot size
+        let fixed_space_usage = RESERVED_PLOT_METADATA
+            + RESERVED_FARM_INFO
+            + Identity::file_size() as u64
+            + KnownPeersManager::file_size(KNOWN_PEERS_CACHE_SIZE) as u64;
+        // Calculate how many sectors can fit
+        let target_sector_count = {
+            let potentially_plottable_space = allocated_space.saturating_sub(fixed_space_usage)
+                / 100
+                * (100 - u64::from(cache_percentage.get()));
+            // Do the rounding to make sure we have exactly as much space as fits whole number of
+            // sectors, account for disk sector size just in case
+            (potentially_plottable_space - DISK_SECTOR_SIZE as u64) / single_sector_overhead
+        };
+
+        if target_sector_count == 0 {
+            let mut single_plot_with_cache_space =
+                single_sector_overhead.div_ceil(100 - u64::from(cache_percentage.get())) * 100;
+            // Cache must not be empty, ensure it contains at least one element even if
+            // percentage-wise it will use more space
+            if single_plot_with_cache_space - single_sector_overhead
+                < DiskPieceCache::element_size() as u64
+            {
+                single_plot_with_cache_space =
+                    single_sector_overhead + DiskPieceCache::element_size() as u64;
+            }
+
+            return Err(SingleDiskFarmError::InsufficientAllocatedSpace {
+                min_space: fixed_space_usage + single_plot_with_cache_space,
+                allocated_space,
+            });
+        }
+        let plot_file_size = target_sector_count * sector_size as u64;
+        // Align plot file size for disk sector size
+        let plot_file_size =
+            plot_file_size.div_ceil(DISK_SECTOR_SIZE as u64) * DISK_SECTOR_SIZE as u64;
+
+        // Remaining space will be used for caching purposes
+        let cache_capacity = {
+            let cache_space = allocated_space
+                - fixed_space_usage
+                - plot_file_size
+                - (sector_metadata_size as u64 * target_sector_count);
+            (cache_space / u64::from(DiskPieceCache::element_size())) as u32
+        };
+        let target_sector_count = match SectorIndex::try_from(target_sector_count) {
+            Ok(target_sector_count) if target_sector_count < SectorIndex::MAX => {
+                target_sector_count
+            }
+            _ => {
+                // We use this for both count and index, hence index must not reach actual `MAX`
+                // (consensus doesn't care about this, just farmer implementation detail)
+                let max_sectors = SectorIndex::MAX - 1;
+                return Err(SingleDiskFarmError::FarmTooLarge {
+                    allocated_space: target_sector_count * sector_size as u64,
+                    allocated_sectors: target_sector_count,
+                    max_space: max_sectors as u64 * sector_size as u64,
+                    max_sectors,
+                });
+            }
+        };
+
+        let metadata_file_path = directory.join(Self::METADATA_FILE);
+        #[cfg(not(windows))]
+        let mut metadata_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .advise_random_access()
+            .open(&metadata_file_path)?;
+
+        #[cfg(not(windows))]
+        metadata_file.advise_random_access()?;
+
+        #[cfg(windows)]
+        let mut metadata_file = UnbufferedIoFileWindows::open(&metadata_file_path)?;
+
+        let metadata_size = metadata_file.size()?;
+        let expected_metadata_size =
+            RESERVED_PLOT_METADATA + sector_metadata_size as u64 * u64::from(target_sector_count);
+        // Align plot file size for disk sector size
+        let expected_metadata_size =
+            expected_metadata_size.div_ceil(DISK_SECTOR_SIZE as u64) * DISK_SECTOR_SIZE as u64;
+        let metadata_header = if metadata_size == 0 {
+            let metadata_header = PlotMetadataHeader {
+                version: 0,
+                plotted_sector_count: 0,
+            };
+
+            metadata_file
+                .preallocate(expected_metadata_size)
+                .map_err(SingleDiskFarmError::CantPreallocateMetadataFile)?;
+            metadata_file.write_all_at(metadata_header.encode().as_slice(), 0)?;
+
+            metadata_header
+        } else {
+            if metadata_size != expected_metadata_size {
+                // Allocating the whole file (`set_len` below can create a sparse file, which will
+                // cause writes to fail later)
+                metadata_file
+                    .preallocate(expected_metadata_size)
+                    .map_err(SingleDiskFarmError::CantPreallocateMetadataFile)?;
+                // Truncating file (if necessary)
+                metadata_file.set_len(expected_metadata_size)?;
+            }
+
+            let mut metadata_header_bytes = vec![0; PlotMetadataHeader::encoded_size()];
+            metadata_file.read_exact_at(&mut metadata_header_bytes, 0)?;
+
+            let mut metadata_header =
+                PlotMetadataHeader::decode(&mut metadata_header_bytes.as_ref())
+                    .map_err(SingleDiskFarmError::FailedToDecodeMetadataHeader)?;
+
+            if metadata_header.version != Self::SUPPORTED_PLOT_VERSION {
+                return Err(SingleDiskFarmError::UnexpectedMetadataVersion(
+                    metadata_header.version,
+                ));
+            }
+
+            if metadata_header.plotted_sector_count > target_sector_count {
+                metadata_header.plotted_sector_count = target_sector_count;
+                metadata_file.write_all_at(&metadata_header.encode(), 0)?;
+            }
+
+            metadata_header
+        };
+
+        let sectors_metadata = {
+            let mut sectors_metadata =
+                Vec::<SectorMetadataChecksummed>::with_capacity(usize::from(target_sector_count));
+
+            let mut sector_metadata_bytes = vec![0; sector_metadata_size];
+            for sector_index in 0..metadata_header.plotted_sector_count {
+                let sector_offset =
+                    RESERVED_PLOT_METADATA + sector_metadata_size as u64 * u64::from(sector_index);
+                metadata_file.read_exact_at(&mut sector_metadata_bytes, sector_offset)?;
+
+                let sector_metadata =
+                    match SectorMetadataChecksummed::decode(&mut sector_metadata_bytes.as_ref()) {
+                        Ok(sector_metadata) => sector_metadata,
+                        Err(error) => {
+                            warn!(
+                                path = %metadata_file_path.display(),
+                                %error,
+                                %sector_index,
+                                "Failed to decode sector metadata, replacing with dummy expired \
+                                sector metadata"
+                            );
+
+                            let dummy_sector = SectorMetadataChecksummed::from(SectorMetadata {
+                                sector_index,
+                                pieces_in_sector,
+                                s_bucket_sizes: Box::new([0; Record::NUM_S_BUCKETS]),
+                                history_size: HistorySize::from(SegmentIndex::ZERO),
+                            });
+                            metadata_file.write_all_at(&dummy_sector.encode(), sector_offset)?;
+
+                            dummy_sector
+                        }
+                    };
+                sectors_metadata.push(sector_metadata);
+            }
+
+            Arc::new(AsyncRwLock::new(sectors_metadata))
+        };
+
+        #[cfg(not(windows))]
+        let mut plot_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .advise_random_access()
+            .open(directory.join(Self::PLOT_FILE))?;
+
+        #[cfg(not(windows))]
+        plot_file.advise_random_access()?;
+
+        #[cfg(windows)]
+        let mut plot_file = UnbufferedIoFileWindows::open(&directory.join(Self::PLOT_FILE))?;
+
+        if plot_file.size()? != plot_file_size {
+            // Allocating the whole file (`set_len` below can create a sparse file, which will cause
+            // writes to fail later)
+            plot_file
+                .preallocate(plot_file_size)
+                .map_err(SingleDiskFarmError::CantPreallocatePlotFile)?;
+            // Truncating file (if necessary)
+            plot_file.set_len(plot_file_size)?;
+
+            // TODO: Hack due to Windows bugs:
+            //  https://learn.microsoft.com/en-us/answers/questions/1608540/getfileinformationbyhandle-followed-by-read-with-f
+            if cfg!(windows) {
+                warn!("Farm was resized, farmer restart is needed for optimal performance!")
+            }
+        }
+
+        let plot_file = Arc::new(plot_file);
+
+        let piece_cache = DiskPieceCache::open(directory, cache_capacity)?;
+        let plot_cache = DiskPlotCache::new(
+            &plot_file,
+            &sectors_metadata,
+            target_sector_count,
+            sector_size,
+        );
+
+        Ok(SingleDiskFarmInit {
+            identity,
+            single_disk_farm_info,
+            single_disk_farm_info_lock,
+            plot_file,
+            metadata_file,
+            metadata_header,
+            target_sector_count,
+            sectors_metadata,
+            piece_cache,
+            plot_cache,
+        })
     }
 
     /// Collect summary of single disk farm for presentational purposes


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/2585 worked well for happy path, but especially after https://github.com/subspace/subspace/pull/2593 that introduced barrier stopped working for error case.

One of the reasons is use of `block_on` with barrier, which means in case of a single farm error farmer will simply get stuck unable to make any progress. By making farm initialization truly async we can abort initialization of any farm early and show error to the user.

First commit simply moves a big chunk of code around such that we can make it run in blocking task in second commit and third commit improves logging.

Another interesting edge case is that already successfully initialized farms were dropped (in case of error) from outside of Tokio context (it was only entered inside of `map`) causing panics with "there is no reactor running, must be called from the context of a Tokio 1.x runtime".

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
