### PR TITLE
Implement SCALE encode/decode on RPC primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12461,6 +12461,7 @@ name = "subspace-rpc-primitives"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "parity-scale-codec",
  "serde",
  "subspace-core-primitives",
  "subspace-farmer-components",

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -25,15 +25,15 @@ mod segment_reconstruction;
 
 use crate::file_ext::FileExt;
 use async_trait::async_trait;
+use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
+use std::error::Error;
 use std::fs::File;
 use std::future::Future;
 use std::io;
 use std::sync::Arc;
 use subspace_core_primitives::{ArchivedHistorySegment, HistorySize, Piece, PieceIndex};
-
-use std::error::Error;
 
 /// Trait representing a way to get pieces
 #[async_trait]
@@ -304,7 +304,7 @@ where
 const_assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u64>());
 
 /// Information about the protocol necessary for farmer operation
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Encode, Decode, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FarmerProtocolInfo {
     /// Size of the blockchain history

--- a/crates/subspace-rpc-primitives/Cargo.toml
+++ b/crates/subspace-rpc-primitives/Cargo.toml
@@ -14,6 +14,7 @@ include = [
 
 [dependencies]
 hex = { version = "0.4.3", features = ["serde"] }
+parity-scale-codec = { version = "3.6.9", features = ["derive"] }
 serde = { version = "1.0.196", features = ["derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }


### PR DESCRIPTION
This is needed in order to send those data structures in binary form.

`dsn_bootstrap_nodes` contains `Multiaddr` that doesn't implement SCALE encoding/decoding, so had to write a manual implementation for that one instead of simple derive.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
