### PR TITLE
Update README.md(fix invalid command)

### DIFF
--- a/domains/README.md
+++ b/domains/README.md
@@ -91,7 +91,7 @@ By default, node data is written to `{subspace-node-base-path}/domains/{domain-i
 Once the project has been built, the following command can be used to explore all parameters and subcommands:
 
 ```bash
-target/production/subspace-node --dev -- --help
+target/production/subspace-node run --dev -- --help
 ```
 
 ### Build from source


### PR DESCRIPTION
```bash
target/production/subspace-node --dev -- --help
```
command is invalid.

should be:
```bash
target/production/subspace-node run --dev -- --help
```

### Code contributor checklist:
* [ ] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
