### PR TITLE
Remove setting receive window size for Yamux

### DIFF
--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -81,8 +81,6 @@ const DIALING_INTERVAL_IN_SECS: Duration = Duration::from_secs(1);
 /// Defines a replication factor for Kademlia on get_record operation.
 /// "Good citizen" supports the network health.
 const YAMUX_MAX_STREAMS: usize = 256;
-/// 1MB of piece + original value (256 KB)
-const YAMUX_RECEIVING_WINDOW: usize = Piece::SIZE + 256 * 1024;
 
 /// Max confidence for autonat protocol. Could affect Kademlia mode change.
 pub(crate) const AUTONAT_MAX_CONFIDENCE: usize = 3;
@@ -304,9 +302,6 @@ where
 
         let mut yamux_config = YamuxConfig::default();
         yamux_config.set_max_num_streams(YAMUX_MAX_STREAMS);
-        // TODO: Replace when new API is available like deprecation message says
-        #[allow(deprecated)]
-        yamux_config.set_receive_window_size(YAMUX_RECEIVING_WINDOW as u32);
 
         let gossipsub = ENABLE_GOSSIP_PROTOCOL.then(|| {
             GossipsubConfigBuilder::default()


### PR DESCRIPTION
[Suggestion from Max](https://github.com/libp2p/rust-yamux/issues/188#issuecomment-2122459393) to address https://forum.subspace.network/t/buffer-of-stream-grows-beyond-limit/3280?u=nazar-pc

One user confirmed it resovled those errors and the API was deprecated anyway, so :man_shrugging: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
