### PR TITLE
Remove obsolete flag `disable_bootstrap_on_start`.

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -314,9 +314,6 @@ struct DsnArgs {
     /// Known external addresses
     #[arg(long, alias = "external-address")]
     external_addresses: Vec<Multiaddr>,
-    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
-    #[arg(long, default_value_t = false)]
-    disable_bootstrap_on_start: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -426,7 +423,6 @@ where
 
     // Override flags with `--dev`
     dsn.allow_private_ips = dsn.allow_private_ips || dev;
-    dsn.disable_bootstrap_on_start = dsn.disable_bootstrap_on_start || dev;
 
     let _tmp_directory = if let Some(plot_size) = tmp {
         let tmp_directory = tempfile::Builder::new()

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm/dsn.rs
@@ -41,7 +41,6 @@ pub(super) fn configure_dsn(
         pending_in_connections,
         pending_out_connections,
         external_addresses,
-        disable_bootstrap_on_start,
     }: DsnArgs,
     weak_plotted_pieces: Weak<Mutex<Option<PlottedPieces>>>,
     node_client: NodeRpcClient,
@@ -180,7 +179,6 @@ pub(super) fn configure_dsn(
         bootstrap_addresses: bootstrap_nodes,
         kademlia_mode: KademliaMode::Dynamic,
         external_addresses,
-        disable_bootstrap_on_start,
         ..default_config
     };
 

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -195,7 +195,6 @@ fn main() -> Result<(), Error> {
                     max_pending_in_connections: 100,
                     max_pending_out_connections: 150,
                     external_addresses: vec![],
-                    disable_bootstrap_on_start: false,
                 }
             };
 

--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -50,11 +50,6 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     pub(crate) autonat: AutonatWrapperConfig,
 }
 
-// #[derive(Debug, Clone, Copy)]
-// pub(crate) struct GeneralConnectedPeersInstance;
-// #[derive(Debug, Clone, Copy)]
-// pub(crate) struct SpecialConnectedPeersInstance;
-
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "Event")]
 #[behaviour(event_process = false)]
@@ -69,12 +64,6 @@ pub(crate) struct Behavior<RecordStore> {
     pub(crate) request_response: RequestResponseFactoryBehaviour,
     pub(crate) block_list: BlockListBehaviour,
     pub(crate) reserved_peers: ReservedPeersBehaviour,
-    // TODO: Restore or remove connected peer later
-    // pub(crate) peer_info: Toggle<PeerInfoBehaviour>,
-    // pub(crate) general_connected_peers:
-    //     Toggle<ConnectedPeersBehaviour<GeneralConnectedPeersInstance>>,
-    // pub(crate) special_connected_peers:
-    //     Toggle<ConnectedPeersBehaviour<SpecialConnectedPeersInstance>>,
     pub(crate) autonat: AutonatWrapper,
 }
 
@@ -100,11 +89,6 @@ where
                 .expect("Correct configuration")
             })
             .into();
-
-        // TODO: Restore or remove connected peer later
-        // let peer_info = config
-        //     .peer_info_provider
-        //     .map(|provider| PeerInfoBehaviour::new(config.peer_info_config, provider));
 
         Self {
             connection_limits: ConnectionLimitsBehaviour::new(config.connection_limits),

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -242,8 +242,6 @@ pub struct Config<LocalRecordProvider> {
     /// Known external addresses to the local peer. The addresses will be added on the swarm start
     /// and enable peer to notify others about its reachable address.
     pub external_addresses: Vec<Multiaddr>,
-    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
-    pub disable_bootstrap_on_start: bool,
 }
 
 impl<LocalRecordProvider> fmt::Debug for Config<LocalRecordProvider> {
@@ -366,7 +364,6 @@ where
             bootstrap_addresses: Vec::new(),
             kademlia_mode: KademliaMode::Static(Mode::Client),
             external_addresses: Vec::new(),
-            disable_bootstrap_on_start: false,
         }
     }
 }
@@ -430,7 +427,6 @@ where
         bootstrap_addresses,
         kademlia_mode,
         external_addresses,
-        disable_bootstrap_on_start,
     } = config;
     let local_peer_id = peer_id(&keypair);
 
@@ -577,7 +573,6 @@ where
         metrics,
         protocol_version,
         bootstrap_addresses,
-        disable_bootstrap_on_start,
     });
 
     Ok((node, node_runner))

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -149,10 +149,6 @@ struct DsnOptions {
     #[arg(long, default_value_t = 150)]
     dsn_pending_out_connections: u32,
 
-    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
-    #[arg(long, default_value_t = false)]
-    dsn_disable_bootstrap_on_start: bool,
-
     /// Known external addresses
     #[arg(long, alias = "dsn-external-address")]
     dsn_external_addresses: Vec<Multiaddr>,
@@ -440,7 +436,7 @@ pub(super) fn create_consensus_chain_configuration(
         mut force_synced,
         mut force_authoring,
         pot_external_entropy,
-        mut dsn_options,
+        dsn_options,
         sync_from_dsn,
         storage_monitor,
         mut timekeeper_options,
@@ -459,7 +455,6 @@ pub(super) fn create_consensus_chain_configuration(
             force_synced = true;
             force_authoring = true;
             network_options.allow_private_ips = true;
-            dsn_options.dsn_disable_bootstrap_on_start = true;
             timekeeper_options.timekeeper = true;
         }
 
@@ -643,7 +638,6 @@ pub(super) fn create_consensus_chain_configuration(
             max_pending_in_connections: dsn_options.dsn_pending_in_connections,
             max_pending_out_connections: dsn_options.dsn_pending_out_connections,
             external_addresses: dsn_options.dsn_external_addresses,
-            disable_bootstrap_on_start: dsn_options.dsn_disable_bootstrap_on_start,
         }
     };
 

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -63,9 +63,6 @@ pub struct DsnConfig {
 
     /// Known external addresses
     pub external_addresses: Vec<Multiaddr>,
-
-    /// Defines whether we should run blocking Kademlia bootstrap() operation before other requests.
-    pub disable_bootstrap_on_start: bool,
 }
 
 pub(crate) fn create_dsn_instance(
@@ -118,7 +115,6 @@ pub(crate) fn create_dsn_instance(
         bootstrap_addresses: dsn_config.bootstrap_nodes,
         external_addresses: dsn_config.external_addresses,
         kademlia_mode: KademliaMode::Static(Mode::Client),
-        disable_bootstrap_on_start: dsn_config.disable_bootstrap_on_start,
 
         ..default_networking_config
     };


### PR DESCRIPTION
This PR removes the obsolete flag `--disable_bootstrap_on_start` for DSN networking and clear some comments.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
