### PR TITLE
Override sync_mode by dev flag.

### DIFF
--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -118,7 +118,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
 
     if maybe_domain_configuration.is_some() && subspace_configuration.sync == ChainSyncMode::Snap {
         return Err(Error::Other(
-            "Snap sync mode is not supported for domains".to_string(),
+            "Snap sync mode is not supported for domains, use full sync".to_string(),
         ));
     }
 

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -407,8 +407,8 @@ pub(super) struct ConsensusChainOptions {
     timekeeper_options: TimekeeperOptions,
 
     /// Sync mode
-    #[arg(long, default_value_t = ChainSyncMode::Snap)]
-    sync: ChainSyncMode,
+    #[arg(long, default_value = None)]
+    sync: Option<ChainSyncMode>,
 }
 
 pub(super) struct PrometheusConfiguration {
@@ -451,11 +451,12 @@ pub(super) fn create_consensus_chain_configuration(
         dsn_options,
         storage_monitor,
         mut timekeeper_options,
-        sync,
+        mut sync,
     } = consensus_node_options;
 
     let transaction_pool;
     let rpc_cors;
+
     // Development mode handling is limited to this section
     {
         if dev {
@@ -468,6 +469,10 @@ pub(super) fn create_consensus_chain_configuration(
             force_authoring = true;
             network_options.allow_private_ips = true;
             timekeeper_options.timekeeper = true;
+
+            if sync.is_none() {
+                sync.replace(ChainSyncMode::Full);
+            }
         }
 
         transaction_pool = pool_config.transaction_pool(dev);
@@ -486,6 +491,9 @@ pub(super) fn create_consensus_chain_configuration(
             }
         });
     }
+
+    // Snap sync is the default mode.
+    let sync = sync.unwrap_or(ChainSyncMode::Snap);
 
     let chain_spec = match chain.as_deref() {
         Some("gemini-3h-compiled") => chain_spec::gemini_3h_compiled()?,

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -407,6 +407,8 @@ pub(super) struct ConsensusChainOptions {
     timekeeper_options: TimekeeperOptions,
 
     /// Sync mode
+    ///
+    /// Examples: `snap`, `full`
     #[arg(long, default_value = None)]
     sync: Option<ChainSyncMode>,
 }

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -306,7 +306,7 @@ impl FromStr for ChainSyncMode {
         match input {
             "full" => Ok(Self::Full),
             "snap" => Ok(Self::Snap),
-            _ => Err("Unsupported sync type".to_string()),
+            _ => Err("Unsupported sync type: use full or snap".to_string()),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/autonomys/subspace/issues/2950

The original issue arises when we use `sync=snap` (default syncing mode) on a new chain. Snap-sync uses `LightState` sync state setting which prevents genesis block saving on start which in turn allows block insertion with arbitrary block numbers, however, it also prevents block importing.

The workaround is to prevent snap-syncing from genesis, which most likely happens during the development runs.

This PR overrides snap-sync settings when `--dev` flag is set.
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
