### PR TITLE
Improve plotting logging

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -151,7 +151,9 @@ where
                 loop {
                     select! {
                         sector_plotting_init_result = sector_plotting_init_fut => {
-                            sectors_being_plotted.push_back(sector_plotting_init_result?);
+                            sectors_being_plotted.push_back(
+                                sector_plotting_init_result?.instrument(info_span!("", %sector_index))
+                            );
                             break;
                         }
                         maybe_sector_plotting_result = maybe_wait_futures_ordered(&mut sectors_being_plotted).fuse() => {


### PR DESCRIPTION
`plot_single_sector` is an async function and returns another future. While first was instrumented with sector index, second wasn't, which made it harder to read debug logs.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
