### PR TITLE
Add fast sync algorithm fixes

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn.rs
+++ b/crates/subspace-service/src/sync_from_dsn.rs
@@ -63,7 +63,6 @@ pub(crate) fn create_observer_and_worker<Block, AS, Client, PG, IQS, B>(
     pause_sync: Arc<AtomicBool>,
     piece_getter: PG,
     fast_sync_enabled: bool,
-    fast_sync_state: Arc<parking_lot::Mutex<Option<NumberFor<Block>>>>,
     sync_service: Arc<SyncingService<Block>>,
 ) -> (
     impl Future<Output = ()> + Send + 'static,
@@ -117,7 +116,6 @@ where
             network_service,
             tx,
             fast_sync_enabled,
-            fast_sync_state,
             sync_service,
         )
         .await
@@ -253,7 +251,6 @@ async fn create_worker<Backend, Block, AS, IQS, Client, PG>(
     network_service: Arc<NetworkService<Block, <Block as BlockT>::Hash>>,
     mut notifications_sender: mpsc::Sender<NotificationReason>,
     fast_sync_enabled: bool,
-    fast_sync_state: Arc<parking_lot::Mutex<Option<NumberFor<Block>>>>,
     sync_service: Arc<SyncingService<Block>>,
 ) -> Result<(), sc_service::Error>
 where
@@ -311,7 +308,6 @@ where
                 client.clone(),
                 import_queue_service.clone(),
                 network_service.clone(),
-                fast_sync_state,
                 sync_service,
             );
 

--- a/crates/subspace-service/src/sync_from_dsn/fast_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/fast_sync.rs
@@ -503,7 +503,10 @@ where
                     .await
                     .expect("Network service must be available.")
                     .iter()
-                    .filter_map(|(peer_id, info)| info.roles.is_full().then_some(*peer_id))
+                    .filter_map(|(peer_id, info)| {
+                        (info.roles.is_full() && info.best_number > state_block_number)
+                            .then_some(*peer_id)
+                    })
                     .collect::<Vec<_>>();
 
                 debug!(?tried_peers, "Sync peers: {}", connected_full_peers.len());


### PR DESCRIPTION
This fixes a few issues I found in my 2 hour testing of https://github.com/subspace/subspace/pull/2763

It fixes frequent state sync download failures, improves block import performance and removes incorrect import of last block of second last segment that breaks invariants expected by archiver and violates specification.

I left a few TODOs I was lazy fixing immediately myself. But I did a few simplifications and removed some of the unnecessary changes.

Now code follows specification more closely except state import is not done atomically during import of the first block of last segment.

With these I have successfully synced Gemini 3h chain without any issues.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
