### PR TITLE
Keep domain compatible with gemini-3h

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1549,7 +1549,7 @@ mod pallet {
                     if let Err(e) = Self::validate_fraud_proof(fraud_proof) {
                         log::warn!(
                             target: "runtime::domains",
-                            "Bad fraud proof {:?}, error: {e:?}", fraud_proof.domain_id(),
+                            "Bad fraud proof {fraud_proof}, error: {e:?}",
                         );
                         return InvalidTransactionCode::FraudProof.into();
                     }

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1549,7 +1549,7 @@ mod pallet {
                     if let Err(e) = Self::validate_fraud_proof(fraud_proof) {
                         log::warn!(
                             target: "runtime::domains",
-                            "Bad fraud proof {fraud_proof}, error: {e:?}",
+                            "Bad fraud proof {fraud_proof:?}, error: {e:?}",
                         );
                         return InvalidTransactionCode::FraudProof.into();
                     }

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -5,6 +5,7 @@ use crate::verification::InvalidBundleEquivocationError;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
+use core::fmt;
 use scale_info::TypeInfo;
 use sp_consensus_slots::Slot;
 use sp_core::H256;
@@ -547,6 +548,53 @@ where
 {
     pub fn hash(&self) -> HeaderHashFor<DomainHeader> {
         HeaderHashingFor::<DomainHeader>::hash(&self.encode())
+    }
+}
+
+impl<Number, Hash, DomainHeader: HeaderT> fmt::Display for FraudProof<Number, Hash, DomainHeader> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let domain_id = self.domain_id();
+        let bad_receipt_hash = self.targeted_bad_receipt_hash();
+        let bad_operator = self.targeted_bad_operator_and_slot_for_bundle_equivocation();
+        f.write_str(
+            match self {
+                Self::InvalidStateTransition(_) => {
+                    format!("InvalidStateTransition({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::InvalidTransaction(_) => {
+                    format!("InvalidTransaction({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::ImproperTransactionSortition(_) => {
+                    format!("ImproperTransactionSortition({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::BundleEquivocation(_) => {
+                    format!("BundleEquivocation({domain_id:?}#{bad_operator:?}) fraud proof")
+                }
+                Self::InvalidExtrinsicsRoot(_) => {
+                    format!("InvalidExtrinsicsRoot({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::InvalidBlockFees(_) => {
+                    format!("InvalidBlockFees({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::ValidBundle(_) => {
+                    format!("ValidBundle({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::InvalidBundles(_) => {
+                    format!("InvalidBundles({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::InvalidDomainBlockHash(_) => {
+                    format!("InvalidDomainBlockHash({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                Self::InvalidTransfers(_) => {
+                    format!("InvalidTransfers({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+                #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
+                Self::Dummy { .. } => {
+                    format!("Dummy({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                }
+            }
+            .as_str(),
+        )
     }
 }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -556,45 +556,72 @@ impl<Number, Hash, DomainHeader: HeaderT> fmt::Display for FraudProof<Number, Ha
         let domain_id = self.domain_id();
         let bad_receipt_hash = self.targeted_bad_receipt_hash();
         let bad_operator = self.targeted_bad_operator_and_slot_for_bundle_equivocation();
-        f.write_str(
-            match self {
-                Self::InvalidStateTransition(_) => {
-                    format!("InvalidStateTransition({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::InvalidTransaction(_) => {
-                    format!("InvalidTransaction({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::ImproperTransactionSortition(_) => {
-                    format!("ImproperTransactionSortition({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::BundleEquivocation(_) => {
-                    format!("BundleEquivocation({domain_id:?}#{bad_operator:?}) fraud proof")
-                }
-                Self::InvalidExtrinsicsRoot(_) => {
-                    format!("InvalidExtrinsicsRoot({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::InvalidBlockFees(_) => {
-                    format!("InvalidBlockFees({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::ValidBundle(_) => {
-                    format!("ValidBundle({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::InvalidBundles(_) => {
-                    format!("InvalidBundles({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::InvalidDomainBlockHash(_) => {
-                    format!("InvalidDomainBlockHash({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                Self::InvalidTransfers(_) => {
-                    format!("InvalidTransfers({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
-                #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
-                Self::Dummy { .. } => {
-                    format!("Dummy({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
-                }
+        match self {
+            Self::InvalidStateTransition(_) => {
+                write!(
+                    f,
+                    "InvalidStateTransition({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
             }
-            .as_str(),
-        )
+            Self::InvalidTransaction(_) => {
+                write!(
+                    f,
+                    "InvalidTransaction({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::ImproperTransactionSortition(_) => {
+                write!(
+                    f,
+                    "ImproperTransactionSortition({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::BundleEquivocation(_) => {
+                write!(
+                    f,
+                    "BundleEquivocation({domain_id:?}#{bad_operator:?}) fraud proof"
+                )
+            }
+            Self::InvalidExtrinsicsRoot(_) => {
+                write!(
+                    f,
+                    "InvalidExtrinsicsRoot({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::InvalidBlockFees(_) => {
+                write!(
+                    f,
+                    "InvalidBlockFees({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::ValidBundle(_) => {
+                write!(
+                    f,
+                    "ValidBundle({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::InvalidBundles(_) => {
+                write!(
+                    f,
+                    "InvalidBundles({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::InvalidDomainBlockHash(_) => {
+                write!(
+                    f,
+                    "InvalidDomainBlockHash({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            Self::InvalidTransfers(_) => {
+                write!(
+                    f,
+                    "InvalidTransfers({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                )
+            }
+            #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
+            Self::Dummy { .. } => {
+                write!(f, "Dummy({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+            }
+        }
     }
 }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -455,7 +455,7 @@ impl<ReceiptHash> InvalidBundlesFraudProof<ReceiptHash> {
 /// Fraud proof.
 // TODO: Revisit when fraud proof v2 is implemented.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+#[derive(Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub enum FraudProof<Number, Hash, DomainHeader: HeaderT> {
     InvalidStateTransition(InvalidStateTransitionProof<HeaderHashFor<DomainHeader>>),
     InvalidTransaction(InvalidTransactionProof<HeaderHashFor<DomainHeader>>),
@@ -551,7 +551,7 @@ where
     }
 }
 
-impl<Number, Hash, DomainHeader: HeaderT> fmt::Display for FraudProof<Number, Hash, DomainHeader> {
+impl<Number, Hash, DomainHeader: HeaderT> fmt::Debug for FraudProof<Number, Hash, DomainHeader> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let domain_id = self.domain_id();
         let bad_receipt_hash = self.targeted_bad_receipt_hash();
@@ -560,66 +560,66 @@ impl<Number, Hash, DomainHeader: HeaderT> fmt::Display for FraudProof<Number, Ha
             Self::InvalidStateTransition(_) => {
                 write!(
                     f,
-                    "InvalidStateTransition({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidStateTransitionFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::InvalidTransaction(_) => {
                 write!(
                     f,
-                    "InvalidTransaction({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidTransactionFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::ImproperTransactionSortition(_) => {
                 write!(
                     f,
-                    "ImproperTransactionSortition({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "ImproperTransactionSortitionFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::BundleEquivocation(_) => {
                 write!(
                     f,
-                    "BundleEquivocation({domain_id:?}#{bad_operator:?}) fraud proof"
+                    "BundleEquivocationFraudProof({domain_id:?}#{bad_operator:?})"
                 )
             }
             Self::InvalidExtrinsicsRoot(_) => {
                 write!(
                     f,
-                    "InvalidExtrinsicsRoot({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidExtrinsicsRootFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::InvalidBlockFees(_) => {
                 write!(
                     f,
-                    "InvalidBlockFees({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidBlockFeesFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::ValidBundle(_) => {
                 write!(
                     f,
-                    "ValidBundle({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "ValidBundleFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::InvalidBundles(_) => {
                 write!(
                     f,
-                    "InvalidBundles({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidBundlesFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::InvalidDomainBlockHash(_) => {
                 write!(
                     f,
-                    "InvalidDomainBlockHash({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidDomainBlockHashFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             Self::InvalidTransfers(_) => {
                 write!(
                     f,
-                    "InvalidTransfers({domain_id:?}#{bad_receipt_hash:?}) fraud proof"
+                    "InvalidTransfersFraudProof({domain_id:?}#{bad_receipt_hash:?})"
                 )
             }
             #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
             Self::Dummy { .. } => {
-                write!(f, "Dummy({domain_id:?}#{bad_receipt_hash:?}) fraud proof")
+                write!(f, "DummyFraudProof({domain_id:?}#{bad_receipt_hash:?})")
             }
         }
     }

--- a/domains/client/block-builder/src/lib.rs
+++ b/domains/client/block-builder/src/lib.rs
@@ -179,9 +179,24 @@ where
 
         if let Some(inherent_data) = maybe_inherent_data {
             let inherent_extrinsics = Self::create_inherents(parent_hash, &api, inherent_data)?;
-            // reverse and push the inherents so that order is maintained
-            for inherent_extrinsic in inherent_extrinsics.into_iter().rev() {
-                extrinsics.push_front(inherent_extrinsic)
+
+            // TODO: This is used to keep compatible with gemini-3h, remove before next network
+            //
+            // HACK: in gemini-3h, the domain inherent extrinsic order is changed in the ER that derived
+            // from the consensus block #168431, we have to follow this change in the client side to ensure
+            // every domain node that sync from genesis will produce the same ER and hence can successfully
+            // submit ER to exend the previous ER.
+            let maintain_runtime_inherent_extrinsic_order = parent_number >= 168430u32.into();
+
+            if maintain_runtime_inherent_extrinsic_order {
+                // reverse and push the inherents so that order is maintained
+                for inherent_extrinsic in inherent_extrinsics.into_iter().rev() {
+                    extrinsics.push_front(inherent_extrinsic)
+                }
+            } else {
+                for inherent_extrinsic in inherent_extrinsics {
+                    extrinsics.push_front(inherent_extrinsic)
+                }
             }
         }
 

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -27,6 +27,7 @@ use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One, Zer
 use sp_runtime::{Digest, Saturating};
 use std::cmp::Ordering;
 use std::collections::VecDeque;
+use std::str::FromStr;
 use std::sync::Arc;
 
 struct DomainBlockBuildResult<Block>
@@ -419,6 +420,15 @@ where
         inherent_digests: Digest,
         inherent_data: sp_inherents::InherentData,
     ) -> Result<DomainBlockBuildResult<Block>, sp_blockchain::Error> {
+        // TODO: This is used to keep compatible with gemini-3h, remove before next network
+        let is_gemini_3h = self.consensus_client.info().genesis_hash
+            == FromStr::from_str(
+                // The genesis hash of gemini-3h
+                "0c121c75f4ef450f40619e1fca9d1e8e7fbabc42c895bc4790801e85d5a91c34",
+            )
+            .map_err(|_| ())
+            .expect("parsing consensus block hash should success");
+
         let block_builder = BlockBuilder::new(
             &*self.client,
             parent_hash,
@@ -428,6 +438,7 @@ where
             &*self.backend,
             extrinsics,
             Some(inherent_data),
+            is_gemini_3h,
         )?;
 
         let BuiltBlock {

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -760,7 +760,7 @@ where
         if let Some(mismatched_receipts) = self.find_mismatch_receipt(consensus_block_hash)? {
             let fraud_proof = self.generate_fraud_proof(mismatched_receipts)?;
 
-            tracing::info!("Submit fraud proof: {fraud_proof}");
+            tracing::info!("Submit fraud proof: {fraud_proof:?}");
             let consensus_best_hash = self.consensus_client.info().best_hash;
             let mut runtime_api = self.consensus_client.runtime_api();
             runtime_api.register_extension(

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -749,6 +749,7 @@ where
         if let Some(mismatched_receipts) = self.find_mismatch_receipt(consensus_block_hash)? {
             let fraud_proof = self.generate_fraud_proof(mismatched_receipts)?;
 
+            tracing::info!("Submit fraud proof: {fraud_proof}");
             let consensus_best_hash = self.consensus_client.info().best_hash;
             let mut runtime_api = self.consensus_client.runtime_api();
             runtime_api.register_extension(

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -433,6 +433,10 @@ where
             inherent_digests.clone(),
             &*self.backend,
             extrinsics.into(),
+            // NOTE: the inherent extrinsic is already contained in the above `extrinsics`, which
+            // is getting from the block body, thus it is okay to pass `maybe_inherent_data` as
+            // `None` and `is_gemini_3h` as `false`, the latter is only used when `maybe_inherent_data`
+            // is `Some`.
             None,
             false,
         )?;

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -434,6 +434,7 @@ where
             &*self.backend,
             extrinsics.into(),
             None,
+            false,
         )?;
 
         let (storage_changes, call_data) = match &execution_phase {


### PR DESCRIPTION
The first commit fixes the recent domain incompatible issue with gemini-3h. The issue is due to the change of the order of the domain inherent extrinsic, the change is used to correct the order to keep consistency with the order on the fraud proof verification side, but because the change is on the client side, the domain node run with different release will produce different ER and trigger fraud proof.

The PR fixes the issue on gemini-3h by using the old order for consensus block <= `#168430` and switching to the new order for consensus block > `#168430`, the block `#168430` is where the order changed in the ER chain on the consensus state.

The second commit is some minor changes to add more detailed log for fraud proof.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
