### PR TITLE
opt: remove unnecessary queue group setup when subscribe to farmer identify broadcast

### DIFF
--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -509,14 +509,7 @@ async fn identify_responder(
     identification_broadcast_interval: Duration,
 ) -> anyhow::Result<()> {
     let mut subscription = nats_client
-        .subscribe_to_broadcasts::<ClusterControllerFarmerIdentifyBroadcast>(
-            None,
-            // Use the first farm as a queue group. Doesn't matter what we use, just needs to be
-            // deterministic.
-            farms_details
-                .first()
-                .map(|farm_details| farm_details.farm_id_string.clone()),
-        )
+        .subscribe_to_broadcasts::<ClusterControllerFarmerIdentifyBroadcast>(None, None)
         .await
         .map_err(|error| {
             anyhow!("Failed to subscribe to farmer identify broadcast requests: {error}")


### PR DESCRIPTION
I'm guessing this design was originally designed to be done for automatic load balancing with multiple services. But now we only have `primary_instance` handling `identification_broadcast`, which no longer needs to be set up.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
