### PR TITLE
Do not spawn task for reading cached pieces on Windows to avoid memory issues

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -156,7 +156,7 @@ impl PieceGetter for MockPieceGetter {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn basic() {
     let current_segment_index = Arc::new(AtomicU64::new(0));
     let pieces = Arc::default();


### PR DESCRIPTION
This effectively reverts part of https://github.com/subspace/subspace/pull/2757/commits/647b363264c8199edcf203098d6442bd07c50f39 in order to address memory usage issues reported in https://github.com/subspace/subspace/issues/2813 and in the forum linked there before that.

This is not a fix, but meant to work around an issue until we find a permanent solution.

Waiting for confirmation on the forum that it helps before merging though.

UPD: One user confirmed that it did help.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
