### PR TITLE
Fix submit receipt issues

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -51,7 +51,6 @@ pub enum Error {
     RuntimeNotFound,
     LastBlockNotFound,
     UnmatchedNewHeadReceipt,
-    UnexpectedConfirmedDomainBlock,
 }
 
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -780,7 +780,7 @@ impl<CHash: Default> ProofOfElection<CHash> {
     }
 }
 
-/// Singleton receipt submit along when there is a gap between `HeadDomainNumber`
+/// Singleton receipt submit along when there is a gap between `domain_best_number`
 /// and `HeadReceiptNumber`
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct SingletonReceipt<Number, Hash, DomainHeader: HeaderT, Balance> {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("subspace"),
     impl_name: create_runtime_str!("subspace"),
     authoring_version: 0,
-    spec_version: 6,
+    spec_version: 7,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 0,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1231,7 +1231,7 @@ impl_runtime_apis! {
         }
 
         fn domain_best_number(domain_id: DomainId) -> Option<DomainNumber> {
-            Domains::domain_best_number(domain_id)
+            Domains::domain_best_number(domain_id).ok()
         }
 
         fn execution_receipt(receipt_hash: DomainHash) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>> {

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -183,7 +183,7 @@ where
 
         let domain_best_number = self.client.info().best_number;
         let consensus_chain_best_hash = self.consensus_client.info().best_hash;
-        let head_domain_number = self
+        let domain_best_number_onchain = self
             .consensus_client
             .runtime_api()
             .domain_best_number(consensus_chain_best_hash, self.domain_id)?
@@ -239,7 +239,7 @@ where
 
             let receipt = self
                 .domain_bundle_proposer
-                .load_next_receipt(head_domain_number, head_receipt_number)?;
+                .load_next_receipt(domain_best_number_onchain, head_receipt_number)?;
 
             let api_version = self
                 .consensus_client
@@ -256,10 +256,10 @@ where
             // instead of bundle
             // TODO: remove api runtime version check before next network
             if api_version >= 5
-                && head_domain_number.saturating_sub(head_receipt_number) > 1u32.into()
+                && domain_best_number_onchain.saturating_sub(head_receipt_number) > 1u32.into()
             {
                 info!(
-                    ?head_domain_number,
+                    ?domain_best_number_onchain,
                     ?head_receipt_number,
                     "🔖 Producing singleton receipt at slot {:?}",
                     slot_info.slot

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -397,18 +397,18 @@ where
     /// Returns the receipt in the next domain bundle.
     pub fn load_next_receipt(
         &self,
-        head_domain_number: NumberFor<Block>,
+        domain_best_number_onchain: NumberFor<Block>,
         head_receipt_number: NumberFor<Block>,
     ) -> sp_blockchain::Result<ExecutionReceiptFor<Block, CBlock>> {
         tracing::trace!(
-            ?head_domain_number,
+            ?domain_best_number_onchain,
             ?head_receipt_number,
             "Collecting receipt"
         );
 
-        // Both `head_domain_number` and `head_receipt_number` are zero means the domain just
+        // Both `domain_best_number_onchain` and `head_receipt_number` are zero means the domain just
         // instantiated and nothing have submitted yet so submit the genesis receipt
-        if head_domain_number.is_zero() && head_receipt_number.is_zero() {
+        if domain_best_number_onchain.is_zero() && head_receipt_number.is_zero() {
             let genesis_hash = self.client.info().genesis_hash;
             let genesis_header = self.client.header(genesis_hash)?.ok_or_else(|| {
                 sp_blockchain::Error::Backend(format!(

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1428,7 +1428,7 @@ impl_runtime_apis! {
         }
 
         fn domain_best_number(domain_id: DomainId) -> Option<DomainNumber> {
-            Domains::domain_best_number(domain_id)
+            Domains::domain_best_number(domain_id).ok()
         }
 
         fn execution_receipt(receipt_hash: DomainHash) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>> {


### PR DESCRIPTION
This PR fixes 2 issues related to the `submit_receipt` and receipt gap changes:

1. Handle the confirmed domain block in `submit_receipt`

The assumption:
https://github.com/autonomys/subspace/blob/55066638508daa4e323ce01e567ec8be1417ea07/crates/pallet-domains/src/lib.rs#L1723-L1728
is only held when resubmitting the receipt that is pruned by the FP, because when submitting the receipt of `#N` it will try to confirm the receipt `#N-144_00` (where 144_00 is the challenge period), so the bad receipt of `#N` already confirm the receipt `#N-144_00` when resubmitting the receipt of `#N` after FP there is no receipt to confirm. Except for this case, there is always a possible new confirmed receipt when submitting a new head receipt.

2. Account for the missed domain runtime upgrade into the `domain_best_number` and use it to calculate the receipt gap

When a domain runtime upgrade happens the `HeadDomainNumber` is lazily updated when there is a new bundle comes, if the domain is idle (i.e. skip producing empty bundle) and a domain runtime upgrade happens, the domain node will derive a new domain block locally and immediately but will still remain idle. If then a domain tx comes, it will be verified and created against the latest domain block and enter the tx pool but it will fail to be included in the bundle due to the `AncientBirthBlock` error when verified against the receipt, as a result, it will be stuck at the pool forever.

This is because the `HeadDomainNumber` is not updated so the operator can't detect the receipt gap and it will submit an old receipt with the bundle, while the tx is created and verified against a newer block that includes the runtime upgrade, it will fail with `AncientBirthBlock` when verifying against an older block that derives the receipt.

Both issues have been reproduced in a local devnet and verified are fixed with the change this PR brings.

This PR also bumps the consensus runtime version as we need to make a new runtime release and deploy to gemini-3h soon.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
