### PR TITLE
Remove usage of SudoKey and use PermissionedAction to do specific actions on pallet-domains

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -527,7 +527,7 @@ mod benchmarks {
 
     #[benchmark]
     fn instantiate_domain() {
-        let creator = T::SudoId::get();
+        let creator = account("domain_creator", 1, SEED);
         T::Currency::set_balance(
             &creator,
             T::DomainInstantiationDeposit::get() + T::MinNominatorStake::get(),
@@ -888,7 +888,7 @@ mod benchmarks {
     }
 
     fn register_domain<T: Config>() -> DomainId {
-        let creator = T::SudoId::get();
+        let creator = account("domain_creator", 1, SEED);
         T::Currency::set_balance(
             &creator,
             T::DomainInstantiationDeposit::get() + T::MinNominatorStake::get(),

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -279,7 +279,6 @@ impl pallet_domains::Config for Test {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type MaxNominators = MaxNominators;
     type Randomness = MockRandomness;
-    type SudoId = ();
     type PalletId = DomainsPalletId;
     type StorageFee = DummyStorageFee;
     type BlockSlot = DummyBlockSlot;
@@ -577,6 +576,10 @@ pub(crate) fn run_to_block<T: Config>(block_number: BlockNumberFor<T>, parent_ha
 
 pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorId>) -> DomainId {
     let raw_genesis_storage = RawGenesis::dummy(vec![1, 2, 3, 4]).encode();
+    assert_ok!(crate::Pallet::<Test>::set_permissioned_action_allowed_by(
+        RawOrigin::Root.into(),
+        sp_domains::PermissionedActionAllowedBy::Anyone
+    ));
     assert_ok!(crate::Pallet::<Test>::register_domain_runtime(
         RawOrigin::Root.into(),
         "evm".to_owned(),
@@ -591,7 +594,7 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorI
             + <Test as pallet_balances::Config>::ExistentialDeposit::get(),
     );
     crate::Pallet::<Test>::instantiate_domain(
-        RawOrigin::Root.into(),
+        RawOrigin::Signed(creator).into(),
         DomainConfig {
             domain_name: "evm-domain".to_owned(),
             runtime_id: 0,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -784,6 +784,22 @@ impl<AccountId: Ord> OperatorAllowList<AccountId> {
     }
 }
 
+/// Permissioned actions allowed by either specific accounts or anyone.
+#[derive(TypeInfo, Encode, Decode, Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum PermissionedActionAllowedBy<AccountId: Codec + Clone> {
+    Accounts(Vec<AccountId>),
+    Anyone,
+}
+
+impl<AccountId: Codec + PartialEq + Clone> PermissionedActionAllowedBy<AccountId> {
+    pub fn is_allowed(&self, who: &AccountId) -> bool {
+        match self {
+            PermissionedActionAllowedBy::Accounts(accounts) => accounts.contains(who),
+            PermissionedActionAllowedBy::Anyone => true,
+        }
+    }
+}
+
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GenesisDomain<AccountId: Ord, Balance> {
     // Domain runtime items
@@ -1309,9 +1325,6 @@ sp_api::decl_runtime_apis! {
 
         /// Get operator id by signing key
         fn operator_id_by_signing_key(signing_key: OperatorPublicKey) -> Option<OperatorId>;
-
-        /// Get the consensus chain sudo account id, currently only used in the intentional malicious operator
-        fn sudo_account_id() -> subspace_runtime_primitives::AccountId;
 
         /// Returns the execution receipt hash of the given domain and domain block number
         fn receipt_hash(domain_id: DomainId, domain_number: HeaderNumberFor<DomainHeader>) -> Option<HeaderHashFor<DomainHeader>>;

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -93,6 +93,7 @@ fn set_default_ss58_version<C: AsRef<dyn ChainSpec>>(chain_spec: C) {
 fn main() -> Result<(), Error> {
     let cli = Cli::from_args();
 
+    let sudo_account = cli.sudo_account();
     let runner = cli.create_runner(&cli.run)?;
     set_default_ss58_version(&runner.config().chain_spec);
     runner.run_node_until_exit(|mut consensus_chain_config| async move {
@@ -354,7 +355,9 @@ fn main() -> Result<(), Error> {
                                 return;
                             }
                         };
-                        if let Err(error) = domain_starter.start(bootstrap_result).await {
+                        if let Err(error) =
+                            domain_starter.start(bootstrap_result, sudo_account).await
+                        {
                             log::error!("Domain starter exited with an error {error:?}");
                         }
                     }),

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -7,7 +7,7 @@ use sc_service::{ChainSpec, ChainType, NoExtension};
 use sp_core::crypto::AccountId32;
 use sp_core::{sr25519, Pair, Public};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_domains::{OperatorAllowList, OperatorPublicKey, PermissionedActionAllowedBy, RuntimeType};
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
 use std::marker::PhantomData;
@@ -94,6 +94,10 @@ pub fn domain_dev_config() -> GenericChainSpec<evm_domain_runtime::RuntimeGenesi
     )
 }
 
+pub(crate) fn consensus_dev_sudo_account() -> AccountId32 {
+    get_account_id_from_seed("Alice")
+}
+
 pub fn create_domain_spec(
     chain_id: &str,
     raw_genesis: RawGenesis,
@@ -151,6 +155,7 @@ struct GenesisDomainParams {
     operator_signing_key: OperatorPublicKey,
     raw_genesis_storage: Vec<u8>,
     initial_balances: Vec<(MultiAccountId, Balance)>,
+    permissioned_action_allowed_by: PermissionedActionAllowedBy<AccountId>,
 }
 
 pub fn dev_config() -> Result<GenericChainSpec<subspace_runtime::RuntimeGenesisConfig>, String> {
@@ -207,6 +212,7 @@ pub fn dev_config() -> Result<GenericChainSpec<subspace_runtime::RuntimeGenesisC
                     operator_signing_key: get_public_key_from_seed::<OperatorPublicKey>("Alice"),
                     raw_genesis_storage: raw_genesis_storage.clone(),
                     initial_balances: endowed_accounts(),
+                    permissioned_action_allowed_by: PermissionedActionAllowedBy::Anyone,
                 },
             )
         },
@@ -271,6 +277,9 @@ fn subspace_genesis_config(
             confirmation_depth_k,
         },
         domains: DomainsConfig {
+            permissioned_action_allowed_by: Some(
+                genesis_domain_params.permissioned_action_allowed_by,
+            ),
             genesis_domain: Some(sp_domains::GenesisDomain {
                 runtime_name: "evm".to_owned(),
                 runtime_type: RuntimeType::Evm,

--- a/crates/subspace-malicious-operator/src/lib.rs
+++ b/crates/subspace-malicious-operator/src/lib.rs
@@ -29,6 +29,7 @@ use sc_cli::{
 };
 use sc_service::config::{KeystoreConfig, NetworkConfiguration};
 use sc_service::{BasePath, BlocksPruning, Configuration, DatabaseSource};
+use sp_core::crypto::{AccountId32, Ss58Codec};
 use sp_domains::DomainId;
 
 /// Subspace Cli.
@@ -43,6 +44,11 @@ pub struct Cli {
     #[clap(flatten)]
     pub run: RunCmd,
 
+    /// Sudo account to use for malicious operator
+    /// If not passed, dev sudo account is used instead.
+    #[arg(long)]
+    pub sudo_account: Option<String>,
+
     /// Domain arguments
     ///
     /// The command-line arguments provided first will be passed to the embedded consensus node,
@@ -51,6 +57,17 @@ pub struct Cli {
     /// subspace-node [consensus-chain-args] -- [domain-args]
     #[arg(raw = true)]
     pub domain_args: Vec<String>,
+}
+
+impl Cli {
+    pub fn sudo_account(&self) -> AccountId32 {
+        self.sudo_account
+            .as_ref()
+            .map(|sudo_account| {
+                AccountId32::from_ss58check(sudo_account).expect("Invalid sudo account")
+            })
+            .unwrap_or(crate::chain_spec::consensus_dev_sudo_account())
+    }
 }
 
 impl SubstrateCli for Cli {

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -23,6 +23,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
+use subspace_runtime_primitives::AccountId;
 use subspace_service::FullClient as CFullClient;
 
 /// `DomainInstanceStarter` used to start a domain instance node based on the given
@@ -51,6 +52,7 @@ where
     pub async fn start(
         self,
         bootstrap_result: BootstrapResult<CBlock>,
+        sudo_account: AccountId,
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let BootstrapResult {
             domain_instance_data,
@@ -178,6 +180,7 @@ where
                     consensus_keystore,
                     consensus_offchain_tx_pool_factory,
                     domain_node.transaction_pool.clone(),
+                    sudo_account,
                 );
 
                 domain_node

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -612,7 +612,6 @@ parameter_types! {
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 512;
     pub const MaxNominators: u32 = 256;
-    pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
     pub const DomainsPalletId: PalletId = PalletId(*b"domains_");
     pub const MaxInitialDomainAccounts: u32 = 10;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
@@ -681,7 +680,6 @@ impl pallet_domains::Config for Runtime {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type MaxNominators = MaxNominators;
     type Randomness = Subspace;
-    type SudoId = SudoId;
     type PalletId = DomainsPalletId;
     type StorageFee = TransactionFees;
     type BlockSlot = BlockSlot;
@@ -1222,10 +1220,6 @@ impl_runtime_apis! {
 
         fn operator_id_by_signing_key(signing_key: OperatorPublicKey) -> Option<OperatorId> {
             Domains::operator_signing_key(signing_key)
-        }
-
-        fn sudo_account_id() -> AccountId {
-            SudoId::get()
         }
 
         fn receipt_hash(domain_id: DomainId, domain_number: DomainNumber) -> Option<DomainHash> {

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -133,6 +133,7 @@ fn create_genesis_config(
         },
         vesting: VestingConfig { vesting },
         domains: DomainsConfig {
+            permissioned_action_allowed_by: Some(sp_domains::PermissionedActionAllowedBy::Anyone),
             genesis_domain: Some(GenesisDomain {
                 runtime_name: "evm".to_owned(),
                 runtime_type: RuntimeType::Evm,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -647,7 +647,6 @@ parameter_types! {
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 512;
     pub const MaxNominators: u32 = 100;
-    pub SudoId: AccountId = Sudo::key().expect("Sudo account must exist");
     pub const DomainsPalletId: PalletId = PalletId(*b"domains_");
     pub const MaxInitialDomainAccounts: u32 = 20;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
@@ -712,7 +711,6 @@ impl pallet_domains::Config for Runtime {
     type MaxPendingStakingOperation = MaxPendingStakingOperation;
     type MaxNominators = MaxNominators;
     type Randomness = Subspace;
-    type SudoId = SudoId;
     type MinNominatorStake = MinNominatorStake;
     type PalletId = DomainsPalletId;
     type StorageFee = TransactionFees;
@@ -1330,10 +1328,6 @@ impl_runtime_apis! {
 
         fn operator_id_by_signing_key(signing_key: OperatorPublicKey) -> Option<OperatorId> {
             Domains::operator_signing_key(signing_key)
-        }
-
-        fn sudo_account_id() -> AccountId {
-            SudoId::get()
         }
 
         fn receipt_hash(domain_id: DomainId, domain_number: DomainNumber) -> Option<DomainHash> {


### PR DESCRIPTION
This PR removes our dependency on SudoKey for pallet domains. Instead we will use PermissionedAction that lets either specific accounts or anyone to do these actions.
This can be passed through GenesisConfig for domains.

For Gemini-3h:
Once we do a runtime upgrade, Sudo account to expliclty call `set_permissioned_action_allowed_by` to update the storage accordinly. Until then, new domains cannot be instantiated.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
