### PR TITLE
Farming cluster direct cache access

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -179,9 +179,17 @@ pub(super) async fn controller(
         {
             let nats_client = nats_client.clone();
             let instance = instance.clone();
+            let farmer_cache = farmer_cache.clone();
 
             move || async move {
-                controller_service(&nats_client, &node_client, &piece_getter, &instance).await
+                controller_service(
+                    &nats_client,
+                    &node_client,
+                    &piece_getter,
+                    &farmer_cache,
+                    &instance,
+                )
+                .await
             }
         },
         "controller-service".to_string(),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
@@ -15,12 +15,10 @@ use std::future::{ready, Future};
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use subspace_farmer::cluster::cache::{
-    ClusterCacheId, ClusterCacheIdentifyBroadcast, ClusterPieceCache,
-};
+use subspace_farmer::cluster::cache::{ClusterCacheIdentifyBroadcast, ClusterPieceCache};
 use subspace_farmer::cluster::controller::ClusterControllerCacheIdentifyBroadcast;
 use subspace_farmer::cluster::nats_client::NatsClient;
-use subspace_farmer::farm::PieceCache;
+use subspace_farmer::farm::{PieceCache, PieceCacheId};
 use subspace_farmer::farmer_cache::FarmerCache;
 use tokio::time::MissedTickBehavior;
 use tracing::{info, trace, warn};
@@ -29,7 +27,7 @@ const SCHEDULE_REINITIALIZATION_DELAY: Duration = Duration::from_secs(3);
 
 #[derive(Debug)]
 struct KnownCache {
-    cache_id: ClusterCacheId,
+    cache_id: PieceCacheId,
     last_identification: Instant,
     piece_cache: Arc<ClusterPieceCache>,
 }
@@ -50,7 +48,7 @@ impl KnownCaches {
     /// Return `true` if farmer cache reinitialization is required
     fn update(
         &mut self,
-        cache_id: ClusterCacheId,
+        cache_id: PieceCacheId,
         max_num_elements: u32,
         nats_client: &NatsClient,
     ) -> bool {

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -64,13 +64,13 @@ impl GenericRequest for ClusterCacheReadPieceIndexRequest {
 
 /// Read piece from cache
 #[derive(Debug, Clone, Encode, Decode)]
-struct ClusterCacheReadPieceRequest {
-    offset: PieceCacheOffset,
+pub(super) struct ClusterCacheReadPieceRequest {
+    pub(super) offset: PieceCacheOffset,
 }
 
 impl GenericRequest for ClusterCacheReadPieceRequest {
     const SUBJECT: &'static str = "subspace.cache.*.read-piece";
-    type Response = Result<Option<Piece>, String>;
+    type Response = Result<Option<(PieceIndex, Piece)>, String>;
 }
 
 /// Request plotted from farmer, request
@@ -153,7 +153,10 @@ impl PieceCache for ClusterPieceCache {
             .await??)
     }
 
-    async fn read_piece(&self, offset: PieceCacheOffset) -> Result<Option<Piece>, FarmError> {
+    async fn read_piece(
+        &self,
+        offset: PieceCacheOffset,
+    ) -> Result<Option<(PieceIndex, Piece)>, FarmError> {
         Ok(self
             .nats_client
             .request(

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -11,79 +11,25 @@ use crate::cluster::controller::ClusterControllerCacheIdentifyBroadcast;
 use crate::cluster::nats_client::{
     GenericBroadcast, GenericRequest, GenericStreamRequest, NatsClient, StreamRequest,
 };
-use crate::farm::{FarmError, PieceCache, PieceCacheOffset};
+use crate::farm::{FarmError, PieceCache, PieceCacheId, PieceCacheOffset};
 use anyhow::anyhow;
 use async_nats::Message;
 use async_trait::async_trait;
-use derive_more::Display;
 use futures::stream::FuturesUnordered;
 use futures::{select, stream, FutureExt, Stream, StreamExt};
-use parity_scale_codec::{Decode, Encode, EncodeLike, Input, Output};
+use parity_scale_codec::{Decode, Encode};
 use std::future::{pending, Future};
 use std::pin::{pin, Pin};
 use std::time::Duration;
 use subspace_core_primitives::{Piece, PieceIndex};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, trace, warn};
-use ulid::Ulid;
-
-/// An ephemeral identifier for a cache
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Display)]
-pub enum ClusterCacheId {
-    Ulid(Ulid),
-}
-
-impl Encode for ClusterCacheId {
-    #[inline]
-    fn size_hint(&self) -> usize {
-        1_usize
-            + match self {
-                ClusterCacheId::Ulid(ulid) => 0_usize.saturating_add(Encode::size_hint(&ulid.0)),
-            }
-    }
-
-    #[inline]
-    fn encode_to<O: Output + ?Sized>(&self, output: &mut O) {
-        match self {
-            ClusterCacheId::Ulid(ulid) => {
-                output.push_byte(0);
-                Encode::encode_to(&ulid.0, output);
-            }
-        }
-    }
-}
-
-impl EncodeLike for ClusterCacheId {}
-
-impl Decode for ClusterCacheId {
-    #[inline]
-    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
-        match input
-            .read_byte()
-            .map_err(|e| e.chain("Could not decode `CacheId`, failed to read variant byte"))?
-        {
-            0 => u128::decode(input)
-                .map(|ulid| ClusterCacheId::Ulid(Ulid(ulid)))
-                .map_err(|e| e.chain("Could not decode `CacheId::Ulid.0`")),
-            _ => Err("Could not decode `CacheId`, variant doesn't exist".into()),
-        }
-    }
-}
-
-#[allow(clippy::new_without_default)]
-impl ClusterCacheId {
-    /// Creates new ID
-    #[inline]
-    pub fn new() -> Self {
-        Self::Ulid(Ulid::new())
-    }
-}
 
 /// Broadcast with identification details by caches
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ClusterCacheIdentifyBroadcast {
     /// Cache ID
-    pub cache_id: ClusterCacheId,
+    pub cache_id: PieceCacheId,
     /// Max number of elements in this cache
     pub max_num_elements: u32,
 }
@@ -139,6 +85,7 @@ impl GenericStreamRequest for ClusterCacheContentsRequest {
 /// Cluster cache implementation
 #[derive(Debug)]
 pub struct ClusterPieceCache {
+    cache_id: PieceCacheId,
     cache_id_string: String,
     max_num_elements: u32,
     nats_client: NatsClient,
@@ -146,6 +93,10 @@ pub struct ClusterPieceCache {
 
 #[async_trait]
 impl PieceCache for ClusterPieceCache {
+    fn id(&self) -> &PieceCacheId {
+        &self.cache_id
+    }
+
     #[inline]
     fn max_num_elements(&self) -> u32 {
         self.max_num_elements
@@ -218,11 +169,12 @@ impl ClusterPieceCache {
     /// [`ClusterCacheIdentifyBroadcast`]
     #[inline]
     pub fn new(
-        cache_id: ClusterCacheId,
+        cache_id: PieceCacheId,
         max_num_elements: u32,
         nats_client: NatsClient,
     ) -> ClusterPieceCache {
         Self {
+            cache_id,
             cache_id_string: cache_id.to_string(),
             max_num_elements,
             nats_client,
@@ -232,7 +184,7 @@ impl ClusterPieceCache {
 
 #[derive(Debug)]
 struct CacheDetails<'a, C> {
-    cache_id: ClusterCacheId,
+    cache_id: PieceCacheId,
     cache_id_string: String,
     cache: &'a C,
 }
@@ -251,7 +203,7 @@ where
     let caches_details = caches
         .iter()
         .map(|cache| {
-            let cache_id = ClusterCacheId::new();
+            let cache_id = *cache.id();
 
             info!(%cache_id, max_num_elements = %cache.max_num_elements(), "Created cache");
 

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -56,9 +56,9 @@ impl GenericBroadcast for ClusterControllerCacheIdentifyBroadcast {
 
 /// Broadcast with slot info sent by controllers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerSlotInfoBroadcast {
-    pub slot_info: SlotInfo,
-    pub instance: String,
+struct ClusterControllerSlotInfoBroadcast {
+    slot_info: SlotInfo,
+    instance: String,
 }
 
 impl GenericBroadcast for ClusterControllerSlotInfoBroadcast {
@@ -75,8 +75,8 @@ impl GenericBroadcast for ClusterControllerSlotInfoBroadcast {
 
 /// Broadcast with reward signing info by controllers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerRewardSigningBroadcast {
-    pub reward_signing_info: RewardSigningInfo,
+struct ClusterControllerRewardSigningBroadcast {
+    reward_signing_info: RewardSigningInfo,
 }
 
 impl GenericBroadcast for ClusterControllerRewardSigningBroadcast {
@@ -85,8 +85,8 @@ impl GenericBroadcast for ClusterControllerRewardSigningBroadcast {
 
 /// Broadcast with archived segment headers by controllers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerArchivedSegmentHeaderBroadcast {
-    pub archived_segment_header: SegmentHeader,
+struct ClusterControllerArchivedSegmentHeaderBroadcast {
+    archived_segment_header: SegmentHeader,
 }
 
 impl GenericBroadcast for ClusterControllerArchivedSegmentHeaderBroadcast {
@@ -107,8 +107,8 @@ impl GenericBroadcast for ClusterControllerArchivedSegmentHeaderBroadcast {
 
 /// Notification messages with solution by farmers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerSolutionNotification {
-    pub solution_response: SolutionResponse,
+struct ClusterControllerSolutionNotification {
+    solution_response: SolutionResponse,
 }
 
 impl GenericNotification for ClusterControllerSolutionNotification {
@@ -117,8 +117,8 @@ impl GenericNotification for ClusterControllerSolutionNotification {
 
 /// Notification messages with reward signature by farmers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerRewardSignatureNotification {
-    pub reward_signature: RewardSignatureResponse,
+struct ClusterControllerRewardSignatureNotification {
+    reward_signature: RewardSignatureResponse,
 }
 
 impl GenericNotification for ClusterControllerRewardSignatureNotification {
@@ -127,7 +127,7 @@ impl GenericNotification for ClusterControllerRewardSignatureNotification {
 
 /// Request farmer app info from controller
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerFarmerAppInfoRequest;
+struct ClusterControllerFarmerAppInfoRequest;
 
 impl GenericRequest for ClusterControllerFarmerAppInfoRequest {
     const SUBJECT: &'static str = "subspace.controller.farmer-app-info";
@@ -136,8 +136,8 @@ impl GenericRequest for ClusterControllerFarmerAppInfoRequest {
 
 /// Request segment headers with specified segment indices
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerSegmentHeadersRequest {
-    pub segment_indices: Vec<SegmentIndex>,
+struct ClusterControllerSegmentHeadersRequest {
+    segment_indices: Vec<SegmentIndex>,
 }
 
 impl GenericRequest for ClusterControllerSegmentHeadersRequest {
@@ -147,8 +147,8 @@ impl GenericRequest for ClusterControllerSegmentHeadersRequest {
 
 /// Request piece with specified index
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterControllerPieceRequest {
-    pub piece_index: PieceIndex,
+struct ClusterControllerPieceRequest {
+    piece_index: PieceIndex,
 }
 
 impl GenericRequest for ClusterControllerPieceRequest {

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -57,13 +57,13 @@ impl GenericBroadcast for ClusterFarmerIdentifyFarmBroadcast {
 
 /// Broadcast with sector updates by farmers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterFarmerSectorUpdateBroadcast {
+struct ClusterFarmerSectorUpdateBroadcast {
     /// Farm ID
-    pub farm_id: FarmId,
+    farm_id: FarmId,
     /// Sector index
-    pub sector_index: SectorIndex,
+    sector_index: SectorIndex,
     /// Sector update
-    pub sector_update: SectorUpdate,
+    sector_update: SectorUpdate,
 }
 
 impl GenericBroadcast for ClusterFarmerSectorUpdateBroadcast {
@@ -72,11 +72,11 @@ impl GenericBroadcast for ClusterFarmerSectorUpdateBroadcast {
 
 /// Broadcast with farming notifications by farmers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterFarmerFarmingNotificationBroadcast {
+struct ClusterFarmerFarmingNotificationBroadcast {
     /// Farm ID
-    pub farm_id: FarmId,
+    farm_id: FarmId,
     /// Farming notification
-    pub farming_notification: FarmingNotification,
+    farming_notification: FarmingNotification,
 }
 
 impl GenericBroadcast for ClusterFarmerFarmingNotificationBroadcast {
@@ -85,11 +85,11 @@ impl GenericBroadcast for ClusterFarmerFarmingNotificationBroadcast {
 
 /// Broadcast with solutions by farmers
 #[derive(Debug, Clone, Encode, Decode)]
-pub struct ClusterFarmerSolutionBroadcast {
+struct ClusterFarmerSolutionBroadcast {
     /// Farm ID
-    pub farm_id: FarmId,
+    farm_id: FarmId,
     /// Solution response
-    pub solution_response: SolutionResponse,
+    solution_response: SolutionResponse,
 }
 
 impl GenericBroadcast for ClusterFarmerSolutionBroadcast {

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -147,7 +147,10 @@ pub trait PieceCache: Send + Sync + fmt::Debug {
     ///
     /// NOTE: it is possible to do concurrent reads and writes, higher level logic must ensure this
     /// doesn't happen for the same piece being accessed!
-    async fn read_piece(&self, offset: PieceCacheOffset) -> Result<Option<Piece>, FarmError>;
+    async fn read_piece(
+        &self,
+        offset: PieceCacheOffset,
+    ) -> Result<Option<(PieceIndex, Piece)>, FarmError>;
 }
 
 #[derive(Debug, Copy, Clone, Encode, Decode)]

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -168,7 +168,7 @@ where
             WorkerCommand::ForgetKey { key } => {
                 let mut caches = self.piece_caches.write().await;
 
-                for (farm_index, cache) in caches.iter_mut().enumerate() {
+                for (cache_index, cache) in caches.iter_mut().enumerate() {
                     let Some(offset) = cache.stored_pieces.remove(&key) else {
                         // Not this disk farm
                         continue;
@@ -182,7 +182,7 @@ where
                         }
                         Ok(None) => {
                             warn!(
-                                %farm_index,
+                                %cache_index,
                                 %offset,
                                 "Piece index out of range, this is likely an implementation bug, \
                                 not freeing heap element"
@@ -191,7 +191,7 @@ where
                         Err(error) => {
                             error!(
                                 %error,
-                                %farm_index,
+                                %cache_index,
                                 ?key,
                                 %offset,
                                 "Error while reading piece from cache, might be a disk corruption"
@@ -467,7 +467,7 @@ where
             // populated first
             sorted_caches.sort_by_key(|(_, cache)| cache.stored_pieces.len());
             if !stream::iter(sorted_caches)
-                .any(|(farm_index, cache)| async move {
+                .any(|(cache_index, cache)| async move {
                     let Some(offset) = cache.free_offsets.pop_front() else {
                         return false;
                     };
@@ -476,7 +476,7 @@ where
                     {
                         error!(
                             %error,
-                            %farm_index,
+                            %cache_index,
                             %piece_index,
                             %offset,
                             "Failed to write piece into cache"
@@ -729,7 +729,7 @@ where
         match worker_state.heap.insert(heap_key) {
             // Entry is already occupied, we need to find and replace old piece with new one
             Some(KeyWrapper(old_piece_index)) => {
-                for (farm_index, cache) in caches.iter_mut().enumerate() {
+                for (cache_index, cache) in caches.iter_mut().enumerate() {
                     let old_record_key = RecordKey::from(old_piece_index.to_multihash());
                     let Some(offset) = cache.stored_pieces.remove(&old_record_key) else {
                         // Not this disk farm
@@ -740,14 +740,14 @@ where
                     {
                         error!(
                             %error,
-                            %farm_index,
+                            %cache_index,
                             %piece_index,
                             %offset,
                             "Failed to write piece into cache"
                         );
                     } else {
                         trace!(
-                            %farm_index,
+                            %cache_index,
                             %old_piece_index,
                             %piece_index,
                             %offset,
@@ -771,7 +771,7 @@ where
                 // Sort piece caches by number of stored pieces to fill those that are less
                 // populated first
                 sorted_caches.sort_by_key(|(_, cache)| cache.stored_pieces.len());
-                for (farm_index, cache) in sorted_caches {
+                for (cache_index, cache) in sorted_caches {
                     let Some(offset) = cache.free_offsets.pop_front() else {
                         // Not this disk farm
                         continue;
@@ -781,14 +781,14 @@ where
                     {
                         error!(
                             %error,
-                            %farm_index,
+                            %cache_index,
                             %piece_index,
                             %offset,
                             "Failed to write piece into cache"
                         );
                     } else {
                         trace!(
-                            %farm_index,
+                            %cache_index,
                             %piece_index,
                             %offset,
                             "Successfully stored piece in cache"
@@ -818,7 +818,7 @@ struct PlotCaches {
 
 impl PlotCaches {
     async fn should_store(&self, piece_index: PieceIndex, key: &RecordKey) -> bool {
-        for (farm_index, cache) in self.caches.read().await.iter().enumerate() {
+        for (cache_index, cache) in self.caches.read().await.iter().enumerate() {
             match cache.is_piece_maybe_stored(key).await {
                 Ok(MaybePieceStoredResult::No) => {
                     // Try another one if there is any
@@ -832,7 +832,7 @@ impl PlotCaches {
                 }
                 Err(error) => {
                     warn!(
-                        %farm_index,
+                        %cache_index,
                         %piece_index,
                         %error,
                         "Failed to check piece stored in cache"
@@ -932,7 +932,7 @@ impl FarmerCache {
 
     /// Get piece from cache
     pub async fn get_piece(&self, key: RecordKey) -> Option<Piece> {
-        for (farm_index, cache) in self.piece_caches.read().await.iter().enumerate() {
+        for (cache_index, cache) in self.piece_caches.read().await.iter().enumerate() {
             let Some(&offset) = cache.stored_pieces.get(&key) else {
                 continue;
             };
@@ -943,7 +943,7 @@ impl FarmerCache {
                 Err(error) => {
                     error!(
                         %error,
-                        %farm_index,
+                        %cache_index,
                         ?key,
                         %offset,
                         "Error while reading piece from cache, might be a disk corruption"

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -12,6 +12,7 @@
     iter_collect_into,
     let_chains,
     never_type,
+    result_flattening,
     slice_flatten,
     split_at_checked,
     trait_alias,

--- a/crates/subspace-farmer/src/piece_cache.rs
+++ b/crates/subspace-farmer/src/piece_cache.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use crate::farm;
-use crate::farm::{FarmError, PieceCacheOffset};
+use crate::farm::{FarmError, PieceCacheId, PieceCacheOffset};
 #[cfg(windows)]
 use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows;
 use crate::single_disk_farm::unbuffered_io_file_windows::DISK_SECTOR_SIZE;
@@ -58,6 +58,7 @@ pub enum PieceCacheError {
 
 #[derive(Debug)]
 struct Inner {
+    id: PieceCacheId,
     #[cfg(not(windows))]
     file: File,
     #[cfg(windows)]
@@ -74,6 +75,10 @@ pub struct PieceCache {
 
 #[async_trait]
 impl farm::PieceCache for PieceCache {
+    fn id(&self) -> &PieceCacheId {
+        &self.inner.id
+    }
+
     #[inline]
     fn max_num_elements(&self) -> u32 {
         self.inner.max_num_elements
@@ -202,6 +207,8 @@ impl PieceCache {
 
         Ok(Self {
             inner: Arc::new(Inner {
+                // ID for cache is ephemeral
+                id: PieceCacheId::new(),
                 file,
                 max_num_elements: capacity,
             }),

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1362,11 +1362,14 @@ impl SingleDiskFarm {
 
         let plot_file = Arc::new(plot_file);
 
-        let piece_cache = DiskPieceCache::new(if cache_capacity == 0 {
-            None
-        } else {
-            Some(PieceCache::open(directory, cache_capacity)?)
-        });
+        let piece_cache = DiskPieceCache::new(
+            *single_disk_farm_info.id(),
+            if cache_capacity == 0 {
+                None
+            } else {
+                Some(PieceCache::open(directory, cache_capacity)?)
+            },
+        );
         let plot_cache = DiskPlotCache::new(
             &plot_file,
             &sectors_metadata,

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -1,5 +1,5 @@
 use crate::farm;
-use crate::farm::{FarmError, PieceCacheOffset};
+use crate::farm::{FarmError, FarmId, PieceCacheId, PieceCacheOffset};
 use crate::piece_cache::PieceCache;
 use async_trait::async_trait;
 use futures::{stream, Stream};
@@ -9,11 +9,16 @@ use subspace_core_primitives::{Piece, PieceIndex};
 /// faster
 #[derive(Debug, Clone)]
 pub struct DiskPieceCache {
+    id: PieceCacheId,
     maybe_piece_cache: Option<PieceCache>,
 }
 
 #[async_trait]
 impl farm::PieceCache for DiskPieceCache {
+    fn id(&self) -> &PieceCacheId {
+        &self.id
+    }
+
     fn max_num_elements(&self) -> u32 {
         if let Some(piece_cache) = &self.maybe_piece_cache {
             piece_cache.max_num_elements()
@@ -74,7 +79,14 @@ impl farm::PieceCache for DiskPieceCache {
 }
 
 impl DiskPieceCache {
-    pub(crate) fn new(maybe_piece_cache: Option<PieceCache>) -> Self {
-        Self { maybe_piece_cache }
+    pub(crate) fn new(farm_id: FarmId, maybe_piece_cache: Option<PieceCache>) -> Self {
+        // Convert farm ID into cache ID for single disk farm
+        let FarmId::Ulid(id) = farm_id;
+        let id = PieceCacheId::Ulid(id);
+
+        Self {
+            id,
+            maybe_piece_cache,
+        }
     }
 }

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -69,7 +69,10 @@ impl farm::PieceCache for DiskPieceCache {
         }
     }
 
-    async fn read_piece(&self, offset: PieceCacheOffset) -> Result<Option<Piece>, FarmError> {
+    async fn read_piece(
+        &self,
+        offset: PieceCacheOffset,
+    ) -> Result<Option<(PieceIndex, Piece)>, FarmError> {
         if let Some(piece_cache) = &self.maybe_piece_cache {
             farm::PieceCache::read_piece(piece_cache, offset).await
         } else {


### PR DESCRIPTION
First 3 commits are minor refactoring.

Last commit instead of proxying pieces through controller in all cases introduces support for pulling pieces directly from cache, so retrieved piece travels `Plotter <- NATS server <- Cache` instead of `Plotter <- NATS server <- Controller <- NATS server <- Cache`. Still not as efficient as P2P, but much better already.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
