### PR TITLE
Support future snap sync

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -452,7 +452,6 @@ where
 {
     confirmation_depth_k: BlockNumber,
     archiver: Archiver,
-    older_archived_segments: Vec<NewArchivedSegment>,
     best_archived_block: (Block::Hash, NumberFor<Block>),
 }
 
@@ -600,8 +599,6 @@ where
             Archiver::new(subspace_link.kzg().clone()).expect("Incorrect parameters for archiver")
         };
 
-    let mut older_archived_segments = Vec::new();
-
     // Process blocks since last fully archived block up to the current head minus K
     {
         let blocks_to_archive_from = archiver
@@ -691,8 +688,6 @@ where
                     .map(|archived_segment| archived_segment.segment_header)
                     .collect();
 
-                older_archived_segments.extend(archived_segments);
-
                 if !new_segment_headers.is_empty() {
                     segment_headers_store.add_segment_headers(&new_segment_headers)?;
                 }
@@ -703,7 +698,6 @@ where
     Ok(InitializedArchiver {
         confirmation_depth_k,
         archiver,
-        older_archived_segments,
         best_archived_block: best_archived_block
             .expect("Must always set if there is no logical error; qed"),
     })
@@ -821,22 +815,12 @@ where
         let InitializedArchiver {
             confirmation_depth_k,
             mut archiver,
-            older_archived_segments,
             best_archived_block,
         } = archiver;
         let (mut best_archived_block_hash, mut best_archived_block_number) = best_archived_block;
 
         let archived_segment_notification_sender =
             subspace_link.archived_segment_notification_sender.clone();
-
-        // Farmers may have not received all previous segments, send them now.
-        for archived_segment in older_archived_segments {
-            send_archived_segment_notification(
-                &archived_segment_notification_sender,
-                archived_segment,
-            )
-            .await;
-        }
 
         while let Some(ref block_import_notification) =
             block_importing_notification_stream.next().await
@@ -865,7 +849,6 @@ where
                 InitializedArchiver {
                     confirmation_depth_k: _,
                     archiver,
-                    older_archived_segments: _,
                     best_archived_block: (best_archived_block_hash, best_archived_block_number),
                 } = initialize_archiver(&segment_headers_store, &subspace_link, client.as_ref())?;
 

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -817,18 +817,18 @@ where
         let archived_segment_notification_sender =
             subspace_link.archived_segment_notification_sender.clone();
 
-        while let Some(block_import_notification) = block_importing_notification_stream.next().await
+        while let Some(block_importing_notification) =
+            block_importing_notification_stream.next().await
         {
-            let block_number_to_archive = match block_import_notification
-                .block_number
-                .checked_sub(&confirmation_depth_k)
-            {
-                Some(block_number_to_archive) => block_number_to_archive,
-                None => {
-                    // Too early to archive blocks
-                    continue;
-                }
-            };
+            let importing_block_number = block_importing_notification.block_number;
+            let block_number_to_archive =
+                match importing_block_number.checked_sub(&confirmation_depth_k) {
+                    Some(block_number_to_archive) => block_number_to_archive,
+                    None => {
+                        // Too early to archive blocks
+                        continue;
+                    }
+                };
 
             if best_archived_block_number >= block_number_to_archive {
                 // This block was already archived, skip
@@ -860,9 +860,8 @@ where
                         "There was a gap in blockchain history and the last contiguous series of \
                         blocks starting with doesn't start with archived segment (best archived \
                         block number {best_archived_block_number}, block number to archive \
-                        {block_number_to_archive}), block about to be imported {}), archiver can't \
-                        continue",
-                        block_import_notification.block_number
+                        {block_number_to_archive}), block about to be imported \
+                        {importing_block_number}), archiver can't continue",
                     );
                     return Err(sp_blockchain::Error::Consensus(sp_consensus::Error::Other(
                         error.into(),

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -851,9 +851,11 @@ where
                     // Special sync mode where verified blocks were inserted into blockchain
                     // directly, archiving of this block will naturally happen later
                     continue;
-                } else if best_archived_block_number.is_zero() {
-                    // We may have imported some block using special sync mode right after genesis,
-                    // in which case archiver will be stuck at genesis block
+                } else if client.hash(importing_block_number - One::one())?.is_none() {
+                    // We may have imported some block using special sync mode and block we're about
+                    // to import is the first one after the gap at which archiver is supposed to be
+                    // initialized, but we are only about to import it, so wait for the next block
+                    // for now
                     continue;
                 } else {
                     let error = format!(

--- a/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -721,7 +721,7 @@ where
     }
 
     fn should_backoff(&self, slot: Slot, chain_head: &Block::Header) -> bool {
-        if let Some(ref strategy) = self.backoff_authoring_blocks {
+        if let Some(strategy) = &self.backoff_authoring_blocks {
             if let Ok(chain_head_slot) = extract_pre_digest(chain_head).map(|digest| digest.slot())
             {
                 return strategy.should_backoff(


### PR DESCRIPTION
This PR contains a few cleanups and at the end improved check for future iterations of Snap sync where we'll be reinitializing archiver not only after genesis, but also after later gaps as well as mentioned in https://github.com/subspace/subspace/pull/2809/files#r1620722599

This is effectively a continuation of https://github.com/subspace/subspace/pull/2809

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
