### PR TITLE
Staking - 1: Accumulate and then mint funds in to treasury when they cross minimum balance

### DIFF
--- a/crates/pallet-domains/src/bundle_storage_fund.rs
+++ b/crates/pallet-domains/src/bundle_storage_fund.rs
@@ -1,6 +1,7 @@
 //! Bundle storage fund
 
 use crate::staking::NewDeposit;
+use crate::staking_epoch::mint_into_treasury;
 use crate::{BalanceOf, Config, Event, HoldIdentifier, Operators, Pallet};
 use codec::{Decode, Encode};
 use frame_support::traits::fungible::{Inspect, Mutate, MutateHold};
@@ -124,8 +125,7 @@ pub fn refund_storage_fee<T: Config>(
 
     // Drop any dust and deregistered/slashed operator's bundle storage fee to the treasury
     if !remaining_fee.is_zero() {
-        T::Currency::mint_into(&T::TreasuryAccount::get(), remaining_fee)
-            .map_err(|_| Error::MintBalance)?;
+        mint_into_treasury::<T>(remaining_fee).ok_or(Error::MintBalance)?;
     }
 
     Ok(())

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -636,10 +636,10 @@ mod pallet {
     pub(super) type PermissionedActionAllowedBy<T: Config> =
         StorageValue<_, sp_domains::PermissionedActionAllowedBy<T::AccountId>, OptionQuery>;
 
-    /// Accumulate treasury funds temporarily until the funds have Exisitential despoit.
-    /// We do this do minting small amounts into treasury would not fail.
+    /// Accumulate treasury funds temporarily until the funds are above Existential despoit.
+    /// We do this to ensure minting small amounts into treasury would not fail.
     #[pallet::storage]
-    pub(super) type TreasuryFunds<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+    pub(super) type AccumulatedTreasuryFunds<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -636,6 +636,11 @@ mod pallet {
     pub(super) type PermissionedActionAllowedBy<T: Config> =
         StorageValue<_, sp_domains::PermissionedActionAllowedBy<T::AccountId>, OptionQuery>;
 
+    /// Accumulate treasury funds temporarily until the funds have Exisitential despoit.
+    /// We do this do minting small amounts into treasury would not fail.
+    #[pallet::storage]
+    pub(super) type TreasuryFunds<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
         /// Can not find the operator for given operator id.

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -9,7 +9,7 @@ use crate::pallet::{
     NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators, PendingOperatorSwitches,
     PendingSlashes, PendingStakingOperationCount, Withdrawals,
 };
-use crate::staking_epoch::mint_funds;
+use crate::staking_epoch::{mint_funds, mint_into_treasury};
 use crate::{
     BalanceOf, Config, DomainBlockNumberFor, Event, HoldIdentifier, NominatorId,
     OperatorEpochSharePrice, Pallet, ReceiptHashFor, SlashedReason,
@@ -1181,7 +1181,7 @@ pub(crate) fn do_unlock_operator<T: Config>(operator_id: OperatorId) -> Result<u
             .map_err(Error::BundleStorageFund)?;
 
         // transfer any remaining amount to treasury
-        mint_funds::<T>(&T::TreasuryAccount::get(), total_stake)?;
+        mint_into_treasury::<T>(total_stake).ok_or(Error::MintBalance)?;
 
         // remove OperatorOwner Details
         OperatorIdOwner::<T>::remove(operator_id);
@@ -1234,7 +1234,7 @@ pub(crate) fn do_reward_operators<T: Config>(
                 .ok_or(Error::BalanceUnderflow)?;
         }
 
-        mint_funds::<T>(&T::TreasuryAccount::get(), rewards)
+        mint_into_treasury::<T>(rewards).ok_or(Error::MintBalance)
     })
 }
 


### PR DESCRIPTION
Currently when distributing rewards, we give the remainder of the funds to treasury. 
If the remainder is less than existential deposit and there is not treasury account created yet, minting fails as noticed in devnet.

This PR adds a temporary storage item to collect the treasury amount until it reaches the minimum balance then only mint funds into treasury.

Closes: #2691

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
