### PR TITLE
Refactor snap-sync.

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -125,7 +125,7 @@ where
                     "Can't get segment header from the store: {last_segment_index}"
                 ))?;
 
-            if segment_header.last_archived_block().number < target_block {
+            if target_block > segment_header.last_archived_block().number {
                 return Err(format!(
                     "Target block is greater than the last archived block. \
                     Last segment index = {last_segment_index}, target block = {target_block}, \
@@ -139,13 +139,13 @@ where
             let mut current_segment_index = last_segment_index;
 
             loop {
-                if segment_header.last_archived_block().number == target_block
+                if target_block == segment_header.last_archived_block().number
                     || current_segment_index <= SegmentIndex::ONE
                 {
                     break;
                 }
 
-                if segment_header.last_archived_block().number < target_block {
+                if target_block > segment_header.last_archived_block().number {
                     current_segment_index += SegmentIndex::ONE;
                     break;
                 }

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -276,7 +276,8 @@ where
         get_blocks_from_target_segment(segment_headers_store, node, piece_getter, target_block)
             .await?
     else {
-        return Ok(()); // Snap-sync skipped
+        // Snap-sync skipped
+        return Ok(());
     };
 
     debug!(


### PR DESCRIPTION
The PR contains changes related to the upcoming snap-sync for domains:
- support for snap-sync on target block number
- conditional block import from the downloaded segment

New `get_blocks_from_target_segment` calculates the target segment for download by the optional target block (None = last segment).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
