### PR TITLE
Clear CI TODOs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,8 @@ env:
   # Not needed in CI, should make things a bit faster
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
-  # Build smaller artifacts to avoid running out of space in CI
-  # TODO: Try to remove once https://github.com/paritytech/substrate/issues/11538 is resolved
-  RUSTFLAGS: -C strip=symbols -C opt-level=s
+  # Build smaller artifacts to avoid running out of space in CI and make it a bit faster
+  RUSTFLAGS: -C strip=symbols
 
 jobs:
   cargo-fmt:
@@ -77,7 +76,6 @@ jobs:
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
-      # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
       - name: Install glibtoolize (macOS)
         run: brew install libtool
         if: runner.os == 'macOS'
@@ -163,7 +161,6 @@ jobs:
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
-      # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
       - name: Install glibtoolize (macOS)
         run: brew install libtool
         if: runner.os == 'macOS'

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -139,7 +139,6 @@ jobs:
           echo "SDKROOT=$(xcrun --show-sdk-path)" >> $GITHUB_ENV
         if: runner.os == 'macOS'
 
-      # TODO: Workaround for https://github.com/actions/runner-images/issues/9290
       - name: Install glibtoolize (macOS)
         run: brew install libtool
         if: runner.os == 'macOS'


### PR DESCRIPTION
Couple of small TODOs that are no longer applicable.

We no longer clone upstream repo, but instead use our fork (which is smaller), we also use gitoxide to have shallow clones and other improvements that lead to smaller clones and lower disk/cache usage.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
