### PR TITLE
De-duplicate farming cluster request/response handling

### DIFF
--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -360,21 +360,20 @@ where
     caches_details
         .iter()
         .map(|cache_details| async move {
-            let process = |request: ClusterCacheWritePieceRequest| async move {
-                Some(
-                    cache_details
-                        .cache
-                        .write_piece(request.offset, request.piece_index, &request.piece)
-                        .await
-                        .map_err(|error| error.to_string()),
-                )
-            };
             nats_client
                 .request_responder(
                     "write piece index",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
-                    process,
+                    |request: ClusterCacheWritePieceRequest| async move {
+                        Some(
+                            cache_details
+                                .cache
+                                .write_piece(request.offset, request.piece_index, &request.piece)
+                                .await
+                                .map_err(|error| error.to_string()),
+                        )
+                    },
                 )
                 .await
         })
@@ -394,21 +393,20 @@ where
     caches_details
         .iter()
         .map(|cache_details| async move {
-            let process = |request: ClusterCacheReadPieceIndexRequest| async move {
-                Some(
-                    cache_details
-                        .cache
-                        .read_piece_index(request.offset)
-                        .await
-                        .map_err(|error| error.to_string()),
-                )
-            };
             nats_client
                 .request_responder(
                     "read piece index",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
-                    process,
+                    |request: ClusterCacheReadPieceIndexRequest| async move {
+                        Some(
+                            cache_details
+                                .cache
+                                .read_piece_index(request.offset)
+                                .await
+                                .map_err(|error| error.to_string()),
+                        )
+                    },
                 )
                 .await
         })
@@ -428,21 +426,20 @@ where
     caches_details
         .iter()
         .map(|cache_details| async move {
-            let process = |request: ClusterCacheReadPieceRequest| async move {
-                Some(
-                    cache_details
-                        .cache
-                        .read_piece(request.offset)
-                        .await
-                        .map_err(|error| error.to_string()),
-                )
-            };
             nats_client
                 .request_responder(
                     "read piece",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
-                    process,
+                    |request: ClusterCacheReadPieceRequest| async move {
+                        Some(
+                            cache_details
+                                .cache
+                                .read_piece(request.offset)
+                                .await
+                                .map_err(|error| error.to_string()),
+                        )
+                    },
                 )
                 .await
         })

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -370,7 +370,7 @@ where
                 )
             };
             nats_client
-                .generic_subscribe_responder(
+                .request_responder(
                     "write piece index",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
@@ -404,7 +404,7 @@ where
                 )
             };
             nats_client
-                .generic_subscribe_responder(
+                .request_responder(
                     "read piece index",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
@@ -438,7 +438,7 @@ where
                 )
             };
             nats_client
-                .generic_subscribe_responder(
+                .request_responder(
                     "read piece",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -362,7 +362,6 @@ where
         .map(|cache_details| async move {
             nats_client
                 .request_responder(
-                    "write piece index",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
                     |request: ClusterCacheWritePieceRequest| async move {
@@ -395,7 +394,6 @@ where
         .map(|cache_details| async move {
             nats_client
                 .request_responder(
-                    "read piece index",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
                     |request: ClusterCacheReadPieceIndexRequest| async move {
@@ -428,7 +426,6 @@ where
         .map(|cache_details| async move {
             nats_client
                 .request_responder(
-                    "read piece",
                     Some(cache_details.cache_id_string.as_str()),
                     Some(cache_details.cache_id_string.clone()),
                     |request: ClusterCacheReadPieceRequest| async move {

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -646,7 +646,6 @@ where
 {
     nats_client
         .request_responder(
-            "farmer app info",
             None,
             Some("subspace.controller".to_string()),
             |_: ClusterControllerFarmerAppInfoRequest| async move {
@@ -670,7 +669,6 @@ where
 {
     nats_client
         .request_responder(
-            "Segment headers",
             None,
             Some("subspace.controller".to_string()),
             |request: ClusterControllerSegmentHeadersRequest| async move {
@@ -692,7 +690,6 @@ async fn find_piece_responder(
 ) -> anyhow::Result<()> {
     nats_client
         .request_responder(
-            "find piece",
             None,
             Some("subspace.controller".to_string()),
             |request: ClusterControllerFindPieceInCacheRequest| async move {
@@ -708,7 +705,6 @@ where
 {
     nats_client
         .request_responder(
-            "piece",
             None,
             Some("subspace.controller".to_string()),
             |request: ClusterControllerPieceRequest| async move {

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -654,7 +654,7 @@ where
     };
 
     nats_client
-        .generic_subscribe_responder(
+        .request_responder(
             "farmer app info",
             None,
             Some("subspace.controller".to_string()),
@@ -681,7 +681,7 @@ where
     };
 
     nats_client
-        .generic_subscribe_responder(
+        .request_responder(
             "Segment headers",
             None,
             Some("subspace.controller".to_string()),
@@ -699,7 +699,7 @@ async fn find_piece_responder(
     };
 
     nats_client
-        .generic_subscribe_responder(
+        .request_responder(
             "find piece",
             None,
             Some("subspace.controller".to_string()),
@@ -723,7 +723,7 @@ where
     };
 
     nats_client
-        .generic_subscribe_responder(
+        .request_responder(
             "piece",
             None,
             Some("subspace.controller".to_string()),

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -15,14 +15,12 @@ use crate::farmer_cache::FarmerCache;
 use crate::node_client::{Error as NodeClientError, NodeClient};
 use anyhow::anyhow;
 use async_lock::Semaphore;
-use async_nats::{HeaderValue, Message};
+use async_nats::HeaderValue;
 use async_trait::async_trait;
-use futures::stream::FuturesUnordered;
 use futures::{select, FutureExt, Stream, StreamExt};
 use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use std::error::Error;
-use std::future::{pending, Future};
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -646,69 +644,23 @@ async fn farmer_app_info_responder<NC>(
 where
     NC: NodeClient,
 {
-    // Initialize with pending future so it never ends
-    let mut processing = FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::from_iter([
-        Box::pin(pending()) as Pin<Box<_>>,
-    ]);
-
-    let subscription = nats_client
-        .queue_subscribe(
-            ClusterControllerFarmerAppInfoRequest::SUBJECT,
-            "subspace.controller".to_string(),
+    let process = |_: ClusterControllerFarmerAppInfoRequest| async move {
+        Some(
+            node_client
+                .farmer_app_info()
+                .await
+                .map_err(|error| error.to_string()),
         )
-        .await
-        .map_err(|error| anyhow!("Failed to subscribe to farmer app info requests: {error}"))?;
-    debug!(?subscription, "Farmer app info requests subscription");
-    let mut subscription = subscription.fuse();
-
-    loop {
-        select! {
-            maybe_message = subscription.next() => {
-                let Some(message) = maybe_message else {
-                    break;
-                };
-
-                // Create background task for concurrent processing
-                processing.push(Box::pin(process_farmer_app_info_request(
-                    nats_client,
-                    node_client,
-                    message,
-                )));
-            }
-            _ = processing.next() => {
-                // Nothing to do here
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn process_farmer_app_info_request<NC>(
-    nats_client: &NatsClient,
-    node_client: &NC,
-    message: Message,
-) where
-    NC: NodeClient,
-{
-    let Some(reply_subject) = message.reply else {
-        return;
     };
 
-    trace!("Farmer app info request");
-
-    let farmer_app_info: <ClusterControllerFarmerAppInfoRequest as GenericRequest>::Response =
-        node_client
-            .farmer_app_info()
-            .await
-            .map_err(|error| error.to_string());
-
-    if let Err(error) = nats_client
-        .publish(reply_subject, farmer_app_info.encode().into())
+    nats_client
+        .generic_subscribe_responder(
+            "farmer app info",
+            None,
+            Some("subspace.controller".to_string()),
+            process,
+        )
         .await
-    {
-        warn!(%error, "Failed to send farmer app info response");
-    }
 }
 
 async fn segment_headers_responder<NC>(
@@ -718,248 +670,64 @@ async fn segment_headers_responder<NC>(
 where
     NC: NodeClient,
 {
-    // Initialize with pending future so it never ends
-    let mut processing = FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::from_iter([
-        Box::pin(pending()) as Pin<Box<_>>,
-    ]);
-
-    let subscription = nats_client
-        .queue_subscribe(
-            ClusterControllerSegmentHeadersRequest::SUBJECT,
-            "subspace.controller".to_string(),
-        )
-        .await
-        .map_err(|error| anyhow!("Failed to subscribe to segment headers requests: {error}"))?;
-    debug!(?subscription, "Segment headers requests subscription");
-    let mut subscription = subscription.fuse();
-
-    loop {
-        select! {
-            maybe_message = subscription.next() => {
-                let Some(message) = maybe_message else {
-                    break;
-                };
-
-                // Create background task for concurrent processing
-                processing.push(Box::pin(process_segment_headers_request(
-                    nats_client,
-                    node_client,
-                    message,
-                )));
-            }
-            _ = processing.next() => {
-                // Nothing to do here
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn process_segment_headers_request<NC>(
-    nats_client: &NatsClient,
-    node_client: &NC,
-    message: Message,
-) where
-    NC: NodeClient,
-{
-    let Some(reply_subject) = message.reply else {
-        return;
-    };
-
-    let request =
-        match ClusterControllerSegmentHeadersRequest::decode(&mut message.payload.as_ref()) {
-            Ok(request) => request,
-            Err(error) => {
-                warn!(
-                    %error,
-                    message = %hex::encode(message.payload),
-                    "Failed to decode segment headers request"
-                );
-                return;
-            }
-        };
-    trace!(?request, "Segment headers request");
-
-    let response: <ClusterControllerSegmentHeadersRequest as GenericRequest>::Response =
-        match node_client
+    let process = |request: ClusterControllerSegmentHeadersRequest| async move {
+        node_client
             .segment_headers(request.segment_indices.clone())
             .await
-        {
-            Ok(segment_headers) => segment_headers,
-            Err(error) => {
-                warn!(
-                    %error,
-                    segment_indices = ?request.segment_indices,
-                    "Failed to get segment headers"
-                );
-                return;
-            }
-        };
+            .inspect_err(|error| {
+                warn!(%error, segment_indices = ?request.segment_indices, "Failed to get segment headers");
+            })
+            .ok()
+    };
 
-    if let Err(error) = nats_client
-        .publish(reply_subject, response.encode().into())
+    nats_client
+        .generic_subscribe_responder(
+            "Segment headers",
+            None,
+            Some("subspace.controller".to_string()),
+            process,
+        )
         .await
-    {
-        warn!(%error, "Failed to send segment headers response");
-    }
 }
 
 async fn find_piece_responder(
     nats_client: &NatsClient,
     farmer_cache: &FarmerCache,
 ) -> anyhow::Result<()> {
-    // Initialize with pending future so it never ends
-    let mut processing = FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::from_iter([
-        Box::pin(pending()) as Pin<Box<_>>,
-    ]);
-
-    let subscription = nats_client
-        .queue_subscribe(
-            ClusterControllerFindPieceInCacheRequest::SUBJECT,
-            "subspace.controller".to_string(),
-        )
-        .await
-        .map_err(|error| anyhow!("Failed to subscribe to find piece requests: {error}"))?;
-    debug!(?subscription, "Find piece requests subscription");
-    let mut subscription = subscription.fuse();
-
-    loop {
-        select! {
-            maybe_message = subscription.next() => {
-                let Some(message) = maybe_message else {
-                    break;
-                };
-
-                // Create background task for concurrent processing
-                processing.push(Box::pin(process_find_piece_request(
-                    nats_client,
-                    farmer_cache,
-                    message,
-                )));
-            }
-            _ = processing.next() => {
-                // Nothing to do here
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn process_find_piece_request(
-    nats_client: &NatsClient,
-    farmer_cache: &FarmerCache,
-    message: Message,
-) {
-    let Some(reply_subject) = message.reply else {
-        return;
+    let process = |request: ClusterControllerFindPieceInCacheRequest| async move {
+        Some(farmer_cache.find_piece(request.piece_index).await)
     };
 
-    let request =
-        match ClusterControllerFindPieceInCacheRequest::decode(&mut message.payload.as_ref()) {
-            Ok(request) => request,
-            Err(error) => {
-                warn!(
-                    %error,
-                    message = %hex::encode(message.payload),
-                    "Failed to decode find piece request"
-                );
-                return;
-            }
-        };
-    trace!(?request, "Find piece request");
-
-    let maybe_retrieval_details: <ClusterControllerFindPieceInCacheRequest as GenericRequest>::Response =
-        farmer_cache.find_piece(request.piece_index).await;
-
-    if let Err(error) = nats_client
-        .publish(reply_subject, maybe_retrieval_details.encode().into())
+    nats_client
+        .generic_subscribe_responder(
+            "find piece",
+            None,
+            Some("subspace.controller".to_string()),
+            process,
+        )
         .await
-    {
-        warn!(%error, "Failed to send find piece response");
-    }
 }
 
 async fn piece_responder<PG>(nats_client: &NatsClient, piece_getter: &PG) -> anyhow::Result<()>
 where
     PG: PieceGetter + Sync,
 {
-    // Initialize with pending future so it never ends
-    let mut processing = FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::from_iter([
-        Box::pin(pending()) as Pin<Box<_>>,
-    ]);
+    let process = |request: ClusterControllerPieceRequest| async move {
+        piece_getter
+            .get_piece(request.piece_index)
+            .await
+            .inspect_err(
+                |error| warn!(%error, piece_index = %request.piece_index, "Failed to get piece"),
+            )
+            .ok()
+    };
 
-    let subscription = nats_client
-        .queue_subscribe(
-            ClusterControllerPieceRequest::SUBJECT,
-            "subspace.controller".to_string(),
+    nats_client
+        .generic_subscribe_responder(
+            "piece",
+            None,
+            Some("subspace.controller".to_string()),
+            process,
         )
         .await
-        .map_err(|error| anyhow!("Failed to subscribe to piece requests: {error}"))?;
-    debug!(?subscription, "Piece requests subscription");
-    let mut subscription = subscription.fuse();
-
-    loop {
-        select! {
-            maybe_message = subscription.next() => {
-                let Some(message) = maybe_message else {
-                    break;
-                };
-
-                // Create background task for concurrent processing
-                processing.push(Box::pin(process_piece_request(
-                    nats_client,
-                    piece_getter,
-                    message,
-                )));
-            }
-            _ = processing.next() => {
-                // Nothing to do here
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn process_piece_request<PG>(nats_client: &NatsClient, piece_getter: &PG, message: Message)
-where
-    PG: PieceGetter,
-{
-    let Some(reply_subject) = message.reply else {
-        return;
-    };
-
-    let request = match ClusterControllerPieceRequest::decode(&mut message.payload.as_ref()) {
-        Ok(request) => request,
-        Err(error) => {
-            warn!(
-                %error,
-                message = %hex::encode(message.payload),
-                "Failed to decode piece request"
-            );
-            return;
-        }
-    };
-    trace!(?request, "Piece request");
-
-    let maybe_piece: <ClusterControllerPieceRequest as GenericRequest>::Response =
-        match piece_getter.get_piece(request.piece_index).await {
-            Ok(maybe_piece) => maybe_piece,
-            Err(error) => {
-                warn!(
-                    %error,
-                    piece_index = %request.piece_index,
-                    "Failed to get piece"
-                );
-                return;
-            }
-        };
-
-    if let Err(error) = nats_client
-        .publish(reply_subject, maybe_piece.encode().into())
-        .await
-    {
-        warn!(%error, "Failed to send get piece response");
-    }
 }

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -702,7 +702,7 @@ async fn read_piece_responder(
             };
 
             nats_client
-                .generic_subscribe_responder(
+                .request_responder(
                     "read piece",
                     Some(farm_details.farm_id_string.as_str()),
                     Some(farm_details.farm_id_string.clone()),

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -690,7 +690,6 @@ async fn read_piece_responder(
         .map(|farm_details| async move {
             nats_client
                 .request_responder(
-                    "read piece",
                     Some(farm_details.farm_id_string.as_str()),
                     Some(farm_details.farm_id_string.clone()),
                     |request: ClusterFarmerReadPieceRequest| async move {

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -688,25 +688,20 @@ async fn read_piece_responder(
     farms_details
         .iter()
         .map(|farm_details| async move {
-            let process = |ClusterFarmerReadPieceRequest {
-                               sector_index,
-                               piece_offset,
-                           }| async move {
-                Some(
-                    farm_details
-                        .piece_reader
-                        .read_piece(sector_index, piece_offset)
-                        .await
-                        .map_err(|error| error.to_string()),
-                )
-            };
-
             nats_client
                 .request_responder(
                     "read piece",
                     Some(farm_details.farm_id_string.as_str()),
                     Some(farm_details.farm_id_string.clone()),
-                    process,
+                    |request: ClusterFarmerReadPieceRequest| async move {
+                        Some(
+                            farm_details
+                                .piece_reader
+                                .read_piece(request.sector_index, request.piece_offset)
+                                .await
+                                .map_err(|error| error.to_string()),
+                        )
+                    },
                 )
                 .await
         })

--- a/crates/subspace-farmer/src/cluster/nats_client.rs
+++ b/crates/subspace-farmer/src/cluster/nats_client.rs
@@ -859,7 +859,7 @@ impl NatsClient {
     /// * `instance` - Optional instance name to use in place of the `*` in the subject
     /// * `group` - The queue group name for the subscription
     /// * `process` - The function to call with the decoded request to produce a response
-    pub async fn generic_subscribe_responder<Request, F, OP>(
+    pub async fn request_responder<Request, F, OP>(
         &self,
         label: &'static str,
         instance: Option<&str>,
@@ -902,7 +902,7 @@ impl NatsClient {
                     };
 
                     // Create background task for concurrent processing
-                    processing.push(Box::pin(self.process_generic_subscribe_request(
+                    processing.push(Box::pin(self.process_request(
                         label,
                         // nats_client,
                         message,
@@ -918,7 +918,7 @@ impl NatsClient {
         Ok(())
     }
 
-    async fn process_generic_subscribe_request<Request, F, OP>(
+    async fn process_request<Request, F, OP>(
         &self,
         label: &'static str,
         message: Message,

--- a/crates/subspace-farmer/src/cluster/nats_client.rs
+++ b/crates/subspace-farmer/src/cluster/nats_client.rs
@@ -14,18 +14,21 @@
 //! * broadcasts and corresponding subscriptions (for example slot info broadcast)
 
 use crate::utils::AsyncJoinOnDrop;
+use anyhow::anyhow;
 use async_nats::{
-    Client, ConnectOptions, HeaderMap, HeaderValue, PublishError, RequestError, RequestErrorKind,
-    Subject, SubscribeError, Subscriber, ToServerAddrs,
+    Client, ConnectOptions, HeaderMap, HeaderValue, Message, PublishError, RequestError,
+    RequestErrorKind, Subject, SubscribeError, Subscriber, ToServerAddrs,
 };
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
 use derive_more::{Deref, DerefMut};
 use futures::channel::mpsc;
-use futures::{FutureExt, Stream, StreamExt};
+use futures::stream::FuturesUnordered;
+use futures::{select, FutureExt, Stream, StreamExt};
 use parity_scale_codec::{Decode, Encode};
 use std::any::type_name;
 use std::collections::VecDeque;
+use std::future::{pending, Future};
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::pin::Pin;
@@ -839,6 +842,110 @@ impl NatsClient {
             subscriber,
             _phantom: PhantomData,
         })
+    }
+
+    /// Spawn a queue responder task that will process requests from the given subject
+    /// using the provided processing function.
+    ///
+    /// This will create a subscription on the subject for the given instance (if provided)
+    /// and queue group. Incoming messages will be deserialized as the request type `GR`
+    /// and passed to the `process` function to produce a response of type `GR::Response`.
+    /// The response will then be sent back on the reply subject from the original request.
+    ///
+    /// # Arguments
+    ///
+    /// * `label` - A label to use for logging
+    /// * `nats_client` - The NATS client to use for the subscription and publishing responses
+    /// * `instance` - Optional instance name to use in place of the `*` in the subject
+    /// * `group` - The queue group name for the subscription
+    /// * `process` - The function to call with the decoded request to produce a response
+    pub async fn generic_subscribe_responder<Request, F, OP>(
+        &self,
+        label: &'static str,
+        instance: Option<&str>,
+        queue_group: Option<String>,
+        process: OP,
+    ) -> anyhow::Result<()>
+    where
+        Request: GenericRequest,
+        F: Future<Output = Option<Request::Response>> + Send,
+        OP: Fn(Request) -> F + Send + Sync,
+    {
+        // Initialize with pending future so it never ends
+        let mut processing =
+            FuturesUnordered::<Pin<Box<dyn Future<Output = ()> + Send>>>::from_iter([Box::pin(
+                pending(),
+            )
+                as Pin<Box<_>>]);
+
+        let subject = subject_with_instance(Request::SUBJECT, instance);
+        let subscription = if let Some(queue_group) = queue_group {
+            self.inner
+                .client
+                .queue_subscribe(subject, queue_group)
+                .await
+        } else {
+            self.inner.client.subscribe(subject).await
+        }
+        .map_err(|error| {
+            anyhow!("Failed to subscribe to {label} requests for  {instance:?}: {error}")
+        })?;
+
+        debug!(%label, "requests subscription");
+        let mut subscription = subscription.fuse();
+
+        loop {
+            select! {
+                maybe_message = subscription.next() => {
+                    let Some(message) = maybe_message else {
+                        break;
+                    };
+
+                    // Create background task for concurrent processing
+                    processing.push(Box::pin(self.process_generic_subscribe_request(
+                        label,
+                        // nats_client,
+                        message,
+                        &process,
+                    )));
+                }
+                _ = processing.next() => {
+                    // Nothing to do here
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn process_generic_subscribe_request<Request, F, OP>(
+        &self,
+        label: &'static str,
+        message: Message,
+        process: OP,
+    ) where
+        Request: GenericRequest,
+        F: Future<Output = Option<Request::Response>> + Send,
+        OP: Fn(Request) -> F + Send + Sync,
+    {
+        let Some(reply_subject) = message.reply else {
+            return;
+        };
+
+        let request = match Request::decode(&mut message.payload.as_ref()) {
+            Ok(request) => request,
+            Err(error) => {
+                warn!(%label, %error, message = %hex::encode(message.payload), "Failed to decode request");
+                return;
+            }
+        };
+
+        trace!(?request, %reply_subject, "{label} request");
+        if let Some(response) = process(request).await
+            && let Err(error) = self.publish(reply_subject, response.encode().into()).await
+        {
+            warn!(%label, %error, "Failed to send response");
+        }
     }
 }
 


### PR DESCRIPTION
code for nats queue subscribe responder & processer are very similar, use generics to abstract them.
This significantly reduces duplicate code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
