### PR TITLE
Plotter abstraction and farm plotting pipelining

### DIFF
--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use futures::executor::block_on;
 use rand::prelude::*;
+use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -156,7 +157,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     black_box(solution_range),
                     black_box(&plotted_sector_bytes),
                     black_box(slice::from_ref(&plotted_sector.sector_metadata)),
-                    black_box(None),
+                    black_box(&HashSet::default()),
                 )
                 .unwrap(),
             );
@@ -201,7 +202,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         black_box(solution_range),
                         black_box(&plot_file),
                         black_box(&sectors_metadata),
-                        black_box(None),
+                        black_box(&HashSet::default()),
                     )
                     .unwrap(),
                 );

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -5,6 +5,7 @@ use futures::executor::block_on;
 use parking_lot::Mutex;
 use rand::prelude::*;
 use schnorrkel::Keypair;
+use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -164,7 +165,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             solution_range,
             &plotted_sector_bytes,
             slice::from_ref(&plotted_sector.sector_metadata),
-            None,
+            &HashSet::default(),
         )
         .unwrap();
 
@@ -253,7 +254,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 solution_range,
                 &plot_file,
                 &sectors_metadata,
-                None,
+                &HashSet::default(),
             )
             .unwrap();
             let solution_candidates = audit_results

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -3,6 +3,7 @@ use anyhow::anyhow;
 use clap::Subcommand;
 use criterion::{black_box, BatchSize, Criterion, Throughput};
 use parking_lot::Mutex;
+use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -153,7 +154,7 @@ fn audit(
                             sectors_metadata: &sectors_metadata,
                             kzg: &kzg,
                             erasure_coding: &erasure_coding,
-                            maybe_sector_being_modified: None,
+                            sectors_being_modified: &HashSet::default(),
                             read_sector_record_chunks_mode:
                                 ReadSectorRecordChunksMode::ConcurrentChunks,
                             table_generator: &table_generator,
@@ -191,7 +192,7 @@ fn audit(
                             sectors_metadata: &sectors_metadata,
                             kzg: &kzg,
                             erasure_coding: &erasure_coding,
-                            maybe_sector_being_modified: None,
+                            sectors_being_modified: &HashSet::default(),
                             read_sector_record_chunks_mode:
                                 ReadSectorRecordChunksMode::ConcurrentChunks,
                             table_generator: &table_generator,
@@ -226,7 +227,7 @@ fn audit(
                             sectors_metadata: &sectors_metadata,
                             kzg: &kzg,
                             erasure_coding: &erasure_coding,
-                            maybe_sector_being_modified: None,
+                            sectors_being_modified: &HashSet::default(),
                             read_sector_record_chunks_mode:
                                 ReadSectorRecordChunksMode::ConcurrentChunks,
                             table_generator: &table_generator,
@@ -310,7 +311,7 @@ fn prove(
                 sectors_metadata: &sectors_metadata,
                 kzg: &kzg,
                 erasure_coding: &erasure_coding,
-                maybe_sector_being_modified: None,
+                sectors_being_modified: &HashSet::default(),
                 read_sector_record_chunks_mode: ReadSectorRecordChunksMode::ConcurrentChunks,
                 table_generator: &Mutex::new(PosTable::generator()),
             };
@@ -383,7 +384,7 @@ fn prove(
                 sectors_metadata: &sectors_metadata,
                 kzg: &kzg,
                 erasure_coding: &erasure_coding,
-                maybe_sector_being_modified: None,
+                sectors_being_modified: &HashSet::default(),
                 read_sector_record_chunks_mode: ReadSectorRecordChunksMode::ConcurrentChunks,
                 table_generator: &table_generator,
             };
@@ -453,7 +454,7 @@ fn prove(
                 sectors_metadata: &sectors_metadata,
                 kzg: &kzg,
                 erasure_coding: &erasure_coding,
-                maybe_sector_being_modified: None,
+                sectors_being_modified: &HashSet::default(),
                 read_sector_record_chunks_mode: ReadSectorRecordChunksMode::ConcurrentChunks,
                 table_generator: &table_generator,
             };

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -37,7 +37,7 @@ use subspace_farmer::utils::ss58::parse_ss58_reward_address;
 use subspace_farmer::utils::{
     all_cpu_cores, create_plotting_thread_pool_manager, parse_cpu_cores_sets,
     recommended_number_of_farming_threads, run_future_in_dedicated_thread,
-    thread_pool_core_indices, AsyncJoinOnDrop, CpuCoreSet,
+    thread_pool_core_indices, AsyncJoinOnDrop,
 };
 use subspace_farmer::{Identity, NodeClient, NodeRpcClient};
 use subspace_farmer_components::plotting::PlottedSector;
@@ -416,8 +416,8 @@ where
         None => farmer_app_info.protocol_info.max_pieces_in_sector,
     };
 
-    let mut plotting_thread_pool_core_indices;
-    let mut replotting_thread_pool_core_indices;
+    let plotting_thread_pool_core_indices;
+    let replotting_thread_pool_core_indices;
     if let Some(plotting_cpu_cores) = plotting_cpu_cores {
         plotting_thread_pool_core_indices = parse_cpu_cores_sets(&plotting_cpu_cores)
             .map_err(|error| anyhow::anyhow!("Failed to parse `--plotting-cpu-cores`: {error}"))?;
@@ -456,18 +456,6 @@ where
                 l3_cache_groups = %plotting_thread_pool_core_indices.len(),
                 "Multiple L3 cache groups detected"
             );
-
-            if plotting_thread_pool_core_indices.len() > disk_farms.len() {
-                plotting_thread_pool_core_indices =
-                    CpuCoreSet::regroup(&plotting_thread_pool_core_indices, disk_farms.len());
-                replotting_thread_pool_core_indices =
-                    CpuCoreSet::regroup(&replotting_thread_pool_core_indices, disk_farms.len());
-
-                info!(
-                    farms_count = %disk_farms.len(),
-                    "Regrouped CPU cores to match number of farms, more farms may leverage CPU more efficiently"
-                );
-            }
         }
     }
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/metrics.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/metrics.rs
@@ -46,6 +46,7 @@ pub(in super::super) struct FarmerMetrics {
     pub(in super::super) sector_written: Counter<u64, AtomicU64>,
     pub(in super::super) sector_plotting: Counter<u64, AtomicU64>,
     pub(in super::super) sector_plotted: Counter<u64, AtomicU64>,
+    pub(in super::super) sector_plotting_error: Counter<u64, AtomicU64>,
 }
 
 impl FarmerMetrics {
@@ -207,6 +208,15 @@ impl FarmerMetrics {
             sector_plotted.clone(),
         );
 
+        let sector_plotting_error = Counter::<_, _>::default();
+
+        sub_registry.register_with_unit(
+            "sector_plotting_error_counter",
+            "Number of sector plotting failures",
+            Unit::Other("sectors".to_string()),
+            sector_plotting_error.clone(),
+        );
+
         Self {
             auditing_time,
             proving_time,
@@ -224,6 +234,7 @@ impl FarmerMetrics {
             sector_written,
             sector_plotting,
             sector_plotted,
+            sector_plotting_error,
         }
     }
 

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -281,6 +281,8 @@ pub enum SectorPlottingDetails {
         /// How much time it took to plot a sector
         time: Duration,
     },
+    /// Plotting failed
+    Error(String),
 }
 
 /// Details about sector expiration

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -42,6 +42,7 @@ pub mod farm;
 pub mod farmer_cache;
 pub(crate) mod identity;
 pub mod node_client;
+pub mod plotter;
 pub mod reward_signing;
 pub mod single_disk_farm;
 pub mod thread_pool_manager;

--- a/crates/subspace-farmer/src/plotter.rs
+++ b/crates/subspace-farmer/src/plotter.rs
@@ -1,0 +1,93 @@
+pub mod cpu;
+
+use async_trait::async_trait;
+use futures::Sink;
+use parity_scale_codec::{Decode, Encode};
+use std::error::Error;
+use std::sync::Arc;
+use std::time::Duration;
+use subspace_core_primitives::{PublicKey, SectorIndex};
+use subspace_farmer_components::plotting::PlottedSector;
+use subspace_farmer_components::FarmerProtocolInfo;
+
+// TODO: It is a bit awkward that this mimics `SectorPlottingDetails` with slight differences, maybe
+//  `SectorPlottingDetails` should be a bit generic and support customization of
+//  `Starting`/`Finished` contents
+/// Sector plotting progress
+#[derive(Debug, Clone, Encode, Decode)]
+#[allow(clippy::large_enum_variant)]
+pub enum SectorPlottingProgress {
+    /// Downloading sector pieces
+    Downloading,
+    /// Downloaded sector pieces
+    Downloaded(Duration),
+    /// Encoding sector pieces
+    Encoding,
+    /// Encoded sector pieces
+    Encoded(Duration),
+    /// Finished plotting
+    Finished {
+        /// Information about plotted sector
+        plotted_sector: PlottedSector,
+        /// How much time it took to plot a sector
+        time: Duration,
+        /// All plotted sector bytes
+        sector: Vec<u8>,
+        /// All plotted sector metadata bytes
+        sector_metadata: Vec<u8>,
+    },
+    /// Plotting failed
+    Error {
+        /// Error message
+        error: String,
+    },
+}
+
+/// Abstract plotter implementation
+#[async_trait]
+pub trait Plotter {
+    /// Plot one sector, returns a stream of sector plotting events.
+    ///
+    /// Future returns once plotting is successfully scheduled (for backpressure purposes).
+    async fn plot_sector<PS>(
+        &self,
+        public_key: PublicKey,
+        sector_index: SectorIndex,
+        farmer_protocol_info: FarmerProtocolInfo,
+        pieces_in_sector: u16,
+        replotting: bool,
+        progress_sender: PS,
+    ) where
+        PS: Sink<SectorPlottingProgress> + Unpin + Send + 'static,
+        PS::Error: Error;
+}
+
+#[async_trait]
+impl<P> Plotter for Arc<P>
+where
+    P: Plotter + Send + Sync,
+{
+    async fn plot_sector<PS>(
+        &self,
+        public_key: PublicKey,
+        sector_index: SectorIndex,
+        farmer_protocol_info: FarmerProtocolInfo,
+        pieces_in_sector: u16,
+        replotting: bool,
+        progress_sender: PS,
+    ) where
+        PS: Sink<SectorPlottingProgress> + Unpin + Send + 'static,
+        PS::Error: Error,
+    {
+        self.as_ref()
+            .plot_sector(
+                public_key,
+                sector_index,
+                farmer_protocol_info,
+                pieces_in_sector,
+                replotting,
+                progress_sender,
+            )
+            .await
+    }
+}

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -1,0 +1,412 @@
+use crate::plotter::{Plotter, SectorPlottingProgress};
+use crate::thread_pool_manager::PlottingThreadPoolManager;
+use crate::utils::AsyncJoinOnDrop;
+use async_lock::Mutex as AsyncMutex;
+use async_trait::async_trait;
+use event_listener_primitives::{Bag, HandlerId};
+use futures::channel::mpsc;
+use futures::stream::FuturesUnordered;
+use futures::{select, FutureExt, Sink, SinkExt, StreamExt};
+use parking_lot::Mutex;
+use std::error::Error;
+use std::future::pending;
+use std::num::NonZeroUsize;
+use std::pin::pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use subspace_core_primitives::crypto::kzg::Kzg;
+use subspace_core_primitives::{PublicKey, SectorIndex};
+use subspace_erasure_coding::ErasureCoding;
+use subspace_farmer_components::plotting::{
+    download_sector, encode_sector, DownloadSectorOptions, EncodeSectorOptions, PlottingError,
+};
+use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
+use subspace_proof_of_space::Table;
+use tokio::sync::Semaphore;
+use tokio::task::yield_now;
+use tracing::warn;
+
+pub type HandlerFn3<A, B, C> = Arc<dyn Fn(&A, &B, &C) + Send + Sync + 'static>;
+type Handler3<A, B, C> = Bag<HandlerFn3<A, B, C>, A, B, C>;
+
+#[derive(Default, Debug)]
+struct Handlers {
+    plotting_progress: Handler3<PublicKey, SectorIndex, SectorPlottingProgress>,
+}
+
+/// CPU plotter
+pub struct CpuPlotter<PG, PosTable>
+where
+    PosTable: Table,
+{
+    piece_getter: PG,
+    downloading_semaphore: Arc<Semaphore>,
+    // TODO: It is ugly that thread pool manager and table generators are both having independent
+    //  mutexes, they should be combined
+    plotting_thread_pool_manager: PlottingThreadPoolManager,
+    table_generators: Arc<Mutex<Vec<Vec<<PosTable as Table>::Generator>>>>,
+    global_mutex: Arc<AsyncMutex<()>>,
+    kzg: Kzg,
+    erasure_coding: ErasureCoding,
+    handlers: Arc<Handlers>,
+    tasks_sender: mpsc::Sender<AsyncJoinOnDrop<()>>,
+    _background_tasks: AsyncJoinOnDrop<()>,
+    abort_early: Arc<AtomicBool>,
+}
+
+impl<PG, PosTable> Drop for CpuPlotter<PG, PosTable>
+where
+    PosTable: Table,
+{
+    fn drop(&mut self) {
+        self.abort_early.store(true, Ordering::Release);
+        self.tasks_sender.close_channel();
+    }
+}
+
+#[async_trait]
+impl<PG, PosTable> Plotter for CpuPlotter<PG, PosTable>
+where
+    PG: PieceGetter + Clone + Send + Sync + 'static,
+    PosTable: Table,
+{
+    async fn plot_sector<PS>(
+        &self,
+        public_key: PublicKey,
+        sector_index: SectorIndex,
+        farmer_protocol_info: FarmerProtocolInfo,
+        pieces_in_sector: u16,
+        replotting: bool,
+        mut progress_sender: PS,
+    ) where
+        PS: Sink<SectorPlottingProgress> + Unpin + Send + 'static,
+        PS::Error: Error,
+    {
+        let progress_updater = ProgressUpdater {
+            public_key,
+            sector_index,
+            handlers: Arc::clone(&self.handlers),
+        };
+
+        let start = Instant::now();
+
+        // Done outside the future below as a backpressure, ensuring that it is not possible to
+        // schedule unbounded number of plotting tasks
+        let downloading_permit = match Arc::clone(&self.downloading_semaphore)
+            .acquire_owned()
+            .await
+        {
+            Ok(downloading_permit) => downloading_permit,
+            Err(error) => {
+                warn!(%error, "Failed to acquire downloading permit");
+
+                progress_updater
+                    .update_progress_and_events(
+                        &mut progress_sender,
+                        SectorPlottingProgress::Error {
+                            error: format!("Failed to acquire downloading permit: {error}"),
+                        },
+                    )
+                    .await;
+
+                return;
+            }
+        };
+
+        let plotting_fut = {
+            let piece_getter = self.piece_getter.clone();
+            let plotting_thread_pool_manager = self.plotting_thread_pool_manager.clone();
+            let table_generators = Arc::clone(&self.table_generators);
+            let global_mutex = Arc::clone(&self.global_mutex);
+            let kzg = self.kzg.clone();
+            let erasure_coding = self.erasure_coding.clone();
+            let abort_early = Arc::clone(&self.abort_early);
+
+            async move {
+                // Downloading
+                let downloaded_sector = {
+                    if !progress_updater
+                        .update_progress_and_events(
+                            &mut progress_sender,
+                            SectorPlottingProgress::Downloading,
+                        )
+                        .await
+                    {
+                        return;
+                    }
+
+                    // Take mutex briefly to make sure plotting is allowed right now
+                    global_mutex.lock().await;
+
+                    let start = Instant::now();
+
+                    let downloaded_sector_fut = download_sector(DownloadSectorOptions {
+                        public_key: &public_key,
+                        sector_index,
+                        piece_getter: &piece_getter,
+                        farmer_protocol_info,
+                        kzg: &kzg,
+                        pieces_in_sector,
+                    });
+
+                    let downloaded_sector = match downloaded_sector_fut.await {
+                        Ok(downloaded_sector) => downloaded_sector,
+                        Err(error) => {
+                            warn!(%error, "Failed to download sector");
+
+                            progress_updater
+                                .update_progress_and_events(
+                                    &mut progress_sender,
+                                    SectorPlottingProgress::Error {
+                                        error: format!("Failed to download sector: {error}"),
+                                    },
+                                )
+                                .await;
+
+                            return;
+                        }
+                    };
+
+                    if !progress_updater
+                        .update_progress_and_events(
+                            &mut progress_sender,
+                            SectorPlottingProgress::Downloaded(start.elapsed()),
+                        )
+                        .await
+                    {
+                        return;
+                    }
+
+                    downloaded_sector
+                };
+
+                // Plotting
+                let (sector, sector_metadata, plotted_sector) = {
+                    let thread_pools = plotting_thread_pool_manager.get_thread_pools().await;
+
+                    let mut local_table_generators = table_generators.lock().pop().expect(
+                        "Number of table generators is the same as number of thread pools; qed",
+                    );
+
+                    let plotting_fn = || {
+                        tokio::task::block_in_place(|| {
+                            let mut sector = Vec::new();
+                            let mut sector_metadata = Vec::new();
+
+                            let plotted_sector = encode_sector::<PosTable>(
+                                downloaded_sector,
+                                EncodeSectorOptions {
+                                    sector_index,
+                                    erasure_coding: &erasure_coding,
+                                    pieces_in_sector,
+                                    sector_output: &mut sector,
+                                    sector_metadata_output: &mut sector_metadata,
+                                    table_generators: &mut local_table_generators,
+                                    abort_early: &abort_early,
+                                    global_mutex: &global_mutex,
+                                },
+                            )?;
+
+                            Ok((sector, sector_metadata, plotted_sector))
+                        })
+                    };
+
+                    let thread_pool = if replotting {
+                        &thread_pools.replotting
+                    } else {
+                        &thread_pools.plotting
+                    };
+
+                    // Give a chance to interrupt plotting if necessary
+                    yield_now().await;
+
+                    if !progress_updater
+                        .update_progress_and_events(
+                            &mut progress_sender,
+                            SectorPlottingProgress::Encoding,
+                        )
+                        .await
+                    {
+                        return;
+                    }
+
+                    let start = Instant::now();
+
+                    let plotting_result = thread_pool.install(plotting_fn);
+
+                    table_generators.lock().push(local_table_generators);
+
+                    match plotting_result {
+                        Ok(plotting_result) => {
+                            if !progress_updater
+                                .update_progress_and_events(
+                                    &mut progress_sender,
+                                    SectorPlottingProgress::Encoded(start.elapsed()),
+                                )
+                                .await
+                            {
+                                return;
+                            }
+
+                            plotting_result
+                        }
+                        Err(PlottingError::AbortEarly) => {
+                            return;
+                        }
+                        Err(error) => {
+                            progress_updater
+                                .update_progress_and_events(
+                                    &mut progress_sender,
+                                    SectorPlottingProgress::Error {
+                                        error: format!("Failed to encode sector: {error}"),
+                                    },
+                                )
+                                .await;
+
+                            return;
+                        }
+                    }
+                };
+
+                progress_updater
+                    .update_progress_and_events(
+                        &mut progress_sender,
+                        SectorPlottingProgress::Finished {
+                            plotted_sector,
+                            time: start.elapsed(),
+                            sector,
+                            sector_metadata,
+                        },
+                    )
+                    .await;
+
+                drop(downloading_permit);
+            }
+        };
+
+        // Spawn a separate task such that `block_in_place` inside will not affect anything else
+        let plotting_task = AsyncJoinOnDrop::new(tokio::spawn(plotting_fut), true);
+        if let Err(error) = self.tasks_sender.clone().send(plotting_task).await {
+            warn!(%error, "Failed to send plotting task");
+
+            let progress = SectorPlottingProgress::Error {
+                error: format!("Failed to send plotting task: {error}"),
+            };
+
+            self.handlers
+                .plotting_progress
+                .call_simple(&public_key, &sector_index, &progress);
+        }
+    }
+}
+
+impl<PG, PosTable> CpuPlotter<PG, PosTable>
+where
+    PG: PieceGetter + Clone + Send + Sync + 'static,
+    PosTable: Table,
+{
+    /// Create new instance
+    pub fn new(
+        piece_getter: PG,
+        downloading_semaphore: Arc<Semaphore>,
+        plotting_thread_pool_manager: PlottingThreadPoolManager,
+        record_encoding_concurrency: NonZeroUsize,
+        global_mutex: Arc<AsyncMutex<()>>,
+        kzg: Kzg,
+        erasure_coding: ErasureCoding,
+    ) -> Self {
+        let table_generators = (0..plotting_thread_pool_manager.thread_pool_pairs().get())
+            .map(|_| {
+                (0..record_encoding_concurrency.get())
+                    .map(|_| PosTable::generator())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        let (tasks_sender, mut tasks_receiver) = mpsc::channel(1);
+
+        // Basically runs plotting tasks in the background and allows to abort on drop
+        let background_tasks = AsyncJoinOnDrop::new(
+            tokio::spawn(async move {
+                let background_tasks = FuturesUnordered::new();
+                let mut background_tasks = pin!(background_tasks);
+                // Just so that `FuturesUnordered` will never end
+                background_tasks.push(AsyncJoinOnDrop::new(tokio::spawn(pending::<()>()), true));
+
+                loop {
+                    select! {
+                        maybe_background_task = tasks_receiver.next().fuse() => {
+                            if let Some(background_task) = maybe_background_task {
+                                background_tasks.push(background_task);
+                            } else {
+                                break;
+                            }
+                        },
+                        _ = background_tasks.select_next_some() => {
+                            // Nothing to do
+                        }
+                    }
+                }
+            }),
+            true,
+        );
+
+        let abort_early = Arc::new(AtomicBool::new(false));
+
+        Self {
+            piece_getter,
+            downloading_semaphore,
+            plotting_thread_pool_manager,
+            table_generators: Arc::new(Mutex::new(table_generators)),
+            global_mutex,
+            kzg,
+            erasure_coding,
+            handlers: Arc::default(),
+            tasks_sender,
+            _background_tasks: background_tasks,
+            abort_early,
+        }
+    }
+
+    /// Subscribe to plotting progress notifications
+    pub fn on_plotting_progress(
+        &self,
+        callback: HandlerFn3<PublicKey, SectorIndex, SectorPlottingProgress>,
+    ) -> HandlerId {
+        self.handlers.plotting_progress.add(callback)
+    }
+}
+
+struct ProgressUpdater {
+    public_key: PublicKey,
+    sector_index: SectorIndex,
+    handlers: Arc<Handlers>,
+}
+
+impl ProgressUpdater {
+    /// Returns `true` on success and `false` if progress receiver channel is gone
+    async fn update_progress_and_events<PS>(
+        &self,
+        progress_sender: &mut PS,
+        progress: SectorPlottingProgress,
+    ) -> bool
+    where
+        PS: Sink<SectorPlottingProgress> + Unpin,
+        PS::Error: Error,
+    {
+        self.handlers.plotting_progress.call_simple(
+            &self.public_key,
+            &self.sector_index,
+            &progress,
+        );
+
+        if let Err(error) = progress_sender.send(progress).await {
+            warn!(%error, "Failed to send error progress update");
+
+            false
+        } else {
+            true
+        }
+    }
+}

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -22,7 +22,7 @@ use crate::single_disk_farm::piece_reader::DiskPieceReader;
 use crate::single_disk_farm::plot_cache::DiskPlotCache;
 pub use crate::single_disk_farm::plotting::PlottingError;
 use crate::single_disk_farm::plotting::{
-    plotting, plotting_scheduler, PlottingOptions, PlottingSchedulerOptions,
+    plotting, plotting_scheduler, PlottingOptions, PlottingSchedulerOptions, SectorPlottingOptions,
 };
 #[cfg(windows)]
 use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows;
@@ -824,20 +824,22 @@ impl SingleDiskFarm {
                 let _span_guard = span.enter();
 
                 let plotting_options = PlottingOptions {
-                    public_key,
-                    node_client: &node_client,
-                    pieces_in_sector,
-                    sector_size,
-                    sector_metadata_size,
                     metadata_header,
-                    plot_file,
-                    metadata_file,
-                    sectors_metadata,
-                    handlers,
-                    sectors_being_modified,
                     sectors_to_plot_receiver,
-                    global_mutex: &global_mutex,
-                    plotter,
+                    sector_plotting_options: SectorPlottingOptions {
+                        public_key,
+                        node_client: &node_client,
+                        pieces_in_sector,
+                        sector_size,
+                        sector_metadata_size,
+                        plot_file: &plot_file,
+                        metadata_file,
+                        sectors_metadata: &sectors_metadata,
+                        handlers: &handlers,
+                        sectors_being_modified: &sectors_being_modified,
+                        global_mutex: &global_mutex,
+                        plotter,
+                    },
                 };
 
                 let plotting_fut = async {

--- a/crates/subspace-farmer/src/thread_pool_manager.rs
+++ b/crates/subspace-farmer/src/thread_pool_manager.rs
@@ -63,6 +63,7 @@ impl Drop for PlottingThreadPoolsGuard {
 #[derive(Debug, Clone)]
 pub struct PlottingThreadPoolManager {
     inner: Arc<(Mutex<Inner>, Event)>,
+    thread_pool_pairs: NonZeroUsize,
 }
 
 impl PlottingThreadPoolManager {
@@ -85,7 +86,13 @@ impl PlottingThreadPoolManager {
 
         Ok(Self {
             inner: Arc::new((Mutex::new(inner), Event::new())),
+            thread_pool_pairs,
         })
+    }
+
+    /// How many thread pool pairs are being managed here
+    pub fn thread_pool_pairs(&self) -> NonZeroUsize {
+        self.thread_pool_pairs
     }
 
     /// Get one of inner thread pool pairs, will wait until one is available if needed


### PR DESCRIPTION
First of all this PR introduces `Plotter` trait for plotting purposes. There is also `CpuPlotter` implementation that will later be extended with both GPU and cluster implmentations. API is specifically designed to make this possible.

`CpuPlotter` is a slightly refactored version of the same thing we had before under single disk farm, just changed to send a serializable stream of events that can be sent over the network.

We will likely also extend it with combinators that are able to use CPU and GPU at the same time to further improve plotting performance, but we'll do that when it is relevant.

Second, this new abstraction is used for single disk farm, simplifying dependencies.

While at it, I also refactored it further to not just being able to download exactly one segment worth of pieces at a time per farm as was the case before, but to fully pipeline plotitng of multiple sectors in the same farm if plotting resources are available. It was a suboptimal implementation detail that I finally resolved.

This is especially important for cluster setup we'll have later that will be able to gather a bunch of resources for plotting purposes and we better be able to leverage them fully no matter how many farms we have.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
