### PR TITLE
Improved plotting threads pinning

### DIFF
--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -200,26 +200,6 @@ impl fmt::Debug for CpuCoreSet {
 }
 
 impl CpuCoreSet {
-    /// Regroup CPU core sets to contain at most `target_sets` sets, useful when there are many L3
-    /// cache groups and not as many farms
-    pub fn regroup(cpu_core_sets: &[Self], target_sets: usize) -> Vec<Self> {
-        cpu_core_sets
-            // Chunk CPU core sets
-            .chunks(cpu_core_sets.len().div_ceil(target_sets))
-            .map(|sets| Self {
-                // Combine CPU cores
-                cores: sets
-                    .iter()
-                    .flat_map(|set| set.cores.iter())
-                    .copied()
-                    .collect(),
-                // Preserve topology object
-                #[cfg(feature = "numa")]
-                topology: sets[0].topology.clone(),
-            })
-            .collect()
-    }
-
     /// Get cpu core numbers in this set
     pub fn cpu_cores(&self) -> &[usize] {
         &self.cores

--- a/crates/subspace-farmer/src/utils.rs
+++ b/crates/subspace-farmer/src/utils.rs
@@ -207,9 +207,74 @@ impl CpuCoreSet {
 
     /// Will truncate list of CPU cores to this number.
     ///
+    /// Truncation will take into account L2 and L3 cache topology in order to use half of the
+    /// actual physical cores and half of each core type in case of heterogeneous CPUs.
+    ///
     /// If `cores` is zero, call will do nothing since zero number of cores is not allowed.
-    pub fn truncate(&mut self, cores: usize) {
-        self.cores.truncate(cores.max(1));
+    pub fn truncate(&mut self, num_cores: usize) {
+        let num_cores = num_cores.clamp(1, self.cores.len());
+
+        #[cfg(feature = "numa")]
+        if let Some(topology) = &self.topology {
+            use hwlocality::object::attributes::ObjectAttributes;
+            use hwlocality::object::types::ObjectType;
+
+            let mut grouped_by_l2_cache_size_and_core_count =
+                std::collections::HashMap::<(usize, usize), Vec<usize>>::new();
+            topology
+                .objects_with_type(ObjectType::L2Cache)
+                .for_each(|object| {
+                    let l2_cache_size =
+                        if let Some(ObjectAttributes::Cache(cache)) = object.attributes() {
+                            cache
+                                .size()
+                                .map(|size| size.get() as usize)
+                                .unwrap_or_default()
+                        } else {
+                            0
+                        };
+                    if let Some(cpuset) = object.complete_cpuset() {
+                        let cpuset = cpuset
+                            .into_iter()
+                            .map(usize::from)
+                            .filter(|core| self.cores.contains(core))
+                            .collect::<Vec<_>>();
+                        let cpuset_len = cpuset.len();
+
+                        if !cpuset.is_empty() {
+                            grouped_by_l2_cache_size_and_core_count
+                                .entry((l2_cache_size, cpuset_len))
+                                .or_default()
+                                .extend(cpuset);
+                        }
+                    }
+                });
+
+            // Make sure all CPU cores in this set were found
+            if grouped_by_l2_cache_size_and_core_count
+                .values()
+                .flatten()
+                .count()
+                == self.cores.len()
+            {
+                // Walk through groups of cores for each (L2 cache size + number of cores in set)
+                // tuple and pull number of CPU cores proportional to the fraction of the cores that
+                // should be returned according to function argument
+                self.cores = grouped_by_l2_cache_size_and_core_count
+                    .into_values()
+                    .flat_map(|cores| {
+                        let limit = cores.len() * num_cores / self.cores.len();
+                        // At least 1 CPU core is needed
+                        cores.into_iter().take(limit.max(1))
+                    })
+                    .collect();
+
+                self.cores.sort();
+
+                return;
+            }
+        }
+        self.cores.truncate(num_cores);
     }
 
     /// Pin current thread to this NUMA node (not just one CPU core)


### PR DESCRIPTION
This improves two specific cases that we might care about.

On Threadripper/Epyc systems (at least, maybe Ryzen too) in contrast to Intel systems logical CPU cores are located after all physical CPU cores. So physical CPU core 0 corresponds to logical CPU cores 0 and 32 on my 7970X instead of cores 0 and 1 that one would expect on Intel system. This meant that simply truncating all CPU cores in half would result in a single logical cores used from each physical CPU core and similar CPU load during replotting to full plotting. This PR changes that to take into account physical CPU cores mapping into logical cores to pick half of physical CPU cores instead as expected.

For hybrid Intel CPUs with P/E cores older code was simply taking first N cores, which always included P-cores, sometimes all P-cores. This resulted in bad user experience when all what was left during replotting was a few E-cores, which resulted in less than optimal experience of using the machine for other tasks. Observation is that both L2 cache size and number of cores per L2 cache size are different on such CPUs, so by grouping CPUs accordingly we can make better decisions. Specifically on systems with 2C4T P-cores and 8C8T E-cores replotting will now use one physical (2 logical) P-cores and 4 E-cores, leaving exactly half of both kinds of cores for other needs.

Space Acres will take advantage of this to make an advanced option available to set number of plotting threads to be the same as number of replotting threads and proper thread pinning is important in that case.

For reference topology on AMD Ryzen Threadripper 7970X:

<details>

![7970X](https://github.com/user-attachments/assets/9d578919-61af-4f12-957d-abcf797d720e)

</details>

And on Intel Core i7-1360U:

<details>

![i7-1360U](https://github.com/user-attachments/assets/9f1a4cbd-b734-4015-b340-9f472b8626a9)

</details>


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
