### PR TITLE
Fix order of farms after initialization

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -767,8 +767,17 @@ where
 
                 error!(%error, "Single disk creation failed");
             }
-            single_disk_farms.push(single_disk_farm?);
+            single_disk_farms.push((disk_farm_index, single_disk_farm?));
         }
+
+        // Restore order after unordered initialization
+        single_disk_farms
+            .sort_unstable_by_key(|(disk_farm_index, _single_disk_farm)| *disk_farm_index);
+
+        let single_disk_farms = single_disk_farms
+            .into_iter()
+            .map(|(_disk_farm_index, single_disk_farm)| single_disk_farm)
+            .collect::<Vec<_>>();
 
         (single_disk_farms, plotting_delay_senders)
     };


### PR DESCRIPTION
Some things down from there expect farms to be in ascending order

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
