### PR TITLE
Print CPU cores used for plotting and replotting thread pools during start of the farmer

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -641,6 +641,12 @@ where
         NonZeroUsize::new((cpu_cores.cpu_cores().len() / 2).max(1).min(8)).expect("Not zero; qed")
     });
 
+    info!(
+        ?plotting_thread_pool_core_indices,
+        ?replotting_thread_pool_core_indices,
+        "Preparing plotting thread pools"
+    );
+
     let plotting_thread_pool_manager = create_plotting_thread_pool_manager(
         plotting_thread_pool_core_indices
             .into_iter()

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(
     array_chunks,
+    array_windows,
     assert_matches,
     const_option,
     exact_size_is_empty,


### PR DESCRIPTION
This is a helpful piece of information for farmers and prints results in format that is close to what they would specify in `--[re|]plotting-cpu-cores` manually.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
