### PR TITLE
Farmer cleanups

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -114,7 +114,7 @@ fn audit(
         NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize)
             .expect("Not zero; qed"),
     )
-    .map_err(|error| anyhow::anyhow!(error))?;
+    .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
     let table_generator = Mutex::new(PosTable::generator());
 
     let sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
@@ -276,7 +276,7 @@ fn prove(
         NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize)
             .expect("Not zero; qed"),
     )
-    .map_err(|error| anyhow::anyhow!(error))?;
+    .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
     let table_generator = Mutex::new(PosTable::generator());
 
     let mut sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
@@ -58,10 +58,10 @@ impl From<PlottingThreadPriority> for Option<ThreadPriority> {
 
 #[derive(Debug, Clone)]
 pub(in super::super) struct DiskFarm {
-    /// Path to directory where data is stored.
+    /// Path to directory where farm is stored
     pub(in super::super) directory: PathBuf,
-    /// How much space in bytes can farm use for plots (metadata space is not included)
-    pub(in super::super) allocated_plotting_space: u64,
+    /// How much space in bytes can farm use
+    pub(in super::super) allocated_space: u64,
     /// Which mode to use for reading of sector record chunks
     pub(in super::super) read_sector_record_chunks_mode: Option<ReadSectorRecordChunksMode>,
 }
@@ -76,7 +76,7 @@ impl FromStr for DiskFarm {
         }
 
         let mut plot_directory = None;
-        let mut allocated_plotting_space = None;
+        let mut allocated_space = None;
         let mut read_sector_record_chunks_mode = None;
 
         for part in parts {
@@ -93,7 +93,7 @@ impl FromStr for DiskFarm {
                     plot_directory.replace(PathBuf::from(value));
                 }
                 "size" => {
-                    allocated_plotting_space.replace(
+                    allocated_space.replace(
                         value
                             .parse::<ByteSize>()
                             .map_err(|error| {
@@ -121,12 +121,10 @@ impl FromStr for DiskFarm {
         }
 
         Ok(DiskFarm {
-            directory: plot_directory.ok_or({
-                "`path` key is required with path to directory where plots will be stored"
-            })?,
-            allocated_plotting_space: allocated_plotting_space.ok_or({
-                "`size` key is required with path to directory where plots will be stored"
-            })?,
+            directory: plot_directory
+                .ok_or("`path` key is required with path to directory where farm will be stored")?,
+            allocated_space: allocated_space
+                .ok_or("`size` key is required with allocated amount of disk space")?,
             read_sector_record_chunks_mode,
         })
     }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -137,8 +137,7 @@ where
 
                         let read_piece_fut = match weak_plotted_pieces.upgrade() {
                             Some(plotted_pieces) => plotted_pieces
-                                .read()
-                                .await
+                                .try_read()?
                                 .read_piece(piece_index)?
                                 .in_current_span(),
                             None => {

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -14,7 +14,7 @@ pub struct DiskPieceCache {
 
 #[async_trait]
 impl farm::PieceCache for DiskPieceCache {
-    fn max_num_elements(&self) -> usize {
+    fn max_num_elements(&self) -> u32 {
         if let Some(piece_cache) = &self.maybe_piece_cache {
             piece_cache.max_num_elements()
         } else {
@@ -24,11 +24,19 @@ impl farm::PieceCache for DiskPieceCache {
 
     async fn contents(
         &self,
-    ) -> Box<dyn Stream<Item = (PieceCacheOffset, Option<PieceIndex>)> + Unpin + Send + '_> {
+    ) -> Result<
+        Box<
+            dyn Stream<Item = Result<(PieceCacheOffset, Option<PieceIndex>), FarmError>>
+                + Unpin
+                + Send
+                + '_,
+        >,
+        FarmError,
+    > {
         if let Some(piece_cache) = &self.maybe_piece_cache {
             farm::PieceCache::contents(piece_cache).await
         } else {
-            Box::new(stream::empty())
+            Ok(Box::new(stream::empty()))
         }
     }
 

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -25,6 +25,7 @@ use tracing::{debug, warn};
 const MAX_DEFAULT_FARMING_THREADS: usize = 32;
 
 /// Joins async join handle on drop
+#[derive(Debug)]
 pub struct AsyncJoinOnDrop<T> {
     handle: Option<task::JoinHandle<T>>,
     abort_on_drop: bool,

--- a/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/utils/farmer_piece_getter.rs
@@ -212,7 +212,10 @@ where
         let inner = &self.inner;
 
         trace!(%piece_index, "Getting piece from local plot");
-        let maybe_read_piece_fut = inner.plotted_pieces.read().await.read_piece(piece_index);
+        let maybe_read_piece_fut = inner
+            .plotted_pieces
+            .try_read()
+            .and_then(|plotted_pieces| plotted_pieces.read_piece(piece_index));
 
         if let Some(read_piece_fut) = maybe_read_piece_fut {
             if let Some(piece) = read_piece_fut.await {


### PR DESCRIPTION
A few things extracted from local branch.

Plotter refactoring is the same code as before, just the way semaphore is acquired is different in `try_plot_sector`.

Not waiting for plotted pieces is important because in farming cluster case it will be re-initialized many times as farms come and go, which wasn't a concern previously. It is still rare, so `try_read()` will succeed in most cases. More sophisticated approach would be to wait until some timeout, someone is free to implement that if they care about it enough.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
