### PR TITLE
Reject blocks below archiving point during verification

### DIFF
--- a/crates/sc-consensus-subspace/src/verifier.rs
+++ b/crates/sc-consensus-subspace/src/verifier.rs
@@ -483,6 +483,21 @@ where
             "Verifying",
         );
 
+        let best_number = self.client.info().best_number;
+        if *block.header.number() + self.chain_constants.confirmation_depth_k().into() < best_number
+        {
+            debug!(
+                header = ?block.header,
+                %best_number,
+                "Rejecting block below archiving point"
+            );
+
+            return Err(format!(
+                "Rejecting block #{} below archiving point",
+                block.header.number()
+            ));
+        }
+
         let hash = block.header.hash();
 
         debug!(


### PR DESCRIPTION
This prevents node from even trying to import way too old blocks that will not be useful anyway, sometimes causing huge PoT verification delays.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
