### PR TITLE
Improve farmer caching

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -844,13 +844,6 @@ impl FarmerCache {
     pub async fn maybe_store_additional_piece(&self, piece_index: PieceIndex, piece: &Piece) {
         let key = RecordKey::from(piece_index.to_multihash());
 
-        for cache in self.piece_caches.read().await.iter() {
-            if cache.stored_pieces.contains_key(&key) {
-                // Already stored in normal piece cache, no need to store it again
-                return;
-            }
-        }
-
         let mut should_store = false;
         for (farm_index, cache) in self.plot_caches.read().await.iter().enumerate() {
             match cache.is_piece_maybe_stored(&key).await {


### PR DESCRIPTION
This improves caching on farmer by storing more things in plot cache than we did before to reduce the need of retrieving pieces from the network in some cases.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
