### PR TITLE
Transporter: Ensure accounts are not reaped while transporting balance through XDM

### DIFF
--- a/domains/pallets/messenger/src/fees.rs
+++ b/domains/pallets/messenger/src/fees.rs
@@ -44,7 +44,7 @@ impl<T: Config> Pallet<T> {
         T::Currency::burn_from(
             sender,
             total_fees,
-            Preservation::Expendable,
+            Preservation::Preserve,
             Precision::Exact,
             Fortitude::Polite,
         )?;

--- a/domains/pallets/transporter/src/lib.rs
+++ b/domains/pallets/transporter/src/lib.rs
@@ -242,7 +242,7 @@ mod pallet {
                 &sender,
                 amount,
                 WithdrawReasons::TRANSFER,
-                ExistenceRequirement::AllowDeath,
+                ExistenceRequirement::KeepAlive,
             )
             .map_err(|_| Error::<T>::LowBalance)?;
 


### PR DESCRIPTION
Transporter was allowing reaping accounts of the balance goes below threshold during fund transfer. This PR ensures accounts do not get reaped while moving transfers as pointed out in Audit - https://github.com/subspace/srlabs-audit/issues/8

I have also updated the messenger to preserve the account while collecting fees for XDM.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
