### PR TITLE
Fix WASM instance warnings

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -81,8 +81,9 @@ use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{BlockNumber, RecordedHistorySegment, SegmentHeader, SegmentIndex};
 use tracing::{debug, info, warn};
 
-/// This corresponds to default value of `--max-runtime-instances` in Substrate
-const BLOCKS_TO_ARCHIVE_CONCURRENCY: usize = 8;
+/// Number of WASM instances is 8, this is a bit lower to avoid warnings exceeding number of
+/// instances
+const BLOCKS_TO_ARCHIVE_CONCURRENCY: usize = 6;
 
 /// How deep (in segments) should block be in order to be finalized.
 ///


### PR DESCRIPTION
Prevents following messages that appear to be more likely after archiver refactoring:
```
2024-04-26T02:09:40.097552Z  WARN wasm-runtime: Ran out of free WASM instances
2024-04-26T02:09:40.097972Z  WARN wasm-runtime: Ran out of free WASM instances
2024-04-26T02:09:40.098224Z  WARN wasm-runtime: Ran out of free WASM instances
2024-04-26T02:09:40.107687Z  WARN wasm-runtime: Ran out of free WASM instances
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
