### PR TITLE
Serialize DSN mappings as a compact tuple

### DIFF
--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -83,6 +83,7 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
 pub type Blake3Hash = [u8; BLAKE3_HASH_SIZE];
 
 /// BLAKE3 hash output wrapper, which serializes it as a hex string
+// TODO: rename this type to Blake3Hash into a newtype, after checking for any breaking changes
 #[derive(
     Debug,
     Default,

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -82,6 +82,30 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
 /// BLAKE3 hash output
 pub type Blake3Hash = [u8; BLAKE3_HASH_SIZE];
 
+/// BLAKE3 hash output wrapper, which serializes it as a hex string
+#[derive(
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    From,
+    Into,
+    Deref,
+    DerefMut,
+    Encode,
+    Decode,
+    TypeInfo,
+    MaxEncodedLen,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Blake3HashHex(#[cfg_attr(feature = "serde", serde(with = "hex"))] Blake3Hash);
+
 /// Type of randomness.
 #[derive(
     Debug,


### PR DESCRIPTION
This PR reduces the size of serialized DSN mappings by removing field labels.

Currently, each mapping response has the same field labels:
> {"jsonrpc":"2.0","method":"subspace_archived_object_mappings","params":{"subscription":"8t473lH1zriHDOoT","result":{"v0":{"objects":[{"hash":"0000000000000000000000000000000000000000000000000000000000000000","pieceIndex":0,"offset":0}]}}}}

But after this PR, those labels are removed:
> {"jsonrpc":"2.0","method":"subspace_archived_object_mappings","params":{"subscription":"8t473lH1zriHDOoT","result":{"v0":{"objects":[["0000000000000000000000000000000000000000000000000000000000000000",0,0]]}}}}

This saves approximately 29 bytes per mapping.

### Alternatives

It might be possible to make the mappings even smaller by encoding their data as binary, then hex-encoding them. But that would make some mappings larger. For example, the all-zeroes mapping above would be 20 bytes larger.

Decimal integers are already a compact encoding, so converting them to a different compact encoding, then hex-encoding them, won't save much space.

These alternatives would also make the mappings harder to debug.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
