### PR TITLE
Fix farming cluster forwarders and identification intervals

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
@@ -188,12 +188,8 @@ pub(super) async fn cache(
                         nats_client,
                         &caches,
                         &cache_group,
-                        // Only one of the tasks needs to send periodic broadcast
-                        if index == 0 {
-                            CACHE_IDENTIFICATION_BROADCAST_INTERVAL
-                        } else {
-                            Duration::MAX
-                        },
+                        CACHE_IDENTIFICATION_BROADCAST_INTERVAL,
+                        index == 0,
                     )
                     .await
                 }),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -196,7 +196,7 @@ pub(super) async fn controller(
     )?;
 
     let mut controller_services = (0..service_instances.get())
-        .map(|_| {
+        .map(|index| {
             let nats_client = nats_client.clone();
             let node_client = node_client.clone();
             let piece_getter = piece_getter.clone();
@@ -211,6 +211,7 @@ pub(super) async fn controller(
                         &piece_getter,
                         &farmer_cache,
                         &instance,
+                        index == 0,
                     )
                     .await
                 }),

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -367,12 +367,8 @@ where
                 tokio::spawn(farmer_service(
                     nats_client.clone(),
                     farms.as_slice(),
-                    // Only one of the tasks needs to send periodic broadcast
-                    if index == 0 {
-                        FARMER_IDENTIFICATION_BROADCAST_INTERVAL
-                    } else {
-                        Duration::MAX
-                    },
+                    FARMER_IDENTIFICATION_BROADCAST_INTERVAL,
+                    index == 0,
                 )),
                 true,
             )

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,5 +1,6 @@
 #![feature(
     const_option,
+    duration_constructors,
     extract_if,
     hash_extract_if,
     let_chains,

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -492,39 +492,57 @@ pub async fn controller_service<NC, PG>(
     piece_getter: &PG,
     farmer_cache: &FarmerCache,
     instance: &str,
+    primary_instance: bool,
 ) -> anyhow::Result<()>
 where
     NC: NodeClient,
     PG: PieceGetter + Sync,
 {
-    select! {
-        result = slot_info_broadcaster(nats_client, node_client, instance).fuse() => {
-            result
-        },
-        result = reward_signing_broadcaster(nats_client, node_client, instance).fuse() => {
-            result
-        },
-        result = archived_segment_headers_broadcaster(nats_client, node_client, instance).fuse() => {
-            result
-        },
-        result = solution_response_forwarder(nats_client, node_client, instance).fuse() => {
-            result
-        },
-        result = reward_signature_forwarder(nats_client, node_client, instance).fuse() => {
-            result
-        },
-        result = farmer_app_info_responder(nats_client, node_client).fuse() => {
-            result
-        },
-        result = segment_headers_responder(nats_client, node_client).fuse() => {
-            result
-        },
-        result = find_piece_responder(nats_client, farmer_cache).fuse() => {
-            result
-        },
-        result = piece_responder(nats_client, piece_getter).fuse() => {
-            result
-        },
+    if primary_instance {
+        select! {
+            result = slot_info_broadcaster(nats_client, node_client, instance).fuse() => {
+                result
+            },
+            result = reward_signing_broadcaster(nats_client, node_client, instance).fuse() => {
+                result
+            },
+            result = archived_segment_headers_broadcaster(nats_client, node_client, instance).fuse() => {
+                result
+            },
+            result = solution_response_forwarder(nats_client, node_client, instance).fuse() => {
+                result
+            },
+            result = reward_signature_forwarder(nats_client, node_client, instance).fuse() => {
+                result
+            },
+            result = farmer_app_info_responder(nats_client, node_client).fuse() => {
+                result
+            },
+            result = segment_headers_responder(nats_client, node_client).fuse() => {
+                result
+            },
+            result = find_piece_responder(nats_client, farmer_cache).fuse() => {
+                result
+            },
+            result = piece_responder(nats_client, piece_getter).fuse() => {
+                result
+            },
+        }
+    } else {
+        select! {
+            result = farmer_app_info_responder(nats_client, node_client).fuse() => {
+                result
+            },
+            result = segment_headers_responder(nats_client, node_client).fuse() => {
+                result
+            },
+            result = find_piece_responder(nats_client, farmer_cache).fuse() => {
+                result
+            },
+            result = piece_responder(nats_client, piece_getter).fuse() => {
+                result
+            },
+        }
     }
 }
 

--- a/crates/subspace-farmer/src/cluster/nats_client.rs
+++ b/crates/subspace-farmer/src/cluster/nats_client.rs
@@ -674,6 +674,7 @@ impl NatsClient {
                             );
                             if received_index != expected_index {
                                 warn!(
+                                    %response_subject,
                                     %received_index,
                                     %expected_index,
                                     request_type = %type_name::<Request>(),
@@ -685,6 +686,7 @@ impl NatsClient {
                             }
                         } else {
                             warn!(
+                                %response_subject,
                                 request_type = %type_name::<Request>(),
                                 response_type = %type_name::<Request::Response>(),
                                 message = %hex::encode(message.payload),
@@ -695,6 +697,7 @@ impl NatsClient {
                     }
                     Ok(None) => {
                         warn!(
+                            %response_subject,
                             request_type = %type_name::<Request>(),
                             response_type = %type_name::<Request::Response>(),
                             "Acknowledgement stream ended unexpectedly"
@@ -703,6 +706,8 @@ impl NatsClient {
                     }
                     Err(_error) => {
                         warn!(
+                            %response_subject,
+                            %expected_index,
                             request_type = %type_name::<Request>(),
                             response_type = %type_name::<Request::Response>(),
                             "Acknowledgement wait timed out"


### PR DESCRIPTION
This fixes two issues:
* `Duration::MAX` support in last tokio release wasn't fixed fully, which this PR avoids in the first place
* Broadcasts are avoided in all threads except one after https://github.com/subspace/subspace/pull/2849 to avoid extra load and unnecessary message duplication (like the same reward being signed tens of times)

I also removed multi-threading from plotter. While nice for consistency, it was useless in that context.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
