### PR TITLE
Fix archiver trying to incorrectly include genesis segment header twice

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -262,17 +262,22 @@ where
 
         // Special case for the initial segment (for genesis block).
         if block_number == 1 {
-            // If there is a segment index present and we store monotonically increasing segment headers,
-            // then the first header exists.
+            // If there is a segment index present, and we store monotonically increasing segment
+            // headers, then the first header exists.
             return vec![self
                 .get_segment_header(SegmentIndex::ZERO)
                 .expect("Segment headers are stored in monotonically increasing order; qed")];
         }
 
+        if last_segment_index == SegmentIndex::ZERO {
+            // Genesis segment already included in block #1
+            return Vec::new();
+        }
+
         let mut current_segment_index = last_segment_index;
         loop {
-            // If the current segment index present and we store monotonically increasing segment headers,
-            // then the current segment header exists as well.
+            // If the current segment index present, and we store monotonically increasing segment
+            // headers, then the current segment header exists as well.
             let current_segment_header = self
                 .get_segment_header(current_segment_index)
                 .expect("Segment headers are stored in monotonically increasing order; qed");

--- a/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -105,16 +105,7 @@ fn segment_headers_store_block_number_queries_work() {
     };
 
     segment_headers
-        .add_segment_headers(
-            vec![
-                segment_header0,
-                segment_header1,
-                segment_header2,
-                segment_header3,
-                segment_header4,
-            ]
-            .as_slice(),
-        )
+        .add_segment_headers(&[segment_header0])
         .unwrap();
 
     // Initial segment
@@ -123,6 +114,24 @@ fn segment_headers_store_block_number_queries_work() {
         .unwrap();
     let result = segment_headers.segment_headers_for_block(1u32);
     assert_eq!(result, vec![segment_header0]);
+
+    // Special case, genesis segment header is included in block 1, not later
+    let result = segment_headers.segment_headers_for_block(confirmation_depth_k + 1);
+    assert_eq!(result, vec![]);
+
+    for num in 2u32..752u32 {
+        let result = segment_headers.segment_headers_for_block(num);
+        assert_eq!(result, vec![]);
+    }
+
+    segment_headers
+        .add_segment_headers(&[
+            segment_header1,
+            segment_header2,
+            segment_header3,
+            segment_header4,
+        ])
+        .unwrap();
 
     for num in 2u32..752u32 {
         let result = segment_headers.segment_headers_for_block(num);


### PR DESCRIPTION
Fix for regression introduced in https://github.com/subspace/subspace/pull/2695

Caught earlier because due to support for multiple segment headers per block it was subtracting with overflow and crashing the node on 5th block in dev environment, otherwise we'd catch it much later when it would try to import Gemini 3h blocks with incorrect segment headers during sync.

Tests succeeded and didn't catch the issue due to adding all segment headers at once, so I updated them to test this case specifically.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
