### PR TITLE
Segment headers tweaks in sync from DSN

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -169,6 +169,11 @@ where
         })
     }
 
+    /// Returns last observed segment header
+    pub fn last_segment_header(&self) -> Option<SegmentHeader> {
+        self.inner.cache.lock().last().cloned()
+    }
+
     /// Returns last observed segment index
     pub fn max_segment_index(&self) -> Option<SegmentIndex> {
         let segment_index = self.inner.cache.lock().len().checked_sub(1)? as u64;

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -101,16 +101,16 @@ where
     IQS: ImportQueueService<Block> + ?Sized,
 {
     {
-        let max_segment_index = segment_headers_store.max_segment_index().ok_or_else(|| {
+        let last_segment_header = segment_headers_store.last_segment_header().ok_or_else(|| {
             sc_service::Error::Other(
                 "Archiver needs to be initialized before syncing from DSN to populate the very \
-                    first segment"
+                first segment"
                     .to_string(),
             )
         })?;
 
         let new_segment_headers = segment_header_downloader
-            .get_segment_headers(max_segment_index)
+            .get_segment_headers(&last_segment_header)
             .await
             .map_err(|error| error.to_string())?;
 

--- a/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
+++ b/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
@@ -22,7 +22,8 @@ impl<'a> SegmentHeaderDownloader<'a> {
         Self { dsn_node }
     }
 
-    /// Returns segment headers known to DSN, ordered from 0 to the last known.
+    /// Returns new segment headers known to DSN, ordered from 0 to the last known, but newer than
+    /// `last_known_segment_index`
     pub async fn get_segment_headers(
         &self,
         last_known_segment_index: SegmentIndex,
@@ -51,9 +52,15 @@ impl<'a> SegmentHeaderDownloader<'a> {
             "Downloading segment headers"
         );
 
-        let mut all_segment_headers =
-            Vec::with_capacity(u64::from(last_segment_header.segment_index()) as usize + 1);
-        all_segment_headers.push(last_segment_header);
+        let Some(new_segment_headers_count) = last_segment_header
+            .segment_index()
+            .checked_sub(last_known_segment_index)
+        else {
+            return Ok(Vec::new());
+        };
+        let mut new_segment_headers =
+            Vec::with_capacity(u64::from(new_segment_headers_count) as usize);
+        new_segment_headers.push(last_segment_header);
 
         while last_segment_header.segment_index() > last_known_segment_index {
             let segment_indexes = (last_known_segment_index..last_segment_header.segment_index())
@@ -82,13 +89,13 @@ impl<'a> SegmentHeaderDownloader<'a> {
                 }
 
                 last_segment_header = segment_header;
-                all_segment_headers.push(segment_header);
+                new_segment_headers.push(segment_header);
             }
         }
 
-        all_segment_headers.reverse();
+        new_segment_headers.reverse();
 
-        Ok(all_segment_headers)
+        Ok(new_segment_headers)
     }
 
     /// Return last segment header known to DSN and agreed on by majority of the peer set with

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -354,7 +354,7 @@ async fn sync_segment_headers<AS>(
 where
     AS: AuxStore,
 {
-    let max_segment_index = segment_headers_store.max_segment_index().ok_or_else(|| {
+    let last_segment_header = segment_headers_store.last_segment_header().ok_or_else(|| {
         Error::Other(
             "Archiver needs to be initialized before syncing from DSN to populate the very first \
             segment"
@@ -362,7 +362,7 @@ where
         )
     })?;
     let new_segment_headers = SegmentHeaderDownloader::new(node)
-        .get_segment_headers(max_segment_index)
+        .get_segment_headers(&last_segment_header)
         .await
         .map_err(|error| error.to_string())?;
 


### PR DESCRIPTION
First commit is just refactoring. Second adds check that downloaded segment headers not only internally consistent, but also extend already known segment headers. Second commit also skips downloading of the last known segemnt header that was accidentally and unnecessarily happening before (though wasn't hurting beyond that).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
