### PR TITLE
Domains: Revert the api function name change

### DIFF
--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1496,7 +1496,9 @@ sp_api::decl_runtime_apis! {
         fn storage_fund_account_balance(operator_id: OperatorId) -> Balance;
 
         /// Return if the domain runtime code is upgraded since `at`
-        fn is_domain_runtime_upgraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool>;
+        // TODO: change from `is_domain_runtime_updraded_since` to `is_domain_runtime_upgraded_since`
+        //  before next network
+        fn is_domain_runtime_updraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool>;
     }
 
     pub trait BundleProducerElectionApi<Balance: Encode + Decode> {

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -302,7 +302,7 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn is_domain_runtime_upgraded_since(_domain_id: DomainId, _at: NumberFor<Block>) -> Option<bool> {
+        fn is_domain_runtime_updraded_since(_domain_id: DomainId, _at: NumberFor<Block>) -> Option<bool> {
             unreachable!()
         }
     }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1242,7 +1242,7 @@ impl_runtime_apis! {
             Domains::storage_fund_account_balance(operator_id)
         }
 
-        fn is_domain_runtime_upgraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool> {
+        fn is_domain_runtime_updraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool> {
             Domains::is_domain_runtime_upgraded_since(domain_id, at)
         }
     }

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -177,7 +177,7 @@ where
                 )
             })?;
         let is_domain_runtime_upgraded_since = runtime_api
-            .is_domain_runtime_upgraded_since(best_hash, domain_id, parent_consensus_number)?
+            .is_domain_runtime_updraded_since(best_hash, domain_id, parent_consensus_number)?
             .ok_or_else(|| {
                 sp_blockchain::Error::Application(
                     "Failed to get domain runtime object".to_string().into(),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1439,7 +1439,7 @@ impl_runtime_apis! {
             Domains::storage_fund_account_balance(operator_id)
         }
 
-        fn is_domain_runtime_upgraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool> {
+        fn is_domain_runtime_updraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool> {
             Domains::is_domain_runtime_upgraded_since(domain_id, at)
         }
     }


### PR DESCRIPTION
In Previous PR #2867 , I have changed the function name of the domains api but before the PR landed, we already made a Runtime upgrade. Next release of the client will break due to this change.
Hence reverting the name change and added a TODO to correct the typo before mainnet

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
