### PR TITLE
Add sync mode names to help and error messages

### DIFF
--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -118,7 +118,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
 
     if maybe_domain_configuration.is_some() && subspace_configuration.sync == ChainSyncMode::Snap {
         return Err(Error::Other(
-            "Snap sync mode is not supported for domains".to_string(),
+            "Snap sync mode is not supported for domains, use full sync".to_string(),
         ));
     }
 

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -407,6 +407,8 @@ pub(super) struct ConsensusChainOptions {
     timekeeper_options: TimekeeperOptions,
 
     /// Sync mode
+    ///
+    /// Examples: `snap`, `full`
     #[arg(long, default_value_t = ChainSyncMode::Snap)]
     sync: ChainSyncMode,
 }

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -306,7 +306,7 @@ impl FromStr for ChainSyncMode {
         match input {
             "full" => Ok(Self::Full),
             "snap" => Ok(Self::Snap),
-            _ => Err("Unsupported sync type".to_string()),
+            _ => Err("Unsupported sync type: use full or snap".to_string()),
         }
     }
 }

--- a/domains/service/src/lib.rs
+++ b/domains/service/src/lib.rs
@@ -90,9 +90,11 @@ where
     if client.requires_full_sync() {
         match config.network.sync_mode {
             SyncMode::LightState { .. } => {
-                return Err("Fast sync doesn't work for archive nodes".into());
+                return Err("Fast sync doesn't work for archive nodes: use full sync".into());
             }
-            SyncMode::Warp => return Err("Warp sync doesn't work for archive nodes".into()),
+            SyncMode::Warp => {
+                return Err("Warp sync doesn't work for archive nodes: use full sync".into())
+            }
             SyncMode::Full => {}
         }
     }


### PR DESCRIPTION
When I was trying to launch an archival node, I couldn't find the name of `full` sync in any error messages or `subspace-node run --help`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
