### PR TITLE
XDM: Close init channels and take protocol fee when channel being closed is in init state

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -2500,6 +2500,11 @@ impl<T: Config> Pallet<T> {
 
         Ok(leaf_data.state_root())
     }
+
+    /// Returns true if the Domain is registered.
+    pub fn is_domain_registered(domain_id: DomainId) -> bool {
+        DomainStakingSummary::<T>::contains_key(domain_id)
+    }
 }
 
 impl<T: Config> sp_domains::DomainOwner<T::AccountId> for Pallet<T> {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -280,6 +280,7 @@ impl pallet_domains::Config for Test {
     type MmrHash = H256;
     type MmrProofVerifier = ();
     type FraudProofStorageKeyProvider = ();
+    type OnChainRewards = ();
 }
 
 pub struct ExtrinsicStorageFees;

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -279,6 +279,10 @@ pub struct BlockFees<Balance> {
     pub domain_execution_fee: Balance,
     /// Burned balances on domain chain
     pub burned_balance: Balance,
+    /// Rewards for the chain.
+    // TODO: remove this before mainnet. Skipping to maintain compatibility with Gemini
+    #[codec(skip)]
+    pub chain_rewards: BTreeMap<ChainId, Balance>,
 }
 
 impl<Balance> BlockFees<Balance>
@@ -289,11 +293,13 @@ where
         domain_execution_fee: Balance,
         consensus_storage_fee: Balance,
         burned_balance: Balance,
+        chain_rewards: BTreeMap<ChainId, Balance>,
     ) -> Self {
         BlockFees {
             consensus_storage_fee,
             domain_execution_fee,
             burned_balance,
+            chain_rewards,
         }
     }
 
@@ -1391,6 +1397,15 @@ pub fn operator_block_fees_final_key() -> Vec<u8> {
 #[derive(Debug, Encode)]
 pub struct OperatorSigningKeyProofOfOwnershipData<AccountId> {
     pub operator_owner: AccountId,
+}
+
+/// Hook to handle chain rewards.
+pub trait OnChainRewards<Balance> {
+    fn on_chain_rewards(chain_id: ChainId, reward: Balance);
+}
+
+impl<Balance> OnChainRewards<Balance> for () {
+    fn on_chain_rewards(_chain_id: ChainId, _reward: Balance) {}
 }
 
 sp_api::decl_runtime_apis! {

--- a/crates/subspace-malicious-operator/src/malicious_bundle_tamper.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_tamper.rs
@@ -129,8 +129,12 @@ where
 
         match bad_receipt_type {
             BadReceiptType::BlockFees => {
-                receipt.block_fees =
-                    BlockFees::new(random_seed.into(), random_seed.into(), random_seed.into());
+                receipt.block_fees = BlockFees::new(
+                    random_seed.into(),
+                    random_seed.into(),
+                    random_seed.into(),
+                    BTreeMap::default(),
+                );
             }
             BadReceiptType::Transfers => {
                 receipt.transfers.transfers_in =

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -83,7 +83,7 @@ use sp_runtime::traits::{
 };
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{
-    create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, ExtrinsicInclusionMode,
+    create_runtime_str, generic, AccountId32, ApplyExtrinsicResult, ExtrinsicInclusionMode, Perbill,
 };
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::marker::PhantomData;
@@ -507,6 +507,7 @@ impl sp_messenger::StorageKeys for StorageKeys {
 parameter_types! {
     // TODO: update value
     pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -531,6 +532,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainOwner = Domains;
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
+    type ChannelInitReservePortion = ChannelInitReservePortion;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -518,6 +518,13 @@ parameter_types! {
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
 }
 
+pub struct DomainRegistration;
+impl sp_messenger::DomainRegistration for DomainRegistration {
+    fn is_domain_registered(domain_id: DomainId) -> bool {
+        Domains::is_domain_registered(domain_id)
+    }
+}
+
 impl pallet_messenger::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
@@ -541,6 +548,7 @@ impl pallet_messenger::Config for Runtime {
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
+    type DomainRegistration = DomainRegistration;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/pallets/block-fees/src/lib.rs
+++ b/domains/pallets/block-fees/src/lib.rs
@@ -34,7 +34,7 @@ mod pallet {
     use frame_system::pallet_prelude::*;
     use scale_info::TypeInfo;
     use sp_block_fees::{InherentError, InherentType, INHERENT_IDENTIFIER};
-    use sp_domains::BlockFees;
+    use sp_domains::{BlockFees, ChainId};
     use sp_runtime::traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize, Saturating};
     use sp_runtime::{FixedPointOperand, SaturatedConversion};
     use sp_std::fmt::Debug;
@@ -191,6 +191,17 @@ mod pallet {
             CollectedBlockFees::<T>::mutate(|block_fees| {
                 block_fees.burned_balance =
                     block_fees.burned_balance.saturating_add(burned_balance);
+            });
+        }
+
+        /// Note chain reward fees.
+        pub fn note_chain_rewards(chain_id: ChainId, balance: T::Balance) {
+            CollectedBlockFees::<T>::mutate(|block_fees| {
+                let total_balance = match block_fees.chain_rewards.get(&chain_id) {
+                    None => balance,
+                    Some(prev_balance) => prev_balance.saturating_add(balance),
+                };
+                block_fees.chain_rewards.insert(chain_id, total_balance)
             });
         }
 

--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -84,6 +84,7 @@ mod benchmarks {
             dst_chain_id,
             dummy_channel_params::<T>(),
             None,
+            true,
         ));
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
         assert_eq!(channel.state, ChannelState::Initiated);
@@ -248,7 +249,12 @@ mod benchmarks {
         let channel_id = NextChannelId::<T>::get(dst_chain_id);
         let list = BTreeSet::from([dst_chain_id]);
         ChainAllowlist::<T>::put(list);
-        assert_ok!(Messenger::<T>::do_init_channel(dst_chain_id, params, None));
+        assert_ok!(Messenger::<T>::do_init_channel(
+            dst_chain_id,
+            params,
+            None,
+            true
+        ));
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
         assert_eq!(channel.state, ChannelState::Initiated);
 

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -953,7 +953,7 @@ mod pallet {
                                 Precision::Exact,
                                 Fortitude::Force,
                             )?;
-                            T::OnXDMRewards::on_xdm_rewards(protocol_fee);
+                            T::OnXDMRewards::on_chain_protocol_fees(chain_id, protocol_fee);
                             release_amount
                         }
                     };

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -161,7 +161,7 @@ mod pallet {
     use sp_messenger::{
         InherentError, InherentType, OnXDMRewards, StorageKeys, INHERENT_IDENTIFIER,
     };
-    use sp_runtime::ArithmeticError;
+    use sp_runtime::{ArithmeticError, Perbill};
     use sp_subspace_mmr::MmrProofVerifier;
     #[cfg(feature = "std")]
     use std::collections::BTreeSet;
@@ -201,6 +201,10 @@ mod pallet {
         /// Channel reserve fee to open a channel.
         #[pallet::constant]
         type ChannelReserveFee: Get<BalanceOf<Self>>;
+        /// Portion of Channel reserve taken by the protocol
+        /// if the channel is in init state and is requested to be closed.
+        #[pallet::constant]
+        type ChannelInitReservePortion: Get<Perbill>;
     }
 
     /// Pallet messenger used to communicate between chains and other blockchains.

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -38,6 +38,7 @@ macro_rules! impl_runtime {
         use sp_domains::MessengerHoldIdentifier;
         use frame_support::traits::VariantCount;
         use core::mem;
+        use sp_runtime::Perbill;
 
         type Block = frame_system::mocking::MockBlock<Runtime>;
 
@@ -59,6 +60,7 @@ macro_rules! impl_runtime {
         parameter_types! {
             pub SelfChainId: ChainId = $chain_id.into();
             pub const ChannelReserveFee: Balance = 10;
+            pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
         }
 
         #[derive(
@@ -90,6 +92,7 @@ macro_rules! impl_runtime {
             type StorageKeys = ();
             type DomainOwner = ();
             type ChannelReserveFee = ChannelReserveFee;
+            type ChannelInitReservePortion = ChannelInitReservePortion;
             type HoldIdentifier = MockHoldIdentifer;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -39,6 +39,7 @@ macro_rules! impl_runtime {
         use frame_support::traits::VariantCount;
         use core::mem;
         use sp_runtime::Perbill;
+        use sp_domains::DomainId;
 
         type Block = frame_system::mocking::MockBlock<Runtime>;
 
@@ -80,6 +81,13 @@ macro_rules! impl_runtime {
             }
         }
 
+        pub struct DomainRegistration;
+        impl sp_messenger::DomainRegistration for DomainRegistration {
+            fn is_domain_registered(_domain_id: DomainId) -> bool {
+                true
+            }
+        }
+
         impl crate::Config for $runtime {
             type RuntimeEvent = RuntimeEvent;
             type SelfChainId = SelfChainId;
@@ -94,6 +102,7 @@ macro_rules! impl_runtime {
             type ChannelReserveFee = ChannelReserveFee;
             type ChannelInitReservePortion = ChannelInitReservePortion;
             type HoldIdentifier = MockHoldIdentifer;
+            type DomainRegistration = DomainRegistration;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(
                 #[allow(unused_variables)] endpoint: &Endpoint,

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -48,6 +48,17 @@ impl<Balance> OnXDMRewards<Balance> for () {
     fn on_chain_protocol_fees(_chain_id: ChainId, _fees: Balance) {}
 }
 
+/// Trait to check if the domain is registered.
+pub trait DomainRegistration {
+    fn is_domain_registered(domain_id: DomainId) -> bool;
+}
+
+impl DomainRegistration for () {
+    fn is_domain_registered(_domain_id: DomainId) -> bool {
+        false
+    }
+}
+
 /// Trait that return various storage keys for storages on Consensus chain and domains
 pub trait StorageKeys {
     /// Returns the storage key for confirmed domain block on conensus chain

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -39,10 +39,13 @@ pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"messengr";
 /// Trait to handle XDM rewards.
 pub trait OnXDMRewards<Balance> {
     fn on_xdm_rewards(rewards: Balance);
+    fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance);
 }
 
 impl<Balance> OnXDMRewards<Balance> for () {
     fn on_xdm_rewards(_: Balance) {}
+
+    fn on_chain_protocol_fees(_chain_id: ChainId, _fees: Balance) {}
 }
 
 /// Trait that return various storage keys for storages on Consensus chain and domains

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -387,6 +387,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 
 parameter_types! {
     pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -411,6 +412,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainOwner = ();
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
+    type ChannelInitReservePortion = ChannelInitReservePortion;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -314,6 +314,12 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
     fn on_xdm_rewards(rewards: Balance) {
         BlockFees::note_domain_execution_fee(rewards)
     }
+    fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
+        // note the burned balance from this chain
+        BlockFees::note_burned_balance(fees);
+        // note the chain rewards
+        BlockFees::note_chain_rewards(chain_id, fees);
+    }
 }
 
 type MmrHash = <Keccak256 as sp_runtime::traits::Hash>::Output;

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -419,6 +419,7 @@ impl pallet_messenger::Config for Runtime {
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
+    type DomainRegistration = ();
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -549,6 +549,7 @@ impl pallet_messenger::Config for Runtime {
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
+    type DomainRegistration = ();
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -443,6 +443,13 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
     fn on_xdm_rewards(rewards: Balance) {
         BlockFees::note_domain_execution_fee(rewards)
     }
+
+    fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
+        // note the burned balance from this chain
+        BlockFees::note_burned_balance(fees);
+        // note the chain rewards
+        BlockFees::note_chain_rewards(chain_id, fees);
+    }
 }
 
 type MmrHash = <Keccak256 as sp_runtime::traits::Hash>::Output;

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -516,6 +516,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 
 parameter_types! {
     pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -540,6 +541,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainOwner = ();
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
+    type ChannelInitReservePortion = ChannelInitReservePortion;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -530,6 +530,7 @@ impl pallet_messenger::Config for Runtime {
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
+    type DomainRegistration = ();
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -429,6 +429,12 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
     fn on_xdm_rewards(rewards: Balance) {
         BlockFees::note_domain_execution_fee(rewards)
     }
+    fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
+        // note the burned balance from this chain
+        BlockFees::note_burned_balance(fees);
+        // note the chain rewards
+        BlockFees::note_chain_rewards(chain_id, fees);
+    }
 }
 
 type MmrHash = <Keccak256 as sp_runtime::traits::Hash>::Output;

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -476,6 +476,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 
 parameter_types! {
     pub const ChannelReserveFee: Balance = SSC;
+    pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
 }
 
 pub struct StorageKeys;
@@ -522,6 +523,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainOwner = ();
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
+    type ChannelInitReservePortion = ChannelInitReservePortion;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -594,6 +594,13 @@ impl sp_messenger::StorageKeys for StorageKeys {
     }
 }
 
+pub struct DomainRegistration;
+impl sp_messenger::DomainRegistration for DomainRegistration {
+    fn is_domain_registered(domain_id: DomainId) -> bool {
+        Domains::is_domain_registered(domain_id)
+    }
+}
+
 parameter_types! {
     pub const ChannelReserveFee: Balance = SSC;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
@@ -622,6 +629,7 @@ impl pallet_messenger::Config for Runtime {
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
+    type DomainRegistration = DomainRegistration;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -595,6 +595,7 @@ impl sp_messenger::StorageKeys for StorageKeys {
 
 parameter_types! {
     pub const ChannelReserveFee: Balance = SSC;
+    pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -619,6 +620,7 @@ impl pallet_messenger::Config for Runtime {
     type DomainOwner = Domains;
     type HoldIdentifier = HoldIdentifier;
     type ChannelReserveFee = ChannelReserveFee;
+    type ChannelInitReservePortion = ChannelInitReservePortion;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime


### PR DESCRIPTION
PR allows closing init channels so that user can get their reserve back as raised by audit here - #2804. Since the channel is in init state, protocol takes a portion of the reserve fee to dis-incentivize users opening channels in init state and gives it the dst_chain which does not have the src_chain in the allowlist

I also took the opportunity to ensure ChainAllowlist is only updated if the domain is already instantiated.

@dariolina I have currently set the reserver portion protocol gets to 20%. Let me know if the percentage needs to be changed.

Closes: #2654

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
