### PR TITLE
Properly handle domain runtime upgrade

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 use crate::{
     BalanceOf, BlockTree, BlockTreeNodeFor, BlockTreeNodes, Config, ConsensusBlockHash,
-    DomainBlockNumberFor, DomainHashingFor, DomainRuntimeUpgradeAt, ExecutionInbox,
+    DomainBlockNumberFor, DomainHashingFor, DomainRuntimeUpgradeRecords, ExecutionInbox,
     ExecutionReceiptOf, HeadReceiptExtended, HeadReceiptNumber, InboxedBundleAuthor,
     LatestConfirmedDomainBlock, LatestSubmittedER, Pallet, ReceiptHashFor,
 };
@@ -13,6 +13,7 @@ use crate::{
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use frame_support::{ensure, PalletError};
+use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::merkle_tree::MerkleTree;
@@ -215,7 +216,7 @@ pub(crate) fn verify_execution_receipt<T: Config>(
 
     let maybe_domain_runtime_upgraded_at = {
         let runtime_id = Pallet::<T>::runtime_id(domain_id).ok_or(Error::RuntimeNotFound)?;
-        DomainRuntimeUpgradeAt::<T>::get(runtime_id).remove(consensus_block_number)
+        DomainRuntimeUpgradeRecords::<T>::get(runtime_id).remove(consensus_block_number)
     };
 
     // Check if the ER is derived from the correct consensus block in the current chain
@@ -233,9 +234,9 @@ pub(crate) fn verify_execution_receipt<T: Config>(
 
                 // The domain runtime upgrade is forced to happen even if there is no bundle, in this case,
                 // the `ConsensusBlockHash` will be empty so we need to get the consensus block hash from
-                // `DomainRuntimeUpgradeAt`
-                } else if let Some(upgraded_at_hash) = maybe_domain_runtime_upgraded_at {
-                    upgraded_at_hash
+                // `DomainRuntimeUpgradeRecords`
+                } else if let Some(ref upgrade_entry) = maybe_domain_runtime_upgraded_at {
+                    upgrade_entry.at_hash
                 } else {
                     return Err(Error::UnavailableConsensusBlockHash);
                 }
@@ -390,6 +391,11 @@ pub(crate) fn process_execution_receipt<T: Config>(
                 update_domain_transfers::<T>(domain_id, &execution_receipt.transfers, block_fees)
                     .map_err(|_| Error::DomainTransfersTracking)?;
 
+                update_domain_runtime_upgrade_records::<T>(
+                    domain_id,
+                    execution_receipt.consensus_block_number,
+                )?;
+
                 LatestConfirmedDomainBlock::<T>::insert(
                     domain_id,
                     ConfirmedDomainBlock {
@@ -483,6 +489,32 @@ fn update_domain_transfers<T: Config>(
     // deduct execution fees from domain
     T::DomainsTransfersTracker::reduce_domain_balance(domain_id, block_fees)?;
 
+    Ok(())
+}
+
+// Update the domain runtime upgrade record at `consensus_number` if there is one
+fn update_domain_runtime_upgrade_records<T: Config>(
+    domain_id: DomainId,
+    consensus_number: BlockNumberFor<T>,
+) -> Result<(), Error> {
+    let runtime_id = Pallet::<T>::runtime_id(domain_id).ok_or(Error::RuntimeNotFound)?;
+    let mut domain_runtime_upgrade_records = DomainRuntimeUpgradeRecords::<T>::get(runtime_id);
+
+    if let Some(upgrade_entry) = domain_runtime_upgrade_records.get_mut(&consensus_number) {
+        // Decrease the `reference_count` by one and remove the whole entry if it drop to zero
+        if upgrade_entry.reference_count > One::one() {
+            upgrade_entry.reference_count =
+                upgrade_entry.reference_count.saturating_sub(One::one());
+        } else {
+            domain_runtime_upgrade_records.remove(&consensus_number);
+        }
+
+        if !domain_runtime_upgrade_records.is_empty() {
+            DomainRuntimeUpgradeRecords::<T>::set(runtime_id, domain_runtime_upgrade_records);
+        } else {
+            DomainRuntimeUpgradeRecords::<T>::remove(runtime_id);
+        }
+    }
     Ok(())
 }
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -34,7 +34,7 @@ pub mod weights;
 
 extern crate alloc;
 
-use crate::block_tree::verify_execution_receipt;
+use crate::block_tree::{verify_execution_receipt, Error as BlockTreeError};
 use crate::bundle_storage_fund::storage_fund_account;
 use crate::domain_registry::Error as DomainRegistryError;
 use crate::runtime_registry::into_complete_raw_genesis;
@@ -234,6 +234,7 @@ mod pallet {
     };
     use sp_runtime::Saturating;
     use sp_std::boxed::Box;
+    use sp_std::collections::btree_map::BTreeMap;
     use sp_std::collections::btree_set::BTreeSet;
     use sp_std::fmt::Debug;
     use sp_subspace_mmr::MmrProofVerifier;
@@ -684,6 +685,18 @@ mod pallet {
     #[pallet::storage]
     pub(super) type AccumulatedTreasuryFunds<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
+    /// Storage used to keep track of which consensus block the domain runtime upgrade happen.
+    ///
+    /// TODO: determine and clear the unneeded domain runtime upgrade record
+    #[pallet::storage]
+    pub(super) type DomainRuntimeUpgradeAt<T: Config> =
+        StorageMap<_, Identity, RuntimeId, BTreeMap<BlockNumberFor<T>, T::Hash>, ValueQuery>;
+
+    /// Temporary storage keep track of domain runtime upgrade happen in the current block, cleared
+    /// in the next block initialization.
+    #[pallet::storage]
+    pub type DomainRuntimeUpgrades<T> = StorageValue<_, Vec<RuntimeId>, ValueQuery>;
+
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
         /// Can not find the operator for given operator id.
@@ -1096,8 +1109,19 @@ mod pallet {
             // consensus block, which also mean a domain block will be produced thus update `HeadDomainNumber`
             // to this domain block's block number.
             if SuccessfulBundles::<T>::get(domain_id).is_empty() {
+                // Domain runtime upgrade is forced happened even if there is no bundle submitted for a given domain
+                // it will still derive a domain block for the upgrade, so we need to increase the `HeadDomainNumber`
+                // by the number of runtime upgrade happen since last block to account for these blocks.
+                //
+                // NOTE: if a domain runtime upgrade happened in the current block it won't be accounted into
+                // `missed_upgrade` because `DomainRuntimeUpgradeAt` is updated in the next block's initialization.
+                let missed_upgrade =
+                    Self::missed_domain_runtime_upgrade(domain_id).map_err(Error::<T>::from)?;
+
                 let next_number = HeadDomainNumber::<T>::get(domain_id)
                     .checked_add(&One::one())
+                    .ok_or::<Error<T>>(BlockTreeError::MaxHeadDomainNumber.into())?
+                    .checked_add(&missed_upgrade.into())
                     .ok_or::<Error<T>>(BlockTreeError::MaxHeadDomainNumber.into())?;
                 HeadDomainNumber::<T>::set(domain_id, next_number);
             }
@@ -1550,13 +1574,20 @@ mod pallet {
     // TODO: proper benchmark
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(block_number: BlockNumberFor<T>) -> Weight {
-            // Do scheduled domain runtime upgrade
+            let parent_number = block_number - One::one();
+            let parent_hash = frame_system::Pallet::<T>::block_hash(parent_number);
+
+            // Record any previous domain runtime upgrade in `DomainRuntimeUpgradeAt` and then do the
+            // domain runtime upgrade scheduled in the current block
+            for runtime_id in DomainRuntimeUpgrades::<T>::take() {
+                DomainRuntimeUpgradeAt::<T>::mutate(runtime_id, |upgrade_record| {
+                    upgrade_record.insert(parent_number, parent_hash)
+                });
+            }
             do_upgrade_runtimes::<T>(block_number);
 
             // Store the hash of the parent consensus block for domain that have bundles submitted
             // in that consensus block
-            let parent_number = block_number - One::one();
-            let parent_hash = frame_system::Pallet::<T>::block_hash(parent_number);
             for (domain_id, _) in SuccessfulBundles::<T>::drain() {
                 ConsensusBlockHash::<T>::insert(domain_id, parent_number, parent_hash);
                 T::DomainBundleSubmitted::domain_bundle_submitted(domain_id);
@@ -2484,6 +2515,28 @@ impl<T: Config> Pallet<T> {
         }
 
         Ok(leaf_data.state_root())
+    }
+
+    // Return the number of domain runtime upgrade happened since `last_domain_block_number`
+    fn missed_domain_runtime_upgrade(domain_id: DomainId) -> Result<u32, BlockTreeError> {
+        let runtime_id = Self::runtime_id(domain_id).ok_or(BlockTreeError::RuntimeNotFound)?;
+        let last_domain_block_number = HeadDomainNumber::<T>::get(domain_id);
+
+        // The consensus block number that derive the last domain block
+        let last_block_at =
+            ExecutionInbox::<T>::iter_key_prefix((domain_id, last_domain_block_number))
+                .next()
+                // If there is no `ExecutionInbox` exist for the `last_domain_block_number` it means
+                // there is no bundle submitted for the domain since it is instantiated, in this case,
+                // we use the `domain_obj.created_at` (which derive the genesis block).
+                .or(DomainRegistry::<T>::get(domain_id).map(|domain_obj| domain_obj.created_at))
+                .ok_or(BlockTreeError::LastBlockNotFound)?;
+
+        Ok(DomainRuntimeUpgradeAt::<T>::get(runtime_id)
+            .into_keys()
+            .rev()
+            .take_while(|upgraded_at| *upgraded_at > last_block_at)
+            .count() as u32)
     }
 }
 

--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -54,6 +54,16 @@ impl Default for DomainRuntimeInfo {
     }
 }
 
+#[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct DomainRuntimeUpgradeEntry<Hash> {
+    // The consensus block hash at which the upgrade happened
+    pub at_hash: Hash,
+    // The expected number of ER (from differnt domains) that derive from the consensus
+    // block `at_hash`, the `reference_count` will decrease by one as one such ER is
+    // confirmed and the whole entry will remove from the state after it become zero.
+    pub reference_count: u32,
+}
+
 fn derive_initial_balances_storages<T: Config, AccountId: Encode>(
     total_issuance: BalanceOf<T>,
     balances: Vec<(AccountId, BalanceOf<T>)>,

--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -3,7 +3,9 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::pallet::{NextRuntimeId, RuntimeRegistry, ScheduledRuntimeUpgrades};
+use crate::pallet::{
+    DomainRuntimeUpgrades, NextRuntimeId, RuntimeRegistry, ScheduledRuntimeUpgrades,
+};
 use crate::{BalanceOf, Config, Event};
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
@@ -286,6 +288,9 @@ pub(crate) fn do_upgrade_runtimes<T: Config>(at: BlockNumberFor<T>) {
             runtime_obj.runtime_upgrades = runtime_obj.runtime_upgrades.saturating_add(1);
             runtime_obj.updated_at = at;
         });
+
+        // Record the runtime upgrade
+        DomainRuntimeUpgrades::<T>::mutate(|upgrades| upgrades.push(runtime_id));
 
         // deposit digest log for light clients
         frame_system::Pallet::<T>::deposit_log(DigestItem::domain_runtime_upgrade(runtime_id));

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,12 +1,14 @@
-use crate::block_tree::BlockTreeNode;
+use crate::block_tree::{verify_execution_receipt, BlockTreeNode};
 use crate::domain_registry::{DomainConfig, DomainObject};
 use crate::pallet::OperatorIdOwner;
+use crate::runtime_registry::ScheduledRuntimeUpgrade;
 use crate::staking::Operator;
 use crate::{
     self as pallet_domains, BalanceOf, BlockSlot, BlockTree, BlockTreeNodes, BundleError, Config,
-    ConsensusBlockHash, DomainBlockNumberFor, DomainHashingFor, DomainRegistry, ExecutionInbox,
-    ExecutionReceiptOf, FraudProofError, FungibleHoldId, HeadReceiptNumber, NextDomainId,
-    Operators,
+    ConsensusBlockHash, DomainBlockNumberFor, DomainHashingFor, DomainRegistry,
+    DomainRuntimeUpgradeAt, DomainRuntimeUpgrades, ExecutionInbox, ExecutionReceiptOf,
+    FraudProofError, FungibleHoldId, HeadDomainNumber, HeadReceiptNumber, NextDomainId, Operators,
+    RuntimeRegistry, ScheduledRuntimeUpgrades,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use domain_runtime_primitives::opaque::Header as DomainHeader;
@@ -25,8 +27,8 @@ use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
     BundleHeader, ChainId, DomainId, DomainsHoldIdentifier, ExecutionReceipt, InboxedBundle,
-    OpaqueBundle, OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, RuntimeType,
-    SealedBundleHeader, StakingHoldIdentifier,
+    OpaqueBundle, OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, RuntimeId,
+    RuntimeType, SealedBundleHeader, StakingHoldIdentifier,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{
@@ -856,4 +858,158 @@ fn test_basic_fraud_proof_processing() {
             }
         });
     }
+}
+
+fn schedule_domain_runtime_upgrade<T: Config>(
+    runtime_id: RuntimeId,
+    scheduled_at: BlockNumberFor<T>,
+) {
+    let runtime_obj = RuntimeRegistry::<T>::get(runtime_id).expect("Unknow runtime id");
+    let scheduled_upgrade = ScheduledRuntimeUpgrade {
+        raw_genesis: runtime_obj.raw_genesis,
+        version: runtime_obj.version,
+        hash: runtime_obj.hash,
+    };
+    ScheduledRuntimeUpgrades::<T>::insert(scheduled_at, runtime_id, scheduled_upgrade);
+}
+
+#[test]
+fn test_domain_runtime_upgrade_record() {
+    let runtime_id = 0u32;
+    let creator = 0u128;
+    let operator_id = 1u64;
+    let mut ext = new_test_ext_with_extensions();
+    ext.execute_with(|| {
+        let domain_id = register_genesis_domain(creator, vec![operator_id]);
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(0));
+
+        // Schedule domain runtime upgrade for the next 2 blocks
+        let current_block = frame_system::Pallet::<Test>::current_block_number();
+        let (upgrade_1, upgrade_2) = (current_block + 1, current_block + 2);
+        schedule_domain_runtime_upgrade::<Test>(runtime_id, upgrade_1);
+        schedule_domain_runtime_upgrade::<Test>(runtime_id, upgrade_2);
+
+        // Run to the block that the first upgrade happen, the upgrade should recorded in
+        // `DomainRuntimeUpgrades` but not `DomainRuntimeUpgradeAt`
+        run_to_block::<Test>(upgrade_1, H256::random());
+        assert_eq!(DomainRuntimeUpgrades::<Test>::get(), vec![runtime_id]);
+        assert!(DomainRuntimeUpgradeAt::<Test>::get(runtime_id).is_empty());
+
+        // In the next block after upgrade, the upgrade is accounted in `missed_domain_runtime_upgrade`
+        run_to_block::<Test>(upgrade_1 + 1, H256::random());
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(1));
+        run_to_block::<Test>(upgrade_2 + 1, H256::random());
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(2));
+
+        // The upgrade record is moved from `DomainRuntimeUpgrades` to `DomainRuntimeUpgradeAt`
+        assert!(DomainRuntimeUpgrades::<Test>::get().is_empty());
+        assert!(DomainRuntimeUpgradeAt::<Test>::get(runtime_id).contains_key(&upgrade_1));
+        assert!(DomainRuntimeUpgradeAt::<Test>::get(runtime_id).contains_key(&upgrade_2));
+    });
+}
+
+#[test]
+fn test_domain_runtime_upgrade_with_bundle() {
+    let runtime_id = 0u32;
+    let creator = 0u128;
+    let operator_id = 1u64;
+    let mut ext = new_test_ext_with_extensions();
+    ext.execute_with(|| {
+        let domain_id = register_genesis_domain(creator, vec![operator_id]);
+        assert_eq!(HeadDomainNumber::<Test>::get(domain_id), 0);
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(0));
+
+        // Schedule domain runtime upgrade for the next 2 blocks
+        let current_block = frame_system::Pallet::<Test>::current_block_number();
+        schedule_domain_runtime_upgrade::<Test>(runtime_id, current_block + 1);
+        schedule_domain_runtime_upgrade::<Test>(runtime_id, current_block + 2);
+        run_to_block::<Test>(current_block + 1, H256::random());
+        run_to_block::<Test>(current_block + 2, H256::random());
+
+        // Run to the next block after the 2 upgrades
+        run_to_block::<Test>(current_block + 3, H256::random());
+        assert_eq!(HeadDomainNumber::<Test>::get(domain_id), 0);
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(2));
+
+        // Submit a bundle after the upgrades, the domain chain should grow by 3 as 2 domain blocks
+        // created for the 2 upgrades and 1 domain block created for the bundle
+        let genesis_receipt = get_block_tree_node_at::<Test>(domain_id, 0)
+            .unwrap()
+            .execution_receipt;
+        let bundle_extrinsics_root = H256::random();
+        let bundle = create_dummy_bundle_with_receipts(
+            domain_id,
+            operator_id,
+            bundle_extrinsics_root,
+            genesis_receipt.clone(),
+        );
+        assert_ok!(crate::Pallet::<Test>::submit_bundle(
+            RawOrigin::None.into(),
+            bundle,
+        ));
+        assert_eq!(HeadReceiptNumber::<Test>::get(domain_id), 0);
+        assert_eq!(HeadDomainNumber::<Test>::get(domain_id), 3);
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(0));
+
+        // Submit bundle that carry the receipt of the domain runtime upgrade block
+        let mut parent_receipt = genesis_receipt;
+        for i in 1..=2 {
+            run_to_block::<Test>(current_block + 3 + i, H256::random());
+            let next_receipt = create_dummy_receipt(
+                current_block + i,
+                frame_system::Pallet::<Test>::block_hash(current_block + i),
+                parent_receipt.hash::<DomainHashingFor<Test>>(),
+                // empty `bundle_extrinsics_root` since these blocks doesn't contain bundle
+                vec![],
+            );
+            // These receipt must able to pass `verify_execution_receipt`
+            assert_ok!(verify_execution_receipt::<Test>(domain_id, &next_receipt));
+            let bundle = create_dummy_bundle_with_receipts(
+                domain_id,
+                operator_id,
+                H256::random(),
+                next_receipt.clone(),
+            );
+            assert_ok!(crate::Pallet::<Test>::submit_bundle(
+                RawOrigin::None.into(),
+                bundle,
+            ));
+            parent_receipt = next_receipt;
+        }
+        assert_eq!(HeadReceiptNumber::<Test>::get(domain_id), 2);
+        // The gap between `HeadDomainNumber` and `HeadReceiptNumber` is increased from 1 to 3 as
+        // there are 2 domain blocks doesn't contain bundle
+        assert_eq!(
+            HeadDomainNumber::<Test>::get(domain_id) - HeadReceiptNumber::<Test>::get(domain_id),
+            3
+        );
+
+        // Schedule another domain runtime upgrade that will happen in a block that also contains bundle
+        schedule_domain_runtime_upgrade::<Test>(runtime_id, current_block + 6);
+        run_to_block::<Test>(current_block + 6, H256::random());
+        let next_receipt = create_dummy_receipt(
+            current_block + 3,
+            frame_system::Pallet::<Test>::block_hash(current_block + 3),
+            parent_receipt.hash::<DomainHashingFor<Test>>(),
+            vec![bundle_extrinsics_root],
+        );
+        assert_ok!(verify_execution_receipt::<Test>(domain_id, &next_receipt));
+        let bundle =
+            create_dummy_bundle_with_receipts(domain_id, operator_id, H256::random(), next_receipt);
+        assert_ok!(crate::Pallet::<Test>::submit_bundle(
+            RawOrigin::None.into(),
+            bundle,
+        ));
+
+        // Since the new domain block contains both runtime upgrade and bundle, the gap between `HeadDomainNumber`
+        // and `HeadReceiptNumber` remain the same and there is no `missed_domain_runtime_upgrade`
+        run_to_block::<Test>(current_block + 7, H256::random());
+        assert!(DomainRuntimeUpgradeAt::<Test>::get(runtime_id).contains_key(&(current_block + 6)));
+        assert_eq!(Domains::missed_domain_runtime_upgrade(domain_id), Ok(0));
+        assert_eq!(HeadReceiptNumber::<Test>::get(domain_id), 3);
+        assert_eq!(
+            HeadDomainNumber::<Test>::get(domain_id) - HeadReceiptNumber::<Test>::get(domain_id),
+            3
+        );
+    });
 }


### PR DESCRIPTION
close #2802

This PR implemented the "Enforce domain runtime upgrade" approach mentioned in #2802 to properly handle the situation where a consensus block only contains domain runtime upgrade but no bundle. 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
