### PR TITLE
Allow disabling farm creation

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -195,6 +195,11 @@ pub(crate) struct FarmingArgs {
     /// Disable farm locking, for example if file system doesn't support it
     #[arg(long)]
     disable_farm_locking: bool,
+    /// Whether to create missing farms during start.
+    ///
+    /// If set to `false` farmer will exit with error if one of the farms doesn't already exist.
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    create: bool,
     /// Exit on farm error.
     ///
     /// By default, farmer will continue running if there are still other working farms.
@@ -242,6 +247,7 @@ where
         plotting_thread_priority,
         plot_cache,
         disable_farm_locking,
+        create,
         exit_on_farm_error,
     } = farming_args;
 
@@ -302,8 +308,19 @@ where
         .expect("Disk farm collection is not be empty as checked above; qed")
         .directory;
 
-    let identity = Identity::open_or_create(first_farm_directory)
-        .map_err(|error| anyhow!("Failed to open or create identity: {error}"))?;
+    let identity = if create {
+        Identity::open_or_create(first_farm_directory)
+            .map_err(|error| anyhow!("Failed to open or create identity: {error}"))?
+    } else {
+        Identity::open(first_farm_directory)
+            .map_err(|error| anyhow!("Failed to open identity of the first farm: {error}"))?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Failed to open identity of the first farm: Farm doesn't exist and creation \
+                    was explicitly disabled"
+                )
+            })?
+    };
     let keypair = derive_libp2p_keypair(identity.secret_key());
     let peer_id = keypair.public().to_peer_id();
 
@@ -536,6 +553,7 @@ where
                             faster_read_sector_record_chunks_mode_barrier,
                             faster_read_sector_record_chunks_mode_concurrency,
                             plotter,
+                            create,
                         },
                         farm_index,
                     );

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -294,6 +294,8 @@ pub struct SingleDiskFarmOptions<NC, P> {
     pub faster_read_sector_record_chunks_mode_barrier: Arc<Barrier>,
     /// Limit concurrency of internal benchmarking between different farms
     pub faster_read_sector_record_chunks_mode_concurrency: Arc<Semaphore>,
+    /// Whether to create a farm if it doesn't yet exist
+    pub create: bool,
 }
 
 /// Errors happening when trying to create/open single disk farm
@@ -1056,6 +1058,7 @@ impl SingleDiskFarm {
             max_pieces_in_sector,
             cache_percentage,
             disable_farm_locking,
+            create,
             ..
         } = options;
 
@@ -1064,7 +1067,16 @@ impl SingleDiskFarm {
 
         fs::create_dir_all(directory)?;
 
-        let identity = Identity::open_or_create(directory)?;
+        let identity = if *create {
+            Identity::open_or_create(directory)?
+        } else {
+            Identity::open(directory)?.ok_or_else(|| {
+                IdentityError::Io(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "Farm does not exist and creation was explicitly disabled",
+                ))
+            })?
+        };
         let public_key = identity.public_key().to_bytes().into();
 
         let single_disk_farm_info = match SingleDiskFarmInfo::load_from(directory)? {


### PR DESCRIPTION
This was requested on the forum as a way to prevent farmer creating farms on root file system or other unexpected places: https://forum.subspace.network/t/validate-farm-creation-on-root-file-system/2897?u=nazar-pc

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
