### PR TITLE
Improve CPU core distribution with custom thread pool options

### DIFF
--- a/crates/subspace-farmer/src/utils/tests.rs
+++ b/crates/subspace-farmer/src/utils/tests.rs
@@ -1,5 +1,9 @@
-use crate::utils::{parse_cpu_cores_sets, run_future_in_dedicated_thread};
+use crate::utils::{
+    parse_cpu_cores_sets, run_future_in_dedicated_thread, thread_pool_core_indices_internal,
+    CpuCoreSet,
+};
 use std::future;
+use std::num::NonZeroUsize;
 use tokio::sync::oneshot;
 
 #[tokio::test]
@@ -77,4 +81,191 @@ fn test_parse_cpu_cores_sets() {
     assert!(parse_cpu_cores_sets("0,").is_err());
     assert!(parse_cpu_cores_sets("0,a").is_err());
     assert!(parse_cpu_cores_sets("0 a").is_err());
+}
+
+#[test]
+fn test_thread_pool_core_indices() {
+    let all_cpu_cores = vec![
+        CpuCoreSet {
+            cores: vec![0, 1],
+            #[cfg(feature = "numa")]
+            topology: None,
+        },
+        CpuCoreSet {
+            cores: vec![4, 5],
+            #[cfg(feature = "numa")]
+            topology: None,
+        },
+        CpuCoreSet {
+            cores: vec![2, 3],
+            #[cfg(feature = "numa")]
+            topology: None,
+        },
+        CpuCoreSet {
+            cores: vec![6, 7],
+            #[cfg(feature = "numa")]
+            topology: None,
+        },
+    ];
+
+    // Default behavior
+    assert_eq!(
+        thread_pool_core_indices_internal(all_cpu_cores.clone(), None, None)
+            .into_iter()
+            .map(|cpu_core_set| cpu_core_set.cores)
+            .collect::<Vec<_>>(),
+        vec![vec![0, 1], vec![4, 5], vec![2, 3], vec![6, 7]]
+    );
+
+    // Custom number of thread pools
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            None,
+            Some(NonZeroUsize::new(1).unwrap())
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1, 4, 5, 2, 3, 6, 7]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            None,
+            Some(NonZeroUsize::new(2).unwrap())
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1, 4, 5], vec![2, 3, 6, 7]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            None,
+            Some(NonZeroUsize::new(3).unwrap())
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1, 4,], vec![5, 2, 3], vec![6, 7]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            None,
+            Some(NonZeroUsize::new(4).unwrap())
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1], vec![4, 5], vec![2, 3], vec![6, 7]]
+    );
+
+    // Custom thread pool size
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(1).unwrap()),
+            None,
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0], vec![1], vec![4], vec![5]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(2).unwrap()),
+            None,
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1], vec![4, 5], vec![2, 3], vec![6, 7]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(3).unwrap()),
+            None,
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1, 4], vec![5, 2, 3], vec![6, 7, 0], vec![1, 4, 5]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(4).unwrap()),
+            None,
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![
+            vec![0, 1, 4, 5],
+            vec![2, 3, 6, 7],
+            vec![0, 1, 4, 5],
+            vec![2, 3, 6, 7]
+        ]
+    );
+
+    // Custom number of thread pools and thread pool size
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(1).unwrap()),
+            Some(NonZeroUsize::new(1).unwrap()),
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(2).unwrap()),
+            Some(NonZeroUsize::new(4).unwrap()),
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1], vec![4, 5], vec![2, 3], vec![6, 7]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(8).unwrap()),
+            Some(NonZeroUsize::new(1).unwrap()),
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![vec![0, 1, 4, 5, 2, 3, 6, 7]]
+    );
+    assert_eq!(
+        thread_pool_core_indices_internal(
+            all_cpu_cores.clone(),
+            Some(NonZeroUsize::new(1).unwrap()),
+            Some(NonZeroUsize::new(8).unwrap()),
+        )
+        .into_iter()
+        .map(|cpu_core_set| cpu_core_set.cores)
+        .collect::<Vec<_>>(),
+        vec![
+            vec![0],
+            vec![1],
+            vec![4],
+            vec![5],
+            vec![2],
+            vec![3],
+            vec![6],
+            vec![7]
+        ]
+    );
 }


### PR DESCRIPTION
There are two changes in behavior here:
* when number of thread pools was specified, but not the size of the thread pool, CPU cores were assumed to be sequential in terms of their locality, which was suboptimal on Threadripper/Epyc systems that look something like this:
  ```
  CpuCoreSet { cores: CpuSet(0-7,32-39) }
  CpuCoreSet { cores: CpuSet(8-15,40-47) }
  CpuCoreSet { cores: CpuSet(16-23,48-55) }
  CpuCoreSet { cores: CpuSet(24-31,56-63) }
  ```
* second, number of thread pools wasn't always what it was specified when thread pool size * thread pools number wasn't the same as total number of cores available

Both of those were fixed and a bunch of test cases added checking various potential permutations.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
