### PR TITLE
Farmer mertrics improvements

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster.rs
@@ -110,7 +110,7 @@ where
     )
     .await
     .map_err(|error| anyhow!("Failed to connect to NATS server: {error}"))?;
-    let mut registry = Registry::default();
+    let mut registry = Registry::with_prefix("subspace_farmer");
 
     let mut tasks = FuturesUnordered::new();
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -136,7 +136,8 @@ pub(super) async fn controller(
     let peer_id = keypair.public().to_peer_id();
     let instance = peer_id.to_string();
 
-    let (farmer_cache, farmer_cache_worker) = FarmerCache::new(node_client.clone(), peer_id);
+    let (farmer_cache, farmer_cache_worker) =
+        FarmerCache::new(node_client.clone(), peer_id, Some(registry));
 
     // TODO: Metrics
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -83,7 +83,7 @@ pub(super) struct PlotterArgs {
 
 pub(super) async fn plotter<PosTableLegacy, PosTable>(
     nats_client: NatsClient,
-    _registry: &mut Registry,
+    registry: &mut Registry,
     plotter_args: PlotterArgs,
 ) -> anyhow::Result<Pin<Box<dyn Future<Output = anyhow::Result<()>>>>>
 where
@@ -169,6 +169,7 @@ where
         Arc::clone(&global_mutex),
         kzg.clone(),
         erasure_coding.clone(),
+        Some(registry),
     ));
     let modern_cpu_plotter = Arc::new(CpuPlotter::<_, PosTable>::new(
         piece_getter.clone(),
@@ -178,9 +179,8 @@ where
         Arc::clone(&global_mutex),
         kzg.clone(),
         erasure_coding.clone(),
+        Some(registry),
     ));
-
-    // TODO: Metrics
 
     Ok(Box::pin(async move {
         select! {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -338,11 +338,11 @@ where
     let keypair = derive_libp2p_keypair(identity.secret_key());
     let peer_id = keypair.public().to_peer_id();
 
-    let (farmer_cache, farmer_cache_worker) = FarmerCache::new(node_client.clone(), peer_id);
-
-    // Metrics
     let mut registry = Registry::with_prefix("subspace_farmer");
     let should_start_prometheus_server = !prometheus_listen_on.is_empty();
+
+    let (farmer_cache, farmer_cache_worker) =
+        FarmerCache::new(node_client.clone(), peer_id, Some(&mut registry));
 
     let node_client = CachingProxyNodeClient::new(node_client)
         .await

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -31,7 +31,6 @@ use subspace_farmer::node_client::rpc_node_client::RpcNodeClient;
 use subspace_farmer::node_client::NodeClient;
 use subspace_farmer::plotter::cpu::CpuPlotter;
 use subspace_farmer::single_disk_farm::identity::Identity;
-use subspace_farmer::single_disk_farm::metrics::SingleDiskFarmMetrics;
 use subspace_farmer::single_disk_farm::{
     SingleDiskFarm, SingleDiskFarmError, SingleDiskFarmOptions,
 };
@@ -526,7 +525,7 @@ where
         let (plotting_delay_senders, plotting_delay_receivers) = (0..disk_farms.len())
             .map(|_| oneshot::channel())
             .unzip::<_, _, Vec<_>, Vec<_>>();
-        let metrics = &SingleDiskFarmMetrics::new(&mut prometheus_metrics_registry);
+        let registry = &Mutex::new(&mut prometheus_metrics_registry);
 
         let mut farms = Vec::with_capacity(disk_farms.len());
         let mut farms_stream = disk_farms
@@ -568,7 +567,7 @@ where
                                 .read_sector_record_chunks_mode,
                             faster_read_sector_record_chunks_mode_barrier,
                             faster_read_sector_record_chunks_mode_concurrency,
-                            metrics: Some(metrics.clone()),
+                            registry: Some(registry),
                             create,
                         },
                         farm_index,

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -228,15 +228,18 @@ pub enum ProvingResult {
     /// Managed to prove within time limit, but node rejected solution, likely due to timeout on its
     /// end
     Rejected,
+    /// Proving failed altogether
+    Failed,
 }
 
 impl fmt::Display for ProvingResult {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            ProvingResult::Success => "Success",
-            ProvingResult::Timeout => "Timeout",
-            ProvingResult::Rejected => "Rejected",
+            Self::Success => "Success",
+            Self::Timeout => "Timeout",
+            Self::Rejected => "Rejected",
+            Self::Failed => "Failed",
         })
     }
 }

--- a/crates/subspace-farmer/src/farmer_cache/metrics.rs
+++ b/crates/subspace-farmer/src/farmer_cache/metrics.rs
@@ -1,0 +1,71 @@
+//! Metrics for farmer cache
+
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::{Registry, Unit};
+use std::sync::atomic::{AtomicI64, AtomicU64};
+
+/// Metrics for farmer cache
+#[derive(Debug)]
+pub(super) struct FarmerCacheMetrics {
+    pub(super) cache_hit: Counter<u64, AtomicU64>,
+    pub(super) cache_miss: Counter<u64, AtomicU64>,
+    pub(super) cache_error: Counter<u64, AtomicU64>,
+    pub(super) piece_cache_capacity_total: Gauge<i64, AtomicI64>,
+    pub(super) piece_cache_capacity_used: Gauge<i64, AtomicI64>,
+}
+
+impl FarmerCacheMetrics {
+    /// Create new instance
+    pub(super) fn new(registry: &mut Registry) -> Self {
+        let registry = registry.sub_registry_with_prefix("farmer_cache");
+
+        let cache_hit = Counter::default();
+        registry.register_with_unit(
+            "cache_hit",
+            "Cache hit",
+            Unit::Other("Requests".to_string()),
+            cache_hit.clone(),
+        );
+
+        let cache_miss = Counter::default();
+        registry.register_with_unit(
+            "cache_miss",
+            "Cache miss",
+            Unit::Other("Requests".to_string()),
+            cache_miss.clone(),
+        );
+
+        let cache_error = Counter::default();
+        registry.register_with_unit(
+            "cache_error",
+            "Cache error",
+            Unit::Other("Requests".to_string()),
+            cache_error.clone(),
+        );
+
+        let piece_cache_capacity_total = Gauge::default();
+        registry.register_with_unit(
+            "piece_cache_capacity_total",
+            "Piece cache capacity total",
+            Unit::Other("Pieces".to_string()),
+            piece_cache_capacity_total.clone(),
+        );
+
+        let piece_cache_capacity_used = Gauge::default();
+        registry.register_with_unit(
+            "piece_cache_capacity_used",
+            "Piece cache capacity used",
+            Unit::Other("Pieces".to_string()),
+            piece_cache_capacity_used.clone(),
+        );
+
+        Self {
+            cache_hit,
+            cache_miss,
+            cache_error,
+            piece_cache_capacity_total,
+            piece_cache_capacity_used,
+        }
+    }
+}

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -185,7 +185,7 @@ async fn basic() {
 
     {
         let (farmer_cache, farmer_cache_worker) =
-            FarmerCache::new(node_client.clone(), public_key.to_peer_id());
+            FarmerCache::new(node_client.clone(), public_key.to_peer_id(), None);
 
         let farmer_cache_worker_exited =
             tokio::spawn(farmer_cache_worker.run(piece_getter.clone()));
@@ -385,7 +385,7 @@ async fn basic() {
         pieces.lock().clear();
 
         let (farmer_cache, farmer_cache_worker) =
-            FarmerCache::new(node_client.clone(), public_key.to_peer_id());
+            FarmerCache::new(node_client.clone(), public_key.to_peer_id(), None);
 
         let farmer_cache_worker_exited = tokio::spawn(farmer_cache_worker.run(piece_getter));
 

--- a/crates/subspace-farmer/src/plotter/cpu/metrics.rs
+++ b/crates/subspace-farmer/src/plotter/cpu/metrics.rs
@@ -62,7 +62,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_downloading_counter",
             "Number of sectors being downloaded",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_downloading.clone(),
         );
 
@@ -70,7 +70,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_downloaded_counter",
             "Number of downloaded sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_downloaded.clone(),
         );
 
@@ -78,7 +78,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_encoding_counter",
             "Number of sectors being encoded",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_encoding.clone(),
         );
 
@@ -86,7 +86,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_encoded_counter",
             "Number of encoded sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_encoded.clone(),
         );
 
@@ -94,7 +94,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_plotting_counter",
             "Number of sectors being plotted",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_plotting.clone(),
         );
 
@@ -102,7 +102,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_plotted_counter",
             "Number of plotted sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_plotted.clone(),
         );
 
@@ -110,7 +110,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "sector_plotting_error_counter",
             "Number of sector plotting failures",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_plotting_error.clone(),
         );
 
@@ -119,7 +119,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "plotting_capacity_total",
             "Plotting capacity total",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             plotting_capacity_total,
         );
 
@@ -127,7 +127,7 @@ impl CpuPlotterMetrics {
         registry.register_with_unit(
             "plotting_capacity_used",
             "Plotting capacity used",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             plotting_capacity_used.clone(),
         );
 

--- a/crates/subspace-farmer/src/plotter/cpu/metrics.rs
+++ b/crates/subspace-farmer/src/plotter/cpu/metrics.rs
@@ -1,0 +1,148 @@
+//! Metrics for CPU plotter
+
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
+use prometheus_client::registry::{Registry, Unit};
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicI64, AtomicU64};
+
+/// Metrics for CPU plotter
+#[derive(Debug)]
+pub(super) struct CpuPlotterMetrics {
+    pub(super) sector_downloading_time: Histogram,
+    pub(super) sector_encoding_time: Histogram,
+    pub(super) sector_plotting_time: Histogram,
+    pub(super) sector_downloading: Counter<u64, AtomicU64>,
+    pub(super) sector_downloaded: Counter<u64, AtomicU64>,
+    pub(super) sector_encoding: Counter<u64, AtomicU64>,
+    pub(super) sector_encoded: Counter<u64, AtomicU64>,
+    pub(super) sector_plotting: Counter<u64, AtomicU64>,
+    pub(super) sector_plotted: Counter<u64, AtomicU64>,
+    pub(super) sector_plotting_error: Counter<u64, AtomicU64>,
+    pub(super) plotting_capacity_used: Gauge<i64, AtomicI64>,
+}
+
+impl CpuPlotterMetrics {
+    /// Create new instance
+    pub(super) fn new(
+        registry: &mut Registry,
+        subtype: &str,
+        total_capacity: NonZeroUsize,
+    ) -> Self {
+        let registry = registry
+            .sub_registry_with_prefix("plotter")
+            .sub_registry_with_label(("kind".into(), format!("cpu-{subtype}").into()));
+
+        let sector_downloading_time = Histogram::new(exponential_buckets(0.1, 2.0, 15));
+        registry.register_with_unit(
+            "sector_downloading_time",
+            "Sector downloading time",
+            Unit::Seconds,
+            sector_downloading_time.clone(),
+        );
+
+        let sector_encoding_time = Histogram::new(exponential_buckets(0.1, 2.0, 15));
+        registry.register_with_unit(
+            "sector_encoding_time",
+            "Sector encoding time",
+            Unit::Seconds,
+            sector_encoding_time.clone(),
+        );
+
+        let sector_plotting_time = Histogram::new(exponential_buckets(0.1, 2.0, 15));
+        registry.register_with_unit(
+            "sector_plotting_time",
+            "Sector plotting time",
+            Unit::Seconds,
+            sector_plotting_time.clone(),
+        );
+
+        let sector_downloading = Counter::default();
+        registry.register_with_unit(
+            "sector_downloading_counter",
+            "Number of sectors being downloaded",
+            Unit::Other("sectors".to_string()),
+            sector_downloading.clone(),
+        );
+
+        let sector_downloaded = Counter::default();
+        registry.register_with_unit(
+            "sector_downloaded_counter",
+            "Number of downloaded sectors",
+            Unit::Other("sectors".to_string()),
+            sector_downloaded.clone(),
+        );
+
+        let sector_encoding = Counter::default();
+        registry.register_with_unit(
+            "sector_encoding_counter",
+            "Number of sectors being encoded",
+            Unit::Other("sectors".to_string()),
+            sector_encoding.clone(),
+        );
+
+        let sector_encoded = Counter::default();
+        registry.register_with_unit(
+            "sector_encoded_counter",
+            "Number of encoded sectors",
+            Unit::Other("sectors".to_string()),
+            sector_encoded.clone(),
+        );
+
+        let sector_plotting = Counter::default();
+        registry.register_with_unit(
+            "sector_plotting_counter",
+            "Number of sectors being plotted",
+            Unit::Other("sectors".to_string()),
+            sector_plotting.clone(),
+        );
+
+        let sector_plotted = Counter::default();
+        registry.register_with_unit(
+            "sector_plotted_counter",
+            "Number of plotted sectors",
+            Unit::Other("sectors".to_string()),
+            sector_plotted.clone(),
+        );
+
+        let sector_plotting_error = Counter::default();
+        registry.register_with_unit(
+            "sector_plotting_error_counter",
+            "Number of sector plotting failures",
+            Unit::Other("sectors".to_string()),
+            sector_plotting_error.clone(),
+        );
+
+        let plotting_capacity_total = Gauge::<i64, AtomicI64>::default();
+        plotting_capacity_total.set(total_capacity.get() as i64);
+        registry.register_with_unit(
+            "plotting_capacity_total",
+            "Plotting capacity total",
+            Unit::Other("sectors".to_string()),
+            plotting_capacity_total,
+        );
+
+        let plotting_capacity_used = Gauge::default();
+        registry.register_with_unit(
+            "plotting_capacity_used",
+            "Plotting capacity used",
+            Unit::Other("sectors".to_string()),
+            plotting_capacity_used.clone(),
+        );
+
+        Self {
+            sector_downloading_time,
+            sector_encoding_time,
+            sector_plotting_time,
+            sector_downloading,
+            sector_downloaded,
+            sector_encoding,
+            sector_encoded,
+            sector_plotting,
+            sector_plotted,
+            sector_plotting_error,
+            plotting_capacity_used,
+        }
+    }
+}

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -318,6 +318,10 @@ where
                     let solution = match maybe_solution {
                         Ok(solution) => solution,
                         Err(error) => {
+                            if let Some(metrics) = &metrics {
+                                metrics
+                                    .observe_proving_time(&start.elapsed(), ProvingResult::Failed);
+                            }
                             error!(%slot, %sector_index, %error, "Failed to prove");
                             // Do not error completely as disk corruption or other reasons why
                             // proving might fail

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -9,6 +9,7 @@ use crate::farm::{
     AuditingDetails, FarmingError, FarmingNotification, ProvingDetails, ProvingResult,
 };
 use crate::node_client::NodeClient;
+use crate::single_disk_farm::metrics::SingleDiskFarmMetrics;
 use crate::single_disk_farm::Handlers;
 use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use futures::channel::mpsc;
@@ -201,6 +202,7 @@ pub(super) struct FarmingOptions<NC, PlotAudit> {
     pub(super) thread_pool: ThreadPool,
     pub(super) read_sector_record_chunks_mode: ReadSectorRecordChunksMode,
     pub(super) global_mutex: Arc<AsyncMutex<()>>,
+    pub(super) metrics: Option<Arc<SingleDiskFarmMetrics>>,
 }
 
 /// Starts farming process.
@@ -229,6 +231,7 @@ where
         thread_pool,
         read_sector_record_chunks_mode,
         global_mutex,
+        metrics,
     } = farming_options;
 
     let farmer_app_info = node_client
@@ -285,12 +288,18 @@ where
                 a_solution_distance.cmp(&b_solution_distance)
             });
 
-            handlers
-                .farming_notification
-                .call_simple(&FarmingNotification::Auditing(AuditingDetails {
-                    sectors_count: sectors_metadata.len() as SectorIndex,
-                    time: start.elapsed(),
-                }));
+            {
+                let time = start.elapsed();
+                if let Some(metrics) = &metrics {
+                    metrics.auditing_time.observe(time.as_secs_f64());
+                }
+                handlers
+                    .farming_notification
+                    .call_simple(&FarmingNotification::Auditing(AuditingDetails {
+                        sectors_count: sectors_metadata.len() as SectorIndex,
+                        time,
+                    }));
+            }
 
             // Take mutex and hold until proving end to make sure nothing else major happens at the
             // same time
@@ -320,20 +329,26 @@ where
                     debug!(%slot, %sector_index, "Solution found");
                     trace!(?solution, "Solution found");
 
-                    if start.elapsed() >= farming_timeout {
-                        handlers
-                            .farming_notification
-                            .call_simple(&FarmingNotification::Proving(ProvingDetails {
-                                result: ProvingResult::Timeout,
-                                time: start.elapsed(),
-                            }));
-                        warn!(
-                            %slot,
-                            %sector_index,
-                            "Proving for solution skipped due to farming time limit",
-                        );
+                    {
+                        let time = start.elapsed();
+                        if time >= farming_timeout {
+                            if let Some(metrics) = &metrics {
+                                metrics.observe_proving_time(&time, ProvingResult::Timeout);
+                            }
+                            handlers.farming_notification.call_simple(
+                                &FarmingNotification::Proving(ProvingDetails {
+                                    result: ProvingResult::Timeout,
+                                    time,
+                                }),
+                            );
+                            warn!(
+                                %slot,
+                                %sector_index,
+                                "Proving for solution skipped due to farming time limit",
+                            );
 
-                        break 'solutions_processing;
+                            break 'solutions_processing;
+                        }
                     }
 
                     let response = SolutionResponse {
@@ -344,11 +359,15 @@ where
                     handlers.solution.call_simple(&response);
 
                     if let Err(error) = node_client.submit_solution_response(response).await {
+                        let time = start.elapsed();
+                        if let Some(metrics) = &metrics {
+                            metrics.observe_proving_time(&time, ProvingResult::Rejected);
+                        }
                         handlers
                             .farming_notification
                             .call_simple(&FarmingNotification::Proving(ProvingDetails {
                                 result: ProvingResult::Rejected,
-                                time: start.elapsed(),
+                                time,
                             }));
                         warn!(
                             %slot,
@@ -359,11 +378,15 @@ where
                         break 'solutions_processing;
                     }
 
+                    let time = start.elapsed();
+                    if let Some(metrics) = &metrics {
+                        metrics.observe_proving_time(&time, ProvingResult::Success);
+                    }
                     handlers
                         .farming_notification
                         .call_simple(&FarmingNotification::Proving(ProvingDetails {
                             result: ProvingResult::Success,
-                            time: start.elapsed(),
+                            time,
                         }));
                     start = Instant::now();
                 }
@@ -386,6 +409,9 @@ where
                 "Non-fatal farming error"
             );
 
+            if let Some(metrics) = &metrics {
+                metrics.note_farming_error(&error);
+            }
             handlers
                 .farming_notification
                 .call_simple(&FarmingNotification::NonFatalError(Arc::new(error)));

--- a/crates/subspace-farmer/src/single_disk_farm/metrics.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/metrics.rs
@@ -66,7 +66,6 @@ impl SingleDiskFarmMetrics {
             .sub_registry_with_label(("farm_id".into(), farm_id.to_string().into()));
 
         let auditing_time = Histogram::new(exponential_buckets(0.0002, 2.0, 15));
-
         sub_registry.register_with_unit(
             "auditing_time",
             "Auditing time",
@@ -77,7 +76,6 @@ impl SingleDiskFarmMetrics {
         let proving_time = Family::<_, _>::new_with_constructor(|| {
             Histogram::new(exponential_buckets(0.0002, 2.0, 15))
         });
-
         sub_registry.register_with_unit(
             "proving_time",
             "Proving time",
@@ -86,7 +84,6 @@ impl SingleDiskFarmMetrics {
         );
 
         let farming_errors = Family::default();
-
         sub_registry.register(
             "farming_errors",
             "Non-fatal farming errors",
@@ -94,7 +91,6 @@ impl SingleDiskFarmMetrics {
         );
 
         let sector_downloading_time = Histogram::new(exponential_buckets(0.1, 2.0, 15));
-
         sub_registry.register_with_unit(
             "sector_downloading_time",
             "Sector downloading time",
@@ -103,7 +99,6 @@ impl SingleDiskFarmMetrics {
         );
 
         let sector_encoding_time = Histogram::new(exponential_buckets(0.1, 2.0, 15));
-
         sub_registry.register_with_unit(
             "sector_encoding_time",
             "Sector encoding time",
@@ -112,7 +107,6 @@ impl SingleDiskFarmMetrics {
         );
 
         let sector_writing_time = Histogram::new(exponential_buckets(0.0002, 2.0, 15));
-
         sub_registry.register_with_unit(
             "sector_writing_time",
             "Sector writing time",
@@ -121,7 +115,6 @@ impl SingleDiskFarmMetrics {
         );
 
         let sector_plotting_time = Histogram::new(exponential_buckets(0.1, 2.0, 15));
-
         sub_registry.register_with_unit(
             "sector_plotting_time",
             "Sector plotting time",
@@ -130,92 +123,82 @@ impl SingleDiskFarmMetrics {
         );
 
         let sectors_total = Family::default();
-
         sub_registry.register_with_unit(
             "sectors_total",
             "Total number of sectors with corresponding state",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sectors_total.clone(),
         );
 
         let sector_downloading = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_downloading_counter",
             "Number of sectors being downloaded",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_downloading.clone(),
         );
 
         let sector_downloaded = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_downloaded_counter",
             "Number of downloaded sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_downloaded.clone(),
         );
 
         let sector_encoding = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_encoding_counter",
             "Number of sectors being encoded",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_encoding.clone(),
         );
 
         let sector_encoded = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_encoded_counter",
             "Number of encoded sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_encoded.clone(),
         );
 
         let sector_writing = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_writing_counter",
             "Number of sectors being written",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_writing.clone(),
         );
 
         let sector_written = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_written_counter",
             "Number of written sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_written.clone(),
         );
 
         let sector_plotting = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_plotting_counter",
             "Number of sectors being plotted",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_plotting.clone(),
         );
 
         let sector_plotted = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_plotted_counter",
             "Number of plotted sectors",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_plotted.clone(),
         );
 
         let sector_plotting_error = Counter::default();
-
         sub_registry.register_with_unit(
             "sector_plotting_error_counter",
             "Number of sector plotting failures",
-            Unit::Other("sectors".to_string()),
+            Unit::Other("Sectors".to_string()),
             sector_plotting_error.clone(),
         );
 

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -1,6 +1,7 @@
 use crate::farm::{SectorExpirationDetails, SectorPlottingDetails, SectorUpdate};
 use crate::node_client::{Error as NodeClientError, NodeClient};
 use crate::plotter::{Plotter, SectorPlottingProgress};
+use crate::single_disk_farm::metrics::{SectorState, SingleDiskFarmMetrics};
 #[cfg(windows)]
 use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows;
 use crate::single_disk_farm::{
@@ -100,6 +101,7 @@ pub(super) struct SectorPlottingOptions<'a, NC> {
     pub(super) handlers: &'a Handlers,
     pub(super) global_mutex: &'a AsyncMutex<()>,
     pub(super) plotter: Arc<dyn Plotter>,
+    pub(super) metrics: Option<Arc<SingleDiskFarmMetrics>>,
 }
 
 pub(super) struct PlottingOptions<'a, NC> {
@@ -292,6 +294,7 @@ where
         handlers,
         global_mutex,
         plotter,
+        metrics,
     } = sector_plotting_options;
 
     let SectorToPlot {
@@ -309,6 +312,9 @@ where
         .cloned();
     let replotting = maybe_old_sector_metadata.is_some();
 
+    if let Some(metrics) = metrics {
+        metrics.sector_plotting.inc();
+    }
     let sector_state = SectorUpdate::Plotting(SectorPlottingDetails::Starting {
         progress,
         replotting,
@@ -392,6 +398,7 @@ where
                 sectors_being_modified,
                 global_mutex,
                 progress_receiver,
+                metrics,
             )
             .await?
             {
@@ -464,10 +471,16 @@ where
 
         let sector_metadata = plotted_sector.sector_metadata.clone();
 
+        let time = start.elapsed();
+        if let Some(metrics) = metrics {
+            metrics.sector_plotting_time.observe(time.as_secs_f64());
+            metrics.sector_plotted.inc();
+            metrics.update_sector_state(SectorState::Plotted);
+        }
         let sector_state = SectorUpdate::Plotting(SectorPlottingDetails::Finished {
             plotted_sector,
             old_plotted_sector: maybe_old_plotted_sector,
-            time: start.elapsed(),
+            time,
         });
         handlers
             .sector_update
@@ -496,30 +509,45 @@ async fn plot_single_sector_internal(
     sectors_being_modified: &AsyncRwLock<HashSet<SectorIndex>>,
     global_mutex: &AsyncMutex<()>,
     mut progress_receiver: mpsc::Receiver<SectorPlottingProgress>,
+    metrics: &Option<Arc<SingleDiskFarmMetrics>>,
 ) -> Result<Result<PlottedSector, PlottingError>, PlottingError> {
     // Process plotting progress notifications
     let progress_processor_fut = async {
         while let Some(progress) = progress_receiver.next().await {
             match progress {
                 SectorPlottingProgress::Downloading => {
+                    if let Some(metrics) = metrics {
+                        metrics.sector_downloading.inc();
+                    }
                     handlers.sector_update.call_simple(&(
                         sector_index,
                         SectorUpdate::Plotting(SectorPlottingDetails::Downloading),
                     ));
                 }
                 SectorPlottingProgress::Downloaded(time) => {
+                    if let Some(metrics) = metrics {
+                        metrics.sector_downloading_time.observe(time.as_secs_f64());
+                        metrics.sector_downloaded.inc();
+                    }
                     handlers.sector_update.call_simple(&(
                         sector_index,
                         SectorUpdate::Plotting(SectorPlottingDetails::Downloaded(time)),
                     ));
                 }
                 SectorPlottingProgress::Encoding => {
+                    if let Some(metrics) = metrics {
+                        metrics.sector_encoding.inc();
+                    }
                     handlers.sector_update.call_simple(&(
                         sector_index,
                         SectorUpdate::Plotting(SectorPlottingDetails::Encoding),
                     ));
                 }
                 SectorPlottingProgress::Encoded(time) => {
+                    if let Some(metrics) = metrics {
+                        metrics.sector_encoding_time.observe(time.as_secs_f64());
+                        metrics.sector_encoded.inc();
+                    }
                     handlers.sector_update.call_simple(&(
                         sector_index,
                         SectorUpdate::Plotting(SectorPlottingDetails::Encoded(time)),
@@ -533,6 +561,9 @@ async fn plot_single_sector_internal(
                     return Ok((plotted_sector, sector));
                 }
                 SectorPlottingProgress::Error { error } => {
+                    if let Some(metrics) = metrics {
+                        metrics.sector_plotting_error.inc();
+                    }
                     handlers.sector_update.call_simple(&(
                         sector_index,
                         SectorUpdate::Plotting(SectorPlottingDetails::Error(error.clone())),
@@ -559,6 +590,9 @@ async fn plot_single_sector_internal(
         // Take mutex briefly to make sure writing is allowed right now
         global_mutex.lock().await;
 
+        if let Some(metrics) = metrics {
+            metrics.sector_writing.inc();
+        }
         handlers.sector_update.call_simple(&(
             sector_index,
             SectorUpdate::Plotting(SectorPlottingDetails::Writing),
@@ -630,9 +664,14 @@ async fn plot_single_sector_internal(
             })??;
         }
 
+        let time = start.elapsed();
+        if let Some(metrics) = metrics {
+            metrics.sector_writing_time.observe(time.as_secs_f64());
+            metrics.sector_written.inc();
+        }
         handlers.sector_update.call_simple(&(
             sector_index,
-            SectorUpdate::Plotting(SectorPlottingDetails::Written(start.elapsed())),
+            SectorUpdate::Plotting(SectorPlottingDetails::Written(time)),
         ));
     }
 
@@ -652,6 +691,7 @@ pub(super) struct PlottingSchedulerOptions<NC> {
     // Delay between segment header being acknowledged by farmer and potentially triggering
     // replotting
     pub(super) new_segment_processing_delay: Duration,
+    pub(super) metrics: Option<Arc<SingleDiskFarmMetrics>>,
 }
 
 pub(super) async fn plotting_scheduler<NC>(
@@ -671,6 +711,7 @@ where
         sectors_metadata,
         sectors_to_plot_sender,
         new_segment_processing_delay,
+        metrics,
     } = plotting_scheduler_options;
 
     // Create a proxy channel with atomically updatable last archived segment that
@@ -706,6 +747,7 @@ where
         sectors_metadata,
         archived_segments_receiver,
         sectors_to_plot_sender,
+        &metrics,
     );
 
     select! {
@@ -770,6 +812,7 @@ async fn send_plotting_notifications<NC>(
     sectors_metadata: Arc<AsyncRwLock<Vec<SectorMetadataChecksummed>>>,
     mut archived_segments_receiver: watch::Receiver<SegmentHeader>,
     mut sectors_to_plot_sender: mpsc::Sender<SectorToPlot>,
+    metrics: &Option<Arc<SingleDiskFarmMetrics>>,
 ) -> Result<(), BackgroundTaskError>
 where
     NC: NodeClient,
@@ -828,14 +871,20 @@ where
                         "Sector expires soon #1, scheduling replotting"
                     );
 
-                    handlers.sector_update.call_simple(&(
-                        sector_index,
-                        SectorUpdate::Expiration(if expires_at <= segment_index {
-                            SectorExpirationDetails::Expired
-                        } else {
-                            SectorExpirationDetails::AboutToExpire
-                        }),
-                    ));
+                    let expiration_details = if expires_at <= segment_index {
+                        if let Some(metrics) = metrics {
+                            metrics.update_sector_state(SectorState::Expired);
+                        }
+                        SectorExpirationDetails::Expired
+                    } else {
+                        if let Some(metrics) = metrics {
+                            metrics.update_sector_state(SectorState::AboutToExpire);
+                        }
+                        SectorExpirationDetails::AboutToExpire
+                    };
+                    handlers
+                        .sector_update
+                        .call_simple(&(sector_index, SectorUpdate::Expiration(expiration_details)));
 
                     // Time to replot
                     sectors_to_replot.push(SectorToReplot {
@@ -898,13 +947,20 @@ where
                             "Sector expires soon #2, scheduling replotting"
                         );
 
+                        let expiration_details = if expires_at <= segment_index {
+                            if let Some(metrics) = metrics {
+                                metrics.update_sector_state(SectorState::Expired);
+                            }
+                            SectorExpirationDetails::Expired
+                        } else {
+                            if let Some(metrics) = metrics {
+                                metrics.update_sector_state(SectorState::AboutToExpire);
+                            }
+                            SectorExpirationDetails::AboutToExpire
+                        };
                         handlers.sector_update.call_simple(&(
                             sector_index,
-                            SectorUpdate::Expiration(if expires_at <= segment_index {
-                                SectorExpirationDetails::Expired
-                            } else {
-                                SectorExpirationDetails::AboutToExpire
-                            }),
+                            SectorUpdate::Expiration(expiration_details),
                         ));
 
                         // Time to replot


### PR DESCRIPTION
This does some more refactoring of metrics and implements metrics for CPU plotter and farmer cache.

More metrics can be added later and I think the pattern works reasonably well to be extended further much more easily than relying on events the way we did it before.

New things users can expect that were not exposed directly:
* total and used plotter capacity (allows to see if plotter is idling for example)
* farmer cache hits/misses, total and used capacity of piece caches contained within farmer cache

Metrics prefixes have also changed, but should be more or less stable going forward.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
