### PR TITLE
Increase farm and cache identification intervals

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
@@ -17,7 +17,7 @@ use subspace_farmer::disk_piece_cache::DiskPieceCache;
 use subspace_farmer::utils::AsyncJoinOnDrop;
 
 /// Interval between cache self-identification broadcast messages
-pub(super) const CACHE_IDENTIFICATION_BROADCAST_INTERVAL: Duration = Duration::from_secs(5);
+pub(super) const CACHE_IDENTIFICATION_BROADCAST_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 struct DiskCache {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -40,7 +40,7 @@ use tracing::{error, info, info_span, warn, Instrument};
 
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);
 /// Interval between farmer self-identification broadcast messages
-pub(super) const FARMER_IDENTIFICATION_BROADCAST_INTERVAL: Duration = Duration::from_secs(5);
+pub(super) const FARMER_IDENTIFICATION_BROADCAST_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Arguments for farmer
 #[derive(Debug, Parser)]


### PR DESCRIPTION
There could be a lot of farms and identification interval measured in seconds seemed excessive.

As for caches, when one of them goes down it is undesirable, but not frequent, so should be fine to increase the interval as well to reduce number of messages sent back and forth.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
