### PR TITLE
Binary only farmer dependencies

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -200,7 +200,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Build farmer (Linux and Windows)
+      - name: Build farmer
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
 

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -11,10 +11,14 @@ include = [
     "/README.md",
 ]
 
+[[bin]]
+name = "subspace-farmer"
+required-features = ["binary"]
+
 [dependencies]
 anyhow = "1.0.86"
 async-lock = "3.3.0"
-async-nats = "0.35.1"
+async-nats = { version = "0.35.1", optional = true }
 async-trait = "0.1.81"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base58 = "0.2.0"
@@ -22,18 +26,18 @@ blake2 = "0.10.6"
 blake3 = { version = "1.5.3", default-features = false }
 bytes = "1.7.1"
 bytesize = "1.3.0"
-clap = { version = "4.5.15", features = ["color", "derive"] }
-criterion = { version = "0.5.1", default-features = false, features = ["rayon", "async"] }
+clap = { version = "4.5.15", features = ["derive"], optional = true }
+criterion = { version = "0.5.1", default-features = false, features = ["rayon", "async"], optional = true }
 derive_more = { version = "1.0.0", features = ["full"] }
 event-listener = "5.3.1"
 event-listener-primitives = "2.0.1"
-fdlimit = "0.3.0"
+fdlimit = { version = "0.3.0", optional = true }
 fs4 = "0.8.4"
 futures = "0.3.29"
 hex = { version = "0.4.3", features = ["serde"] }
 hwlocality = { version = "1.0.0-alpha.6", features = ["vendored"], optional = true }
 jsonrpsee = { version = "0.24.2", features = ["ws-client"] }
-mimalloc = "0.1.43"
+mimalloc = { version = "0.1.43", optional = true }
 num_cpus = "1.16.0"
 parity-scale-codec = "3.6.12"
 parking_lot = "0.12.2"
@@ -51,22 +55,38 @@ subspace-archiving = { version = "0.1.0", path = "../subspace-archiving" }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding" }
 subspace-farmer-components = { version = "0.1.0", path = "../subspace-farmer-components" }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
-subspace-metrics = { version = "0.1.0", path = "../../shared/subspace-metrics" }
+subspace-metrics = { version = "0.1.0", path = "../../shared/subspace-metrics", optional = true }
 subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-proof-of-space = { version = "0.1.0", path = "../subspace-proof-of-space" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
 substrate-bip39 = "0.6.0"
-supports-color = "3.0.0"
+supports-color = { version = "3.0.0", optional = true }
 tempfile = "3.12.0"
 thiserror = "1.0.63"
 thread-priority = "1.1.0"
 tokio = { version = "1.39.2", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }
 ulid = { version = "1.1.3", features = ["serde"] }
 zeroize = "1.8.1"
 
 [features]
-default = ["numa"]
+default = ["default-library", "binary"]
+cluster = ["dep:async-nats"]
 numa = ["dep:hwlocality"]
+
+# TODO: This is a hack for https://github.com/rust-lang/cargo/issues/1982, `default-library` is what would essentially
+#  be default, but because binary compilation will require explicit feature to be specified without `binary` feature we
+#  make `binary` the default feature and allow user of the library to opt-out when then need just a library instead,
+#  while still being able to leverage default feature
+default-library = ["cluster", "numa"]
+binary = [
+    "dep:clap",
+    "dep:criterion",
+    "dep:fdlimit",
+    "dep:mimalloc",
+    "dep:subspace-metrics",
+    "dep:supports-color",
+    "dep:tracing-subscriber",
+]


### PR DESCRIPTION
This implements a reasonably convenient workaround that will allow for Space Acres to not pull a bunch of dependencies (or at least improve compilation parallelism of some) by segregating binary-only dependencies from the rest. The default behavior was kept the same for convenience.

Workflow fix is something that remained from the time when `numa` feature didn't work in CI on macOS and we had a separate compilation step for it, which is no longer the case.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
