### PR TITLE
feat: add api for query connected peers

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1106,11 +1106,13 @@ where
                     reward_signing_notification_stream: reward_signing_notification_stream.clone(),
                     archived_segment_notification_stream: archived_segment_notification_stream
                         .clone(),
+
                     dsn_bootstrap_nodes: dsn_bootstrap_nodes.clone(),
                     segment_headers_store: segment_headers_store.clone(),
                     sync_oracle: sync_oracle.clone(),
                     kzg: subspace_link.kzg().clone(),
                     backend: backend.clone(),
+                    node: node.clone(),
                 };
 
                 rpc::create_full(deps).map_err(Into::into)

--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -45,6 +45,7 @@ use std::sync::Arc;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::BlockNumber;
 use subspace_networking::libp2p::Multiaddr;
+use subspace_networking::Node;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Nonce};
 use substrate_frame_rpc_system::{System, SystemApiServer};
@@ -82,6 +83,8 @@ where
     pub kzg: Kzg,
     /// Backend used by the node.
     pub backend: Arc<B>,
+    /// Node used for network
+    pub node: Node,
 }
 
 /// Instantiate all full RPC extensions.
@@ -123,6 +126,7 @@ where
         sync_oracle,
         kzg,
         backend,
+        node,
     } = deps;
 
     let chain_name = chain_spec.name().to_string();
@@ -145,6 +149,7 @@ where
             sync_oracle,
             kzg,
             deny_unsafe,
+            node,
         })?
         .into_rpc(),
     )?;


### PR DESCRIPTION
### Code contributor checklist:

add api to insepect which node connection, for example i add a timekeep connect to my frends, but i cannot confirm the peer is in connection. so i add this api and use curl command 

```
curl.exe -i -X POST -H "Content-Type: application/json" -d "{\"jsonrpc\": \"2.0\", \"method\": \"subspace_connectedPeers\", \"id\": 1}" http://127.0.0.1:9944
```

* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
