### PR TITLE
Plotting metadata refactoring

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -416,7 +416,6 @@ pub fn create_signed_vote(
 
     for sector_index in iter::from_fn(|| Some(rand::random())) {
         let mut plotted_sector_bytes = Vec::new();
-        let mut plotted_sector_metadata_bytes = Vec::new();
 
         let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
             public_key: &public_key,
@@ -427,7 +426,6 @@ pub fn create_signed_vote(
             erasure_coding,
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
-            sector_metadata_output: &mut plotted_sector_metadata_bytes,
             downloading_semaphore: None,
             encoding_semaphore: None,
             table_generators: slice::from_mut(&mut table_generator),

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -114,7 +114,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         println!("Plotting one sector...");
 
         let mut plotted_sector_bytes = Vec::new();
-        let mut plotted_sector_metadata_bytes = Vec::new();
 
         let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
             public_key,
@@ -125,7 +124,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             erasure_coding: &erasure_coding,
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
-            sector_metadata_output: &mut plotted_sector_metadata_bytes,
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             table_generators: slice::from_mut(&mut table_generator),

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -69,7 +69,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let sector_size = sector_size(pieces_in_sector);
     let mut sector_bytes = Vec::new();
-    let mut sector_metadata_bytes = Vec::new();
 
     let mut group = c.benchmark_group("plotting");
     group.throughput(Throughput::Bytes(sector_size as u64));
@@ -84,7 +83,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 erasure_coding: black_box(&erasure_coding),
                 pieces_in_sector: black_box(pieces_in_sector),
                 sector_output: black_box(&mut sector_bytes),
-                sector_metadata_output: black_box(&mut sector_metadata_bytes),
                 downloading_semaphore: black_box(None),
                 encoding_semaphore: black_box(None),
                 table_generators: black_box(&mut table_generators),

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -122,7 +122,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         println!("Plotting one sector...");
 
         let mut plotted_sector_bytes = Vec::new();
-        let mut plotted_sector_metadata_bytes = Vec::new();
 
         let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
             public_key,
@@ -133,7 +132,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             erasure_coding,
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
-            sector_metadata_output: &mut plotted_sector_metadata_bytes,
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             table_generators: slice::from_mut(&mut table_generator),

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -113,7 +113,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         println!("Plotting one sector...");
 
         let mut plotted_sector_bytes = Vec::new();
-        let mut plotted_sector_metadata_bytes = Vec::new();
 
         let plotted_sector = block_on(plot_sector::<PosTable, _>(PlotSectorOptions {
             public_key: &public_key,
@@ -124,7 +123,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             erasure_coding: &erasure_coding,
             pieces_in_sector,
             sector_output: &mut plotted_sector_bytes,
-            sector_metadata_output: &mut plotted_sector_metadata_bytes,
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             table_generators: slice::from_mut(&mut table_generator),

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -5,6 +5,7 @@
     const_option,
     duration_constructors,
     exact_size_is_empty,
+    fmt_helpers_for_derive,
     hash_extract_if,
     impl_trait_in_assoc_type,
     int_roundings,

--- a/crates/subspace-farmer/src/plotter.rs
+++ b/crates/subspace-farmer/src/plotter.rs
@@ -1,21 +1,17 @@
 pub mod cpu;
 
 use async_trait::async_trait;
-use futures::Sink;
-use parity_scale_codec::{Decode, Encode};
+use futures::{Sink, Stream};
 use std::error::Error;
+use std::fmt;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::{PublicKey, SectorIndex};
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::FarmerProtocolInfo;
 
-// TODO: It is a bit awkward that this mimics `SectorPlottingDetails` with slight differences, maybe
-//  `SectorPlottingDetails` should be a bit generic and support customization of
-//  `Starting`/`Finished` contents
 /// Sector plotting progress
-#[derive(Debug, Clone, Encode, Decode)]
-#[allow(clippy::large_enum_variant)]
 pub enum SectorPlottingProgress {
     /// Downloading sector pieces
     Downloading,
@@ -31,14 +27,44 @@ pub enum SectorPlottingProgress {
         plotted_sector: PlottedSector,
         /// How much time it took to plot a sector
         time: Duration,
-        /// All plotted sector bytes
-        sector: Vec<u8>,
+        /// Stream of all plotted sector bytes
+        sector: Pin<Box<dyn Stream<Item = Result<Vec<u8>, String>> + Send + Sync>>,
     },
     /// Plotting failed
     Error {
         /// Error message
         error: String,
     },
+}
+
+impl fmt::Debug for SectorPlottingProgress {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SectorPlottingProgress::Downloading => fmt::Formatter::write_str(f, "Downloading"),
+            SectorPlottingProgress::Downloaded(time) => {
+                f.debug_tuple_field1_finish("Downloaded", &time)
+            }
+            SectorPlottingProgress::Encoding => fmt::Formatter::write_str(f, "Encoding"),
+            SectorPlottingProgress::Encoded(time) => f.debug_tuple_field1_finish("Encoded", &time),
+            SectorPlottingProgress::Finished {
+                plotted_sector,
+                time,
+                sector: _,
+            } => f.debug_struct_field3_finish(
+                "Finished",
+                "plotted_sector",
+                plotted_sector,
+                "time",
+                time,
+                "sector",
+                &"<stream>",
+            ),
+            SectorPlottingProgress::Error { error } => {
+                f.debug_struct_field1_finish("Error", "error", &error)
+            }
+        }
+    }
 }
 
 /// Abstract plotter implementation

--- a/crates/subspace-farmer/src/plotter.rs
+++ b/crates/subspace-farmer/src/plotter.rs
@@ -33,8 +33,6 @@ pub enum SectorPlottingProgress {
         time: Duration,
         /// All plotted sector bytes
         sector: Vec<u8>,
-        /// All plotted sector metadata bytes
-        sector_metadata: Vec<u8>,
     },
     /// Plotting failed
     Error {

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -175,13 +175,12 @@ where
                 };
 
                 // Plotting
-                let (sector, sector_metadata, plotted_sector) = {
+                let (sector, plotted_sector) = {
                     let thread_pools = plotting_thread_pool_manager.get_thread_pools().await;
 
                     let plotting_fn = || {
                         tokio::task::block_in_place(|| {
                             let mut sector = Vec::new();
-                            let mut sector_metadata = Vec::new();
 
                             let plotted_sector = encode_sector::<PosTable>(
                                 downloaded_sector,
@@ -190,7 +189,6 @@ where
                                     erasure_coding: &erasure_coding,
                                     pieces_in_sector,
                                     sector_output: &mut sector,
-                                    sector_metadata_output: &mut sector_metadata,
                                     table_generators: &mut (0..record_encoding_concurrency.get())
                                         .map(|_| PosTable::generator())
                                         .collect::<Vec<_>>(),
@@ -199,7 +197,7 @@ where
                                 },
                             )?;
 
-                            Ok((sector, sector_metadata, plotted_sector))
+                            Ok((sector, plotted_sector))
                         })
                     };
 
@@ -265,7 +263,6 @@ where
                             plotted_sector,
                             time: start.elapsed(),
                             sector,
-                            sector_metadata,
                         },
                     )
                     .await;

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::mpsc;
 use futures::stream::FuturesUnordered;
-use futures::{select, FutureExt, Sink, SinkExt, StreamExt};
+use futures::{select, stream, FutureExt, Sink, SinkExt, StreamExt};
 use std::error::Error;
 use std::future::pending;
 use std::marker::PhantomData;
@@ -262,7 +262,7 @@ where
                         SectorPlottingProgress::Finished {
                             plotted_sector,
                             time: start.elapsed(),
-                            sector,
+                            sector: Box::pin(stream::once(async move { Ok(sector) })),
                         },
                     )
                     .await;

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -702,7 +702,6 @@ impl SingleDiskFarm {
         let public_key = *single_disk_farm_info.public_key();
         let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
         let sector_size = sector_size(pieces_in_sector);
-        let sector_metadata_size = SectorMetadataChecksummed::encoded_size();
 
         let SingleDiskFarmOptions {
             directory,
@@ -824,8 +823,6 @@ impl SingleDiskFarm {
                         public_key,
                         node_client: &node_client,
                         pieces_in_sector,
-                        sector_size,
-                        sector_metadata_size,
                         plot_file: &plot_file,
                         metadata_file,
                         sectors_metadata: &sectors_metadata,

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -823,6 +823,7 @@ impl SingleDiskFarm {
                         public_key,
                         node_client: &node_client,
                         pieces_in_sector,
+                        sector_size,
                         plot_file: &plot_file,
                         metadata_file,
                         sectors_metadata: &sectors_metadata,

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -224,7 +224,6 @@ where
         .expect("First block is always producing one segment; qed");
     let history_size = HistorySize::from(SegmentIndex::ZERO);
     let mut sector = Vec::new();
-    let mut sector_metadata = Vec::new();
     let sector_index = 0;
     let public_key = PublicKey::from(keypair.public.to_bytes());
     let farmer_protocol_info = FarmerProtocolInfo {
@@ -247,7 +246,6 @@ where
         erasure_coding,
         pieces_in_sector,
         sector_output: &mut sector,
-        sector_metadata_output: &mut sector_metadata,
         downloading_semaphore: None,
         encoding_semaphore: None,
         table_generators: slice::from_mut(&mut table_generator),


### PR DESCRIPTION
Two things changed here:
* sector metadata was sent twice unnecessarily before in the plotting result, so encoded duplicate was removed
* plotted sector as a whole was in the plotting progress notification, which was a problem if we were sending it across the network due to both large allocation necessary and awkwarness with data structure encoding that doesn't fit into NATS message size

With these changes implementation of farming cluster and similar use cases will be much easier and more memory-efficient.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
