### PR TITLE
feat: skip send archived segment notification during initial sync

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -829,15 +829,6 @@ where
         let archived_segment_notification_sender =
             subspace_link.archived_segment_notification_sender.clone();
 
-        // Farmers may have not received all previous segments, send them now.
-        for archived_segment in older_archived_segments {
-            send_archived_segment_notification(
-                &archived_segment_notification_sender,
-                archived_segment,
-            )
-            .await;
-        }
-
         while let Some(ref block_import_notification) =
             block_importing_notification_stream.next().await
         {


### PR DESCRIPTION
>  farmer will wait for initial segment headers sync on the node before doing piece cache sync itself. So we don't need those notifications strictly speaking.

close #1797 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
