### PR TITLE
Remove `Clone` from `NodeClient` super trait

### DIFF
--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -14,7 +14,7 @@ pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Abstraction of the Node Client
 #[async_trait]
-pub trait NodeClient: Clone + fmt::Debug + Send + Sync + 'static {
+pub trait NodeClient: fmt::Debug + Send + Sync + 'static {
     /// Get farmer app info
     async fn farmer_app_info(&self) -> Result<FarmerAppInfo, Error>;
 

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -257,7 +257,10 @@ impl PlotMetadataHeader {
 }
 
 /// Options used to open single disk farm
-pub struct SingleDiskFarmOptions<NC, P> {
+pub struct SingleDiskFarmOptions<NC, P>
+where
+    NC: Clone,
+{
     /// Path to directory where farm is stored.
     pub directory: PathBuf,
     /// Information necessary for farmer application
@@ -669,7 +672,7 @@ impl SingleDiskFarm {
         farm_index: usize,
     ) -> Result<Self, SingleDiskFarmError>
     where
-        NC: NodeClient,
+        NC: NodeClient + Clone,
         P: Plotter + Send + 'static,
         PosTable: Table,
     {
@@ -1056,7 +1059,10 @@ impl SingleDiskFarm {
 
     fn init<NC, P>(
         options: &SingleDiskFarmOptions<NC, P>,
-    ) -> Result<SingleDiskFarmInit, SingleDiskFarmError> {
+    ) -> Result<SingleDiskFarmInit, SingleDiskFarmError>
+    where
+        NC: Clone,
+    {
         let SingleDiskFarmOptions {
             directory,
             farmer_app_info,


### PR DESCRIPTION
### Context

Since `Clone` is not object-safe, it is not possible to use `NodeClient` as trait object (`dyn NodeClient`). We [have](https://github.com/subspace/space-acres/pull/192) a use case in `space-acres` that is blocked by this right now.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
