### PR TITLE
Skip adding XDM to the tx pool during major sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "sc-utils",
  "sp-api",
  "sp-blockchain",
+ "sp-consensus",
  "sp-core",
  "sp-domains",
  "sp-messenger",

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -316,6 +316,7 @@ fn main() -> Result<(), Error> {
 
             let consensus_network_service = consensus_chain_node.network_service.clone();
             let consensus_task_spawn_essential_handler = consensus_chain_node.task_manager.spawn_essential_handle();
+            let consensus_sync_service = consensus_chain_node.sync_service.clone();
             consensus_chain_node
                 .task_manager
                 .spawn_essential_handle()
@@ -352,6 +353,7 @@ fn main() -> Result<(), Error> {
                                         _,
                                         DomainBlock,
                                         _,
+                                        _,
                                     >(
                                         ChainId::Consensus,
                                         consensus_chain_node.client.clone(),
@@ -359,7 +361,8 @@ fn main() -> Result<(), Error> {
                                         consensus_chain_node.transaction_pool.clone(),
                                         consensus_network_service,
                                         consensus_msg_receiver,
-                                        domain_code_executor
+                                        domain_code_executor,
+                                        consensus_sync_service,
                                     );
 
                                 consensus_task_spawn_essential_handler

--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -234,6 +234,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                                 _,
                                 DomainBlock,
                                 _,
+                                _,
                             >(
                                 ChainId::Consensus,
                                 consensus_chain_node.client.clone(),
@@ -242,6 +243,7 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                                 consensus_chain_node.network_service.clone(),
                                 consensus_msg_receiver,
                                 domain_code_executor.into(),
+                                consensus_chain_node.sync_service.clone(),
                             ),
                         ),
                     );

--- a/domains/client/cross-domain-message-gossip/Cargo.toml
+++ b/domains/client/cross-domain-message-gossip/Cargo.toml
@@ -25,6 +25,7 @@ sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", re
 sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 sp-blockchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
+sp-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -500,7 +500,7 @@ where
                 client.clone(),
                 // domain will use consensus chain sync oracle instead of domain sync oracle
                 // since domain sync oracle will always return `synced` due to force sync being set.
-                consensus_network_sync_oracle,
+                consensus_network_sync_oracle.clone(),
                 gossip_message_sink,
             );
 
@@ -512,16 +512,25 @@ where
     }
 
     // Start cross domain message listener for domain
-    let domain_listener =
-        cross_domain_message_gossip::start_cross_chain_message_listener::<_, _, _, _, _, Block, _>(
-            ChainId::Domain(domain_id),
-            consensus_client.clone(),
-            client.clone(),
-            params.transaction_pool.clone(),
-            consensus_network,
-            domain_message_receiver,
-            code_executor.clone(),
-        );
+    let domain_listener = cross_domain_message_gossip::start_cross_chain_message_listener::<
+        _,
+        _,
+        _,
+        _,
+        _,
+        Block,
+        _,
+        _,
+    >(
+        ChainId::Domain(domain_id),
+        consensus_client.clone(),
+        client.clone(),
+        params.transaction_pool.clone(),
+        consensus_network,
+        domain_message_receiver,
+        code_executor.clone(),
+        consensus_network_sync_oracle,
+    );
 
     spawn_essential.spawn_essential_blocking(
         "domain-message-listener",

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -524,6 +524,7 @@ impl MockConsensusNode {
             _,
             DomainBlock,
             _,
+            _,
         >(
             ChainId::Consensus,
             client.clone(),
@@ -532,6 +533,7 @@ impl MockConsensusNode {
             network_service.clone(),
             consensus_msg_receiver,
             domain_executor,
+            sync_service.clone(),
         );
 
         task_manager


### PR DESCRIPTION
Without this change, the domain node will keep receiving XDM, validating XDM, and fail (since the XDM is not valid in the old state).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
