### PR TITLE
Removing the version parameter from docker config documentation as it is obsolete

### DIFF
--- a/docs/farming.md
+++ b/docs/farming.md
@@ -189,7 +189,6 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 
 Create `subspace` directory and `docker-compose.yml` in it with following contents:
 ```yml
-version: "3.7"
 services:
   node:
     # Replace `snapshot-DATE` with the latest release (like `snapshot-2022-apr-29`)


### PR DESCRIPTION
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
