### PR TITLE
Ensure to use the domain executor within the messenger and fraud proof host function

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -233,7 +233,6 @@ struct SubspaceExtensionsFactory<PosTable, Client, DomainBlock> {
     client: Arc<Client>,
     backend: Arc<FullBackend>,
     pot_verifier: PotVerifier,
-    executor: Arc<RuntimeExecutor>,
     domains_executor: Arc<sc_domains::RuntimeExecutor>,
     _pos_table: PhantomData<(PosTable, DomainBlock)>,
 }
@@ -403,7 +402,7 @@ where
         exts.register(MessengerExtension::new(Arc::new(
             MessengerHostFunctionsImpl::<Block, _, DomainBlock, _>::new(
                 self.client.clone(),
-                self.executor.clone(),
+                self.domains_executor.clone(),
             ),
         )));
 
@@ -500,15 +499,12 @@ where
         POT_VERIFIER_CACHE_SIZE,
     );
 
-    let executor = Arc::new(executor);
-
     client
         .execution_extensions()
         .set_extensions_factory(SubspaceExtensionsFactory::<PosTable, _, DomainBlock> {
             kzg: kzg.clone(),
             client: Arc::clone(&client),
             pot_verifier: pot_verifier.clone(),
-            executor: executor.clone(),
             domains_executor: Arc::new(domains_executor),
             backend: backend.clone(),
             _pos_table: PhantomData,

--- a/domains/primitives/messenger-host-functions/src/host_functions.rs
+++ b/domains/primitives/messenger-host-functions/src/host_functions.rs
@@ -32,17 +32,17 @@ impl MessengerExtension {
 /// Implementation of Messenger host function.
 pub struct MessengerHostFunctionsImpl<Block, Client, DomainBlock, Executor> {
     consensus_client: Arc<Client>,
-    executor: Arc<Executor>,
+    domain_executor: Arc<Executor>,
     _phantom: PhantomData<(Block, DomainBlock)>,
 }
 
 impl<Block, Client, DomainBlock, Executor>
     MessengerHostFunctionsImpl<Block, Client, DomainBlock, Executor>
 {
-    pub fn new(consensus_client: Arc<Client>, executor: Arc<Executor>) -> Self {
+    pub fn new(consensus_client: Arc<Client>, domain_executor: Arc<Executor>) -> Self {
         MessengerHostFunctionsImpl {
             consensus_client,
-            executor,
+            domain_executor,
             _phantom: Default::default(),
         }
     }
@@ -81,8 +81,10 @@ where
             .ok()
             .flatten()
             .map(|(data, _)| data.raw_genesis.into_storage())?;
-        let mut domain_stateless_runtime =
-            StatelessRuntime::<DomainBlock, _>::new(self.executor.clone(), domain_runtime.into());
+        let mut domain_stateless_runtime = StatelessRuntime::<DomainBlock, _>::new(
+            self.domain_executor.clone(),
+            domain_runtime.into(),
+        );
 
         domain_stateless_runtime.set_storage(domain_state);
         Some(domain_stateless_runtime)


### PR DESCRIPTION
In main when the consensus node verifies XDM it will fail with the following error:
```
2024-06-14T10:49:50.939598Z DEBUG cross_chain_gossip_worker: Incoming cross chain message for chain from Relayer: Consensus
2024-06-14T10:49:50.939716Z DEBUG domain_message_listener: Extrinsic received for Chain: Consensus
2024-06-14T10:49:50.939728Z DEBUG domain_message_listener: Submitting extrinsic to tx pool at block: 0x48b8596d7b992e18dc9a8cf8fa96edbdaa09579ee55f7e401d10ef60ea2f1231
thread 'tokio-runtime-worker' panicked at ./subspace/domains/primitives/messenger-host-functions/src/host_functions.rs:140:10:
Runtime Api should not fail in host function, there is no recovery from this; qed.: Application("failed to read domain runtime version: Other error happened while constructing the runtime: runtime requires function imports which are not present on the host: 'env:ext_domain_mmr_runtime_interface_verify_mmr_proof_version_1'")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

due to the host function `env:ext_domain_mmr_runtime_interface_verify_mmr_proof_version_1` not present when calling a stateless domain runtime API `inbox_response_storage_key`, in fact calling any domain runtime API will fail the same error even all of these runtime API doesn't tough this host function at all.

Looking into more detail in the upstream, it seems as long as a host function is imported into the runtime code, it is required when instantiating the runtime no matter the host function is used or not. And in main, we are actually using the consensus executor in `MessengerHostFunctionsImpl` which doesn't include the `verify_mmr_proof` host function (in the integration test and FP host function we are using the domain executor so we didn't get this issue when running the test and the malicious operator):
https://github.com/subspace/subspace/blob/faa7a3fa7c7e6d27aa94af0237c36e6307fcab81/crates/subspace-service/src/lib.rs#L403-L408

This PR fixes the issue by ensuring the domain executor is used in both the `MessengerHostFunctionsImpl` and `FraudProofHostFunctionsImpl` when executing the domain runtime code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
