### PR TITLE
Add the auto-id domain bootstrap node to chain spec

### DIFF
--- a/crates/sc-subspace-chain-specs/res/chain-spec-raw-gemini-3h.json
+++ b/crates/sc-subspace-chain-specs/res/chain-spec-raw-gemini-3h.json
@@ -18,13 +18,12 @@
   "properties": {
     "domainsBootstrapNodes": {
       "0": [
-        "/dns/bootstrap-0.nova.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWBm1PHFHAP9mA6LNd72uFimyPoo6ixjdfgajzizXDYND2"
+        "/dns/bootstrap-0.nova.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWBm1PHFHAP9mA6LNd72uFimyPoo6ixjdfgajzizXDYND2",
+        "/dns/bootstrap-1.nova.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWD3Q8JpAPoXR67ZQ1H1nXfPqCgPHCvWVcGxNKbfFmuPnu",
+        "/dns/bootstrap-2.nova.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWEYs5yikat5NanzN7c2Sb4ngxJoCro9vXMULM2ZYVWW9H"
       ],
       "1": [
-        "/dns/bootstrap-1.nova.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWD3Q8JpAPoXR67ZQ1H1nXfPqCgPHCvWVcGxNKbfFmuPnu"
-      ],
-      "2": [
-        "/dns/bootstrap-2.nova.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWEYs5yikat5NanzN7c2Sb4ngxJoCro9vXMULM2ZYVWW9H"
+        "/dns/bootstrap-0.autoid.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWFoiz2iTkmnnSqiL2oQRhGzaqgtUjYNz2jyWKQqgPXgx9"
       ]
     },
     "dsnBootstrapNodes": [


### PR DESCRIPTION
This PR adds the auto-id domain bootstrap node to the chain spec. Also, it fixes a minor issue to correctly parsing the `domainsBootstrapNodes` as `HashMap<DomainId, Vec<MultiaddrWithPeerId>`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
