### PR TITLE
Disable flaky test test_stale_fork_xdm_true_invalid_fraud_proof

### DIFF
--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -5241,7 +5241,10 @@ async fn test_xdm_false_invalid_fraud_proof() {
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
 
+// TODO: this test is flaky and sometime hang forever in CI thus disable it temporary,
+// do investigate and fix it
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 


### PR DESCRIPTION
This test is flaky and sometimes hangs forever in CI thus disable it temporary to remove this blocker of our workflow, and I will investigate and fix it when I have the time.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
