### PR TITLE
Fix dependency in `cross-domain-message-gossip`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.11",
+ "ahash",
  "base64 0.22.1",
  "bitflags 2.5.0",
  "brotli",
@@ -156,7 +156,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.11",
+ "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -251,17 +251,6 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle 2.6.0",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -1148,7 +1137,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-block-builder",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-genesis-builder",
  "sp-inherents",
@@ -1156,10 +1145,10 @@ dependencies = [
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
+ "sp-storage",
  "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-version",
@@ -2186,7 +2175,7 @@ name = "cross-domain-message-gossip"
 version = "0.1.0"
 dependencies = [
  "domain-block-preprocessor",
- "fp-account 1.0.0-dev (git+https://github.com/subspace/frontier?rev=0596ed9c113fa130d39e54ca3f21a3d0e0aed3be)",
+ "fp-account",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -2198,10 +2187,10 @@ dependencies = [
  "sc-utils",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "subspace-runtime-primitives",
  "thiserror",
  "tracing",
@@ -2658,10 +2647,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
  "tracing",
 ]
 
@@ -2678,18 +2667,18 @@ dependencies = [
  "sp-api",
  "sp-block-fees",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-executive",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
  "sp-inherents",
  "sp-keyring",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-timestamp",
  "sp-version",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "tracing",
@@ -2703,8 +2692,8 @@ dependencies = [
  "sc-consensus",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -2722,11 +2711,11 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-messenger",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-subspace-mmr",
  "tracing",
 ]
@@ -2766,20 +2755,20 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domain-digests",
  "sp-domains",
  "sp-domains-fraud-proof",
  "sp-inherents",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-keystore",
  "sp-messenger",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-subspace-mmr",
  "sp-transaction-pool",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-trie",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "subspace-test-primitives",
@@ -2819,9 +2808,9 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "substrate-frame-rpc-system",
 ]
 
@@ -2837,13 +2826,13 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-executive",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-tracing",
  "sp-version",
 ]
 
@@ -2852,16 +2841,16 @@ name = "domain-runtime-primitives"
 version = "0.1.0"
 dependencies = [
  "fixed-hash",
- "fp-account 1.0.0-dev (git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78916bc9e43acefde)",
+ "fp-account",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
 ]
@@ -2907,15 +2896,15 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
  "sp-messenger",
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
  "sp-subspace-mmr",
  "sp-transaction-pool",
@@ -2948,7 +2937,7 @@ dependencies = [
  "domain-service",
  "domain-test-primitives",
  "evm-domain-test-runtime",
- "fp-account 1.0.0-dev (git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78916bc9e43acefde)",
+ "fp-account",
  "fp-rpc",
  "frame-support",
  "frame-system",
@@ -2965,16 +2954,16 @@ dependencies = [
  "sc-utils",
  "serde",
  "sp-api",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-keyring",
  "sp-messenger",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
  "sp-transaction-pool",
  "subspace-runtime-primitives",
@@ -3086,20 +3075,6 @@ dependencies = [
  "sha2 0.10.8",
  "signature 2.2.0",
  "subtle 2.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "hashbrown 0.12.3",
- "hex",
- "rand_core 0.6.4",
- "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -3398,7 +3373,7 @@ version = "0.1.0"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
- "fp-account 1.0.0-dev (git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78916bc9e43acefde)",
+ "fp-account",
  "fp-rpc",
  "fp-self-contained",
  "frame-benchmarking",
@@ -3427,7 +3402,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-block-builder",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-genesis-builder",
  "sp-inherents",
@@ -3435,10 +3410,10 @@ dependencies = [
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
+ "sp-storage",
  "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-version",
@@ -3454,7 +3429,7 @@ dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
  "domain-test-primitives",
- "fp-account 1.0.0-dev (git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78916bc9e43acefde)",
+ "fp-account",
  "fp-rpc",
  "fp-self-contained",
  "frame-support",
@@ -3481,7 +3456,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-block-builder",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-genesis-builder",
  "sp-inherents",
@@ -3489,9 +3464,9 @@ dependencies = [
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
  "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-version",
@@ -3584,8 +3559,8 @@ dependencies = [
  "async-trait",
  "fp-storage",
  "parity-scale-codec",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3600,7 +3575,7 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -3618,9 +3593,9 @@ dependencies = [
  "parking_lot 0.12.3",
  "sc-client-db",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-database",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3641,7 +3616,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3685,13 +3660,13 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
  "sp-inherents",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -3710,7 +3685,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0",
+ "sp-crypto-hashing",
 ]
 
 [[package]]
@@ -3725,9 +3700,9 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sp-api",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
+ "sp-storage",
 ]
 
 [[package]]
@@ -3891,25 +3866,6 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/subspace/frontier?rev=0596ed9c113fa130d39e54ca3f21a3d0e0aed3be#0596ed9c113fa130d39e54ca3f21a3d0e0aed3be"
-dependencies = [
- "hex",
- "impl-serde",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
-]
-
-[[package]]
-name = "fp-account"
-version = "1.0.0-dev"
 source = "git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78916bc9e43acefde#4fc29bc287338e3eb51137f78916bc9e43acefde"
 dependencies = [
  "hex",
@@ -3919,10 +3875,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
 ]
 
 [[package]]
@@ -3932,8 +3888,8 @@ source = "git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78
 dependencies = [
  "ethereum",
  "parity-scale-codec",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3959,8 +3915,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3974,9 +3930,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -3988,7 +3944,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4021,13 +3977,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "static_assertions",
 ]
 
@@ -4065,18 +4021,18 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-trie",
+ "sp-wasm-interface",
  "thiserror",
  "thousands",
 ]
@@ -4093,11 +4049,11 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -4135,20 +4091,20 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
+ "sp-core",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-debug-derive",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-staking",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
  "static_assertions",
  "tt-call",
 ]
@@ -4168,7 +4124,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0",
+ "sp-crypto-hashing",
  "syn 2.0.67",
 ]
 
@@ -4206,12 +4162,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "sp-version",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-weights",
 ]
 
 [[package]]
@@ -4224,9 +4180,9 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4246,8 +4202,8 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4693,9 +4649,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4703,7 +4656,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
 ]
 
 [[package]]
@@ -4712,7 +4665,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -6852,15 +6805,6 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -7028,9 +6972,9 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-beefy",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7043,9 +6987,9 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7669,10 +7613,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7692,9 +7636,9 @@ dependencies = [
  "ring 0.17.8",
  "scale-info",
  "sp-auto-id",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "subspace-runtime-primitives",
  "x509-parser 0.16.0",
 ]
@@ -7711,8 +7655,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7725,8 +7669,8 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7741,8 +7685,8 @@ dependencies = [
  "scale-info",
  "sp-block-fees",
  "sp-domains",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7753,10 +7697,10 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7777,13 +7721,13 @@ dependencies = [
  "scale-info",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "sp-subspace-mmr",
  "sp-version",
  "subspace-core-primitives",
@@ -7808,8 +7752,8 @@ dependencies = [
  "pallet-evm",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7819,7 +7763,7 @@ source = "git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78
 dependencies = [
  "environmental",
  "evm",
- "fp-account 1.0.0-dev (git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78916bc9e43acefde)",
+ "fp-account",
  "fp-evm",
  "frame-benchmarking",
  "frame-support",
@@ -7830,9 +7774,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7854,8 +7798,8 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7883,7 +7827,7 @@ source = "git+https://github.com/subspace/frontier?rev=4fc29bc287338e3eb51137f78
 dependencies = [
  "fp-evm",
  "ripemd",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
 ]
 
 [[package]]
@@ -7894,9 +7838,9 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "subspace-core-primitives",
 ]
 
@@ -7913,12 +7857,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7934,14 +7878,14 @@ dependencies = [
  "pallet-transporter",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-messenger",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-subspace-mmr",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-trie",
 ]
 
 [[package]]
@@ -7955,11 +7899,11 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7972,9 +7916,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "subspace-core-primitives",
 ]
 
@@ -7988,10 +7932,10 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8006,9 +7950,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "subspace-runtime-primitives",
 ]
 
@@ -8021,9 +7965,9 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8045,10 +7989,10 @@ dependencies = [
  "serde",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",
@@ -8066,10 +8010,10 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
  "sp-subspace-mmr",
 ]
 
@@ -8084,9 +8028,9 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8102,10 +8046,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-storage",
  "sp-timestamp",
 ]
 
@@ -8130,10 +8074,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8146,10 +8090,10 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8160,8 +8104,8 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8175,12 +8119,12 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8193,10 +8137,10 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -9933,8 +9877,8 @@ version = "23.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "log",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-wasm-interface",
  "thiserror",
 ]
 
@@ -9954,9 +9898,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -9969,10 +9913,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -9993,13 +9937,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-crypto-hashing 0.1.0",
+ "sp-core",
+ "sp-crypto-hashing",
  "sp-genesis-builder",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -10044,11 +9988,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-keyring",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-panic-handler 13.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-keystore",
+ "sp-panic-handler",
+ "sp-runtime",
  "sp-version",
  "thiserror",
  "tokio",
@@ -10070,14 +10014,14 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-statement-store",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-storage",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10097,13 +10041,13 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-database",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10124,9 +10068,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10147,16 +10091,16 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10174,14 +10118,14 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -10210,10 +10154,10 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
  "sp-objects",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-proof-of-space",
@@ -10243,9 +10187,9 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-objects",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-farmer-components",
@@ -10265,13 +10209,13 @@ dependencies = [
  "sp-api",
  "sp-auto-id",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
+ "sp-io",
  "sp-messenger-host-functions",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-subspace-mmr",
 ]
 
@@ -10287,14 +10231,14 @@ dependencies = [
  "sc-executor-wasmtime",
  "schnellru",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-panic-handler 13.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-panic-handler",
+ "sp-runtime-interface",
+ "sp-trie",
  "sp-version",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-wasm-interface",
  "tracing",
 ]
 
@@ -10306,7 +10250,7 @@ dependencies = [
  "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
 ]
@@ -10319,7 +10263,7 @@ dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-wasm-interface",
 ]
 
 [[package]]
@@ -10335,8 +10279,8 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "wasmtime",
 ]
 
@@ -10354,7 +10298,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10365,9 +10309,9 @@ dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror",
 ]
 
@@ -10393,10 +10337,10 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-api",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-keystore",
  "sp-mixnet",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10437,10 +10381,10 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10466,7 +10410,7 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10474,7 +10418,7 @@ name = "sc-network-gossip"
 version = "0.34.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "futures",
  "futures-timer",
  "libp2p 0.51.4",
@@ -10484,7 +10428,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -10505,8 +10449,8 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -10535,12 +10479,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -10563,7 +10507,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10609,11 +10553,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -10640,7 +10584,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-consensus-subspace",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "subspace-core-primitives",
  "subspace-proof-of-time",
  "thread-priority",
@@ -10678,11 +10622,11 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
  "sp-statement-store",
  "sp-version",
@@ -10702,9 +10646,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-version",
  "thiserror",
 ]
@@ -10752,9 +10696,9 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-version",
  "thiserror",
  "tokio",
@@ -10805,16 +10749,16 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-state-machine",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-trie",
  "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
@@ -10833,7 +10777,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
 ]
 
 [[package]]
@@ -10844,7 +10788,7 @@ dependencies = [
  "clap",
  "fs4 0.7.0",
  "log",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "thiserror",
  "tokio",
 ]
@@ -10866,7 +10810,7 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-api",
  "sp-consensus-subspace",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "strum_macros 0.26.4",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -10892,10 +10836,10 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-crypto-hashing 0.1.0",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -10938,14 +10882,14 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-log 0.2.0",
- "tracing-subscriber 0.3.18",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10977,10 +10921,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-crypto-hashing 0.1.0",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -10997,8 +10941,8 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -11014,7 +10958,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "prometheus",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -11058,7 +11002,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -11561,14 +11505,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
  "sp-version",
  "thiserror",
 ]
@@ -11590,42 +11534,14 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "30.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "23.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "docify",
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "static_assertions",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -11639,7 +11555,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
  "static_assertions",
 ]
 
@@ -11667,9 +11583,9 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime-interface",
  "subspace-runtime-primitives",
  "x509-parser 0.16.0",
 ]
@@ -11681,7 +11597,7 @@ source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce
 dependencies = [
  "sp-api",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11692,7 +11608,7 @@ dependencies = [
  "domain-runtime-primitives",
  "parity-scale-codec",
  "sp-inherents",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11708,8 +11624,8 @@ dependencies = [
  "sp-api",
  "sp-consensus",
  "sp-database",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -11721,10 +11637,10 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror",
 ]
 
@@ -11737,10 +11653,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
  "sp-consensus-slots",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -11754,13 +11670,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-crypto-hashing 0.1.0",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-io",
+ "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "strum 0.26.2",
 ]
 
@@ -11775,10 +11691,10 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11802,67 +11718,20 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
  "sp-inherents",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
  "sp-timestamp",
  "subspace-core-primitives",
  "subspace-proof-of-space",
  "subspace-verification",
  "thiserror",
-]
-
-[[package]]
-name = "sp-core"
-version = "28.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "array-bytes",
- "bandersnatch_vrfs",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections",
- "bs58 0.5.1",
- "dyn-clonable",
- "ed25519-zebra 3.1.0",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.10.5",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "paste",
- "primitive-types",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "serde",
- "sp-crypto-hashing 0.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "ss58-registry",
- "substrate-bip39 0.4.7 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "thiserror",
- "tracing",
- "w3f-bls",
- "zeroize",
 ]
 
 [[package]]
@@ -11877,7 +11746,7 @@ dependencies = [
  "bounded-collections",
  "bs58 0.5.1",
  "dyn-clonable",
- "ed25519-zebra 4.0.3",
+ "ed25519-zebra",
  "futures",
  "hash-db",
  "hash256-std-hasher",
@@ -11898,14 +11767,14 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde",
- "sp-crypto-hashing 0.1.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.4.7 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "substrate-bip39 0.4.7",
  "thiserror",
  "tracing",
  "w3f-bls",
@@ -11929,20 +11798,7 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-crypto-hashing"
-version = "0.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.10.7",
- "sha2 0.10.8",
- "sha3",
- "twox-hash",
+ "sp-runtime-interface",
 ]
 
 [[package]]
@@ -11964,7 +11820,7 @@ version = "0.1.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0",
+ "sp-crypto-hashing",
  "syn 2.0.67",
 ]
 
@@ -11975,16 +11831,6 @@ source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.67",
 ]
 
 [[package]]
@@ -12002,7 +11848,7 @@ name = "sp-domain-digests"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12023,18 +11869,18 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
  "sp-version",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -12069,18 +11915,18 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus-slots",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domain-digests",
  "sp-domains",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
  "sp-subspace-mmr",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-trie",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-runtime-primitives",
  "subspace-test-client",
@@ -12088,7 +11934,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -12103,21 +11949,11 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-storage",
 ]
 
 [[package]]
@@ -12129,7 +11965,7 @@ dependencies = [
  "scale-info",
  "serde_json",
  "sp-api",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12141,34 +11977,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "thiserror",
-]
-
-[[package]]
-name = "sp-io"
-version = "30.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "bytes",
- "ed25519-dalek 2.1.1",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive",
- "rustversion",
- "secp256k1",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-crypto-hashing 0.0.0",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -12184,15 +11994,15 @@ dependencies = [
  "polkavm-derive",
  "rustversion",
  "secp256k1",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-crypto-hashing 0.1.0",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -12202,20 +12012,9 @@ name = "sp-keyring"
 version = "31.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
  "strum 0.26.2",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.34.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
 ]
 
 [[package]]
@@ -12225,8 +12024,8 @@ source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -12250,13 +12049,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-inherents",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-subspace-mmr",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-trie",
 ]
 
 [[package]]
@@ -12269,12 +12068,12 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-runtime-interface",
 ]
 
 [[package]]
@@ -12295,7 +12094,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -12309,9 +12108,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-debug-derive",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -12330,18 +12129,8 @@ version = "26.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "13.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "backtrace",
- "lazy_static",
- "regex",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12361,31 +12150,7 @@ source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce
 dependencies = [
  "rustc-hash",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "31.0.1"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
+ "sp-core",
 ]
 
 [[package]]
@@ -12405,31 +12170,12 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive",
- "primitive-types",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "static_assertions",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "sp-weights",
 ]
 
 [[package]]
@@ -12442,26 +12188,13 @@ dependencies = [
  "parity-scale-codec",
  "polkavm-derive",
  "primitive-types",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-storage 19.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-tracing 16.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.1.0",
- "proc-macro2",
- "quote",
- "syn 2.0.67",
 ]
 
 [[package]]
@@ -12485,9 +12218,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
  "sp-staking",
 ]
 
@@ -12500,28 +12233,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.35.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "smallvec",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-panic-handler 13.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "thiserror",
- "tracing",
- "trie-db 0.28.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12535,13 +12248,13 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "smallvec",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-panic-handler 13.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie",
  "thiserror",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -12558,12 +12271,12 @@ dependencies = [
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-crypto-hashing 0.1.0",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-runtime-interface",
  "thiserror",
  "x25519-dalek 2.0.1",
 ]
@@ -12571,24 +12284,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-
-[[package]]
-name = "sp-std"
-version = "14.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
-]
 
 [[package]]
 name = "sp-storage"
@@ -12599,7 +12295,7 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -12610,11 +12306,11 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-runtime-interface",
  "subspace-core-primitives",
 ]
 
@@ -12626,19 +12322,8 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "thiserror",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -12649,7 +12334,7 @@ dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -12658,7 +12343,7 @@ version = "26.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "sp-api",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12669,33 +12354,10 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-trie 29.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
-]
-
-[[package]]
-name = "sp-trie"
-version = "29.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "thiserror",
- "tracing",
- "trie-db 0.28.0",
- "trie-root",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -12703,7 +12365,7 @@ name = "sp-trie"
 version = "29.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "hash-db",
  "lazy_static",
  "memory-db",
@@ -12713,11 +12375,11 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-externalities",
  "thiserror",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
  "trie-root",
 ]
 
@@ -12732,8 +12394,8 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
+ "sp-std",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -12752,16 +12414,6 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "20.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "anyhow",
@@ -12774,20 +12426,6 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6)",
-]
-
-[[package]]
-name = "sp-weights"
-version = "27.0.0"
 source = "git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f#98914adb256fed32c13ce251c5b4c9972af8ea0f"
 dependencies = [
  "bounded-collections",
@@ -12795,8 +12433,8 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-debug-derive 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-arithmetic",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -13009,7 +12647,7 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
  "sp-genesis-builder",
@@ -13017,7 +12655,7 @@ dependencies = [
  "sp-messenger",
  "sp-objects",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
  "sp-transaction-pool",
  "sp-version",
@@ -13080,7 +12718,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
  "ulid",
  "zeroize",
 ]
@@ -13161,15 +12799,15 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domain-digests",
  "sp-domains",
  "sp-keyring",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-keystore",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-transaction-pool",
- "sp-weights 27.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-weights",
  "subspace-core-primitives",
  "subspace-networking",
  "subspace-proof-of-space",
@@ -13225,7 +12863,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
  "unsigned-varint 0.8.0",
  "void",
 ]
@@ -13277,13 +12915,13 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domain-digests",
  "sp-domains",
  "sp-domains-fraud-proof",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-keystore",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "subspace-core-primitives",
  "subspace-metrics",
  "subspace-networking",
@@ -13299,7 +12937,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -13379,20 +13017,20 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-io",
  "sp-messenger",
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
  "sp-objects",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
  "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-version",
@@ -13411,9 +13049,9 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "subspace-core-primitives",
 ]
 
@@ -13467,17 +13105,17 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-io 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
+ "sp-io",
  "sp-messenger",
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
  "sp-objects",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
  "sp-subspace-mmr",
  "sp-timestamp",
@@ -13512,9 +13150,9 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-erasure-coding",
@@ -13532,10 +13170,10 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-messenger",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-subspace-mmr",
  "subspace-runtime-primitives",
 ]
@@ -13572,7 +13210,7 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
  "sp-genesis-builder",
@@ -13582,9 +13220,9 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-objects",
  "sp-offchain",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-std",
  "sp-subspace-mmr",
  "sp-transaction-pool",
  "sp-version",
@@ -13625,21 +13263,21 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
- "sp-application-crypto 30.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-domains",
  "sp-domains-fraud-proof",
- "sp-externalities 0.25.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-externalities",
  "sp-inherents",
  "sp-keyring",
  "sp-messenger",
  "sp-messenger-host-functions",
  "sp-mmr-primitives",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-runtime",
  "sp-subspace-mmr",
  "sp-timestamp",
  "subspace-core-primitives",
@@ -13664,18 +13302,6 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-proof-of-space",
  "thiserror",
-]
-
-[[package]]
-name = "substrate-bip39"
-version = "0.4.7"
-source = "git+https://github.com/subspace/polkadot-sdk?rev=6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6#6da3c45e1d5b3c1f09b5e54152b8848149f9d5e6"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
 ]
 
 [[package]]
@@ -13723,8 +13349,8 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13758,11 +13384,11 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 28.0.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-core",
  "sp-keyring",
- "sp-keystore 0.34.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-runtime 31.0.1 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
- "sp-state-machine 0.35.0 (git+https://github.com/subspace/polkadot-sdk?rev=98914adb256fed32c13ce251c5b4c9972af8ea0f)",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
  "tokio",
 ]
 
@@ -14292,17 +13918,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -14313,44 +13928,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-serde",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers 0.1.0",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
  "parking_lot 0.12.3",
@@ -14360,20 +13943,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
-dependencies = [
- "hash-db",
- "hashbrown 0.13.2",
- "log",
- "rustc-hex",
- "smallvec",
+ "tracing-log",
 ]
 
 [[package]]

--- a/domains/client/cross-domain-message-gossip/Cargo.toml
+++ b/domains/client/cross-domain-message-gossip/Cargo.toml
@@ -12,8 +12,8 @@ include = [
 ]
 
 [dependencies]
-domain-block-preprocessor = { version = "0.1.0",  path = "../../client/block-preprocessor" }
-fp-account = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "0596ed9c113fa130d39e54ca3f21a3d0e0aed3be" }
+domain-block-preprocessor = { version = "0.1.0", path = "../../client/block-preprocessor" }
+fp-account = { version = "1.0.0-dev", git = "https://github.com/subspace/frontier", rev = "4fc29bc287338e3eb51137f78916bc9e43acefde" }
 futures = "0.3.29"
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
 parking_lot = "0.12.2"


### PR DESCRIPTION
It was pointing to the old version of Frontier and pulling a bunch of outdated dependencies, including two versions of some of the Substrate crates

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
