### PR TITLE
Split DSN mapping RPC into a piece index subscription and full mapping method

### DIFF
--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -183,7 +183,8 @@ pub struct NewArchivedSegment {
 }
 
 impl NewArchivedSegment {
-    /// Returns all the object mappings in this archived segment as a lazy iterator.
+    /// Returns all the object mappings in this archived segment as a lazy iterator,
+    /// in archived order.
     pub fn global_object_mappings(&self) -> impl Iterator<Item = GlobalObject> + 'static {
         // Save memory by only returning the necessary parts of NewArchivedSegment
         let object_mapping = self.object_mapping.clone();


### PR DESCRIPTION
This PR makes large volumes of DSN mappings easier to retrieve, by:
- changing the subscription to return a list of piece indexes that contain mappings
- adding a method that takes a piece index range, and returns all mappings in that range

To implement this method, the PR also adds a mapping cache, which uses around 44 bytes per cached mapping. We can make the cache limits user adjustable in a future PR, and set better defaults there.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
