### PR TITLE
Fix `CachingProxyNodeClient::last_segment_headers()`

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -199,11 +199,10 @@ where
                     match internal_result {
                         Ok(segment_headers) => segment_headers
                             .into_iter()
-                            .map(|maybe_segment_header| {
+                            .inspect(|maybe_segment_header| {
                                 if maybe_segment_header.is_none() {
                                     error!("Received empty optional segment header!");
                                 }
-                                maybe_segment_header
                             })
                             .collect::<Option<Vec<_>>>()
                             .map(|segment_headers| SegmentHeaderResponse { segment_headers }),

--- a/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -52,7 +52,6 @@ impl SegmentHeaders {
             .copied()
             .rev()
             .take(limit as usize)
-            .rev()
             .map(Some)
             .collect()
     }
@@ -88,10 +87,7 @@ impl SegmentHeaders {
                     break 'outer;
                 };
 
-                if self.segment_headers.len() == u64::from(segment_header.segment_index()) as usize
-                {
-                    self.segment_headers.push(segment_header);
-                }
+                self.push(segment_header);
             }
 
             segment_index_offset += segment_index_step;

--- a/crates/subspace-networking/src/protocols/request_response/handlers/segment_header.rs
+++ b/crates/subspace-networking/src/protocols/request_response/handlers/segment_header.rs
@@ -15,7 +15,9 @@ pub enum SegmentHeaderRequest {
         /// Segment indexes to get.
         segment_indexes: Vec<SegmentIndex>,
     },
-    /// Defines how many segment headers to return.
+    // TODO: Should this be changed to return segments in normal order once we can introduce
+    //  breaking changes?
+    /// Defines how many segment headers to return, segments will be in reverse order.
     LastSegmentHeaders {
         /// Number of segment headers to return.
         // TODO: Replace u64 with a smaller type when able to make breaking changes


### PR DESCRIPTION
There was this error happening in logs for some time now and I finally found the reason:
```
2024-07-25T20:31:47.980977Z  WARN Consensus: subspace_service::sync_from_dsn::segment_header_downloader: Received last segment headers response was invalid peer_id=12D3KooWFnhvYT8TyoUt9NuWKX9SERTgoBs5AA4q1LMfd1YzfaB5
2024-07-25T20:31:47.995699Z TRACE Consensus: subspace_service::sync_from_dsn::segment_header_downloader: Last segment headers request succeeded peer_id=12D3KooWRW4GQqjAZp45GVXWKmF1r5YXkGZouezQ7qyKpdmeNmDL segment_headers_number=2
```

The ordering we have is confusing, so I have added TODO to maybe change it when we can.

I also did a few tiny cleanups in the process that I noticed while reading code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/subspace/subspace/blob/main/CONTRIBUTING.md)
