### PR TITLE
Fix span guard location

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -684,9 +684,9 @@ impl SingleDiskFarm {
 
         let single_disk_farm_init_fut = tokio::task::spawn_blocking({
             let span = span.clone();
-            let _span_guard = span.enter();
 
             move || {
+                let _span_guard = span.enter();
                 Self::init(&options).map(|single_disk_farm_init| (single_disk_farm_init, options))
             }
         });


### PR DESCRIPTION
Without this plot cache logs were not labeled properly

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
