### PR TITLE
Introduce `submit_receipt` to fill up the unbounded gap between `HeadDomainNumber` and `HeadReceiptNumber`

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -29,7 +29,8 @@ use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_core::ByteArray;
 use sp_domains::{
     dummy_opaque_bundle, BlockFees, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
-    OperatorPublicKey, OperatorSignature, PermissionedActionAllowedBy, RuntimeType, Transfers,
+    OperatorPublicKey, OperatorSignature, PermissionedActionAllowedBy, ProofOfElection,
+    RuntimeType, SealedSingletonReceipt, SingletonReceipt, Transfers,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{CheckedAdd, One, Zero};
@@ -860,6 +861,36 @@ mod benchmarks {
         assert_eq!(domain_obj.domain_config.operator_allow_list, new_allow_list);
     }
 
+    #[benchmark]
+    fn submit_receipt() {
+        let domain_id = register_domain::<T>();
+        let (_, operator_id) =
+            register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
+
+        assert_eq!(Domains::<T>::head_receipt_number(domain_id), 0u32.into());
+
+        let receipt = {
+            let mut er = BlockTree::<T>::get::<_, DomainBlockNumberFor<T>>(domain_id, Zero::zero())
+                .and_then(BlockTreeNodes::<T>::get)
+                .expect("genesis receipt must exist")
+                .execution_receipt;
+            er.domain_block_number = One::one();
+            er
+        };
+        let sealed_singleton_receipt = SealedSingletonReceipt {
+            singleton_receipt: SingletonReceipt {
+                proof_of_election: ProofOfElection::dummy(domain_id, operator_id),
+                receipt,
+            },
+            signature: OperatorSignature::unchecked_from([0u8; 64]),
+        };
+
+        #[extrinsic_call]
+        submit_receipt(RawOrigin::None, sealed_singleton_receipt);
+
+        assert_eq!(Domains::<T>::head_receipt_number(domain_id), 1u32.into());
+    }
+
     fn register_runtime<T: Config>() -> RuntimeId {
         let genesis_storage = include_bytes!("../res/evm-domain-genesis-storage").to_vec();
         let runtime_id = NextRuntimeId::<T>::get();
@@ -961,6 +992,9 @@ mod benchmarks {
     }
 
     fn run_to_block<T: Config>(block_number: BlockNumberFor<T>, parent_hash: T::Hash) {
+        if let Some(parent_block_number) = block_number.checked_sub(&One::one()) {
+            <Domains<T> as Hooks<BlockNumberFor<T>>>::on_finalize(parent_block_number);
+        }
         System::<T>::set_block_number(block_number);
         System::<T>::initialize(&block_number, &parent_hash, &Default::default());
         <Domains<T> as Hooks<BlockNumberFor<T>>>::on_initialize(block_number);

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -158,9 +158,11 @@ pub(crate) fn execution_receipt_type<T: Config>(
             }
 
             // Add confirm to the head receipt that added in the current block or it is
-            // the genesis receipt
+            // the first genesis receipt
+            let is_first_genesis_receipt =
+                receipt_number.is_zero() && HeadDomainNumber::<T>::get(domain_id).is_zero();
             if receipt_number == head_receipt_number
-                && (head_receipt_extended || receipt_number.is_zero())
+                && (head_receipt_extended || is_first_genesis_receipt)
             {
                 return ReceiptType::Accepted(AcceptedReceiptType::CurrentHead);
             }

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -49,6 +49,7 @@ pub enum Error {
     OverwritingER,
     RuntimeNotFound,
     LastBlockNotFound,
+    UnexpectedConfirmedDomainBlock,
 }
 
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -606,12 +606,12 @@ mod pallet {
     pub(super) type HeadReceiptNumber<T: Config> =
         StorageMap<_, Identity, DomainId, DomainBlockNumberFor<T>, ValueQuery>;
 
-    /// Whether the head receipt have extended in the current consensus block
+    /// The hash of the new head receipt added in the current consensus block
     ///
     /// Temporary storage only exist during block execution
     #[pallet::storage]
-    pub(super) type HeadReceiptExtended<T: Config> =
-        StorageMap<_, Identity, DomainId, bool, ValueQuery>;
+    pub(super) type NewAddedHeadReceipt<T: Config> =
+        StorageMap<_, Identity, DomainId, T::DomainHash, OptionQuery>;
 
     /// The consensus block hash used to verify ER,
     /// only store the consensus block hash for a domain
@@ -1856,7 +1856,7 @@ mod pallet {
 
         fn on_finalize(_: BlockNumberFor<T>) {
             let _ = LastEpochStakingDistribution::<T>::clear(u32::MAX, None);
-            let _ = HeadReceiptExtended::<T>::clear(u32::MAX, None);
+            let _ = NewAddedHeadReceipt::<T>::clear(u32::MAX, None);
         }
     }
 

--- a/crates/pallet-domains/src/weights.rs
+++ b/crates/pallet-domains/src/weights.rs
@@ -48,6 +48,7 @@ pub trait WeightInfo {
 	fn unlock_funds() -> Weight;
 	fn unlock_nominator() -> Weight;
 	fn update_domain_operator_allow_list() -> Weight;
+	fn submit_receipt() -> Weight;
 }
 
 /// Weights for pallet_domains using the Substrate node and recommended hardware.
@@ -478,6 +479,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	/// Storage: `Domains::HeadReceiptNumber` (r:1 w:1)
+	/// Proof: `Domains::HeadReceiptNumber` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::NewAddedHeadReceipt` (r:1 w:1)
+	/// Proof: `Domains::NewAddedHeadReceipt` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::LatestConfirmedDomainExecutionReceipt` (r:1 w:0)
+	/// Proof: `Domains::LatestConfirmedDomainExecutionReceipt` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::BlockTree` (r:1 w:1)
+	/// Proof: `Domains::BlockTree` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::LatestSubmittedER` (r:1 w:1)
+	/// Proof: `Domains::LatestSubmittedER` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::BlockTreeNodes` (r:0 w:1)
+	/// Proof: `Domains::BlockTreeNodes` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn submit_receipt() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `655`
+		//  Estimated: `4120`
+		// Minimum execution time: 32_000_000 picoseconds.
+		Weight::from_parts(35_000_000, 4120)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -906,5 +928,26 @@ impl WeightInfo for () {
 		Weight::from_parts(17_000_000, 3917)
 			.saturating_add(ParityDbWeight::get().reads(1_u64))
 			.saturating_add(ParityDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `Domains::HeadReceiptNumber` (r:1 w:1)
+	/// Proof: `Domains::HeadReceiptNumber` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::NewAddedHeadReceipt` (r:1 w:1)
+	/// Proof: `Domains::NewAddedHeadReceipt` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::LatestConfirmedDomainExecutionReceipt` (r:1 w:0)
+	/// Proof: `Domains::LatestConfirmedDomainExecutionReceipt` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::BlockTree` (r:1 w:1)
+	/// Proof: `Domains::BlockTree` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::LatestSubmittedER` (r:1 w:1)
+	/// Proof: `Domains::LatestSubmittedER` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Domains::BlockTreeNodes` (r:0 w:1)
+	/// Proof: `Domains::BlockTreeNodes` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn submit_receipt() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `655`
+		//  Estimated: `4120`
+		// Minimum execution time: 32_000_000 picoseconds.
+		Weight::from_parts(35_000_000, 4120)
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(5_u64))
 	}
 }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -754,6 +754,10 @@ impl<CHash> ProofOfElection<CHash> {
         bytes.append(&mut self.vrf_signature.proof.encode());
         blake3_hash(&bytes)
     }
+
+    pub fn slot_number(&self) -> u64 {
+        self.slot_number
+    }
 }
 
 impl<CHash: Default> ProofOfElection<CHash> {
@@ -773,6 +777,93 @@ impl<CHash: Default> ProofOfElection<CHash> {
             operator_id,
             consensus_block_hash: Default::default(),
         }
+    }
+}
+
+/// Singleton receipt submit along when there is a gap between `HeadDomainNumber`
+/// and `HeadReceiptNumber`
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub struct SingletonReceipt<Number, Hash, DomainHeader: HeaderT, Balance> {
+    /// Proof of receipt producer election.
+    pub proof_of_election: ProofOfElection<Hash>,
+    /// The receipt to submit
+    pub receipt: ExecutionReceipt<
+        Number,
+        Hash,
+        HeaderNumberFor<DomainHeader>,
+        HeaderHashFor<DomainHeader>,
+        Balance,
+    >,
+}
+
+impl<Number: Encode, Hash: Encode, DomainHeader: HeaderT, Balance: Encode>
+    SingletonReceipt<Number, Hash, DomainHeader, Balance>
+{
+    pub fn hash(&self) -> HeaderHashFor<DomainHeader> {
+        HeaderHashingFor::<DomainHeader>::hash_of(&self)
+    }
+}
+
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub struct SealedSingletonReceipt<Number, Hash, DomainHeader: HeaderT, Balance> {
+    /// A collection of the receipt.
+    pub singleton_receipt: SingletonReceipt<Number, Hash, DomainHeader, Balance>,
+    /// Signature of the receipt bundle.
+    pub signature: OperatorSignature,
+}
+
+impl<Number: Encode, Hash: Encode, DomainHeader: HeaderT, Balance: Encode>
+    SealedSingletonReceipt<Number, Hash, DomainHeader, Balance>
+{
+    /// Returns the `domain_id`
+    pub fn domain_id(&self) -> DomainId {
+        self.singleton_receipt.proof_of_election.domain_id
+    }
+
+    /// Return the `operator_id`
+    pub fn operator_id(&self) -> OperatorId {
+        self.singleton_receipt.proof_of_election.operator_id
+    }
+
+    /// Return the `slot_number` of the `proof_of_election`
+    pub fn slot_number(&self) -> u64 {
+        self.singleton_receipt.proof_of_election.slot_number
+    }
+
+    /// Return the receipt
+    pub fn receipt(
+        &self,
+    ) -> &ExecutionReceipt<
+        Number,
+        Hash,
+        HeaderNumberFor<DomainHeader>,
+        HeaderHashFor<DomainHeader>,
+        Balance,
+    > {
+        &self.singleton_receipt.receipt
+    }
+
+    /// Consume this `SealedSingletonReceipt` and return the receipt
+    pub fn into_receipt(
+        self,
+    ) -> ExecutionReceipt<
+        Number,
+        Hash,
+        HeaderNumberFor<DomainHeader>,
+        HeaderHashFor<DomainHeader>,
+        Balance,
+    > {
+        self.singleton_receipt.receipt
+    }
+
+    /// Returns the hash of `SingletonReceipt`
+    pub fn pre_hash(&self) -> HeaderHashFor<DomainHeader> {
+        HeaderHashingFor::<DomainHeader>::hash_of(&self.singleton_receipt)
+    }
+
+    /// Return the encode size of `SealedSingletonReceipt`
+    pub fn size(&self) -> u32 {
+        self.encoded_size() as u32
     }
 }
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1511,6 +1511,9 @@ sp_api::decl_runtime_apis! {
         /// Submits the transaction bundle via an unsigned extrinsic.
         fn submit_bundle_unsigned(opaque_bundle: OpaqueBundle<NumberFor<Block>, Block::Hash, DomainHeader, Balance>);
 
+        // Submit singleton receipt via an unsigned extrinsic.
+        fn submit_receipt_unsigned(singleton_receipt: SealedSingletonReceipt<NumberFor<Block>, Block::Hash, DomainHeader, Balance>);
+
         /// Extract the bundles stored successfully from the given extrinsics.
         fn extract_successful_bundles(
             domain_id: DomainId,

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -199,6 +199,12 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
+        fn submit_receipt_unsigned(
+            _singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+        ) {
+            unreachable!()
+        }
+
         fn extract_successful_bundles(
             _domain_id: DomainId,
             _extrinsics: Vec<<Block as BlockT>::Extrinsic>,

--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -183,6 +183,7 @@ where
                 None
             })
             .await
+            .and_then(|res| res.into_opaque_bundle())
     }
 
     pub async fn start<NSNS: Stream<Item = (Slot, PotOutput)> + Send + 'static>(

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1153,6 +1153,12 @@ impl_runtime_apis! {
             Domains::submit_bundle_unsigned(opaque_bundle)
         }
 
+        fn submit_receipt_unsigned(
+            singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+        ) {
+            Domains::submit_receipt_unsigned(singleton_receipt)
+        }
+
         fn extract_successful_bundles(
             domain_id: DomainId,
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -3273,16 +3273,19 @@ async fn stale_and_in_future_bundle_should_be_rejected() {
         .produce_bundle(operator_id, slot_info(valid_slot, valid_pot))
         .await
         .unwrap()
+        .and_then(|res| res.into_opaque_bundle())
         .unwrap();
     let bundle_with_unknow_pot = bundle_producer
         .produce_bundle(operator_id, slot_info(valid_slot, unknow_pot))
         .await
         .unwrap()
+        .and_then(|res| res.into_opaque_bundle())
         .unwrap();
     let bundle_with_slot_in_future = bundle_producer
         .produce_bundle(operator_id, slot_info(slot_in_future, valid_pot))
         .await
         .unwrap()
+        .and_then(|res| res.into_opaque_bundle())
         .unwrap();
     for bundle in [
         bundle_with_unknow_pot.clone(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -13,6 +13,7 @@ use domain_test_service::EcdsaKeyring::{Alice, Bob, Charlie, Eve};
 use domain_test_service::Sr25519Keyring::{self, Alice as Sr25519Alice, Ferdie};
 use domain_test_service::{construct_extrinsic_generic, AUTO_ID_DOMAIN_ID, EVM_DOMAIN_ID};
 use futures::StreamExt;
+use pallet_domains::OperatorConfig;
 use pallet_messenger::ChainAllowlistUpdate;
 use sc_client_api::{Backend, BlockBackend, BlockchainEvents, HeaderBackend};
 use sc_consensus::SharedBlockImport;
@@ -32,7 +33,7 @@ use sp_domains::core_api::DomainCoreApi;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
     Bundle, BundleValidity, ChainId, ChannelId, DomainsApi, HeaderHashingFor, InboxedBundle,
-    InvalidBundleType, Transfers,
+    InvalidBundleType, OperatorSignature, OperatorSigningKeyProofOfOwnershipData, Transfers,
 };
 use sp_domains_fraud_proof::fraud_proof::{
     ApplyExtrinsicMismatch, ExecutionPhase, FinalizeBlockMismatch, FraudProofVariant,
@@ -2868,6 +2869,8 @@ async fn test_valid_bundle_proof_generation_and_verification() {
     .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
     for i in 0..3 {
         let tx = alice.construct_extrinsic(
             alice.account_nonce() + i,
@@ -4328,7 +4331,7 @@ async fn test_bad_receipt_chain() {
     // Start Ferdie
     let mut ferdie = MockConsensusNode::run(
         tokio_handle.clone(),
-        Ferdie,
+        Sr25519Alice,
         BasePath::new(directory.path().join("ferdie")),
     );
 
@@ -4368,10 +4371,11 @@ async fn test_bad_receipt_chain() {
         )
     };
 
-    produce_blocks!(ferdie, alice, 5).await.unwrap();
+    produce_blocks!(ferdie, alice, 15).await.unwrap();
 
     // Get a bundle from the txn pool and modify the receipt of the target bundle to an invalid one
     let (slot, mut opaque_bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let stale_bundle = opaque_bundle.clone();
     let (bad_receipt_hash, bad_submit_bundle_tx) = {
         let receipt = &mut opaque_bundle.sealed_header.header.receipt;
         receipt.domain_block_hash = Default::default();
@@ -4425,6 +4429,7 @@ async fn test_bad_receipt_chain() {
             )
             .await
             .expect("produce bundle must success")
+            .and_then(|res| res.into_opaque_bundle())
             .expect("must win the challenge");
         let (receipt_hash, bad_submit_bundle_tx) = {
             let mut opaque_bundle = bundle;
@@ -4466,12 +4471,115 @@ async fn test_bad_receipt_chain() {
 
     let ferdie_best_hash = ferdie.client.info().best_hash;
     let runtime_api = ferdie.client.runtime_api();
-    for receipt_hash in bad_receipt_descendants {
-        assert!(ferdie.does_receipt_exist(receipt_hash).unwrap());
+    for receipt_hash in &bad_receipt_descendants {
+        assert!(ferdie.does_receipt_exist(*receipt_hash).unwrap());
         assert!(runtime_api
-            .is_bad_er_pending_to_prune(ferdie_best_hash, EVM_DOMAIN_ID, receipt_hash)
+            .is_bad_er_pending_to_prune(ferdie_best_hash, EVM_DOMAIN_ID, *receipt_hash)
             .unwrap());
     }
+
+    // There should be a receipt gap
+    let head_domain_number = ferdie
+        .client
+        .runtime_api()
+        .domain_best_number(ferdie_best_hash, EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    let head_receipt_number = ferdie
+        .client
+        .runtime_api()
+        .head_receipt_number(ferdie_best_hash, EVM_DOMAIN_ID)
+        .unwrap();
+    assert_eq!(head_domain_number - head_receipt_number, 9);
+    // The previou bundle will be rejected as there is a receipt gap
+    match ferdie
+        .submit_transaction(bundle_to_tx(stale_bundle))
+        .await
+        .unwrap_err()
+    {
+        sc_transaction_pool::error::Error::Pool(TxPoolError::InvalidTransaction(invalid_tx)) => {
+            assert_eq!(invalid_tx, InvalidTransactionCode::Bundle.into())
+        }
+        e => panic!("Unexpected error: {e}"),
+    }
+
+    // Register another operator as Alice is slashed
+    ferdie
+        .construct_and_send_extrinsic_with(pallet_domains::Call::register_operator {
+            domain_id: EVM_DOMAIN_ID,
+            amount: 1000 * SSC,
+            config: OperatorConfig {
+                signing_key: Sr25519Keyring::Charlie.public().into(),
+                minimum_nominator_stake: Balance::MAX,
+                nomination_tax: Default::default(),
+            },
+            signing_key_proof_of_ownership: OperatorSignature::from(
+                OperatorSigningKeyProofOfOwnershipData {
+                    operator_owner: Sr25519Alice.to_account_id(),
+                }
+                .using_encoded(|e| Sr25519Keyring::Charlie.sign(e)),
+            ),
+        })
+        .await
+        .unwrap();
+    ferdie.produce_blocks(1).await.unwrap();
+
+    ferdie
+        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
+            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
+                pallet_domains::Call::force_staking_epoch_transition {
+                    domain_id: EVM_DOMAIN_ID,
+                },
+            )),
+        })
+        .await
+        .unwrap();
+    ferdie.produce_blocks(1).await.unwrap();
+
+    let alice_best_number = alice.client.info().best_number;
+    drop(alice);
+
+    // Start another operator node
+    let bob = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        BasePath::new(directory.path().join("bob")),
+    )
+    .operator_id(2)
+    .build_evm_node(Role::Authority, Charlie, &mut ferdie)
+    .await;
+    ferdie.produce_blocks(1).await.unwrap();
+
+    let bob_best_number = bob.client.info().best_number;
+    assert_eq!(alice_best_number, bob_best_number);
+
+    // Bad receipt should be pruned as singletone receipt submitting
+    for receipt_hash in vec![bad_receipt_hash]
+        .into_iter()
+        .chain(bad_receipt_descendants)
+    {
+        let slot = ferdie.produce_slot();
+        ferdie.notify_new_slot_and_wait_for_bundle(slot).await;
+        ferdie.produce_block_with_slot(slot).await.unwrap();
+        assert!(!ferdie.does_receipt_exist(receipt_hash).unwrap());
+    }
+
+    // The receipt gap should be fill up
+    let ferdie_best_hash = ferdie.client.info().best_hash;
+    let head_domain_number = ferdie
+        .client
+        .runtime_api()
+        .domain_best_number(ferdie_best_hash, EVM_DOMAIN_ID)
+        .unwrap()
+        .unwrap();
+    let head_receipt_number = ferdie
+        .client
+        .runtime_api()
+        .head_receipt_number(ferdie_best_hash, EVM_DOMAIN_ID)
+        .unwrap();
+    assert_eq!(head_domain_number - head_receipt_number, 1);
+    assert_eq!(bob_best_number, bob.client.info().best_number);
+
+    produce_blocks!(ferdie, bob, 15).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1349,6 +1349,12 @@ impl_runtime_apis! {
             Domains::submit_bundle_unsigned(opaque_bundle)
         }
 
+        fn submit_receipt_unsigned(
+            singleton_receipt: sp_domains::SealedSingletonReceipt<NumberFor<Block>, <Block as BlockT>::Hash, DomainHeader, Balance>,
+        ) {
+            Domains::submit_receipt_unsigned(singleton_receipt)
+        }
+
         fn extract_successful_bundles(
             domain_id: DomainId,
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,


### PR DESCRIPTION
close #1673 

The workflow of domain block production in main:
1. The operator collects tx from tx pool and verifies the tx against its last block, and submits the tx with the ER at `HeadReceiptNumber + 1` (in its local view)
2. The consensus runtime verifies the bundle and only accepts it if its ER is `HeadReceiptNumber + 1`
3. All the domain nodes validate the bundle included by the consensus block and mark the bundle as invalid if any tx fails to pass the verification against the last domain block

In step 1, the operator performs the check against its local view of the last block and the ER at `HeadReceiptNumber + 1`, if the operator is lagging its last block is an older block and it may include invalid tx (at a global view) into its bundle, this is inevitable in a distributed system. But as long as `HeadDomainNumber - HeadReceiptNumber == 1`, the consensus runtime only accepts the bundle if it carries an ER at `HeadDomainNumber` (i.e. the last domain block), and the stale bundle produced by the lagging operator will be rejected safely. This safeguard is broken if there is a receipt gap and `HeadReceiptNumber + 1 < HeadDomainNumber`, so the consensus runtime will accept the stale bundle even if it carries an ER derived from an older block.

The receipt gap can be brought by:
- FP which revert the `HeadReceiptNumber`
- Domain runtime upgrade which increase `HeadDomainNumber`
- An edge case about the genesis receipt which is fixed in https://github.com/subspace/subspace/pull/2933/commits/0de87289291ccf7f4bc285ecd37817c1979c873e


This PR fixes the issue by:
- Reject any bundle if there is a receipt gap where `HeadDomainNumber - HeadReceiptNumber >= 1`
- Introduce `submit_receipt` that is used to submit receipts to fill up the gap
    - `submit_receipt` is similar to `submit_bundle` that also requires `proof_of_election` and performs the similar check
    - `submit_receipt` doesn't contain any tx and thus doesn't derive any new domain block
    - `submit_receipt` is only allowed when there is indeed a receipt gap
- Explicitly check the bundle tx against `ER::domain_block_hash` in step 1 and check the bundle carries the ER of the parent domain block in step 3
- (Non-related to the isse) Use the head domain number to trigger epoch transition instead of the confirmed domain block

The security model:
1. The operator when producing the bundle, commits the validity of all the tx to the ER that is submitted together
2. The consensus chain only accepts the bundle if it can ensure the ER is derived from the parent domain block
3. The domain node re-validates all tx in the bundle against the parent domain block and builds the next block

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
