### PR TITLE
Skip duplicate node client notifications

### DIFF
--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -239,6 +239,9 @@ impl From<SegmentIndex> for HistorySize {
 }
 
 impl HistorySize {
+    /// History size of one
+    pub const ONE: Self = Self(NonZeroU64::new(1).expect("Not zero; qed"));
+
     /// Create new instance.
     pub const fn new(value: NonZeroU64) -> Self {
         Self(value)

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -295,15 +295,28 @@ impl NodeClient for ClusterNodeClient {
     async fn subscribe_slot_info(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, NodeClientError> {
-        let last_slot_info_instance = Arc::clone(&self.last_slot_info_instance);
         let subscription = self
             .nats_client
             .subscribe_to_broadcasts::<ClusterControllerSlotInfoBroadcast>(None, None)
             .await?
-            .map(move |broadcast| {
-                *last_slot_info_instance.lock() = broadcast.instance;
+            .filter_map({
+                let mut last_slot_number = None;
+                let last_slot_info_instance = Arc::clone(&self.last_slot_info_instance);
 
-                broadcast.slot_info
+                move |broadcast| {
+                    let slot_info = broadcast.slot_info;
+
+                    let maybe_slot_info = if last_slot_number == Some(slot_info.slot_number) {
+                        None
+                    } else {
+                        last_slot_number.replace(slot_info.slot_number);
+                        *last_slot_info_instance.lock() = broadcast.instance;
+
+                        Some(slot_info)
+                    };
+
+                    async move { maybe_slot_info }
+                }
             });
 
         Ok(Box::pin(subscription))
@@ -357,7 +370,25 @@ impl NodeClient for ClusterNodeClient {
             .nats_client
             .subscribe_to_broadcasts::<ClusterControllerArchivedSegmentHeaderBroadcast>(None, None)
             .await?
-            .map(|broadcast| broadcast.archived_segment_header);
+            .filter_map({
+                let mut last_archived_segment_index = None;
+
+                move |broadcast| {
+                    let archived_segment_header = broadcast.archived_segment_header;
+                    let segment_index = archived_segment_header.segment_index();
+
+                    let maybe_archived_segment_header =
+                        if last_archived_segment_index == Some(segment_index) {
+                            None
+                        } else {
+                            last_archived_segment_index.replace(segment_index);
+
+                            Some(archived_segment_header)
+                        };
+
+                    async move { maybe_archived_segment_header }
+                }
+            });
 
         Ok(Box::pin(subscription))
     }

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -306,7 +306,9 @@ impl NodeClient for ClusterNodeClient {
                 move |broadcast| {
                     let slot_info = broadcast.slot_info;
 
-                    let maybe_slot_info = if last_slot_number == Some(slot_info.slot_number) {
+                    let maybe_slot_info = if let Some(last_slot_number) = last_slot_number
+                        && last_slot_number >= slot_info.slot_number
+                    {
                         None
                     } else {
                         last_slot_number.replace(slot_info.slot_number);
@@ -377,14 +379,16 @@ impl NodeClient for ClusterNodeClient {
                     let archived_segment_header = broadcast.archived_segment_header;
                     let segment_index = archived_segment_header.segment_index();
 
-                    let maybe_archived_segment_header =
-                        if last_archived_segment_index == Some(segment_index) {
-                            None
-                        } else {
-                            last_archived_segment_index.replace(segment_index);
+                    let maybe_archived_segment_header = if let Some(last_archived_segment_index) =
+                        last_archived_segment_index
+                        && last_archived_segment_index >= segment_index
+                    {
+                        None
+                    } else {
+                        last_archived_segment_index.replace(segment_index);
 
-                            Some(archived_segment_header)
-                        };
+                        Some(archived_segment_header)
+                    };
 
                     async move { maybe_archived_segment_header }
                 }

--- a/crates/subspace-farmer/src/cluster/nats_client.rs
+++ b/crates/subspace-farmer/src/cluster/nats_client.rs
@@ -281,7 +281,7 @@ impl<Response> StreamResponseSubscriber<Response> {
 
                 async move {
                     while let Some((subject, index)) = acknowledgement_receiver.next().await {
-                        warn!(
+                        trace!(
                             %subject,
                             %index,
                             %response_subject,

--- a/crates/subspace-farmer/src/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/cluster/plotter.rs
@@ -533,6 +533,12 @@ where
     PS: Sink<SectorPlottingProgress> + Unpin + Send + 'static,
     PS::Error: Error,
 {
+    if !matches!(response, ClusterSectorPlottingProgress::SectorChunk(_)) {
+        trace!(?response, "Processing plotting response notification");
+    } else {
+        trace!("Processing plotting response notification (sector chunk)");
+    }
+
     match response {
         ClusterSectorPlottingProgress::Occupied => {
             debug!(%free_instance, "Instance was occupied, retrying #2");

--- a/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -142,7 +142,9 @@ where
             async move {
                 let mut last_slot_number = None;
                 while let Some(slot_info) = slot_info_subscription.next().await {
-                    if last_slot_number == Some(slot_info.slot_number) {
+                    if let Some(last_slot_number) = last_slot_number
+                        && last_slot_number >= slot_info.slot_number
+                    {
                         continue;
                     }
                     last_slot_number.replace(slot_info.slot_number);
@@ -182,7 +184,9 @@ where
                         );
                     }
 
-                    if last_archived_segment_index == Some(segment_index) {
+                    if let Some(last_archived_segment_index) = last_archived_segment_index
+                        && last_archived_segment_index >= segment_index
+                    {
                         continue;
                     }
                     last_archived_segment_index.replace(segment_index);

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -107,7 +107,7 @@ impl Decode for FarmerAppInfo {
 }
 
 /// Information about new slot that just arrived
-#[derive(Debug, Copy, Clone, Encode, Decode, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Encode, Decode, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SlotInfo {
     /// Slot number


### PR DESCRIPTION
In farming cluster there is no guarantee that a single node/controller will exist, hence despite trying to de-duplicate NATS messages, there is a chance that multiple notifications will arrive. First commit de-duplicates them.

Second commit does follow-up cleanup that was only happening when the same sector was scheduled twice in a row due to duplicated notification and resulted in a loop until new segment is archived, preventing other sectors from being plotted, which to user looked like plotting was stuck.

Ignore whitespace changes for cleaner diff.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
