### PR TITLE
Farmer metrics improvements (part 2)

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/cache.rs
@@ -115,7 +115,7 @@ pub(super) struct CacheArgs {
 
 pub(super) async fn cache(
     nats_client: NatsClient,
-    _registry: &mut Registry,
+    registry: &mut Registry,
     cache_args: CacheArgs,
 ) -> anyhow::Result<Pin<Box<dyn Future<Output = anyhow::Result<()>>>>> {
     let CacheArgs {
@@ -157,8 +157,6 @@ pub(super) async fn cache(
         None
     };
 
-    // TODO: Metrics
-
     let caches = disk_caches
         .iter()
         .map(|disk_cache| {
@@ -166,6 +164,8 @@ pub(super) async fn cache(
                 &disk_cache.directory,
                 u32::try_from(disk_cache.allocated_space / DiskPieceCache::element_size() as u64)
                     .unwrap_or(u32::MAX),
+                None,
+                Some(registry),
             )
             .map_err(|error| {
                 anyhow!(

--- a/crates/subspace-farmer/src/disk_piece_cache/metrics.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache/metrics.rs
@@ -1,0 +1,87 @@
+//! Metrics for disk piece cache
+
+use crate::farm::PieceCacheId;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::{Registry, Unit};
+use std::sync::atomic::{AtomicI64, AtomicU64};
+
+/// Metrics for disk piece cache
+#[derive(Debug)]
+pub(super) struct DiskPieceCacheMetrics {
+    pub(super) contents: Counter<u64, AtomicU64>,
+    pub(super) read_piece: Counter<u64, AtomicU64>,
+    pub(super) read_piece_index: Counter<u64, AtomicU64>,
+    pub(super) write_piece: Counter<u64, AtomicU64>,
+    pub(super) capacity_used: Gauge<i64, AtomicI64>,
+}
+
+impl DiskPieceCacheMetrics {
+    /// Create new instance
+    pub(super) fn new(
+        registry: &mut Registry,
+        cache_id: &PieceCacheId,
+        max_num_elements: u32,
+    ) -> Self {
+        let registry = registry
+            .sub_registry_with_prefix("disk_piece_cache")
+            .sub_registry_with_label(("cache_id".into(), cache_id.to_string().into()));
+
+        let contents = Counter::default();
+        registry.register_with_unit(
+            "contents",
+            "Contents requests",
+            Unit::Other("Requests".to_string()),
+            contents.clone(),
+        );
+
+        let read_piece = Counter::default();
+        registry.register_with_unit(
+            "read_piece",
+            "Read piece requests",
+            Unit::Other("Pieces".to_string()),
+            read_piece.clone(),
+        );
+
+        let read_piece_index = Counter::default();
+        registry.register_with_unit(
+            "read_piece_index",
+            "Read piece index requests",
+            Unit::Other("Requests".to_string()),
+            read_piece_index.clone(),
+        );
+
+        let write_piece = Counter::default();
+        registry.register_with_unit(
+            "write_piece",
+            "Write piece requests",
+            Unit::Other("Pieces".to_string()),
+            write_piece.clone(),
+        );
+
+        let capacity_total = Gauge::<i64, AtomicI64>::default();
+        capacity_total.set(i64::from(max_num_elements));
+        registry.register_with_unit(
+            "capacity_total",
+            "Piece cache capacity total",
+            Unit::Other("Pieces".to_string()),
+            capacity_total,
+        );
+
+        let capacity_used = Gauge::default();
+        registry.register_with_unit(
+            "capacity_used",
+            "Piece cache capacity used",
+            Unit::Other("Pieces".to_string()),
+            capacity_used.clone(),
+        );
+
+        Self {
+            contents,
+            read_piece,
+            read_piece_index,
+            write_piece,
+            capacity_used,
+        }
+    }
+}

--- a/crates/subspace-farmer/src/disk_piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache/tests.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 fn basic() {
     let path = tempdir().unwrap();
     {
-        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2).unwrap();
+        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2, None, None).unwrap();
 
         // Initially empty
         assert_eq!(
@@ -115,7 +115,7 @@ fn basic() {
 
     // Reopening works
     {
-        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2).unwrap();
+        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2, None, None).unwrap();
         // Two pieces stored
         assert_eq!(
             disk_piece_cache
@@ -130,7 +130,7 @@ fn basic() {
     {
         DiskPieceCache::wipe(path.as_ref()).unwrap();
 
-        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2).unwrap();
+        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2, None, None).unwrap();
         // Wiped successfully
         assert_eq!(
             disk_piece_cache

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -990,13 +990,13 @@ impl FarmerCache {
                     return match maybe_piece {
                         Some((_piece_index, piece)) => {
                             if let Some(metrics) = &self.metrics {
-                                metrics.cache_hit.inc();
+                                metrics.cache_get_hit.inc();
                             }
                             Some(piece)
                         }
                         None => {
                             if let Some(metrics) = &self.metrics {
-                                metrics.cache_miss.inc();
+                                metrics.cache_get_miss.inc();
                             }
                             None
                         }
@@ -1020,7 +1020,7 @@ impl FarmerCache {
                     }
 
                     if let Some(metrics) = &self.metrics {
-                        metrics.cache_error.inc();
+                        metrics.cache_get_error.inc();
                     }
                     return None;
                 }
@@ -1030,14 +1030,14 @@ impl FarmerCache {
         for cache in self.plot_caches.caches.read().await.iter() {
             if let Ok(Some(piece)) = cache.read_piece(&key).await {
                 if let Some(metrics) = &self.metrics {
-                    metrics.cache_hit.inc();
+                    metrics.cache_get_hit.inc();
                 }
                 return Some(piece);
             }
         }
 
         if let Some(metrics) = &self.metrics {
-            metrics.cache_miss.inc();
+            metrics.cache_get_miss.inc();
         }
         None
     }
@@ -1053,9 +1053,15 @@ impl FarmerCache {
             let Some(&offset) = cache.stored_pieces.get(&key) else {
                 continue;
             };
+            if let Some(metrics) = &self.metrics {
+                metrics.cache_find_hit.inc();
+            }
             return Some((*cache.backend.id(), offset));
         }
 
+        if let Some(metrics) = &self.metrics {
+            metrics.cache_find_miss.inc();
+        }
         None
     }
 

--- a/crates/subspace-farmer/src/farmer_cache/metrics.rs
+++ b/crates/subspace-farmer/src/farmer_cache/metrics.rs
@@ -8,9 +8,11 @@ use std::sync::atomic::{AtomicI64, AtomicU64};
 /// Metrics for farmer cache
 #[derive(Debug)]
 pub(super) struct FarmerCacheMetrics {
-    pub(super) cache_hit: Counter<u64, AtomicU64>,
-    pub(super) cache_miss: Counter<u64, AtomicU64>,
-    pub(super) cache_error: Counter<u64, AtomicU64>,
+    pub(super) cache_get_hit: Counter<u64, AtomicU64>,
+    pub(super) cache_get_miss: Counter<u64, AtomicU64>,
+    pub(super) cache_get_error: Counter<u64, AtomicU64>,
+    pub(super) cache_find_hit: Counter<u64, AtomicU64>,
+    pub(super) cache_find_miss: Counter<u64, AtomicU64>,
     pub(super) piece_cache_capacity_total: Gauge<i64, AtomicI64>,
     pub(super) piece_cache_capacity_used: Gauge<i64, AtomicI64>,
 }
@@ -20,28 +22,44 @@ impl FarmerCacheMetrics {
     pub(super) fn new(registry: &mut Registry) -> Self {
         let registry = registry.sub_registry_with_prefix("farmer_cache");
 
-        let cache_hit = Counter::default();
+        let cache_get_hit = Counter::default();
         registry.register_with_unit(
-            "cache_hit",
-            "Cache hit",
+            "cache_get_hit",
+            "Cache get hit",
             Unit::Other("Requests".to_string()),
-            cache_hit.clone(),
+            cache_get_hit.clone(),
         );
 
-        let cache_miss = Counter::default();
+        let cache_get_miss = Counter::default();
         registry.register_with_unit(
-            "cache_miss",
-            "Cache miss",
+            "cache_get_miss",
+            "Cache get miss",
             Unit::Other("Requests".to_string()),
-            cache_miss.clone(),
+            cache_get_miss.clone(),
         );
 
-        let cache_error = Counter::default();
+        let cache_get_error = Counter::default();
         registry.register_with_unit(
             "cache_error",
-            "Cache error",
+            "Cache get error",
             Unit::Other("Requests".to_string()),
-            cache_error.clone(),
+            cache_get_error.clone(),
+        );
+
+        let cache_find_hit = Counter::default();
+        registry.register_with_unit(
+            "cache_find_hit",
+            "Cache find hit",
+            Unit::Other("Requests".to_string()),
+            cache_find_hit.clone(),
+        );
+
+        let cache_find_miss = Counter::default();
+        registry.register_with_unit(
+            "cache_find_miss",
+            "Cache find miss",
+            Unit::Other("Requests".to_string()),
+            cache_find_miss.clone(),
         );
 
         let piece_cache_capacity_total = Gauge::default();
@@ -61,9 +79,11 @@ impl FarmerCacheMetrics {
         );
 
         Self {
-            cache_hit,
-            cache_miss,
-            cache_error,
+            cache_get_hit,
+            cache_get_miss,
+            cache_get_error,
+            cache_find_hit,
+            cache_find_miss,
             piece_cache_capacity_total,
             piece_cache_capacity_used,
         }

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -207,8 +207,8 @@ async fn basic() {
         farmer_cache
             .replace_backing_caches(
                 vec![
-                    Arc::new(DiskPieceCache::open(path1.as_ref(), 1).unwrap()),
-                    Arc::new(DiskPieceCache::open(path2.as_ref(), 1).unwrap()),
+                    Arc::new(DiskPieceCache::open(path1.as_ref(), 1, None, None).unwrap()),
+                    Arc::new(DiskPieceCache::open(path2.as_ref(), 1, None, None).unwrap()),
                 ],
                 vec![],
             )
@@ -407,8 +407,8 @@ async fn basic() {
         farmer_cache
             .replace_backing_caches(
                 vec![
-                    Arc::new(DiskPieceCache::open(path1.as_ref(), 1).unwrap()),
-                    Arc::new(DiskPieceCache::open(path2.as_ref(), 1).unwrap()),
+                    Arc::new(DiskPieceCache::open(path1.as_ref(), 1, None, None).unwrap()),
+                    Arc::new(DiskPieceCache::open(path2.as_ref(), 1, None, None).unwrap()),
                 ],
                 vec![],
             )

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -1070,9 +1070,10 @@ impl SingleDiskFarm {
 
         tasks.push(Box::pin({
             let node_client = node_client.clone();
+            let metrics = metrics.clone();
 
             async move {
-                slot_notification_forwarder(&node_client, slot_info_forwarder_sender)
+                slot_notification_forwarder(&node_client, slot_info_forwarder_sender, metrics)
                     .await
                     .map_err(BackgroundTaskError::Farming)
             }

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -17,8 +17,8 @@ pub mod unbuffered_io_file_windows;
 
 use crate::disk_piece_cache::{DiskPieceCache, DiskPieceCacheError};
 use crate::farm::{
-    Farm, FarmId, FarmingError, FarmingNotification, HandlerFn, PieceReader, PlottedSectors,
-    SectorUpdate,
+    Farm, FarmId, FarmingError, FarmingNotification, HandlerFn, PieceCacheId, PieceReader,
+    PlottedSectors, SectorUpdate,
 };
 use crate::node_client::NodeClient;
 use crate::plotter::Plotter;
@@ -86,6 +86,7 @@ use subspace_rpc_primitives::{FarmerAppInfo, SolutionResponse};
 use thiserror::Error;
 use tokio::runtime::Handle;
 use tokio::sync::{broadcast, Barrier, Semaphore};
+use tokio::task;
 use tracing::{debug, error, info, trace, warn, Instrument, Span};
 
 // Refuse to compile on non-64-bit platforms, offsets may fail on those when converting from u64 to
@@ -684,7 +685,7 @@ struct SingleDiskFarmInit {
     metadata_header: PlotMetadataHeader,
     target_sector_count: u16,
     sectors_metadata: Arc<AsyncRwLock<Vec<SectorMetadataChecksummed>>>,
-    piece_cache: SingleDiskPieceCache,
+    piece_cache_capacity: u32,
     plot_cache: DiskPlotCache,
 }
 
@@ -839,9 +840,35 @@ impl SingleDiskFarm {
             metadata_header,
             target_sector_count,
             sectors_metadata,
-            piece_cache,
+            piece_cache_capacity,
             plot_cache,
         } = single_disk_farm_init;
+
+        let piece_cache = {
+            // Convert farm ID into cache ID for single disk farm
+            let FarmId::Ulid(id) = *single_disk_farm_info.id();
+            let id = PieceCacheId::Ulid(id);
+
+            SingleDiskPieceCache::new(
+                id,
+                if piece_cache_capacity == 0 {
+                    None
+                } else {
+                    Some(task::block_in_place(|| {
+                        if let Some(registry) = registry {
+                            DiskPieceCache::open(
+                                &directory,
+                                piece_cache_capacity,
+                                Some(id),
+                                Some(*registry.lock()),
+                            )
+                        } else {
+                            DiskPieceCache::open(&directory, piece_cache_capacity, Some(id), None)
+                        }
+                    })?)
+                },
+            )
+        };
 
         let public_key = *single_disk_farm_info.public_key();
         let pieces_in_sector = single_disk_farm_info.pieces_in_sector();
@@ -1397,7 +1424,7 @@ impl SingleDiskFarm {
             plot_file_size.div_ceil(DISK_SECTOR_SIZE as u64) * DISK_SECTOR_SIZE as u64;
 
         // Remaining space will be used for caching purposes
-        let cache_capacity = if cache_percentage > 0 {
+        let piece_cache_capacity = if cache_percentage > 0 {
             let cache_space = allocated_space
                 - fixed_space_usage
                 - plot_file_size
@@ -1553,14 +1580,6 @@ impl SingleDiskFarm {
 
         let plot_file = Arc::new(plot_file);
 
-        let piece_cache = SingleDiskPieceCache::new(
-            *single_disk_farm_info.id(),
-            if cache_capacity == 0 {
-                None
-            } else {
-                Some(DiskPieceCache::open(directory, cache_capacity)?)
-            },
-        );
         let plot_cache = DiskPlotCache::new(
             &plot_file,
             &sectors_metadata,
@@ -1577,7 +1596,7 @@ impl SingleDiskFarm {
             metadata_header,
             target_sector_count,
             sectors_metadata,
-            piece_cache,
+            piece_cache_capacity,
             plot_cache,
         })
     }

--- a/crates/subspace-farmer/src/single_disk_farm/metrics.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/metrics.rs
@@ -35,6 +35,7 @@ impl fmt::Display for SectorState {
 #[derive(Debug)]
 pub(super) struct SingleDiskFarmMetrics {
     pub(super) auditing_time: Histogram,
+    pub(super) skipped_slots: Counter<u64, AtomicU64>,
     proving_time: Family<Vec<(&'static str, String)>, Histogram>,
     farming_errors: Family<Vec<(&'static str, String)>, Counter<u64, AtomicU64>>,
     pub(super) sector_downloading_time: Histogram,
@@ -71,6 +72,13 @@ impl SingleDiskFarmMetrics {
             "Auditing time",
             Unit::Seconds,
             auditing_time.clone(),
+        );
+
+        let skipped_slots = Counter::default();
+        sub_registry.register(
+            "skipped_slots",
+            "Completely skipped slots (not even auditing)",
+            skipped_slots.clone(),
         );
 
         let proving_time = Family::<_, _>::new_with_constructor(|| {
@@ -204,6 +212,7 @@ impl SingleDiskFarmMetrics {
 
         let metrics = Self {
             auditing_time,
+            skipped_slots,
             proving_time,
             farming_errors,
             sector_downloading_time,

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -2,7 +2,7 @@
 
 use crate::disk_piece_cache::DiskPieceCache;
 use crate::farm;
-use crate::farm::{FarmError, FarmId, PieceCacheId, PieceCacheOffset};
+use crate::farm::{FarmError, PieceCacheId, PieceCacheOffset};
 use async_trait::async_trait;
 use futures::{stream, Stream};
 use subspace_core_primitives::{Piece, PieceIndex};
@@ -84,11 +84,7 @@ impl farm::PieceCache for SingleDiskPieceCache {
 }
 
 impl SingleDiskPieceCache {
-    pub(crate) fn new(farm_id: FarmId, maybe_piece_cache: Option<DiskPieceCache>) -> Self {
-        // Convert farm ID into cache ID for single disk farm
-        let FarmId::Ulid(id) = farm_id;
-        let id = PieceCacheId::Ulid(id);
-
+    pub(crate) fn new(id: PieceCacheId, maybe_piece_cache: Option<DiskPieceCache>) -> Self {
         Self {
             id,
             maybe_piece_cache,


### PR DESCRIPTION
Some more metrics:
* skipped slots (not even audited)
* piece cache metrics
* farmer cache find hit/miss (and some refactoring to names)

Still thinking what to do about cluster metrics (maintenance functions in binary code are a bit annoying for encapsulation).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
