### PR TITLE
Node client optimization

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 #v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Remove once Substrate upgrades libp2p and we no longer have rustls 0.20.9 in our dependencies
-          ignore: RUSTSEC-2024-0336
+          # TODO: Remove once Substrate upgrades libp2p and we no longer have rustls 0.20.9 and curve25519-dalek 3.2.0
+          #  in our dependencies: https://github.com/paritytech/polkadot-sdk/pull/1631
+          ignore: RUSTSEC-2024-0336,RUSTSEC-2024-0344

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,16 +2311,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle 2.5.0",
  "zeroize",
@@ -3061,7 +3060,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -5715,9 +5714,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -6240,7 +6239,7 @@ checksum = "8ecd0545ce077f6ea5434bcb76e8d0fe942693b4380aaad0d34a358c2bd05793"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "futures",
  "libp2p-core 0.41.2",
  "libp2p-identity 0.2.8",
@@ -7056,7 +7055,7 @@ dependencies = [
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "c2-chacha",
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "either",
  "hashlink",
  "lioness",
@@ -8380,9 +8379,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -8391,9 +8390,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -8401,9 +8400,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -8414,9 +8413,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -8497,12 +8496,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "plotters"
@@ -10940,7 +10933,7 @@ dependencies = [
  "aead",
  "arrayref",
  "arrayvec",
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "getrandom_or_panic",
  "merlin",
  "rand_core 0.6.4",
@@ -11350,7 +11343,7 @@ dependencies = [
  "aes-gcm",
  "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring 0.17.8",
  "rustc_version",
@@ -12175,7 +12168,7 @@ version = "10.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
 dependencies = [
  "aes-gcm",
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
@@ -14953,7 +14946,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.1.2",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12628,6 +12628,7 @@ dependencies = [
  "thiserror",
  "thread-priority",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber 0.3.18",
  "ulid",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -61,6 +61,7 @@ tempfile = "3.10.1"
 thiserror = "1.0.59"
 thread-priority = "1.1.0"
 tokio = { version = "1.38.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
+tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ulid = { version = "1.1.2", features = ["serde"] }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -25,6 +25,7 @@ use subspace_farmer::farm::plotted_pieces::PlottedPieces;
 use subspace_farmer::farmer_cache::FarmerCache;
 use subspace_farmer::farmer_piece_getter::piece_validator::SegmentCommitmentPieceValidator;
 use subspace_farmer::farmer_piece_getter::{DsnCacheRetryPolicy, FarmerPieceGetter};
+use subspace_farmer::node_client::caching_proxy_node_client::CachingProxyNodeClient;
 use subspace_farmer::node_client::rpc_node_client::RpcNodeClient;
 use subspace_farmer::node_client::NodeClient;
 use subspace_farmer::single_disk_farm::identity::Identity;
@@ -158,6 +159,10 @@ pub(super) async fn controller(
         )
         .map_err(|error| anyhow!("Failed to configure networking: {error}"))?
     };
+
+    let node_client = CachingProxyNodeClient::new(node_client)
+        .await
+        .map_err(|error| anyhow!("Failed to create caching proxy node client: {error}"))?;
 
     let kzg = Kzg::new(embedded_kzg_settings());
     let validator = Some(SegmentCommitmentPieceValidator::new(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -24,6 +24,7 @@ use subspace_farmer::cluster::plotter::ClusterPlotter;
 use subspace_farmer::farm::{
     Farm, FarmingNotification, SectorExpirationDetails, SectorPlottingDetails, SectorUpdate,
 };
+use subspace_farmer::node_client::caching_proxy_node_client::CachingProxyNodeClient;
 use subspace_farmer::node_client::NodeClient;
 use subspace_farmer::single_disk_farm::{
     SingleDiskFarm, SingleDiskFarmError, SingleDiskFarmOptions,
@@ -171,9 +172,13 @@ where
         None
     };
 
-    let node_client = ClusterNodeClient::new(nats_client.clone())
-        .await
-        .map_err(|error| anyhow!("Failed to create cluster node client: {error}"))?;
+    let node_client = CachingProxyNodeClient::new(
+        ClusterNodeClient::new(nats_client.clone())
+            .await
+            .map_err(|error| anyhow!("Failed to create cluster node client: {error}"))?,
+    )
+    .await
+    .map_err(|error| anyhow!("Failed to create caching proxy node client: {error}"))?;
 
     let farmer_app_info = node_client
         .farmer_app_info()

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -30,6 +30,7 @@ use subspace_farmer::farm::{
 use subspace_farmer::farmer_cache::FarmerCache;
 use subspace_farmer::farmer_piece_getter::piece_validator::SegmentCommitmentPieceValidator;
 use subspace_farmer::farmer_piece_getter::{DsnCacheRetryPolicy, FarmerPieceGetter};
+use subspace_farmer::node_client::caching_proxy_node_client::CachingProxyNodeClient;
 use subspace_farmer::node_client::rpc_node_client::RpcNodeClient;
 use subspace_farmer::node_client::NodeClient;
 use subspace_farmer::plotter::cpu::CpuPlotter;
@@ -367,6 +368,10 @@ where
         )
         .map_err(|error| anyhow!("Failed to configure networking: {error}"))?
     };
+
+    let node_client = CachingProxyNodeClient::new(node_client)
+        .await
+        .map_err(|error| anyhow!("Failed to create caching proxy node client: {error}"))?;
 
     let _prometheus_worker = if should_start_prometheus_server {
         let prometheus_task = start_prometheus_metrics_server(

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -8,6 +8,7 @@
 //! middleware or even wired without network directly if node and farmer are both running in the
 //! same process.
 
+pub mod caching_proxy_node_client;
 pub mod rpc_node_client;
 
 use async_trait::async_trait;

--- a/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -1,0 +1,216 @@
+//! Node client wrapper around another node client that caches some data for better performance and
+//! proxies other requests through
+
+use crate::node_client::{Error as RpcError, Error, NodeClient};
+use crate::utils::AsyncJoinOnDrop;
+use async_lock::RwLock as AsyncRwLock;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use std::pin::Pin;
+use std::sync::Arc;
+use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
+use subspace_rpc_primitives::{
+    FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
+    MAX_SEGMENT_HEADERS_PER_REQUEST,
+};
+use tracing::{info, trace, warn};
+
+async fn sync_segment_headers<NC>(
+    segment_headers: &mut Vec<SegmentHeader>,
+    client: &NC,
+) -> Result<(), Error>
+where
+    NC: NodeClient,
+{
+    let mut segment_index_offset = SegmentIndex::from(segment_headers.len() as u64);
+    let segment_index_step = SegmentIndex::from(MAX_SEGMENT_HEADERS_PER_REQUEST as u64);
+
+    'outer: loop {
+        let from = segment_index_offset;
+        let to = segment_index_offset + segment_index_step;
+        trace!(%from, %to, "Requesting segment headers");
+
+        for maybe_segment_header in client
+            .segment_headers((from..to).collect::<Vec<_>>())
+            .await
+            .map_err(|error| {
+                format!("Failed to download segment headers {from}..{to} from node: {error}")
+            })?
+        {
+            let Some(segment_header) = maybe_segment_header else {
+                // Reached non-existent segment header
+                break 'outer;
+            };
+
+            if segment_headers.len() == u64::from(segment_header.segment_index()) as usize {
+                segment_headers.push(segment_header);
+            }
+        }
+
+        segment_index_offset += segment_index_step;
+    }
+
+    Ok(())
+}
+
+/// Node client wrapper around another node client that caches some data for better performance and
+/// proxies other requests through.
+///
+/// NOTE: Archived segment acknowledgement is ignored in this client, all subscriptions are
+/// acknowledged implicitly and immediately.
+#[derive(Debug, Clone)]
+pub struct CachingProxyNodeClient<NC> {
+    inner: NC,
+    segment_headers: Arc<AsyncRwLock<Vec<SegmentHeader>>>,
+    _background_task: Arc<AsyncJoinOnDrop<()>>,
+}
+
+impl<NC> CachingProxyNodeClient<NC>
+where
+    NC: NodeClient + Clone,
+{
+    /// Create a new instance
+    pub async fn new(client: NC) -> Result<Self, Error> {
+        let mut segment_headers = Vec::<SegmentHeader>::new();
+        let mut archived_segments_notifications =
+            client.subscribe_archived_segment_headers().await?;
+
+        info!("Downloading all segment headers from node...");
+        sync_segment_headers(&mut segment_headers, &client).await?;
+        info!("Downloaded all segment headers from node successfully");
+
+        let segment_headers = Arc::new(AsyncRwLock::new(segment_headers));
+        let background_task = tokio::spawn({
+            let client = client.clone();
+            let segment_headers = Arc::clone(&segment_headers);
+
+            async move {
+                while let Some(archived_segment_header) =
+                    archived_segments_notifications.next().await
+                {
+                    trace!(
+                        ?archived_segment_header,
+                        "New archived archived segment header notification"
+                    );
+
+                    let mut segment_headers = segment_headers.write().await;
+                    if segment_headers.len()
+                        == u64::from(archived_segment_header.segment_index()) as usize
+                    {
+                        segment_headers.push(archived_segment_header);
+                    }
+
+                    while let Err(error) = client
+                        .acknowledge_archived_segment_header(
+                            archived_segment_header.segment_index(),
+                        )
+                        .await
+                    {
+                        warn!(
+                            %error,
+                            "Failed to acknowledge archived segment header, trying again"
+                        );
+                    }
+                }
+            }
+        });
+
+        let node_client = Self {
+            inner: client,
+            segment_headers,
+            _background_task: Arc::new(AsyncJoinOnDrop::new(background_task, true)),
+        };
+
+        Ok(node_client)
+    }
+}
+
+#[async_trait]
+impl<NC> NodeClient for CachingProxyNodeClient<NC>
+where
+    NC: NodeClient,
+{
+    async fn farmer_app_info(&self) -> Result<FarmerAppInfo, Error> {
+        self.inner.farmer_app_info().await
+    }
+
+    async fn subscribe_slot_info(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, RpcError> {
+        self.inner.subscribe_slot_info().await
+    }
+
+    async fn submit_solution_response(
+        &self,
+        solution_response: SolutionResponse,
+    ) -> Result<(), RpcError> {
+        self.inner.submit_solution_response(solution_response).await
+    }
+
+    async fn subscribe_reward_signing(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, RpcError> {
+        self.inner.subscribe_reward_signing().await
+    }
+
+    /// Submit a block signature
+    async fn submit_reward_signature(
+        &self,
+        reward_signature: RewardSignatureResponse,
+    ) -> Result<(), RpcError> {
+        self.inner.submit_reward_signature(reward_signature).await
+    }
+
+    async fn subscribe_archived_segment_headers(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = SegmentHeader> + Send + 'static>>, RpcError> {
+        self.inner.subscribe_archived_segment_headers().await
+    }
+
+    async fn segment_headers(
+        &self,
+        segment_indices: Vec<SegmentIndex>,
+    ) -> Result<Vec<Option<SegmentHeader>>, RpcError> {
+        let retrieved_segment_headers = {
+            let segment_headers = self.segment_headers.read().await;
+
+            segment_indices
+                .iter()
+                .map(|segment_index| {
+                    segment_headers
+                        .get(u64::from(*segment_index) as usize)
+                        .copied()
+                })
+                .collect::<Vec<_>>()
+        };
+
+        if retrieved_segment_headers.iter().all(Option::is_some) {
+            Ok(retrieved_segment_headers)
+        } else {
+            // Re-sync segment headers
+            let mut segment_headers = self.segment_headers.write().await;
+            sync_segment_headers(&mut segment_headers, &self.inner).await?;
+
+            Ok(segment_indices
+                .iter()
+                .map(|segment_index| {
+                    segment_headers
+                        .get(u64::from(*segment_index) as usize)
+                        .copied()
+                })
+                .collect::<Vec<_>>())
+        }
+    }
+
+    async fn piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, RpcError> {
+        self.inner.piece(piece_index).await
+    }
+
+    async fn acknowledge_archived_segment_header(
+        &self,
+        _segment_index: SegmentIndex,
+    ) -> Result<(), Error> {
+        // Not supported
+        Ok(())
+    }
+}


### PR DESCRIPTION
There were numerous issues related to how much we're loading node client connection with subscriptions and requests. This PR attempts to de-duplicate some of the logic under single proxy wrapper and add more caching there, such that very few subscriptions and requests are actually made to node (or controller), optimizing load on node RPC and controller massively.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
