### PR TITLE
Check the max domain block proof size when instantiating domain

### DIFF
--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -166,7 +166,9 @@ pub(crate) fn can_instantiate_domain<T: Config>(
         Error::ExceedMaxDomainBlockSize
     );
     ensure!(
-        domain_config.max_block_weight.ref_time() <= T::MaxDomainBlockWeight::get().ref_time(),
+        domain_config
+            .max_block_weight
+            .all_lte(T::MaxDomainBlockWeight::get()),
         Error::ExceedMaxDomainBlockWeight
     );
     ensure!(


### PR DESCRIPTION
Minor fix to check the proof size of `domain_config.max_block_weight` when instantiating domain since the proof size is set to realistic value in #2801.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
