### PR TITLE
Remove `atomic` dependency from `subspace-farmer` and simplify code a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11618,7 +11618,6 @@ dependencies = [
  "anyhow",
  "async-lock 3.3.0",
  "async-trait",
- "atomic",
  "backoff",
  "base58",
  "blake2 0.10.6",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -15,7 +15,6 @@ include = [
 anyhow = "1.0.79"
 async-lock = "3.3.0"
 async-trait = "0.1.77"
-atomic = "0.5.3"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base58 = "0.2.0"
 blake2 = "0.10.6"


### PR DESCRIPTION
`watch` in `tokio` does exactly what was manually done there

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
