### PR TITLE
Fix PoT verification when number of iterations change

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -958,6 +958,13 @@ impl<T: Config> Pallet<T> {
         T::EraChangeTrigger::trigger::<T>(block_number);
 
         {
+            let pot_slot_iterations =
+                PotSlotIterations::<T>::get().expect("Always initialized during genesis; qed");
+            // This is what we had after previous block
+            frame_system::Pallet::<T>::deposit_log(DigestItem::pot_slot_iterations(
+                pot_slot_iterations,
+            ));
+
             let mut maybe_pot_slot_iterations_update = PotSlotIterationsUpdate::<T>::get();
             // Check PoT slot iterations update and apply it if it is time to do so, while also
             // removing corresponding storage item
@@ -976,14 +983,10 @@ impl<T: Config> Pallet<T> {
                 PotSlotIterations::<T>::put(update.slot_iterations);
                 update.slot_iterations
             } else {
-                PotSlotIterations::<T>::get().expect("Always initialized during genesis; qed")
+                pot_slot_iterations
             };
             let pot_entropy_injection_interval = T::PotEntropyInjectionInterval::get();
             let pot_entropy_injection_delay = T::PotEntropyInjectionDelay::get();
-
-            frame_system::Pallet::<T>::deposit_log(DigestItem::pot_slot_iterations(
-                pot_slot_iterations,
-            ));
 
             let mut entropy = PotEntropy::<T>::get();
             let lookback_in_blocks = pot_entropy_injection_interval

--- a/crates/sc-consensus-subspace/src/verifier.rs
+++ b/crates/sc-consensus-subspace/src/verifier.rs
@@ -294,7 +294,7 @@ where
             }
 
             let future_slot = slot + self.chain_constants.block_authoring_delay();
-            let slot_to_check = Slot::from(
+            let first_slot_to_check = Slot::from(
                 future_slot
                     .checked_sub(checkpoints.len() as u64 - 1)
                     .ok_or(VerificationError::InvalidProofOfTime)?,
@@ -303,13 +303,13 @@ where
                 .pot_parameters_change
                 .as_ref()
                 .and_then(|parameters_change| {
-                    (parameters_change.slot == slot_to_check)
+                    (parameters_change.slot <= first_slot_to_check)
                         .then_some(parameters_change.slot_iterations)
                 })
                 .unwrap_or(subspace_digest_items.pot_slot_iterations);
 
             let mut pot_input = PotNextSlotInput {
-                slot: slot_to_check,
+                slot: first_slot_to_check,
                 slot_iterations,
                 seed,
             };


### PR DESCRIPTION
Trivial change, it was necessary to account for slot at which PoT iterations change correctly or else it didn't work in absolute majority of cases on nodes other than block author.

Variable was renamed for clarity.

@NingLin-P @DaMandal0rian this needs to be applied to the devnet to fix nodes other than block producing farmer.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
