### PR TITLE
Increase sector encoding concurrency for farming cluster farmer

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -79,11 +79,11 @@ pub(super) struct FarmerArgs {
     /// Do not print info about configured farms on startup
     #[arg(long)]
     no_info: bool,
-    /// Defines max number sectors farmer will encode concurrently, defaults to 8. Might be limited
+    /// Defines max number sectors farmer will encode concurrently, defaults to 50. Might be limited
     /// by plotting capacity available in the cluster.
     ///
     /// Increase will result in higher memory usage.
-    #[arg(long, default_value = "8")]
+    #[arg(long, default_value = "50")]
     sector_encoding_concurrency: NonZeroUsize,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
     /// compute-intensive operations during proving), defaults to number of logical CPUs


### PR DESCRIPTION
Initially the assumption was that we would have to allocate in-memory sector before writing it to disk, but now that we stream sector chunks and write them to disk right away, the limit can be set much higher by default.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
