### PR TITLE
Remove QUIC protocol support

### DIFF
--- a/crates/sc-subspace-chain-specs/res/chain-spec-raw-devnet.json
+++ b/crates/sc-subspace-chain-specs/res/chain-spec-raw-devnet.json
@@ -17,7 +17,7 @@
   "properties": {
     "domainsBootstrapNodes": {},
     "dsnBootstrapNodes": [
-      "/dns/bootstrap-0.devnet.subspace.network/udp/30533/quic-v1/p2p/12D3KooWJgLU8DmkXwBpQtHgSURFfJ4f2SyuNVBgVY96aDJsDWFK"
+      "/dns/bootstrap-0.devnet.subspace.network/tcp/30533/p2p/12D3KooWJgLU8DmkXwBpQtHgSURFfJ4f2SyuNVBgVY96aDJsDWFK"
     ],
     "potExternalEntropy": null,
     "ss58Format": 2254,

--- a/crates/sc-subspace-chain-specs/res/chain-spec-raw-gemini-3h.json
+++ b/crates/sc-subspace-chain-specs/res/chain-spec-raw-gemini-3h.json
@@ -28,8 +28,6 @@
       ]
     },
     "dsnBootstrapNodes": [
-      "/dns/bootstrap-0.gemini-3h.subspace.network/udp/30533/quic-v1/p2p/12D3KooWK7NuL4S6aEdy5gELnvhCGo6EyrWVARnBy7W4AJTVkaF1",
-      "/dns/bootstrap-1.gemini-3h.subspace.network/udp/30533/quic-v1/p2p/12D3KooWQK33n2raSXzjH8JyqbFtczBmbwZiK9Tpicdw3rveJesj",
       "/dns/bootstrap-0.gemini-3h.subspace.network/tcp/30533/p2p/12D3KooWK7NuL4S6aEdy5gELnvhCGo6EyrWVARnBy7W4AJTVkaF1",
       "/dns/bootstrap-1.gemini-3h.subspace.network/tcp/30533/p2p/12D3KooWQK33n2raSXzjH8JyqbFtczBmbwZiK9Tpicdw3rveJesj"
     ],

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -286,16 +286,10 @@ struct DsnArgs {
     /// Multiaddr to listen on for subspace networking, for instance `/ip4/0.0.0.0/tcp/0`,
     /// multiple are supported.
     #[arg(long, default_values_t = [
-    Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-    .with(Protocol::Udp(30533))
-    .with(Protocol::QuicV1),
-    Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
-    .with(Protocol::Udp(30533))
-    .with(Protocol::QuicV1),
-    Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-    .with(Protocol::Tcp(30533)),
-    Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
-    .with(Protocol::Tcp(30533))
+        Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+            .with(Protocol::Tcp(30533)),
+        Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
+            .with(Protocol::Tcp(30533))
     ])]
     listen_on: Vec<Multiaddr>,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -4,8 +4,8 @@ mod commands;
 mod utils;
 
 use clap::Parser;
+use std::fs;
 use std::path::PathBuf;
-use std::{env, fs};
 use subspace_farmer::single_disk_farm::SingleDiskFarm;
 use subspace_proof_of_space::chia::ChiaTable;
 use tracing::info;
@@ -61,11 +61,6 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // TODO: This is a hack to work around https://github.com/quinn-rs/quinn/issues/1750, should be
-    //  removed once fixed upstream
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "info,quinn_udp=error");
-    }
     tracing_subscriber::registry()
         .with(
             fmt::layer()

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -183,14 +183,9 @@ fn main() -> Result<(), Error> {
                 DsnConfig {
                     keypair,
                     network_path: consensus_chain_config.base_path.path().join("network"),
-                    listen_on: vec![
-                        "/ip4/0.0.0.0/udp/30433/quic-v1"
-                            .parse::<Multiaddr>()
-                            .expect("Manual setting"),
-                        "/ip4/0.0.0.0/tcp/30433"
-                            .parse::<Multiaddr>()
-                            .expect("Manual setting"),
-                    ],
+                    listen_on: vec!["/ip4/0.0.0.0/tcp/30433"
+                        .parse::<Multiaddr>()
+                        .expect("Manual setting")],
                     bootstrap_nodes: dsn_bootstrap_nodes,
                     reserved_peers: vec![],
                     allow_non_global_addresses_in_dht: false,

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -64,7 +64,6 @@ features = [
     "noise",
     "ping",
     "plaintext",
-    "quic",
     "request-response",
     "serde",
     "tcp",

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -500,7 +500,7 @@ impl KnownPeersManager {
 
     fn single_peer_encoded_address_size() -> usize {
         let multiaddr = Multiaddr::from_str(
-            "/ip4/127.0.0.1/udp/1234/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp",
+            "/ip4/127.0.0.1/tcp/1234/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp",
         )
         .expect("Valid multiaddr; qed");
         // Use multiaddr size that is 3x larger than typical, should be enough for most practical

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -47,12 +47,6 @@ enum Command {
         /// Multiaddr to listen on for subspace networking, multiple are supported
         #[arg(long, default_values_t = [
             Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-                .with(Protocol::Udp(0))
-                .with(Protocol::QuicV1),
-            Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
-                .with(Protocol::Udp(0))
-                .with(Protocol::QuicV1),
-            Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
                 .with(Protocol::Tcp(0)),
             Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
                 .with(Protocol::Tcp(0))

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -539,24 +539,10 @@ where
 
             let addr_string = addr.to_string();
             // Listen on random port if specified is already occupied
-            match addr.pop() {
-                Some(Protocol::Tcp(_port)) => {
-                    info!(
-                        "Failed to listen on {addr_string} ({error}), falling back to random port"
-                    );
-                    addr.push(Protocol::Tcp(0));
-                    swarm.listen_on(addr)?;
-                }
-                Some(Protocol::Udp(_port)) => {
-                    info!(
-                        "Failed to listen on {addr_string} ({error}), falling back to random port"
-                    );
-                    addr.push(Protocol::Udp(0));
-                    swarm.listen_on(addr)?;
-                }
-                _ => {
-                    // Do not care about other protocols
-                }
+            if let Some(Protocol::Tcp(_port)) = addr.pop() {
+                info!("Failed to listen on {addr_string} ({error}), falling back to random port");
+                addr.push(Protocol::Tcp(0));
+                swarm.listen_on(addr)?;
             }
         }
     }

--- a/crates/subspace-networking/src/protocols/autonat_wrapper.rs
+++ b/crates/subspace-networking/src/protocols/autonat_wrapper.rs
@@ -49,7 +49,6 @@ impl Behaviour {
 
     fn address_corresponds_to_listening_addresses(&self, addr: &Multiaddr) -> bool {
         let Some(candidate_protocol) = addr.iter().find_map(|protocol| match protocol {
-            udp @ Protocol::Udp(_) => Some(udp),
             tcp @ Protocol::Tcp(_) => Some(tcp),
             _ => None,
         }) else {

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -119,12 +119,6 @@ struct DsnOptions {
     // TODO: Add more DSN-related parameters
     #[arg(long, default_values_t = [
         Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-            .with(Protocol::Udp(30433))
-            .with(Protocol::QuicV1),
-        Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
-            .with(Protocol::Udp(30433))
-            .with(Protocol::QuicV1),
-        Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
             .with(Protocol::Tcp(30433)),
         Multiaddr::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
             .with(Protocol::Tcp(30433))

--- a/crates/subspace-node/src/commands/shared.rs
+++ b/crates/subspace-node/src/commands/shared.rs
@@ -6,7 +6,6 @@ use sp_core::sr25519::Pair;
 use sp_core::Pair as PairT;
 use sp_domains::KEY_TYPE;
 use sp_keystore::Keystore;
-use std::env;
 use std::path::PathBuf;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
@@ -59,11 +58,6 @@ pub(super) struct InitLoggerResult {
 }
 
 pub(super) fn init_logger() -> InitLoggerResult {
-    // TODO: This is a hack to work around https://github.com/quinn-rs/quinn/issues/1750, should be
-    //  removed once fixed upstream
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "info,quinn_udp=error");
-    }
     // TODO: Workaround for https://github.com/tokio-rs/tracing/issues/2214, also on
     //  Windows terminal doesn't support the same colors as bash does
     let enable_color = if cfg!(windows) {

--- a/docs/farming.md
+++ b/docs/farming.md
@@ -25,11 +25,11 @@ Install [Polkadot.js extension](https://polkadot.js.org/extension/) into your br
 The address of your account will be necessary at the last step.
 
 ## Required ports
-Currently, TCP and UDP ports `30333`, `30433` and `30533` need to be exposed for node and farmer to work properly.
+Currently, TCP ports `30333`, `30433` and `30533` need to be exposed for node and farmer to work properly.
 
-If you have a server with no firewall, there is nothing to be done, but otherwise make sure to open TCP and UDP ports `30333`, `30433` and `30533` for incoming connections.
+If you have a server with no firewall, there is nothing to be done, but otherwise make sure to open TCP ports `30333`, `30433` and `30533` for incoming connections.
 
-On the desktop side if you have a router in front of your computer, you'll need to forward TCP and UDP ports `30333`, `30433` and `30533` to the machine on which your node is running (how this is done varied from router to router, but there is always a feature like this, ask [on the forum](https://forum.subspace.network/) if you have questions).
+On the desktop side if you have a router in front of your computer, you'll need to forward TCP ports `30333`, `30433` and `30533` to the machine on which your node is running (how this is done varied from router to router, but there is always a feature like this, ask [on the forum](https://forum.subspace.network/) if you have questions).
 If you're connected directly without any router, then again nothing needs to be done in such case.
 
 ## 🖼️ Windows Instructions
@@ -204,9 +204,7 @@ services:
     ports:
 # If port 30333 or 30433 is already occupied by another Substrate-based node, replace all
 # occurrences of `30333` or `30433` in this file with another value
-      - "0.0.0.0:30333:30333/udp"
       - "0.0.0.0:30333:30333/tcp"
-      - "0.0.0.0:30433:30433/udp"
       - "0.0.0.0:30433:30433/tcp"
     restart: unless-stopped
     command: [
@@ -214,7 +212,6 @@ services:
       "--chain", "gemini-3h",
       "--base-path", "/var/subspace",
       "--listen-on", "/ip4/0.0.0.0/tcp/30333",
-      "--dsn-listen-on", "/ip4/0.0.0.0/udp/30433/quic-v1",
       "--dsn-listen-on", "/ip4/0.0.0.0/tcp/30433",
       "--rpc-listen-on", "0.0.0.0:9944",
       "--rpc-cors", "all",
@@ -245,13 +242,11 @@ services:
     ports:
 # If port 30533 is already occupied by something else, replace all
 # occurrences of `30533` in this file with another value
-      - "0.0.0.0:30533:30533/udp"
       - "0.0.0.0:30533:30533/tcp"
     restart: unless-stopped
     command: [
       "farm",
       "--node-rpc-url", "ws://node:9944",
-      "--listen-on", "/ip4/0.0.0.0/udp/30533/quic-v1",
       "--listen-on", "/ip4/0.0.0.0/tcp/30533",
 # Replace `WALLET_ADDRESS` with your Polkadot.js wallet address
       "--reward-address", "WALLET_ADDRESS",


### PR DESCRIPTION
As discussed [on the forum](https://forum.subspace.network/t/network-latency-timeouts-after-starting-node-farmer/2460/54?u=nazar-pc) and further in Slack this PR removes QUIC support from Subspace networking stack.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
