### PR TITLE
Prepare for making Snap sync the default

### DIFF
--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -17,6 +17,7 @@ use domain_runtime_primitives::opaque::Block as DomainBlock;
 use futures::FutureExt;
 use sc_cli::Signals;
 use sc_consensus_slots::SlotProportion;
+use sc_network::config::SyncMode;
 use sc_service::{BlocksPruning, PruningMode};
 use sc_storage_monitor::StorageMonitorService;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
@@ -155,6 +156,13 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                     //  https://github.com/paritytech/polkadot-sdk/issues/4671 is implemented
                     consensus_state_pruning = PruningMode::ArchiveCanonical;
                     subspace_configuration.base.state_pruning = Some(PruningMode::ArchiveCanonical);
+
+                    // TODO: revisit SyncMode change after https://github.com/paritytech/polkadot-sdk/issues/4407
+                    if subspace_configuration.base.network.sync_mode.light_state() {
+                        // In case of archival pruning mode sync mode needs to be set to full or
+                        // else Substrate network will fail to initialize
+                        subspace_configuration.base.network.sync_mode = SyncMode::Full;
+                    }
 
                     subspace_service::new_partial::<PosTable, RuntimeApi>(
                         &subspace_configuration,


### PR DESCRIPTION
With the way Substrate is designed right now, it'll not be possible to switch from snap sync to full sync. It would be nice to make snap sync the default though.

With this hack it is possible to start node with `--sync snap` if node was previously using full sync, which is a better upgrade experience that doesn't break existing setups that started prior and have archival database state.

I'd like to experiment with making Snap sync the default in Space Acres first and then after additional testing make it the default in CLI as well. But for that I need this workaround.

Expand a few lines above this change to see the context, it will make more sense that way.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
