### PR TITLE
Bump consensus runtime spec version

### DIFF
--- a/crates/sp-domains-fraud-proof/src/storage_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/storage_proof.rs
@@ -420,8 +420,6 @@ pub struct DomainInherentExtrinsicDataProof {
     pub dynamic_cost_of_storage_proof: DynamicCostOfStorageProof,
     pub consensus_chain_byte_fee_proof: ConsensusTransactionByteFeeProof,
     pub domain_chain_allowlist_proof: DomainChainsAllowlistUpdateStorageProof,
-    // TODO: remove this before next consensus runtime upgrade. Skipping to maintain compatibility with Gemini
-    #[codec(skip)]
     pub maybe_domain_sudo_call_proof: Option<DomainSudoCallStorageProof>,
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 5,
+    spec_version: 6,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,


### PR DESCRIPTION
This PR bumps the consensus runtime spec version from 5 to 6 as preparation for the upcoming consensus runtime upgrade in gemini-3h. Also, this PR removes the `#[codec(skip)]` for the `maybe_domain_sudo_call_proof` field in FP.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
