### PR TITLE
Atomic fast sync block import

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -722,8 +722,8 @@ where
         mut telemetry,
     } = other;
 
-    // Clear block gap after fast sync on reruns.
-    // Substrate detects a gap and inserts on each sync.
+    // TODO: Fast sync is not actually removed during fast sync right now, so it needs to be cleared
+    //  on every restart
     if config.sync == ChainSyncMode::Snap {
         let finalized_hash_existed = client.info().finalized_hash != client.info().genesis_hash;
         if finalized_hash_existed {

--- a/crates/subspace-service/src/sync_from_dsn/fast_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/fast_sync.rs
@@ -4,7 +4,10 @@ use crate::sync_from_dsn::segment_header_downloader::SegmentHeaderDownloader;
 use crate::sync_from_dsn::DsnSyncPieceGetter;
 use sc_client_api::{AuxStore, BlockBackend, LockImportRun, ProofProvider};
 use sc_consensus::import_queue::ImportQueueService;
-use sc_consensus::{BlockImportParams, ForkChoiceStrategy, IncomingBlock, StateAction};
+use sc_consensus::{
+    BlockImportParams, ForkChoiceStrategy, ImportedState, IncomingBlock, StateAction,
+    StorageChanges,
+};
 use sc_consensus_subspace::archiver::{decode_block, SegmentHeadersStore};
 use sc_network::{NetworkService, PeerId};
 use sc_network_sync::service::syncing_service::SyncRestartArgs;
@@ -252,18 +255,16 @@ where
             "Blocks from last segment downloaded"
         );
 
-        let signed_block =
-            decode_block::<Block>(&first_block_bytes).map_err(|error| error.to_string())?;
-
+        let signed_block = decode_block::<Block>(&first_block_bytes)
+            .map_err(|error| format!("Failed to decode archived block: {error}"))?;
         let (header, extrinsics) = signed_block.block.deconstruct();
-        let block_hash = header.hash();
 
-        debug!(
-            %first_block_number,
-            ?block_hash,
-            parent_hash = ?header.parent_hash(),
-            "Reconstructed block for raw block import"
-        );
+        // Download state for the first block, so it can be imported even without doing execution
+        let first_block_state = self.download_state(&header).await.map_err(|error| {
+            format!("Failed to download state for the first block of last segment: {error}")
+        })?;
+
+        debug!("Downloaded state of the first block of the last segment");
 
         let mut import_block = BlockImportParams::new(
             // In case there is just one block we need to notify Substrate sync about it
@@ -283,7 +284,13 @@ where
         // Raw import of the first block in the last segment
         let result = self
             .client
-            .lock_import_and_run(|operation| self.client.apply_block(operation, import_block, None))
+            .lock_import_and_run(|operation| {
+                self.client.apply_block(
+                    operation,
+                    import_block,
+                    Some(StorageChanges::Import(first_block_state)),
+                )
+            })
             .map_err(|e| {
                 error!("Error during importing of the raw block: {}", e);
                 sp_consensus::Error::ClientImport(e.to_string())
@@ -291,51 +298,9 @@ where
 
         debug!(
             %first_block_number,
-            ?block_hash,
             ?result,
             "Raw block imported"
         );
-
-        // Sync state for the above block
-        let download_state_result = self
-            // TODO: Replace this with reconstructed block instead of bytes
-            .download_state(first_block_bytes, first_block_number.into())
-            .await;
-
-        match download_state_result {
-            Ok(Some(state_block)) => {
-                if let Some(state_block_header) = state_block.header {
-                    if *state_block_header.number() != NumberFor::<Block>::from(first_block_number)
-                    {
-                        error!(
-                            expected = %first_block_number,
-                            actual = %*state_block_header.number(),
-                            "Download state operation returned invalid state block."
-                        );
-                        return Err(Error::Other(
-                            "Download state operation returned invalid state block.".into(),
-                        ));
-                    }
-                } else {
-                    error!("Download state operation returned empty state block header.");
-                    return Err(Error::Other(
-                        "Download state operation returned empty state block header.".into(),
-                    ));
-                }
-            }
-            Ok(None) => {
-                error!("Download state operation returned empty result.");
-                return Err(Error::Other(
-                    "Download state operation returned empty result.".into(),
-                ));
-            }
-            Err(err) => {
-                error!(?err, "Download state operation failed.");
-                return Err(err);
-            }
-        };
-
-        // 4. Import and execute blocks from the last segment
 
         debug!(
             blocks_count = %blocks.len(),
@@ -481,12 +446,9 @@ where
         Ok((header, extrinsics, justifications))
     }
 
-    async fn download_state(
-        &self,
-        state_block_bytes: Vec<u8>,
-        state_block_number: NumberFor<Block>,
-    ) -> Result<Option<IncomingBlock<Block>>, sc_service::Error> {
-        let (header, extrinsics, justifications) = Self::deconstruct_block(state_block_bytes)?;
+    /// Download and return state for specified block
+    async fn download_state(&self, header: &Block::Header) -> Result<ImportedState<Block>, Error> {
+        let block_number = *header.number();
 
         const STATE_SYNC_RETRIES: u32 = 5;
         const LOOP_PAUSE: Duration = Duration::from_secs(20);
@@ -499,7 +461,7 @@ where
             let mut tried_peers = HashSet::<PeerId>::new();
 
             // TODO: add loop timeout
-            let peer_candidates = loop {
+            let current_peer_id = loop {
                 let connected_full_peers = self
                     .sync_service
                     .peers_info()
@@ -507,7 +469,7 @@ where
                     .expect("Network service must be available.")
                     .iter()
                     .filter_map(|(peer_id, info)| {
-                        (info.roles.is_full() && info.best_number > state_block_number)
+                        (info.roles.is_full() && info.best_number > block_number)
                             .then_some(*peer_id)
                     })
                     .collect::<Vec<_>>();
@@ -516,22 +478,13 @@ where
 
                 let active_peers_set = HashSet::from_iter(connected_full_peers.into_iter());
 
-                let diff = active_peers_set
-                    .difference(&tried_peers)
-                    .cloned()
-                    .collect::<HashSet<_>>();
-
-                if !diff.is_empty() {
-                    break diff;
+                if let Some(peer_id) = active_peers_set.difference(&tried_peers).next().cloned() {
+                    break peer_id;
                 }
 
                 sleep(LOOP_PAUSE).await;
             };
 
-            let current_peer_id = peer_candidates
-                .into_iter()
-                .next()
-                .expect("Length is checked within the loop.");
             tried_peers.insert(current_peer_id);
 
             let sync_engine = FastSyncingEngine::<Block, IQS>::new(
@@ -539,10 +492,14 @@ where
                 self.import_queue_service.clone(),
                 None,
                 header.clone(),
-                Some(extrinsics.clone()),
-                justifications.clone(),
+                // We only care about the state, this value is just forwarded back into block to
+                // import that is thrown away below
+                None,
+                // We only care about the state, this value is just forwarded back into block to
+                // import that is thrown away below
+                None,
                 false,
-                (current_peer_id, state_block_number),
+                (current_peer_id, block_number),
                 network_service,
             )
             .map_err(Error::Client)?;
@@ -550,26 +507,20 @@ where
             let last_block_from_sync_result = sync_engine.download_state().await;
 
             match last_block_from_sync_result {
-                Ok(Some(last_block_from_sync)) => {
-                    debug!("Sync worker handle result: {:?}", last_block_from_sync,);
+                Ok(block_to_import) => {
+                    debug!("Sync worker handle result: {:?}", block_to_import);
 
-                    // State block import delay
-                    // TODO: Replace this hack with actual watching of block import
-                    self.wait_for_block_import(state_block_number).await;
-
-                    return Ok(Some(last_block_from_sync));
-                }
-                Ok(None) => {
-                    error!("State sync error (state download failed).");
-                    continue;
+                    return block_to_import.state.ok_or_else(|| {
+                        Error::Other("Imported state was missing in synced block".into())
+                    });
                 }
                 Err(error) => {
-                    error!(?error, "State sync error.");
+                    error!(%error, "State sync error");
                     continue;
                 }
             }
         }
 
-        Err(Error::Other("All fast sync retries failed.".into()))
+        Err(Error::Other("All fast sync retries failed".into()))
     }
 }


### PR DESCRIPTION
So the "state downloading" that was present before was actually not just downloading state, but also importing block with it. After reading code carefully I decided to refactor it to return the state we need instead and finally importing block atomically with the state as described in the spec.

Since originally "state downloading" was returning block that is ready to be imported we could theoretically just prepend it to the list of blocks to import and it'd work. This is why I did changes in the second commit that make it possible. There was just one small issue in the archiver where it was not able to restart because by the time we trigger it, we have just genesis block, while we're about to import a lot higher block, which was breaking assumptions archiver had about the state of the blockchain database.

Specifically these are the logs:
```
2024-05-27T04:52:40.896825Z DEBUG Consensus: subspace_service::sync_from_dsn::fast_sync: Importing the last block from the last segment last_block_number=1680201 last_segment_index=284
2024-05-27T04:52:41.585666Z  INFO Consensus: sc_consensus_subspace::archiver: Resuming archiver from last archived block last_archived_block_number=0
2024-05-27T04:52:46.384871Z ERROR Consensus: subspace_service: Archiver exited with error error=There was a gap in blockchain history and the last contiguous series of blocks starting with doesn't start with archived segment (best archived block number 0, block number to archive 1665479), block about to be imported 1665579), archiver can't continue
2024-05-27T04:52:46.384938Z ERROR Consensus: sc_service::task_manager: Essential task `subspace-archiver` failed. Shutting down service.
```

We can actually fix it with some cleverness, but I didn't think it was worth it at this moment, so I decided to continue using `apply_block` like we did before, just atomically.
UPD: Done in upcoming PR.

Last commit does tiny cleanups, for example it clears block gap right after it is created and not some time later, which makes it much easier to understand.

Ignore whitespace changes during review, it is much easier that way.

This continues series of incremental patches and still syncs fine from my testing.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
