### PR TITLE
Revert "Find the actual first matching element when generating PoS proofs or finding quality"

### DIFF
--- a/crates/subspace-proof-of-space/src/chiapos/tables.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/tables.rs
@@ -124,19 +124,20 @@ where
                 .try_into()
                 .expect("Challenge is known to statically have enough bytes; qed"),
         ) >> (u32::BITS as usize - usize::from(K));
-        let mut first_matching_element = ys
+        let first_matching_element = ys
             .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
             .unwrap_or_else(|insert| insert);
 
-        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
-        // find the very first match in case there are multiple
-        for index in (0..first_matching_element).rev() {
-            if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
-                first_matching_element = index;
-            } else {
-                break;
-            }
-        }
+        // TODO: Restore this when making a breaking change to the protocol
+        // // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
+        // // find the very first match in case there are multiple
+        // for index in (0..first_matching_element).rev() {
+        //     if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
+        //         first_matching_element = index;
+        //     } else {
+        //         break;
+        //     }
+        // }
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
         ys[first_matching_element..]
@@ -207,19 +208,20 @@ where
                 .try_into()
                 .expect("Challenge is known to statically have enough bytes; qed"),
         ) >> (u32::BITS as usize - usize::from(K));
-        let mut first_matching_element = ys
+        let first_matching_element = ys
             .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
             .unwrap_or_else(|insert| insert);
 
-        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
-        // find the very first match in case there are multiple
-        for index in (0..first_matching_element).rev() {
-            if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
-                first_matching_element = index;
-            } else {
-                break;
-            }
-        }
+        // TODO: Restore this when making a breaking change to the protocol
+        // // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
+        // // find the very first match in case there are multiple
+        // for index in (0..first_matching_element).rev() {
+        //     if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
+        //         first_matching_element = index;
+        //     } else {
+        //         break;
+        //     }
+        // }
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
         ys[first_matching_element..]


### PR DESCRIPTION
This mostly reverts commit f9d2a4e7786e5021ae8c17d4df998cc3b27d817c.

Changing proofs we're returning causes farmer to fail to decode data from plots, thus this is a breaking change.

We can (and should!) do this when we're introducing a breaking change to the protocol.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
