### PR TITLE
Faster piece getting via RPC

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -531,7 +531,7 @@ where
             debug!(%segment_index, "Downloading potentially useful pieces");
 
             // We do not insert pieces into cache/heap yet, so we don't know if all of these pieces
-            // will be included, but there is a good chance they will be and we want to acknowledge
+            // will be included, but there is a good chance they will be, and we want to acknowledge
             // new segment header as soon as possible
             let pieces_to_maybe_include = segment_index
                 .segment_piece_indexes()


### PR DESCRIPTION
JSON decoding is apparently quite costly for pieces, so new archived segment causes head-of-line blocking on RPC connection and apparently this results in some subscriptions to silently break somewhere in jsonrpsee (see https://github.com/paritytech/jsonrpsee/issues/1409). Not sure what breaks, where or why, but this change makes a lot of sense either way.

Before:
```
2024-06-15T19:08:06.603299Z  INFO subspace_farmer::farmer_cache: Synchronizing piece cache
2024-06-15T19:08:08.105973Z  INFO subspace_farmer::farmer_cache: Finished piece cache synchronization
```

After:
```
2024-06-15T19:04:43.315030Z  INFO subspace_farmer::farmer_cache: Synchronizing piece cache
2024-06-15T19:04:43.793678Z  INFO subspace_farmer::farmer_cache: Finished piece cache synchronization
```

So even with fresh farmer in dev network initial piece cache sync is measurably faster. We'll see if this is sufficient, didn't want to use `tokio::task::spawn_blocking` here (though it is an option if we want to offload decoding compute out of async code completely).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
