### PR TITLE
Increase RPC request timeout

### DIFF
--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -3,6 +3,7 @@
     array_windows,
     assert_matches,
     const_option,
+    duration_constructors,
     exact_size_is_empty,
     hash_extract_if,
     impl_trait_in_assoc_type,

--- a/crates/subspace-farmer/src/node_client/node_rpc_client.rs
+++ b/crates/subspace-farmer/src/node_client/node_rpc_client.rs
@@ -6,6 +6,7 @@ use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
@@ -17,6 +18,7 @@ const RPC_MAX_CONCURRENT_REQUESTS: usize = 1_000_000;
 /// Node is having a hard time responding for many piece requests
 // TODO: Remove this once https://github.com/paritytech/jsonrpsee/issues/1189 is resolved
 const MAX_CONCURRENT_PIECE_REQUESTS: usize = 10;
+const REQUEST_TIMEOUT: Duration = Duration::from_mins(5);
 
 /// `WsClient` wrapper.
 #[derive(Debug, Clone)]
@@ -32,6 +34,7 @@ impl NodeRpcClient {
             WsClientBuilder::default()
                 .max_concurrent_requests(RPC_MAX_CONCURRENT_REQUESTS)
                 .max_request_size(20 * 1024 * 1024)
+                .request_timeout(REQUEST_TIMEOUT)
                 .build(url)
                 .await?,
         );


### PR DESCRIPTION
There were many comments from farmers that their farmers disconnect from node due to timeout. This seems to happen when they have a lot of farms connected to the same node and/or node is slow for some reason.

Increasing default timeout of 1m to 5m should help with that even though this is certainly suboptimal situation to begin with, but it is still better than farmers stopping farming/plotting.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
