### PR TITLE
Sync and pruning tweaks

### DIFF
--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -17,7 +17,7 @@ use domain_runtime_primitives::opaque::Block as DomainBlock;
 use futures::FutureExt;
 use sc_cli::Signals;
 use sc_consensus_slots::SlotProportion;
-use sc_service::PruningMode;
+use sc_service::{BlocksPruning, PruningMode};
 use sc_storage_monitor::StorageMonitorService;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::tracing_unbounded;
@@ -113,6 +113,22 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
     );
     info!("🏷  Node name: {}", subspace_configuration.network.node_name);
     info!("💾 Node path: {}", base_path.display());
+
+    if maybe_domain_configuration.is_some()
+        && (matches!(
+            subspace_configuration.blocks_pruning,
+            BlocksPruning::Some(_)
+        ) || matches!(
+            subspace_configuration.state_pruning,
+            Some(PruningMode::Constrained(_))
+        ))
+    {
+        return Err(Error::Other(
+            "Running an operator requires both `--blocks-pruning` and `--state-pruning` to be set \
+            to either `archive` or `archive-canonical`"
+                .to_string(),
+        ));
+    }
 
     let mut consensus_state_pruning = subspace_configuration
         .state_pruning

--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -17,6 +17,7 @@ use domain_runtime_primitives::opaque::Block as DomainBlock;
 use futures::FutureExt;
 use sc_cli::Signals;
 use sc_consensus_slots::SlotProportion;
+use sc_service::PruningMode;
 use sc_storage_monitor::StorageMonitorService;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::tracing_unbounded;
@@ -86,7 +87,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
 
     let ConsensusChainConfiguration {
         maybe_tmp_dir: _maybe_tmp_dir,
-        subspace_configuration,
+        mut subspace_configuration,
         dev,
         pot_external_entropy,
         storage_monitor,
@@ -113,7 +114,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
     info!("🏷  Node name: {}", subspace_configuration.network.node_name);
     info!("💾 Node path: {}", base_path.display());
 
-    let consensus_state_pruning = subspace_configuration
+    let mut consensus_state_pruning = subspace_configuration
         .state_pruning
         .clone()
         .unwrap_or_default();
@@ -122,15 +123,39 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
             let span = info_span!("Consensus");
             let _enter = span.enter();
 
-            let partial_components = subspace_service::new_partial::<PosTable, RuntimeApi>(
+            let partial_components = match subspace_service::new_partial::<PosTable, RuntimeApi>(
                 &subspace_configuration,
                 &pot_external_entropy,
-            )
-            .map_err(|error| {
-                sc_service::Error::Other(format!(
-                    "Failed to build a full subspace node 1: {error:?}"
-                ))
-            })?;
+            ) {
+                Ok(partial_components) => partial_components,
+                Err(sc_service::Error::Client(sp_blockchain::Error::StateDatabase(error)))
+                    if error.to_string().contains(
+                        "Incompatible pruning modes [stored: ArchiveCanonical; requested: \
+                        Constrained",
+                    ) =>
+                {
+                    // TODO: Workaround for supporting older default `archive-canonical` while new
+                    //  default has become pruned state, can be removed if/when
+                    //  https://github.com/paritytech/polkadot-sdk/issues/4671 is implemented
+                    consensus_state_pruning = PruningMode::ArchiveCanonical;
+                    subspace_configuration.base.state_pruning = Some(PruningMode::ArchiveCanonical);
+
+                    subspace_service::new_partial::<PosTable, RuntimeApi>(
+                        &subspace_configuration,
+                        &pot_external_entropy,
+                    )
+                    .map_err(|error| {
+                        sc_service::Error::Other(format!(
+                            "Failed to build a full subspace node 1: {error:?}"
+                        ))
+                    })?
+                }
+                Err(error) => {
+                    return Err(Error::Other(format!(
+                        "Failed to build a full subspace node 2: {error:?}"
+                    )));
+                }
+            };
 
             let full_node_fut = subspace_service::new_full::<PosTable, _>(
                 subspace_configuration,
@@ -146,7 +171,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
 
             full_node_fut.await.map_err(|error| {
                 sc_service::Error::Other(format!(
-                    "Failed to build a full subspace node 2: {error:?}"
+                    "Failed to build a full subspace node 3: {error:?}"
                 ))
             })?
         };

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -8,7 +8,7 @@ use sc_cli::{
     TransactionPoolParams, RPC_DEFAULT_PORT,
 };
 use sc_informant::OutputFormat;
-use sc_network::config::{MultiaddrWithPeerId, NonReservedPeerMode, SetConfig, SyncMode};
+use sc_network::config::{MultiaddrWithPeerId, NonReservedPeerMode, SetConfig};
 use sc_service::{BlocksPruning, Configuration, PruningMode};
 use sc_storage_monitor::StorageMonitorParams;
 use sc_telemetry::TelemetryEndpoints;
@@ -550,6 +550,7 @@ pub(super) fn create_consensus_chain_configuration(
             },
             node_name,
             allow_private_ips: network_options.allow_private_ips,
+            sync_mode: sync,
             force_synced,
         },
         state_pruning: pruning_params.state_pruning(),
@@ -591,14 +592,7 @@ pub(super) fn create_consensus_chain_configuration(
         chain_spec: Box::new(chain_spec),
         informant_output_format: OutputFormat { enable_color },
     };
-    let mut consensus_chain_config = Configuration::from(consensus_chain_config);
-    // TODO: revisit SyncMode change after https://github.com/paritytech/polkadot-sdk/issues/4407
-    if sync == ChainSyncMode::Snap {
-        consensus_chain_config.network.sync_mode = SyncMode::LightState {
-            skip_proofs: true,
-            storage_chain_mode: false,
-        };
-    }
+    let consensus_chain_config = Configuration::from(consensus_chain_config);
 
     let pot_external_entropy =
         derive_pot_external_entropy(&consensus_chain_config, pot_external_entropy)?;

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -72,6 +72,8 @@ pub struct SubstrateNetworkConfiguration {
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
     /// in Kademlia DHT.
     pub allow_private_ips: bool,
+    /// Sync mode
+    pub sync_mode: ChainSyncMode,
     /// Parameter that allows node to forcefully assume it is synced, needed for network
     /// bootstrapping only, as long as two synced nodes remain on the network at any time, this
     /// doesn't need to be used.
@@ -148,8 +150,14 @@ impl From<SubstrateConfiguration> for Configuration {
                 max_parallel_downloads: 5,
                 // Substrate's default
                 max_blocks_per_request: 64,
-                // Substrate's default, full mode
-                sync_mode: SyncMode::Full,
+                sync_mode: match configuration.network.sync_mode {
+                    ChainSyncMode::Full => SyncMode::Full,
+                    // TODO: revisit SyncMode change after https://github.com/paritytech/polkadot-sdk/issues/4407
+                    ChainSyncMode::Snap => SyncMode::LightState {
+                        skip_proofs: false,
+                        storage_chain_mode: false,
+                    },
+                },
                 pause_sync: Arc::new(AtomicBool::new(false)),
                 // Substrate's default
                 enable_dht_random_walk: true,


### PR DESCRIPTION
The first commit is a cleanup after https://github.com/subspace/subspace/pull/2809, second commit changes state pruning default from `archive-canonical` to 140k blocks that will decrease disk usage for new farmers. I implemented a hack to ensure painless upgrade for existing farmers, but I don't expect them to re-sync unless with snap sync.

@vedhavyas @NingLin-P let me know if you are aware of any side-effects for farmers or operators, we may need to update docs if operators will be affected by this.

UPD: Syncing node with these parameters to see what database size can we get as the result.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
