### PR TITLE
Remove polkadot-sdk from `subspace-farmer`'s dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12787,7 +12787,6 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
- "sp-arithmetic",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-proof-of-space",

--- a/crates/subspace-verification/Cargo.toml
+++ b/crates/subspace-verification/Cargo.toml
@@ -18,7 +18,6 @@ include = [
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false }
 schnorrkel = { version = "0.11.4", default-features = false }
-sp-arithmetic = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 subspace-archiving = { version = "0.1.0", path = "../subspace-archiving", default-features = false }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", default-features = false }
@@ -29,7 +28,6 @@ default = ["std"]
 std = [
     "codec/std",
     "schnorrkel/std",
-    "sp-arithmetic/std",
     "subspace-archiving/std",
     "subspace-core-primitives/std",
     "thiserror"

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -25,7 +25,6 @@ use core::mem;
 use core::simd::Simd;
 use schnorrkel::context::SigningContext;
 use schnorrkel::SignatureError;
-use sp_arithmetic::traits::SaturatedConversion;
 use subspace_archiving::archiver;
 use subspace_core_primitives::crypto::kzg::{Commitment, Kzg, Witness};
 use subspace_core_primitives::crypto::{
@@ -335,13 +334,14 @@ pub fn derive_next_solution_range(
     // next_solution_range =
     //     (solution_ranges.current as f64 * adjustment_factor).round() as u64;
     // ```
-    u64::saturated_from(
+    u64::try_from(
         u128::from(current_solution_range)
             .saturating_mul(u128::from(era_slot_count))
             .saturating_mul(u128::from(slot_probability.0))
             / u128::from(era_duration)
             / u128::from(slot_probability.1),
     )
+    .unwrap_or(u64::MAX)
     .clamp(
         current_solution_range / 4,
         current_solution_range.saturating_mul(4),

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -27,10 +27,11 @@ use crate::messages::MessageKey;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
-use frame_support::inherent::{InherentData, InherentIdentifier, IsFatalError};
+#[cfg(feature = "std")]
+use frame_support::inherent::InherentData;
+use frame_support::inherent::{InherentIdentifier, IsFatalError};
 use messages::{BlockMessagesWithStorageKey, CrossDomainMessage, MessageId};
 use sp_domains::{ChainId, DomainAllowlistUpdates, DomainId};
-use sp_inherents::Error;
 
 /// Messenger inherent identifier.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"messengr";
@@ -133,7 +134,9 @@ impl sp_inherents::InherentDataProvider for InherentDataProvider {
 
         let error = InherentError::decode(&mut &*error).ok()?;
 
-        Some(Err(Error::Application(Box::from(format!("{error:?}")))))
+        Some(Err(sp_inherents::Error::Application(Box::from(format!(
+            "{error:?}"
+        )))))
     }
 }
 


### PR DESCRIPTION
Just noticed that `sp-arithmetic` was pulled in by `subspace-farmer` indirectly and decided to get rid of it since `subspace-*` crates (except node, runtime and service I guess) are not supposed to import Substrate dependencies.

While fixing some intermediate compilation errors I noticed some warnings in messenger primitives and fixed those as well.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
