### PR TITLE
No `--dry-run` by default

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -46,7 +46,7 @@ enum Command {
         #[arg(long)]
         disable_farm_locking: bool,
         /// Check for errors, but do not attempt to correct them
-        #[arg(long)]
+        #[arg(long, default_value_t = false, action = clap::ArgAction::Set)]
         dry_run: bool,
     },
     /// Wipes the farm


### PR DESCRIPTION
Was accidentally used by default

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
