### PR TITLE
Set CollectedBlockFees to an empty value during block initialization

### DIFF
--- a/domains/pallets/block-fees/src/lib.rs
+++ b/domains/pallets/block-fees/src/lib.rs
@@ -90,7 +90,10 @@ mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(_now: BlockNumberFor<T>) -> Weight {
-            CollectedBlockFees::<T>::take();
+            // NOTE: set the `CollectedBlockFees` to an empty value instead of removing the value
+            // completely so we can generate a storage proof to prove the empty value, which is used
+            // in the fraud proof.
+            CollectedBlockFees::<T>::set(BlockFees::<T::Balance>::default());
             T::DbWeight::get().writes(1)
         }
 

--- a/domains/pallets/transporter/src/lib.rs
+++ b/domains/pallets/transporter/src/lib.rs
@@ -292,6 +292,9 @@ mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+            // NOTE: set the `ChainTransfers` to an empty value instead of removing the value completely
+            // so we can generate a storage proof to prove the empty value, which is required by the fraud
+            // proof.
             ChainTransfers::<T>::set(Default::default());
             T::DbWeight::get().writes(1)
         }


### PR DESCRIPTION
We can't remove the `CollectedBlockFees` value completely because the fraud proof needs to generate a proof of empty value for this storage, this is similar to how we handled the `DomainChainAllowlistUpdate` storage in https://github.com/subspace/subspace/pull/2746/commits/9dba588a5cfce3b2aae9c09925d4a65562094d68

I also checked all other storage proofs, they should not have this problem.

BTW, an interesting finding, if a storage does not exist in the state:
- With `ValueQuery`, it can successfully generate storage proof but fail with `MissingValue` error when verifying the proof (e.g. `CollectedBlockFees`)
- With `OptionQuery`, it will fail with `MissingValue` error when generating the storage proof (e.g. `DomainChainAllowlistUpdate`)

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
