### PR TITLE
Optimize new segment processing by farmer

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -181,14 +181,7 @@ pub(super) async fn controller(
             let instance = instance.clone();
 
             move || async move {
-                controller_service(
-                    &nats_client,
-                    &node_client,
-                    &piece_getter,
-                    &instance,
-                    &AsyncRwLock::default(),
-                )
-                .await
+                controller_service(&nats_client, &node_client, &piece_getter, &instance).await
             }
         },
         "controller-service".to_string(),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -162,7 +162,7 @@ where
         None
     };
 
-    let node_client = ClusterNodeClient::new(nats_client.clone());
+    let node_client = ClusterNodeClient::new(nats_client.clone()).await?;
 
     let farmer_app_info = node_client
         .farmer_app_info()

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -10,8 +10,9 @@ use crate::cluster::nats_client::{
     GenericBroadcast, GenericNotification, GenericRequest, NatsClient,
 };
 use crate::node_client::{Error as NodeClientError, NodeClient};
+use crate::utils::AsyncJoinOnDrop;
 use anyhow::anyhow;
-use async_lock::{Mutex as AsyncMutex, Semaphore};
+use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock, Semaphore};
 use async_nats::{HeaderValue, Message};
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
@@ -24,12 +25,15 @@ use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
+use subspace_core_primitives::{
+    ArchivedBlockProgress, Blake3Hash, LastArchivedBlock, Piece, PieceIndex, SegmentHeader,
+    SegmentIndex,
+};
 use subspace_farmer_components::PieceGetter;
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 const FARMER_APP_INFO_DEDUPLICATION_WINDOW: Duration = Duration::from_secs(1);
 
@@ -193,16 +197,94 @@ pub struct ClusterNodeClient {
     // Store last slot info instance that can be used to send solution response to (some instances
     // may be not synced and not able to receive solution responses)
     last_slot_info_instance: Arc<Mutex<String>>,
+    segment_headers: Arc<AsyncRwLock<Vec<SegmentHeader>>>,
+    _background_task: Arc<AsyncJoinOnDrop<()>>,
 }
 
 impl ClusterNodeClient {
     /// Create a new instance
-    #[inline]
-    pub fn new(nats_client: NatsClient) -> Self {
-        Self {
+    pub async fn new(nats_client: NatsClient) -> anyhow::Result<Self> {
+        let mut segment_headers = Vec::<SegmentHeader>::new();
+        let mut archived_segments_notifications = nats_client
+            .subscribe_to_broadcasts::<ClusterControllerArchivedSegmentHeaderBroadcast>(None, None)
+            .await?
+            .map(|broadcast| broadcast.archived_segment_header);
+
+        info!("Downloading all segment headers from controller...");
+        {
+            let mut segment_index_offset = SegmentIndex::from(segment_headers.len() as u64);
+            let dummy_header = SegmentHeader::V0 {
+                segment_index: Default::default(),
+                segment_commitment: Default::default(),
+                prev_segment_header_hash: Blake3Hash::default(),
+                last_archived_block: LastArchivedBlock {
+                    number: 0,
+                    archived_progress: ArchivedBlockProgress::Partial(0),
+                },
+            };
+            let segment_index_step = SegmentIndex::from(
+                nats_client.approximate_max_message_size() as u64
+                    / dummy_header.encoded_size() as u64,
+            );
+
+            'outer: loop {
+                let from = segment_index_offset;
+                let to = segment_index_offset + segment_index_step;
+                trace!(%from, %to, "Requesting segment headers");
+
+                for maybe_segment_header in nats_client
+                    .request(
+                        &ClusterControllerSegmentHeadersRequest {
+                            segment_indices: (from..to).collect::<Vec<_>>(),
+                        },
+                        None,
+                    )
+                    .await?
+                {
+                    let Some(segment_header) = maybe_segment_header else {
+                        // Reached non-existent segment header
+                        break 'outer;
+                    };
+
+                    if segment_headers.len() == u64::from(segment_header.segment_index()) as usize {
+                        segment_headers.push(segment_header);
+                    }
+                }
+
+                segment_index_offset += segment_index_step;
+            }
+        }
+        info!("Downloaded all segment headers from node successfully");
+
+        let segment_headers = Arc::new(AsyncRwLock::new(segment_headers));
+        let background_task = tokio::spawn({
+            let segment_headers = Arc::clone(&segment_headers);
+
+            async move {
+                while let Some(archived_segment_header) =
+                    archived_segments_notifications.next().await
+                {
+                    trace!(
+                        ?archived_segment_header,
+                        "New archived archived segment header notification"
+                    );
+
+                    let mut segment_headers = segment_headers.write().await;
+                    if segment_headers.len()
+                        == u64::from(archived_segment_header.segment_index()) as usize
+                    {
+                        segment_headers.push(archived_segment_header);
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
             nats_client,
             last_slot_info_instance: Arc::default(),
-        }
+            segment_headers,
+            _background_task: Arc::new(AsyncJoinOnDrop::new(background_task, true)),
+        })
     }
 }
 
@@ -289,13 +371,15 @@ impl NodeClient for ClusterNodeClient {
         &self,
         segment_indices: Vec<SegmentIndex>,
     ) -> Result<Vec<Option<SegmentHeader>>, NodeClientError> {
-        Ok(self
-            .nats_client
-            .request(
-                &ClusterControllerSegmentHeadersRequest { segment_indices },
-                None,
-            )
-            .await?)
+        let segment_headers = self.segment_headers.read().await;
+        Ok(segment_indices
+            .into_iter()
+            .map(|segment_index| {
+                segment_headers
+                    .get(u64::from(segment_index) as usize)
+                    .copied()
+            })
+            .collect())
     }
 
     async fn piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, NodeClientError> {

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -48,7 +48,7 @@ pub trait NodeClient: fmt::Debug + Send + Sync + 'static {
     /// Get segment headers for the segments
     async fn segment_headers(
         &self,
-        segment_indexes: Vec<SegmentIndex>,
+        segment_indices: Vec<SegmentIndex>,
     ) -> Result<Vec<Option<SegmentHeader>>, Error>;
 
     /// Get piece by index.


### PR DESCRIPTION
Looks like frequency of segment headers requests can be overwhelming to both node's RPC and farming cluster subscriptions.

Second commit moves segment headers cache into node client such that more farmer components can reuse it (with minimal code changes). Third commit does the same to clsuter node client.

Last commit removes extra caching from plotting code since it is no longer necessary (even though that cache was potentially more compact due to only storing segment commitments).

Will wait for some feedback from community.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
