### PR TITLE
Prevent executor stalling during plotting

### DIFF
--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -21,7 +21,7 @@ use tempfile::tempdir;
 const FAKE_SECTOR_SIZE: usize = 2 * 1024 * 1024;
 const TARGET_SECTOR_COUNT: SectorIndex = 5;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn basic() {
     let dummy_sector_metadata = SectorMetadataChecksummed::from(SectorMetadata {
         sector_index: 0,


### PR DESCRIPTION
Users are still testing it, but I believe this is the root cause of many of our unexplainable issues on the farmer. Basically `block_in_place` needs to be called in the task itself, while it was called from a completely different thread, which likely resulted in non-deterministic tasks that share the same thread as the plotting task being stalled for the duration of the plotting process.

See https://forum.subspace.network/t/timed-out-without-ping-from-plotter/4262/12?u=nazar-pc for more details.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
