### PR TITLE
XDM: use same fee model for channels 

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -74,7 +74,7 @@ use sp_domains_fraud_proof::storage_proof::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
@@ -516,6 +516,8 @@ parameter_types! {
     // TODO: update value
     pub const ChannelReserveFee: Balance = 100 * SSC;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+    // TODO update the fee model
+    pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
 }
 
 pub struct DomainRegistration;
@@ -549,6 +551,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = DomainRegistration;
+    type ChannelFeeModel = ChannelFeeModel;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -38,7 +38,7 @@ use sp_domains_fraud_proof::fraud_proof::{
     InvalidExtrinsicsRootProof, InvalidTransfersProof,
 };
 use sp_domains_fraud_proof::InvalidTransactionCode;
-use sp_messenger::messages::{CrossDomainMessage, FeeModel, InitiateChannelParams, Proof};
+use sp_messenger::messages::{CrossDomainMessage, Proof};
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
 use sp_runtime::generic::{BlockId, DigestItem};
 use sp_runtime::traits::{
@@ -3474,14 +3474,12 @@ async fn test_cross_domains_messages_should_work() {
     produce_blocks!(ferdie, alice, 1).await.unwrap();
 
     // Open channel between the Consensus chain and EVM domains
-    let fee_model = FeeModel { relay_fee: 1 };
     alice
         .construct_and_send_extrinsic(evm_domain_test_runtime::RuntimeCall::Messenger(
             pallet_messenger::Call::initiate_channel {
                 dst_chain_id: ChainId::Consensus,
-                params: InitiateChannelParams {
+                params: pallet_messenger::InitiateChannelParams {
                     max_outgoing_messages: 100,
-                    fee_model,
                 },
             },
         ))

--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -15,7 +15,7 @@ use frame_support::traits::Get;
 use frame_system::RawOrigin;
 use sp_messenger::endpoint::{Endpoint, EndpointRequest};
 use sp_messenger::messages::{
-    CrossDomainMessage, InitiateChannelParams, Message, MessageWeightTag, Payload, Proof,
+    ChannelOpenParams, CrossDomainMessage, Message, MessageWeightTag, Payload, Proof,
     RequestResponse, VersionedPayload,
 };
 use sp_mmr_primitives::{EncodableOpaqueLeaf, Proof as MmrProof};
@@ -32,7 +32,9 @@ mod benchmarks {
     fn initiate_channel() {
         let dst_chain_id: ChainId = u32::MAX.into();
         assert_ne!(T::SelfChainId::get(), dst_chain_id);
-        let channel_params = dummy_channel_params::<T>();
+        let channel_params = InitiateChannelParams {
+            max_outgoing_messages: 100,
+        };
         let channel_id = NextChannelId::<T>::get(dst_chain_id);
         let account = account("account", 0, 0);
         T::Currency::set_balance(
@@ -232,11 +234,11 @@ mod benchmarks {
         );
     }
 
-    fn dummy_channel_params<T: Config>() -> InitiateChannelParams<BalanceOf<T>> {
+    fn dummy_channel_params<T: Config>() -> ChannelOpenParams<BalanceOf<T>> {
         let fee_model = FeeModel {
             relay_fee: 1u32.into(),
         };
-        InitiateChannelParams {
+        ChannelOpenParams {
             max_outgoing_messages: 100,
             fee_model,
         }
@@ -244,7 +246,7 @@ mod benchmarks {
 
     fn open_channel<T: Config>(
         dst_chain_id: ChainId,
-        params: InitiateChannelParams<BalanceOf<T>>,
+        params: ChannelOpenParams<BalanceOf<T>>,
     ) -> ChannelId {
         let channel_id = NextChannelId::<T>::get(dst_chain_id);
         let list = BTreeSet::from([dst_chain_id]);

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -28,7 +28,7 @@ macro_rules! impl_runtime {
         use pallet_balances::AccountData;
         use sp_core::H256;
         use sp_messenger::endpoint::{Endpoint, EndpointHandler, EndpointId};
-        use sp_messenger::messages::ChainId;
+        use sp_messenger::messages::{ChainId, FeeModel};
         use sp_runtime::traits::Convert;
         use sp_runtime::BuildStorage;
         use crate::HoldIdentifier;
@@ -62,6 +62,7 @@ macro_rules! impl_runtime {
             pub SelfChainId: ChainId = $chain_id.into();
             pub const ChannelReserveFee: Balance = 10;
             pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+            pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: 1};
         }
 
         #[derive(
@@ -103,6 +104,7 @@ macro_rules! impl_runtime {
             type ChannelInitReservePortion = ChannelInitReservePortion;
             type HoldIdentifier = MockHoldIdentifer;
             type DomainRegistration = DomainRegistration;
+            type ChannelFeeModel = ChannelFeeModel;
             /// function to fetch endpoint response handler by Endpoint.
             fn get_endpoint_handler(
                 #[allow(unused_variables)] endpoint: &Endpoint,

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -29,9 +29,9 @@ pub struct FeeModel<Balance> {
     pub relay_fee: Balance,
 }
 
-/// Parameters for a new channel between two chains.
+/// Channel open parameters
 #[derive(Default, Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo, Copy)]
-pub struct InitiateChannelParams<Balance> {
+pub struct ChannelOpenParams<Balance> {
     pub max_outgoing_messages: u32,
     pub fee_model: FeeModel<Balance>,
 }
@@ -40,7 +40,7 @@ pub struct InitiateChannelParams<Balance> {
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 pub enum ProtocolMessageRequest<Balance> {
     /// Request to open a channel with foreign chain.
-    ChannelOpen(InitiateChannelParams<Balance>),
+    ChannelOpen(ChannelOpenParams<Balance>),
     /// Request to close an open channel with foreign chain.
     ChannelClose,
 }

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -42,7 +42,7 @@ use sp_core::{Get, OpaqueMetadata};
 use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
@@ -394,6 +394,8 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 parameter_types! {
     pub const ChannelReserveFee: Balance = 100 * SSC;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+    // TODO update the fee model
+    pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -420,6 +422,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();
+    type ChannelFeeModel = ChannelFeeModel;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -55,7 +55,7 @@ use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
 use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
@@ -524,6 +524,8 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 parameter_types! {
     pub const ChannelReserveFee: Balance = 100 * SSC;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+    // TODO update the fee model
+    pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -550,6 +552,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();
+    type ChannelFeeModel = ChannelFeeModel;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -53,7 +53,8 @@ use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
 use sp_domains::{DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
+    MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
@@ -483,6 +484,7 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 parameter_types! {
     pub const ChannelReserveFee: Balance = SSC;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+    pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
 }
 
 pub struct StorageKeys;
@@ -531,6 +533,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();
+    type ChannelFeeModel = ChannelFeeModel;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -66,7 +66,8 @@ use sp_domains_fraud_proof::storage_proof::{
 };
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
-    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
+    BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
+    MessageKey,
 };
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
@@ -604,6 +605,7 @@ impl sp_messenger::DomainRegistration for DomainRegistration {
 parameter_types! {
     pub const ChannelReserveFee: Balance = SSC;
     pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+    pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
 }
 
 impl pallet_messenger::Config for Runtime {
@@ -630,6 +632,7 @@ impl pallet_messenger::Config for Runtime {
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = DomainRegistration;
+    type ChannelFeeModel = ChannelFeeModel;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime


### PR DESCRIPTION
This PR removes the custom fee defined for each channels but rather takes the defined constant fee model from the Config. This should ensure user dont take advantage of this as raised by audit - #2808

Notes:
Since each chain could potentially define different fee models. Channel use the fee model of the src_chain to ensure same fee is used across both the chains. If two chains have a different fee model, then users can potentially pick the src_chain that has lower fee model. This may not be a problem right now since all our chains will use the same fee model but down the like we need to put more thoughts into this @dariolina 

If the Feemodel of src_chain changes after channel is open, the old fee model is retained for the already existing channel to ensure there are no surprises to the users. If the fee model for old channels are very low, Consensus sudo or Domain owner can close the channel and open a new channel with updated Fee model

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
