### PR TITLE
Add segment acknowledgement timeout

### DIFF
--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -44,7 +44,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["sync"] }
+tokio = { version = "1.37.0", features = ["sync", "time"] }
 tracing = "0.1.40"
 
 [dev-dependencies]

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -23,6 +23,7 @@
 //! All of the modules here are crucial for consensus, open each module for specific details.
 
 #![feature(const_option, let_chains, try_blocks)]
+#![feature(duration_constructors)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Sometimes farmers disconnect/crash for a variety of reasons. In case this happens while node is waiting for segment acknowledgement from farmer, node can get stuck forever in paused state.

To avoid this unfortunate situation I decided to add a generous timeout and move on regardless of whether acknowledgement is received or not. This is not a fatal error anyway even though it may affect cache of affected farmers.

I also increased warning level for the channel to better handle large setups like https://forum.subspace.network/t/node-out-of-sync/4164/6?u=nazar-pc. A better approach would be to pass through RPC options all the way through and configure channel size accordingly to actual RPC limits, but it is not a recommended setup to connect to remote nodes anyway, so this will do for now.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
