### PR TITLE
Auto-id: use non-der encoded value of common name for auto id

### DIFF
--- a/domains/pallets/auto-id/src/lib.rs
+++ b/domains/pallets/auto-id/src/lib.rs
@@ -53,8 +53,8 @@ pub struct X509Certificate {
     /// Serial number for this certificate
     pub serial: U256,
     /// Subject common name of the certificate.
-    pub subject_common_name: DerVec,
-    /// Der encoded certificate's subject's public key info
+    pub subject_common_name: Vec<u8>,
+    /// Der encoded certificate's subject's public key info.
     pub subject_public_key_info: DerVec,
     /// Validity of the certificate
     pub validity: Validity,
@@ -76,7 +76,7 @@ pub enum Certificate {
 impl Certificate {
     /// Returns the subject distinguished name.
     #[cfg(test)]
-    fn subject_common_name(&self) -> DerVec {
+    fn subject_common_name(&self) -> Vec<u8> {
         match self {
             Certificate::X509(cert) => cert.subject_common_name.clone(),
         }

--- a/domains/pallets/auto-id/src/tests.rs
+++ b/domains/pallets/auto-id/src/tests.rs
@@ -135,8 +135,8 @@ fn identifier_from_x509_cert(
         .next()
         .unwrap()
         .attr_value()
-        .to_der_vec()
-        .unwrap();
+        .as_bytes()
+        .to_vec();
 
     if let Some(issuer_id) = issuer_id {
         let mut data = issuer_id.to_fixed_bytes().to_vec();
@@ -173,9 +173,8 @@ fn register_issuer_auto_id() -> Identifier {
             .next()
             .unwrap()
             .attr_value()
-            .to_der_vec()
-            .unwrap()
-            .into()
+            .as_bytes()
+            .to_vec()
     );
 
     auto_id_identifier
@@ -207,9 +206,8 @@ fn register_leaf_auto_id(issuer_auto_id: Identifier) -> Identifier {
             .next()
             .unwrap()
             .attr_value()
-            .to_der_vec()
-            .unwrap()
-            .into(),
+            .as_bytes()
+            .to_vec()
     );
 
     auto_id_identifier
@@ -411,7 +409,7 @@ fn test_auto_id_identifier_is_deterministic() {
         let auto_id = crate::AutoId {
             certificate: Certificate::X509(X509Certificate {
                 issuer_id: None,
-                subject_common_name: vec![0].into(),
+                subject_common_name: b"Test".to_vec(),
                 validity: Validity {
                     not_before: 0,
                     not_after: 0,
@@ -425,7 +423,7 @@ fn test_auto_id_identifier_is_deterministic() {
         };
 
         let expected_auto_id_identifier =
-            "0x3170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314";
+            "0x8d2143d76615c515b5cc88fa7806aef268edeea87571c8f8b21a19f77b9993ba";
         assert_eq!(
             to_hex(
                 &auto_id.certificate.derive_identifier().to_fixed_bytes(),
@@ -437,7 +435,7 @@ fn test_auto_id_identifier_is_deterministic() {
         let auto_id_child = crate::AutoId {
             certificate: Certificate::X509(X509Certificate {
                 issuer_id: Some(auto_id.certificate.derive_identifier()),
-                subject_common_name: vec![0].into(),
+                subject_common_name: b"child".to_vec(),
                 validity: Validity {
                     not_before: 0,
                     not_after: 0,
@@ -451,7 +449,7 @@ fn test_auto_id_identifier_is_deterministic() {
         };
 
         let expected_auto_id_child_identifier =
-            "0x1f6c133e7bca8c7714c5c9df36562e5cd51304530cc85e583351167bb75e072f";
+            "0xb273167fb0c55e2df1fcd5c44fcf90e497bd826e2eb4be2f167ff1c46b4d686d";
         assert_eq!(
             to_hex(
                 &auto_id_child

--- a/domains/primitives/auto-id/src/host_functions.rs
+++ b/domains/primitives/auto-id/src/host_functions.rs
@@ -1,7 +1,7 @@
 use crate::{DerVec, SignatureVerificationRequest, TbsCertificate, Validity};
 use sp_core::U256;
 use std::sync::Arc;
-use x509_parser::der_parser::asn1_rs::{BitString, ToDer};
+use x509_parser::der_parser::asn1_rs::BitString;
 use x509_parser::prelude::{AlgorithmIdentifier, FromDer, SubjectPublicKeyInfo};
 use x509_parser::verify::verify_signature;
 
@@ -51,8 +51,7 @@ impl HostFunctions for HostFunctionsImpl {
             .subject
             .iter_common_name()
             .next()
-            .and_then(|cn| cn.attr_value().to_der_vec().ok())?
-            .into();
+            .map(|cn| cn.attr_value().as_bytes().to_vec())?;
 
         Some(TbsCertificate {
             serial,

--- a/domains/primitives/auto-id/src/lib.rs
+++ b/domains/primitives/auto-id/src/lib.rs
@@ -103,8 +103,8 @@ pub struct TbsCertificate {
     /// Certificate serial number.
     pub serial: U256,
     /// Certificate subject common name.
-    pub subject_common_name: DerVec,
-    /// Certificate subject public key info.
+    pub subject_common_name: Vec<u8>,
+    /// Certificate subject public key info, der encoded.
     pub subject_public_key_info: DerVec,
     /// Certificate validity.
     pub validity: Validity,


### PR DESCRIPTION
closes #2752 
check also https://github.com/subspace/auto-kit/pull/11
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
