### PR TITLE
Remove macOS workaround

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,14 @@ jobs:
       - name: Install LLVM and Clang for macOS
         uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
         with:
+          env: true
           version: 17
+        if: runner.os == 'macOS'
+
+      # Because macOS, see https://andreasfertig.blog/2021/02/clang-and-gcc-on-macos-catalina-finding-the-include-paths/
+      - name: Configure C compiler macOS
+        run: |
+          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
@@ -149,7 +156,14 @@ jobs:
       - name: Install LLVM and Clang for macOS
         uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
         with:
+          env: true
           version: 17
+        if: runner.os == 'macOS'
+
+      # Because macOS, see https://andreasfertig.blog/2021/02/clang-and-gcc-on-macos-catalina-finding-the-include-paths/
+      - name: Configure C compiler macOS
+        run: |
+          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -112,10 +112,6 @@ jobs:
             # TODO: AES flag is such that we have decent performance on ARMv8, remove once `aes` crate with MSRV bump ships:
             #  https://github.com/RustCrypto/block-ciphers/pull/395
             rustflags: "--cfg aes_armv8"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-14-arm64"]' || '"macos-14"') }}
-            target: x86_64-apple-darwin
-            suffix: macos-x86_64-${{ github.ref_name }}
-            rustflags: ""
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || '"windows-2022"') }}
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-skylake-${{ github.ref_name }}

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -138,7 +138,14 @@ jobs:
       - name: Install LLVM and Clang for macOS
         uses: KyleMayes/install-llvm-action@dec985c8d7b46a2f363ea1a78f660c946a3349ea # v2.0.1
         with:
+          env: true
           version: 17
+        if: runner.os == 'macOS'
+
+      # Because macOS, see https://andreasfertig.blog/2021/02/clang-and-gcc-on-macos-catalina-finding-the-include-paths/
+      - name: Configure C compiler macOS
+        run: |
+          echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
       # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
@@ -206,13 +213,6 @@ jobs:
       - name: Build farmer (Linux and Windows)
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
-        if: runner.os != 'macOS'
-
-      # We build macOS without `numa` feature, primarily because of https://github.com/HadrienG2/hwlocality/issues/31
-      - name: Build farmer (macOS)
-        run: |
-          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --no-default-features
-        if: runner.os == 'macOS'
 
       - name: Build node
         run: |


### PR DESCRIPTION
macOS previously had issues with `numa` feature due to LLVM compiler, now I got back to it and fixed so we can compile farmer the same way everywhere. I had to replace one kind of hack with a different one though for macOS :upside_down_face:

One drawback is that even more hacks were necessary for hwloc in order to cross-compile from aarch64 to x86-64, so I decided to drop x86-64 build from official releases, don't think many will cry because of it, but we'll see. It was failing with following error:
```
  thread 'main' panicked at /Users/hetzner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hwlocality-sys-0.4.1/build.rs:77:10:
  Could not find a suitable version of hwloc: pkg-config has not been configured to support cross-compilation.

  Install a sysroot for the target platform and configure it via
  PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_PATH, or install a
  cross-compiling wrapper for pkg-config and set it via
  PKG_CONFIG environment variable.
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It is 100% solvable, but I don't have patience for it myself.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
