### PR TITLE
Update frontier to fix the old runtime compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,7 +3512,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3540,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "async-trait",
  "fc-api",
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -3580,7 +3580,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3635,7 +3635,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3806,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "evm",
  "frame-support",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "environmental",
  "evm",
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7596,7 +7596,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "fp-evm",
  "num",
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7614,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=4354330f71535a5459b8e3c7e7ed0c0d612b5e0e#4354330f71535a5459b8e3c7e7ed0c0d612b5e0e"
+source = "git+https://github.com/subspace/frontier?rev=1fe202805f3a3158b278386200ca6761f22b271e#1fe202805f3a3158b278386200ca6761f22b271e"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/crates/sp-domains-fraud-proof/Cargo.toml
+++ b/crates/sp-domains-fraud-proof/Cargo.toml
@@ -43,15 +43,15 @@ domain-block-builder = { version = "0.1.0", path = "../../domains/client/block-b
 domain-block-preprocessor = { version = "0.1.0", path = "../../domains/client/block-preprocessor" }
 domain-test-service = { version = "0.1.0", path = "../../domains/test/service" }
 ethereum = "0.15.0"
-fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", features = ['default'] }
-fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", features = ['default'] }
+fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", features = ['default'] }
+fp-self-contained = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", features = ['default'] }
 frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 futures = "0.3.29"
 libsecp256k1 = { version = "0.7.1", features = ["static-context", "hmac"] }
 pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
-pallet-ethereum = { git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", features = ['default'] }
-pallet-evm = { version = "6.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", default-features = false }
+pallet-ethereum = { git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", features = ['default'] }
+pallet-evm = { version = "6.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", default-features = false }
 parking_lot = "0.12.2"
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 rlp = "0.5.2"

--- a/crates/subspace-malicious-operator/Cargo.toml
+++ b/crates/subspace-malicious-operator/Cargo.toml
@@ -28,7 +28,7 @@ domain-eth-service = { version = "0.1.0", path = "../../domains/client/eth-servi
 domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 evm-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/evm" }
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 futures = "0.3.29"

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -32,7 +32,7 @@ domain-service = { version = "0.1.0", path = "../../domains/service" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 evm-domain-runtime = { version = "0.1.0", path = "../../domains/runtime/evm" }
 fdlimit = "0.3.0"
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 frame-benchmarking = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
 frame-benchmarking-cli = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed", default-features = false }
 frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }

--- a/domains/client/eth-service/Cargo.toml
+++ b/domains/client/eth-service/Cargo.toml
@@ -15,13 +15,13 @@ include = [
 clap = { version = "4.5.4", features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime" }
 domain-service = { version = "0.1.0", path = "../../service" }
-fc-consensus = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fc-db = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", default-features = false }
-fc-mapping-sync = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", default-features = false }
-fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", default-features = false, features = ['rpc-binary-search-estimate'] }
-fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fc-storage = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", features = ['default'] }
+fc-consensus = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fc-db = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", default-features = false }
+fc-mapping-sync = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", default-features = false }
+fc-rpc = { version = "2.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", default-features = false, features = ['rpc-binary-search-estimate'] }
+fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fc-storage = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", features = ['default'] }
 futures = "0.3.29"
 jsonrpsee = { version = "0.22.5", features = ["server"] }
 pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }

--- a/domains/primitives/runtime/Cargo.toml
+++ b/domains/primitives/runtime/Cargo.toml
@@ -12,7 +12,7 @@ description = "Common primitives of subspace domain runtime"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-fp-account = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+fp-account = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 parity-scale-codec = { version = "3.6.9", default-features = false, features = ["derive"] }

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -20,25 +20,25 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive"] }
 domain-pallet-executive = { version = "0.1.0", path = "../../pallets/executive", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
-fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system-benchmarking = { default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 pallet-balances = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
-pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 pallet-block-fees = { version = "0.1.0", path = "../../pallets/block-fees", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "../../pallets/domain-id", default-features = false }
-pallet-ethereum = { default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+pallet-ethereum = { default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 pallet-evm-nonce-tracker = { version = "0.1.0", path = "../../pallets/evm_nonce_tracker", default-features = false }
-pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 pallet-messenger = { version = "0.1.0", path = "../../pallets/messenger", default-features = false }
 pallet-sudo = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 pallet-timestamp = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }

--- a/domains/test/runtime/evm/Cargo.toml
+++ b/domains/test/runtime/evm/Cargo.toml
@@ -21,23 +21,23 @@ codec = { package = "parity-scale-codec", version = "3.2.1", default-features = 
 domain-pallet-executive = { version = "0.1.0", path = "../../../pallets/executive", default-features = false }
 domain-test-primitives = { version = "0.1.0", path = "../../primitives", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../../primitives/runtime", default-features = false }
-fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fp-rpc = { version = "3.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fp-self-contained = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 pallet-balances = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
-pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+pallet-base-fee = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 pallet-block-fees = { version = "0.1.0", path = "../../../pallets/block-fees", default-features = false }
 pallet-domain-id = { version = "0.1.0", path = "../../../pallets/domain-id", default-features = false }
-pallet-ethereum = { default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+pallet-ethereum = { default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm = { version = "6.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm-chain-id = { version = "1.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 pallet-evm-nonce-tracker = { version = "0.1.0", path = "../../../pallets/evm_nonce_tracker", default-features = false }
-pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+pallet-evm-precompile-modexp = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm-precompile-sha3fips = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+pallet-evm-precompile-simple = { version = "2.0.0-dev", default-features = false, git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 pallet-messenger = { version = "0.1.0", path = "../../../pallets/messenger", default-features = false }
 pallet-sudo = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 pallet-timestamp = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }

--- a/domains/test/service/Cargo.toml
+++ b/domains/test/service/Cargo.toml
@@ -18,8 +18,8 @@ domain-service = { version = "0.1.0", path = "../../service" }
 domain-test-primitives = { version = "0.1.0", path = "../primitives" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
 evm-domain-test-runtime = { version = "0.1.0", path = "../runtime/evm" }
-fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
-fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e", features = ['default'] }
+fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
+fp-rpc = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e", features = ['default'] }
 frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 frame-support = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }
 rand = "0.8.5"

--- a/test/subspace-test-client/Cargo.toml
+++ b/test/subspace-test-client/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.5", features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 evm-domain-test-runtime = { version = "0.1.0", path = "../../domains/test/runtime/evm" }
-fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4354330f71535a5459b8e3c7e7ed0c0d612b5e0e" }
+fp-evm = { version = "3.0.0-dev", git = "https://github.com/subspace/frontier", rev = "1fe202805f3a3158b278386200ca6761f22b271e" }
 futures = "0.3.29"
 schnorrkel = "0.11.4"
 sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "44d742b90e7852aed1f08ab5299d5d88cfa1c6ed" }


### PR DESCRIPTION
This PR updates the frontier deps to the [commit](https://github.com/subspace/frontier/commit/1fe202805f3a3158b278386200ca6761f22b271e) that patches the old runtime compatibility issue when initializing block on pending ETH RPC

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
