### PR TITLE
Make sure metadata for plotted sectors is written sequentially

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -814,6 +814,8 @@ impl SingleDiskFarm {
 
                 let plotting_options = PlottingOptions {
                     metadata_header,
+                    sectors_metadata: &sectors_metadata,
+                    sectors_being_modified: &sectors_being_modified,
                     sectors_to_plot_receiver,
                     sector_plotting_options: SectorPlottingOptions {
                         public_key,
@@ -822,9 +824,7 @@ impl SingleDiskFarm {
                         sector_size,
                         plot_file: &plot_file,
                         metadata_file,
-                        sectors_metadata: &sectors_metadata,
                         handlers: &handlers,
-                        sectors_being_modified: &sectors_being_modified,
                         global_mutex: &global_mutex,
                         plotter,
                     },


### PR DESCRIPTION
https://github.com/subspace/subspace/pull/2698 refactored plotting to add pipelining, but I think there is a chance it wasn't actually guaranteed to work correctly.

There is `process_plotting_result` that processes sectors strictly sequentially, however `sectors_metadata` extension (we store metadata in a flat vector for efficiency reasons) was potentially racy, leading to sector metadata stored out of order and leading to issues like described in https://forum.subspace.network/t/cluster-farm-plotter-farmer-panic/4170?u=nazar-pc

Pushing metadata sequentially should address this issue.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
