### PR TITLE
Fix benchmark run

### DIFF
--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -91,10 +91,11 @@ substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk
 [features]
 default = []
 runtime-benchmarks = [
+    "auto-id-domain-runtime/runtime-benchmarks",
     "domain-service/runtime-benchmarks",
     "evm-domain-runtime/runtime-benchmarks",
-    "frame-benchmarking/runtime-benchmarks",
     "frame-benchmarking-cli/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
     "subspace-runtime/runtime-benchmarks",
     "subspace-service/runtime-benchmarks",
 ]

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -105,10 +105,11 @@ impl DomainCli {
     /// Creates domain configuration from domain cli.
     pub fn create_domain_configuration(
         &self,
+        cmd: &impl CliConfiguration,
         base_path: &Path,
         tokio_handle: tokio::runtime::Handle,
     ) -> sc_cli::Result<Configuration> {
-        let mut domain_config = SubstrateCli::create_configuration(self, self, tokio_handle)?;
+        let mut domain_config = SubstrateCli::create_configuration(self, cmd, tokio_handle)?;
 
         // Change default paths to Subspace structure
         let domain_base_path = base_path.join(self.domain_id.to_string());
@@ -173,8 +174,13 @@ impl SubstrateCli for DomainCli {
     }
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
-        // TODO: Fetch the runtime name of `self.domain_id` properly.
-        let runtime_name = "evm";
+        // TODO: properly fetch the runtime name of `self.domain_id`
+        let runtime_name = if self.domain_id == 0.into() {
+            "auto-id"
+        } else {
+            "evm"
+        };
+
         match runtime_name {
             "evm" => evm_chain_spec::load_chain_spec(id),
             "auto-id" => auto_id_chain_spec::load_chain_spec(id),

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -333,6 +333,7 @@ fn main() -> Result<(), Error> {
                     );
                     let domain_config = domain_cli
                         .create_domain_configuration(
+                            &cmd,
                             consensus_chain_config.base_path.path(),
                             consensus_chain_config.tokio_handle,
                         )
@@ -363,6 +364,7 @@ fn main() -> Result<(), Error> {
                     let domain_cli = DomainCli::new(cmd.domain_args.clone().into_iter());
                     let domain_config = domain_cli
                         .create_domain_configuration(
+                            &cmd,
                             consensus_chain_config.base_path.path(),
                             consensus_chain_config.tokio_handle,
                         )


### PR DESCRIPTION
### Problem

Currently, if we compile the node and try to run domain benchmarks, we get this:

```sh
$ cargo build --release --features runtime-benchmarks

$ ./target/release/subspace-node domain benchmark pallet --list --dev
Error: SubstrateCli(Service(Other("Failed to create domain configuration: Input(\"Error opening spec file ``: No such file or directory (os error 2)\")")))
```

It seems like the problem arises from the `DomainCli::new()` [function](https://github.com/subspace/subspace/blob/main/crates/subspace-node/src/domain/cli.rs#L102) and also this [line](https://github.com/subspace/subspace/blob/main/crates/subspace-node/src/domain/cli.rs#L111). Here, since only `Self::executable_name` is provided as an argument to `run: SubstrateRunCmd`, all the other arg values of `SubstrateRunCmd` are `None`, f.e `chain_id()` returns empty string, `is_dev()` returns false, etc. This in turn makes `load_spec()` try to load a chain spec from path "", which obv fails with the above message.

### Fix

To fix it, I am passing the parent `CliConfiguration` type, when creating new `CliConfiguration` in `create_domain_configuration()`. This makes sure that `SubstrateRunCmd` gets the parent arg values. After this change:

```sh
$ ./target/release/subspace-node domain benchmark pallet --list --dev

pallet,extrinsic
domain_pallet_executive,set_code
frame_benchmarking,addition
....
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
