### PR TITLE
Refactor archiver.

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -262,16 +262,20 @@ where
 
         // Special case for the initial segment (for genesis block).
         if block_number == 1 {
+            // If there is a segment index present and we store monotonically increasing segment headers,
+            // then the first header exists.
             return vec![self
                 .get_segment_header(SegmentIndex::ZERO)
-                .expect("Segment headers are stored in monononically increasing order; qed")];
+                .expect("Segment headers are stored in monotonically increasing order; qed")];
         }
 
         let mut current_segment_index = last_segment_index;
         loop {
+            // If the current segment index present and we store monotonically increasing segment headers,
+            // then the current segment header exists as well.
             let current_segment_header = self
                 .get_segment_header(current_segment_index)
-                .expect("Current segment must always exist.");
+                .expect("Segment headers are stored in monotonically increasing order; qed");
 
             // The block immediately after the archived segment adding the confirmation depth
             let target_block_number =

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -256,7 +256,8 @@ where
     /// Get segment headers that are expected to be included at specified block number.
     pub fn segment_headers_for_block(&self, block_number: BlockNumber) -> Vec<SegmentHeader> {
         let Some(last_segment_index) = self.max_segment_index() else {
-            return Vec::new(); // not initialized
+            // Not initialized
+            return Vec::new();
         };
 
         // Special case for the initial segment (for genesis block).

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -264,7 +264,7 @@ where
         if block_number == 1 {
             return vec![self
                 .get_segment_header(SegmentIndex::ZERO)
-                .expect("The initial segment header must exist at this point.")];
+                .expect("Segment headers are stored in monononically increasing order; qed")];
         }
 
         let mut current_segment_index = last_segment_index;

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -281,7 +281,23 @@ where
             let target_block_number =
                 current_segment_header.last_archived_block().number + 1 + self.confirmation_depth_k;
             if target_block_number == block_number {
-                return vec![current_segment_header];
+                let mut headers_for_block = vec![current_segment_header];
+
+                // Check block spanning multiple segments
+                let last_archived_block_number =
+                    current_segment_header.last_archived_block().number;
+                let mut segment_index = current_segment_index - SegmentIndex::ONE;
+
+                while let Some(segment_header) = self.get_segment_header(segment_index) {
+                    if segment_header.last_archived_block().number == last_archived_block_number {
+                        headers_for_block.insert(0, segment_header);
+                        segment_index -= SegmentIndex::ONE;
+                    } else {
+                        break;
+                    }
+                }
+
+                return headers_for_block;
             }
 
             // iterate segments further

--- a/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -1,0 +1,148 @@
+use crate::archiver::SegmentHeadersStore;
+use parking_lot::RwLock;
+use sc_client_api::AuxStore;
+use std::collections::HashMap;
+use std::sync::Arc;
+use subspace_core_primitives::{
+    ArchivedBlockProgress, LastArchivedBlock, SegmentHeader, SegmentIndex,
+};
+
+struct MemAuxStore {
+    store: RwLock<HashMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl MemAuxStore {
+    fn new() -> Self {
+        Self {
+            store: RwLock::new(Default::default()),
+        }
+    }
+}
+
+impl AuxStore for MemAuxStore {
+    fn insert_aux<
+        'a,
+        'b: 'a,
+        'c: 'a,
+        I: IntoIterator<Item = &'a (&'c [u8], &'c [u8])>,
+        D: IntoIterator<Item = &'a &'b [u8]>,
+    >(
+        &self,
+        insert: I,
+        delete: D,
+    ) -> sp_blockchain::Result<()> {
+        let mut storage = self.store.write();
+        for (k, v) in insert {
+            storage.insert(k.to_vec(), v.to_vec());
+        }
+        for k in delete {
+            storage.remove(*k);
+        }
+        Ok(())
+    }
+
+    fn get_aux(&self, key: &[u8]) -> sp_blockchain::Result<Option<Vec<u8>>> {
+        Ok(self.store.read().get(key).cloned())
+    }
+}
+
+#[test]
+fn segment_headers_store_block_number_queries_work() {
+    let confirmation_depth_k = 100;
+    let segment_headers =
+        SegmentHeadersStore::new(Arc::new(MemAuxStore::new()), confirmation_depth_k).unwrap();
+
+    // Several starting segments from gemini-3h
+
+    let segment_header0 = SegmentHeader::V0 {
+        segment_index: SegmentIndex::ZERO,
+        segment_commitment: Default::default(),
+        prev_segment_header_hash: Default::default(),
+        last_archived_block: LastArchivedBlock {
+            number: 0,
+            archived_progress: ArchivedBlockProgress::Partial(5),
+        },
+    };
+
+    let segment_header1 = SegmentHeader::V0 {
+        segment_index: SegmentIndex::ONE,
+        segment_commitment: Default::default(),
+        prev_segment_header_hash: Default::default(),
+        last_archived_block: LastArchivedBlock {
+            number: 652,
+            archived_progress: ArchivedBlockProgress::Partial(5),
+        },
+    };
+
+    let segment_header2 = SegmentHeader::V0 {
+        segment_index: SegmentIndex::from(2),
+        segment_commitment: Default::default(),
+        prev_segment_header_hash: Default::default(),
+        last_archived_block: LastArchivedBlock {
+            number: 752,
+            archived_progress: ArchivedBlockProgress::Partial(5),
+        },
+    };
+
+    let segment_header3 = SegmentHeader::V0 {
+        segment_index: SegmentIndex::from(3),
+        segment_commitment: Default::default(),
+        prev_segment_header_hash: Default::default(),
+        last_archived_block: LastArchivedBlock {
+            number: 806,
+            archived_progress: ArchivedBlockProgress::Partial(5),
+        },
+    };
+
+    segment_headers
+        .add_segment_headers(
+            vec![
+                segment_header0,
+                segment_header1,
+                segment_header2,
+                segment_header3,
+            ]
+            .as_slice(),
+        )
+        .unwrap();
+
+    // Initial segment
+    let segment_header0 = segment_headers
+        .get_segment_header(SegmentIndex::ZERO)
+        .unwrap();
+    let result = segment_headers.segment_headers_for_block(1u32);
+    assert_eq!(result, vec![segment_header0]);
+
+    for num in 2u32..752u32 {
+        let result = segment_headers.segment_headers_for_block(num);
+        assert_eq!(result, vec![]);
+    }
+
+    // End of first segment
+    let segment_header1 = segment_headers
+        .get_segment_header(SegmentIndex::ONE)
+        .unwrap();
+    // last archived block + confirmation depth + 1
+    let result = segment_headers.segment_headers_for_block(753u32);
+    assert_eq!(result, vec![segment_header1]);
+
+    // No segment headers in between
+    for num in 754u32..852u32 {
+        let result = segment_headers.segment_headers_for_block(num);
+        assert_eq!(result, vec![]);
+    }
+
+    // End of the second segment
+    let segment_header2 = segment_headers
+        .get_segment_header(SegmentIndex::from(2))
+        .unwrap();
+    let result = segment_headers.segment_headers_for_block(853u32);
+    assert_eq!(result, vec![segment_header2]);
+
+    // End of third segment
+    let segment_header3 = segment_headers
+        .get_segment_header(SegmentIndex::from(3))
+        .unwrap();
+    let result = segment_headers.segment_headers_for_block(907u32);
+    assert_eq!(result, vec![segment_header3]);
+}

--- a/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -94,6 +94,16 @@ fn segment_headers_store_block_number_queries_work() {
         },
     };
 
+    let segment_header4 = SegmentHeader::V0 {
+        segment_index: SegmentIndex::from(4),
+        segment_commitment: Default::default(),
+        prev_segment_header_hash: Default::default(),
+        last_archived_block: LastArchivedBlock {
+            number: 806,
+            archived_progress: ArchivedBlockProgress::Partial(5),
+        },
+    };
+
     segment_headers
         .add_segment_headers(
             vec![
@@ -101,6 +111,7 @@ fn segment_headers_store_block_number_queries_work() {
                 segment_header1,
                 segment_header2,
                 segment_header3,
+                segment_header4,
             ]
             .as_slice(),
         )
@@ -144,5 +155,5 @@ fn segment_headers_store_block_number_queries_work() {
         .get_segment_header(SegmentIndex::from(3))
         .unwrap();
     let result = segment_headers.segment_headers_for_block(907u32);
-    assert_eq!(result, vec![segment_header3]);
+    assert_eq!(result, vec![segment_header3, segment_header4]);
 }

--- a/crates/sc-consensus-subspace/src/block_import.rs
+++ b/crates/sc-consensus-subspace/src/block_import.rs
@@ -316,7 +316,7 @@ where
     Block: BlockT,
     Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + HeaderBackend<Block> + AuxStore,
     Client::Api: BlockBuilderApi<Block> + SubspaceApi<Block, FarmerPublicKey> + ApiExt<Block>,
-    CIDP: CreateInherentDataProviders<Block, SubspaceLink<Block>> + Send + Sync + 'static,
+    CIDP: CreateInherentDataProviders<Block, ()> + Send + Sync + 'static,
     AS: AuxStore + Send + Sync + 'static,
     BlockNumber: From<<<Block as BlockT>::Header as HeaderT>::Number>,
 {
@@ -563,7 +563,7 @@ where
             if let Some(extrinsics) = extrinsics {
                 let create_inherent_data_providers = self
                     .create_inherent_data_providers
-                    .create_inherent_data_providers(parent_hash, self.subspace_link.clone())
+                    .create_inherent_data_providers(parent_hash, ())
                     .await
                     .map_err(|error| Error::Client(sp_blockchain::Error::from(error)))?;
 
@@ -610,7 +610,7 @@ where
         + Send
         + Sync,
     Client::Api: BlockBuilderApi<Block> + SubspaceApi<Block, FarmerPublicKey> + ApiExt<Block>,
-    CIDP: CreateInherentDataProviders<Block, SubspaceLink<Block>> + Send + Sync + 'static,
+    CIDP: CreateInherentDataProviders<Block, ()> + Send + Sync + 'static,
     AS: AuxStore + Send + Sync + 'static,
     BlockNumber: From<<<Block as BlockT>::Header as HeaderT>::Number>,
 {

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -26,8 +26,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
-extern crate core;
-
 pub mod archiver;
 pub mod aux_schema;
 pub mod block_import;

--- a/crates/sc-proof-of-time/src/lib.rs
+++ b/crates/sc-proof-of-time/src/lib.rs
@@ -19,8 +19,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 use subspace_core_primitives::PotCheckpoints;
 use tokio::sync::broadcast::error::RecvError;
-use tracing::log::info;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 pub trait PotSlotWorker<Block>
 where

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -531,7 +531,7 @@ where
             let client = client.clone();
             let segment_headers_store = segment_headers_store.clone();
 
-            move |parent_hash, _| {
+            move |parent_hash, ()| {
                 let client = client.clone();
                 let segment_headers_store = segment_headers_store.clone();
 

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -510,25 +510,30 @@ where
 
     let select_chain = sc_consensus::LongestChain::new(backend.clone());
 
-    let segment_headers_store =
-        tokio::task::block_in_place(|| SegmentHeadersStore::new(client.clone()))
-            .map_err(|error| ServiceError::Application(error.into()))?;
-
     let chain_constants = client
         .runtime_api()
         .chain_constants(client_info.best_hash)
         .map_err(|error| ServiceError::Application(error.into()))?;
 
+    let segment_headers_store = tokio::task::block_in_place(|| {
+        SegmentHeadersStore::new(client.clone(), chain_constants.confirmation_depth_k())
+    })
+    .map_err(|error| ServiceError::Application(error.into()))?;
+
     let subspace_link = SubspaceLink::new(chain_constants, kzg.clone());
+    let segment_headers_store = segment_headers_store.clone();
+
     let block_import = SubspaceBlockImport::<PosTable, _, _, _, _, _>::new(
         client.clone(),
         client.clone(),
         subspace_link.clone(),
         {
             let client = client.clone();
+            let segment_headers_store = segment_headers_store.clone();
 
-            move |parent_hash, subspace_link: SubspaceLink<Block>| {
+            move |parent_hash, _| {
                 let client = client.clone();
+                let segment_headers_store = segment_headers_store.clone();
 
                 async move {
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -541,7 +546,8 @@ where
 
                     let subspace_inherents =
                         sp_consensus_subspace::inherents::InherentDataProvider::new(
-                            subspace_link.segment_headers_for_block(parent_block_number + 1),
+                            segment_headers_store
+                                .segment_headers_for_block(parent_block_number + 1),
                         );
 
                     Ok((timestamp, subspace_inherents))
@@ -1038,11 +1044,11 @@ where
 
         let create_inherent_data_providers = {
             let client = client.clone();
-            let subspace_link = subspace_link.clone();
+            let segment_headers_store = segment_headers_store.clone();
 
             move |parent_hash, ()| {
                 let client = client.clone();
-                let subspace_link = subspace_link.clone();
+                let segment_headers_store = segment_headers_store.clone();
 
                 async move {
                     let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -1055,7 +1061,8 @@ where
 
                     let subspace_inherents =
                         sp_consensus_subspace::inherents::InherentDataProvider::new(
-                            subspace_link.segment_headers_for_block(parent_block_number + 1),
+                            segment_headers_store
+                                .segment_headers_for_block(parent_block_number + 1),
                         );
 
                     Ok((timestamp, subspace_inherents))


### PR DESCRIPTION
This PR refactors the `segment_headers_for_block` feature from the archiver and moves it to `SegmentHeadersStore`. It follows the discussion started [here](https://github.com/subspace/subspace/pull/2684). It also contains tests for the several starting segments of the gemini-3h.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
