### PR TITLE
Make thread pool manager async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite 0.2.13",
+]
+
+[[package]]
 name = "event-listener-primitives"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11616,6 +11627,7 @@ dependencies = [
  "clap",
  "criterion",
  "derive_more",
+ "event-listener 5.2.0",
  "event-listener-primitives",
  "fdlimit",
  "fs4 0.8.0",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -24,6 +24,7 @@ bytesize = "1.3.0"
 clap = { version = "4.4.18", features = ["color", "derive"] }
 criterion = { version = "0.5.1", default-features = false, features = ["rayon", "async"] }
 derive_more = "0.99.17"
+event-listener = "5.2.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.3.0"
 fs4 = "0.8.0"

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -374,7 +374,7 @@ where
                 })
             };
 
-            let thread_pools = plotting_thread_pool_manager.get_thread_pools();
+            let thread_pools = plotting_thread_pool_manager.get_thread_pools().await;
             let thread_pool = if replotting {
                 &thread_pools.replotting
             } else {


### PR DESCRIPTION
This is a simple change that I'll need for plotting pausing in Space Acres. While it would be possible to implement with blocking API as well, it makes things unnecessarily more complex than with async API.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
