### PR TITLE
Refactoring the XDM relayer

### DIFF
--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -14,7 +14,6 @@ use sc_consensus_subspace::block_import::BlockImportingNotification;
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::slot_worker::NewSlotNotification;
 use sc_network::NetworkPeers;
-use sc_service::PruningMode;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_api::ProvideRuntimeApi;
@@ -47,7 +46,6 @@ pub struct DomainInstanceStarter {
     pub domain_message_receiver: TracingUnboundedReceiver<ChainMsg>,
     pub gossip_message_sink: TracingUnboundedSender<Message>,
     pub consensus_network: Arc<dyn NetworkPeers + Send + Sync>,
-    pub consensus_state_pruning: PruningMode,
 }
 
 impl DomainInstanceStarter {
@@ -80,7 +78,6 @@ impl DomainInstanceStarter {
             domain_message_receiver,
             gossip_message_sink,
             consensus_network,
-            consensus_state_pruning,
         } = self;
 
         let domain_id = domain_cli.domain_id.into();
@@ -163,7 +160,6 @@ impl DomainInstanceStarter {
                     skip_out_of_order_slot: false,
                     // Always set it to `None` to not running the normal bundle producer
                     maybe_operator_id: None,
-                    consensus_state_pruning,
                     confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 };
 
@@ -222,7 +218,6 @@ impl DomainInstanceStarter {
                     skip_out_of_order_slot: false,
                     // Always set it to `None` to not running the normal bundle producer
                     maybe_operator_id: None,
-                    consensus_state_pruning,
                     confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 };
 

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -24,7 +24,7 @@ use sc_network::config::{MultiaddrWithPeerId, NonReservedPeerMode, SetConfig, Tr
 use sc_network::NetworkPeers;
 use sc_proof_of_time::source::PotSlotInfo;
 use sc_service::config::KeystoreConfig;
-use sc_service::{Configuration, PruningMode};
+use sc_service::Configuration;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_api::ProvideRuntimeApi;
@@ -381,7 +381,6 @@ pub(super) struct DomainStartOptions {
     pub(super) domain_message_receiver:
         TracingUnboundedReceiver<cross_domain_message_gossip::ChainMsg>,
     pub(super) gossip_message_sink: TracingUnboundedSender<cross_domain_message_gossip::Message>,
-    pub(super) consensus_state_pruning: PruningMode,
 }
 
 pub(super) async fn run_domain(
@@ -421,7 +420,6 @@ pub(super) async fn run_domain(
         consensus_network_sync_oracle,
         domain_message_receiver,
         gossip_message_sink,
-        consensus_state_pruning,
     } = domain_start_options;
 
     let block_importing_notification_stream = block_importing_notification_stream.subscribe().then(
@@ -493,7 +491,6 @@ pub(super) async fn run_domain(
                 skip_empty_bundle_production: true,
                 skip_out_of_order_slot: false,
                 maybe_operator_id: operator_id,
-                consensus_state_pruning,
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
             };
 
@@ -532,7 +529,6 @@ pub(super) async fn run_domain(
                 skip_empty_bundle_production: true,
                 skip_out_of_order_slot: false,
                 maybe_operator_id: operator_id,
-                consensus_state_pruning,
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
             };
 

--- a/domains/client/cross-domain-message-gossip/src/lib.rs
+++ b/domains/client/cross-domain-message-gossip/src/lib.rs
@@ -4,7 +4,7 @@ mod aux_schema;
 mod gossip_worker;
 mod message_listener;
 
-pub use aux_schema::{ChannelDetail, ChannelStorage};
+pub use aux_schema::{get_channel_state, set_channel_state, ChannelDetail};
 pub use gossip_worker::{
     xdm_gossip_peers_set_config, ChainMsg, ChainSink, ChannelUpdate, GossipWorker,
     GossipWorkerBuilder, Message, MessageData,

--- a/domains/client/relayer/src/worker.rs
+++ b/domains/client/relayer/src/worker.rs
@@ -2,8 +2,7 @@ use crate::{BlockT, Error, GossipMessageSink, HeaderBackend, HeaderT, Relayer, L
 use cross_domain_message_gossip::{ChannelUpdate, Message as GossipMessage, MessageData};
 use futures::StreamExt;
 use sc_client_api::{AuxStore, BlockchainEvents, ProofProvider};
-use sc_state_db::PruningMode;
-use sp_api::{ApiError, ApiExt, ProvideRuntimeApi};
+use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_consensus::SyncOracle;
 use sp_domains::{DomainId, DomainsApi};
 use sp_messenger::messages::ChainId;
@@ -141,72 +140,11 @@ where
     Ok(())
 }
 
-/// Starts relaying consensus chain messages to other domains.
-/// If the node is in major sync, worker waits until the sync is finished.
-pub async fn relay_consensus_chain_messages<Client, Block, SO>(
-    consensus_chain_client: Arc<Client>,
-    confirmation_depth_k: NumberFor<Block>,
-    state_pruning_mode: PruningMode,
-    sync_oracle: SO,
-    gossip_message_sink: GossipMessageSink,
-) where
-    Block: BlockT,
-    Client: BlockchainEvents<Block>
-        + HeaderBackend<Block>
-        + AuxStore
-        + ProofProvider<Block>
-        + ProvideRuntimeApi<Block>,
-    Client::Api: RelayerApi<Block, NumberFor<Block>, NumberFor<Block>, Block::Hash>
-        + MmrApi<Block, sp_core::H256, NumberFor<Block>>,
-    SO: SyncOracle,
-{
-    let result = start_relaying_messages(
-        ChainId::Consensus,
-        consensus_chain_client.clone(),
-        confirmation_depth_k,
-        |client, block_id, _| {
-            Relayer::submit_messages_from_consensus_chain(client, block_id, &gossip_message_sink)
-        },
-        sync_oracle,
-        |block_number| -> Result<Option<()>, ApiError> {
-            // since a parent mmr leaf is included in its child,
-            // we process the finalized block's parent instead since we know parent is implicitly finalized
-            // so we ensure the state of the parent is available here
-            Ok(block_number
-                .checked_sub(&One::one())
-                .and_then(|number_to_check| {
-                    is_state_available(
-                        &state_pruning_mode,
-                        &consensus_chain_client,
-                        number_to_check,
-                    )
-                    .then_some(())
-                }))
-        },
-    )
-    .await;
-
-    if let Err(err) = result {
-        tracing::error!(
-            target: LOG_TARGET,
-            ?err,
-            "Failed to start relayer for Consensus chain"
-        )
-    }
-}
-
-type DomainExtraData<Block> = (NumberFor<Block>, <Block as BlockT>::Hash);
-
-/// Starts relaying domain messages to other chains.
-/// If the domain node is in major sync, worker waits until the sync is finished.
-#[allow(clippy::too_many_arguments)]
-pub async fn relay_domain_messages<CClient, Client, CBlock, Block, SO>(
+pub async fn start_relaying_messages<CClient, Client, CBlock, Block, SO>(
     domain_id: DomainId,
-    consensus_chain_client: Arc<CClient>,
-    confirmation_depth_k: NumberFor<CBlock>,
-    consensus_state_pruning: PruningMode,
+    consensus_client: Arc<CClient>,
     domain_client: Arc<Client>,
-    domain_state_pruning: PruningMode,
+    confirmation_depth_k: NumberFor<CBlock>,
     sync_oracle: SO,
     gossip_message_sink: GossipMessageSink,
 ) where
@@ -221,140 +159,13 @@ pub async fn relay_domain_messages<CClient, Client, CBlock, Block, SO>(
         + AuxStore,
     CClient::Api: DomainsApi<CBlock, Block::Header>
         + MessengerApi<CBlock, NumberFor<CBlock>, CBlock::Hash>
-        + MmrApi<CBlock, sp_core::H256, NumberFor<CBlock>>,
+        + MmrApi<CBlock, sp_core::H256, NumberFor<CBlock>>
+        + RelayerApi<CBlock, NumberFor<CBlock>, NumberFor<CBlock>, CBlock::Hash>,
     SO: SyncOracle + Send,
-{
-    let result = start_relaying_messages(
-        ChainId::Domain(domain_id),
-        consensus_chain_client.clone(),
-        confirmation_depth_k,
-        |consensus_chain_client, consensus_block, (_domain_block_number, domain_hash)| {
-            Relayer::submit_messages_from_domain(
-                domain_id,
-                &domain_client,
-                consensus_chain_client,
-                consensus_block,
-                domain_hash,
-                &gossip_message_sink,
-            )
-        },
-        sync_oracle,
-        |consensus_block_number|
-         -> Result<Option<DomainExtraData<Block>>, ApiError> {
-            // since a parent mmr leaf is included in its child,
-            // we process the finalized block's parent instead since we know parent is implicitly finalized
-            // so we ensure the state of the parent is available here
-            let consensus_block_number = match consensus_block_number.checked_sub(&One::one()) {
-                None => return Ok(None),
-                Some(number) => number
-            };
-
-            if !is_state_available(
-                &consensus_state_pruning,
-                &consensus_chain_client,
-                consensus_block_number,
-            ) {
-                return Ok(None);
-            }
-
-            let consensus_hash_to_process = consensus_chain_client
-                .hash(consensus_block_number)?
-                .ok_or(ApiError::UnknownBlock(format!("Missing Hash for block number: {consensus_block_number:?}")))?;
-            let api = consensus_chain_client.runtime_api();
-
-            // TODO: This is used to keep compatible with gemini-3h, remove before next network
-            let api_version = api
-            .api_version::<dyn DomainsApi<CBlock, Block::Header>>(consensus_hash_to_process)
-            .map_err(sp_blockchain::Error::RuntimeApiError)?
-            .ok_or_else(|| {
-                sp_blockchain::Error::RuntimeApiError(ApiError::Application(
-                    format!("DomainsApi not found at: {:?}", consensus_hash_to_process).into(),
-                ))
-            })?;
-            if api_version < 2 {
-                return Ok(None)
-            }
-
-            let confirmed_domain_block =
-                api.latest_confirmed_domain_block(consensus_hash_to_process, domain_id)?;
-
-            if let Some((domain_block_number, domain_block_hash)) = confirmed_domain_block {
-                // short circuit if the domain state is unavailable to relay messages.
-                if !is_state_available(&domain_state_pruning, &domain_client, domain_block_number) {
-                    return Ok(None);
-                }
-
-                tracing::debug!(
-                    target: LOG_TARGET,
-                    "Domain block: {domain_block_number:?} and {domain_block_hash:?} confirmed at Consensus block {consensus_block_number:?}"
-                );
-
-                Ok(confirmed_domain_block)
-            } else {
-                // if there is not confirmed domain block for this domain, skip
-                Ok(None)
-            }
-        },
-    )
-        .await;
-    if let Err(err) = result {
-        tracing::error!(
-            target: LOG_TARGET,
-            ?err,
-            "Failed to start relayer for domain"
-        )
-    }
-}
-
-fn is_state_available<Client, Block>(
-    state_pruning_mode: &PruningMode,
-    client: &Arc<Client>,
-    relay_number: NumberFor<Block>,
-) -> bool
-where
-    Block: BlockT,
-    Client: HeaderBackend<Block>,
-{
-    match state_pruning_mode {
-        // all the state is available for archive and archive canonical.
-        // we can relay any message from any block
-        PruningMode::ArchiveAll | PruningMode::ArchiveCanonical => true,
-        // If the pruning mode is constrained, then check if the state is available for the `relay_number`
-        PruningMode::Constrained(constraints) => {
-            let max_blocks = NumberFor::<Block>::from(constraints.max_blocks.unwrap_or(0));
-            let current_best_block = client.info().best_number;
-            match current_best_block.checked_sub(&max_blocks) {
-                // we still have the state available as there was no pruning yet.
-                None => true,
-                Some(available_block_state) => relay_number >= available_block_state,
-            }
-        }
-    }
-}
-
-async fn start_relaying_messages<CClient, CBlock, MP, SO, CRM, ExtraData>(
-    chain_id: ChainId,
-    consensus_client: Arc<CClient>,
-    confirmation_depth_k: NumberFor<CBlock>,
-    message_processor: MP,
-    sync_oracle: SO,
-    can_relay_message_from_block: CRM,
-) -> Result<(), Error>
-where
-    CBlock: BlockT,
-    CClient: BlockchainEvents<CBlock>
-        + HeaderBackend<CBlock>
-        + AuxStore
-        + ProofProvider<CBlock>
-        + ProvideRuntimeApi<CBlock>,
-    MP: Fn(&Arc<CClient>, (NumberFor<CBlock>, CBlock::Hash), ExtraData) -> Result<(), Error>,
-    SO: SyncOracle,
-    CRM: Fn(NumberFor<CBlock>) -> Result<Option<ExtraData>, ApiError>,
 {
     tracing::info!(
         target: LOG_TARGET,
-        "Starting relayer for chain: {:?}",
-        chain_id,
+        "Starting relayer for domain: {domain_id:?} and the consensus chain",
     );
     let mut chain_block_imported = consensus_client.every_import_notification_stream();
 
@@ -363,63 +174,44 @@ where
     // then fetch new messages in the block
     // construct proof of each message to be relayed
     // submit XDM as unsigned extrinsic.
-    while let Some(block) = chain_block_imported.next().await {
+    while let Some(imported_block) = chain_block_imported.next().await {
         // if the client is in major sync, wait until sync is complete
         if sync_oracle.is_major_syncing() {
             tracing::debug!(target: LOG_TARGET, "Client is in major sync. Skipping...");
             continue;
         }
 
-        if !block.is_new_best {
+        if !imported_block.is_new_best {
             tracing::debug!(target: LOG_TARGET, "Imported non-best block. Skipping...");
             continue;
         }
 
-        let (number, hash) = {
-            let imported_block_number = *block.header.number();
-            if let Some(block_to_relay) = imported_block_number.checked_sub(&confirmation_depth_k) {
-                let block_to_relay_hash = consensus_client
-                    .hash(block_to_relay)?
-                    .ok_or(Error::MissingBlockHash)?;
-                (block_to_relay, block_to_relay_hash)
-            } else {
-                tracing::debug!(target: LOG_TARGET, "Not enough confirmed blocks. Skipping...");
-                continue;
-            }
+        let Some(finalized_block_number) = imported_block
+            .header
+            .number()
+            .checked_sub(&confirmation_depth_k)
+        else {
+            tracing::debug!(target: LOG_TARGET, "Not enough confirmed blocks. Skipping...");
+            continue;
         };
 
-        tracing::debug!(
-            target: LOG_TARGET,
-            "Checking messages to be submitted from chain: {chain_id:?} at block: ({number:?}, {hash:?})",
-        );
-
-        // check if the message is ready to be relayed.
-        // if not, the node is lagging behind and/or there is no way to generate a proof.
-        // mark this block processed and continue to next one.
-        if let Some(extra_data) = can_relay_message_from_block(number)? {
-            match message_processor(&consensus_client, (number, hash), extra_data) {
-                Ok(_) => {
-                    tracing::debug!(
-                        target: LOG_TARGET,
-                        "Messages from {chain_id:?} at block({number:?}, {hash:?}) are processed."
-                    )
-                }
-                Err(err) => {
-                    tracing::error!(
-                        target: LOG_TARGET,
-                        ?err,
-                        "Failed to submit messages from the chain {chain_id:?} at the block ({number:?}, {hash:?})"
-                    );
-                    break;
-                }
-            }
-        } else {
-            tracing::debug!(
-                target: LOG_TARGET,
-                "Chain({chain_id:?}) messages in the Block ({number:?}, {hash:?}) cannot be relayed. Skipping...",
+        for chain_id in [ChainId::Consensus, ChainId::Domain(domain_id)] {
+            let res = Relayer::construct_and_submit_xdm(
+                chain_id,
+                &domain_client,
+                &consensus_client,
+                finalized_block_number,
+                &gossip_message_sink,
             );
+
+            if let Err(err) = res {
+                tracing::error!(
+                    target: LOG_TARGET,
+                    ?err,
+                    "Failed to submit messages from the chain {chain_id:?} at the block ({finalized_block_number:?}"
+                );
+                continue;
+            }
         }
     }
-
-    Ok(())
 }

--- a/domains/client/relayer/src/worker.rs
+++ b/domains/client/relayer/src/worker.rs
@@ -186,7 +186,7 @@ pub async fn start_relaying_messages<CClient, Client, CBlock, Block, SO>(
             continue;
         }
 
-        let Some(finalized_block_number) = imported_block
+        let Some(confirmed_block_number) = imported_block
             .header
             .number()
             .checked_sub(&confirmation_depth_k)
@@ -200,7 +200,7 @@ pub async fn start_relaying_messages<CClient, Client, CBlock, Block, SO>(
                 chain_id,
                 &domain_client,
                 &consensus_client,
-                finalized_block_number,
+                confirmed_block_number,
                 &gossip_message_sink,
             );
 
@@ -208,7 +208,7 @@ pub async fn start_relaying_messages<CClient, Client, CBlock, Block, SO>(
                 tracing::error!(
                     target: LOG_TARGET,
                     ?err,
-                    "Failed to submit messages from the chain {chain_id:?} at the block ({finalized_block_number:?}"
+                    "Failed to submit messages from the chain {chain_id:?} at the block ({confirmed_block_number:?}"
                 );
                 continue;
             }

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -264,6 +264,12 @@ pub struct BlockMessagesWithStorageKey {
     pub inbox_responses: Vec<BlockMessageWithStorageKey>,
 }
 
+impl BlockMessagesWithStorageKey {
+    pub fn is_empty(&self) -> bool {
+        self.outbox.is_empty() && self.inbox_responses.is_empty()
+    }
+}
+
 impl<BlockNumber, BlockHash, MmrHash> CrossDomainMessage<BlockNumber, BlockHash, MmrHash> {
     pub fn from_relayer_msg_with_proof(
         r_msg: BlockMessageWithStorageKey,

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -257,6 +257,12 @@ pub struct BlockMessageWithStorageKey {
     pub weight_tag: MessageWeightTag,
 }
 
+impl BlockMessageWithStorageKey {
+    pub fn id(&self) -> (ChannelId, Nonce) {
+        (self.channel_id, self.nonce)
+    }
+}
+
 /// Set of messages with storage keys to be relayed in a given block..
 #[derive(Default, Debug, Encode, Decode, TypeInfo, Clone, Eq, PartialEq)]
 pub struct BlockMessagesWithStorageKey {

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -21,7 +21,7 @@ use sc_domains::RuntimeExecutor;
 use sc_network::{NetworkService, NetworkStateInfo};
 use sc_network_sync::SyncingService;
 use sc_service::config::MultiaddrWithPeerId;
-use sc_service::{BasePath, PruningMode, Role, RpcHandlers, TFullBackend, TaskManager};
+use sc_service::{BasePath, Role, RpcHandlers, TFullBackend, TaskManager};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 use sp_api::{ApiExt, ConstructRuntimeApi, Metadata, ProvideRuntimeApi};
@@ -213,7 +213,6 @@ where
             skip_empty_bundle_production,
             skip_out_of_order_slot: true,
             maybe_operator_id,
-            consensus_state_pruning: PruningMode::ArchiveCanonical,
             confirmation_depth_k: chain_constants.confirmation_depth_k(),
         };
 


### PR DESCRIPTION
This PR is a refactoring of the XDM relayer,  the change set is quite large so I didn't organize the change commit by commit but the logic after refactoring should be clear and easy to review.

 The relayer works as follows:
1. For every imported consensus block
    - Skip if it is in major sync
    - Skip if the block is not the best block
2. Get the `finalized_block` as `imported_block - confirmation_depth_k`
    - The `finalized_block` won't be processed directly but instead the relayer will process `finalized_block - 1` and `finalized_block` is used to generate the MMR proof of `finalized_block - 1`
3. Fetch and filter XDM in `finalized_block - 1`
    - The relayer will check against the current best block state to see if the XDM in `finalized_block - 1` is already relayed
4. Construct XDM proof which consists of:
    - The MMR proof of `finalized_block - 1`
    - The message proof
    - If the src chain is a domain there is also a storage proof of the `LastConfirmedDomainBlockReceipt`
5. Gossip/submit the XDM to the network

A few notable logical changes:
- The relayer of the consensus chain and the domain is merged into one worker
- The relayer when encountering an error will not shut down the whole node but instead just print an error log, since it is not fatal
- The `is_state_available` check is removed so the relayer just prints an error log if the state at `finalized_block - 1` and `LastConfirmedDomainBlock` is not available

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
