### PR TITLE
Stateless mmr proof for the consensus chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "sp-messenger",
  "sp-mmr-primitives",
  "sp-runtime",
+ "sp-subspace-mmr",
  "tracing",
 ]
 
@@ -2725,11 +2726,13 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-state-machine",
+ "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-trie",
  "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
+ "subspace-test-primitives",
  "subspace-test-runtime",
  "subspace-test-service",
  "tempfile",
@@ -7643,6 +7646,7 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-state-machine",
+ "sp-subspace-mmr",
  "sp-trie",
 ]
 
@@ -11562,6 +11566,7 @@ dependencies = [
  "sp-inherents",
  "sp-mmr-primitives",
  "sp-runtime",
+ "sp-subspace-mmr",
  "sp-trie",
 ]
 
@@ -12652,7 +12657,11 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
+ "sp-core",
+ "sp-domains",
  "sp-messenger",
+ "sp-runtime",
+ "sp-subspace-mmr",
  "subspace-runtime-primitives",
 ]
 

--- a/crates/pallet-subspace-mmr/src/lib.rs
+++ b/crates/pallet-subspace-mmr/src/lib.rs
@@ -41,10 +41,10 @@ mod pallet {
     pub trait Config: frame_system::Config<Hash: Into<H256> + From<H256>> {
         type MmrRootHash: Parameter + Copy + MaxEncodedLen;
 
-        /// The number of mmr root hash store in runtime, it will be used to verify mmmr
-        /// proof stateless, the number of roots stored here represent the number of blocks
-        /// for which the mmr proof is valid since it is generated, after that the mmr proof
-        /// will be expired and the prover need to re-generate the proof.
+        /// The number of mmr root hashes to store in the runtime. It will be used to verify mmr
+        /// proof statelessly and the number of roots stored here represents the number of blocks
+        /// for which the mmr proof is valid since it is generated. After that the mmr proof
+        /// will be expired and the prover needs to re-generate the proof.
         type MmrRootHashCount: Get<u32>;
     }
 

--- a/crates/pallet-subspace-mmr/src/lib.rs
+++ b/crates/pallet-subspace-mmr/src/lib.rs
@@ -57,6 +57,8 @@ mod pallet {
 
 impl<T: Config> OnNewRoot<T::MmrRootHash> for Pallet<T> {
     fn on_new_root(root: &T::MmrRootHash) {
+        // TODO: this digest is not used remove it before next network reset but keep it
+        // as is for now to keep compatible with gemini-3h.
         let digest = DigestItem::new_mmr_root(*root);
         <frame_system::Pallet<T>>::deposit_log(digest);
 

--- a/crates/pallet-subspace-mmr/src/lib.rs
+++ b/crates/pallet-subspace-mmr/src/lib.rs
@@ -20,6 +20,7 @@
 
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use pallet::*;
+use sp_core::Get;
 use sp_mmr_primitives::{LeafDataProvider, OnNewRoot};
 use sp_runtime::traits::{CheckedSub, One};
 use sp_runtime::DigestItem;
@@ -28,7 +29,9 @@ use sp_subspace_mmr::{LeafDataV0, MmrDigest, MmrLeaf};
 
 #[frame_support::pallet]
 mod pallet {
+    use frame_support::pallet_prelude::*;
     use frame_support::Parameter;
+    use frame_system::pallet_prelude::BlockNumberFor;
     use sp_core::H256;
 
     #[pallet::pallet]
@@ -36,14 +39,32 @@ mod pallet {
 
     #[pallet::config]
     pub trait Config: frame_system::Config<Hash: Into<H256> + From<H256>> {
-        type MmrRootHash: Parameter + Copy;
+        type MmrRootHash: Parameter + Copy + MaxEncodedLen;
+
+        /// The number of mmr root hash store in runtime, it will be used to verify mmmr
+        /// proof stateless, the number of roots stored here represent the number of blocks
+        /// for which the mmr proof is valid since it is generated, after that the mmr proof
+        /// will be expired and the prover need to re-generate the proof.
+        type MmrRootHashCount: Get<u32>;
     }
+
+    /// Map of block numbers to mmr root hashes.
+    #[pallet::storage]
+    #[pallet::getter(fn mmr_root_hash)]
+    pub type MmrRootHashes<T: Config> =
+        StorageMap<_, Twox64Concat, BlockNumberFor<T>, T::MmrRootHash, OptionQuery>;
 }
 
 impl<T: Config> OnNewRoot<T::MmrRootHash> for Pallet<T> {
     fn on_new_root(root: &T::MmrRootHash) {
         let digest = DigestItem::new_mmr_root(*root);
         <frame_system::Pallet<T>>::deposit_log(digest);
+
+        let block_number = frame_system::Pallet::<T>::block_number();
+        <MmrRootHashes<T>>::insert(block_number, *root);
+        if let Some(to_prune) = block_number.checked_sub(&T::MmrRootHashCount::get().into()) {
+            <MmrRootHashes<T>>::remove(to_prune);
+        }
     }
 }
 

--- a/crates/sp-subspace-mmr/src/lib.rs
+++ b/crates/sp-subspace-mmr/src/lib.rs
@@ -112,3 +112,19 @@ impl<CBlockNumber: Clone, CBlockHash: Clone, MmrHash: Clone> Clone
         }
     }
 }
+
+/// Trait to verify MMR proofs
+pub trait MmrProofVerifier<MmrHash, CBlockNumber, CBlockHash> {
+    /// Returns consensus state root if the given MMR proof is valid
+    fn verify_proof_and_extract_consensus_state_root(
+        mmr_leaf_proof: ConsensusChainMmrLeafProof<CBlockNumber, CBlockHash, MmrHash>,
+    ) -> Option<CBlockHash>;
+}
+
+impl<MmrHash, CBlockNumber, CBlockHash> MmrProofVerifier<MmrHash, CBlockNumber, CBlockHash> for () {
+    fn verify_proof_and_extract_consensus_state_root(
+        _mmr_leaf_proof: ConsensusChainMmrLeafProof<CBlockNumber, CBlockHash, MmrHash>,
+    ) -> Option<CBlockHash> {
+        None
+    }
+}

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -123,6 +123,7 @@ std = [
     "sp-std/std",
     "sp-subspace-mmr/std",
     "sp-transaction-pool/std",
+    "sp-subspace-mmr/std",
     "sp-version/std",
     "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -763,8 +763,13 @@ impl pallet_mmr::Config for Runtime {
     type WeightInfo = ();
 }
 
+parameter_types! {
+    pub const MmrRootHashCount: u32 = 1024;
+}
+
 impl pallet_subspace_mmr::Config for Runtime {
     type MmrRootHash = mmr::Hash;
+    type MmrRootHashCount = MmrRootHashCount;
 }
 
 construct_runtime!(

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -72,7 +72,7 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
-use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof};
+use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
     AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Keccak256, NumberFor,
 };
@@ -85,6 +85,7 @@ use sp_std::collections::btree_map::BTreeMap;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 use sp_subspace_mmr::subspace_mmr_runtime_interface::consensus_block_hash;
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_core_primitives::objects::BlockObjectMapping;
@@ -504,11 +505,17 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
 
 pub struct MmrProofVerifier;
 
-impl sp_messenger::MmrProofVerifier<mmr::Hash, Hash> for MmrProofVerifier {
+// TODO: verify the proof stateless
+impl sp_subspace_mmr::MmrProofVerifier<mmr::Hash, NumberFor<Block>, Hash> for MmrProofVerifier {
     fn verify_proof_and_extract_consensus_state_root(
-        opaque_leaf: EncodableOpaqueLeaf,
-        proof: Proof<mmr::Hash>,
+        mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Hash, mmr::Hash>,
     ) -> Option<Hash> {
+        let ConsensusChainMmrLeafProof {
+            opaque_mmr_leaf: opaque_leaf,
+            proof,
+            ..
+        } = mmr_leaf_proof;
+
         let leaf: mmr::Leaf = opaque_leaf.into_opaque_leaf().try_decode()?;
         let state_root = leaf.state_root();
         Mmr::verify_leaves(vec![leaf], proof).ok()?;
@@ -1342,16 +1349,16 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::RelayerApi<Block, BlockNumber, <Block as BlockT>::Hash> for Runtime {
+    impl sp_messenger::RelayerApi<Block, BlockNumber, BlockNumber, <Block as BlockT>::Hash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<<Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<<Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -29,8 +29,10 @@ sp-domain-digests = { version = "0.1.0", path = "../../primitives/digests" }
 sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-keystore = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
+sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
+sp-subspace-mmr = { version = "0.1.0", default-features = false, path = "../../../crates/sp-subspace-mmr" }
 sp-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-trie = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-weights = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
@@ -54,9 +56,9 @@ pallet-transporter = { version = "0.1.0", path = "../../../domains/pallets/trans
 sc-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f", default-features = false }
 sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
-sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-state-machine = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 subspace-core-primitives = { version = "0.1.0", default-features = false, path = "../../../crates/subspace-core-primitives" }
 subspace-test-runtime = { version = "0.1.0", path = "../../../test/subspace-test-runtime" }
 subspace-test-service = { version = "0.1.0", path = "../../../test/subspace-test-service" }
+subspace-test-primitives = { version = "0.1.0", path = "../../../test/subspace-test-primitives" }
 tempfile = "3.10.1"

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -23,8 +23,10 @@ use sp_domains::{BundleValidity, DomainId, DomainsApi, ExecutionReceipt, HeaderH
 use sp_domains_fraud_proof::fraud_proof::{FraudProof, ValidBundleProof};
 use sp_domains_fraud_proof::FraudProofApi;
 use sp_messenger::MessengerApi;
+use sp_mmr_primitives::MmrApi;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One, Zero};
 use sp_runtime::{Digest, Saturating};
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::str::FromStr;
@@ -975,6 +977,58 @@ where
             local_receipt {local_receipt:?}, bad_receipt {bad_receipt:?}"
         ))))
     }
+}
+
+/// Generate MMR proof for the block `to_prove` in the current best fork. The returned proof
+/// can be later used to verify stateless (without query offchain MMR leaf) and extract the state
+/// root at `to_prove`.
+// TODO: remove `dead_code` after it is used in fraud proof generation
+#[allow(dead_code)]
+pub(crate) fn generate_mmr_proof<CClient, CBlock>(
+    consensus_client: &Arc<CClient>,
+    to_prove: NumberFor<CBlock>,
+) -> sp_blockchain::Result<ConsensusChainMmrLeafProof<NumberFor<CBlock>, CBlock::Hash, H256>>
+where
+    CBlock: BlockT,
+    CClient: HeaderBackend<CBlock> + ProvideRuntimeApi<CBlock> + 'static,
+    CClient::Api: MmrApi<CBlock, H256, NumberFor<CBlock>>,
+{
+    let api = consensus_client.runtime_api();
+    let prove_at_hash = consensus_client.info().best_hash;
+    let prove_at_number = consensus_client.info().best_number;
+
+    if to_prove >= prove_at_number {
+        return Err(sp_blockchain::Error::Application(Box::from(format!(
+            "Can't generate MMR proof for block {to_prove:?} >= best block {prove_at_number:?}"
+        ))));
+    }
+
+    let (mut leaves, proof) = api
+        // NOTE: the mmr leaf data is added in the next block so to generate the MMR proof of
+        // block `to_prove` we need to use `to_prove + 1` here.
+        .generate_proof(
+            prove_at_hash,
+            vec![to_prove + One::one()],
+            Some(prove_at_number),
+        )?
+        .map_err(|err| {
+            sp_blockchain::Error::Application(Box::from(format!(
+                "Failed to generate MMR proof: {err}"
+            )))
+        })?;
+    debug_assert!(leaves.len() == 1, "should always be of length 1");
+    let leaf = leaves
+        .pop()
+        .ok_or(sp_blockchain::Error::Application(Box::from(
+            "Unexpected missing mmr leaf".to_string(),
+        )))?;
+
+    Ok(ConsensusChainMmrLeafProof {
+        consensus_block_number: prove_at_number,
+        consensus_block_hash: prove_at_hash,
+        opaque_mmr_leaf: leaf,
+        proof,
+    })
 }
 
 #[cfg(test)]

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -39,9 +39,7 @@ use sp_domains_fraud_proof::fraud_proof::{
     InvalidTransfersProof,
 };
 use sp_domains_fraud_proof::InvalidTransactionCode;
-use sp_messenger::messages::{
-    ConsensusChainMmrLeafProof, CrossDomainMessage, FeeModel, InitiateChannelParams, Proof,
-};
+use sp_messenger::messages::{CrossDomainMessage, FeeModel, InitiateChannelParams, Proof};
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
 use sp_runtime::generic::{BlockId, DigestItem};
 use sp_runtime::traits::{
@@ -50,6 +48,7 @@ use sp_runtime::traits::{
 use sp_runtime::transaction_validity::InvalidTransaction;
 use sp_runtime::OpaqueExtrinsic;
 use sp_state_machine::backend::AsTrieBackend;
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use subspace_core_primitives::PotOutput;
@@ -1558,6 +1557,7 @@ async fn test_invalid_xdm_proof_creation_and_verification() {
                     nonce: Default::default(),
                     proof: Proof::Domain {
                         consensus_chain_mmr_proof: ConsensusChainMmrLeafProof {
+                            consensus_block_number: Default::default(),
                             consensus_block_hash: Default::default(),
                             opaque_mmr_leaf: EncodableOpaqueLeaf(vec![0, 1, 2]),
                             proof: MmrProof {

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::domain_block_processor::{DomainBlockProcessor, PendingConsensusBlocks};
+use crate::domain_block_processor::{
+    generate_mmr_proof, DomainBlockProcessor, PendingConsensusBlocks,
+};
 use crate::domain_bundle_producer::DomainBundleProducer;
 use crate::domain_bundle_proposer::DomainBundleProposer;
 use crate::fraud_proof::{FraudProofGenerator, TraceDiffType};
@@ -4570,4 +4572,86 @@ async fn test_handle_duplicated_tx_with_diff_nonce_in_previous_bundle() {
         .unwrap();
     assert_eq!(alice.free_balance(Bob.to_account_id()), bob_pre_balance + 3);
     assert_eq!(alice.account_nonce(), nonce + 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_verify_mmr_proof_stateless() {
+    use subspace_test_primitives::OnchainStateApi as _;
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
+
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie with Alice Key since that is the sudo key
+    let mut ferdie = MockConsensusNode::run_with_finalization_depth(
+        tokio_handle.clone(),
+        Sr25519Alice,
+        BasePath::new(directory.path().join("ferdie")),
+        // finalization depth
+        Some(10),
+    );
+
+    // Run Alice (an evm domain)
+    let alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Alice,
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .await;
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    let to_prove = ferdie.client.info().best_number;
+    let expected_state_root = *ferdie
+        .client
+        .header(ferdie.client.info().best_hash)
+        .unwrap()
+        .unwrap()
+        .state_root();
+
+    // Can't generate MMR proof for the current best block
+    assert!(generate_mmr_proof(&ferdie.client, to_prove).is_err());
+
+    produce_blocks!(ferdie, alice, 1).await.unwrap();
+
+    let proof = generate_mmr_proof(&ferdie.client, to_prove).unwrap();
+    for i in 0..20 {
+        let res = ferdie
+            .client
+            .runtime_api()
+            .verify_proof_and_extract_consensus_state_root(
+                ferdie.client.info().best_hash,
+                proof.clone(),
+            )
+            .unwrap();
+
+        produce_blocks!(ferdie, alice, 1).await.unwrap();
+
+        // The MMR is proof is valid for the first `MmrRootHashCount` (i.e. 15) blocks but then expired
+        if i < 15 {
+            assert_eq!(res, Some(expected_state_root));
+        } else {
+            assert_eq!(res, None);
+        }
+    }
+
+    // Re-generate MMR proof for the same block, it will be valid for the next `MmrRootHashCount` blocks
+    let proof = generate_mmr_proof(&ferdie.client, to_prove).unwrap();
+    for _ in 0..15 {
+        let res = ferdie
+            .client
+            .runtime_api()
+            .verify_proof_and_extract_consensus_state_root(
+                ferdie.client.info().best_hash,
+                proof.clone(),
+            )
+            .unwrap();
+
+        assert_eq!(res, Some(expected_state_root));
+        produce_blocks!(ferdie, alice, 1).await.unwrap();
+    }
 }

--- a/domains/client/relayer/Cargo.toml
+++ b/domains/client/relayer/Cargo.toml
@@ -27,4 +27,5 @@ sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", path = "../../primitives/messenger" }
 sp-mmr-primitives = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
+sp-subspace-mmr = { version = "0.1.0", default-features = false, path = "../../../crates/sp-subspace-mmr" }
 tracing = "0.1.40"

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -106,7 +106,7 @@ where
     let best_number = consensus_chain_client.info().best_number;
 
     let (prove_at_number, prove_at_hash) = match dst_chain_id {
-        // The consensus chain will verify the MMR proof stateless with the MMR root
+        // The consensus chain will verify the MMR proof statelessly with the MMR root
         // stored in the runtime, we need to generate the proof with the best block
         // with the latest MMR root in the runtime so the proof will be valid as long
         // as the MMR root is available when verifying the proof.

--- a/domains/client/relayer/src/worker.rs
+++ b/domains/client/relayer/src/worker.rs
@@ -25,7 +25,7 @@ pub async fn relay_consensus_chain_messages<Client, Block, SO>(
         + AuxStore
         + ProofProvider<Block>
         + ProvideRuntimeApi<Block>,
-    Client::Api: RelayerApi<Block, NumberFor<Block>, Block::Hash>
+    Client::Api: RelayerApi<Block, NumberFor<Block>, NumberFor<Block>, Block::Hash>
         + MmrApi<Block, sp_core::H256, NumberFor<Block>>,
     SO: SyncOracle,
 {
@@ -79,7 +79,7 @@ pub async fn relay_domain_messages<CClient, Client, CBlock, Block, SO>(
     Block: BlockT,
     CBlock: BlockT,
     Client: HeaderBackend<Block> + AuxStore + ProofProvider<Block> + ProvideRuntimeApi<Block>,
-    Client::Api: RelayerApi<Block, NumberFor<Block>, CBlock::Hash>,
+    Client::Api: RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, CBlock::Hash>,
     CClient: BlockchainEvents<CBlock>
         + HeaderBackend<CBlock>
         + ProvideRuntimeApi<CBlock>

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -26,6 +26,7 @@ sp-messenger = { version = "0.1.0", default-features = false, path = "../../prim
 sp-mmr-primitives = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-runtime = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-trie = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
+sp-subspace-mmr = { version = "0.1.0", default-features = false, path = "../../../crates/sp-subspace-mmr" }
 
 [dev-dependencies]
 domain-runtime-primitives = { path = "../../primitives/runtime" }
@@ -48,6 +49,7 @@ std = [
     "sp-mmr-primitives/std",
     "sp-runtime/std",
     "sp-trie/std",
+    "sp-subspace-mmr/std",
 ]
 try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [

--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -8,10 +8,11 @@ use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use sp_messenger::endpoint::{Endpoint, EndpointRequest};
 use sp_messenger::messages::{
-    ConsensusChainMmrLeafProof, CrossDomainMessage, InitiateChannelParams, Message,
-    MessageWeightTag, Payload, Proof, RequestResponse, VersionedPayload,
+    CrossDomainMessage, InitiateChannelParams, Message, MessageWeightTag, Payload, Proof,
+    RequestResponse, VersionedPayload,
 };
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_trie::StorageProof;
 
 #[benchmarks]
@@ -120,7 +121,7 @@ mod benchmarks {
         };
         Inbox::<T>::put(msg);
 
-        let xdm = CrossDomainMessage::<T::Hash, T::MmrHash> {
+        let xdm = CrossDomainMessage::<BlockNumberFor<T>, T::Hash, T::MmrHash> {
             src_chain_id: dst_chain_id,
             dst_chain_id: T::SelfChainId::get(),
             channel_id,
@@ -187,7 +188,7 @@ mod benchmarks {
         };
         OutboxResponses::<T>::put(resp_msg);
 
-        let xdm = CrossDomainMessage::<T::Hash, T::MmrHash> {
+        let xdm = CrossDomainMessage::<BlockNumberFor<T>, T::Hash, T::MmrHash> {
             src_chain_id: dst_chain_id,
             dst_chain_id: T::SelfChainId::get(),
             channel_id,
@@ -240,12 +241,14 @@ mod benchmarks {
     );
 }
 
-pub fn dummy_proof<CBlockHash, MmrHash>() -> Proof<CBlockHash, MmrHash>
+pub fn dummy_proof<CNumber, CBlockHash, MmrHash>() -> Proof<CNumber, CBlockHash, MmrHash>
 where
+    CNumber: Default,
     CBlockHash: Default,
 {
     Proof::Consensus {
         consensus_chain_mmr_proof: ConsensusChainMmrLeafProof {
+            consensus_block_number: Default::default(),
             consensus_block_hash: Default::default(),
             opaque_mmr_leaf: EncodableOpaqueLeaf(vec![]),
             proof: MmrProof {

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -17,11 +17,12 @@ use sp_core::{Blake2Hasher, H256};
 use sp_domains::proof_provider_and_verifier::{StorageProofVerifier, VerificationError};
 use sp_messenger::endpoint::{Endpoint, EndpointPayload, EndpointRequest, Sender};
 use sp_messenger::messages::{
-    ChainId, ConsensusChainMmrLeafProof, CrossDomainMessage, InitiateChannelParams,
-    MessageWeightTag, Payload, Proof, ProtocolMessageRequest, RequestResponse, VersionedPayload,
+    ChainId, CrossDomainMessage, InitiateChannelParams, MessageWeightTag, Payload, Proof,
+    ProtocolMessageRequest, RequestResponse, VersionedPayload,
 };
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
 use sp_runtime::traits::Convert;
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_trie::StorageProof;
 use std::collections::BTreeSet;
 
@@ -83,8 +84,9 @@ fn create_channel(chain_id: ChainId, channel_id: ChannelId, fee_model: FeeModel<
     assert_eq!(messages_with_keys.outbox[0].storage_key, expected_key);
 }
 
-fn default_consensus_proof() -> ConsensusChainMmrLeafProof<H256, H256> {
+fn default_consensus_proof() -> ConsensusChainMmrLeafProof<u64, H256, H256> {
     ConsensusChainMmrLeafProof {
+        consensus_block_number: Default::default(),
         consensus_block_hash: Default::default(),
         opaque_mmr_leaf: EncodableOpaqueLeaf(vec![]),
         proof: MmrProof {

--- a/domains/primitives/messenger/Cargo.toml
+++ b/domains/primitives/messenger/Cargo.toml
@@ -28,6 +28,7 @@ sp-inherents = { default-features = false, git = "https://github.com/subspace/po
 sp-mmr-primitives = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-runtime = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-trie = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
+sp-subspace-mmr = { version = "0.1.0", default-features = false,  path = "../../../crates/sp-subspace-mmr" }
 
 [features]
 default = ["std"]
@@ -45,7 +46,8 @@ std = [
     "sp-inherents/std",
     "sp-mmr-primitives/std",
     "sp-runtime/std",
-    "sp-trie/std"
+    "sp-trie/std",
+    "sp-subspace-mmr/std"
 ]
 
 runtime-benchmarks = []

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -31,7 +31,6 @@ use frame_support::inherent::{InherentData, InherentIdentifier, IsFatalError};
 use messages::{BlockMessagesWithStorageKey, CrossDomainMessage, MessageId};
 use sp_domains::{ChainId, DomainAllowlistUpdates, DomainId};
 use sp_inherents::Error;
-use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof};
 
 /// Messenger inherent identifier.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"messengr";
@@ -43,24 +42,6 @@ pub trait OnXDMRewards<Balance> {
 
 impl<Balance> OnXDMRewards<Balance> for () {
     fn on_xdm_rewards(_: Balance) {}
-}
-
-/// Trait to verify MMR proofs
-pub trait MmrProofVerifier<MmrHash, StateRoot> {
-    /// Returns consensus state root if the given MMR proof is valid
-    fn verify_proof_and_extract_consensus_state_root(
-        leaf: EncodableOpaqueLeaf,
-        proof: Proof<MmrHash>,
-    ) -> Option<StateRoot>;
-}
-
-impl<MmrHash, StateRoot> MmrProofVerifier<MmrHash, StateRoot> for () {
-    fn verify_proof_and_extract_consensus_state_root(
-        _leaf: EncodableOpaqueLeaf,
-        _proof: Proof<MmrHash>,
-    ) -> Option<StateRoot> {
-        None
-    }
 }
 
 /// Trait that return various storage keys for storages on Consensus chain and domains
@@ -158,9 +139,10 @@ impl sp_inherents::InherentDataProvider for InherentDataProvider {
 
 sp_api::decl_runtime_apis! {
     /// Api useful for relayers to fetch messages and submit transactions.
-    pub trait RelayerApi<BlockNumber, CHash>
+    pub trait RelayerApi<BlockNumber, CNumber, CHash>
     where
         BlockNumber: Encode + Decode,
+        CNumber: Encode + Decode,
         CHash: Encode + Decode,
     {
         /// Returns all the outbox and inbox responses to deliver.
@@ -169,12 +151,12 @@ sp_api::decl_runtime_apis! {
 
         /// Constructs an outbox message to the dst_chain as an unsigned extrinsic.
         fn outbox_message_unsigned(
-            msg: CrossDomainMessage<CHash, sp_core::H256>,
+            msg: CrossDomainMessage<CNumber, CHash, sp_core::H256>,
         ) -> Option<Block::Extrinsic>;
 
         /// Constructs an inbox response message to the dst_chain as an unsigned extrinsic.
         fn inbox_response_message_unsigned(
-            msg: CrossDomainMessage<CHash, sp_core::H256>,
+            msg: CrossDomainMessage<CNumber, CHash, sp_core::H256>,
         ) -> Option<Block::Extrinsic>;
 
         /// Returns true if the outbox message is ready to be relayed to dst_chain.

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -7,9 +7,9 @@ use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 pub use sp_domains::{ChainId, ChannelId};
-use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
 use sp_runtime::app_crypto::sp_core::U256;
 use sp_runtime::DispatchError;
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_trie::StorageProof;
 
 /// Nonce used as an identifier and ordering of messages within a channel.
@@ -135,43 +135,17 @@ pub struct Message<Balance> {
     pub last_delivered_message_response_nonce: Option<Nonce>,
 }
 
-/// Consensus chain MMR leaf and its Proof at specific block
-#[derive(Debug, Encode, Decode, Eq, PartialEq, TypeInfo)]
-pub struct ConsensusChainMmrLeafProof<BlockHash, MmrHash> {
-    /// Consensus block info from which this proof was generated.
-    pub consensus_block_hash: BlockHash,
-    /// Encoded MMR leaf
-    pub opaque_mmr_leaf: EncodableOpaqueLeaf,
-    /// MMR proof for the leaf above.
-    pub proof: MmrProof<MmrHash>,
-}
-
-// TODO: update upstream `EncodableOpaqueLeaf` to derive clone.
-impl<BlockHash, MmrHash> Clone for ConsensusChainMmrLeafProof<BlockHash, MmrHash>
-where
-    BlockHash: Clone,
-    MmrHash: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            consensus_block_hash: self.consensus_block_hash.clone(),
-            opaque_mmr_leaf: EncodableOpaqueLeaf(self.opaque_mmr_leaf.0.clone()),
-            proof: self.proof.clone(),
-        }
-    }
-}
-
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
-pub enum Proof<CBlockHash, MmrHash> {
+pub enum Proof<CBlockNumber, CBlockHash, MmrHash> {
     Consensus {
         /// Consensus chain MMR leaf proof.
-        consensus_chain_mmr_proof: ConsensusChainMmrLeafProof<CBlockHash, MmrHash>,
+        consensus_chain_mmr_proof: ConsensusChainMmrLeafProof<CBlockNumber, CBlockHash, MmrHash>,
         /// Storage proof that message is processed on src_chain.
         message_proof: StorageProof,
     },
     Domain {
         /// Consensus chain MMR leaf proof.
-        consensus_chain_mmr_proof: ConsensusChainMmrLeafProof<CBlockHash, MmrHash>,
+        consensus_chain_mmr_proof: ConsensusChainMmrLeafProof<CBlockNumber, CBlockHash, MmrHash>,
         /// Storage proof that src domain chain's block is out of the challenge period on Consensus chain.
         domain_proof: StorageProof,
         /// Storage proof that message is processed on src_chain.
@@ -179,7 +153,7 @@ pub enum Proof<CBlockHash, MmrHash> {
     },
 }
 
-impl<CBlockHash, MmrHash> Proof<CBlockHash, MmrHash> {
+impl<CBlockNumber, CBlockHash, MmrHash> Proof<CBlockNumber, CBlockHash, MmrHash> {
     pub fn message_proof(&self) -> StorageProof {
         match self {
             Proof::Consensus { message_proof, .. } => message_proof.clone(),
@@ -187,8 +161,11 @@ impl<CBlockHash, MmrHash> Proof<CBlockHash, MmrHash> {
         }
     }
 
-    pub fn consensus_mmr_proof(&self) -> ConsensusChainMmrLeafProof<CBlockHash, MmrHash>
+    pub fn consensus_mmr_proof(
+        &self,
+    ) -> ConsensusChainMmrLeafProof<CBlockNumber, CBlockHash, MmrHash>
     where
+        CBlockNumber: Clone,
         CBlockHash: Clone,
         MmrHash: Clone,
     {
@@ -214,7 +191,7 @@ impl<CBlockHash, MmrHash> Proof<CBlockHash, MmrHash> {
 
 /// Cross Domain message contains Message and its proof on src_chain.
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
-pub struct CrossDomainMessage<CBlockHash, MmrHash> {
+pub struct CrossDomainMessage<CBlockNumber, CBlockHash, MmrHash> {
     /// Chain which initiated this message.
     pub src_chain_id: ChainId,
     /// Chain this message is intended for.
@@ -224,7 +201,7 @@ pub struct CrossDomainMessage<CBlockHash, MmrHash> {
     /// Message nonce within the channel.
     pub nonce: Nonce,
     /// Proof of message processed on src_chain.
-    pub proof: Proof<CBlockHash, MmrHash>,
+    pub proof: Proof<CBlockNumber, CBlockHash, MmrHash>,
     /// The message weight tag
     pub weight_tag: MessageWeightTag,
 }
@@ -253,10 +230,10 @@ pub struct BlockMessagesWithStorageKey {
     pub inbox_responses: Vec<BlockMessageWithStorageKey>,
 }
 
-impl<BlockHash, MmrHash> CrossDomainMessage<BlockHash, MmrHash> {
+impl<BlockNumber, BlockHash, MmrHash> CrossDomainMessage<BlockNumber, BlockHash, MmrHash> {
     pub fn from_relayer_msg_with_proof(
         r_msg: BlockMessageWithStorageKey,
-        proof: Proof<BlockHash, MmrHash>,
+        proof: Proof<BlockNumber, BlockHash, MmrHash>,
     ) -> Self {
         CrossDomainMessage {
             src_chain_id: r_msg.src_chain_id,

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -45,11 +45,11 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
-use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof};
+use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
 use sp_runtime::traits::{
-    AccountIdLookup, BlakeTwo256, Block as BlockT, Checkable, Keccak256, One, SignedExtension,
-    ValidateUnsigned, Zero,
+    AccountIdLookup, BlakeTwo256, Block as BlockT, Checkable, Keccak256, NumberFor, One,
+    SignedExtension, ValidateUnsigned, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -62,7 +62,7 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill};
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 use sp_subspace_mmr::domain_mmr_runtime_interface::verify_mmr_proof;
-use sp_subspace_mmr::MmrLeaf;
+use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 use sp_version::RuntimeVersion;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, Hash as ConsensusBlockHash, Moment,
@@ -314,11 +314,16 @@ type MmrHash = <Keccak256 as sp_runtime::traits::Hash>::Output;
 
 pub struct MmrProofVerifier;
 
-impl sp_messenger::MmrProofVerifier<MmrHash, Hash> for MmrProofVerifier {
+impl sp_subspace_mmr::MmrProofVerifier<MmrHash, NumberFor<Block>, Hash> for MmrProofVerifier {
     fn verify_proof_and_extract_consensus_state_root(
-        opaque_leaf: EncodableOpaqueLeaf,
-        proof: Proof<MmrHash>,
+        mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Hash, MmrHash>,
     ) -> Option<Hash> {
+        let ConsensusChainMmrLeafProof {
+            opaque_mmr_leaf: opaque_leaf,
+            proof,
+            ..
+        } = mmr_leaf_proof;
+
         let leaf: MmrLeaf<ConsensusBlockNumber, ConsensusBlockHash> =
             opaque_leaf.into_opaque_leaf().try_decode()?;
         let state_root = leaf.state_root();
@@ -825,16 +830,16 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockHash> for Runtime {
+    impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<<Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<<Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -86,7 +86,7 @@ where
         + TransactionPaymentRuntimeApi<Block, Balance>
         + DomainCoreApi<Block>
         + MessengerApi<Block>
-        + RelayerApi<Block, NumberFor<Block>, CBlock::Hash>,
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, CBlock::Hash>,
     AccountId: Encode + Decode,
 {
     /// Task manager.
@@ -273,7 +273,7 @@ where
         + Sync
         + 'static,
     CClient::Api: DomainsApi<CBlock, Header>
-        + RelayerApi<CBlock, NumberFor<CBlock>, CBlock::Hash>
+        + RelayerApi<CBlock, NumberFor<CBlock>, NumberFor<CBlock>, CBlock::Hash>
         + MessengerApi<CBlock>
         + BundleProducerElectionApi<CBlock, subspace_runtime_primitives::Balance>
         + FraudProofApi<CBlock, Header>
@@ -293,7 +293,7 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + RelayerApi<Block, NumberFor<Block>, CBlock::Hash>,
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, CBlock::Hash>,
     AccountId: DeserializeOwned
         + Encode
         + Decode

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -53,12 +53,12 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
-use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof};
+use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
 use sp_runtime::traits::{
     BlakeTwo256, Block as BlockT, Checkable, DispatchInfoOf, Dispatchable, IdentifyAccount,
-    IdentityLookup, Keccak256, One, PostDispatchInfoOf, SignedExtension, UniqueSaturatedInto,
-    ValidateUnsigned, Verify, Zero,
+    IdentityLookup, Keccak256, NumberFor, One, PostDispatchInfoOf, SignedExtension,
+    UniqueSaturatedInto, ValidateUnsigned, Verify, Zero,
 };
 use sp_runtime::transaction_validity::{
     InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -71,7 +71,7 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill};
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 use sp_subspace_mmr::domain_mmr_runtime_interface::verify_mmr_proof;
-use sp_subspace_mmr::MmrLeaf;
+use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 use sp_version::RuntimeVersion;
 use subspace_runtime_primitives::{
     BlockNumber as ConsensusBlockNumber, Hash as ConsensusBlockHash, Moment, SSC,
@@ -412,11 +412,16 @@ type MmrHash = <Keccak256 as sp_runtime::traits::Hash>::Output;
 
 pub struct MmrProofVerifier;
 
-impl sp_messenger::MmrProofVerifier<MmrHash, Hash> for MmrProofVerifier {
+impl sp_subspace_mmr::MmrProofVerifier<MmrHash, NumberFor<Block>, Hash> for MmrProofVerifier {
     fn verify_proof_and_extract_consensus_state_root(
-        opaque_leaf: EncodableOpaqueLeaf,
-        proof: Proof<MmrHash>,
+        mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Hash, MmrHash>,
     ) -> Option<Hash> {
+        let ConsensusChainMmrLeafProof {
+            opaque_mmr_leaf: opaque_leaf,
+            proof,
+            ..
+        } = mmr_leaf_proof;
+
         let leaf: MmrLeaf<ConsensusBlockNumber, ConsensusBlockHash> =
             opaque_leaf.into_opaque_leaf().try_decode()?;
         let state_root = leaf.state_root();
@@ -1083,16 +1088,16 @@ impl_runtime_apis! {
         }
     }
 
-    impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockHash> for Runtime {
+    impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
         fn block_messages() -> BlockMessagesWithStorageKey {
             Messenger::get_block_messages()
         }
 
-        fn outbox_message_unsigned(msg: CrossDomainMessage<<Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
             Messenger::outbox_message_unsigned(msg)
         }
 
-        fn inbox_response_message_unsigned(msg: CrossDomainMessage<<Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
             Messenger::inbox_response_message_unsigned(msg)
         }
 

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -86,7 +86,7 @@ where
         + TaggedTransactionQueue<Block>
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
-        + RelayerApi<Block, NumberFor<Block>, <CBlock as BlockT>::Hash>,
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, <CBlock as BlockT>::Hash>,
     AccountId: Encode + Decode + FromKeyring,
 {
     /// The domain id
@@ -137,7 +137,7 @@ where
         + AccountNonceApi<Block, AccountId, Nonce>
         + TransactionPaymentRuntimeApi<Block, Balance>
         + MessengerApi<Block>
-        + RelayerApi<Block, NumberFor<Block>, <CBlock as BlockT>::Hash>
+        + RelayerApi<Block, NumberFor<Block>, NumberFor<CBlock>, <CBlock as BlockT>::Hash>
         + OnchainStateApi<Block, AccountId, Balance>
         + EthereumRuntimeRPCApi<Block>,
     AccountId: DeserializeOwned

--- a/test/subspace-test-primitives/Cargo.toml
+++ b/test/subspace-test-primitives/Cargo.toml
@@ -14,13 +14,22 @@ include = [
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false, features = ["derive"] }
 sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f", default-features = false }
+sp-domains = { version = "0.1.0", path = "../../crates/sp-domains", default-features = false }
+sp-core = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../domains/primitives/messenger" }
+sp-runtime = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "ac2f3efb476ee3f5ac6bafefb458e9be158adb7f" }
+sp-subspace-mmr = { version = "0.1.0", default-features = false, path = "../../crates/sp-subspace-mmr" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+    "codec/std",
     "sp-api/std",
+    "sp-domains/std",
+    "sp-core/std",
     "sp-messenger/std",
+    "sp-runtime/std",
+    "sp-subspace-mmr/std",
     "subspace-runtime-primitives/std",
 ]

--- a/test/subspace-test-primitives/src/lib.rs
+++ b/test/subspace-test-primitives/src/lib.rs
@@ -2,7 +2,10 @@
 //! Test primitive crates that expose necessary extensions that are used in tests.
 
 use codec::{Decode, Encode};
+use sp_core::H256;
 use sp_messenger::messages::{ChainId, ChannelId};
+use sp_runtime::traits::NumberFor;
+use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 
 sp_api::decl_runtime_apis! {
     /// Api for querying onchain state in the test
@@ -16,5 +19,8 @@ sp_api::decl_runtime_apis! {
 
         /// Returns the last open channel for a given domain.
         fn get_open_channel_for_chain(dst_chain_id: ChainId) -> Option<ChannelId>;
+
+        /// Verify the mmr proof stateless and extract the state root.
+        fn verify_proof_and_extract_consensus_state_root(proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Block::Hash, H256>) -> Option<Block::Hash>;
     }
 }

--- a/test/subspace-test-primitives/src/lib.rs
+++ b/test/subspace-test-primitives/src/lib.rs
@@ -20,7 +20,7 @@ sp_api::decl_runtime_apis! {
         /// Returns the last open channel for a given domain.
         fn get_open_channel_for_chain(dst_chain_id: ChainId) -> Option<ChannelId>;
 
-        /// Verify the mmr proof stateless and extract the state root.
+        /// Verify the mmr proof statelessly and extract the state root.
         fn verify_proof_and_extract_consensus_state_root(proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Block::Hash, H256>) -> Option<Block::Hash>;
     }
 }

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -114,6 +114,7 @@ std = [
     "sp-std/std",
     "sp-subspace-mmr/std",
     "sp-transaction-pool/std",
+    "sp-subspace-mmr/std",
     "sp-version/std",
     "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -549,15 +549,26 @@ impl sp_subspace_mmr::MmrProofVerifier<mmr::Hash, NumberFor<Block>, Hash> for Mm
         mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Hash, mmr::Hash>,
     ) -> Option<Hash> {
         let ConsensusChainMmrLeafProof {
-            opaque_mmr_leaf: opaque_leaf,
+            consensus_block_number,
+            opaque_mmr_leaf,
             proof,
             ..
         } = mmr_leaf_proof;
 
-        let leaf: mmr::Leaf = opaque_leaf.into_opaque_leaf().try_decode()?;
-        let state_root = leaf.state_root();
-        Mmr::verify_leaves(vec![leaf], proof).ok()?;
-        Some(state_root)
+        let mmr_root = SubspaceMmr::mmr_root_hash(consensus_block_number)?;
+
+        pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(
+            mmr_root,
+            vec![mmr::DataOrHash::Data(
+                EncodableOpaqueLeaf(opaque_mmr_leaf.0.clone()).into_opaque_leaf(),
+            )],
+            proof,
+        )
+        .ok()?;
+
+        let leaf: mmr::Leaf = opaque_mmr_leaf.into_opaque_leaf().try_decode()?;
+
+        Some(leaf.state_root())
     }
 }
 
@@ -1543,28 +1554,8 @@ impl_runtime_apis! {
             Messenger::get_open_channel_for_chain(dst_chain_id).map(|(c, _)| c)
         }
 
-        fn verify_proof_and_extract_consensus_state_root(mmr_leaf_proof: sp_subspace_mmr::ConsensusChainMmrLeafProof<NumberFor<Block>, <Block as BlockT>::Hash, H256>) -> Option<H256> {
-            let sp_subspace_mmr::ConsensusChainMmrLeafProof {
-                consensus_block_number,
-                opaque_mmr_leaf,
-                proof,
-                ..
-            } = mmr_leaf_proof;
-    
-            let mmr_root = SubspaceMmr::mmr_root_hash(consensus_block_number)?;
-    
-            pallet_mmr::verify_leaves_proof::<mmr::Hashing, _>(
-                mmr_root,
-                vec![mmr::DataOrHash::Data(
-                    EncodableOpaqueLeaf(opaque_mmr_leaf.0.clone()).into_opaque_leaf(),
-                )],
-                proof,
-            )
-            .ok()?;
-    
-            let leaf: mmr::Leaf = opaque_mmr_leaf.into_opaque_leaf().try_decode()?;
-    
-            Some(leaf.state_root())
+        fn verify_proof_and_extract_consensus_state_root(mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, <Block as BlockT>::Hash, H256>) -> Option<H256> {
+            <MmrProofVerifier as sp_subspace_mmr::MmrProofVerifier<_, _, _,>>::verify_proof_and_extract_consensus_state_root(mmr_leaf_proof)
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -788,8 +788,13 @@ impl pallet_mmr::Config for Runtime {
     type WeightInfo = ();
 }
 
+parameter_types! {
+    pub const MmrRootHashCount: u32 = 15;
+}
+
 impl pallet_subspace_mmr::Config for Runtime {
     type MmrRootHash = mmr::Hash;
+    type MmrRootHashCount = MmrRootHashCount;
 }
 
 construct_runtime!(


### PR DESCRIPTION
This PR adds support for generating & verifying mmr proof in a stateless fashion for the consensus chain, so the consensus node (i.e. farmer) won't be required to maintain the offchain MMR leaf and resolves the conflict with fast-sync (fast-synced node won't has MMR data) and toward our goal to make the farmer lightweight. This is done by storing `MmrRootHashCount` number of mmr root in the consensus runtime, and use these roots in mmr proof verification instead of getting from offchain storage.

In this PR this is only used in the XDM verification of the consensus chain, while the domain is still and MUST be the same as before because the mmr proof verification in the domain chain is done by a runtime API call (via a host function) to its consensus node and the result very depends on the hash we used to this call (we use the parent hash of the best block currently) which means the result may be different since the best block may be different in different node thus the domain block execution can be indeterministic (Also, I run the `test_cross_domains_messages_should_work` test locally it passes, but this test is disabled in CI due flaky).

In the upcoming PR, the fraud proof verification will also be updated to use the stateless mmr proof.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
