### PR TITLE
Force EVM test runtime with `release` profile to get compressed compacted wasm

### DIFF
--- a/domains/test/runtime/evm/build.rs
+++ b/domains/test/runtime/evm/build.rs
@@ -3,6 +3,7 @@ fn main() {
     {
         // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
         std::env::set_var("CFLAGS", "-mcpu=mvp");
+        std::env::set_var("WASM_BUILD_TYPE", "release");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()


### PR DESCRIPTION
Force EVM test runtime with `release` profile to get compressed compacted wasm

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
