### PR TITLE
PoS improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12606,10 +12606,12 @@ dependencies = [
  "chacha20",
  "criterion",
  "derive_more",
+ "parking_lot 0.12.2",
  "rand",
  "rayon",
  "seq-macro",
  "sha2 0.10.8",
+ "spin 0.9.8",
  "subspace-chiapos",
  "subspace-core-primitives",
 ]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -18,9 +18,12 @@ bench = false
 [dependencies]
 chacha20 = { version = "0.9.1", default-features = false }
 derive_more = "0.99.17"
+parking_lot = { version = "0.12.2", optional = true }
 rayon = { version = "1.10.0", optional = true }
 seq-macro = "0.3.5"
 sha2 = { version = "0.10.7", default-features = false }
+# Replacement for `parking_lot` in `no_std` environment
+spin = "0.9.7"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]
@@ -38,6 +41,8 @@ harness = false
 default = ["std"]
 std = [
     "chacha20/std",
+    # In no-std environment we use `spin`
+    "parking_lot",
     "sha2/std",
     "subspace-core-primitives/std",
 ]

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -119,9 +119,9 @@ fn calculate_left_targets() -> LeftTargets {
     LeftTargets { left_targets }
 }
 
-fn calculate_left_target_on_demand(parity: usize, r: usize, m: usize) -> usize {
-    let param_b = usize::from(PARAM_B);
-    let param_c = usize::from(PARAM_C);
+fn calculate_left_target_on_demand(parity: u32, r: u32, m: u32) -> u32 {
+    let param_b = u32::from(PARAM_B);
+    let param_c = u32::from(PARAM_C);
 
     let c = r / param_c;
 
@@ -344,11 +344,11 @@ fn find_matches<'a>(
 
 /// Simplified version of [`find_matches`] for verification purposes.
 pub(super) fn has_match(left_y: Y, right_y: Y) -> bool {
-    let right_r = usize::from(right_y) % usize::from(PARAM_BC);
-    let parity = (usize::from(left_y) / usize::from(PARAM_BC)) % 2;
-    let left_r = usize::from(left_y) % usize::from(PARAM_BC);
+    let right_r = u32::from(right_y) % u32::from(PARAM_BC);
+    let parity = (u32::from(left_y) / u32::from(PARAM_BC)) % 2;
+    let left_r = u32::from(left_y) % u32::from(PARAM_BC);
 
-    for m in 0..usize::from(PARAM_M) {
+    for m in 0..u32::from(PARAM_M) {
         let r_target = calculate_left_target_on_demand(parity, left_r, m);
         if r_target == right_r {
             return true;

--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -124,9 +124,19 @@ where
                 .try_into()
                 .expect("Challenge is known to statically have enough bytes; qed"),
         ) >> (u32::BITS as usize - usize::from(K));
-        let first_matching_element = ys
+        let mut first_matching_element = ys
             .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
             .unwrap_or_else(|insert| insert);
+
+        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
+        // find the very first match in case there are multiple
+        for index in (0..first_matching_element).rev() {
+            if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
+                first_matching_element = index;
+            } else {
+                break;
+            }
+        }
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
         ys[first_matching_element..]
@@ -197,9 +207,19 @@ where
                 .try_into()
                 .expect("Challenge is known to statically have enough bytes; qed"),
         ) >> (u32::BITS as usize - usize::from(K));
-        let first_matching_element = ys
+        let mut first_matching_element = ys
             .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
             .unwrap_or_else(|insert| insert);
+
+        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
+        // find the very first match in case there are multiple
+        for index in (0..first_matching_element).rev() {
+            if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
+                first_matching_element = index;
+            } else {
+                break;
+            }
+        }
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
         ys[first_matching_element..]


### PR DESCRIPTION
Supranational repored that out code didn't find all proofs/qualities, which while didn't actually matter for Subspace, was strictly speaking slightly wrong, I fixed that in the first commit.

Then I found two more ways to make table generation faster, which cumulatively resulted in a nice performance improvement.

Before:
```
chia/table/parallel/1x  time:   [192.64 ms 197.94 ms 203.28 ms]
chia/table/parallel/8x  time:   [949.34 ms 953.08 ms 957.16 ms]
```

After:
```
chia/table/parallel/1x  time:   [149.95 ms 152.86 ms 155.13 ms]
chia/table/parallel/8x  time:   [913.09 ms 925.22 ms 938.36 ms]
```

I had nicer API for `LeftTables` with methods and two more data structures, but it was not clear how to convince Rust to agree that lifetimes are correct, so I had to resort to memory slices in `find_matches`. Future borrow checked in Rust should help cleaning up the code a bit.

I tried to apply the same trick with not collecting buckets as in third commit for single-threaded implementation, but I think due to code cache it was slightly slower to the same, but more code and harder to read, so I didn't commit those changes.

I also experimented with data alignment and a few other things, but none of them resulted in conclusive consistent performance improvement.

There might be more performance optimizations, but for now I exhausted ideas and not looking forward to spend hours reading x86-64 assembly looking for opportunities.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
