### PR TITLE
Constrain farmer piece getter concurrency

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -28,7 +28,7 @@ pub(super) struct PlotterArgs {
     /// Increase can result in NATS communication issues if too many messages arrive via NATS, but
     /// are not processed quickly enough for some reason and might require increasing cluster-level
     /// `--nats-pool-size` parameter.
-    #[arg(long, default_value = "100")]
+    #[arg(long, default_value = "32")]
     piece_getter_concurrency: NonZeroUsize,
     /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
     /// the plotting process, defaults to `--sector-encoding-concurrency` + 1 to download future

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -116,6 +116,11 @@ pub(crate) struct FarmingArgs {
     /// one specified endpoint. Format: 127.0.0.1:8080
     #[arg(long, aliases = ["metrics-endpoint", "metrics-endpoints"])]
     prometheus_listen_on: Vec<SocketAddr>,
+    /// Piece getter concurrency.
+    ///
+    /// Increase will result in higher memory usage.
+    #[arg(long, default_value = "128")]
+    piece_getter_concurrency: NonZeroUsize,
     /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
     /// the plotting process, defaults to `--sector-encoding-concurrency` + 1 to download future
     /// sector ahead of time.
@@ -242,6 +247,7 @@ where
         tmp,
         mut disk_farms,
         prometheus_listen_on,
+        piece_getter_concurrency,
         sector_downloading_concurrency,
         sector_encoding_concurrency,
         record_encoding_concurrency,
@@ -398,6 +404,7 @@ where
                 ..ExponentialBackoff::default()
             },
         },
+        piece_getter_concurrency,
     );
 
     let farmer_cache_worker_fut = run_future_in_dedicated_thread(


### PR DESCRIPTION
Without any constrants with higher plotting capacity it was very easy to overflow subscriptions of the controller when plotting starts on multiple plotters.

With this change not only the default retrieval concurrency is much more reasonable, users will also be able to customize it as they see fit if desired.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
