### PR TITLE
Switch from `taiki-e/cargo-cache-install-action` to `taiki-e/install-action`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -197,7 +197,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install cargo-nextest
-        uses: taiki-e/cache-cargo-install-action@5b024fe3a0a2c7f2aaff0e47871acf0d14b07207 # v2.0.0
+        uses: taiki-e/install-action@07a34f8347b1eeb5f5469cdfa451b0a5db2ae4e8 # 2.38.4
         with:
           tool: cargo-nextest
 


### PR DESCRIPTION
This is a recommended tool, but due to https://github.com/taiki-e/install-action/issues/224 we were not able to use it before. Now that it is resolved, we can finally switch to it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
