### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Build node image
         id: build
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # @v3.2.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           file: Dockerfile-node
           push: false
@@ -32,7 +32,7 @@ jobs:
           docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain gemini-3h-compiled --disable-default-bootnode --raw > chain-spec-raw-gemini-3h.json
 
       - name: Upload chain specifications to artifacts
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.1.3
         with:
           name: chain-specifications
           path: |
@@ -41,7 +41,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload chain specifications to assets
-        uses: alexellis/upload-assets@259de5111cb56966d046ced998941e93f91d2c93 # @0.4.0
+        uses: alexellis/upload-assets@13926a61cdb2cb35f5fdef1c06b8b591523236d3 # 0.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Build node image
         id: build
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # @v3.2.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           file: Dockerfile-node
           push: false
@@ -31,7 +31,7 @@ jobs:
           docker run --rm -u root ${{ steps.build.outputs.digest }} domain build-genesis-storage --chain devnet > domain-genesis-storage-devnet
 
       - name: Upload domain genesis storages to artifacts
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.1.3
         with:
           name: domain-genesis-storage
           path: |
@@ -40,7 +40,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload domain genesis storages to assets
-        uses: alexellis/upload-assets@259de5111cb56966d046ced998941e93f91d2c93 # @0.4.0
+        uses: alexellis/upload-assets@13926a61cdb2cb35f5fdef1c06b8b591523236d3 # 0.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Build runtime
         id: build
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # @v3.2.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           file: Dockerfile-runtime
           push: false
@@ -36,7 +36,7 @@ jobs:
           echo "SPEC_VERSION=$SPEC_VERSION" >> $GITHUB_ENV
 
       - name: Upload runtime to artifacts
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.1.3
         with:
           name: subspace_runtime
           path: |
@@ -44,7 +44,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload runtime to assets
-        uses: alexellis/upload-assets@259de5111cb56966d046ced998941e93f91d2c93 # @0.4.0
+        uses: alexellis/upload-assets@13926a61cdb2cb35f5fdef1c06b8b591523236d3 # 0.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,15 +34,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cargo/registry
@@ -63,14 +63,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
         with:
-          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
-          version: 15.0.7
+          version: 17
         if: runner.os == 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
@@ -79,7 +78,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -96,7 +95,7 @@ jobs:
         continue-on-error: true
 
       - name: Configure cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cargo/registry
@@ -113,15 +112,15 @@ jobs:
     runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || '"ubuntu-22.04"') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cargo/registry
@@ -144,14 +143,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
         with:
-          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
-          version: 15.0.7
+          version: 17
         if: runner.os == 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
@@ -160,7 +158,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -177,7 +175,7 @@ jobs:
         continue-on-error: true
 
       - name: Configure cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cargo/registry
@@ -189,8 +187,6 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/cache-cargo-install-action@1b76958d032c4d048c599f9fdfa48abe804d6319 # v1.2.2
         with:
-          # TODO: Remove when cargo-nextest 0.9.68+ is out and has crates compatible with latest nightly in lock file
-          locked: false
           tool: cargo-nextest
 
       - name: cargo nextest run --locked

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,8 +2,8 @@ name: rustdoc
 
 on:
   push:
-   branches:
-   - main
+    branches:
+      - main
 
 concurrency:
   group: rustdoc-${{ github.workflow }}-${{ github.ref }}
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cargo/registry
@@ -44,7 +44,7 @@ jobs:
           RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
 
       - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6 # @v4.4.1
+        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
         with:
           branch: gh-pages
           folder: target/doc

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # @v2.2.0
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # @v2.2.1
+        uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
 
       - name: Log into registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # @v2.2.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea # @v4.1.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
@@ -70,7 +70,7 @@ jobs:
             suffix=${{ matrix.platform.image-suffix }}
 
       - name: Build and push ${{ matrix.image }} image
-        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # @v3.2.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           file: Dockerfile-${{ matrix.image }}${{ matrix.platform.dockerfile-suffix }}
           platforms: ${{ matrix.platform.arch }}
@@ -82,7 +82,7 @@ jobs:
             RUSTFLAGS=${{ matrix.platform.rustflags }}
 
       - name: Trigger trivy-security-scan Workflow
-        uses: peter-evans/repository-dispatch@a4a90276d01e3a2ae44fa10a0247287f045afd59 # @v2.1.2
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # @v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: trivy-scan-dispatch
@@ -132,14 +132,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       - name: Install LLVM and Clang for macOS
-        uses: KyleMayes/install-llvm-action@be40c5af3a4adc3e4a03199995ab73aa37536712 # v1.9.0
+        uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
         with:
-          # TODO: Switch to LLVM 17 on arm64 runners once https://github.com/KyleMayes/install-llvm-action/issues/61 is resolved
-          version: 15.0.7
+          version: 17
         if: runner.os == 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
@@ -148,7 +147,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -195,7 +194,7 @@ jobs:
         if: matrix.build.target == 'aarch64-unknown-linux-gnu'
 
       - name: Configure cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             ~/.cargo/registry
@@ -299,7 +298,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Upload node and farmer executables to artifacts
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.1.3
         with:
           name: executables-${{ matrix.build.suffix }}
           path: |
@@ -307,7 +306,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload node and farmer executables to assets
-        uses: alexellis/upload-assets@259de5111cb56966d046ced998941e93f91d2c93 # @0.4.0
+        uses: alexellis/upload-assets@13926a61cdb2cb35f5fdef1c06b8b591523236d3 # 0.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/trivy-security-scan.yml
+++ b/.github/workflows/trivy-security-scan.yml
@@ -7,7 +7,7 @@ name: trivy-security-scan
 
 on:
   repository_dispatch:
-    types: [trivy-scan-dispatch]
+    types: [ trivy-scan-dispatch ]
 
 jobs:
   wait-for-image:
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run Trivy vulnerability scanner on image
-        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # @v0.16.1
+        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # @v0.19.0
         with:
           image-ref: ${{ github.event.client_payload.image }}
           format: "sarif"
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # @v0.16.1
+        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # @v0.19.0
         with:
           scan-type: fs
           ignore-unfixed: true
@@ -80,6 +80,6 @@ jobs:
           severity: CRITICAL
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@4759df8df70c5ebe7042c3029bbace20eee13edd # @v2.23.1
+        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
This fixes annoying warnings about outdated Node.js, fixes some inconsistencies and generally brings things up to date.

Also we can finally enjoy much newer version of LLVM on macOS.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
