### PR TITLE
Fix consensus runtime benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8132,6 +8132,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-messenger",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -25,7 +25,7 @@ use frame_support::traits::fungible::{Inspect, Mutate};
 use frame_support::traits::Hooks;
 use frame_support::weights::Weight;
 use frame_system::{Pallet as System, RawOrigin};
-use sp_core::crypto::UncheckedFrom;
+use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_core::ByteArray;
 use sp_domains::{
     dummy_opaque_bundle, BlockFees, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
@@ -568,20 +568,18 @@ mod benchmarks {
         let domain_id = register_domain::<T>();
         let operator_id = NextOperatorId::<T>::get();
         let (key, signature) = {
-            // Signing requires randomness which is not available in `no_std` environment so use
-            // a hard coded (key, signature) here
-
-            let key = OperatorPublicKey::from_slice(&[
-                114, 172, 2, 55, 186, 130, 245, 128, 64, 159, 70, 62, 237, 238, 168, 252, 145, 234,
-                106, 186, 63, 235, 44, 127, 164, 207, 14, 108, 184, 60, 50, 0,
-            ])
+            let key = OperatorPublicKey::from_ss58check(
+                "5Gv1Uopoqo1k7125oDtFSCmxH4DzuCiBU7HBKu2bF1GZFsEb",
+            )
             .unwrap();
 
+            // signature data included operator_account since result from `account` with same
+            // input is always deterministic
             let sig = OperatorSignature::from_slice(&[
-                226, 244, 36, 105, 120, 27, 189, 218, 101, 81, 252, 107, 144, 154, 27, 45, 71, 232,
-                230, 238, 111, 254, 196, 171, 93, 164, 92, 195, 200, 169, 205, 6, 108, 67, 213,
-                226, 158, 102, 187, 5, 93, 178, 231, 92, 84, 191, 117, 32, 177, 150, 196, 194, 208,
-                201, 163, 154, 209, 12, 182, 140, 179, 157, 211, 131,
+                88, 91, 154, 118, 137, 117, 109, 164, 232, 186, 101, 199, 94, 12, 91, 47, 228, 198,
+                61, 146, 200, 227, 152, 191, 205, 114, 81, 127, 192, 158, 48, 96, 211, 199, 237,
+                121, 170, 38, 118, 109, 3, 44, 198, 54, 155, 133, 240, 77, 200, 117, 107, 34, 248,
+                238, 144, 101, 200, 146, 20, 94, 180, 98, 40, 134,
             ])
             .unwrap();
             (key, sig)

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -567,6 +567,9 @@ mod benchmarks {
 
         let domain_id = register_domain::<T>();
         let operator_id = NextOperatorId::<T>::get();
+
+        // TODO: the `(key, signature)` is failed to verify in `cargo test --features runtime-benchmarks` but it
+        // will pass when doing the actual benchmark with `subspace-node benchmark pallet ...`, need more investigations.
         let (key, signature) = {
             let key = OperatorPublicKey::from_ss58check(
                 "5Gv1Uopoqo1k7125oDtFSCmxH4DzuCiBU7HBKu2bF1GZFsEb",

--- a/crates/subspace-runtime/Cargo.toml
+++ b/crates/subspace-runtime/Cargo.toml
@@ -149,10 +149,12 @@ runtime-benchmarks = [
     "pallet-collective/runtime-benchmarks",
     "pallet-domains/runtime-benchmarks",
     "pallet-mmr/runtime-benchmarks",
+    "pallet-messenger/runtime-benchmarks",
     "pallet-rewards/runtime-benchmarks",
     "pallet-runtime-configs/runtime-benchmarks",
     "pallet-subspace/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
+    "pallet-transporter/runtime-benchmarks",
     "pallet-utility/runtime-benchmarks",
     "sp-runtime/runtime-benchmarks",
 ]

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1110,6 +1110,8 @@ mod benches {
         [pallet_runtime_configs, RuntimeConfigs]
         [pallet_subspace, Subspace]
         [pallet_timestamp, Timestamp]
+        [pallet_messenger, Messenger]
+        [pallet_transporter, Transporter]
     );
 }
 

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -863,6 +863,7 @@ mod pallet {
                 max_outgoing_messages: 100,
                 fee_model,
             };
+            ChainAllowlist::<T>::mutate(|list| list.insert(dst_chain_id));
             let channel_id = Self::do_init_channel(dst_chain_id, init_params, None, true)?;
             Self::do_open_channel(dst_chain_id, channel_id)?;
             Ok(())

--- a/domains/pallets/transporter/Cargo.toml
+++ b/domains/pallets/transporter/Cargo.toml
@@ -52,6 +52,6 @@ runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
-    "sp-messenger/runtime-benchmarks",
     "pallet-messenger/runtime-benchmarks",
+    "sp-messenger/runtime-benchmarks",
 ]

--- a/domains/pallets/transporter/Cargo.toml
+++ b/domains/pallets/transporter/Cargo.toml
@@ -28,6 +28,7 @@ sp-std = { default-features = false, git = "https://github.com/subspace/polkadot
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
+pallet-messenger = { version = "0.1.0", path = "../messenger" }
 sp-io = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 
 [features]
@@ -52,4 +53,5 @@ runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
     "sp-messenger/runtime-benchmarks",
+    "pallet-messenger/runtime-benchmarks",
 ]

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -99,9 +99,7 @@ impl pallet_messenger::Config for MockRuntime {
     type DomainRegistration = DomainRegistration;
     type ChannelFeeModel = ChannelFeeModel;
     /// function to fetch endpoint response handler by Endpoint.
-    fn get_endpoint_handler(
-        #[allow(unused_variables)] endpoint: &Endpoint,
-    ) -> Option<Box<dyn EndpointHandler<MessageId>>> {
+    fn get_endpoint_handler(_endpoint: &Endpoint) -> Option<Box<dyn EndpointHandler<MessageId>>> {
         #[cfg(feature = "runtime-benchmarks")]
         return Some(Box::new(crate::EndpointHandler::<MockRuntime>(
             core::marker::PhantomData,


### PR DESCRIPTION
This PR brings some misc fixes to the consensus runtime benchmark
- In #2980, the `(key, signature)` pair used in the `register_operator` benchmark was replaced by a new `(key, signature)` pair because the old pair can't pass `cargo test --features runtime-benchmarks`, but turn out the new pair can't pass `subspace-node benchmark ...` while the old pair can, probably there is something (like the signing algorithm?) control by `--features runtime-benchmarks` causing this, I spent some time but didn't figure it out so just revert #2980 and add a TODO comment for now
- Add and fix the `pallet-messenger` and `pallet-transporter` benchmark in consensus runtime

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
