### PR TITLE
Improve error handling

### DIFF
--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -390,5 +390,5 @@ pub trait Farm {
     fn on_solution(&self, callback: HandlerFn<SolutionResponse>) -> Box<dyn HandlerId>;
 
     /// Run and wait for background threads to exit or return an error
-    fn run(self: Box<Self>) -> Pin<Box<dyn Future<Output = anyhow::Result<FarmId>> + Send>>;
+    fn run(self: Box<Self>) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
 }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -660,7 +660,7 @@ impl Farm for SingleDiskFarm {
         Box::new(self.on_solution(callback))
     }
 
-    fn run(self: Box<Self>) -> Pin<Box<dyn Future<Output = anyhow::Result<FarmId>> + Send>> {
+    fn run(self: Box<Self>) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
         Box::pin((*self).run())
     }
 }
@@ -1571,7 +1571,7 @@ impl SingleDiskFarm {
     }
 
     /// Run and wait for background threads to exit or return an error
-    pub async fn run(mut self) -> anyhow::Result<FarmId> {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         if let Some(start_sender) = self.start_sender.take() {
             // Do not care if anyone is listening on the other side
             let _ = start_sender.send(());
@@ -1581,7 +1581,7 @@ impl SingleDiskFarm {
             result?;
         }
 
-        Ok(*self.id())
+        Ok(())
     }
 
     /// Wipe everything that belongs to this single disk farm


### PR DESCRIPTION
This PR addresses a few UX pain points described in https://forum.subspace.network/t/farm-stops-if-drive-drops-out/3051?u=nazar-pc and https://forum.subspace.network/t/can-farmer-still-continue-if-there-is-a-broken-plot-disk/2906?u=nazar-pc before that (not counting many other cases).

First of all, in case we had a single broken/missing (for example after scrub) element in piece cache, piece cache was stopping reading further pieces, which may still be there, forcing larger than necessary piece cache sync on restart. We change that to tolerate a series of a few broken/missing pieces instead.

Second, completely missing/broken disk can cause farmer to print an infinite list of error messages, this change prevents it by having a threshold after which non-fatal errors become fatal.

Third, after crash of one farm farmer will no longer exit by default if there are other farms working successfully, this allows user to continue plotting/farming until they have a chance to check what is going on with farmer. Previous default behavior can be restored with `--exit-on-farm-error`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
