### PR TITLE
Add DSN object mappings for system.remark, fix offsets

### DIFF
--- a/crates/sc-consensus-subspace/Cargo.toml
+++ b/crates/sc-consensus-subspace/Cargo.toml
@@ -61,3 +61,7 @@ tracing = "0.1.40"
 #substrate-test-runtime = { version = "2.0.0", path = "../../substrate/substrate-test-runtime" }
 #substrate-test-runtime-client = { version = "2.0.0", path = "../../substrate/substrate-test-runtime-client" }
 #tokio = "1.27.0"
+
+[features]
+# Temporary feature, TODO: replace with a CLI option
+full-archive = []

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -850,9 +850,11 @@ where
                 %last_archived_block_number,
                 "Checking if block needs to be skipped"
             );
-            if best_archived_block_number >= block_number_to_archive
-                || last_archived_block_number > block_number_to_archive
-            {
+
+            // TODO: replace this cfg! with a CLI option
+            let skip_last_archived_blocks = last_archived_block_number > block_number_to_archive
+                && !cfg!(feature = "full-archive");
+            if best_archived_block_number >= block_number_to_archive || skip_last_archived_blocks {
                 // This block was already archived, skip
                 debug!(
                     %importing_block_number,

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -22,8 +22,6 @@ use crate::archiver::incremental_record_commitments::{
 };
 use alloc::collections::VecDeque;
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
 use alloc::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -200,14 +200,9 @@ impl NewArchivedSegment {
             .zip(piece_indexes)
             .flat_map(|(piece_mappings, piece_index)| {
                 // And then through each individual object mapping in the piece
-                piece_mappings
-                    .objects
-                    .into_iter()
-                    .map(move |piece_object| GlobalObject::V0 {
-                        piece_index,
-                        offset: piece_object.offset(),
-                        hash: piece_object.hash(),
-                    })
+                piece_mappings.objects.into_iter().map(move |piece_object| {
+                    GlobalObject::new(piece_object.hash(), piece_index, piece_object.offset())
+                })
             })
     }
 }

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -42,6 +42,7 @@ pub enum BlockObject {
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
         /// Object hash
+        #[cfg_attr(feature = "serde", serde(with = "hex"))]
         hash: Blake3Hash,
         /// Offset of object in the encoded block.
         offset: u32,
@@ -92,6 +93,7 @@ pub enum PieceObject {
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
         /// Object hash
+        #[cfg_attr(feature = "serde", serde(with = "hex"))]
         hash: Blake3Hash,
         // TODO: This is a raw record offset, not a regular one
         /// Offset of the object in that piece
@@ -131,6 +133,7 @@ pub struct PieceObjectMapping {
 pub struct GlobalObject {
     /// Object hash.
     /// We order by hash, so object hash lookups can be performed efficiently.
+    #[cfg_attr(feature = "serde", serde(with = "hex"))]
     hash: Blake3Hash,
     /// Piece index where object is contained (at least its beginning, might not fit fully)
     piece_index: PieceIndex,

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -38,6 +38,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum BlockObject {
     /// V0 of object mapping data structure
+    // TODO: move the enum and accessor method to BlockObjectMapping
     #[codec(index = 0)]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {
@@ -89,6 +90,7 @@ pub struct BlockObjectMapping {
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum PieceObject {
     /// V0 of object mapping data structure
+    // TODO: move the enum and accessor method to PieceObjectMapping
     #[codec(index = 0)]
     #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
     V0 {

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -95,8 +95,7 @@ pub enum PieceObject {
         /// Object hash
         #[cfg_attr(feature = "serde", serde(with = "hex"))]
         hash: Blake3Hash,
-        // TODO: This is a raw record offset, not a regular one
-        /// Offset of the object in that piece
+        /// Raw record offset of the object in that piece, for use with `Record::to_raw_record_bytes`
         offset: u32,
     },
 }
@@ -109,7 +108,7 @@ impl PieceObject {
         }
     }
 
-    /// Offset of the object
+    /// Raw record offset of the object in that piece, for use with `Record::to_raw_record_bytes`
     pub fn offset(&self) -> u32 {
         match self {
             Self::V0 { offset, .. } => *offset,
@@ -134,36 +133,21 @@ pub struct GlobalObject {
     /// Object hash.
     /// We order by hash, so object hash lookups can be performed efficiently.
     #[cfg_attr(feature = "serde", serde(with = "hex"))]
-    hash: Blake3Hash,
+    pub hash: Blake3Hash,
     /// Piece index where object is contained (at least its beginning, might not fit fully)
-    piece_index: PieceIndex,
-    /// Offset of the object in that piece
-    offset: u32,
+    pub piece_index: PieceIndex,
+    /// Raw record offset of the object in that piece, for use with `Record::to_raw_record_bytes`
+    pub offset: u32,
 }
 
 impl GlobalObject {
-    /// Returns a newly created GlobalObject from its fields.
-    pub fn new(hash: Blake3Hash, piece_index: PieceIndex, offset: u32) -> Self {
+    /// Returns a newly created GlobalObject from a piece index and object.
+    pub fn new(piece_index: PieceIndex, piece_object: &PieceObject) -> Self {
         Self {
-            hash,
+            hash: piece_object.hash(),
             piece_index,
-            offset,
+            offset: piece_object.offset(),
         }
-    }
-
-    /// Object hash
-    pub fn hash(&self) -> Blake3Hash {
-        self.hash
-    }
-
-    /// Piece index where object is contained (at least its beginning, might not fit fully)
-    pub fn piece_index(&self) -> PieceIndex {
-        self.piece_index
-    }
-
-    /// Offset of the object
-    pub fn offset(&self) -> u32 {
-        self.offset
     }
 }
 

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -650,6 +650,15 @@ impl Record {
         // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
+
+    /// Convert from a record to its raw bytes. Used for object reconstruction.
+    pub fn to_raw_record_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        // We have zero byte padding from [`Scalar::SAFE_BYTES`] to [`Scalar::FULL_BYTES`] that we need
+        // to skip
+        self.iter()
+            .flat_map(|bytes| &bytes[..Scalar::SAFE_BYTES])
+            .copied()
+    }
 }
 
 /// Record commitment contained within a piece.

--- a/domains/pallets/transporter/src/benchmarking.rs
+++ b/domains/pallets/transporter/src/benchmarking.rs
@@ -1,8 +1,5 @@
 //! Benchmarking for `pallet-transporter`.
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
 use super::*;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;


### PR DESCRIPTION
This PR prepares for manual testing of the DSN data retrieval object mapping RPC by:

Extracting content-addressed mappings from system.remark extrinsics.

Fixing offset bugs:
- Convert raw offsets to regular offsets
- Provide access methods for both (some tests depend on raw offsets)

Reducing RPC response size:
- move the versioning outside the GlobalObject vector
- encode hashes as hex (todo: revise encoding after testing)
- split mappings into batches (todo: revise batch size after testing)

Improving lookup efficiency:
- order mappings by hash

Activating full archiving:
- using a compile-time cfg (todo: use a command-line option)

Some parts of the design need more changes, this PR is the proof of concept for initial testing.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
