### PR TITLE
Remove .cargo/config and `+aes` feature on x86-64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.'cfg(target_arch = "x86_64")']
-# Require AES-NI on x86-64 by default
-rustflags = ["-C", "target-feature=+aes"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 *
-!/.cargo
 !/crates
 !/domains
 !/orml

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -99,7 +99,7 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-20.04-x86-64"]' || '"ubuntu-20.04"') }}
             target: x86_64-unknown-linux-gnu
             suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
-            rustflags: "-C target-cpu=x86-64-v2 -C target-feature=+aes"
+            rustflags: "-C target-cpu=x86-64-v2"
           - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-20.04-x86-64"]' || '"ubuntu-20.04"') }}
             target: aarch64-unknown-linux-gnu
             suffix: ubuntu-aarch64-${{ github.ref_name }}
@@ -114,7 +114,7 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "windows-server-2022-x86-64"]' || '"windows-2022"') }}
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-v2-${{ github.ref_name }}
-            rustflags: "-C target-cpu=x86-64-v2 -C target-feature=+aes"
+            rustflags: "-C target-cpu=x86-64-v2"
       fail-fast: false
     runs-on: ${{ matrix.build.os }}
     env:

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-bootstrap-node.aarch64
+++ b/Dockerfile-bootstrap-node.aarch64
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-farmer.aarch64
+++ b/Dockerfile-farmer.aarch64
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-node.aarch64
+++ b/Dockerfile-node.aarch64
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -27,7 +27,6 @@ RUN \
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY .cargo /code/.cargo
 COPY Cargo.lock /code/Cargo.lock
 COPY Cargo.toml /code/Cargo.toml
 COPY rust-toolchain.toml /code/rust-toolchain.toml

--- a/crates/subspace-proof-of-time/src/aes.rs
+++ b/crates/subspace-proof-of-time/src/aes.rs
@@ -1,7 +1,7 @@
 //! AES related functionality.
 
 // TODO: Similarly optimized version for aarch64
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "aes"))]
 mod x86_64;
 
 #[cfg(not(feature = "std"))]
@@ -15,15 +15,15 @@ use subspace_core_primitives::{PotCheckpoints, PotKey, PotOutput, PotSeed};
 /// Creates the AES based proof.
 #[inline(always)]
 pub(crate) fn create(seed: PotSeed, key: PotKey, checkpoint_iterations: u32) -> PotCheckpoints {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", target_feature = "aes"))]
     {
         unsafe { x86_64::create(seed.as_ref(), key.as_ref(), checkpoint_iterations) }
     }
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "aes")))]
     create_generic(seed, key, checkpoint_iterations)
 }
 
-#[cfg(any(not(target_arch = "x86_64"), test))]
+#[cfg(any(not(all(target_arch = "x86_64", target_feature = "aes")), test))]
 #[inline(always)]
 fn create_generic(seed: PotSeed, key: PotKey, checkpoint_iterations: u32) -> PotCheckpoints {
     let key = Array::from(*key);


### PR DESCRIPTION
This is not strictly necessary and reduces clutter in project's root.

`aes` crate will do runtime feature detection and still benefit from hardware instructions even when `+aes` is not specified. While PoT proving is more efficient the way we have it with intrinsics (which requires `+aes`), timekeepers are running optimized binaries that are compiled for newer CPU architectures (Skylake right now) that imply `+aes` anyway.

As the result there is little to no value in removed code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
