### PR TITLE
Faster `--tmp` farmer start

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -32,6 +32,7 @@ use subspace_farmer::utils::ss58::parse_ss58_reward_address;
 use subspace_farmer::utils::{
     recommended_number_of_farming_threads, run_future_in_dedicated_thread, AsyncJoinOnDrop,
 };
+use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_proof_of_space::Table;
 use tokio::sync::{Barrier, Semaphore};
 use tracing::{error, info, info_span, warn, Instrument};
@@ -139,7 +140,7 @@ where
         disk_farms = vec![DiskFarm {
             directory: tmp_directory.as_ref().to_path_buf(),
             allocated_space: plot_size.as_u64(),
-            read_sector_record_chunks_mode: None,
+            read_sector_record_chunks_mode: Some(ReadSectorRecordChunksMode::ConcurrentChunks),
         }];
 
         Some(tmp_directory)

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -44,6 +44,7 @@ use subspace_farmer::utils::{
 };
 use subspace_farmer::Identity;
 use subspace_farmer_components::plotting::PlottedSector;
+use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_metrics::{start_prometheus_metrics_server, RegistryAdapter};
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
@@ -277,7 +278,7 @@ where
         disk_farms = vec![DiskFarm {
             directory: tmp_directory.as_ref().to_path_buf(),
             allocated_space: plot_size.as_u64(),
-            read_sector_record_chunks_mode: None,
+            read_sector_record_chunks_mode: Some(ReadSectorRecordChunksMode::ConcurrentChunks),
         }];
 
         Some(tmp_directory)


### PR DESCRIPTION
No need to do benchmarking when `--tmp` is used

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
