### PR TITLE
Snap sync without light state sync

### DIFF
--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -215,6 +215,7 @@ fn main() -> Result<(), Error> {
 
             let partial_components = subspace_service::new_partial::<PosTable, RuntimeApi>(
                 &consensus_chain_config,
+                false,
                 &pot_external_entropy,
             )
             .map_err(|error| {

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -148,6 +148,7 @@ fn main() -> Result<(), Error> {
                     ..
                 } = subspace_service::new_partial::<PosTable, RuntimeApi>(
                     &config,
+                    false,
                     &derive_pot_external_entropy(&config, None)?,
                 )?;
                 Ok((
@@ -166,6 +167,7 @@ fn main() -> Result<(), Error> {
                     ..
                 } = subspace_service::new_partial::<PosTable, RuntimeApi>(
                     &config,
+                    false,
                     &derive_pot_external_entropy(&config, None)?,
                 )?;
                 Ok((
@@ -185,6 +187,7 @@ fn main() -> Result<(), Error> {
                     ..
                 } = subspace_service::new_partial::<PosTable, RuntimeApi>(
                     &config,
+                    false,
                     &derive_pot_external_entropy(&config, None)?,
                 )?;
                 Ok((
@@ -205,6 +208,7 @@ fn main() -> Result<(), Error> {
                     ..
                 } = subspace_service::new_partial::<PosTable, RuntimeApi>(
                     &config,
+                    false,
                     &derive_pot_external_entropy(&config, None)?,
                 )?;
                 Ok((
@@ -227,6 +231,7 @@ fn main() -> Result<(), Error> {
                     ..
                 } = subspace_service::new_partial::<PosTable, RuntimeApi>(
                     &config,
+                    false,
                     &derive_pot_external_entropy(&config, None)?,
                 )?;
                 Ok((
@@ -263,6 +268,7 @@ fn main() -> Result<(), Error> {
                         let PartialComponents { client, .. } =
                             subspace_service::new_partial::<PosTable, RuntimeApi>(
                                 &config,
+                                false,
                                 &derive_pot_external_entropy(&config, None)?,
                             )?;
 
@@ -279,6 +285,7 @@ fn main() -> Result<(), Error> {
                             client, backend, ..
                         } = subspace_service::new_partial::<PosTable, RuntimeApi>(
                             &config,
+                            false,
                             &derive_pot_external_entropy(&config, None)?,
                         )?;
                         let db = backend.expose_db();

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -154,14 +154,7 @@ impl From<SubstrateConfiguration> for Configuration {
                 max_parallel_downloads: 5,
                 // Substrate's default
                 max_blocks_per_request: 64,
-                sync_mode: match configuration.network.sync_mode {
-                    ChainSyncMode::Full => SyncMode::Full,
-                    // TODO: revisit SyncMode change after https://github.com/paritytech/polkadot-sdk/issues/4407
-                    ChainSyncMode::Snap => SyncMode::LightState {
-                        skip_proofs: false,
-                        storage_chain_mode: false,
-                    },
-                },
+                sync_mode: SyncMode::Full,
                 pause_sync: Arc::new(AtomicBool::new(false)),
                 // Substrate's default
                 enable_dht_random_walk: true,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -460,11 +460,12 @@ type PartialComponents<RuntimeApi> = sc_service::PartialComponents<
 >;
 
 /// Creates `PartialComponents` for Subspace client.
-#[allow(clippy::type_complexity)]
 pub fn new_partial<PosTable, RuntimeApi>(
     // TODO: Stop using `Configuration` once
     //  https://github.com/paritytech/polkadot-sdk/pull/5364 is in our fork
     config: &Configuration,
+    // TODO: Replace with check for `ChainSyncMode` once we get rid of ^ `Configuration`
+    snap_sync: bool,
     pot_external_entropy: &[u8],
 ) -> Result<PartialComponents<RuntimeApi>, ServiceError>
 where
@@ -502,7 +503,7 @@ where
 
     let genesis_block_builder = GenesisBlockBuilder::new(
         config.chain_spec.as_storage_builder(),
-        !config.no_genesis(),
+        !snap_sync,
         backend.clone(),
         executor.clone(),
     )?;

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -52,6 +52,7 @@ use pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi;
 use parking_lot::Mutex;
 use prometheus_client::registry::Registry;
 use sc_basic_authorship::ProposerFactory;
+use sc_chain_spec::GenesisBlockBuilder;
 use sc_client_api::execution_extensions::ExtensionsFactory;
 use sc_client_api::{
     AuxStore, Backend, BlockBackend, BlockchainEvents, ExecutorProvider, HeaderBackend,
@@ -461,6 +462,8 @@ type PartialComponents<RuntimeApi> = sc_service::PartialComponents<
 /// Creates `PartialComponents` for Subspace client.
 #[allow(clippy::type_complexity)]
 pub fn new_partial<PosTable, RuntimeApi>(
+    // TODO: Stop using `Configuration` once
+    //  https://github.com/paritytech/polkadot-sdk/pull/5364 is in our fork
     config: &Configuration,
     pot_external_entropy: &[u8],
 ) -> Result<PartialComponents<RuntimeApi>, ServiceError>
@@ -495,11 +498,23 @@ where
     let executor = sc_service::new_wasm_executor(config);
     let domains_executor = sc_service::new_wasm_executor(config);
 
+    let backend = sc_service::new_db_backend(config.db_config())?;
+
+    let genesis_block_builder = GenesisBlockBuilder::new(
+        config.chain_spec.as_storage_builder(),
+        !config.no_genesis(),
+        backend.clone(),
+        executor.clone(),
+    )?;
+
     let (client, backend, keystore_container, task_manager) =
-        sc_service::new_full_parts::<Block, RuntimeApi, _>(
+        sc_service::new_full_parts_with_genesis_builder::<Block, RuntimeApi, _, _>(
             config,
             telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
             executor.clone(),
+            backend,
+            genesis_block_builder,
+            false,
         )?;
 
     let kzg = tokio::task::block_in_place(|| Kzg::new(embedded_kzg_settings()));

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -10,9 +10,7 @@ use sc_consensus::{
 };
 use sc_consensus_subspace::archiver::{decode_block, SegmentHeadersStore};
 use sc_network::{NetworkRequest, PeerId};
-use sc_network_sync::service::syncing_service::SyncRestartArgs;
 use sc_network_sync::SyncingService;
-use sc_service::config::SyncMode;
 use sc_service::{ClientExt, Error};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -90,15 +88,6 @@ pub(crate) async fn snap_sync<Backend, Block, AS, Client, PG, NR>(
     } else {
         debug!("Snap sync can only work with genesis state, skipping");
     }
-
-    // Switch back to full sync mode
-    let info = client.info();
-    sync_service
-        .restart(SyncRestartArgs {
-            sync_mode: SyncMode::Full,
-            new_best_block: Some(info.best_number),
-        })
-        .await;
 }
 
 // Get blocks from the last segment or from the segment containing the target block.


### PR DESCRIPTION
Turns out we don't need light state sync or sync restart, we just need to tell Substrate to not store genesis state and that can be done without Substrate modifications as explained in https://github.com/paritytech/polkadot-sdk/issues/5366

Things will be even nicer with https://github.com/paritytech/polkadot-sdk/pull/5364, but not horrible already.

Synced 3h with Snap sync with no issues with these changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
