### PR TITLE
refactor: improve FarmerCache::get_piece

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -14,6 +14,7 @@ use subspace_farmer::KNOWN_PEERS_CACHE_SIZE;
 use subspace_networking::libp2p::identity::Keypair;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
+use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::strip_peer_id;
 use subspace_networking::{
     construct, Config, KademliaMode, KnownPeersManager, KnownPeersManagerConfig, Node, NodeRunner,
@@ -126,7 +127,7 @@ where
                 let farmer_cache = farmer_cache.clone();
 
                 async move {
-                    let piece_from_cache = farmer_cache.get_piece(piece_index).await;
+                    let piece_from_cache = farmer_cache.get_piece(piece_index.to_multihash()).await;
 
                     if let Some(piece) = piece_from_cache {
                         Some(PieceByIndexResponse { piece: Some(piece) })

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -12,10 +12,8 @@ use subspace_farmer::farmer_cache::FarmerCache;
 use subspace_farmer::node_client::NodeClientExt;
 use subspace_farmer::KNOWN_PEERS_CACHE_SIZE;
 use subspace_networking::libp2p::identity::Keypair;
-use subspace_networking::libp2p::kad::RecordKey;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
-use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::strip_peer_id;
 use subspace_networking::{
     construct, Config, KademliaMode, KnownPeersManager, KnownPeersManagerConfig, Node, NodeRunner,
@@ -128,8 +126,7 @@ where
                 let farmer_cache = farmer_cache.clone();
 
                 async move {
-                    let key = RecordKey::from(piece_index.to_multihash());
-                    let piece_from_cache = farmer_cache.get_piece(key).await;
+                    let piece_from_cache = farmer_cache.get_piece(piece_index).await;
 
                     if let Some(piece) = piece_from_cache {
                         Some(PieceByIndexResponse { piece: Some(piece) })

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -1059,8 +1059,11 @@ where
     }
 
     /// Get piece from cache
-    pub async fn get_piece(&self, piece_index: PieceIndex) -> Option<Piece> {
-        let key = RecordKey::from(piece_index.to_multihash());
+    pub async fn get_piece<Key>(&self, key: Key) -> Option<Piece>
+    where
+        RecordKey: From<Key>,
+    {
+        let key = RecordKey::from(key);
         let maybe_piece_found = {
             let caches = self.piece_caches.read().await;
 

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -1059,7 +1059,8 @@ where
     }
 
     /// Get piece from cache
-    pub async fn get_piece(&self, key: RecordKey) -> Option<Piece> {
+    pub async fn get_piece(&self, piece_index: PieceIndex) -> Option<Piece> {
+        let key = RecordKey::from(piece_index.to_multihash());
         let maybe_piece_found = {
             let caches = self.piece_caches.read().await;
 

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -17,8 +17,6 @@ use subspace_core_primitives::{
 };
 use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_networking::libp2p::identity;
-use subspace_networking::libp2p::kad::RecordKey;
-use subspace_networking::utils::multihash::ToMultihash;
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -227,17 +225,11 @@ async fn basic() {
             assert_eq!(requested_pieces, expected_pieces);
 
             for piece_index in requested_pieces {
-                farmer_cache
-                    .get_piece(RecordKey::from(piece_index.to_multihash()))
-                    .await
-                    .unwrap();
+                farmer_cache.get_piece(piece_index).await.unwrap();
             }
 
             // Other piece indices are not requested or cached
-            assert!(farmer_cache
-                .get_piece(RecordKey::from(PieceIndex::from(10).to_multihash()))
-                .await
-                .is_none());
+            assert!(farmer_cache.get_piece(PieceIndex::from(10)).await.is_none());
         }
 
         // Update current segment header such that we keep-up after initial sync is triggered
@@ -294,19 +286,13 @@ async fn basic() {
 
             let stored_pieces = vec![PieceIndex::from(196), PieceIndex::from(276)];
             for piece_index in &stored_pieces {
-                farmer_cache
-                    .get_piece(RecordKey::from(piece_index.to_multihash()))
-                    .await
-                    .unwrap();
+                farmer_cache.get_piece(*piece_index).await.unwrap();
             }
 
             for piece_index in requested_pieces {
                 if !stored_pieces.contains(&piece_index) {
                     // Other piece indices are not stored anymore
-                    assert!(farmer_cache
-                        .get_piece(RecordKey::from(PieceIndex::from(10).to_multihash()))
-                        .await
-                        .is_none());
+                    assert!(farmer_cache.get_piece(PieceIndex::from(10)).await.is_none());
                 }
             }
         }
@@ -360,19 +346,13 @@ async fn basic() {
 
             let stored_pieces = vec![PieceIndex::from(823), PieceIndex::from(859)];
             for piece_index in &stored_pieces {
-                farmer_cache
-                    .get_piece(RecordKey::from(piece_index.to_multihash()))
-                    .await
-                    .unwrap();
+                farmer_cache.get_piece(*piece_index).await.unwrap();
             }
 
             for piece_index in requested_pieces {
                 if !stored_pieces.contains(&piece_index) {
                     // Other piece indices are not stored anymore
-                    assert!(farmer_cache
-                        .get_piece(RecordKey::from(PieceIndex::from(10).to_multihash()))
-                        .await
-                        .is_none());
+                    assert!(farmer_cache.get_piece(PieceIndex::from(10)).await.is_none());
                 }
             }
         }

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -17,6 +17,7 @@ use subspace_core_primitives::{
 };
 use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_networking::libp2p::identity;
+use subspace_networking::utils::multihash::ToMultihash;
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
@@ -225,11 +226,17 @@ async fn basic() {
             assert_eq!(requested_pieces, expected_pieces);
 
             for piece_index in requested_pieces {
-                farmer_cache.get_piece(piece_index).await.unwrap();
+                farmer_cache
+                    .get_piece(piece_index.to_multihash())
+                    .await
+                    .unwrap();
             }
 
             // Other piece indices are not requested or cached
-            assert!(farmer_cache.get_piece(PieceIndex::from(10)).await.is_none());
+            assert!(farmer_cache
+                .get_piece(PieceIndex::from(10).to_multihash())
+                .await
+                .is_none());
         }
 
         // Update current segment header such that we keep-up after initial sync is triggered
@@ -286,13 +293,19 @@ async fn basic() {
 
             let stored_pieces = vec![PieceIndex::from(196), PieceIndex::from(276)];
             for piece_index in &stored_pieces {
-                farmer_cache.get_piece(*piece_index).await.unwrap();
+                farmer_cache
+                    .get_piece(piece_index.to_multihash())
+                    .await
+                    .unwrap();
             }
 
             for piece_index in requested_pieces {
                 if !stored_pieces.contains(&piece_index) {
                     // Other piece indices are not stored anymore
-                    assert!(farmer_cache.get_piece(PieceIndex::from(10)).await.is_none());
+                    assert!(farmer_cache
+                        .get_piece(PieceIndex::from(10).to_multihash())
+                        .await
+                        .is_none());
                 }
             }
         }
@@ -346,13 +359,19 @@ async fn basic() {
 
             let stored_pieces = vec![PieceIndex::from(823), PieceIndex::from(859)];
             for piece_index in &stored_pieces {
-                farmer_cache.get_piece(*piece_index).await.unwrap();
+                farmer_cache
+                    .get_piece(piece_index.to_multihash())
+                    .await
+                    .unwrap();
             }
 
             for piece_index in requested_pieces {
                 if !stored_pieces.contains(&piece_index) {
                     // Other piece indices are not stored anymore
-                    assert!(farmer_cache.get_piece(PieceIndex::from(10)).await.is_none());
+                    assert!(farmer_cache
+                        .get_piece(PieceIndex::from(10).to_multihash())
+                        .await
+                        .is_none());
                 }
             }
         }

--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Weak};
 use subspace_core_primitives::{Piece, PieceIndex};
 use subspace_farmer_components::PieceGetter;
+use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
 use tracing::{debug, error, trace};
 
@@ -196,7 +197,11 @@ where
         let inner = &self.inner;
 
         trace!(%piece_index, "Getting piece from farmer cache");
-        if let Some(piece) = inner.farmer_cache.get_piece(piece_index).await {
+        if let Some(piece) = inner
+            .farmer_cache
+            .get_piece(piece_index.to_multihash())
+            .await
+        {
             trace!(%piece_index, "Got piece from farmer cache successfully");
             return Some(piece);
         }

--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -20,8 +20,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Weak};
 use subspace_core_primitives::{Piece, PieceIndex};
 use subspace_farmer_components::PieceGetter;
-use subspace_networking::libp2p::kad::RecordKey;
-use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
 use tracing::{debug, error, trace};
 
@@ -195,12 +193,10 @@ where
     }
 
     async fn get_piece_fast_internal(&self, piece_index: PieceIndex) -> Option<Piece> {
-        let key = RecordKey::from(piece_index.to_multihash());
-
         let inner = &self.inner;
 
         trace!(%piece_index, "Getting piece from farmer cache");
-        if let Some(piece) = inner.farmer_cache.get_piece(key).await {
+        if let Some(piece) = inner.farmer_cache.get_piece(piece_index).await {
             trace!(%piece_index, "Got piece from farmer cache successfully");
             return Some(piece);
         }


### PR DESCRIPTION
All calls manually convert the PieceIndex to a RecordKey. In this case, it doesn't make sense to set the get_piece method's argument to a RecordKey. It is more flexible and efficient to use the PieceIndex directly and do the type conversion internally.

#2960  benefit from this pr.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
