### PR TITLE
Fix farming custer cache group handling

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
@@ -96,7 +96,7 @@ pub(super) async fn maintain_caches(
         (Box::pin(ready(())) as Pin<Box<dyn Future<Output = ()>>>).fuse();
 
     let cache_identify_subscription = pin!(nats_client
-        .subscribe_to_broadcasts::<ClusterCacheIdentifyBroadcast>(None, None)
+        .subscribe_to_broadcasts::<ClusterCacheIdentifyBroadcast>(Some(cache_group), None)
         .await
         .map_err(|error| anyhow!("Failed to subscribe to cache identify broadcast: {error}"))?);
 


### PR DESCRIPTION
The code was a bit... random :smiling_face_with_tear: 

It should not suse queue groups for identification (not with cache group anyway) and should use cache group as "instance" there.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
