### PR TITLE
Move `DsnSyncPieceGetter` to `sync_from_dsn`

### DIFF
--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -1,5 +1,5 @@
 use crate::dsn::DsnConfig;
-use crate::sync_from_dsn::import_blocks::DsnSyncPieceGetter;
+use crate::sync_from_dsn::DsnSyncPieceGetter;
 use sc_chain_spec::ChainSpec;
 use sc_network::config::{
     MultiaddrWithPeerId, NetworkConfiguration, NodeKeyConfig, SetConfig, SyncMode, TransportConfig,


### PR DESCRIPTION
Re-export was recently removed that made it impossible for Space Acres to upgrade. I decided it makes sense to simply move the trait to a higher level module.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
