### PR TITLE
Fix networking warnings for request-response protocol.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5606,7 +5606,7 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-quic 0.10.2",
  "libp2p-request-response 0.26.1",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "libp2p-tcp 0.41.0",
  "libp2p-upnp",
  "libp2p-yamux 0.45.1",
@@ -5636,7 +5636,7 @@ checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
 dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "void",
 ]
 
@@ -5654,7 +5654,7 @@ dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
  "libp2p-request-response 0.26.1",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "quick-protobuf",
  "quick-protobuf-codec 0.2.0",
  "rand",
@@ -5681,7 +5681,7 @@ checksum = "c7cd50a78ccfada14de94cbacd3ce4b0138157f376870f13d3a8422cd075b4fd"
 dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "void",
 ]
 
@@ -5791,7 +5791,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "prometheus-client 0.22.2",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
@@ -5839,7 +5839,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "lru 0.12.3",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
@@ -5931,7 +5931,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "quick-protobuf",
  "quick-protobuf-codec 0.3.1",
  "rand",
@@ -5977,7 +5977,7 @@ dependencies = [
  "if-watch",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "rand",
  "smallvec",
  "socket2 0.5.7",
@@ -6014,7 +6014,7 @@ dependencies = [
  "libp2p-identity 0.2.8",
  "libp2p-kad 0.45.3",
  "libp2p-ping 0.44.0",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "pin-project",
  "prometheus-client 0.22.2",
 ]
@@ -6097,7 +6097,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "rand",
  "tracing",
  "void",
@@ -6194,7 +6194,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "rand",
  "smallvec",
  "tracing",
@@ -6224,9 +6224,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92532fc3c4fb292ae30c371815c9b10103718777726ea5497abc268a4761866"
+checksum = "80cae6cb75f89dbca53862f9ebe0b9f463aa7b302762fcfaafb9e51dcc9b0f7e"
 dependencies = [
  "async-std",
  "either",
@@ -6236,7 +6236,8 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
- "libp2p-swarm-derive 0.34.1",
+ "libp2p-swarm-derive 0.34.2",
+ "lru 0.12.3",
  "multistream-select 0.13.0",
  "once_cell",
  "rand",
@@ -6259,11 +6260,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.34.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b644268b4acfdaa6a6100b31226ee7a36d96ab4c43287d113bfd2308607d8b6f"
+checksum = "5daceb9dd908417b6dfcfe8e94098bc4aac54500c282e78120b885dadc09b999"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -6281,7 +6282,7 @@ dependencies = [
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
  "libp2p-plaintext",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "libp2p-tcp 0.41.0",
  "libp2p-yamux 0.45.1",
  "rand",
@@ -6370,7 +6371,7 @@ dependencies = [
  "futures-timer",
  "igd-next",
  "libp2p-core 0.41.2",
- "libp2p-swarm 0.44.1",
+ "libp2p-swarm 0.44.2",
  "tokio",
  "tracing",
  "void",

--- a/crates/subspace-networking/src/protocols/request_response/request_response_factory.rs
+++ b/crates/subspace-networking/src/protocols/request_response/request_response_factory.rs
@@ -560,6 +560,11 @@ impl NetworkBehaviour for RequestResponseFactoryBehaviour {
                     protocol.on_swarm_event(FromSwarm::ExternalAddrExpired(inner));
                 }
             }
+            FromSwarm::NewExternalAddrOfPeer(inner) => {
+                for (protocol, _) in self.protocols.values_mut() {
+                    protocol.on_swarm_event(FromSwarm::NewExternalAddrOfPeer(inner));
+                }
+            }
             event => {
                 warn!(
                     ?event,


### PR DESCRIPTION
This PR addresses the warnings reported in the issue: https://github.com/subspace/subspace/issues/2747

The `subspace-networking` crate used the version of the `libp2p_swarm crate` = 0.44.1 and some other clients (Space Acres) can have a different but compatible version. "Request-response protocol factory" had a warning mechanism to report newly added and unhandled events.

The PR fixes dependencies and event handling for `subspace-networking`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
