### PR TITLE
Running the message listener for the consensus chain

### DIFF
--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -222,9 +222,11 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
             let gossip_message_sink = xdm_gossip_worker_builder.gossip_msg_sink();
             let (domain_message_sink, domain_message_receiver) =
                 tracing_unbounded("domain_message_channel", 100);
+            let (consensus_msg_sink, consensus_msg_receiver) =
+                tracing_unbounded("consensus_message_channel", 100);
 
-            // Start relayer for consensus chain
-            let consensus_msg_receiver = {
+            // Start XDM related workers for consensus chain
+            {
                 let span = info_span!("Consensus");
                 let _enter = span.enter();
                 let consensus_best_hash = consensus_chain_node.client.info().best_hash;
@@ -251,6 +253,36 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                         ),
                     );
 
+                // Start cross domain message listener for Consensus chain to receive messages from domains in the network
+                let domain_code_executor: sc_domains::RuntimeExecutor =
+                    sc_service::new_wasm_executor(&domain_configuration.domain_config);
+                consensus_chain_node
+                    .task_manager
+                    .spawn_essential_handle()
+                    .spawn_essential_blocking(
+                        "consensus-message-listener",
+                        None,
+                        Box::pin(
+                            cross_domain_message_gossip::start_cross_chain_message_listener::<
+                                _,
+                                _,
+                                _,
+                                _,
+                                _,
+                                DomainBlock,
+                                _,
+                            >(
+                                ChainId::Consensus,
+                                consensus_chain_node.client.clone(),
+                                consensus_chain_node.client.clone(),
+                                consensus_chain_node.transaction_pool.clone(),
+                                consensus_chain_node.network_service.clone(),
+                                consensus_msg_receiver,
+                                domain_code_executor.into(),
+                            ),
+                        ),
+                    );
+
                 consensus_chain_node
                     .task_manager
                     .spawn_essential_handle()
@@ -271,9 +303,6 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                             ),
                         ),
                     );
-
-                let (consensus_msg_sink, consensus_msg_receiver) =
-                    tracing_unbounded("consensus_message_channel", 100);
 
                 xdm_gossip_worker_builder.push_chain_sink(ChainId::Consensus, consensus_msg_sink);
                 xdm_gossip_worker_builder.push_chain_sink(
@@ -296,15 +325,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                         None,
                         Box::pin(cross_domain_message_gossip_worker.run()),
                     );
-
-                consensus_msg_receiver
             };
-
-            let consensus_client = consensus_chain_node.client.clone();
-            let consensus_network_service = consensus_chain_node.network_service.clone();
-            let consensus_tx_pool = consensus_chain_node.transaction_pool.clone();
-            let consensus_task_essential_handler =
-                consensus_chain_node.task_manager.spawn_essential_handle();
 
             let domain_start_options = DomainStartOptions {
                 consensus_client: consensus_chain_node.client,
@@ -349,39 +370,8 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                             domain_start_options,
                         );
 
-                        match start_domain.await {
-                            Ok(domain_code_executor) => {
-                                let span = info_span!("Consensus");
-                                let _enter = span.enter();
-                                // Start cross domain message listener for Consensus chain to receive messages from domains in the network
-                                consensus_task_essential_handler
-                                    .spawn_essential_blocking(
-                                        "consensus-message-listener",
-                                        None,
-                                        Box::pin(
-                                            cross_domain_message_gossip::start_cross_chain_message_listener::<
-                                            _,
-                                            _,
-                                            _,
-                                            _,
-                                            _,
-                                            DomainBlock,
-                                            _,
-                                            >(
-                                                ChainId::Consensus,
-                                                consensus_client.clone(),
-                                                consensus_client.clone(),
-                                                consensus_tx_pool,
-                                                consensus_network_service,
-                                                consensus_msg_receiver,
-                                                domain_code_executor
-                                            ),
-                                        ),
-                                    );
-                            }
-                            Err(err) => {
-                                error!(%err, "Domain starter exited with an error");
-                            }
+                        if let Err(error) = start_domain.await {
+                            error!(%error, "Domain starter exited with an error");
                         }
                     }),
                 );

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -388,7 +388,7 @@ pub(super) async fn run_domain(
     bootstrap_result: BootstrapResult<CBlock>,
     domain_configuration: DomainConfiguration,
     domain_start_options: DomainStartOptions,
-) -> Result<Arc<sc_domains::RuntimeExecutor>, Error> {
+) -> Result<(), Error> {
     let BootstrapResult {
         domain_instance_data,
         domain_created_at,
@@ -514,7 +514,7 @@ pub(super) async fn run_domain(
 
             domain_node.task_manager.future().await?;
 
-            Ok(domain_node.code_executor.clone())
+            Ok(())
         }
         RuntimeType::AutoId => {
             let domain_params = domain_service::DomainParams {
@@ -553,7 +553,7 @@ pub(super) async fn run_domain(
 
             domain_node.task_manager.future().await?;
 
-            Ok(domain_node.code_executor.clone())
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
In main the consensus chain message listener only starts after the `run_domain` returns the `domain_code_executor`:
https://github.com/autonomys/subspace/blob/38d6b5be8209b9ad5cd08a788dff7675e621540f/crates/subspace-node/src/commands/run.rs#L346-L362

which won't happen until the domain worker shuts down, as a result, the consensus chain message listener is not running at all.

This PR fixes the issue by constructing a new domain executor and using it to start the consensus chain message listener without waiting.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
