### PR TITLE
Add `PlottedSectors` abstraction in `Farm`

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -660,7 +660,7 @@ where
             plotted_pieces.add_farm(farm_index, farm.piece_reader());
 
             for (sector_index, mut plotted_sectors) in
-                (0 as SectorIndex..).zip(farm.plotted_sectors().await)
+                (0 as SectorIndex..).zip(farm.plotted_sectors().get().await)
             {
                 while let Some(plotted_sector_result) = plotted_sectors.next().await {
                     match plotted_sector_result {

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -22,6 +22,17 @@ use ulid::Ulid;
 pub type FarmError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type HandlerFn<A> = Arc<dyn Fn(&A) + Send + Sync + 'static>;
 
+/// Getter for plotted sectors
+#[async_trait]
+pub trait PlottedSectors: Send + Sync + fmt::Debug {
+    async fn get(
+        &self,
+    ) -> Result<
+        Box<dyn Stream<Item = Result<PlottedSector, FarmError>> + Unpin + Send + '_>,
+        FarmError,
+    >;
+}
+
 /// Offset wrapper for pieces in [`PieceCache`]
 #[derive(Debug, Display, Copy, Clone, Encode, Decode)]
 #[repr(transparent)]
@@ -362,10 +373,8 @@ pub trait Farm {
     /// Number of sectors successfully plotted so far
     async fn plotted_sectors_count(&self) -> Result<SectorIndex, FarmError>;
 
-    /// Read information about sectors plotted so far
-    async fn plotted_sectors(
-        &self,
-    ) -> Result<Box<dyn Stream<Item = Result<PlottedSector, FarmError>> + Unpin + '_>, FarmError>;
+    /// Get plotted sectors instance
+    fn plotted_sectors(&self) -> Arc<dyn PlottedSectors + 'static>;
 
     /// Get piece cache instance
     fn piece_cache(&self) -> Arc<dyn PieceCache + 'static>;

--- a/crates/subspace-farmer/src/single_disk_farm/plotted_sectors.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotted_sectors.rs
@@ -1,0 +1,57 @@
+use crate::farm::{FarmError, PlottedSectors};
+use async_lock::RwLock as AsyncRwLock;
+use async_trait::async_trait;
+use futures::{stream, Stream};
+use std::sync::Arc;
+use subspace_core_primitives::{PieceOffset, PublicKey, SectorId};
+use subspace_farmer_components::plotting::PlottedSector;
+use subspace_farmer_components::sector::SectorMetadataChecksummed;
+use subspace_farmer_components::FarmerProtocolInfo;
+
+/// Getter for single disk plotted sectors
+#[derive(Debug)]
+pub struct SingleDiskPlottedSectors {
+    pub(super) public_key: PublicKey,
+    pub(super) pieces_in_sector: u16,
+    pub(super) farmer_protocol_info: FarmerProtocolInfo,
+    pub(super) sectors_metadata: Arc<AsyncRwLock<Vec<SectorMetadataChecksummed>>>,
+}
+
+#[async_trait]
+impl PlottedSectors for SingleDiskPlottedSectors {
+    async fn get(
+        &self,
+    ) -> Result<
+        Box<dyn Stream<Item = Result<PlottedSector, FarmError>> + Unpin + Send + '_>,
+        FarmError,
+    > {
+        let public_key_hash = self.public_key.hash();
+        let sectors_metadata = self.sectors_metadata.read().await.clone();
+        Ok(Box::new(stream::iter((0..).zip(sectors_metadata).map(
+            move |(sector_index, sector_metadata)| {
+                let sector_id = SectorId::new(public_key_hash, sector_index);
+
+                let mut piece_indexes = Vec::with_capacity(usize::from(self.pieces_in_sector));
+                (PieceOffset::ZERO..)
+                    .take(usize::from(self.pieces_in_sector))
+                    .map(|piece_offset| {
+                        sector_id.derive_piece_index(
+                            piece_offset,
+                            sector_metadata.history_size,
+                            self.farmer_protocol_info.max_pieces_in_sector,
+                            self.farmer_protocol_info.recent_segments,
+                            self.farmer_protocol_info.recent_history_fraction,
+                        )
+                    })
+                    .collect_into(&mut piece_indexes);
+
+                Ok(PlottedSector {
+                    sector_id,
+                    sector_index,
+                    sector_metadata,
+                    piece_indexes,
+                })
+            },
+        ))))
+    }
+}


### PR DESCRIPTION
This is helpful for https://github.com/subspace/subspace/issues/2402 because it'll be necessary to return plotted pieces in response to controller's request, while the farm itself will be consumed by `.run()` call and will not be available anymore.

Having a clonable instance, just like with cache and other things, allows to keep an independent instance for later usage.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
