### PR TITLE
Remove incorrect usage of Pays::No attribute for unsigned calls

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1145,8 +1145,7 @@ mod pallet {
             T::WeightInfo::submit_fraud_proof().saturating_add(
                 T::WeightInfo::handle_bad_receipt(MAX_BUNLDE_PER_BLOCK)
             ),
-            DispatchClass::Operational,
-            Pays::No
+            DispatchClass::Operational
         ))]
         pub fn submit_fraud_proof(
             origin: OriginFor<T>,

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -550,7 +550,7 @@ pub mod pallet {
         /// Submit new segment header to the blockchain. This is an inherent extrinsic and part of
         /// the Subspace consensus logic.
         #[pallet::call_index(1)]
-        #[pallet::weight((< T as Config >::WeightInfo::store_segment_headers(segment_headers.len() as u32), DispatchClass::Mandatory, Pays::No))]
+        #[pallet::weight((< T as Config >::WeightInfo::store_segment_headers(segment_headers.len() as u32), DispatchClass::Mandatory))]
         pub fn store_segment_headers(
             origin: OriginFor<T>,
             segment_headers: Vec<SegmentHeader>,
@@ -584,7 +584,7 @@ pub mod pallet {
 
         /// Farmer vote, currently only used for extra rewards to farmers.
         #[pallet::call_index(3)]
-        #[pallet::weight((< T as Config >::WeightInfo::vote(), DispatchClass::Operational, Pays::No))]
+        #[pallet::weight((< T as Config >::WeightInfo::vote(), DispatchClass::Operational))]
         // Suppression because the custom syntax will also generate an enum and we need enum to have
         // boxed value.
         #[allow(clippy::boxed_local)]

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -487,12 +487,6 @@ fn store_segment_header_works() {
 
         let segment_header = create_segment_header(SegmentIndex::ZERO);
 
-        let call = Call::<Test>::store_segment_headers {
-            segment_headers: vec![segment_header],
-        };
-        // Segment headers don't require fee
-        assert_eq!(call.get_dispatch_info().pays_fee, Pays::No);
-
         Subspace::store_segment_headers(RuntimeOrigin::none(), vec![segment_header]).unwrap();
         assert_eq!(
             System::events(),

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -619,7 +619,7 @@ mod pallet {
 
         /// Receives an Inbox message that needs to be validated and processed.
         #[pallet::call_index(2)]
-        #[pallet::weight((T::WeightInfo::relay_message().saturating_add(Pallet::< T >::message_weight(& msg.weight_tag)), Pays::No))]
+        #[pallet::weight(T::WeightInfo::relay_message().saturating_add(Pallet::< T >::message_weight(& msg.weight_tag)))]
         pub fn relay_message(
             origin: OriginFor<T>,
             msg: CrossDomainMessage<BlockNumberFor<T>, T::Hash, T::MmrHash>,
@@ -632,7 +632,7 @@ mod pallet {
 
         /// Receives a response from the dst_chain for a message in Outbox.
         #[pallet::call_index(3)]
-        #[pallet::weight((T::WeightInfo::relay_message_response().saturating_add(Pallet::< T >::message_weight(& msg.weight_tag)), Pays::No))]
+        #[pallet::weight(T::WeightInfo::relay_message_response().saturating_add(Pallet::< T >::message_weight(& msg.weight_tag)))]
         pub fn relay_message_response(
             origin: OriginFor<T>,
             msg: CrossDomainMessage<BlockNumberFor<T>, T::Hash, T::MmrHash>,


### PR DESCRIPTION
This PR removes the incorrect usage of Pays::No attribute for unsigned as raised by audit team

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
