### PR TITLE
chore: fix typo in `MAX_BUNDLE_PER_BLOCK`

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -189,7 +189,7 @@ mod benchmarks {
 
     /// Benchmark prune bad ER and slash the submitter based on the number of submitter
     #[benchmark]
-    fn handle_bad_receipt(n: Linear<1, MAX_BUNLDE_PER_BLOCK>) {
+    fn handle_bad_receipt(n: Linear<1, MAX_BUNDLE_PER_BLOCK>) {
         let minimum_nominator_stake = T::MinNominatorStake::get();
         let domain_id = register_domain::<T>();
         let mut operator_ids = Vec::new();
@@ -246,8 +246,8 @@ mod benchmarks {
     /// in this block
     #[benchmark]
     fn confirm_domain_block(
-        n: Linear<1, MAX_BUNLDE_PER_BLOCK>,
-        s: Linear<0, MAX_BUNLDE_PER_BLOCK>,
+        n: Linear<1, MAX_BUNDLE_PER_BLOCK>,
+        s: Linear<0, MAX_BUNDLE_PER_BLOCK>,
     ) {
         let minimum_nominator_stake = T::MinNominatorStake::get();
         let operator_rewards =
@@ -314,7 +314,7 @@ mod benchmarks {
     /// Benchmark `operator_take_reward_tax_and_stake` based on the number of operator who has reward
     /// in the current epoch
     #[benchmark]
-    fn operator_reward_tax_and_restake(n: Linear<1, MAX_BUNLDE_PER_BLOCK>) {
+    fn operator_reward_tax_and_restake(n: Linear<1, MAX_BUNDLE_PER_BLOCK>) {
         let minimum_nominator_stake = T::MinNominatorStake::get();
         let operator_rewards =
             T::Currency::minimum_balance().saturating_mul(BalanceOf::<T>::from(1000u32));

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -159,7 +159,7 @@ const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 /// and based on the consensus chain slot probability and domain bundle slot probability, usually
 /// the value is 6 on average, smaller/bigger value with less probability, we hypocritically use
 /// 100 as the maximum number of bundle per block for benchmarking.
-const MAX_BUNLDE_PER_BLOCK: u32 = 100;
+const MAX_BUNDLE_PER_BLOCK: u32 = 100;
 
 pub(crate) type StateRootOf<T> = <<T as frame_system::Config>::Hashing as Hash>::Output;
 
@@ -204,7 +204,7 @@ mod pallet {
     use crate::{
         BalanceOf, BlockSlot, BlockTreeNodeFor, DomainBlockNumberFor, ElectionVerificationParams,
         ExecutionReceiptOf, FraudProofFor, HoldIdentifier, NominatorId, OpaqueBundleOf,
-        ReceiptHashFor, StateRootOf, MAX_BUNLDE_PER_BLOCK, STORAGE_VERSION,
+        ReceiptHashFor, StateRootOf, MAX_BUNDLE_PER_BLOCK, STORAGE_VERSION,
     };
     #[cfg(not(feature = "std"))]
     use alloc::string::String;
@@ -1203,7 +1203,7 @@ mod pallet {
         #[pallet::call_index(15)]
         #[pallet::weight((
             T::WeightInfo::submit_fraud_proof().saturating_add(
-                T::WeightInfo::handle_bad_receipt(MAX_BUNLDE_PER_BLOCK)
+                T::WeightInfo::handle_bad_receipt(MAX_BUNDLE_PER_BLOCK)
             ),
             DispatchClass::Operational
         ))]
@@ -1248,7 +1248,7 @@ mod pallet {
                     .ok_or::<Error<T>>(FraudProofError::BadReceiptNotFound.into())?;
 
                 actual_weight = actual_weight.saturating_add(T::WeightInfo::handle_bad_receipt(
-                    (block_tree_node.operator_ids.len() as u32).min(MAX_BUNLDE_PER_BLOCK),
+                    (block_tree_node.operator_ids.len() as u32).min(MAX_BUNDLE_PER_BLOCK),
                 ));
 
                 do_mark_operators_as_slashed::<T>(
@@ -1608,7 +1608,7 @@ mod pallet {
                 .ok_or::<Error<T>>(FraudProofError::BadReceiptNotFound.into())?;
 
             actual_weight = actual_weight.saturating_add(T::WeightInfo::handle_bad_receipt(
-                (block_tree_node.operator_ids.len() as u32).min(MAX_BUNLDE_PER_BLOCK),
+                (block_tree_node.operator_ids.len() as u32).min(MAX_BUNDLE_PER_BLOCK),
             ));
 
             do_mark_operators_as_slashed::<T>(
@@ -2545,11 +2545,11 @@ impl<T: Config> Pallet<T> {
                 // NOTE: within `submit_bundle`, only one of (or none) `handle_bad_receipt` and
                 // `confirm_domain_block` can happen, thus we use the `max` of them
 
-                // We use `MAX_BUNLDE_PER_BLOCK` number to assume the number of slashed operators.
+                // We use `MAX_BUNDLE_PER_BLOCK` number to assume the number of slashed operators.
                 // We do not expect so many operators to be slashed but nontheless, if it did happen
                 // we will limit the weight to 100 operators.
-                T::WeightInfo::handle_bad_receipt(MAX_BUNLDE_PER_BLOCK).max(
-                    T::WeightInfo::confirm_domain_block(MAX_BUNLDE_PER_BLOCK, MAX_BUNLDE_PER_BLOCK),
+                T::WeightInfo::handle_bad_receipt(MAX_BUNDLE_PER_BLOCK).max(
+                    T::WeightInfo::confirm_domain_block(MAX_BUNDLE_PER_BLOCK, MAX_BUNDLE_PER_BLOCK),
                 ),
             )
             .saturating_add(Self::max_staking_epoch_transition())
@@ -2557,13 +2557,13 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn max_staking_epoch_transition() -> Weight {
-        T::WeightInfo::operator_reward_tax_and_restake(MAX_BUNLDE_PER_BLOCK).saturating_add(
+        T::WeightInfo::operator_reward_tax_and_restake(MAX_BUNDLE_PER_BLOCK).saturating_add(
             T::WeightInfo::finalize_domain_epoch_staking(T::MaxPendingStakingOperation::get()),
         )
     }
 
     pub fn max_prune_domain_execution_receipt() -> Weight {
-        T::WeightInfo::handle_bad_receipt(MAX_BUNLDE_PER_BLOCK)
+        T::WeightInfo::handle_bad_receipt(MAX_BUNDLE_PER_BLOCK)
             .saturating_add(T::DbWeight::get().reads_writes(3, 1))
     }
 


### PR DESCRIPTION
Minor change to fix typo: `MAX_BUNLDE_PER_BLOCK` -> `MAX_BUNDLE_PER_BLOCK`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
