### PR TITLE
Plotted pieces refactoring

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -1,5 +1,5 @@
+use async_lock::RwLock as AsyncRwLock;
 use clap::Parser;
-use parking_lot::Mutex;
 use prometheus_client::registry::Registry;
 use std::collections::HashSet;
 use std::fmt;
@@ -85,13 +85,13 @@ pub(in super::super) fn configure_network<FarmIndex>(
         pending_out_connections,
         external_addresses,
     }: NetworkArgs,
-    weak_plotted_pieces: Weak<Mutex<Option<PlottedPieces<FarmIndex>>>>,
+    weak_plotted_pieces: Weak<AsyncRwLock<PlottedPieces<FarmIndex>>>,
     node_client: NodeRpcClient,
     farmer_cache: FarmerCache,
     prometheus_metrics_registry: Option<&mut Registry>,
 ) -> Result<(Node, NodeRunner<FarmerCache>), anyhow::Error>
 where
-    FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + 'static,
+    FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + Sync + 'static,
     usize: From<FarmIndex>,
 {
     let networking_parameters_registry = KnownPeersManager::new(KnownPeersManagerConfig {
@@ -135,27 +135,16 @@ where
                             "No piece in the cache. Trying archival storage..."
                         );
 
-                        let read_piece_fut = {
-                            let plotted_pieces = match weak_plotted_pieces.upgrade() {
-                                Some(plotted_pieces) => plotted_pieces,
-                                None => {
-                                    debug!("A readers and pieces are already dropped");
-                                    return None;
-                                }
-                            };
-                            let plotted_pieces = plotted_pieces.lock();
-                            let plotted_pieces = match plotted_pieces.as_ref() {
-                                Some(plotted_pieces) => plotted_pieces,
-                                None => {
-                                    debug!(
-                                        ?piece_index,
-                                        "Readers and pieces are not initialized yet"
-                                    );
-                                    return None;
-                                }
-                            };
-
-                            plotted_pieces.read_piece(piece_index)?.in_current_span()
+                        let read_piece_fut = match weak_plotted_pieces.upgrade() {
+                            Some(plotted_pieces) => plotted_pieces
+                                .read()
+                                .await
+                                .read_piece(piece_index)?
+                                .in_current_span(),
+                            None => {
+                                debug!("A readers and pieces are already dropped");
+                                return None;
+                            }
                         };
 
                         let piece = read_piece_fut.await;

--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -10,6 +10,7 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
+use std::hash::Hash;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Weak};
 use subspace_core_primitives::{Piece, PieceIndex};
@@ -29,27 +30,27 @@ pub struct DsnCacheRetryPolicy {
     pub backoff: ExponentialBackoff,
 }
 
-struct Inner<PV, NC> {
+struct Inner<FarmIndex, PV, NC> {
     piece_provider: PieceProvider<PV>,
     farmer_cache: FarmerCache,
     node_client: NC,
-    plotted_pieces: Arc<Mutex<Option<PlottedPieces>>>,
+    plotted_pieces: Arc<Mutex<Option<PlottedPieces<FarmIndex>>>>,
     dsn_cache_retry_policy: DsnCacheRetryPolicy,
     in_progress_pieces: Mutex<HashMap<PieceIndex, Arc<AsyncMutex<Option<Piece>>>>>,
 }
 
-pub struct FarmerPieceGetter<PV, NC> {
-    inner: Arc<Inner<PV, NC>>,
+pub struct FarmerPieceGetter<FarmIndex, PV, NC> {
+    inner: Arc<Inner<FarmIndex, PV, NC>>,
 }
 
-impl<PV, NC> fmt::Debug for FarmerPieceGetter<PV, NC> {
+impl<FarmIndex, PV, NC> fmt::Debug for FarmerPieceGetter<FarmIndex, PV, NC> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("FarmerPieceGetter").finish_non_exhaustive()
     }
 }
 
-impl<PV, NC> Clone for FarmerPieceGetter<PV, NC> {
+impl<FarmIndex, PV, NC> Clone for FarmerPieceGetter<FarmIndex, PV, NC> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
@@ -57,8 +58,10 @@ impl<PV, NC> Clone for FarmerPieceGetter<PV, NC> {
     }
 }
 
-impl<PV, NC> FarmerPieceGetter<PV, NC>
+impl<FarmIndex, PV, NC> FarmerPieceGetter<FarmIndex, PV, NC>
 where
+    FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + 'static,
+    usize: From<FarmIndex>,
     PV: PieceValidator + Send + 'static,
     NC: NodeClient,
 {
@@ -66,7 +69,7 @@ where
         piece_provider: PieceProvider<PV>,
         farmer_cache: FarmerCache,
         node_client: NC,
-        plotted_pieces: Arc<Mutex<Option<PlottedPieces>>>,
+        plotted_pieces: Arc<Mutex<Option<PlottedPieces<FarmIndex>>>>,
         dsn_cache_retry_policy: DsnCacheRetryPolicy,
     ) -> Self {
         Self {
@@ -248,7 +251,7 @@ where
 
     /// Downgrade to [`WeakFarmerPieceGetter`] in order to break reference cycles with internally
     /// used [`Arc`]
-    pub fn downgrade(&self) -> WeakFarmerPieceGetter<PV, NC> {
+    pub fn downgrade(&self) -> WeakFarmerPieceGetter<FarmIndex, PV, NC> {
         WeakFarmerPieceGetter {
             inner: Arc::downgrade(&self.inner),
         }
@@ -256,8 +259,10 @@ where
 }
 
 #[async_trait]
-impl<PV, NC> PieceGetter for FarmerPieceGetter<PV, NC>
+impl<FarmIndex, PV, NC> PieceGetter for FarmerPieceGetter<FarmIndex, PV, NC>
 where
+    FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + 'static,
+    usize: From<FarmIndex>,
     PV: PieceValidator + Send + 'static,
     NC: NodeClient,
 {
@@ -351,11 +356,11 @@ where
 }
 
 /// Weak farmer piece getter, can be upgraded to [`FarmerPieceGetter`]
-pub struct WeakFarmerPieceGetter<PV, NC> {
-    inner: Weak<Inner<PV, NC>>,
+pub struct WeakFarmerPieceGetter<FarmIndex, PV, NC> {
+    inner: Weak<Inner<FarmIndex, PV, NC>>,
 }
 
-impl<PV, NC> fmt::Debug for WeakFarmerPieceGetter<PV, NC> {
+impl<FarmIndex, PV, NC> fmt::Debug for WeakFarmerPieceGetter<FarmIndex, PV, NC> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("WeakFarmerPieceGetter")
@@ -363,7 +368,7 @@ impl<PV, NC> fmt::Debug for WeakFarmerPieceGetter<PV, NC> {
     }
 }
 
-impl<PV, NC> Clone for WeakFarmerPieceGetter<PV, NC> {
+impl<FarmIndex, PV, NC> Clone for WeakFarmerPieceGetter<FarmIndex, PV, NC> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -372,8 +377,10 @@ impl<PV, NC> Clone for WeakFarmerPieceGetter<PV, NC> {
 }
 
 #[async_trait]
-impl<PV, NC> PieceGetter for WeakFarmerPieceGetter<PV, NC>
+impl<FarmIndex, PV, NC> PieceGetter for WeakFarmerPieceGetter<FarmIndex, PV, NC>
 where
+    FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + 'static,
+    usize: From<FarmIndex>,
     PV: PieceValidator + Send + 'static,
     NC: NodeClient,
 {
@@ -390,9 +397,9 @@ where
     }
 }
 
-impl<PV, NC> WeakFarmerPieceGetter<PV, NC> {
+impl<FarmIndex, PV, NC> WeakFarmerPieceGetter<FarmIndex, PV, NC> {
     /// Try to upgrade to [`FarmerPieceGetter`] if there is at least one other instance of it alive
-    pub fn upgrade(&self) -> Option<FarmerPieceGetter<PV, NC>> {
+    pub fn upgrade(&self) -> Option<FarmerPieceGetter<FarmIndex, PV, NC>> {
         Some(FarmerPieceGetter {
             inner: self.inner.upgrade()?,
         })


### PR DESCRIPTION
Another refactoring for https://github.com/subspace/subspace/issues/2402

In farming cluster we'll likely have many more farms in total, likely exceeding current `u8` limit for indexing them. First commit makes farm index generic, such that for individual farmers we can still use less memory with `u8`, but for farming cluser we'll be able to use `u16` and significantly increase number of supported farms, while also using more memory.

Since farmers in cluster can join and leave any time, it is important for this to be supported and supported in an efficient way. Second commit adds APIs for farm addition and removal in `PlottedPieces` as well as replaces synchronous `Mutex` with async `RwLock` such that more concurrency can be supported gracefully.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
