### PR TITLE
Work around spurious errors that only happen in some IDEs

### DIFF
--- a/crates/pallet-feeds/src/mock.rs
+++ b/crates/pallet-feeds/src/mock.rs
@@ -1,3 +1,7 @@
+// Silence a rust-analyzer warning in `construct_runtime!`. This warning isn't present in rustc output.
+// TODO: remove when upstream issue is fixed: <https://github.com/rust-lang/rust-analyzer/issues/16514>
+#![allow(non_camel_case_types)]
+
 use crate::feed_processor::{FeedObjectMapping, FeedProcessor, FeedProcessor as FeedProcessorT};
 use crate::{self as pallet_feeds};
 use codec::{Compact, CompactLen, Decode, Encode};

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -18,6 +18,9 @@
 #![feature(const_option, const_trait_impl, variant_count)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+// Silence a rust-analyzer warning in `construct_runtime!`. This warning isn't present in rustc output.
+// TODO: remove when upstream issue is fixed: <https://github.com/rust-lang/rust-analyzer/issues/16514>
+#![allow(non_camel_case_types)]
 
 mod domains;
 mod fees;

--- a/domains/pallets/executive/src/mock.rs
+++ b/domains/pallets/executive/src/mock.rs
@@ -1,3 +1,7 @@
+// Silence a rust-analyzer warning in `construct_runtime!`. This warning isn't present in rustc output.
+// TODO: remove when upstream issue is fixed: <https://github.com/rust-lang/rust-analyzer/issues/16514>
+#![allow(non_camel_case_types)]
+
 use crate as pallet_executive;
 use crate::Config;
 use frame_support::dispatch::DispatchInfo;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -18,6 +18,9 @@
 #![feature(const_option, variant_count)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+// Silence a rust-analyzer warning in `construct_runtime!`. This warning isn't present in rustc output.
+// TODO: remove when upstream issue is fixed: <https://github.com/rust-lang/rust-analyzer/issues/16514>
+#![allow(non_camel_case_types)]
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]


### PR DESCRIPTION
This PR fixes two warnings/errors that I've seen in Visual Studio Code + rust-analyzer:
- identifier style warning in a macro
- trait resolution bugs in `rust-analyzer`

These workarounds don't change the meaning of the code.

### Alternative Fixes

This isn't an ideal solution, because the code compiles fine without warnings in CI, and [on my local machine using `cargo` directly](https://gist.github.com/teor2345/58e245122df947fae77cf321ee2cdb3d). So this is likely a `rust-analyzer` bug, or VS Code isn't respecting `rust-toolchain.toml` (or some other config inconsistency).

Some alternative fixes could be:
1. ~~upgrading `rust-toolchain.toml` to a compiler/rust-analyzer version that:~~ Edit: this error still happens on the latest nightly
    - ~~correctly ignores warnings in macros, and~~
    - ~~correctly resolves traits like `rustc` does~~
2. using `block_hash()` (from `BlockBackend`) instead of `hash()`, to avoid the name collision, but there's no guarantee that it calls the same code as `HeaderBackend<Block>::hash()`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
