### PR TITLE
Domains: Limit domain's max extrinsic weight to max domain bundle weight

### DIFF
--- a/crates/subspace-runtime-primitives/Cargo.toml
+++ b/crates/subspace-runtime-primitives/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.5", default-features = false, features = ["derive"] }
 frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
-frame-system = { default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
+frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 pallet-transaction-payment = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-core = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
@@ -31,6 +31,7 @@ default = ["std"]
 std = [
     "codec/std",
     "frame-support/std",
+    "frame-system/std",
     "pallet-transaction-payment/std",
     "scale-info/std",
     "sp-core/std",
@@ -38,6 +39,5 @@ std = [
     "subspace-core-primitives/std",
 ]
 testing = [
-    "frame-system",
     "sp-io"
 ]

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -27,6 +27,7 @@ use codec::{Codec, Decode, Encode};
 use frame_support::pallet_prelude::Weight;
 use frame_support::traits::tokens;
 use frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND;
+use frame_system::limits::BlockLength;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use scale_info::TypeInfo;
 use sp_core::parameter_types;
@@ -52,6 +53,14 @@ pub const SLOT_PROBABILITY: (u64, u64) = (1, 6);
 /// The block weight for 2 seconds of compute
 pub const BLOCK_WEIGHT_FOR_2_SEC: Weight =
     Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
+
+/// Maximum block length for non-`Normal` extrinsic is 5 MiB.
+pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
+
+/// We allow for 3.75 MiB for `Normal` extrinsic with 5 MiB maximum block length.
+pub fn maximum_normal_block_length() -> BlockLength {
+    BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO)
+}
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -24,12 +24,14 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use codec::{Codec, Decode, Encode};
+use frame_support::pallet_prelude::Weight;
 use frame_support::traits::tokens;
+use frame_support::weights::constants::WEIGHT_REF_TIME_PER_SECOND;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use scale_info::TypeInfo;
 use sp_core::parameter_types;
 use sp_runtime::traits::{Bounded, IdentifyAccount, Verify};
-use sp_runtime::{FixedPointNumber, MultiSignature, Perquintill};
+use sp_runtime::{FixedPointNumber, MultiSignature, Perbill, Perquintill};
 pub use subspace_core_primitives::BlockNumber;
 
 /// Minimum desired number of replicas of the blockchain to be stored by the network,
@@ -42,6 +44,14 @@ pub const SHANNON: Balance = 1;
 pub const DECIMAL_PLACES: u8 = 18;
 /// One Subspace Credit.
 pub const SSC: Balance = (10 * SHANNON).pow(DECIMAL_PLACES as u32);
+/// A ratio of `Normal` dispatch class within block, for `BlockWeight` and `BlockLength`.
+pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+/// 1 in 6 slots (on average, not counting collisions) will have a block.
+/// Must match ratio between block and slot duration in constants above.
+pub const SLOT_PROBABILITY: (u64, u64) = (1, 6);
+/// The block weight for 2 seconds of compute
+pub const BLOCK_WEIGHT_FOR_2_SEC: Weight =
+    Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -35,7 +35,8 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use core::num::NonZeroU64;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::{
-    AccountIdConverter, BlockNumber as DomainNumber, Hash as DomainHash,
+    maximum_domain_block_weight, AccountIdConverter, BlockNumber as DomainNumber,
+    Hash as DomainHash,
 };
 use frame_support::genesis_builder_helper::{build_config, create_default_config};
 use frame_support::inherent::ProvideInherent;
@@ -43,7 +44,7 @@ use frame_support::traits::{
     ConstU16, ConstU32, ConstU64, ConstU8, Currency, Everything, Get, OnRuntimeUpgrade,
     VariantCount,
 };
-use frame_support::weights::constants::{ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND};
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
 use frame_support::{construct_runtime, parameter_types, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
@@ -82,7 +83,7 @@ use sp_runtime::traits::{
 };
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{
-    create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, ExtrinsicInclusionMode, Perbill,
+    create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, ExtrinsicInclusionMode,
 };
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::marker::PhantomData;
@@ -98,7 +99,8 @@ use subspace_core_primitives::{
 };
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash, Moment, Nonce, Signature,
-    SlowAdjustingFeeUpdate, MIN_REPLICATION_FACTOR, SHANNON, SSC,
+    SlowAdjustingFeeUpdate, BLOCK_WEIGHT_FOR_2_SEC, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO,
+    SHANNON, SLOT_PROBABILITY, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -145,10 +147,6 @@ pub const MILLISECS_PER_BLOCK: u64 = 6000;
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.
 const SLOT_DURATION: u64 = 1000;
-
-/// 1 in 6 slots (on average, not counting collisions) will have a block.
-/// Must match ratio between block and slot duration in constants above.
-const SLOT_PROBABILITY: (u64, u64) = (1, 6);
 
 /// Number of slots between slot arrival and when corresponding block can be produced.
 const BLOCK_AUTHORING_DELAY: SlotNumber = 4;
@@ -197,13 +195,6 @@ const RECENT_HISTORY_FRACTION: (HistorySize, HistorySize) = (
 /// Minimum lifetime of a plotted sector, measured in archived segment.
 const MIN_SECTOR_LIFETIME: HistorySize =
     HistorySize::new(NonZeroU64::new(4).expect("Not zero; qed"));
-
-/// The block weight for 2 seconds of compute
-const BLOCK_WEIGHT_FOR_2_SEC: Weight =
-    Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
-
-/// A ratio of `Normal` dispatch class within block, for `BlockWeight` and `BlockLength`.
-const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 /// Maximum block length for non-`Normal` extrinsic is 5 MiB.
 const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
@@ -587,7 +578,7 @@ parameter_types! {
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
-    pub MaxDomainBlockWeight: Weight = NORMAL_DISPATCH_RATIO * BLOCK_WEIGHT_FOR_2_SEC;
+    pub MaxDomainBlockWeight: Weight = maximum_domain_block_weight();
     pub const MaxBundlesPerBlock: u32 = 10;
     pub const DomainInstantiationDeposit: Balance = 100 * SSC;
     pub const MaxDomainNameLength: u32 = 32;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -98,9 +98,9 @@ use subspace_core_primitives::{
     SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, SolutionRange, U256,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash, Moment, Nonce, Signature,
-    SlowAdjustingFeeUpdate, BLOCK_WEIGHT_FOR_2_SEC, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO,
-    SHANNON, SLOT_PROBABILITY, SSC,
+    maximum_normal_block_length, AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash,
+    Moment, Nonce, Signature, SlowAdjustingFeeUpdate, BLOCK_WEIGHT_FOR_2_SEC, MAX_BLOCK_LENGTH,
+    MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -196,16 +196,13 @@ const RECENT_HISTORY_FRACTION: (HistorySize, HistorySize) = (
 const MIN_SECTOR_LIFETIME: HistorySize =
     HistorySize::new(NonZeroU64::new(4).expect("Not zero; qed"));
 
-/// Maximum block length for non-`Normal` extrinsic is 5 MiB.
-const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
-
 parameter_types! {
     pub const Version: RuntimeVersion = VERSION;
     pub const BlockHashCount: BlockNumber = 250;
     /// We allow for 2 seconds of compute with a 6 second average block time.
     pub SubspaceBlockWeights: BlockWeights = BlockWeights::with_sensible_defaults(BLOCK_WEIGHT_FOR_2_SEC, NORMAL_DISPATCH_RATIO);
     /// We allow for 3.75 MiB for `Normal` extrinsic with 5 MiB maximum block length.
-    pub SubspaceBlockLength: BlockLength = BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO);
+    pub SubspaceBlockLength: BlockLength = maximum_normal_block_length();
 }
 
 pub type SS58Prefix = ConstU16<2254>;

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -16,7 +16,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
     block_weights, maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
-    EXISTENTIAL_DEPOSIT, MAXIMUM_BLOCK_WEIGHT,
+    EXISTENTIAL_DEPOSIT,
 };
 use domain_runtime_primitives::{
     AccountId, Address, CheckExtrinsicsValidityError, DecodeExtrinsicError, Signature,

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -17,8 +17,8 @@ use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
-    block_weights, maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
-    EXISTENTIAL_DEPOSIT, MAXIMUM_BLOCK_WEIGHT,
+    block_weights, maximum_block_length, maximum_domain_block_weight, opaque, Balance, BlockNumber,
+    Hash, Nonce, EXISTENTIAL_DEPOSIT,
 };
 use domain_runtime_primitives::{
     CheckExtrinsicsValidityError, DecodeExtrinsicError, ERR_BALANCE_OVERFLOW, ERR_NONCE_OVERFLOW,
@@ -589,7 +589,7 @@ pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PE
 parameter_types! {
     /// EVM block gas limit is set to maximum to allow all the transaction stored on Consensus chain.
     pub BlockGasLimit: U256 = U256::from(
-        MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS
+        maximum_domain_block_weight().ref_time() / WEIGHT_PER_GAS
     );
     pub PrecompilesValue: Precompiles = Precompiles::default();
     pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -17,8 +17,8 @@ use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
 pub use domain_runtime_primitives::opaque::Header;
 use domain_runtime_primitives::{
-    block_weights, maximum_block_length, ERR_BALANCE_OVERFLOW, ERR_NONCE_OVERFLOW,
-    EXISTENTIAL_DEPOSIT, MAXIMUM_BLOCK_WEIGHT, SLOT_DURATION,
+    block_weights, maximum_block_length, maximum_domain_block_weight, ERR_BALANCE_OVERFLOW,
+    ERR_NONCE_OVERFLOW, EXISTENTIAL_DEPOSIT, SLOT_DURATION,
 };
 pub use domain_runtime_primitives::{
     opaque, Balance, BlockNumber, CheckExtrinsicsValidityError, DecodeExtrinsicError, Hash, Nonce,
@@ -571,7 +571,7 @@ pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(GAS_PE
 parameter_types! {
     /// EVM block gas limit is set to maximum to allow all the transaction stored on Consensus chain.
     pub BlockGasLimit: U256 = U256::from(
-        MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS
+        maximum_domain_block_weight().ref_time() / WEIGHT_PER_GAS
     );
     pub PrecompilesValue: Precompiles = Precompiles::default();
     pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);


### PR DESCRIPTION
We introduced a regression while setting the [maximum domain block limit](https://github.com/subspace/subspace/pull/2369) where in individual domain extrinsic was equal to max domain block limit. This would lead to excessive extrinsic weight allowance on domain leading to transaction being in txpool forever since this value exceeds the bundle weight limit defined on the consensus chain.

This PR ensures to use max bundle limit as the max domain extrinsic weight with bundle slot probability to always set `1`.  The current domain weights post this change
```
{
  baseBlock: {
    refTime: 390,584,000
    proofSize: 0
  }
  maxBlock: {
    refTime: 18,446,744,073,709,551,615
    proofSize: 18,446,744,073,709,551,615
  }
  perClass: {
    normal: {
      baseExtrinsic: {
        refTime: 124,414,000
        proofSize: 0
      }
      maxExtrinsic: {
        refTime: 216,666,666,666
        proofSize: 3,407,872
      }
      maxTotal: {
        refTime: 18,446,744,073,709,551,615
        proofSize: 18,446,744,073,709,551,615
      }
      reserved: {
        refTime: 0
        proofSize: 0
      }
    }
    operational: {
      baseExtrinsic: {
        refTime: 124,414,000
        proofSize: 0
      }
      maxExtrinsic: {
        refTime: 216,666,666,666
        proofSize: 3,407,872
      }
      maxTotal: {
        refTime: 18,446,744,073,709,551,615
        proofSize: 18,446,744,073,709,551,615
      }
      reserved: {
        refTime: 0
        proofSize: 0
      }
    }
    mandatory: {
      baseExtrinsic: {
        refTime: 124,414,000
        proofSize: 0
      }
      maxExtrinsic: {
        refTime: 216,666,666,666
        proofSize: 3,407,872
      }
      maxTotal: {
        refTime: 18,446,744,073,709,551,615
        proofSize: 18,446,744,073,709,551,615
      }
      reserved: null
    }
  }
}
```

If the domain bundle slot probability is lower than `1`, the value of the maximum domain block increases but each extrinsic max weight will be limited to `250,000,000,000` which is `250 ms` execution time.

TLDR:

**On Consensus Chain:**
Max allowed proof size for Normal extrinsics: 3.75 MiB
Max bundle weight:
	- Execution: 250 ms
	- Proof size: 3.25 MiB to have room for additional storage coming as part of Fraud proof
This is the bundle weight that operator uses while proposing the bundles. So each bundle should include one or more transactions that meet this bundle weight.

**On Domains:**
Max Domain block weight:
	- Execution: u64::MAX, this is set to ensure all the extrinsics from bundles are executed irrespective of execution time
	- Proof Size: u64::MAX, total proof size for entire domain block will not be used for FP but rather each extrinsic within the domain block

Max Extrinsic block weight: 
This is same as max bundle weight on consensus chain. 
	- Execution: 250 ms
	- Proof Size: 3.25 MiB, Single extrinsic can use this size with consideration for Fraud proof size

Closes: #2387

cc: @dariolina 
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
