### PR TITLE
Improve farming cluster logging

### DIFF
--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -24,7 +24,7 @@ use std::pin::{pin, Pin};
 use std::time::Duration;
 use subspace_core_primitives::{Piece, PieceIndex};
 use tokio::time::MissedTickBehavior;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use ulid::Ulid;
 
 /// An ephemeral identifier for a cache
@@ -252,6 +252,8 @@ where
         .iter()
         .map(|cache| {
             let cache_id = ClusterCacheId::new();
+
+            info!(%cache_id, max_num_elements = %cache.max_num_elements(), "Created cache");
 
             CacheDetails {
                 cache_id,


### PR DESCRIPTION
Due to usage of inline span guard in async context with concurrent tasks logs looked very odd sometimes:
```
2024-05-24T07:51:19.176133Z  INFO {farm_index=0}:{public_key=8cea533ae6691fd7167f9565993bbb4e7f4fd17150f8f41c306fc9778e10a071 sector_index=79}:{public_key=8cea533ae6691fd7167f9565993bbb4e7f4fd17150f8f41c306fc9778e10a071 sector_index=74}:{public_key=8cea533ae6691fd7167f9565993bbb4e7f4fd17150f8f41c306fc9778e10a071 sector_index=71}:{public_key=8cea533ae6691fd7167f9565993bbb4e7f4fd17150f8f41c306fc9778e10a071 sector_index=80}: subspace_farmer::single_disk_farm::plotting: Plotting sector retry sector_index=71
```

Instrumenting future fixes this awkwardness. Cache log is helpful for debugging when cache goes offline according to controller logs.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
