### PR TITLE
Use snap sync by default

### DIFF
--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -407,7 +407,7 @@ pub(super) struct ConsensusChainOptions {
     timekeeper_options: TimekeeperOptions,
 
     /// Sync mode
-    #[arg(long, default_value_t = ChainSyncMode::Full)]
+    #[arg(long, default_value_t = ChainSyncMode::Snap)]
     sync: ChainSyncMode,
 }
 


### PR DESCRIPTION
With all domains changes landed and some tests done by the community I think it is time to make it the default sync mode.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
