### PR TITLE
Implement support for updating PoT slot iterations with an extrinsic

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -389,11 +389,6 @@ pub mod pallet {
     pub type BlockSlots<T: Config> =
         StorageValue<_, BoundedBTreeMap<BlockNumberFor<T>, Slot, T::BlockSlotCount>, ValueQuery>;
 
-    // TODO: Clarify when this value is updated (when it is updated, right now it is not)
-    /// Number of iterations for proof of time per slot
-    #[pallet::storage]
-    pub(super) type PotSlotIterations<T> = StorageValue<_, NonZeroU32>;
-
     /// Solution ranges used for challenges.
     #[pallet::storage]
     #[pallet::getter(fn solution_ranges)]
@@ -490,6 +485,11 @@ pub mod pallet {
             (T::AccountId, FarmerSignature),
         >,
     >;
+
+    // TODO: Clarify when this value is updated (when it is updated, right now it is not)
+    /// Number of iterations for proof of time per slot
+    #[pallet::storage]
+    pub(super) type PotSlotIterations<T> = StorageValue<_, NonZeroU32>;
 
     /// Entropy that needs to be injected into proof of time chain at specific slot associated with
     /// block number it came from.

--- a/crates/pallet-subspace/src/weights.rs
+++ b/crates/pallet-subspace/src/weights.rs
@@ -37,6 +37,7 @@ pub trait WeightInfo {
 	fn vote() -> Weight;
 	fn enable_rewards() -> Weight;
 	fn enable_authoring_by_anyone() -> Weight;
+	fn set_pot_slot_iterations() -> Weight;
 }
 
 /// Weights for pallet_subspace using the Substrate node and recommended hardware.
@@ -133,6 +134,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
+	/// Storage: Subspace PotSlotIterations (r:1 w:0)
+	/// Storage: Subspace PotSlotIterationsUpdate (r:1 w:1)
+	/// Proof Skipped: Subspace PotSlotIterationsUpdate (max_values: Some(1), max_size: None, mode: Measured)
+	fn set_pot_slot_iterations() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `48`
+		//  Estimated: `1533`
+		// Minimum execution time: 6_000_000 picoseconds.
+		Weight::from_parts(6_000_000, 1533)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -227,5 +240,17 @@ impl WeightInfo for () {
 		Weight::from_parts(7_000_000, 3114)
 			.saturating_add(ParityDbWeight::get().reads(2_u64))
 			.saturating_add(ParityDbWeight::get().writes(2_u64))
+	}
+	/// Storage: Subspace PotSlotIterations (r:1 w:0)
+	/// Storage: Subspace PotSlotIterationsUpdate (r:1 w:1)
+	/// Proof Skipped: Subspace PotSlotIterationsUpdate (max_values: Some(1), max_size: None, mode: Measured)
+	fn set_pot_slot_iterations() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `48`
+		//  Estimated: `1533`
+		// Minimum execution time: 6_000_000 picoseconds.
+		Weight::from_parts(6_000_000, 1533)
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -446,6 +446,8 @@ where
             ) {
                 warn!(
                     %slot,
+                    ?pot_input,
+                    ?parent_pot_parameters,
                     "Proof of time is invalid, skipping block authoring at slot"
                 );
                 return None;

--- a/crates/sc-proof-of-time/src/source/timekeeper.rs
+++ b/crates/sc-proof-of-time/src/source/timekeeper.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use subspace_core_primitives::{PotCheckpoints, PotSeed};
 use subspace_proof_of_time::PotError;
-use tracing::debug;
+use tracing::{debug, trace};
 
 /// Proof of time slot information
 pub(super) struct TimekeeperProof {
@@ -32,6 +32,11 @@ pub(super) fn run_timekeeper(
     let mut next_slot_input = state.next_slot_input(Ordering::Acquire);
 
     loop {
+        trace!(
+            "Proving for slot {} with {} iterations",
+            next_slot_input.slot,
+            next_slot_input.slot_iterations
+        );
         let checkpoints =
             subspace_proof_of_time::prove(next_slot_input.seed, next_slot_input.slot_iterations)?;
 

--- a/crates/sp-consensus-subspace/src/lib.rs
+++ b/crates/sp-consensus-subspace/src/lib.rs
@@ -160,7 +160,7 @@ pub struct PotNextSlotInput {
 impl PotNextSlotInput {
     /// Derive next slot input while taking parameters change into account.
     ///
-    /// NOTE: base slot iterations doesn't have to be parent block, just something that is after
+    /// NOTE: `base_slot_iterations` doesn't have to be parent block, just something that is after
     /// prior parameters change (if any) took effect, in most cases this value corresponds to parent
     /// block's slot.
     pub fn derive(

--- a/crates/subspace-proof-of-time/src/lib.rs
+++ b/crates/subspace-proof-of-time/src/lib.rs
@@ -10,11 +10,11 @@ use subspace_core_primitives::{PotCheckpoints, PotOutput, PotSeed};
 #[derive(Debug)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum PotError {
-    /// Iterations is not multiple of number of checkpoints times two
+    /// Iterations are not multiple of number of checkpoints times two
     #[cfg_attr(
         feature = "thiserror",
         error(
-            "Iterations {iterations} is not multiple of number of checkpoints {num_checkpoints} \
+            "Iterations {iterations} are not multiple of number of checkpoints {num_checkpoints} \
             times two"
         )
     )]


### PR DESCRIPTION
First two commits are minor refactorings, only last one has actual changes.

While not trivial, it is not complex either. Client code is fully prepared for number of iterations to change alongside entropy, we just didn't have runtime logic for this.

In order to implement this feature I introduced `PotSlotIterationsUpdate` storage item that holds an upcoming update. It can be updated any time unless target slot is set, after which runtime will wait for change to be applied before accepting further updates, which is done to prevent timekeeper and verification code from getting conflicting inputs.

Once we initialize block we check if update needs to be applied right now, which is easy.

Since number of iterations is updated together with entropy, that is when we determine target slot at which new number of iterations taked effect. And then two places take this future update into account: when generating `PotParametersChange` digest item and returning parameters from `Pallet::pot_parameters()`.

We do not have any infrastructure for testing the runtime logic of consensus right now, so tests were only added for the new extrinsic. It worked fine from my testing with local dev chain, but eventually we should have good test coverage for this kind of stuff.

I have updated logs in a few places that were helpful for debugging purposes as well, but no client-side logic was necessary.

Resolves https://github.com/subspace/subspace/issues/2331

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
