### PR TITLE
Remove `BlockOrigin::ConsensusBroadcast` workaround and use a proper sync notification

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -996,6 +996,7 @@ where
         node.clone(),
         Arc::clone(&client),
         import_queue_service2,
+        sync_service.clone(),
         sync_target_block_number,
         pause_sync,
         dsn_sync_piece_getter,

--- a/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -221,20 +221,7 @@ where
 
         if !blocks_to_import.is_empty() {
             // Import queue handles verification and importing it into the client
-            let last_segment = segment_indices_iter.peek().is_none();
-            if last_segment {
-                let last_block = blocks_to_import
-                    .pop()
-                    .expect("Not empty, checked above; qed");
-                import_queue_service
-                    .import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
-                // This will notify Substrate's sync mechanism and allow regular Substrate sync to continue gracefully
-                import_queue_service
-                    .import_blocks(BlockOrigin::ConsensusBroadcast, vec![last_block]);
-            } else {
-                import_queue_service
-                    .import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
-            }
+            import_queue_service.import_blocks(BlockOrigin::NetworkInitialSync, blocks_to_import);
         }
 
         *last_processed_segment_index = segment_index;


### PR DESCRIPTION
I was reading Substrate code a lot recently and found that there is actually a notification we should use instead of block origin workaround.

Tested with Snap sync on 3h, worked correctly and successfully.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
