### PR TITLE
Fix sector scrub

### DIFF
--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -460,6 +460,7 @@ where
     // * sector contents map
     // * record chunks as s-buckets
     // * record metadata
+    // * checksum
     {
         let (sector_contents_map_region, remaining_bytes) =
             sector_output.split_at_mut(SectorContentsMap::encoded_size(pieces_in_sector));

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/scrub.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/scrub.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use subspace_farmer::single_disk_farm::SingleDiskFarm;
 use tracing::{error, info, info_span};
 
-pub(crate) fn scrub(disk_farms: &[PathBuf], disable_farm_locking: bool) {
+pub(crate) fn scrub(disk_farms: &[PathBuf], disable_farm_locking: bool, dry_run: bool) {
     disk_farms
         .into_par_iter()
         .enumerate()
@@ -15,7 +15,7 @@ pub(crate) fn scrub(disk_farms: &[PathBuf], disable_farm_locking: bool) {
                 "Start scrubbing farm"
             );
 
-            match SingleDiskFarm::scrub(directory, disable_farm_locking) {
+            match SingleDiskFarm::scrub(directory, disable_farm_locking, dry_run) {
                 Ok(()) => {
                     info!(
                         path = %directory.display(),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -45,6 +45,9 @@ enum Command {
         /// Disable farm locking, for example if file system doesn't support it
         #[arg(long)]
         disable_farm_locking: bool,
+        /// Check for errors, but do not attempt to correct them
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Wipes the farm
     Wipe {
@@ -101,11 +104,12 @@ async fn main() -> anyhow::Result<()> {
         Command::Scrub {
             disk_farms,
             disable_farm_locking,
+            dry_run,
         } => {
             if disk_farms.is_empty() {
                 info!("No farm was specified, so there is nothing to do");
             } else {
-                commands::scrub(&disk_farms, disable_farm_locking);
+                commands::scrub(&disk_farms, disable_farm_locking, dry_run);
             }
         }
         Command::Wipe { disk_farms } => {


### PR DESCRIPTION
First of all this PR implements `--dry-run` option for scrubbing, which was both useful for debugging for me and could be useful in some other scenarios for farmers.

Second, due to incorrect assumptions of sector layout scrubbing wasn't working correctly and due to https://github.com/subspace/subspace/pull/2633 was silently expiring all sectors, forcing replotting. Reading sector as a series of opaque bytes rather than some specific contents fixes that and makes it more resilient to potential future changes.

Tested with both correctly plotted farm and corrupted one, works as expected for me.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
