### PR TITLE
Skip the maybe_domain_sudo_call_proof field in fraud proof to keep compatibility with gemini-3h

### DIFF
--- a/crates/sp-domains-fraud-proof/src/storage_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/storage_proof.rs
@@ -420,6 +420,8 @@ pub struct DomainInherentExtrinsicDataProof {
     pub dynamic_cost_of_storage_proof: DynamicCostOfStorageProof,
     pub consensus_chain_byte_fee_proof: ConsensusTransactionByteFeeProof,
     pub domain_chain_allowlist_proof: DomainChainsAllowlistUpdateStorageProof,
+    // TODO: remove this before next consensus runtime upgrade. Skipping to maintain compatibility with Gemini
+    #[codec(skip)]
     pub maybe_domain_sudo_call_proof: Option<DomainSudoCallStorageProof>,
 }
 


### PR DESCRIPTION
This field doesn't exist in the current gemini-3h consensus runtime so if the invalid extrinsic root fraud proof is triggered the domain node will shut down due to fail to submit FP.

This PR skip codec for this field and we should bring it back before the next consensus runtime upgrade.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
