### PR TITLE
Add benchmark for the `set_pot_slot_iterations` extrinsic

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -269,7 +269,7 @@ pub mod pallet {
         pub(super) entropy: Blake3Hash,
     }
 
-    #[derive(Debug, Copy, Clone, Encode, Decode, TypeInfo)]
+    #[derive(Debug, Copy, Clone, Encode, Decode, TypeInfo, PartialEq)]
     pub(super) struct PotSlotIterationsUpdateValue {
         /// Target slot at which entropy should be injected (when known)
         pub(super) target_slot: Option<Slot>,


### PR DESCRIPTION
This PR adds the missing benchmark for the `set_pot_slot_iterations` extrinsic

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
