### PR TITLE
Last confirmed domain block data acquisition.

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -669,7 +669,8 @@ mod pallet {
 
     /// Storage to hold all the domain's latest confirmed block.
     #[pallet::storage]
-    pub(super) type LatestConfirmedDomainExecutionReceipt<T: Config> =
+    #[pallet::getter(fn latest_confirmed_domain_execution_receipt)]
+    pub type LatestConfirmedDomainExecutionReceipt<T: Config> =
         StorageMap<_, Identity, DomainId, ExecutionReceiptOf<T>, OptionQuery>;
 
     /// The latest ER submitted by the operator for a given domain. It is used to determine if the operator

--- a/crates/sp-domains-fraud-proof/src/storage_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/storage_proof.rs
@@ -50,6 +50,7 @@ pub enum VerificationError {
     ExtrinsicStorageProof(StorageProofVerificationError),
     DomainSudoCallStorageProof(StorageProofVerificationError),
     MmrRootStorageProof(StorageProofVerificationError),
+    LastConfirmedDomainBlockReceiptProof(StorageProofVerificationError),
 }
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
@@ -64,6 +65,7 @@ pub enum FraudProofStorageKeyRequest<Number> {
     DynamicCostOfStorage,
     DomainSudoCall(DomainId),
     MmrRoot(Number),
+    LastConfirmedDomainBlockReceipt(DomainId),
 }
 
 impl<Number> FraudProofStorageKeyRequest<Number> {
@@ -83,6 +85,9 @@ impl<Number> FraudProofStorageKeyRequest<Number> {
                 VerificationError::DomainSudoCallStorageProof(err)
             }
             Self::MmrRoot(_) => VerificationError::MmrRootStorageProof(err),
+            Self::LastConfirmedDomainBlockReceipt(_) => {
+                VerificationError::LastConfirmedDomainBlockReceiptProof(err)
+            }
         }
     }
 }
@@ -158,6 +163,18 @@ pub trait BasicStorageProof<Block: BlockT>:
             StorageKey(storage_key),
         )
         .map_err(|err| storage_key_req.into_error(err))
+    }
+}
+
+#[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
+pub struct LastConfirmedDomainBlockReceiptProof(StorageProof);
+
+impl_storage_proof!(LastConfirmedDomainBlockReceiptProof);
+impl<Block: BlockT> BasicStorageProof<Block> for LastConfirmedDomainBlockReceiptProof {
+    type StorageValue = Vec<H256>;
+    type Key = DomainId;
+    fn storage_key_request(key: Self::Key) -> FraudProofStorageKeyRequest<NumberFor<Block>> {
+        FraudProofStorageKeyRequest::LastConfirmedDomainBlockReceipt(key)
     }
 }
 

--- a/crates/sp-domains-fraud-proof/src/storage_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/storage_proof.rs
@@ -171,7 +171,7 @@ pub struct LastConfirmedDomainBlockReceiptProof(StorageProof);
 
 impl_storage_proof!(LastConfirmedDomainBlockReceiptProof);
 impl<Block: BlockT> BasicStorageProof<Block> for LastConfirmedDomainBlockReceiptProof {
-    type StorageValue = Vec<H256>;
+    type StorageValue = Vec<u8>;
     type Key = DomainId;
     fn storage_key_request(key: Self::Key) -> FraudProofStorageKeyRequest<NumberFor<Block>> {
         FraudProofStorageKeyRequest::LastConfirmedDomainBlockReceipt(key)

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1600,7 +1600,10 @@ sp_api::decl_runtime_apis! {
 
         /// Return domain sudo call.
         fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>>;
-    }
+
+        /// Return last confirmed domain block execution receipt.
+        fn last_confirmed_domain_block_receipt(domain_id: DomainId) ->Option<ExecutionReceiptFor<DomainHeader, Block, Balance>>;
+}
 
     pub trait BundleProducerElectionApi<Balance: Encode + Decode> {
         fn bundle_producer_election_params(domain_id: DomainId) -> Option<BundleProducerElectionParams<Balance>>;

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1506,7 +1506,7 @@ impl<Balance> OnChainRewards<Balance> for () {
 
 sp_api::decl_runtime_apis! {
     /// API necessary for domains pallet.
-    #[api_version(5)]
+    #[api_version(6)]
     pub trait DomainsApi<DomainHeader: HeaderT> {
         /// Submits the transaction bundle via an unsigned extrinsic.
         fn submit_bundle_unsigned(opaque_bundle: OpaqueBundle<NumberFor<Block>, Block::Hash, DomainHeader, Balance>);

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -316,6 +316,10 @@ sp_api::impl_runtime_apis! {
         fn domain_sudo_call(_domain_id: DomainId) -> Option<Vec<u8>> {
             unreachable!()
         }
+
+        fn last_confirmed_domain_block_receipt(_domain_id: DomainId) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>> {
+            unreachable!()
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1279,6 +1279,10 @@ impl_runtime_apis! {
         fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>> {
             Domains::domain_sudo_call(domain_id)
         }
+
+        fn last_confirmed_domain_block_receipt(domain_id: DomainId) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>>{
+            Domains::latest_confirmed_domain_execution_receipt(domain_id)
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -951,6 +951,11 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::MmrRoot(block_number) => {
                 pallet_subspace_mmr::MmrRootHashes::<Runtime>::hashed_key_for(block_number)
             }
+            FraudProofStorageKeyRequest::LastConfirmedDomainBlockReceipt(domain_id) => {
+                pallet_domains::LatestConfirmedDomainExecutionReceipt::<Runtime>::hashed_key_for(
+                    domain_id,
+                )
+            }
         }
     }
 }

--- a/crates/subspace-service/src/domains.rs
+++ b/crates/subspace-service/src/domains.rs
@@ -1,0 +1,177 @@
+// Remove after adding domain snap-sync
+#![allow(dead_code)]
+
+use crate::domains::request_handler::{
+    generate_protocol_name, LastConfirmedBlockRequest, LastConfirmedBlockResponse,
+};
+use domain_runtime_primitives::Balance;
+use futures::channel::oneshot;
+use parity_scale_codec::{Decode, Encode};
+use sc_network::{IfDisconnected, NetworkRequest, PeerId, RequestFailure};
+use sc_network_sync::SyncingService;
+use sp_blockchain::HeaderBackend;
+use sp_domains::{DomainId, ExecutionReceiptFor};
+use sp_domains_fraud_proof::storage_proof::LastConfirmedDomainBlockReceiptProof;
+use sp_runtime::traits::{Block as BlockT, Header};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{debug, error, trace};
+
+pub(crate) mod request_handler;
+
+const REQUEST_PAUSE: Duration = Duration::from_secs(5);
+
+/// Last confirmed domain block info error
+#[derive(Debug, thiserror::Error)]
+pub enum LastConfirmedDomainBlockResponseError {
+    #[error("Last confirmed domain block info request failed: {0}")]
+    RequestFailed(#[from] RequestFailure),
+
+    #[error("Last confirmed domain block info request canceled")]
+    RequestCanceled,
+
+    #[error("Last confirmed domain block info request failed: invalid protocol")]
+    InvalidProtocol,
+
+    #[error("Failed to decode response: {0}")]
+    DecodeFailed(String),
+}
+
+pub async fn get_last_confirmed_domain_block_info<Block, Client, NR, DomainHeader>(
+    domain_id: DomainId,
+    fork_id: Option<String>,
+    client: Arc<Client>,
+    network_service: NR,
+    sync_service: Arc<SyncingService<Block>>,
+) -> Option<(
+    ExecutionReceiptFor<DomainHeader, Block, Balance>,
+    LastConfirmedDomainBlockReceiptProof,
+)>
+where
+    Block: BlockT,
+    NR: NetworkRequest,
+    Client: HeaderBackend<Block>,
+    DomainHeader: Header,
+{
+    let info = client.info();
+    let protocol_name = generate_protocol_name(info.genesis_hash, fork_id.as_deref());
+
+    debug!(%domain_id, %protocol_name, "Starting obtaining domain info...");
+
+    loop {
+        let peers_info = match sync_service.peers_info().await {
+            Ok(peers_info) => peers_info,
+            Err(error) => {
+                error!("Peers info request returned an error: {error}",);
+                sleep(REQUEST_PAUSE).await;
+
+                continue;
+            }
+        };
+
+        //  Enumerate peers until we find a suitable source for domain info
+        'peers: for (peer_id, peer_info) in peers_info.iter() {
+            trace!(
+                "Domain data request. peer = {peer_id}, info = {:?}",
+                peer_info
+            );
+
+            if !peer_info.is_synced {
+                trace!("Domain data request skipped (not synced). peer = {peer_id}");
+
+                continue;
+            }
+
+            let request = LastConfirmedBlockRequest { domain_id };
+
+            let response = send_request::<NR, Block, DomainHeader>(
+                protocol_name.clone(),
+                *peer_id,
+                request,
+                &network_service,
+            )
+            .await;
+
+            match response {
+                Ok(response) => {
+                    trace!(
+                        "Response from a peer {peer_id}: data={},",
+                        response.last_confirmed_block_data.is_some()
+                    );
+
+                    if response.last_confirmed_block_data.is_some() {
+                        return response.last_confirmed_block_data;
+                    }
+
+                    if response.last_confirmed_block_data.is_none() {
+                        debug!("Empty response from peer={}", peer_id);
+                        continue 'peers;
+                    }
+                }
+                Err(error) => {
+                    debug!("Domain info request failed. peer = {peer_id}: {error}");
+
+                    continue 'peers;
+                }
+            }
+        }
+        debug!(
+            %domain_id,
+            "No synced peers to handle the domain confirmed block infor request. Pausing..."
+        );
+
+        sleep(REQUEST_PAUSE).await;
+    }
+}
+
+async fn send_request<NR: NetworkRequest, Block: BlockT, DomainHeader: Header>(
+    protocol_name: String,
+    peer_id: PeerId,
+    request: LastConfirmedBlockRequest,
+    network_service: &NR,
+) -> Result<LastConfirmedBlockResponse<Block, DomainHeader>, LastConfirmedDomainBlockResponseError>
+{
+    let (tx, rx) = oneshot::channel();
+
+    debug!("Sending request: {request:?}  (peer={peer_id})");
+
+    let encoded_request = request.encode();
+
+    network_service.start_request(
+        peer_id,
+        protocol_name.clone().into(),
+        encoded_request,
+        None,
+        tx,
+        IfDisconnected::ImmediateError,
+    );
+
+    let result = rx
+        .await
+        .map_err(|_| LastConfirmedDomainBlockResponseError::RequestCanceled)?;
+
+    match result {
+        Ok((data, response_protocol_name)) => {
+            if response_protocol_name != protocol_name.into() {
+                return Err(LastConfirmedDomainBlockResponseError::InvalidProtocol);
+            }
+
+            let response = decode_response(&data)
+                .map_err(LastConfirmedDomainBlockResponseError::DecodeFailed)?;
+
+            Ok(response)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn decode_response<Block: BlockT, DomainHeader: Header>(
+    mut response: &[u8],
+) -> Result<LastConfirmedBlockResponse<Block, DomainHeader>, String> {
+    let response = LastConfirmedBlockResponse::decode(&mut response).map_err(|error| {
+        format!("Failed to decode last confirmed domain block info response: {error}")
+    })?;
+
+    Ok(response)
+}

--- a/crates/subspace-service/src/domains.rs
+++ b/crates/subspace-service/src/domains.rs
@@ -95,19 +95,9 @@ where
 
             match response {
                 Ok(response) => {
-                    trace!(
-                        "Response from a peer {peer_id}: data={},",
-                        response.last_confirmed_block_data.is_some()
-                    );
+                    trace!("Response from a peer {peer_id},",);
 
-                    if response.last_confirmed_block_data.is_some() {
-                        return response.last_confirmed_block_data;
-                    }
-
-                    if response.last_confirmed_block_data.is_none() {
-                        debug!("Empty response from peer={}", peer_id);
-                        continue 'peers;
-                    }
+                    return Some(response.last_confirmed_block_data);
                 }
                 Err(error) => {
                     debug!("Domain info request failed. peer = {peer_id}: {error}");

--- a/crates/subspace-service/src/domains/request_handler.rs
+++ b/crates/subspace-service/src/domains/request_handler.rs
@@ -1,0 +1,268 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use domain_runtime_primitives::Balance;
+use futures::channel::oneshot;
+use futures::stream::StreamExt;
+use parity_scale_codec::{Decode, Encode};
+use sc_client_api::{BlockBackend, ProofProvider};
+use sc_domains::FPStorageKeyProvider;
+use sc_network::config::ProtocolId;
+use sc_network::request_responses::{IncomingRequest, OutgoingResponse};
+use sc_network::{NetworkBackend, PeerId};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_domains::{DomainId, DomainsApi, ExecutionReceiptFor};
+use sp_domains_fraud_proof::storage_proof::{
+    BasicStorageProof, LastConfirmedDomainBlockReceiptProof,
+};
+use sp_domains_fraud_proof::FraudProofApi;
+use sp_runtime::codec;
+use sp_runtime::traits::{Block as BlockT, Header};
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, error, trace};
+
+/// Generates a `RequestResponseProtocolConfig` for the state request protocol, refusing incoming
+/// requests.
+pub fn generate_protocol_config<
+    Hash: AsRef<[u8]>,
+    B: BlockT,
+    N: NetworkBackend<B, <B as BlockT>::Hash>,
+>(
+    _: &ProtocolId,
+    genesis_hash: Hash,
+    fork_id: Option<&str>,
+    inbound_queue: async_channel::Sender<IncomingRequest>,
+) -> N::RequestResponseProtocolConfig {
+    N::request_response_config(
+        generate_protocol_name(genesis_hash, fork_id).into(),
+        Vec::new(),
+        1024 * 1024,
+        16 * 1024 * 1024,
+        Duration::from_secs(40),
+        Some(inbound_queue),
+    )
+}
+
+/// Generate the state protocol name from the genesis hash and fork id.
+pub fn generate_protocol_name<Hash: AsRef<[u8]>>(
+    genesis_hash: Hash,
+    fork_id: Option<&str>,
+) -> String {
+    let genesis_hash = genesis_hash.as_ref();
+    if let Some(fork_id) = fork_id {
+        format!(
+            "/{}/{}/last-confirmed-block/1",
+            array_bytes::bytes2hex("", genesis_hash),
+            fork_id
+        )
+    } else {
+        format!(
+            "/{}/last-confirmed-block/1",
+            array_bytes::bytes2hex("", genesis_hash)
+        )
+    }
+}
+
+/// Request last confirmed domain block data from a peer.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, Encode, Decode, Debug)]
+pub struct LastConfirmedBlockRequest {
+    pub domain_id: DomainId,
+}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, Encode, Decode, Debug)]
+pub struct LastConfirmedBlockResponse<Block: BlockT, DomainHeader: Header> {
+    pub last_confirmed_block_data: Option<(
+        ExecutionReceiptFor<DomainHeader, Block, Balance>,
+        LastConfirmedDomainBlockReceiptProof,
+    )>,
+}
+
+/// Handler for incoming block requests from a remote peer.
+pub struct LastDomainBlockERRequestHandler<Block: BlockT, Client, DomainHeader> {
+    request_receiver: async_channel::Receiver<IncomingRequest>,
+
+    _phantom: PhantomData<(Block, DomainHeader)>,
+
+    client: Arc<Client>,
+}
+
+impl<Block, Client, DomainHeader> LastDomainBlockERRequestHandler<Block, Client, DomainHeader>
+where
+    Block: BlockT,
+    Client: ProvideRuntimeApi<Block>
+        + BlockBackend<Block>
+        + ProofProvider<Block>
+        + HeaderBackend<Block>
+        + Send
+        + Sync
+        + 'static,
+    Client::Api: DomainsApi<Block, DomainHeader> + FraudProofApi<Block, DomainHeader>,
+    DomainHeader: Header,
+{
+    /// Create a new [`LastDomainBlockERRequestHandler`].
+    pub fn new<NB>(
+        protocol_id: &ProtocolId,
+        fork_id: Option<&str>,
+        client: Arc<Client>,
+        num_peer_hint: usize,
+    ) -> (Self, NB::RequestResponseProtocolConfig)
+    where
+        NB: NetworkBackend<Block, <Block as BlockT>::Hash>,
+    {
+        // Reserve enough request slots for one request per peer when we are at the maximum
+        // number of peers.
+        let capacity = std::cmp::max(num_peer_hint, 1);
+        let (tx, request_receiver) = async_channel::bounded(capacity);
+
+        let protocol_config = generate_protocol_config::<_, Block, NB>(
+            protocol_id,
+            client
+                .block_hash(0u32.into())
+                .ok()
+                .flatten()
+                .expect("Genesis block exists; qed"),
+            fork_id,
+            tx,
+        );
+
+        (
+            Self {
+                request_receiver,
+                client,
+                _phantom: PhantomData,
+            },
+            protocol_config,
+        )
+    }
+
+    /// Run [`StateRequestHandler`].
+    pub async fn run(mut self) {
+        while let Some(request) = self.request_receiver.next().await {
+            let IncomingRequest {
+                peer,
+                payload,
+                pending_response,
+            } = request;
+
+            match self.handle_request(payload, pending_response, &peer) {
+                Ok(()) => debug!("Handled domain block info request from {}.", peer),
+                Err(e) => error!(
+                    "Failed to handle domain block info request from {}: {}",
+                    peer, e,
+                ),
+            }
+        }
+    }
+
+    fn handle_request(
+        &mut self,
+        payload: Vec<u8>,
+        pending_response: oneshot::Sender<OutgoingResponse>,
+        peer: &PeerId,
+    ) -> Result<(), HandleRequestError> {
+        let request = LastConfirmedBlockRequest::decode(&mut payload.as_slice())?;
+
+        trace!("Handle last confirmed domain block info request: {peer}, request: {request:?}",);
+
+        let result = {
+            let info = self.client.info();
+            let best_hash = info.best_hash;
+
+            let storage_key_provider = FPStorageKeyProvider::new(self.client.clone());
+
+            let storage_proof = LastConfirmedDomainBlockReceiptProof::generate(
+                self.client.as_ref(),
+                best_hash,
+                request.domain_id,
+                &storage_key_provider,
+            );
+
+            let last_confirmed_block_receipt = self
+                .client
+                .runtime_api()
+                .last_confirmed_domain_block_receipt(best_hash, request.domain_id);
+
+            let response = match (storage_proof, last_confirmed_block_receipt) {
+                (Ok(storage_proof), Ok(Some(last_confirmed_block_receipt))) => {
+                    LastConfirmedBlockResponse::<Block, DomainHeader> {
+                        last_confirmed_block_data: Some((
+                            last_confirmed_block_receipt,
+                            storage_proof,
+                        )),
+                    }
+                }
+                (storage_proof, last_confirmed_block_receipt) => {
+                    if let Err(err) = storage_proof {
+                        debug!(
+                            domain_id=%request.domain_id,
+                            %best_hash,
+                            ?err,
+                            "Storage proof generation failed.",
+                        );
+                    }
+
+                    if let Err(ref err) = last_confirmed_block_receipt {
+                        debug!(
+                            domain_id=%request.domain_id,
+                            %best_hash,
+                            ?err,
+                            "Last confirmed domain block acquisition failed.",
+                        );
+                    }
+
+                    if let Ok(None) = last_confirmed_block_receipt {
+                        debug!(
+                            domain_id=%request.domain_id,
+                            %best_hash,
+                            "Last confirmed domain block acquisition failed: no data.",
+                        );
+                    }
+
+                    LastConfirmedBlockResponse::<Block, DomainHeader> {
+                        last_confirmed_block_data: None,
+                    }
+                }
+            };
+
+            Ok(response.encode())
+        };
+
+        pending_response
+            .send(OutgoingResponse {
+                result,
+                reputation_changes: Vec::new(),
+                sent_feedback: None,
+            })
+            .map_err(|_| HandleRequestError::SendResponse)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum HandleRequestError {
+    #[error(transparent)]
+    Client(#[from] sp_blockchain::Error),
+
+    #[error("Failed to send response.")]
+    SendResponse,
+
+    #[error("Failed to decode request: {0}.")]
+    Decode(#[from] codec::Error),
+}

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -27,6 +27,7 @@
 )]
 
 pub mod config;
+pub(crate) mod domains;
 pub mod dsn;
 mod metrics;
 pub(crate) mod mmr;
@@ -35,6 +36,7 @@ pub mod sync_from_dsn;
 pub mod transaction_pool;
 
 use crate::config::{ChainSyncMode, SubspaceConfiguration, SubspaceNetworking};
+use crate::domains::request_handler::LastDomainBlockERRequestHandler;
 use crate::dsn::{create_dsn_instance, DsnConfigurationError};
 use crate::metrics::NodeMetrics;
 use crate::mmr::request_handler::MmrRequestHandler;
@@ -848,14 +850,14 @@ where
     net_config.add_notification_protocol(pot_gossip_notification_config);
     let pause_sync = Arc::clone(&net_config.network_config.pause_sync);
 
-    if let Some(offchain_storage) = backend.offchain_storage() {
-        let num_peer_hint = net_config.network_config.default_peers_set_num_full as usize
-            + net_config
-                .network_config
-                .default_peers_set
-                .reserved_nodes
-                .len();
+    let num_peer_hint = net_config.network_config.default_peers_set_num_full as usize
+        + net_config
+            .network_config
+            .default_peers_set
+            .reserved_nodes
+            .len();
 
+    if let Some(offchain_storage) = backend.offchain_storage() {
         // Allow both outgoing and incoming requests.
         let (handler, protocol_config) =
             MmrRequestHandler::new::<NetworkWorker<Block, <Block as BlockT>::Hash>, _>(
@@ -868,6 +870,24 @@ where
         task_manager
             .spawn_handle()
             .spawn("mmr-request-handler", Some("networking"), handler.run());
+
+        net_config.add_request_response_protocol(protocol_config);
+    }
+
+    // "Last confirmed domain block execution receipt" request handler
+    {
+        let (handler, protocol_config) =
+            LastDomainBlockERRequestHandler::new::<NetworkWorker<Block, <Block as BlockT>::Hash>>(
+                &config.base.protocol_id(),
+                fork_id.as_deref(),
+                client.clone(),
+                num_peer_hint,
+            );
+        task_manager.spawn_handle().spawn(
+            "last-domain-execution-receipt-request-handler",
+            Some("networking"),
+            handler.run(),
+        );
 
         net_config.add_request_response_protocol(protocol_config);
     }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1476,6 +1476,10 @@ impl_runtime_apis! {
         fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>> {
             Domains::domain_sudo_call(domain_id)
         }
+
+        fn last_confirmed_domain_block_receipt(domain_id: DomainId) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>>{
+            Domains::latest_confirmed_domain_execution_receipt(domain_id)
+        }
     }
 
     impl sp_domains::BundleProducerElectionApi<Block, Balance> for Runtime {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1168,6 +1168,11 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::MmrRoot(block_number) => {
                 pallet_subspace_mmr::MmrRootHashes::<Runtime>::hashed_key_for(block_number)
             }
+            FraudProofStorageKeyRequest::LastConfirmedDomainBlockReceipt(domain_id) => {
+                pallet_domains::LatestConfirmedDomainExecutionReceipt::<Runtime>::hashed_key_for(
+                    domain_id,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces a custom request-response protocol and runtime API changes related to the last confirmed domain block info acquisition. We need this information to get the consensus chain block number for the future snap sync.

### Changes
- new request handler for a custom request-response protocol that accepts domain ID and returns the last confirmed domain block execution receipt along with its storage proof
- new storage proof 
- new runtime API method

### Comment
Storage proof verification is delayed until the future consensus chain snap-sync.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
