### PR TITLE
More details in farmer errors

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
@@ -118,7 +118,8 @@ pub(super) async fn cache(
     let tmp_directory = if let Some(plot_size) = tmp {
         let tmp_directory = tempfile::Builder::new()
             .prefix("subspace-cache-")
-            .tempdir()?;
+            .tempdir()
+            .map_err(|error| anyhow!("Failed to create temporary directory: {error}"))?;
 
         disk_caches = vec![DiskCache {
             directory: tmp_directory.as_ref().to_path_buf(),
@@ -171,7 +172,8 @@ pub(super) async fn cache(
             &cache_group,
             CACHE_IDENTIFICATION_BROADCAST_INTERVAL,
         )
-        .await?;
+        .await
+        .map_err(|error| anyhow!("Cache service failed: {error}"))?;
 
         drop(tmp_directory);
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -134,7 +134,8 @@ where
     let tmp_directory = if let Some(plot_size) = tmp {
         let tmp_directory = tempfile::Builder::new()
             .prefix("subspace-farmer-")
-            .tempdir()?;
+            .tempdir()
+            .map_err(|error| anyhow!("Failed to create temporary directory: {error}"))?;
 
         disk_farms = vec![DiskFarm {
             directory: tmp_directory.as_ref().to_path_buf(),
@@ -162,7 +163,9 @@ where
         None
     };
 
-    let node_client = ClusterNodeClient::new(nats_client.clone()).await?;
+    let node_client = ClusterNodeClient::new(nats_client.clone())
+        .await
+        .map_err(|error| anyhow!("Failed to create cluster node client: {error}"))?;
 
     let farmer_app_info = node_client
         .farmer_app_info()
@@ -356,7 +359,11 @@ where
         FARMER_IDENTIFICATION_BROADCAST_INTERVAL,
     );
     let farmer_service_fut = run_future_in_dedicated_thread(
-        move || farmer_service_fut,
+        move || async move {
+            farmer_service_fut
+                .await
+                .map_err(|error| anyhow!("Farmer service failed: {error}"))
+        },
         "controller-service".to_string(),
     )?;
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -158,7 +158,8 @@ where
             .into_iter()
             .zip(replotting_thread_pool_core_indices),
         plotting_thread_priority.into(),
-    )?;
+    )
+    .map_err(|error| anyhow!("Failed to create thread pool manager: {error}"))?;
     let global_mutex = Arc::default();
     let cpu_plotter = CpuPlotter::<_, PosTable>::new(
         piece_getter,
@@ -173,6 +174,8 @@ where
     // TODO: Metrics
 
     Ok(Box::pin(async move {
-        plotter_service(&nats_client, &cpu_plotter).await
+        plotter_service(&nats_client, &cpu_plotter)
+            .await
+            .map_err(|error| anyhow!("Ploter service failed: {error}"))
     }))
 }


### PR DESCRIPTION
Due to not using error enums in farmer CLI (not yet anyway) forwarding sometimes results in a generic error like this:
```
Error: I/O error: Permission denied (os error 13)

Caused by:
    Permission denied (os error 13)
```

While obviously something somewhere is not right with permissions, but in case a few things are involved it dosn't tell what and where.

I have added details into the error such that it is easier to understand what is going on.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
