### PR TITLE
Staking - 2: Weighted reward distribution to operators

### DIFF
--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -289,6 +289,7 @@ impl pallet_domains::Config for Test {
     type BundleLongevity = BundleLongevity;
     type ConsensusSlotProbability = SlotProbability;
     type DomainBundleSubmitted = ();
+    type Balance = Balance;
 }
 
 pub struct ExtrinsicStorageFees;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -714,6 +714,7 @@ impl pallet_domains::Config for Runtime {
     type MaxInitialDomainAccounts = MaxInitialDomainAccounts;
     type MinInitialDomainAccountBalance = MinInitialDomainAccountBalance;
     type DomainBundleSubmitted = Messenger;
+    type Balance = Balance;
 }
 
 parameter_types! {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -742,6 +742,7 @@ impl pallet_domains::Config for Runtime {
     type MaxInitialDomainAccounts = MaxInitialDomainAccounts;
     type MinInitialDomainAccountBalance = MinInitialDomainAccountBalance;
     type DomainBundleSubmitted = Messenger;
+    type Balance = Balance;
 }
 
 parameter_types! {


### PR DESCRIPTION
This PR updated how we distribute rewards to operators using weighted distribution.
Also replaces `PerBill` to `Perquintall` to reduce the rounding dust.

Note: we still use Perbill for StorageFund and SharePrice. I would prefer not to use `Perquintall` for Gemini-3h and proceed to use to use it before next network

Closes: #2692

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
