### PR TITLE
Make piece reading during `scrub` recoverable

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1931,12 +1931,8 @@ impl SingleDiskFarm {
                                 %offset,
                                 "Failed to read piece bytes"
                             );
-                            return Err(SingleDiskFarmScrubError::FailedToReadBytes {
-                                file: plot_file_path.clone(),
-                                size: piece.len() as u64,
-                                offset,
-                                error,
-                            });
+
+                            continue;
                         }
 
                         hasher.update(piece.as_ref());
@@ -1949,12 +1945,13 @@ impl SingleDiskFarm {
                             + u64::from(pieces_in_sector) * Piece::SIZE as u64;
                         if let Err(error) = plot_file.read_exact_at(&mut expected_checksum, offset)
                         {
-                            return Err(SingleDiskFarmScrubError::FailedToReadBytes {
-                                file: plot_file_path.clone(),
-                                size: expected_checksum.len() as u64,
-                                offset,
-                                error,
-                            });
+                            warn!(
+                                path = %plot_file_path.display(),
+                                %error,
+                                %sector_index,
+                                %offset,
+                                "Failed to read checksum bytes"
+                            );
                         }
                     }
 


### PR DESCRIPTION
It was possible to correct read errors on metadata, but not on sectors, which makes no logical sense. This could happen when SSD returns errors and is no longer able to recover some of the information. In that case we can just write a dummy sector over it and that should be sufficient to fix the issue, otherwise some farmers were throwing the whole farm away :confused: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
