### PR TITLE
Allow importing older blocks in DSN/Snap sync if necessary

### DIFF
--- a/crates/sc-consensus-subspace/src/verifier.rs
+++ b/crates/sc-consensus-subspace/src/verifier.rs
@@ -484,7 +484,9 @@ where
         );
 
         let best_number = self.client.info().best_number;
+        // Reject block below archiving point, but only if we received it from the network
         if *block.header.number() + self.chain_constants.confirmation_depth_k().into() < best_number
+            && matches!(block.origin, BlockOrigin::NetworkBroadcast)
         {
             debug!(
                 header = ?block.header,
@@ -579,7 +581,8 @@ where
         } = checked_header;
 
         let slot = pre_digest.slot();
-        // Estimate what the "current" slot is according to sync target since we don't have other way to know it
+        // Estimate what the "current" slot is according to sync target since we don't have other
+        // way to know it
         let diff_in_blocks = self
             .sync_target_block_number
             .load(Ordering::Relaxed)

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -227,7 +227,8 @@ where
                 import_queue_service
                     .import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
                 // This will notify Substrate's sync mechanism and allow regular Substrate sync to continue gracefully
-                import_queue_service.import_blocks(BlockOrigin::NetworkBroadcast, vec![last_block]);
+                import_queue_service
+                    .import_blocks(BlockOrigin::ConsensusBroadcast, vec![last_block]);
             } else {
                 import_queue_service
                     .import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -294,7 +294,7 @@ where
         );
 
         import_queue_service
-            .import_blocks(BlockOrigin::NetworkBroadcast, vec![last_block_to_import]);
+            .import_blocks(BlockOrigin::ConsensusBroadcast, vec![last_block_to_import]);
     }
 
     // Wait for blocks to be imported


### PR DESCRIPTION
This addresses an edge-case with Snap sync for domains described in https://github.com/subspace/subspace/pull/2927#issuecomment-2236041708

Didn't test it, but it should work. At least there will be no rejection error.

I'm still not happy that this happens in the first place, for example best block will remain higher while many blocks before it are missing, not sure if something in the protocol will be confused by that. Consensus should be fine.

This is built on top of https://github.com/subspace/subspace/pull/2927 for convenience.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
