### PR TITLE
Fix farm locking Windows

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -146,6 +146,12 @@ impl SingleDiskFarmInfo {
             }
         };
 
+        // TODO: Workaround for farm corruption where file is replaced with an empty one, remove at
+        //  some point in the future
+        if bytes.is_empty() {
+            return Ok(None);
+        }
+
         serde_json::from_slice(&bytes)
             .map(Some)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1076,96 +1076,86 @@ impl SingleDiskFarm {
         let identity = Identity::open_or_create(directory)?;
         let public_key = identity.public_key().to_bytes().into();
 
-        let (single_disk_farm_info, single_disk_farm_info_lock) =
-            match SingleDiskFarmInfo::load_from(directory)? {
-                Some(mut single_disk_farm_info) => {
-                    let single_disk_farm_info_lock = if *disable_farm_locking {
-                        None
-                    } else {
-                        Some(
-                            SingleDiskFarmInfo::try_lock(directory)
-                                .map_err(SingleDiskFarmError::LikelyAlreadyInUse)?,
-                        )
-                    };
+        let single_disk_farm_info = match SingleDiskFarmInfo::load_from(directory)? {
+            Some(mut single_disk_farm_info) => {
+                if &farmer_app_info.genesis_hash != single_disk_farm_info.genesis_hash() {
+                    return Err(SingleDiskFarmError::WrongChain {
+                        id: *single_disk_farm_info.id(),
+                        correct_chain: hex::encode(single_disk_farm_info.genesis_hash()),
+                        wrong_chain: hex::encode(farmer_app_info.genesis_hash),
+                    });
+                }
 
-                    if &farmer_app_info.genesis_hash != single_disk_farm_info.genesis_hash() {
-                        return Err(SingleDiskFarmError::WrongChain {
-                            id: *single_disk_farm_info.id(),
-                            correct_chain: hex::encode(single_disk_farm_info.genesis_hash()),
-                            wrong_chain: hex::encode(farmer_app_info.genesis_hash),
-                        });
-                    }
+                if &public_key != single_disk_farm_info.public_key() {
+                    return Err(SingleDiskFarmError::IdentityMismatch {
+                        id: *single_disk_farm_info.id(),
+                        correct_public_key: *single_disk_farm_info.public_key(),
+                        wrong_public_key: public_key,
+                    });
+                }
 
-                    if &public_key != single_disk_farm_info.public_key() {
-                        return Err(SingleDiskFarmError::IdentityMismatch {
-                            id: *single_disk_farm_info.id(),
-                            correct_public_key: *single_disk_farm_info.public_key(),
-                            wrong_public_key: public_key,
-                        });
-                    }
+                let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
 
-                    let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
+                if max_pieces_in_sector < pieces_in_sector {
+                    return Err(SingleDiskFarmError::InvalidPiecesInSector {
+                        id: *single_disk_farm_info.id(),
+                        max_supported: max_pieces_in_sector,
+                        initialized_with: pieces_in_sector,
+                    });
+                }
 
-                    if max_pieces_in_sector < pieces_in_sector {
-                        return Err(SingleDiskFarmError::InvalidPiecesInSector {
-                            id: *single_disk_farm_info.id(),
-                            max_supported: max_pieces_in_sector,
-                            initialized_with: pieces_in_sector,
-                        });
-                    }
-
-                    if max_pieces_in_sector > pieces_in_sector {
-                        info!(
+                if max_pieces_in_sector > pieces_in_sector {
+                    info!(
                         pieces_in_sector,
                         max_pieces_in_sector,
                         "Farm initialized with smaller number of pieces in sector, farm needs to \
                         be re-created for increase"
                     );
-                    }
-
-                    if allocated_space != single_disk_farm_info.allocated_space() {
-                        info!(
-                            old_space = %bytesize::to_string(single_disk_farm_info.allocated_space(), true),
-                            new_space = %bytesize::to_string(allocated_space, true),
-                            "Farm size has changed"
-                        );
-
-                        {
-                            let new_allocated_space = allocated_space;
-                            let SingleDiskFarmInfo::V0 {
-                                allocated_space, ..
-                            } = &mut single_disk_farm_info;
-                            *allocated_space = new_allocated_space;
-                        }
-
-                        single_disk_farm_info.store_to(directory)?;
-                    }
-
-                    (single_disk_farm_info, single_disk_farm_info_lock)
                 }
-                None => {
-                    let single_disk_farm_info = SingleDiskFarmInfo::new(
-                        FarmId::new(),
-                        farmer_app_info.genesis_hash,
-                        public_key,
-                        max_pieces_in_sector,
-                        allocated_space,
+
+                if allocated_space != single_disk_farm_info.allocated_space() {
+                    info!(
+                        old_space = %bytesize::to_string(single_disk_farm_info.allocated_space(), true),
+                        new_space = %bytesize::to_string(allocated_space, true),
+                        "Farm size has changed"
                     );
 
+                    {
+                        let new_allocated_space = allocated_space;
+                        let SingleDiskFarmInfo::V0 {
+                            allocated_space, ..
+                        } = &mut single_disk_farm_info;
+                        *allocated_space = new_allocated_space;
+                    }
+
                     single_disk_farm_info.store_to(directory)?;
-
-                    let single_disk_farm_info_lock = if *disable_farm_locking {
-                        None
-                    } else {
-                        Some(
-                            SingleDiskFarmInfo::try_lock(directory)
-                                .map_err(SingleDiskFarmError::LikelyAlreadyInUse)?,
-                        )
-                    };
-
-                    (single_disk_farm_info, single_disk_farm_info_lock)
                 }
-            };
+
+                single_disk_farm_info
+            }
+            None => {
+                let single_disk_farm_info = SingleDiskFarmInfo::new(
+                    FarmId::new(),
+                    farmer_app_info.genesis_hash,
+                    public_key,
+                    max_pieces_in_sector,
+                    allocated_space,
+                );
+
+                single_disk_farm_info.store_to(directory)?;
+
+                single_disk_farm_info
+            }
+        };
+
+        let single_disk_farm_info_lock = if *disable_farm_locking {
+            None
+        } else {
+            Some(
+                SingleDiskFarmInfo::try_lock(directory)
+                    .map_err(SingleDiskFarmError::LikelyAlreadyInUse)?,
+            )
+        };
 
         let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
         let sector_size = sector_size(pieces_in_sector);


### PR DESCRIPTION
This PR reverts https://github.com/subspace/subspace/pull/2668, adds workaround to support recovery of corrupted farms and adds an alternative to https://github.com/subspace/subspace/pull/2668 by locking farm while writing.

The root issue here is Windows again. If file is locked, writes to the file fail with following error:
```
called `Result::unwrap()` on an `Err` value: Os { code: 33, kind: Uncategorized, message: "The process cannot access the file because another process has locked a portion of the file." }
```

However, file is still being modified, erased to be specific :facepalm: 

I'm not in the mood right now, but I'll try to create a bug report to Microsoft about this as well.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
