### PR TITLE
Domains: Store confirmed ER instead of subset of ER fields for each domain

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -28,8 +28,8 @@ use frame_system::{Pallet as System, RawOrigin};
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_core::ByteArray;
 use sp_domains::{
-    dummy_opaque_bundle, ConfirmedDomainBlock, DomainId, ExecutionReceipt, OperatorAllowList,
-    OperatorId, OperatorPublicKey, OperatorSignature, PermissionedActionAllowedBy, RuntimeType,
+    dummy_opaque_bundle, BlockFees, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
+    OperatorPublicKey, OperatorSignature, PermissionedActionAllowedBy, RuntimeType, Transfers,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{CheckedAdd, One, Zero};
@@ -753,19 +753,26 @@ mod benchmarks {
         do_finalize_domain_epoch_staking::<T>(domain_id)
             .expect("finalize domain staking should success");
 
-        // Update the `LatestConfirmedDomainBlock` so unlock can success
+        // Update the `LatestConfirmedDomainExecutionReceipt` so unlock can success
         let confirmed_domain_block_number =
             Pallet::<T>::latest_confirmed_domain_block_number(domain_id)
                 + T::StakeWithdrawalLockingPeriod::get()
                 + One::one();
-        LatestConfirmedDomainBlock::<T>::insert(
+        LatestConfirmedDomainExecutionReceipt::<T>::insert(
             domain_id,
-            ConfirmedDomainBlock {
-                block_number: confirmed_domain_block_number,
-                block_hash: Default::default(),
-                parent_block_receipt_hash: Default::default(),
-                state_root: Default::default(),
-                extrinsics_root: Default::default(),
+            ExecutionReceiptOf::<T> {
+                domain_block_number: confirmed_domain_block_number,
+                domain_block_hash: Default::default(),
+                domain_block_extrinsic_root: Default::default(),
+                parent_domain_block_receipt_hash: Default::default(),
+                consensus_block_number: Default::default(),
+                consensus_block_hash: Default::default(),
+                inboxed_bundles: vec![],
+                final_state_root: Default::default(),
+                execution_trace: vec![],
+                execution_trace_root: Default::default(),
+                block_fees: BlockFees::default(),
+                transfers: Transfers::default(),
             },
         );
 
@@ -797,19 +804,26 @@ mod benchmarks {
             operator_id,
         ));
 
-        // Update the `LatestConfirmedDomainBlock` so unlock can success
+        // Update the `LatestConfirmedDomainExecutionReceipt` so unlock can success
         let confirmed_domain_block_number =
             Pallet::<T>::latest_confirmed_domain_block_number(domain_id)
                 + T::StakeWithdrawalLockingPeriod::get()
                 + One::one();
-        LatestConfirmedDomainBlock::<T>::insert(
+        LatestConfirmedDomainExecutionReceipt::<T>::insert(
             domain_id,
-            ConfirmedDomainBlock {
-                block_number: confirmed_domain_block_number,
-                block_hash: Default::default(),
-                parent_block_receipt_hash: Default::default(),
-                state_root: Default::default(),
-                extrinsics_root: Default::default(),
+            ExecutionReceiptOf::<T> {
+                domain_block_number: confirmed_domain_block_number,
+                domain_block_hash: Default::default(),
+                domain_block_extrinsic_root: Default::default(),
+                parent_domain_block_receipt_hash: Default::default(),
+                consensus_block_number: Default::default(),
+                consensus_block_hash: Default::default(),
+                inboxed_bundles: vec![],
+                final_state_root: Default::default(),
+                execution_trace: vec![],
+                execution_trace_root: Default::default(),
+                block_fees: BlockFees::default(),
+                transfers: Transfers::default(),
             },
         );
 

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -7,7 +7,7 @@ use crate::{
     BalanceOf, BlockTree, BlockTreeNodeFor, BlockTreeNodes, Config, ConsensusBlockHash,
     DomainBlockNumberFor, DomainHashingFor, DomainRuntimeUpgradeRecords, ExecutionInbox,
     ExecutionReceiptOf, HeadReceiptExtended, HeadReceiptNumber, InboxedBundleAuthor,
-    LatestConfirmedDomainBlock, LatestSubmittedER, Pallet, ReceiptHashFor,
+    LatestConfirmedDomainExecutionReceipt, LatestSubmittedER, Pallet, ReceiptHashFor,
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -18,8 +18,8 @@ use scale_info::TypeInfo;
 use sp_core::Get;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
-    ChainId, ConfirmedDomainBlock, DomainId, DomainsTransfersTracker, ExecutionReceipt,
-    OnChainRewards, OperatorId, Transfers,
+    ChainId, DomainId, DomainsTransfersTracker, ExecutionReceipt, OnChainRewards, OperatorId,
+    Transfers,
 };
 use sp_runtime::traits::{BlockNumberProvider, CheckedSub, One, Saturating, Zero};
 use sp_std::cmp::Ordering;
@@ -371,6 +371,11 @@ pub(crate) fn process_execution_receipt<T: Config>(
                 // its receipt's `extrinsics_root` anymore.
                 let _ = ExecutionInbox::<T>::clear_prefix((domain_id, to_prune), u32::MAX, None);
 
+                LatestConfirmedDomainExecutionReceipt::<T>::insert(
+                    domain_id,
+                    execution_receipt.clone(),
+                );
+
                 ConsensusBlockHash::<T>::remove(
                     domain_id,
                     execution_receipt.consensus_block_number,
@@ -404,18 +409,6 @@ pub(crate) fn process_execution_receipt<T: Config>(
                     .for_each(|(chain_id, reward)| {
                         T::OnChainRewards::on_chain_rewards(chain_id, reward)
                     });
-
-                LatestConfirmedDomainBlock::<T>::insert(
-                    domain_id,
-                    ConfirmedDomainBlock {
-                        block_number: to_prune,
-                        block_hash: execution_receipt.domain_block_hash,
-                        parent_block_receipt_hash: execution_receipt
-                            .parent_domain_block_receipt_hash,
-                        state_root: execution_receipt.final_state_root,
-                        extrinsics_root: execution_receipt.domain_block_extrinsic_root,
-                    },
-                );
 
                 return Ok(Some(ConfirmedDomainBlockInfo {
                     domain_block_number: to_prune,
@@ -559,16 +552,7 @@ pub(crate) fn import_genesis_receipt<T: Config>(
     let er_hash = genesis_receipt.hash::<DomainHashingFor<T>>();
     let domain_block_number = genesis_receipt.domain_block_number;
 
-    LatestConfirmedDomainBlock::<T>::insert(
-        domain_id,
-        ConfirmedDomainBlock {
-            block_number: domain_block_number,
-            block_hash: genesis_receipt.domain_block_hash,
-            parent_block_receipt_hash: Default::default(),
-            state_root: genesis_receipt.final_state_root,
-            extrinsics_root: genesis_receipt.domain_block_extrinsic_root,
-        },
-    );
+    LatestConfirmedDomainExecutionReceipt::<T>::insert(domain_id, genesis_receipt.clone());
 
     let block_tree_node = BlockTreeNode {
         execution_receipt: genesis_receipt,

--- a/crates/pallet-domains/src/migrations.rs
+++ b/crates/pallet-domains/src/migrations.rs
@@ -12,17 +12,24 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV0ToV1<T> {
 }
 
 pub(super) mod runtime_registry_instance_count_migration {
-    use crate::pallet::{DomainRegistry, RuntimeRegistry as RuntimeRegistryV1};
-    use crate::{Config, DomainSudoCalls};
+    use crate::pallet::{
+        DomainRegistry, LatestConfirmedDomainExecutionReceipt, RuntimeRegistry as RuntimeRegistryV1,
+    };
+    use crate::{Config, DomainBlockNumberFor, DomainSudoCalls, ExecutionReceiptOf};
     #[cfg(not(feature = "std"))]
     use alloc::string::String;
-    use codec::{Decode, Encode};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+    use codec::{Codec, Decode, Encode};
     use frame_support::pallet_prelude::{OptionQuery, TypeInfo, Weight};
     use frame_support::{storage_alias, Identity};
     use frame_system::pallet_prelude::BlockNumberFor;
     use sp_core::Get;
     use sp_domains::storage::RawGenesis;
-    use sp_domains::{DomainSudoCall, RuntimeId, RuntimeObject as RuntimeObjectV1, RuntimeType};
+    use sp_domains::{
+        BlockFees, DomainId, DomainSudoCall, RuntimeId, RuntimeObject as RuntimeObjectV1,
+        RuntimeType, Transfers,
+    };
     use sp_version::RuntimeVersion;
 
     #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -39,6 +46,21 @@ pub(super) mod runtime_registry_instance_count_migration {
         pub updated_at: Number,
     }
 
+    /// Type holding the block details of confirmed domain block.
+    #[derive(TypeInfo, Encode, Decode, Debug, Clone, PartialEq, Eq)]
+    pub struct ConfirmedDomainBlock<DomainBlockNumber: Codec, DomainHash: Codec> {
+        /// Block number of the confirmed domain block.
+        pub block_number: DomainBlockNumber,
+        /// Block hash of the confirmed domain block.
+        pub block_hash: DomainHash,
+        /// Parent block hash of the confirmed domain block.
+        pub parent_block_receipt_hash: DomainHash,
+        /// State root of the domain block.
+        pub state_root: DomainHash,
+        /// Extrinsic root of the domain block.
+        pub extrinsics_root: DomainHash,
+    }
+
     #[storage_alias]
     pub type RuntimeRegistry<T: Config> = StorageMap<
         crate::Pallet<T>,
@@ -48,18 +70,58 @@ pub(super) mod runtime_registry_instance_count_migration {
         OptionQuery,
     >;
 
+    #[storage_alias]
+    pub(super) type LatestConfirmedDomainBlock<T: Config> = StorageMap<
+        crate::Pallet<T>,
+        Identity,
+        DomainId,
+        ConfirmedDomainBlock<DomainBlockNumberFor<T>, <T as Config>::DomainHash>,
+        OptionQuery,
+    >;
+
     // Return the number of domain instance that instantiated with the given runtime
-    fn domain_instance_count<T: Config>(runtime_id: RuntimeId) -> (u32, u64) {
-        let mut read_write_count = 0;
+    fn domain_instance_count<T: Config>(runtime_id: RuntimeId) -> (u32, (u64, u64)) {
+        let (mut read_count, mut write_count) = (0, 0);
         (
             DomainRegistry::<T>::iter()
                 .filter(|(domain_id, domain_obj)| {
-                    read_write_count += 1;
+                    read_count += 1;
+
+                    // migrate domain sudo call
                     DomainSudoCalls::<T>::insert(domain_id, DomainSudoCall { maybe_call: None });
+                    write_count += 1;
+
+                    // migrate domain latest confirmed domain block
+                    read_count += 1;
+                    match LatestConfirmedDomainBlock::<T>::take(domain_id) {
+                        None => {}
+                        Some(confirmed_domain_block) => {
+                            write_count += 1;
+                            LatestConfirmedDomainExecutionReceipt::<T>::insert(
+                                domain_id,
+                                ExecutionReceiptOf::<T> {
+                                    domain_block_number: confirmed_domain_block.block_number,
+                                    domain_block_hash: confirmed_domain_block.block_hash,
+                                    domain_block_extrinsic_root: confirmed_domain_block
+                                        .extrinsics_root,
+                                    parent_domain_block_receipt_hash: confirmed_domain_block
+                                        .parent_block_receipt_hash,
+                                    consensus_block_number: Default::default(),
+                                    consensus_block_hash: Default::default(),
+                                    inboxed_bundles: vec![],
+                                    final_state_root: confirmed_domain_block.state_root,
+                                    execution_trace: vec![],
+                                    execution_trace_root: Default::default(),
+                                    block_fees: BlockFees::default(),
+                                    transfers: Transfers::default(),
+                                },
+                            )
+                        }
+                    }
                     domain_obj.domain_config.runtime_id == runtime_id
                 })
                 .count() as u32,
-            read_write_count,
+            (read_count, write_count),
         )
     }
 
@@ -67,7 +129,8 @@ pub(super) mod runtime_registry_instance_count_migration {
     pub(super) fn migrate_runtime_registry_storages<T: Config>() -> Weight {
         let (mut read_count, mut write_count) = (0, 0);
         RuntimeRegistry::<T>::drain().for_each(|(runtime_id, runtime_obj)| {
-            let (instance_count, domain_read_write_count) = domain_instance_count::<T>(runtime_id);
+            let (instance_count, (domain_read_count, domain_write_count)) =
+                domain_instance_count::<T>(runtime_id);
             RuntimeRegistryV1::<T>::set(
                 runtime_id,
                 Some(RuntimeObjectV1 {
@@ -84,9 +147,9 @@ pub(super) mod runtime_registry_instance_count_migration {
             );
 
             // domain_read_count + 1 since we read the old runtime registry as well
-            read_count += domain_read_write_count + 1;
-            // 1 write to new registry and 1 for old registry + domain_write_count to load Sudo Domain runtime call.
-            write_count += 2 + domain_read_write_count;
+            read_count += domain_read_count + 1;
+            // 1 write to new registry and 1 for old registry + domain_write_count.
+            write_count += 2 + domain_write_count;
         });
 
         T::DbWeight::get().reads_writes(read_count, write_count)
@@ -97,9 +160,11 @@ pub(super) mod runtime_registry_instance_count_migration {
 mod tests {
     use crate::domain_registry::{do_instantiate_domain, DomainConfig};
     use crate::migrations::runtime_registry_instance_count_migration::{
-        RuntimeObject, RuntimeRegistry,
+        ConfirmedDomainBlock, LatestConfirmedDomainBlock, RuntimeObject, RuntimeRegistry,
     };
-    use crate::pallet::RuntimeRegistry as RuntimeRegistryV1;
+    use crate::pallet::{
+        LatestConfirmedDomainExecutionReceipt, RuntimeRegistry as RuntimeRegistryV1,
+    };
     use crate::tests::{new_test_ext, Balances, Test};
     use crate::{Config, DomainSudoCalls};
     use domain_runtime_primitives::{AccountId20, AccountId20Converter};
@@ -132,7 +197,7 @@ mod tests {
         };
         let creator = 1u128;
 
-        ext.execute_with(|| {
+        let expected_er = ext.execute_with(|| {
             // create old registry
             RuntimeRegistry::<Test>::insert(
                 domain_config.runtime_id,
@@ -186,6 +251,18 @@ mod tests {
             );
 
             do_instantiate_domain::<Test>(domain_config.clone(), creator, 0u64).unwrap();
+            let er = LatestConfirmedDomainExecutionReceipt::<Test>::take(DomainId::new(0)).unwrap();
+            LatestConfirmedDomainBlock::<Test>::insert(
+                DomainId::new(0),
+                ConfirmedDomainBlock {
+                    block_number: er.domain_block_number,
+                    block_hash: er.domain_block_hash,
+                    parent_block_receipt_hash: er.parent_domain_block_receipt_hash,
+                    state_root: er.final_state_root,
+                    extrinsics_root: er.domain_block_extrinsic_root,
+                },
+            );
+            er
         });
 
         ext.commit_all().unwrap();
@@ -195,7 +272,7 @@ mod tests {
                 crate::migrations::runtime_registry_instance_count_migration::migrate_runtime_registry_storages::<Test>();
             assert_eq!(
                 weights,
-                <Test as frame_system::Config>::DbWeight::get().reads_writes(2, 3),
+                <Test as frame_system::Config>::DbWeight::get().reads_writes(3, 4),
             );
 
             assert_eq!(
@@ -204,6 +281,14 @@ mod tests {
             );
 
             assert!(DomainSudoCalls::<Test>::contains_key(DomainId::new(0)));
+
+            assert!(LatestConfirmedDomainBlock::<Test>::get(DomainId::new(0)).is_none());
+            let er = LatestConfirmedDomainExecutionReceipt::<Test>::get(DomainId::new(0)).unwrap();
+            assert_eq!(er.domain_block_number, expected_er.domain_block_number);
+            assert_eq!(er.domain_block_hash, expected_er.domain_block_hash);
+            assert_eq!(er.domain_block_extrinsic_root, expected_er.domain_block_extrinsic_root);
+            assert_eq!(er.final_state_root, expected_er.final_state_root);
+            assert_eq!(er.parent_domain_block_receipt_hash, expected_er.parent_domain_block_receipt_hash);
         });
     }
 }

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1311,8 +1311,9 @@ pub(crate) fn do_mark_operators_as_slashed<T: Config>(
 pub(crate) mod tests {
     use crate::domain_registry::{DomainConfig, DomainObject};
     use crate::pallet::{
-        Config, Deposits, DomainRegistry, DomainStakingSummary, LatestConfirmedDomainBlock,
-        NextOperatorId, NominatorCount, OperatorIdOwner, Operators, PendingSlashes, Withdrawals,
+        Config, Deposits, DomainRegistry, DomainStakingSummary,
+        LatestConfirmedDomainExecutionReceipt, NextOperatorId, NominatorCount, OperatorIdOwner,
+        Operators, PendingSlashes, Withdrawals,
     };
     use crate::staking::{
         do_convert_previous_epoch_withdrawal, do_mark_operators_as_slashed, do_nominate_operator,
@@ -1322,7 +1323,8 @@ pub(crate) mod tests {
     use crate::staking_epoch::{do_finalize_domain_current_epoch, do_slash_operator};
     use crate::tests::{new_test_ext, ExistentialDeposit, RuntimeOrigin, Test};
     use crate::{
-        bundle_storage_fund, BalanceOf, Error, NominatorId, SlashedReason, MAX_NOMINATORS_TO_SLASH,
+        bundle_storage_fund, BalanceOf, Error, ExecutionReceiptOf, NominatorId, SlashedReason,
+        MAX_NOMINATORS_TO_SLASH,
     };
     use codec::Encode;
     use frame_support::traits::fungible::Mutate;
@@ -1332,8 +1334,8 @@ pub(crate) mod tests {
     use sp_core::crypto::UncheckedFrom;
     use sp_core::{sr25519, Pair, U256};
     use sp_domains::{
-        ConfirmedDomainBlock, DomainId, OperatorAllowList, OperatorId, OperatorPair,
-        OperatorPublicKey, OperatorSignature,
+        BlockFees, DomainId, OperatorAllowList, OperatorId, OperatorPair, OperatorPublicKey,
+        OperatorSignature, Transfers,
     };
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Perbill};
@@ -1889,14 +1891,21 @@ pub(crate) mod tests {
 
             let nominator_count = NominatorCount::<Test>::get(operator_id);
             let confirmed_domain_block = 100;
-            LatestConfirmedDomainBlock::<Test>::insert(
+            LatestConfirmedDomainExecutionReceipt::<Test>::insert(
                 domain_id,
-                ConfirmedDomainBlock {
-                    block_number: confirmed_domain_block,
-                    block_hash: Default::default(),
-                    parent_block_receipt_hash: Default::default(),
-                    state_root: Default::default(),
-                    extrinsics_root: Default::default(),
+                ExecutionReceiptOf::<Test> {
+                    domain_block_number: confirmed_domain_block,
+                    domain_block_hash: Default::default(),
+                    domain_block_extrinsic_root: Default::default(),
+                    parent_domain_block_receipt_hash: Default::default(),
+                    consensus_block_number: Default::default(),
+                    consensus_block_hash: Default::default(),
+                    inboxed_bundles: vec![],
+                    final_state_root: Default::default(),
+                    execution_trace: vec![],
+                    execution_trace_root: Default::default(),
+                    block_fees: BlockFees::default(),
+                    transfers: Transfers::default(),
                 },
             );
 
@@ -1957,14 +1966,21 @@ pub(crate) mod tests {
                 // staking withdrawal is 5 blocks
                 // to unlock funds, confirmed block should be atleast 105
                 let confirmed_domain_block = 105;
-                LatestConfirmedDomainBlock::<Test>::insert(
+                LatestConfirmedDomainExecutionReceipt::<Test>::insert(
                     domain_id,
-                    ConfirmedDomainBlock {
-                        block_number: confirmed_domain_block,
-                        block_hash: Default::default(),
-                        parent_block_receipt_hash: Default::default(),
-                        state_root: Default::default(),
-                        extrinsics_root: Default::default(),
+                    ExecutionReceiptOf::<Test> {
+                        domain_block_number: confirmed_domain_block,
+                        domain_block_hash: Default::default(),
+                        domain_block_extrinsic_root: Default::default(),
+                        parent_domain_block_receipt_hash: Default::default(),
+                        consensus_block_number: Default::default(),
+                        consensus_block_hash: Default::default(),
+                        inboxed_bundles: vec![],
+                        final_state_root: Default::default(),
+                        execution_trace: vec![],
+                        execution_trace_root: Default::default(),
+                        block_fees: BlockFees::default(),
+                        transfers: Transfers::default(),
                     },
                 );
                 assert_ok!(do_unlock_funds::<Test>(operator_id, nominator_id));

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -526,8 +526,9 @@ pub(crate) fn do_slash_operator<T: Config>(
 mod tests {
     use crate::bundle_storage_fund::STORAGE_FEE_RESERVE;
     use crate::pallet::{
-        Deposits, DomainStakingSummary, LastEpochStakingDistribution, LatestConfirmedDomainBlock,
-        NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators, Withdrawals,
+        Deposits, DomainStakingSummary, LastEpochStakingDistribution,
+        LatestConfirmedDomainExecutionReceipt, NominatorCount, OperatorIdOwner, OperatorSigningKey,
+        Operators, Withdrawals,
     };
     use crate::staking::tests::{register_operator, Share};
     use crate::staking::{
@@ -538,13 +539,13 @@ mod tests {
         do_finalize_domain_current_epoch, operator_take_reward_tax_and_stake,
     };
     use crate::tests::{new_test_ext, Test};
-    use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
+    use crate::{BalanceOf, Config, ExecutionReceiptOf, HoldIdentifier, NominatorId};
     use codec::Encode;
     use frame_support::assert_ok;
     use frame_support::traits::fungible::InspectHold;
     use sp_core::{Pair, U256};
     use sp_domains::{
-        ConfirmedDomainBlock, DomainId, OperatorPair, OperatorSigningKeyProofOfOwnershipData,
+        BlockFees, DomainId, OperatorPair, OperatorSigningKeyProofOfOwnershipData, Transfers,
     };
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
@@ -618,14 +619,21 @@ mod tests {
 
             // de-register operator
             let domain_block_number = 100;
-            LatestConfirmedDomainBlock::<Test>::insert(
+            LatestConfirmedDomainExecutionReceipt::<Test>::insert(
                 domain_id,
-                ConfirmedDomainBlock {
-                    block_number: domain_block_number,
-                    block_hash: Default::default(),
-                    parent_block_receipt_hash: Default::default(),
-                    state_root: Default::default(),
-                    extrinsics_root: Default::default(),
+                ExecutionReceiptOf::<Test> {
+                    domain_block_number,
+                    domain_block_hash: Default::default(),
+                    domain_block_extrinsic_root: Default::default(),
+                    parent_domain_block_receipt_hash: Default::default(),
+                    consensus_block_number: Default::default(),
+                    consensus_block_hash: Default::default(),
+                    inboxed_bundles: vec![],
+                    final_state_root: Default::default(),
+                    execution_trace: vec![],
+                    execution_trace_root: Default::default(),
+                    block_fees: BlockFees::default(),
+                    transfers: Transfers::default(),
                 },
             );
             do_deregister_operator::<Test>(operator_account, operator_id).unwrap();
@@ -636,14 +644,21 @@ mod tests {
             // staking withdrawal is 5 blocks,
             // to unlock funds, confirmed block should be atleast 105
             let domain_block_number = 105;
-            LatestConfirmedDomainBlock::<Test>::insert(
+            LatestConfirmedDomainExecutionReceipt::<Test>::insert(
                 domain_id,
-                ConfirmedDomainBlock {
-                    block_number: domain_block_number,
-                    block_hash: Default::default(),
-                    parent_block_receipt_hash: Default::default(),
-                    state_root: Default::default(),
-                    extrinsics_root: Default::default(),
+                ExecutionReceiptOf::<Test> {
+                    domain_block_number,
+                    domain_block_hash: Default::default(),
+                    domain_block_extrinsic_root: Default::default(),
+                    parent_domain_block_receipt_hash: Default::default(),
+                    consensus_block_number: Default::default(),
+                    consensus_block_hash: Default::default(),
+                    inboxed_bundles: vec![],
+                    final_state_root: Default::default(),
+                    execution_trace: vec![],
+                    execution_trace_root: Default::default(),
+                    block_fees: BlockFees::default(),
+                    transfers: Transfers::default(),
                 },
             );
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -776,21 +776,6 @@ impl<CHash: Default> ProofOfElection<CHash> {
     }
 }
 
-/// Type holding the block details of confirmed domain block.
-#[derive(TypeInfo, Encode, Decode, Debug, Clone, PartialEq, Eq)]
-pub struct ConfirmedDomainBlock<DomainBlockNumber: Codec, DomainHash: Codec> {
-    /// Block number of the confirmed domain block.
-    pub block_number: DomainBlockNumber,
-    /// Block hash of the confirmed domain block.
-    pub block_hash: DomainHash,
-    /// Parent block hash of the confirmed domain block.
-    pub parent_block_receipt_hash: DomainHash,
-    /// State root of the domain block.
-    pub state_root: DomainHash,
-    /// Extrinsic root of the domain block.
-    pub extrinsics_root: DomainHash,
-}
-
 /// Type that represents an operator allow list for Domains.
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperatorAllowList<AccountId: Ord> {

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -1265,7 +1265,13 @@ mod pallet {
                         .ok_or(UnknownTransaction::CannotLookup)?;
 
                 StorageProofVerifier::<T::Hashing>::get_decoded_value::<
-                    sp_domains::ConfirmedDomainBlock<BlockNumberFor<T>, T::Hash>,
+                    sp_domains::ExecutionReceipt<
+                        BlockNumberFor<T>,
+                        T::Hash,
+                        BlockNumberFor<T>,
+                        T::Hash,
+                        BalanceOf<T>,
+                    >,
                 >(
                     &consensus_state_root,
                     domain_proof,
@@ -1279,7 +1285,7 @@ mod pallet {
                     );
                     TransactionValidityError::Invalid(InvalidTransaction::BadProof)
                 })?
-                .state_root
+                .final_state_root
             } else {
                 consensus_state_root
             };


### PR DESCRIPTION
Updates the domain storage to store the full Latest confirmed ER for each domain instead of subset of ER fields.

Note: Since XDM uses this for storage, it is important to get this PR landed and runtime upgrade before enabling XDM

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
