### PR TITLE
Multithreaded farming cluster services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13594,9 +13594,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -13613,9 +13613,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -44,7 +44,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primiti
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["sync", "time"] }
+tokio = { version = "1.38.0", features = ["sync", "time"] }
 tracing = "0.1.40"
 
 [dev-dependencies]

--- a/crates/sc-proof-of-time/Cargo.toml
+++ b/crates/sc-proof-of-time/Cargo.toml
@@ -33,5 +33,5 @@ sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-proof-of-time = { version = "0.1.0", path = "../subspace-proof-of-time" }
 thread-priority = "1.1.0"
-tokio = { version = "1.37.0", features = ["sync"] }
+tokio = { version = "1.38.0", features = ["sync"] }
 tracing = "0.1.40"

--- a/crates/sp-domains-fraud-proof/Cargo.toml
+++ b/crates/sp-domains-fraud-proof/Cargo.toml
@@ -64,7 +64,7 @@ subspace-test-client = { version = "0.1.0", path = "../../test/subspace-test-cli
 subspace-test-service = { version = "0.1.0", path = "../../test/subspace-test-service" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives" }
 tempfile = "3.10.1"
-tokio = "1.37.0"
+tokio = "1.38.0"
 
 [features]
 default = ["std"]

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -38,7 +38,7 @@ subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-codin
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space", features = ["parallel"] }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification" }
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync"] }
+tokio = { version = "1.38.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync"] }
 tracing = "0.1.40"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -60,7 +60,7 @@ supports-color = "3.0.0"
 tempfile = "3.10.1"
 thiserror = "1.0.59"
 thread-priority = "1.1.0"
-tokio = { version = "1.37.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.38.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ulid = { version = "1.1.2", features = ["serde"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -1,6 +1,8 @@
 use crate::commands::shared::PlottingThreadPriority;
 use anyhow::anyhow;
 use clap::Parser;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use prometheus_client::registry::Registry;
 use std::future::Future;
 use std::num::NonZeroUsize;
@@ -15,6 +17,7 @@ use subspace_farmer::cluster::plotter::plotter_service;
 use subspace_farmer::plotter::cpu::CpuPlotter;
 use subspace_farmer::utils::{
     create_plotting_thread_pool_manager, parse_cpu_cores_sets, thread_pool_core_indices,
+    AsyncJoinOnDrop,
 };
 use subspace_proof_of_space::Table;
 use tokio::sync::Semaphore;
@@ -77,6 +80,12 @@ pub(super) struct PlotterArgs {
     /// "min", "max" or "default".
     #[arg(long, default_value_t = PlottingThreadPriority::Min)]
     plotting_thread_priority: PlottingThreadPriority,
+    /// Number of service instances.
+    ///
+    /// Increasing number of services allows to process more concurrent requests, but increasing
+    /// beyond number of CPU cores doesn't make sense and will likely hurt performance instead.
+    #[arg(long, default_value = "32")]
+    service_instances: NonZeroUsize,
     /// Additional cluster components
     #[clap(raw = true)]
     pub(super) additional_components: Vec<String>,
@@ -98,6 +107,7 @@ where
         plotting_thread_pool_size,
         plotting_cpu_cores,
         plotting_thread_priority,
+        service_instances,
         additional_components: _,
     } = plotter_args;
 
@@ -161,7 +171,7 @@ where
     )
     .map_err(|error| anyhow!("Failed to create thread pool manager: {error}"))?;
     let global_mutex = Arc::default();
-    let cpu_plotter = CpuPlotter::<_, PosTable>::new(
+    let cpu_plotter = Arc::new(CpuPlotter::<_, PosTable>::new(
         piece_getter,
         downloading_semaphore,
         plotting_thread_pool_manager,
@@ -169,13 +179,27 @@ where
         Arc::clone(&global_mutex),
         kzg.clone(),
         erasure_coding.clone(),
-    );
+    ));
 
     // TODO: Metrics
+    let mut plotter_services = (0..service_instances.get())
+        .map(|_| {
+            let nats_client = nats_client.clone();
+            let cpu_plotter = Arc::clone(&cpu_plotter);
+
+            AsyncJoinOnDrop::new(
+                tokio::spawn(async move { plotter_service(&nats_client, &cpu_plotter).await }),
+                true,
+            )
+        })
+        .collect::<FuturesUnordered<_>>();
 
     Ok(Box::pin(async move {
-        plotter_service(&nats_client, &cpu_plotter)
+        plotter_services
+            .next()
             .await
-            .map_err(|error| anyhow!("Ploter service failed: {error}"))
+            .expect("Not empty; qed")
+            .map_err(|error| anyhow!("Plotter service failed: {error}"))?
+            .map_err(|error| anyhow!("Plotter service failed: {error}"))
     }))
 }

--- a/crates/subspace-malicious-operator/Cargo.toml
+++ b/crates/subspace-malicious-operator/Cargo.toml
@@ -74,7 +74,7 @@ subspace-runtime = { version = "0.1.0", path = "../subspace-runtime" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-primitives" }
 subspace-service = { version = "0.1.0", path = "../subspace-service" }
 thiserror = "1.0.59"
-tokio = "1.37.0"
+tokio = "1.38.0"
 rand = "0.8.5"
 tracing = "0.1.40"
 

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1.0.116"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-metrics = { version = "0.1.0", path = "../../shared/subspace-metrics" }
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.38.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 unsigned-varint = { version = "0.8.0", features = ["futures", "asynchronous_codec"] }

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -81,7 +81,7 @@ substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sd
 supports-color = "3.0.0"
 tempfile = "3.10.1"
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 tokio-stream = { version = "0.1.15" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -83,7 +83,7 @@ subspace-runtime-primitives = { version = "0.1.0", path = "../subspace-runtime-p
 substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["sync"] }
+tokio = { version = "1.38.0", features = ["sync"] }
 tracing = "0.1.40"
 
 sp-session = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -41,7 +41,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../../../crates/subspace
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives" }
 tracing = "0.1.40"
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 
 [dev-dependencies]
 domain-test-service = { version = "0.1.0", path = "../../test/service" }

--- a/domains/service/Cargo.toml
+++ b/domains/service/Cargo.toml
@@ -66,7 +66,7 @@ subspace-core-primitives = { version = "0.1.0", path = "../../crates/subspace-co
 subspace-runtime-primitives = { version = "0.1.0", path = "../../crates/subspace-runtime-primitives" }
 substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
-tokio = "1.37.0"
+tokio = "1.38.0"
 tracing = "0.1.40"
 
 [build-dependencies]

--- a/domains/test/service/Cargo.toml
+++ b/domains/test/service/Cargo.toml
@@ -52,5 +52,5 @@ subspace-test-client = { version = "0.1.0", path = "../../../test/subspace-test-
 subspace-test-service = { version = "0.1.0", path = "../../../test/subspace-test-service" }
 substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
-tokio = { version = "1.37.0", features = ["macros"] }
+tokio = { version = "1.38.0", features = ["macros"] }
 tracing = "0.1.40"

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -66,7 +66,7 @@ subspace-test-primitives = { version = "0.1.0", path = "../subspace-test-primiti
 subspace-test-runtime = { version = "0.1.0", path = "../subspace-test-runtime" }
 substrate-frame-rpc-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
 substrate-test-client = { git = "https://github.com/subspace/polkadot-sdk", rev = "6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6" }
-tokio = "1.37.0"
+tokio = "1.38.0"
 tracing = "0.1.40"
 
 [dev-dependencies]


### PR DESCRIPTION
Cluster components were originally designed to support multi-threaded listening for messages, so I think it is time to take advantage of that. Some users are running setups with hundreds of farms across multiple machines in local network and during bursts of activity having more listeners to respond might improve general performance and reliability.

Updated tokio to fix https://github.com/tokio-rs/tokio/issues/6634

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
