### PR TITLE
Add support to run the auto-id domain node in the integration test and re-enable XDM tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-id-domain-test-runtime"
+version = "0.1.0"
+dependencies = [
+ "domain-pallet-executive",
+ "domain-runtime-primitives",
+ "domain-test-primitives",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "pallet-auto-id",
+ "pallet-balances",
+ "pallet-block-fees",
+ "pallet-domain-id",
+ "pallet-domain-sudo",
+ "pallet-messenger",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-transporter",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-block-builder",
+ "sp-core",
+ "sp-domain-sudo",
+ "sp-domains",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-messenger",
+ "sp-messenger-host-functions",
+ "sp-mmr-primitives",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-std",
+ "sp-storage",
+ "sp-subspace-mmr",
+ "sp-transaction-pool",
+ "sp-version",
+ "subspace-core-primitives",
+ "subspace-runtime-primitives",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +2775,7 @@ dependencies = [
 name = "domain-client-operator"
 version = "0.1.0"
 dependencies = [
+ "auto-id-domain-test-runtime",
  "cross-domain-message-gossip",
  "domain-block-builder",
  "domain-block-preprocessor",
@@ -2936,6 +2984,7 @@ dependencies = [
 name = "domain-test-service"
 version = "0.1.0"
 dependencies = [
+ "auto-id-domain-test-runtime",
  "cross-domain-message-gossip",
  "domain-client-operator",
  "domain-runtime-primitives",
@@ -13171,6 +13220,7 @@ dependencies = [
 name = "subspace-test-client"
 version = "0.1.0"
 dependencies = [
+ "auto-id-domain-test-runtime",
  "domain-runtime-primitives",
  "evm-domain-test-runtime",
  "fp-evm",

--- a/crates/sp-domains-fraud-proof/src/tests.rs
+++ b/crates/sp-domains-fraud-proof/src/tests.rs
@@ -8,7 +8,7 @@ use domain_test_service::evm_domain_test_runtime::{
 };
 use domain_test_service::EcdsaKeyring::{Alice, Charlie};
 use domain_test_service::Sr25519Keyring::Ferdie;
-use domain_test_service::{construct_extrinsic_raw_payload, EvmDomainNode, GENESIS_DOMAIN_ID};
+use domain_test_service::{construct_extrinsic_raw_payload, EvmDomainNode};
 use ethereum::TransactionV2 as Transaction;
 use fp_rpc::EthereumRuntimeRPCApi;
 use frame_support::pallet_prelude::DispatchClass;
@@ -295,10 +295,9 @@ async fn domain_bundle_storage_proof_benchmark() {
     // Run Alice (a evm domain authority node)
     let alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
-        Alice,
         BasePath::new(directory.path().join("alice")),
     )
-    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
     let (recorded_keys, storage_proof) = benchmark_bundle_with_evm_tx(400, alice, ferdie).await;
@@ -335,10 +334,9 @@ async fn storage_change_of_the_same_runtime_instance_should_perserved_cross_runt
     // Run Alice (a evm domain authority node)
     let mut alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
-        Alice,
         BasePath::new(directory.path().join("alice")),
     )
-    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
     let best_hash = alice.client.as_ref().info().best_hash;
@@ -529,10 +527,9 @@ async fn check_bundle_validity_runtime_api_should_work() {
     // Run Alice (a evm domain authority node)
     let mut alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
-        Alice,
         BasePath::new(directory.path().join("alice")),
     )
-    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
     let mut alice_nonce = alice.account_nonce();
@@ -687,10 +684,9 @@ async fn test_evm_domain_block_fee() {
     // Run Alice (a evm domain authority node)
     let mut alice = domain_test_service::DomainNodeBuilder::new(
         tokio_handle.clone(),
-        Alice,
         BasePath::new(directory.path().join("alice")),
     )
-    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
@@ -807,10 +803,10 @@ async fn test_evm_domain_block_fee() {
 //     // Run Alice (a evm domain authority node)
 //     let mut alice = domain_test_service::DomainNodeBuilder::new(
 //         tokio_handle.clone(),
-//         Alice,
+//
 //         BasePath::new(directory.path().join("alice")),
 //     )
-//     .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+//     .build_evm_node(Role::Authority, Alice, &mut ferdie)
 //     .await;
 //
 //     // Run Bob (a evm domain full node)
@@ -819,7 +815,7 @@ async fn test_evm_domain_block_fee() {
 //         Bob,
 //         BasePath::new(directory.path().join("bob")),
 //     )
-//     .build_evm_node(Role::Full, GENESIS_DOMAIN_ID, &mut ferdie)
+//     .build_evm_node(Role::Full, Alice, &mut ferdie)
 //     .await;
 //
 //     // Bob is able to sync blocks.
@@ -1101,10 +1097,10 @@ async fn test_evm_domain_block_fee() {
 //     // Run Alice (a evm domain authority node)
 //     let mut alice = domain_test_service::DomainNodeBuilder::new(
 //         tokio_handle.clone(),
-//         Alice,
+//
 //         BasePath::new(directory.path().join("alice")),
 //     )
-//     .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+//     .build_evm_node(Role::Authority, Alice, &mut ferdie)
 //     .await;
 //
 //     // Run Bob (a evm domain full node)
@@ -1113,7 +1109,7 @@ async fn test_evm_domain_block_fee() {
 //         Bob,
 //         BasePath::new(directory.path().join("bob")),
 //     )
-//     .build_evm_node(Role::Full, GENESIS_DOMAIN_ID, &mut ferdie)
+//     .build_evm_node(Role::Full, Alice, &mut ferdie)
 //     .await;
 //
 //     // Bob is able to sync blocks.
@@ -1294,7 +1290,7 @@ async fn test_evm_domain_block_fee() {
 //     // Run Alice (a system domain authority node)
 //     let mut alice = domain_test_service::DomainNodeBuilder::new(
 //         tokio_handle.clone(),
-//         Alice,
+//
 //         BasePath::new(directory.path().join("alice")),
 //     )
 //     .build_evm_node(Role::Authority, &mut ferdie)

--- a/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
+++ b/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
@@ -85,6 +85,11 @@ impl GossipWorkerBuilder {
         self.chain_sinks.insert(chain_id, sink);
     }
 
+    // Remove the chain sink
+    pub fn remove_chain_sink(&mut self, chain_id: &ChainId) -> Option<ChainSink> {
+        self.chain_sinks.remove(chain_id)
+    }
+
     /// Get the gossip message sink
     pub fn gossip_msg_sink(&self) -> TracingUnboundedSender<Message> {
         self.gossip_msg_sink.clone()

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["macros"] }
 
 [dev-dependencies]
+auto-id-domain-test-runtime = { version = "0.1.0", path = "../../test/runtime/auto-id" }
 cross-domain-message-gossip = { path = "../../client/cross-domain-message-gossip" }
 domain-test-service = { version = "0.1.0", path = "../../test/service" }
 domain-test-primitives = { version = "0.1.0", path = "../../test/primitives" }

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -11,7 +11,9 @@ use domain_test_primitives::{OnchainStateApi, TimestampApi};
 use domain_test_service::evm_domain_test_runtime::{Header, UncheckedExtrinsic};
 use domain_test_service::EcdsaKeyring::{Alice, Bob, Charlie, Eve};
 use domain_test_service::Sr25519Keyring::{self, Alice as Sr25519Alice, Ferdie};
-use domain_test_service::{construct_extrinsic_generic, GENESIS_DOMAIN_ID};
+use domain_test_service::{
+    construct_extrinsic_generic, AUTO_ID_DOMAIN_ID, EVM_DOMAIN_ID, GENESIS_DOMAIN_ID,
+};
 use futures::StreamExt;
 use pallet_messenger::ChainAllowlistUpdate;
 use sc_client_api::{Backend, BlockBackend, BlockchainEvents, HeaderBackend};
@@ -21,10 +23,11 @@ use sc_service::{BasePath, Role};
 use sc_transaction_pool::error::Error as PoolError;
 use sc_transaction_pool_api::error::Error as TxPoolError;
 use sc_transaction_pool_api::TransactionPool;
+use sc_utils::mpsc::tracing_unbounded;
 use sp_api::{ProvideRuntimeApi, StorageProof};
 use sp_consensus::SyncOracle;
 use sp_core::storage::StateVersion;
-use sp_core::traits::FetchRuntimeCode;
+use sp_core::traits::{FetchRuntimeCode, SpawnEssentialNamed};
 use sp_core::{Pair, H256};
 use sp_domain_digests::AsPredigest;
 use sp_domains::core_api::DomainCoreApi;
@@ -54,7 +57,7 @@ use sp_state_machine::backend::AsTrieBackend;
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use sp_weights::Weight;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use subspace_core_primitives::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
@@ -3541,7 +3544,7 @@ async fn test_domain_sudo_calls() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_cross_domains_messages_should_work() {
+async fn test_xdm_between_consensus_and_domain_should_work() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
     let mut builder = sc_cli::LoggerBuilder::new("");
@@ -3745,384 +3748,278 @@ async fn test_cross_domains_messages_should_work() {
     );
 }
 
-// TODO: Unlock test when multiple domains are supported in DecEx v2.
-// #[tokio::test(flavor = "multi_thread")]
-// async fn test_cross_domains_message_should_work() {
-//     let directory = TempDir::new().expect("Must be able to create temporary directory");
-//
-//     let mut builder = sc_cli::LoggerBuilder::new("");
-//     builder.with_colors(false);
-//     let _ = builder.init();
-//
-//     let tokio_handle = tokio::runtime::Handle::current();
-//
-//     // Start Ferdie
-//     let mut ferdie = MockConsensusNode::run(
-//         tokio_handle.clone(),
-//         Ferdie,
-//         BasePath::new(directory.path().join("ferdie")),
-//     );
-//
-//     // Run Alice (a system domain authority node)
-//     let mut alice = domain_test_service::DomainNodeBuilder::new(
-//         tokio_handle.clone(),
-//         Alice,
-//         BasePath::new(directory.path().join("alice")),
-//     )
-//     .run_relayer()
-//     .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
-//     .await;
-//
-//     // Run Bob (a core payments domain authority node)
-//     let mut bob = domain_test_service::DomainNodeBuilder::new(
-//         tokio_handle.clone(),
-//         Bob,
-//         BasePath::new(directory.path().join("bob")),
-//     )
-//     .run_relayer()
-//     .build_core_payments_node(Role::Authority, &mut ferdie, &alice)
-//     .await;
-//
-//     // Run Charlie (a core eth relay domain authority node)
-//     let mut charlie = domain_test_service::DomainNodeBuilder::new(
-//         tokio_handle.clone(),
-//         Charlie,
-//         BasePath::new(directory.path().join("charlie")),
-//     )
-//     .run_relayer()
-//     .build_core_eth_relay_node(Role::Authority, &mut ferdie, &alice)
-//     .await;
-//
-//     // Run the cross domain gossip message worker
-//     ferdie.start_cross_domain_gossip_message_worker();
-//
-//     produce_blocks!(ferdie, alice, bob, charlie, 3)
-//         .await
-//         .unwrap();
-//
-//     // Open channel between the system domain and the core payments domain
-//     let fee_model = FeeModel {
-//         outbox_fee: ExecutionFee {
-//             relayer_pool_fee: 2,
-//             compute_fee: 0,
-//         },
-//         inbox_fee: ExecutionFee {
-//             relayer_pool_fee: 0,
-//             compute_fee: 5,
-//         },
-//     };
-//     bob.construct_and_send_extrinsic(pallet_sudo::Call::sudo {
-//         call: Box::new(core_payments_domain_test_runtime::RuntimeCall::Messenger(
-//             pallet_messenger::Call::initiate_channel {
-//                 dst_domain_id: DomainId::SYSTEM,
-//                 params: InitiateChannelParams {
-//                     max_outgoing_messages: 100,
-//                     fee_model,
-//                 },
-//             },
-//         )),
-//     })
-//     .await
-//     .expect("Failed to construct and send extrinsic");
-//     // Wait until channel open
-//     produce_blocks_until!(ferdie, alice, bob, {
-//         alice
-//             .get_open_channel_for_domain(DomainId::CORE_PAYMENTS)
-//             .is_some()
-//             && bob.get_open_channel_for_domain(DomainId::SYSTEM).is_some()
-//     })
-//     .await
-//     .unwrap();
-//
-//     // Transfer balance cross the system domain and the core payments domain
-//     let pre_alice_free_balance = alice.free_balance(alice.key.to_account_id());
-//     let pre_bob_free_balance = bob.free_balance(bob.key.to_account_id());
-//     let transfer_amount = 10;
-//     alice
-//         .construct_and_send_extrinsic(pallet_transporter::Call::transfer {
-//             dst_location: pallet_transporter::Location {
-//                 domain_id: DomainId::CORE_PAYMENTS,
-//                 account_id: AccountIdConverter::convert(Bob.into()),
-//             },
-//             amount: transfer_amount,
-//         })
-//         .await
-//         .expect("Failed to construct and send extrinsic");
-//     // Wait until transfer succeed
-//     produce_blocks_until!(ferdie, alice, bob, charlie, {
-//         let post_alice_free_balance = alice.free_balance(alice.key.to_account_id());
-//         let post_bob_free_balance = bob.free_balance(bob.key.to_account_id());
-//
-//         post_alice_free_balance
-//             == pre_alice_free_balance
-//                 - transfer_amount
-//                 - fee_model.outbox_fee().unwrap()
-//                 - fee_model.inbox_fee().unwrap()
-//             && post_bob_free_balance == pre_bob_free_balance + transfer_amount
-//     })
-//     .await
-//     .unwrap();
-//
-//     // Open channel between the core payments domain and the core eth relay domain
-//     let fee_model = FeeModel {
-//         outbox_fee: ExecutionFee {
-//             relayer_pool_fee: 1,
-//             compute_fee: 5,
-//         },
-//         inbox_fee: ExecutionFee {
-//             relayer_pool_fee: 2,
-//             compute_fee: 3,
-//         },
-//     };
-//     charlie
-//         .construct_and_send_extrinsic(pallet_sudo::Call::sudo {
-//             call: Box::new(core_eth_relay_domain_test_runtime::RuntimeCall::Messenger(
-//                 pallet_messenger::Call::initiate_channel {
-//                     dst_domain_id: DomainId::CORE_PAYMENTS,
-//                     params: InitiateChannelParams {
-//                         max_outgoing_messages: 100,
-//                         fee_model,
-//                     },
-//                 },
-//             )),
-//         })
-//         .await
-//         .expect("Failed to construct and send extrinsic");
-//     // Wait until channel open
-//     produce_blocks_until!(ferdie, alice, bob, charlie, {
-//         bob.get_open_channel_for_domain(DomainId::CORE_ETH_RELAY)
-//             .is_some()
-//             && charlie
-//                 .get_open_channel_for_domain(DomainId::CORE_PAYMENTS)
-//                 .is_some()
-//     })
-//     .await
-//     .unwrap();
-//
-//     // Transfer balance cross the core payments domain and the core eth relay domain
-//     let pre_bob_free_balance = bob.free_balance(bob.key.to_account_id());
-//     let pre_charlie_free_balance = charlie.free_balance(charlie.key.to_account_id());
-//     let transfer_amount = 10;
-//     bob.construct_and_send_extrinsic(pallet_transporter::Call::transfer {
-//         dst_location: pallet_transporter::Location {
-//             domain_id: DomainId::CORE_ETH_RELAY,
-//             account_id: AccountIdConverter::convert(Charlie.into()),
-//         },
-//         amount: transfer_amount,
-//     })
-//     .await
-//     .expect("Failed to construct and send extrinsic");
-//     // Wait until transfer succeed
-//     produce_blocks_until!(ferdie, alice, bob, charlie, {
-//         let post_bob_free_balance = bob.free_balance(bob.key.to_account_id());
-//         let post_charlie_free_balance = charlie.free_balance(charlie.key.to_account_id());
-//
-//         post_bob_free_balance
-//             == pre_bob_free_balance
-//                 - transfer_amount
-//                 - fee_model.outbox_fee().unwrap()
-//                 - fee_model.inbox_fee().unwrap()
-//             && post_charlie_free_balance == pre_charlie_free_balance + transfer_amount
-//     })
-//     .await
-//     .unwrap();
-// }
+#[tokio::test(flavor = "multi_thread")]
+async fn test_xdm_between_domains_should_work() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
 
-// TODO: Unlock test when multiple domains are supported in DecEx v2.
-// #[tokio::test(flavor = "multi_thread")]
-// async fn test_unordered_cross_domains_message_should_work() {
-// let directory = TempDir::new().expect("Must be able to create temporary directory");
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
 
-// let mut builder = sc_cli::LoggerBuilder::new("");
-// builder.with_colors(false);
-// let _ = builder.init();
+    let tokio_handle = tokio::runtime::Handle::current();
 
-// let tokio_handle = tokio::runtime::Handle::current();
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Sr25519Alice,
+        BasePath::new(directory.path().join("ferdie")),
+    );
 
-// // Start Ferdie
-// let mut ferdie = MockConsensusNode::run(
-// tokio_handle.clone(),
-// Ferdie,
-// BasePath::new(directory.path().join("ferdie")),
-// );
+    // Run Alice (a system domain authority node)
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Alice,
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .await;
 
-// // Run Alice (a system domain authority node)
-// let mut alice = domain_test_service::DomainNodeBuilder::new(
-// tokio_handle.clone(),
-// Alice,
-// BasePath::new(directory.path().join("alice")),
-// )
-// .run_relayer()
-// .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
-// .await;
+    // Run Bob (a auto-id domain authority node)
+    let mut bob = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Bob,
+        BasePath::new(directory.path().join("bob")),
+    )
+    .build_auto_id_node(Sr25519Keyring::Bob, Role::Authority, &mut ferdie)
+    .await;
 
-// // Run Bob (a core payments domain authority node)
-// let mut bob = domain_test_service::DomainNodeBuilder::new(
-// tokio_handle.clone(),
-// Bob,
-// BasePath::new(directory.path().join("bob")),
-// )
-// .run_relayer()
-// .build_core_payments_node(Role::Authority, &mut ferdie, &alice)
-// .await;
+    // Run the cross domain gossip message worker
+    ferdie.start_cross_domain_gossip_message_worker();
 
-// // Run Charlie (a core eth relay domain full node) and don't its relayer worker
-// let charlie = domain_test_service::DomainNodeBuilder::new(
-// tokio_handle.clone(),
-// Charlie,
-// BasePath::new(directory.path().join("charlie")),
-// )
-// .build_core_payments_node(Role::Full, &mut ferdie, &alice)
-// .await;
-// let gossip_msg_sink = ferdie.xdm_gossip_worker_builder().gossip_msg_sink();
+    produce_blocks!(ferdie, alice, 3, bob).await.unwrap();
 
-// // Run the cross domain gossip message worker
-// ferdie.start_cross_domain_gossip_message_worker();
+    // add consensus chain to domain chain allow list
+    ferdie
+        .construct_and_send_extrinsic_with(subspace_test_runtime::RuntimeCall::Messenger(
+            pallet_messenger::Call::initiate_domain_update_chain_allowlist {
+                domain_id: EVM_DOMAIN_ID,
+                update: ChainAllowlistUpdate::Add(ChainId::Domain(AUTO_ID_DOMAIN_ID)),
+            },
+        ))
+        .await
+        .expect("Failed to construct and send domain chain allowlist update");
 
-// produce_blocks!(ferdie, alice, bob, 3).await.unwrap();
+    // produce another block so allowlist on  domain are updated
+    produce_blocks!(ferdie, alice, 1, bob).await.unwrap();
 
-// // Open channel between the system domain and the core payments domain
-// let fee_model = FeeModel {
-// outbox_fee: ExecutionFee {
-// relayer_pool_fee: 2,
-// compute_fee: 0,
-// },
-// inbox_fee: ExecutionFee {
-// relayer_pool_fee: 0,
-// compute_fee: 5,
-// },
-// };
-// bob.construct_and_send_extrinsic(pallet_sudo::Call::sudo {
-// call: Box::new(core_payments_domain_test_runtime::RuntimeCall::Messenger(
-// pallet_messenger::Call::initiate_channel {
-// dst_domain_id: DomainId::SYSTEM,
-// params: InitiateChannelParams {
-// max_outgoing_messages: 1000,
-// fee_model,
-// },
-// },
-// )),
-// })
-// .await
-// .expect("Failed to construct and send extrinsic");
-// // Wait until channel open
-// produce_blocks_until!(ferdie, alice, bob, charlie, {
-// alice
-// .get_open_channel_for_domain(DomainId::CORE_PAYMENTS)
-// .is_some()
-// && bob.get_open_channel_for_domain(DomainId::SYSTEM).is_some()
-// })
-// .await
-// .unwrap();
+    // add consensus chain to domain chain allow list
+    ferdie
+        .construct_and_send_extrinsic_with(subspace_test_runtime::RuntimeCall::Messenger(
+            pallet_messenger::Call::initiate_domain_update_chain_allowlist {
+                domain_id: AUTO_ID_DOMAIN_ID,
+                update: ChainAllowlistUpdate::Add(ChainId::Domain(EVM_DOMAIN_ID)),
+            },
+        ))
+        .await
+        .expect("Failed to construct and send domain chain allowlist update");
 
-// // Register `charlie` as relayer such that message will assign to it, but as its relayer
-// // is not started these massage won't be relayed.
-// bob.construct_and_send_extrinsic(pallet_messenger::Call::join_relayer_set {
-// relayer_id: Charlie.into(),
-// })
-// .await
-// .expect("Failed to construct and send extrinsic");
-// produce_blocks!(ferdie, alice, bob, charlie, 3)
-// .await
-// .unwrap();
+    // produce another block so allowlist on  domain are updated
+    produce_blocks!(ferdie, alice, 1, bob).await.unwrap();
 
-// // Create cross domain message, only message assigned to `alice` and `bob` will be relayed
-// // and send to tx pool, and these message is unordered because the message assigned to `charlie`
-// // is not relayed.
-// let relayer_id: AccountId = Charlie.into();
-// let alice_transfer_amount = 1;
-// let bob_transfer_amount = 2;
-// let pre_alice_free_balance = alice.free_balance(alice.key.to_account_id());
-// let pre_bob_free_balance = bob.free_balance(bob.key.to_account_id());
-// let mut alice_account_nonce = alice.account_nonce();
-// let mut bob_account_nonce = bob.account_nonce();
-// // Assigne `inbox_response` message to `charlie`
-// for _ in 0..10 {
-// let tx = alice.construct_extrinsic(
-// alice_account_nonce,
-// pallet_transporter::Call::transfer {
-// dst_location: pallet_transporter::Location {
-// domain_id: DomainId::CORE_PAYMENTS,
-// account_id: AccountIdConverter::convert(Bob.into()),
-// },
-// amount: alice_transfer_amount,
-// },
-// );
-// alice
-// .send_extrinsic(tx)
-// .await
-// .expect("Failed to send extrinsic");
-// alice_account_nonce += 1;
+    // Open channel between the evm domain and the auto-id domain
+    bob.construct_and_send_extrinsic(auto_id_domain_test_runtime::RuntimeCall::Messenger(
+        pallet_messenger::Call::initiate_channel {
+            dst_chain_id: ChainId::Domain(EVM_DOMAIN_ID),
+            params: pallet_messenger::InitiateChannelParams {
+                max_outgoing_messages: 100,
+            },
+        },
+    ))
+    .await
+    .expect("Failed to construct and send extrinsic");
 
-// produce_blocks!(ferdie, alice, bob, charlie, 1)
-// .await
-// .unwrap();
-// }
-// // Assigne `outbox` message to `charlie`
-// for _ in 0..10 {
-// let tx = bob.construct_extrinsic(
-// bob_account_nonce,
-// pallet_transporter::Call::transfer {
-// dst_location: pallet_transporter::Location {
-// domain_id: DomainId::SYSTEM,
-// account_id: AccountIdConverter::convert(Alice.into()),
-// },
-// amount: bob_transfer_amount,
-// },
-// );
-// bob.send_extrinsic(tx)
-// .await
-// .expect("Failed to send extrinsic");
-// bob_account_nonce += 1;
+    // Wait until channel open
+    produce_blocks_until!(
+        ferdie,
+        alice,
+        {
+            alice
+                .get_open_channel_for_chain(ChainId::Domain(AUTO_ID_DOMAIN_ID))
+                .is_some()
+                && bob
+                    .get_open_channel_for_chain(ChainId::Domain(EVM_DOMAIN_ID))
+                    .is_some()
+        },
+        bob
+    )
+    .await
+    .unwrap();
 
-// produce_blocks!(ferdie, alice, bob, charlie, 1)
-// .await
-// .unwrap();
-// }
+    // Transfer balance cross the system domain and the core payments domain
+    let pre_alice_free_balance = alice.free_balance(alice.key.to_account_id());
+    let pre_bob_free_balance = bob.free_balance(bob.key.to_account_id());
+    let transfer_amount = 10;
+    alice
+        .construct_and_send_extrinsic(pallet_transporter::Call::transfer {
+            dst_location: pallet_transporter::Location {
+                chain_id: ChainId::Domain(AUTO_ID_DOMAIN_ID),
+                account_id: AccountIdConverter::convert(Sr25519Keyring::Bob.into()),
+            },
+            amount: transfer_amount,
+        })
+        .await
+        .expect("Failed to construct and send extrinsic");
+    // Wait until transfer succeed
+    produce_blocks_until!(
+        ferdie,
+        alice,
+        {
+            let post_alice_free_balance = alice.free_balance(alice.key.to_account_id());
+            let post_bob_free_balance = bob.free_balance(bob.key.to_account_id());
 
-// // Run charlie's relayer worker, the message assigned to `charlie` will be relayed
-// // and send to tx pool now
-// let relayer_worker = domain_client_message_relayer::worker::relay_core_domain_messages::<
-// _,
-// _,
-// PBlock,
-// _,
-// _,
-// _,
-// _,
-// _,
-// >(
-// relayer_id,
-// charlie.client.clone(),
-// alice.client.clone(),
-// alice.sync_service.clone(),
-// charlie.sync_service.clone(),
-// gossip_msg_sink,
-// );
-// bob.task_manager
-// .spawn_essential_handle()
-// .spawn_essential_blocking(
-// "core-domain-relayer-charlie",
-// None,
-// Box::pin(relayer_worker),
-// );
+            post_alice_free_balance <= pre_alice_free_balance - transfer_amount
+                && post_bob_free_balance == pre_bob_free_balance + transfer_amount
+        },
+        bob
+    )
+    .await
+    .unwrap();
+}
 
-// // Wait until all message are relayed and handled
-// let fee = fee_model.outbox_fee().unwrap() + fee_model.inbox_fee().unwrap();
-// produce_blocks_until!(ferdie, alice, bob, {
-// let post_alice_free_balance = alice.free_balance(alice.key.to_account_id());
-// let post_bob_free_balance = bob.free_balance(bob.key.to_account_id());
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unordered_cross_domains_message_should_work() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
 
-// post_alice_free_balance
-// == pre_alice_free_balance - alice_transfer_amount * 10 + bob_transfer_amount * 10
-// - fee * 10
-// && post_bob_free_balance
-// == pre_bob_free_balance - bob_transfer_amount * 10 + alice_transfer_amount * 10
-// - fee * 10
-// })
-// .await
-// .unwrap();
-// }
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Sr25519Alice,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+
+    // Run Alice (a system domain authority node)
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        Alice,
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, GENESIS_DOMAIN_ID, &mut ferdie)
+    .await;
+
+    let evm_domain_tx_pool_sink = ferdie
+        .xdm_gossip_worker_builder()
+        .remove_chain_sink(&ChainId::Domain(EVM_DOMAIN_ID))
+        .unwrap();
+    let (reorder_xdm_sink, mut reorder_xdm_receiver) = tracing_unbounded("reorder_xdm", 100);
+    ferdie
+        .xdm_gossip_worker_builder()
+        .push_chain_sink(ChainId::Domain(EVM_DOMAIN_ID), reorder_xdm_sink);
+
+    alice
+        .task_manager
+        .spawn_essential_handle()
+        .spawn_essential_blocking(
+            "reordering-xdm",
+            None,
+            Box::pin(async move {
+                let mut i = 0;
+                let mut msg_buffer = VecDeque::new();
+                while let Some(xdm) = reorder_xdm_receiver.next().await {
+                    if i % 3 == 0 {
+                        msg_buffer.push_back(xdm);
+                        if let Some(xdm) = msg_buffer.pop_front() {
+                            if i % 2 == 0 {
+                                evm_domain_tx_pool_sink.unbounded_send(xdm).unwrap();
+                            }
+                        }
+                    } else {
+                        evm_domain_tx_pool_sink.unbounded_send(xdm).unwrap();
+                    }
+                    i += 1;
+                }
+            }),
+        );
+
+    // Run the cross domain gossip message worker
+    ferdie.start_cross_domain_gossip_message_worker();
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    // add domain to consensus chain allowlist
+    ferdie
+        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
+            call: Box::new(subspace_test_runtime::RuntimeCall::Messenger(
+                pallet_messenger::Call::update_consensus_chain_allowlist {
+                    update: ChainAllowlistUpdate::Add(ChainId::Domain(GENESIS_DOMAIN_ID)),
+                },
+            )),
+        })
+        .await
+        .expect("Failed to construct and send consensus chain allowlist update");
+
+    // produce another block so allowlist on consensus is updated
+    produce_blocks!(ferdie, alice, 1).await.unwrap();
+
+    // add consensus chain to domain chain allow list
+    ferdie
+        .construct_and_send_extrinsic_with(subspace_test_runtime::RuntimeCall::Messenger(
+            pallet_messenger::Call::initiate_domain_update_chain_allowlist {
+                domain_id: GENESIS_DOMAIN_ID,
+                update: ChainAllowlistUpdate::Add(ChainId::Consensus),
+            },
+        ))
+        .await
+        .expect("Failed to construct and send domain chain allowlist update");
+
+    // produce another block so allowlist on  domain are updated
+    produce_blocks!(ferdie, alice, 1).await.unwrap();
+
+    // Open channel between the evm domain and the auto-id domain
+    alice
+        .construct_and_send_extrinsic(evm_domain_test_runtime::RuntimeCall::Messenger(
+            pallet_messenger::Call::initiate_channel {
+                dst_chain_id: ChainId::Consensus,
+                params: pallet_messenger::InitiateChannelParams {
+                    max_outgoing_messages: 100,
+                },
+            },
+        ))
+        .await
+        .expect("Failed to construct and send extrinsic");
+
+    // Wait until channel open
+    produce_blocks_until!(ferdie, alice, {
+        alice
+            .get_open_channel_for_chain(ChainId::Consensus)
+            .is_some()
+    })
+    .await
+    .unwrap();
+
+    // Transfer balance cross the system domain and the core payments domain
+    let pre_alice_free_balance = alice.free_balance(alice.key.to_account_id());
+    let pre_ferdie_free_balance = ferdie.free_balance(ferdie.key.to_account_id());
+    let transfer_amount = 10;
+    for _ in 0..20 {
+        ferdie
+            .construct_and_send_extrinsic_with(pallet_transporter::Call::transfer {
+                dst_location: pallet_transporter::Location {
+                    chain_id: ChainId::Domain(GENESIS_DOMAIN_ID),
+                    account_id: AccountId20Converter::convert(Alice.to_account_id()),
+                },
+                amount: transfer_amount,
+            })
+            .await
+            .expect("Failed to construct and send extrinsic");
+        produce_blocks!(ferdie, alice, 1).await.unwrap();
+    }
+    // Wait until transfer succeed
+    produce_blocks_until!(ferdie, alice, {
+        let post_alice_free_balance = alice.free_balance(alice.key.to_account_id());
+        let post_ferdie_free_balance = ferdie.free_balance(ferdie.key.to_account_id());
+
+        post_alice_free_balance == pre_alice_free_balance + transfer_amount * 20
+            && post_ferdie_free_balance <= pre_ferdie_free_balance - transfer_amount * 20
+    })
+    .await
+    .unwrap();
+}
 
 #[tokio::test(flavor = "multi_thread")]
 // TODO: https://github.com/subspace/subspace/pull/1954 broke this on Windows, we suspect the test

--- a/domains/test/runtime/auto-id/Cargo.toml
+++ b/domains/test/runtime/auto-id/Cargo.toml
@@ -1,0 +1,126 @@
+[package]
+name = "auto-id-domain-test-runtime"
+version = "0.1.0"
+authors = ["Subspace Labs <https://subspace.network>"]
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/subspace/subspace/"
+edition = "2021"
+description = "Subspace AutoId domain test runtime"
+include = [
+    "/src",
+    "/build.rs",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+domain-pallet-executive = { version = "0.1.0", path = "../../../pallets/executive", default-features = false }
+domain-runtime-primitives = { version = "0.1.0", path = "../../../primitives/runtime", default-features = false }
+domain-test-primitives = { version = "0.1.0", path = "../../primitives", default-features = false }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+frame-system-benchmarking = { default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+pallet-auto-id = { version = "0.1.0", path = "../../../pallets/auto-id", default-features = false }
+pallet-balances = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+pallet-block-fees = { version = "0.1.0", path = "../../../pallets/block-fees", default-features = false }
+pallet-domain-id = { version = "0.1.0", path = "../../../pallets/domain-id", default-features = false }
+pallet-domain-sudo = { version = "0.1.0", path = "../../../pallets/domain-sudo", default-features = false }
+pallet-messenger = { version = "0.1.0", path = "../../../pallets/messenger", default-features = false }
+pallet-timestamp = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+pallet-transaction-payment = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+pallet-transporter = { version = "0.1.0", path = "../../../pallets/transporter", default-features = false }
+scale-info = { version = "2.11.2", default-features = false, features = ["derive"] }
+sp-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-block-builder = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-core = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-domains = { version = "0.1.0", path = "../../../../crates/sp-domains", default-features = false }
+sp-domain-sudo = { version = "0.1.0", path = "../../../primitives/domain-sudo", default-features = false }
+sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", default-features = false }
+sp-inherents = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-messenger = { version = "0.1.0", default-features = false, path = "../../../primitives/messenger" }
+sp-messenger-host-functions = { version = "0.1.0", default-features = false, path = "../../../primitives/messenger-host-functions" }
+sp-mmr-primitives = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-offchain = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-runtime = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-session = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-std = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-storage = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", optional = true }
+sp-subspace-mmr = { version = "0.1.0", default-features = false, path = "../../../../crates/sp-subspace-mmr" }
+sp-transaction-pool = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+sp-version = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef" }
+subspace-core-primitives = { version = "0.1.0", path = "../../../../crates/subspace-core-primitives", default-features = false }
+subspace-runtime-primitives = { version = "0.1.0", path = "../../../../crates/subspace-runtime-primitives", default-features = false }
+
+[dev-dependencies]
+subspace-runtime-primitives = { version = "0.1.0", features = ["testing"], path = "../../../../crates/subspace-runtime-primitives" }
+
+[build-dependencies]
+substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "0cbfcb0232bbf71ac5b14cc8c99bf043cec420ef", optional = true }
+
+[features]
+default = [
+    "std",
+]
+std = [
+    "codec/std",
+    "domain-pallet-executive/std",
+    "domain-runtime-primitives/std",
+    "domain-test-primitives/std",
+    "frame-benchmarking?/std",
+    "frame-support/std",
+    "frame-system/std",
+    "frame-system-rpc-runtime-api/std",
+    "pallet-auto-id/std",
+    "pallet-balances/std",
+    "pallet-block-fees/std",
+    "pallet-domain-id/std",
+    "pallet-domain-sudo/std",
+    "pallet-messenger/std",
+    "pallet-timestamp/std",
+    "pallet-transaction-payment/std",
+    "pallet-transaction-payment-rpc-runtime-api/std",
+    "pallet-transporter/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-block-builder/std",
+    "sp-core/std",
+    "sp-domains/std",
+    "sp-domain-sudo/std",
+    "sp-genesis-builder/std",
+    "sp-inherents/std",
+    "sp-messenger/std",
+    "sp-messenger-host-functions/std",
+    "sp-mmr-primitives/std",
+    "sp-offchain/std",
+    "sp-runtime/std",
+    "sp-session/std",
+    "sp-std/std",
+    "sp-storage?/std",
+    "sp-subspace-mmr/std",
+    "sp-transaction-pool/std",
+    "sp-version/std",
+    "subspace-core-primitives/std",
+    "subspace-runtime-primitives/std",
+    "substrate-wasm-builder",
+]
+runtime-benchmarks = [
+    "domain-pallet-executive/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "sp-storage",
+    "frame-benchmarking",
+    "frame-system-benchmarking",
+    "frame-system-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "pallet-auto-id/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "pallet-messenger/runtime-benchmarks",
+    "pallet-domain-id/runtime-benchmarks"
+]

--- a/domains/test/runtime/auto-id/build.rs
+++ b/domains/test/runtime/auto-id/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    #[cfg(feature = "std")]
+    {
+        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
+        std::env::set_var("CFLAGS", "-mcpu=mvp");
+        std::env::set_var("WASM_BUILD_TYPE", "release");
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .export_heap_base()
+            .import_memory()
+            .build();
+    }
+}

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -1,0 +1,1031 @@
+#![feature(variant_count)]
+#![cfg_attr(not(feature = "std"), no_std)]
+// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
+#![recursion_limit = "256"]
+
+// Make the WASM binary available.
+#[cfg(feature = "std")]
+include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::format;
+use codec::{Decode, Encode, MaxEncodedLen};
+use domain_runtime_primitives::opaque::Header;
+pub use domain_runtime_primitives::{
+    block_weights, maximum_block_length, opaque, AccountId, Address, Balance, BlockNumber, Hash,
+    Nonce, Signature, EXISTENTIAL_DEPOSIT,
+};
+use domain_runtime_primitives::{
+    CheckExtrinsicsValidityError, DecodeExtrinsicError, ERR_BALANCE_OVERFLOW, SLOT_DURATION,
+};
+use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
+use frame_support::genesis_builder_helper::{build_state, get_preset};
+use frame_support::inherent::ProvideInherent;
+use frame_support::pallet_prelude::TypeInfo;
+use frame_support::traits::fungible::Credit;
+use frame_support::traits::{
+    ConstU16, ConstU32, ConstU64, Everything, Imbalance, OnUnbalanced, VariantCount,
+};
+use frame_support::weights::constants::ParityDbWeight;
+use frame_support::weights::{ConstantMultiplier, IdentityFee, Weight};
+use frame_support::{construct_runtime, parameter_types};
+use frame_system::limits::{BlockLength, BlockWeights};
+use pallet_block_fees::fees::OnChargeDomainTransaction;
+use pallet_transporter::EndpointHandler;
+use sp_api::impl_runtime_apis;
+use sp_core::crypto::KeyTypeId;
+use sp_core::{Get, OpaqueMetadata};
+use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
+use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
+use sp_messenger::messages::{
+    BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
+};
+use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
+use sp_mmr_primitives::EncodableOpaqueLeaf;
+use sp_runtime::generic::Era;
+use sp_runtime::traits::{
+    AccountIdLookup, BlakeTwo256, Block as BlockT, Checkable, Keccak256, NumberFor, One,
+    SignedExtension, ValidateUnsigned, Zero,
+};
+use sp_runtime::transaction_validity::{
+    InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
+};
+use sp_runtime::{
+    create_runtime_str, generic, impl_opaque_keys, ApplyExtrinsicResult, Digest,
+    ExtrinsicInclusionMode,
+};
+pub use sp_runtime::{MultiAddress, Perbill, Permill};
+use sp_std::collections::btree_set::BTreeSet;
+use sp_std::marker::PhantomData;
+use sp_std::prelude::*;
+use sp_subspace_mmr::domain_mmr_runtime_interface::{
+    is_consensus_block_finalized, verify_mmr_proof,
+};
+use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
+use sp_version::RuntimeVersion;
+use subspace_runtime_primitives::{
+    BlockNumber as ConsensusBlockNumber, Hash as ConsensusBlockHash, Moment,
+    SlowAdjustingFeeUpdate, SSC,
+};
+
+/// Block type as expected by this runtime.
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+
+/// A Block signed with a Justification
+pub type SignedBlock = generic::SignedBlock<Block>;
+
+/// BlockId type as expected by this runtime.
+pub type BlockId = generic::BlockId<Block>;
+
+/// The SignedExtension to the basic transaction logic.
+pub type SignedExtra = (
+    frame_system::CheckNonZeroSender<Runtime>,
+    frame_system::CheckSpecVersion<Runtime>,
+    frame_system::CheckTxVersion<Runtime>,
+    frame_system::CheckGenesis<Runtime>,
+    frame_system::CheckMortality<Runtime>,
+    frame_system::CheckNonce<Runtime>,
+    frame_system::CheckWeight<Runtime>,
+    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+);
+
+/// Unchecked extrinsic type as expected by this runtime.
+pub type UncheckedExtrinsic =
+    generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+
+/// Extrinsic type that has already been checked.
+pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
+
+/// Executive: handles dispatch to the various modules.
+pub type Executive = domain_pallet_executive::Executive<
+    Runtime,
+    frame_system::ChainContext<Runtime>,
+    Runtime,
+    AllPalletsWithSystem,
+>;
+
+impl_opaque_keys! {
+    pub struct SessionKeys {
+        /// Primarily used for adding the operator signing key into the Keystore.
+        pub operator: sp_domains::OperatorKey,
+    }
+}
+
+#[sp_version::runtime_version]
+pub const VERSION: RuntimeVersion = RuntimeVersion {
+    spec_name: create_runtime_str!("subspace-auto-id-domain"),
+    impl_name: create_runtime_str!("subspace-auto-id-domain"),
+    authoring_version: 0,
+    spec_version: 1,
+    impl_version: 0,
+    apis: RUNTIME_API_VERSIONS,
+    transaction_version: 0,
+    state_version: 0,
+    extrinsic_state_version: 1,
+};
+
+parameter_types! {
+    pub const Version: RuntimeVersion = VERSION;
+    pub const BlockHashCount: BlockNumber = 2400;
+    pub RuntimeBlockLength: BlockLength = maximum_block_length();
+    pub RuntimeBlockWeights: BlockWeights = block_weights();
+}
+
+impl frame_system::Config for Runtime {
+    /// The identifier used to distinguish between accounts.
+    type AccountId = AccountId;
+    /// The aggregated dispatch type that is available for extrinsics.
+    type RuntimeCall = RuntimeCall;
+    /// The aggregated `RuntimeTask` type.
+    type RuntimeTask = RuntimeTask;
+    /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
+    type Lookup = AccountIdLookup<AccountId, ()>;
+    /// The type for storing how many extrinsics an account has signed.
+    type Nonce = Nonce;
+    /// The type for hashing blocks and tries.
+    type Hash = Hash;
+    /// The hashing algorithm used.
+    type Hashing = BlakeTwo256;
+    /// The block type.
+    type Block = Block;
+    /// The ubiquitous event type.
+    type RuntimeEvent = RuntimeEvent;
+    /// The ubiquitous origin type.
+    type RuntimeOrigin = RuntimeOrigin;
+    /// Maximum number of block number to block hash mappings to keep (oldest pruned first).
+    type BlockHashCount = BlockHashCount;
+    /// Runtime version.
+    type Version = Version;
+    /// Converts a module to an index of this module in the runtime.
+    type PalletInfo = PalletInfo;
+    /// The data to be stored in an account.
+    type AccountData = pallet_balances::AccountData<Balance>;
+    /// What to do if a new account is created.
+    type OnNewAccount = ();
+    /// What to do if an account is fully reaped from the system.
+    type OnKilledAccount = ();
+    /// The weight of database operations that the runtime can invoke.
+    type DbWeight = ParityDbWeight;
+    /// The basic call filter to use in dispatchable.
+    type BaseCallFilter = Everything;
+    /// Weight information for the extrinsics of this pallet.
+    type SystemWeightInfo = ();
+    /// Block & extrinsics weights: base values and limits.
+    type BlockWeights = RuntimeBlockWeights;
+    /// The maximum length of a block (in bytes).
+    type BlockLength = RuntimeBlockLength;
+    type SS58Prefix = ConstU16<2254>;
+    /// The action to take on a Runtime Upgrade
+    type OnSetCode = ();
+    type SingleBlockMigrations = ();
+    type MultiBlockMigrator = ();
+    type PreInherents = ();
+    type PostInherents = ();
+    type PostTransactions = ();
+    type MaxConsumers = ConstU32<16>;
+}
+
+impl pallet_timestamp::Config for Runtime {
+    /// A timestamp: milliseconds since the unix epoch.
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+    pub const MaxLocks: u32 = 50;
+    pub const MaxReserves: u32 = 50;
+}
+
+/// `DustRemovalHandler` used to collect all the SSC dust left when the account is reaped.
+pub struct DustRemovalHandler;
+
+impl OnUnbalanced<Credit<AccountId, Balances>> for DustRemovalHandler {
+    fn on_nonzero_unbalanced(dusted_amount: Credit<AccountId, Balances>) {
+        BlockFees::note_burned_balance(dusted_amount.peek());
+    }
+}
+
+impl pallet_balances::Config for Runtime {
+    type RuntimeFreezeReason = RuntimeFreezeReason;
+    type MaxLocks = MaxLocks;
+    /// The type for recording an account's balance.
+    type Balance = Balance;
+    /// The ubiquitous event type.
+    type RuntimeEvent = RuntimeEvent;
+    type DustRemoval = DustRemovalHandler;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
+    type MaxReserves = MaxReserves;
+    type ReserveIdentifier = [u8; 8];
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
+    type RuntimeHoldReason = HoldIdentifier;
+}
+
+parameter_types! {
+    pub const OperationalFeeMultiplier: u8 = 5;
+    pub const DomainChainByteFee: Balance = 1;
+}
+
+impl pallet_block_fees::Config for Runtime {
+    type Balance = Balance;
+    type DomainChainByteFee = DomainChainByteFee;
+}
+
+pub struct FinalDomainTransactionByteFee;
+
+impl Get<Balance> for FinalDomainTransactionByteFee {
+    fn get() -> Balance {
+        BlockFees::final_domain_transaction_byte_fee()
+    }
+}
+
+impl pallet_transaction_payment::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type OnChargeTransaction = OnChargeDomainTransaction<Balances>;
+    type WeightToFee = IdentityFee<Balance>;
+    type LengthToFee = ConstantMultiplier<Balance, FinalDomainTransactionByteFee>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
+    type OperationalFeeMultiplier = OperationalFeeMultiplier;
+}
+
+impl pallet_auto_id::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type Time = Timestamp;
+    type Weights = pallet_auto_id::weights::SubstrateWeight<Self>;
+}
+
+pub struct ExtrinsicStorageFees;
+
+impl domain_pallet_executive::ExtrinsicStorageFees<Runtime> for ExtrinsicStorageFees {
+    fn extract_signer(xt: UncheckedExtrinsic) -> (Option<AccountId>, DispatchInfo) {
+        let dispatch_info = xt.get_dispatch_info();
+        let lookup = frame_system::ChainContext::<Runtime>::default();
+        let maybe_signer = extract_signer_inner(&xt, &lookup).and_then(|res| res.ok());
+        (maybe_signer, dispatch_info)
+    }
+
+    fn on_storage_fees_charged(
+        charged_fees: Balance,
+        tx_size: u32,
+    ) -> Result<(), TransactionValidityError> {
+        let consensus_storage_fee = BlockFees::consensus_chain_byte_fee()
+            .checked_mul(Balance::from(tx_size))
+            .ok_or(InvalidTransaction::Custom(ERR_BALANCE_OVERFLOW))?;
+
+        let (paid_consensus_storage_fee, paid_domain_fee) = if charged_fees <= consensus_storage_fee
+        {
+            (charged_fees, Zero::zero())
+        } else {
+            (consensus_storage_fee, charged_fees - consensus_storage_fee)
+        };
+
+        BlockFees::note_consensus_storage_fee(paid_consensus_storage_fee);
+        BlockFees::note_domain_execution_fee(paid_domain_fee);
+        Ok(())
+    }
+}
+
+impl domain_pallet_executive::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = domain_pallet_executive::weights::SubstrateWeight<Runtime>;
+    type Currency = Balances;
+    type LengthToFee = <Runtime as pallet_transaction_payment::Config>::LengthToFee;
+    type ExtrinsicStorageFees = ExtrinsicStorageFees;
+}
+
+parameter_types! {
+    pub SelfChainId: ChainId = SelfDomainId::self_domain_id().into();
+}
+
+pub struct OnXDMRewards;
+
+impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
+    fn on_xdm_rewards(rewards: Balance) {
+        BlockFees::note_domain_execution_fee(rewards)
+    }
+    fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
+        // note the burned balance from this chain
+        BlockFees::note_burned_balance(fees);
+        // note the chain rewards
+        BlockFees::note_chain_rewards(chain_id, fees);
+    }
+}
+
+type MmrHash = <Keccak256 as sp_runtime::traits::Hash>::Output;
+
+pub struct MmrProofVerifier;
+
+impl sp_subspace_mmr::MmrProofVerifier<MmrHash, NumberFor<Block>, Hash> for MmrProofVerifier {
+    fn verify_proof_and_extract_leaf(
+        mmr_leaf_proof: ConsensusChainMmrLeafProof<NumberFor<Block>, Hash, MmrHash>,
+    ) -> Option<MmrLeaf<ConsensusBlockNumber, ConsensusBlockHash>> {
+        let ConsensusChainMmrLeafProof {
+            consensus_block_number,
+            opaque_mmr_leaf: opaque_leaf,
+            proof,
+            ..
+        } = mmr_leaf_proof;
+
+        if !is_consensus_block_finalized(consensus_block_number) {
+            return None;
+        }
+
+        let leaf: MmrLeaf<ConsensusBlockNumber, ConsensusBlockHash> =
+            opaque_leaf.into_opaque_leaf().try_decode()?;
+
+        verify_mmr_proof(vec![EncodableOpaqueLeaf::from_leaf(&leaf)], proof.encode())
+            .then_some(leaf)
+    }
+}
+
+pub struct StorageKeys;
+
+impl sp_messenger::StorageKeys for StorageKeys {
+    fn confirmed_domain_block_storage_key(domain_id: DomainId) -> Option<Vec<u8>> {
+        get_storage_key(StorageKeyRequest::ConfirmedDomainBlockStorageKey(domain_id))
+    }
+
+    fn outbox_storage_key(chain_id: ChainId, message_key: MessageKey) -> Option<Vec<u8>> {
+        get_storage_key(StorageKeyRequest::OutboxStorageKey {
+            chain_id,
+            message_key,
+        })
+    }
+
+    fn inbox_responses_storage_key(chain_id: ChainId, message_key: MessageKey) -> Option<Vec<u8>> {
+        get_storage_key(StorageKeyRequest::InboxResponseStorageKey {
+            chain_id,
+            message_key,
+        })
+    }
+}
+
+/// Hold identifier for balances for this runtime.
+#[derive(
+    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
+)]
+pub enum HoldIdentifier {
+    Messenger(MessengerHoldIdentifier),
+}
+
+impl VariantCount for HoldIdentifier {
+    // TODO: revist this value, it is used as the max number of hold an account can
+    // create. Currently, opening an XDM channel will create 1 hold, so this value
+    // also used as the limit of how many channel an account can open.
+    //
+    // TODO: HACK this is not the actual variant count but it is required see
+    // https://github.com/subspace/subspace/issues/2674 for more details. It
+    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
+    const VARIANT_COUNT: u32 = 100;
+}
+
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
+    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    }
+}
+
+parameter_types! {
+    pub const ChannelReserveFee: Balance = 100 * SSC;
+    pub const ChannelInitReservePortion: Perbill = Perbill::from_percent(20);
+    // TODO update the fee model
+    pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
+}
+
+impl pallet_messenger::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type SelfChainId = SelfChainId;
+
+    fn get_endpoint_handler(endpoint: &Endpoint) -> Option<Box<dyn EndpointHandlerT<MessageId>>> {
+        if endpoint == &Endpoint::Id(TransporterEndpointId::get()) {
+            Some(Box::new(EndpointHandler(PhantomData::<Runtime>)))
+        } else {
+            None
+        }
+    }
+
+    type Currency = Balances;
+    type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
+    type WeightToFee = IdentityFee<Balance>;
+    type OnXDMRewards = OnXDMRewards;
+    type MmrHash = MmrHash;
+    type MmrProofVerifier = MmrProofVerifier;
+    type StorageKeys = StorageKeys;
+    type DomainOwner = ();
+    type HoldIdentifier = HoldIdentifier;
+    type ChannelReserveFee = ChannelReserveFee;
+    type ChannelInitReservePortion = ChannelInitReservePortion;
+    type DomainRegistration = ();
+    type ChannelFeeModel = ChannelFeeModel;
+}
+
+impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
+where
+    RuntimeCall: From<C>,
+{
+    type Extrinsic = UncheckedExtrinsic;
+    type OverarchingCall = RuntimeCall;
+}
+
+parameter_types! {
+    pub const TransporterEndpointId: EndpointId = 1;
+}
+
+impl pallet_transporter::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type SelfChainId = SelfChainId;
+    type SelfEndpointId = TransporterEndpointId;
+    type Currency = Balances;
+    type Sender = Messenger;
+    type AccountIdConverter = domain_runtime_primitives::AccountIdConverter;
+    type WeightInfo = pallet_transporter::weights::SubstrateWeight<Runtime>;
+}
+
+impl pallet_domain_id::Config for Runtime {}
+
+pub struct IntoRuntimeCall;
+
+impl sp_domain_sudo::IntoRuntimeCall<RuntimeCall> for IntoRuntimeCall {
+    fn runtime_call(call: Vec<u8>) -> RuntimeCall {
+        UncheckedExtrinsic::decode(&mut call.as_slice())
+            .expect("must always be a valid extrinsic as checked by consensus chain; qed")
+            .function
+    }
+}
+
+impl pallet_domain_sudo::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type IntoRuntimeCall = IntoRuntimeCall;
+}
+
+// Create the runtime by composing the FRAME pallets that were previously configured.
+//
+// NOTE: Currently domain runtime does not naturally support the pallets with inherent extrinsics.
+construct_runtime!(
+    pub struct Runtime {
+        // System support stuff.
+        System: frame_system = 0,
+        // Note: Ensure index of the timestamp matches with the index of timestamp on Consensus
+        //  so that consensus can construct encoded extrinsic that matches with Domain encoded
+        //  extrinsic.
+        Timestamp: pallet_timestamp = 1,
+        ExecutivePallet: domain_pallet_executive = 2,
+
+        // monetary stuff
+        Balances: pallet_balances = 20,
+        TransactionPayment: pallet_transaction_payment = 21,
+
+        // AutoId
+        AutoId: pallet_auto_id = 40,
+
+        // messenger stuff
+        // Note: Indexes should match with indexes on other chains and domains
+        Messenger: pallet_messenger = 60,
+        Transporter: pallet_transporter = 61,
+
+        // domain instance stuff
+        SelfDomainId: pallet_domain_id = 90,
+        BlockFees: pallet_block_fees = 91,
+
+        // Sudo account
+        Sudo: pallet_domain_sudo = 100,
+    }
+);
+
+fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
+    match &ext.function {
+        RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
+        | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+            let ConsensusChainMmrLeafProof {
+                consensus_block_number,
+                opaque_mmr_leaf,
+                proof,
+                ..
+            } = msg.proof.consensus_mmr_proof();
+
+            if !is_consensus_block_finalized(consensus_block_number) {
+                return Some(false);
+            }
+
+            Some(verify_mmr_proof(vec![opaque_mmr_leaf], proof.encode()))
+        }
+        _ => None,
+    }
+}
+
+/// Returns a valid Sudo call.
+/// Should extend this function to limit specific calls Sudo can make when needed.
+fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
+    UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()
+}
+
+fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+    let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice())
+        .expect("must always be an valid extrinsic due to the check above; qed");
+    UncheckedExtrinsic::new_unsigned(
+        pallet_domain_sudo::Call::sudo {
+            call: Box::new(ext.function),
+        }
+        .into(),
+    )
+}
+
+fn extract_signer_inner<Lookup>(
+    ext: &UncheckedExtrinsic,
+    lookup: &Lookup,
+) -> Option<Result<AccountId, TransactionValidityError>>
+where
+    Lookup: sp_runtime::traits::Lookup<Source = Address, Target = AccountId>,
+{
+    ext.signature
+        .as_ref()
+        .map(|(signed, _, _)| lookup.lookup(signed.clone()).map_err(|e| e.into()))
+}
+
+pub fn extract_signer(
+    extrinsics: Vec<UncheckedExtrinsic>,
+) -> Vec<(Option<opaque::AccountId>, UncheckedExtrinsic)> {
+    let lookup = frame_system::ChainContext::<Runtime>::default();
+
+    extrinsics
+        .into_iter()
+        .map(|extrinsic| {
+            let maybe_signer =
+                extract_signer_inner(&extrinsic, &lookup).and_then(|account_result| {
+                    account_result.ok().map(|account_id| account_id.encode())
+                });
+            (maybe_signer, extrinsic)
+        })
+        .collect()
+}
+
+fn extrinsic_era(extrinsic: &<Block as BlockT>::Extrinsic) -> Option<Era> {
+    extrinsic.signature.as_ref().map(|(_, _, extra)| extra.4 .0)
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benches {
+    frame_benchmarking::define_benchmarks!(
+        [frame_benchmarking, BaselineBench::<Runtime>]
+        [frame_system, SystemBench::<Runtime>]
+        [domain_pallet_executive, ExecutivePallet]
+        [pallet_messenger, Messenger]
+        [pallet_auto_id, AutoId]
+    );
+}
+
+fn check_transaction_and_do_pre_dispatch_inner(
+    uxt: &<Block as BlockT>::Extrinsic,
+) -> Result<(), TransactionValidityError> {
+    let lookup = frame_system::ChainContext::<Runtime>::default();
+
+    let xt = uxt.clone().check(&lookup)?;
+
+    let dispatch_info = xt.get_dispatch_info();
+
+    if dispatch_info.class == DispatchClass::Mandatory {
+        return Err(InvalidTransaction::MandatoryValidation.into());
+    }
+
+    let encoded_len = uxt.encoded_size();
+
+    // We invoke `pre_dispatch` in addition to `validate_transaction`(even though the validation is almost same)
+    // as that will add the side effect of SignedExtension in the storage buffer
+    // which would help to maintain context across multiple transaction validity check against same
+    // runtime instance.
+    match xt.signed {
+        // signed transaction
+        Some((account_id, extra)) => extra
+            .pre_dispatch(&account_id, &xt.function, &dispatch_info, encoded_len)
+            .map(|_| ()),
+        // unsigned transaction
+        None => {
+            if let RuntimeCall::Messenger(call) = &xt.function {
+                Messenger::pre_dispatch_with_trusted_mmr_proof(call)?;
+            } else {
+                Runtime::pre_dispatch(&xt.function).map(|_| ())?;
+            }
+            SignedExtra::pre_dispatch_unsigned(&xt.function, &dispatch_info, encoded_len)
+                .map(|_| ())
+        }
+    }
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl frame_system_benchmarking::Config for Runtime {}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl frame_benchmarking::baseline::Config for Runtime {}
+
+impl_runtime_apis! {
+    impl sp_api::Core<Block> for Runtime {
+        fn version() -> RuntimeVersion {
+            VERSION
+        }
+
+        fn execute_block(block: Block) {
+            Executive::execute_block(block)
+        }
+
+        fn initialize_block(header: &<Block as BlockT>::Header) -> ExtrinsicInclusionMode {
+            Executive::initialize_block(header)
+        }
+    }
+
+    impl sp_api::Metadata<Block> for Runtime {
+        fn metadata() -> OpaqueMetadata {
+            OpaqueMetadata::new(Runtime::metadata().into())
+        }
+
+        fn metadata_at_version(version: u32) -> Option<OpaqueMetadata> {
+            Runtime::metadata_at_version(version)
+        }
+
+        fn metadata_versions() -> Vec<u32> {
+            Runtime::metadata_versions()
+        }
+    }
+
+    impl sp_block_builder::BlockBuilder<Block> for Runtime {
+        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+            Executive::apply_extrinsic(extrinsic)
+        }
+
+        fn finalize_block() -> <Block as BlockT>::Header {
+            Executive::finalize_block()
+        }
+
+        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+            data.create_extrinsics()
+        }
+
+        fn check_inherents(
+            block: Block,
+            data: sp_inherents::InherentData,
+        ) -> sp_inherents::CheckInherentsResult {
+            data.check_extrinsics(&block)
+        }
+    }
+
+    impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
+        fn validate_transaction(
+            source: TransactionSource,
+            tx: <Block as BlockT>::Extrinsic,
+            block_hash: <Block as BlockT>::Hash,
+        ) -> TransactionValidity {
+            Executive::validate_transaction(source, tx, block_hash)
+        }
+    }
+
+    impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
+        fn offchain_worker(header: &<Block as BlockT>::Header) {
+            Executive::offchain_worker(header)
+        }
+    }
+
+    impl sp_session::SessionKeys<Block> for Runtime {
+        fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
+            SessionKeys::generate(seed)
+        }
+
+        fn decode_session_keys(
+            encoded: Vec<u8>,
+        ) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
+            SessionKeys::decode_into_raw_public_keys(&encoded)
+        }
+    }
+
+    impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Nonce> for Runtime {
+        fn account_nonce(account: AccountId) -> Nonce {
+            System::account_nonce(account)
+        }
+    }
+
+    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
+        fn query_info(
+            uxt: <Block as BlockT>::Extrinsic,
+            len: u32,
+        ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+            TransactionPayment::query_info(uxt, len)
+        }
+        fn query_fee_details(
+            uxt: <Block as BlockT>::Extrinsic,
+            len: u32,
+        ) -> pallet_transaction_payment::FeeDetails<Balance> {
+            TransactionPayment::query_fee_details(uxt, len)
+        }
+        fn query_weight_to_fee(weight: Weight) -> Balance {
+            TransactionPayment::weight_to_fee(weight)
+        }
+        fn query_length_to_fee(length: u32) -> Balance {
+            TransactionPayment::length_to_fee(length)
+        }
+    }
+
+    impl sp_domains::core_api::DomainCoreApi<Block> for Runtime {
+        fn extract_signer(
+            extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+        ) -> Vec<(Option<opaque::AccountId>, <Block as BlockT>::Extrinsic)> {
+            extract_signer(extrinsics)
+        }
+
+        fn is_within_tx_range(
+            extrinsic: &<Block as BlockT>::Extrinsic,
+            bundle_vrf_hash: &subspace_core_primitives::U256,
+            tx_range: &subspace_core_primitives::U256
+        ) -> bool {
+            use subspace_core_primitives::U256;
+            use subspace_core_primitives::crypto::blake3_hash;
+
+            let lookup = frame_system::ChainContext::<Runtime>::default();
+            if let Some(signer) = extract_signer_inner(extrinsic, &lookup).and_then(|account_result| {
+                    account_result.ok().map(|account_id| account_id.encode())
+                }) {
+                // Check if the signer Id hash is within the tx range
+                let signer_id_hash = U256::from_be_bytes(blake3_hash(&signer.encode()));
+                sp_domains::signer_in_tx_range(bundle_vrf_hash, &signer_id_hash, tx_range)
+            } else {
+                // Unsigned transactions are always in the range.
+                true
+            }
+        }
+
+        fn intermediate_roots() -> Vec<[u8; 32]> {
+            ExecutivePallet::intermediate_roots()
+        }
+
+        fn initialize_block_with_post_state_root(header: &<Block as BlockT>::Header) -> Vec<u8> {
+            Executive::initialize_block(header);
+            Executive::storage_root()
+        }
+
+        fn apply_extrinsic_with_post_state_root(extrinsic: <Block as BlockT>::Extrinsic) -> Vec<u8> {
+            let _ = Executive::apply_extrinsic(extrinsic);
+            Executive::storage_root()
+        }
+
+        fn construct_set_code_extrinsic(code: Vec<u8>) -> Vec<u8> {
+            UncheckedExtrinsic::new_unsigned(
+                domain_pallet_executive::Call::set_code {
+                    code
+                }.into()
+            ).encode()
+        }
+
+        fn construct_timestamp_extrinsic(moment: Moment) -> <Block as BlockT>::Extrinsic {
+            UncheckedExtrinsic::new_unsigned(
+                pallet_timestamp::Call::set{ now: moment }.into()
+            )
+        }
+
+        fn is_inherent_extrinsic(extrinsic: &<Block as BlockT>::Extrinsic) -> bool {
+            match &extrinsic.function {
+                RuntimeCall::Timestamp(call) => Timestamp::is_inherent(call),
+                RuntimeCall::ExecutivePallet(call) => ExecutivePallet::is_inherent(call),
+                RuntimeCall::Messenger(call) => Messenger::is_inherent(call),
+                RuntimeCall::Sudo(call) => Sudo::is_inherent(call),
+                _ => false,
+            }
+        }
+
+        fn check_extrinsics_and_do_pre_dispatch(uxts: Vec<<Block as BlockT>::Extrinsic>, block_number: BlockNumber,
+            block_hash: <Block as BlockT>::Hash) -> Result<(), CheckExtrinsicsValidityError> {
+            // Initializing block related storage required for validation
+            System::initialize(
+                &(block_number + BlockNumber::one()),
+                &block_hash,
+                &Default::default(),
+            );
+
+            for (extrinsic_index, uxt) in uxts.iter().enumerate() {
+                check_transaction_and_do_pre_dispatch_inner(uxt).map_err(|e| {
+                    CheckExtrinsicsValidityError {
+                        extrinsic_index: extrinsic_index as u32,
+                        transaction_validity_error: e
+                    }
+                })?;
+            }
+
+            Ok(())
+        }
+
+        fn decode_extrinsic(
+            opaque_extrinsic: sp_runtime::OpaqueExtrinsic,
+        ) -> Result<<Block as BlockT>::Extrinsic, DecodeExtrinsicError> {
+            let encoded = opaque_extrinsic.encode();
+            UncheckedExtrinsic::decode(&mut encoded.as_slice())
+                .map_err(|err| DecodeExtrinsicError(format!("{}", err)))
+        }
+
+        fn extrinsic_era(
+          extrinsic: &<Block as BlockT>::Extrinsic
+        ) -> Option<Era> {
+            extrinsic_era(extrinsic)
+        }
+
+        fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
+            ext.get_dispatch_info().weight
+        }
+
+        fn block_fees() -> sp_domains::BlockFees<Balance> {
+            BlockFees::collected_block_fees()
+        }
+
+        fn block_digest() -> Digest {
+            System::digest()
+        }
+
+        fn block_weight() -> Weight {
+            System::block_weight().total()
+        }
+
+        fn construct_consensus_chain_byte_fee_extrinsic(transaction_byte_fee: Balance) -> <Block as BlockT>::Extrinsic {
+            UncheckedExtrinsic::new_unsigned(
+                pallet_block_fees::Call::set_next_consensus_chain_byte_fee{ transaction_byte_fee }.into()
+            )
+        }
+
+        fn construct_domain_update_chain_allowlist_extrinsic(updates: DomainAllowlistUpdates) -> <Block as BlockT>::Extrinsic {
+             UncheckedExtrinsic::new_unsigned(
+                pallet_messenger::Call::update_domain_allowlist{ updates }.into()
+            )
+        }
+
+        fn transfers() -> Transfers<Balance> {
+            Transporter::chain_transfers()
+        }
+
+        fn transfers_storage_key() -> Vec<u8> {
+            Transporter::transfers_storage_key()
+        }
+
+        fn block_fees_storage_key() -> Vec<u8> {
+            BlockFees::block_fees_storage_key()
+        }
+    }
+
+    impl sp_messenger::MessengerApi<Block, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
+        fn is_xdm_mmr_proof_valid(
+            extrinsic: &<Block as BlockT>::Extrinsic,
+        ) -> Option<bool> {
+            is_xdm_mmr_proof_valid(extrinsic)
+        }
+
+        fn extract_xdm_mmr_proof(ext: &<Block as BlockT>::Extrinsic) -> Option<ConsensusChainMmrLeafProof<ConsensusBlockNumber, ConsensusBlockHash, sp_core::H256>> {
+            match &ext.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })
+                | RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(msg.proof.consensus_mmr_proof())
+                }
+                _ => None,
+            }
+        }
+
+        fn confirmed_domain_block_storage_key(_domain_id: DomainId) -> Vec<u8> {
+            // invalid call from Domain runtime
+            vec![]
+        }
+
+        fn outbox_storage_key(message_key: MessageKey) -> Vec<u8> {
+            Messenger::outbox_storage_key(message_key)
+        }
+
+        fn inbox_response_storage_key(message_key: MessageKey) -> Vec<u8> {
+            Messenger::inbox_response_storage_key(message_key)
+        }
+
+        fn domain_chains_allowlist_update(_domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
+            // not valid call on domains
+            None
+        }
+    }
+
+    impl sp_messenger::RelayerApi<Block, BlockNumber, ConsensusBlockNumber, ConsensusBlockHash> for Runtime {
+        fn block_messages() -> BlockMessagesWithStorageKey {
+            Messenger::get_block_messages()
+        }
+
+        fn outbox_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+            Messenger::outbox_message_unsigned(msg)
+        }
+
+        fn inbox_response_message_unsigned(msg: CrossDomainMessage<NumberFor<Block>, <Block as BlockT>::Hash, <Block as BlockT>::Hash>) -> Option<<Block as BlockT>::Extrinsic> {
+            Messenger::inbox_response_message_unsigned(msg)
+        }
+
+        fn should_relay_outbox_message(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
+            Messenger::should_relay_outbox_message(dst_chain_id, msg_id)
+        }
+
+        fn should_relay_inbox_message_response(dst_chain_id: ChainId, msg_id: MessageId) -> bool {
+            Messenger::should_relay_inbox_message_response(dst_chain_id, msg_id)
+        }
+
+        fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::updated_channels()
+        }
+
+        fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
+            Messenger::channel_storage_key(chain_id, channel_id)
+        }
+    }
+
+    impl sp_domain_sudo::DomainSudoApi<Block> for Runtime {
+        fn is_valid_sudo_call(extrinsic: Vec<u8>) -> bool {
+            is_valid_sudo_call(extrinsic)
+        }
+
+        fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> <Block as BlockT>::Extrinsic {
+            construct_sudo_call_extrinsic(inner)
+        }
+    }
+
+    impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
+        fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
+            build_state::<RuntimeGenesisConfig>(config)
+        }
+
+        fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+            get_preset::<RuntimeGenesisConfig>(id, |_| None)
+        }
+
+        fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
+            vec![]
+        }
+    }
+
+    impl domain_test_primitives::OnchainStateApi<Block, AccountId, Balance> for Runtime {
+        fn free_balance(account_id: AccountId) -> Balance {
+            Balances::free_balance(account_id)
+        }
+
+        fn get_open_channel_for_chain(dst_chain_id: ChainId) -> Option<ChannelId> {
+            Messenger::get_open_channel_for_chain(dst_chain_id).map(|(c, _)| c)
+        }
+
+        fn consensus_chain_byte_fee() -> Balance {
+            BlockFees::consensus_chain_byte_fee()
+        }
+    }
+
+    #[cfg(feature = "runtime-benchmarks")]
+    impl frame_benchmarking::Benchmark<Block> for Runtime {
+        fn benchmark_metadata(extra: bool) -> (
+            Vec<frame_benchmarking::BenchmarkList>,
+            Vec<frame_support::traits::StorageInfo>,
+        ) {
+            use frame_benchmarking::{baseline, Benchmarking, BenchmarkList};
+            use frame_support::traits::StorageInfoTrait;
+            use frame_system_benchmarking::Pallet as SystemBench;
+            use baseline::Pallet as BaselineBench;
+
+            let mut list = Vec::<BenchmarkList>::new();
+
+            list_benchmarks!(list, extra);
+
+            let storage_info = AllPalletsWithSystem::storage_info();
+
+            (list, storage_info)
+        }
+
+        fn dispatch_benchmark(
+            config: frame_benchmarking::BenchmarkConfig
+        ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
+            use frame_benchmarking::{baseline, Benchmarking, BenchmarkBatch};
+            use sp_storage::TrackedStorageKey;
+            use frame_system_benchmarking::Pallet as SystemBench;
+            use frame_support::traits::WhitelistedStorageKeys;
+            use baseline::Pallet as BaselineBench;
+
+            let whitelist: Vec<TrackedStorageKey> = AllPalletsWithSystem::whitelisted_storage_keys();
+
+            let mut batches = Vec::<BenchmarkBatch>::new();
+            let params = (&config, &whitelist);
+
+            add_benchmarks!(params, batches);
+
+            if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
+            Ok(batches)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Runtime, RuntimeBlockWeights as BlockWeights};
+    use subspace_runtime_primitives::tests_utils::FeeMultiplierUtils;
+
+    #[test]
+    fn multiplier_can_grow_from_zero() {
+        FeeMultiplierUtils::<Runtime, BlockWeights>::multiplier_can_grow_from_zero()
+    }
+}

--- a/domains/test/service/Cargo.toml
+++ b/domains/test/service/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+auto-id-domain-test-runtime = { version = "0.1.0", path = "../runtime/auto-id" }
 cross-domain-message-gossip = { version = "0.1.0", path = "../../client/cross-domain-message-gossip" }
 domain-client-operator = { version = "0.1.0", path = "../../client/domain-operator" }
 domain-service = { version = "0.1.0", path = "../../service" }

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -269,7 +269,6 @@ where
             rpc_handlers,
             operator,
             tx_pool_sink: domain_message_sink,
-            // _phantom_data: Default::default(),
         }
     }
 

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -406,7 +406,6 @@ where
 /// A builder to create a [`DomainNode`].
 pub struct DomainNodeBuilder {
     tokio_handle: tokio::runtime::Handle,
-    key: EcdsaKeyring,
     domain_nodes: Vec<MultiaddrWithPeerId>,
     domain_nodes_exclusive: bool,
     skip_empty_bundle_production: bool,
@@ -418,13 +417,8 @@ impl DomainNodeBuilder {
     ///
     /// `tokio_handle` - The tokio handler to use.
     /// `base_path` - Where databases will be stored.
-    pub fn new(
-        tokio_handle: tokio::runtime::Handle,
-        key: EcdsaKeyring,
-        base_path: BasePath,
-    ) -> Self {
+    pub fn new(tokio_handle: tokio::runtime::Handle, base_path: BasePath) -> Self {
         DomainNodeBuilder {
-            key,
             tokio_handle,
             domain_nodes: Vec::new(),
             domain_nodes_exclusive: false,
@@ -460,13 +454,13 @@ impl DomainNodeBuilder {
     pub async fn build_evm_node(
         self,
         role: Role,
-        domain_id: DomainId,
+        key: EcdsaKeyring,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> EvmDomainNode {
         DomainNode::build(
-            domain_id,
+            EVM_DOMAIN_ID,
             self.tokio_handle,
-            self.key,
+            key,
             self.base_path,
             self.domain_nodes,
             self.domain_nodes_exclusive,
@@ -480,8 +474,8 @@ impl DomainNodeBuilder {
     /// Build a evm domain node
     pub async fn build_auto_id_node(
         self,
-        key: Sr25519Keyring,
         role: Role,
+        key: Sr25519Keyring,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> AutoIdDomainNode {
         DomainNode::build(

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -53,9 +53,6 @@ use std::str::FromStr;
 pub use domain::*;
 pub use evm_domain_test_runtime;
 
-/// The domain id of the genesis domain
-pub const GENESIS_DOMAIN_ID: DomainId = DomainId::new(0u32);
-
 /// The domain id of the evm domain
 pub const EVM_DOMAIN_ID: DomainId = DomainId::new(0u32);
 

--- a/test/subspace-test-client/Cargo.toml
+++ b/test/subspace-test-client/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+auto-id-domain-test-runtime = { version = "0.1.0", path = "../../domains/test/runtime/auto-id" }
 codec = { package = "parity-scale-codec", version = "3.6.12", features = ["derive"] }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 evm-domain-test-runtime = { version = "0.1.0", path = "../../domains/test/runtime/evm" }

--- a/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
@@ -1,0 +1,102 @@
+//! Chain specification for the auto-id domain.
+
+use crate::chain_spec::get_from_seed;
+use auto_id_domain_test_runtime::{BalancesConfig, RuntimeGenesisConfig, SystemConfig};
+use codec::Encode;
+use domain_runtime_primitives::AccountIdConverter;
+use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
+use sp_core::crypto::AccountId32;
+use sp_core::{sr25519, Pair, Public};
+use sp_domains::storage::RawGenesis;
+use sp_domains::{GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_runtime::traits::{Convert, IdentifyAccount};
+use sp_runtime::{BuildStorage, MultiSigner, Percent};
+use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_test_runtime::{MaxDomainBlockSize, MaxDomainBlockWeight};
+
+/// Get public key from keypair seed.
+pub(crate) fn get_public_key_from_seed<TPublic: Public>(
+    seed: &'static str,
+) -> <TPublic::Pair as Pair>::Public {
+    TPublic::Pair::from_string(&format!("//{seed}"), None)
+        .expect("Static values are valid; qed")
+        .public()
+}
+
+/// Generate an account ID from seed.
+pub(crate) fn get_account_id_from_seed(seed: &'static str) -> AccountId32 {
+    MultiSigner::from(get_public_key_from_seed::<sr25519::Public>(seed)).into_account()
+}
+
+pub(crate) fn endowed_accounts() -> Vec<AccountId32> {
+    vec![
+        get_account_id_from_seed("Alice"),
+        get_account_id_from_seed("Bob"),
+        get_account_id_from_seed("Charlie"),
+        get_account_id_from_seed("Dave"),
+        get_account_id_from_seed("Eve"),
+        get_account_id_from_seed("Ferdie"),
+        get_account_id_from_seed("Alice//stash"),
+        get_account_id_from_seed("Bob//stash"),
+        get_account_id_from_seed("Charlie//stash"),
+        get_account_id_from_seed("Dave//stash"),
+        get_account_id_from_seed("Eve//stash"),
+        get_account_id_from_seed("Ferdie//stash"),
+    ]
+}
+
+fn testnet_auto_id_genesis() -> RuntimeGenesisConfig {
+    RuntimeGenesisConfig {
+        system: SystemConfig::default(),
+        balances: BalancesConfig::default(),
+        ..Default::default()
+    }
+}
+
+pub fn get_genesis_domain(
+    sudo_account: subspace_runtime_primitives::AccountId,
+) -> Result<GenesisDomain<AccountId, Balance>, String> {
+    let raw_genesis_storage = {
+        let domain_chain_spec = GenericChainSpec::<NoExtension, ()>::builder(
+            auto_id_domain_test_runtime::WASM_BINARY
+                .ok_or_else(|| "Development wasm not available".to_string())?,
+            None,
+        )
+        .with_chain_type(ChainType::Development)
+        .with_genesis_config(
+            serde_json::to_value(testnet_auto_id_genesis())
+                .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
+        )
+        .build();
+        let storage = domain_chain_spec
+            .build_storage()
+            .expect("Failed to build genesis storage from genesis runtime config");
+        let raw_genesis = RawGenesis::from_storage(storage);
+        raw_genesis.encode()
+    };
+
+    Ok(GenesisDomain {
+        runtime_name: "auto-id".to_owned(),
+        runtime_type: RuntimeType::AutoId,
+        runtime_version: auto_id_domain_test_runtime::VERSION,
+        raw_genesis_storage,
+
+        // Domain config, mainly for placeholder the concrete value TBD
+        owner_account_id: sudo_account,
+        domain_name: "auto-id-domain".to_owned(),
+        max_block_size: MaxDomainBlockSize::get(),
+        max_block_weight: MaxDomainBlockWeight::get(),
+        bundle_slot_probability: (1, 1),
+        target_bundles_per_block: 10,
+        operator_allow_list: OperatorAllowList::Anyone,
+
+        signing_key: get_from_seed::<OperatorPublicKey>("Bob"),
+        minimum_nominator_stake: 100 * SSC,
+        nomination_tax: Percent::from_percent(5),
+        initial_balances: endowed_accounts()
+            .iter()
+            .cloned()
+            .map(|k| (AccountIdConverter::convert(k), 2_000_000 * SSC))
+            .collect(),
+    })
+}

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -1,21 +1,15 @@
 //! Chain specification for the test runtime.
 
-use crate::domain_chain_spec::testnet_evm_genesis;
-use codec::Encode;
-use domain_runtime_primitives::AccountId20Converter;
-use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
+use sc_chain_spec::{ChainType, GenericChainSpec};
 use sp_core::{sr25519, Pair, Public};
-use sp_domains::storage::RawGenesis;
-use sp_domains::{GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
-use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
-use sp_runtime::{BuildStorage, Percent};
+use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use subspace_runtime_primitives::{AccountId, Balance, BlockNumber, Signature};
 use subspace_test_runtime::{
-    AllowAuthoringBy, BalancesConfig, DomainsConfig, EnableRewardsAt, MaxDomainBlockSize,
-    MaxDomainBlockWeight, RewardsConfig, RuntimeGenesisConfig, SubspaceConfig, SudoConfig,
-    SystemConfig, VestingConfig, SSC, WASM_BINARY,
+    AllowAuthoringBy, BalancesConfig, DomainsConfig, EnableRewardsAt, RewardsConfig,
+    RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, VestingConfig, SSC,
+    WASM_BINARY,
 };
 
 /// Generate a crypto pair from seed.
@@ -48,13 +42,7 @@ pub fn subspace_local_testnet_config() -> Result<GenericChainSpec, String> {
             // Pre-funded accounts
             // Alice also get more funds that are used during the domain instantiation
             vec![
-                (
-                    get_account_id_from_seed("Alice"),
-                    (5_000
-                        + crate::domain_chain_spec::endowed_accounts().len() as Balance
-                            * 2_000_000)
-                        * SSC,
-                ),
+                (get_account_id_from_seed("Alice"), 1_000_000_000 * SSC),
                 (get_account_id_from_seed("Bob"), 1_000 * SSC),
                 (get_account_id_from_seed("Charlie"), 1_000 * SSC),
                 (get_account_id_from_seed("Dave"), 1_000 * SSC),
@@ -82,24 +70,6 @@ fn create_genesis_config(
     // who, start, period, period_count, per_period
     vesting: Vec<(AccountId, BlockNumber, BlockNumber, u32, Balance)>,
 ) -> Result<RuntimeGenesisConfig, String> {
-    let raw_genesis_storage = {
-        let domain_chain_spec = GenericChainSpec::<NoExtension, ()>::builder(
-            evm_domain_test_runtime::WASM_BINARY
-                .ok_or_else(|| "Development wasm not available".to_string())?,
-            None,
-        )
-        .with_chain_type(ChainType::Development)
-        .with_genesis_config(
-            serde_json::to_value(testnet_evm_genesis())
-                .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
-        )
-        .build();
-        let storage = domain_chain_spec
-            .build_storage()
-            .expect("Failed to build genesis storage from genesis runtime config");
-        let raw_genesis = RawGenesis::from_storage(storage);
-        raw_genesis.encode()
-    };
     Ok(RuntimeGenesisConfig {
         system: SystemConfig::default(),
         balances: BalancesConfig { balances },
@@ -122,35 +92,12 @@ fn create_genesis_config(
         vesting: VestingConfig { vesting },
         domains: DomainsConfig {
             permissioned_action_allowed_by: Some(sp_domains::PermissionedActionAllowedBy::Anyone),
-            genesis_domains: vec![GenesisDomain {
-                runtime_name: "evm".to_owned(),
-                runtime_type: RuntimeType::Evm,
-                runtime_version: evm_domain_test_runtime::VERSION,
-                raw_genesis_storage,
-
-                // Domain config, mainly for placeholder the concrete value TBD
-                owner_account_id: sudo_account,
-                domain_name: "evm-domain".to_owned(),
-                max_block_size: MaxDomainBlockSize::get(),
-                max_block_weight: MaxDomainBlockWeight::get(),
-                bundle_slot_probability: (1, 1),
-                target_bundles_per_block: 10,
-                operator_allow_list: OperatorAllowList::Anyone,
-
-                signing_key: get_from_seed::<OperatorPublicKey>("Alice"),
-                minimum_nominator_stake: 100 * SSC,
-                nomination_tax: Percent::from_percent(5),
-                initial_balances: crate::domain_chain_spec::endowed_accounts()
-                    .iter()
-                    .cloned()
-                    .map(|k| {
-                        (
-                            AccountId20Converter::convert(k),
-                            2_000_000 * subspace_runtime_primitives::SSC,
-                        )
-                    })
-                    .collect(),
-            }],
+            genesis_domains: vec![
+                crate::evm_domain_chain_spec::get_genesis_domain(sudo_account.clone())
+                    .expect("Must success"),
+                crate::auto_id_domain_chain_spec::get_genesis_domain(sudo_account)
+                    .expect("Must success"),
+            ],
         },
         runtime_configs: Default::default(),
     })

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -1,11 +1,19 @@
 //! Chain specification for the evm domain.
 
+use crate::chain_spec::get_from_seed;
+use codec::Encode;
+use domain_runtime_primitives::AccountId20Converter;
 use evm_domain_test_runtime::{
     AccountId as AccountId20, Precompiles, RuntimeGenesisConfig, Signature,
 };
+use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
 use sp_core::{ecdsa, Pair, Public};
-use sp_domains::DomainId;
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_domains::storage::RawGenesis;
+use sp_domains::{DomainId, GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
+use sp_runtime::{BuildStorage, Percent};
+use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_test_runtime::{MaxDomainBlockSize, MaxDomainBlockWeight};
 
 type AccountPublic = <Signature as Verify>::Signer;
 
@@ -81,4 +89,52 @@ pub fn testnet_evm_genesis() -> RuntimeGenesisConfig {
         },
         ..Default::default()
     }
+}
+
+pub fn get_genesis_domain(
+    sudo_account: subspace_runtime_primitives::AccountId,
+) -> Result<GenesisDomain<AccountId, Balance>, String> {
+    let raw_genesis_storage = {
+        let domain_chain_spec = GenericChainSpec::<NoExtension, ()>::builder(
+            evm_domain_test_runtime::WASM_BINARY
+                .ok_or_else(|| "Development wasm not available".to_string())?,
+            None,
+        )
+        .with_chain_type(ChainType::Development)
+        .with_genesis_config(
+            serde_json::to_value(testnet_evm_genesis())
+                .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
+        )
+        .build();
+        let storage = domain_chain_spec
+            .build_storage()
+            .expect("Failed to build genesis storage from genesis runtime config");
+        let raw_genesis = RawGenesis::from_storage(storage);
+        raw_genesis.encode()
+    };
+
+    Ok(GenesisDomain {
+        runtime_name: "evm".to_owned(),
+        runtime_type: RuntimeType::Evm,
+        runtime_version: evm_domain_test_runtime::VERSION,
+        raw_genesis_storage,
+
+        // Domain config, mainly for placeholder the concrete value TBD
+        owner_account_id: sudo_account,
+        domain_name: "evm-domain".to_owned(),
+        max_block_size: MaxDomainBlockSize::get(),
+        max_block_weight: MaxDomainBlockWeight::get(),
+        bundle_slot_probability: (1, 1),
+        target_bundles_per_block: 10,
+        operator_allow_list: OperatorAllowList::Anyone,
+
+        signing_key: get_from_seed::<OperatorPublicKey>("Alice"),
+        minimum_nominator_stake: 100 * SSC,
+        nomination_tax: Percent::from_percent(5),
+        initial_balances: endowed_accounts()
+            .iter()
+            .cloned()
+            .map(|k| (AccountId20Converter::convert(k), 2_000_000 * SSC))
+            .collect(),
+    })
 }

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -16,10 +16,11 @@
 
 //! Subspace test client only.
 
-#![warn(missing_docs, unused_crate_dependencies)]
+#![warn(unused_crate_dependencies)]
 
+pub mod auto_id_domain_chain_spec;
 pub mod chain_spec;
-pub mod domain_chain_spec;
+pub mod evm_domain_chain_spec;
 
 use futures::executor::block_on;
 use futures::StreamExt;


### PR DESCRIPTION
This PR mainly does:
- Add support to run the auto-id domain node in the integration test
- Re-enable (previously comment-out) XDM tests

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
