### PR TITLE
Disable snap-sync for domains.

### DIFF
--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -30,6 +30,7 @@ use sp_messenger::messages::ChainId;
 use std::env;
 use subspace_metrics::{start_prometheus_metrics_server, RegistryAdapter};
 use subspace_runtime::{Block, RuntimeApi};
+use subspace_service::config::ChainSyncMode;
 use tracing::{debug, error, info, info_span, warn};
 
 /// Options for running a node
@@ -114,6 +115,12 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
     );
     info!("🏷  Node name: {}", subspace_configuration.network.node_name);
     info!("💾 Node path: {}", base_path.display());
+
+    if maybe_domain_configuration.is_some() && subspace_configuration.sync == ChainSyncMode::Snap {
+        return Err(Error::Other(
+            "Snap sync mode is not supported for domains".to_string(),
+        ));
+    }
 
     if maybe_domain_configuration.is_some()
         && (matches!(


### PR DESCRIPTION
This PR disables snap-sync for domains. It adds an error when CLI args contain both `--sync=snap` and `-- --domain-id`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
