### PR TITLE
Fix records encoding

### DIFF
--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -650,8 +650,8 @@ fn record_encoding<PosTable>(
         .drain(..)
         .zip(encoded_chunks_used.iter_mut())
         .filter_map(|(maybe_encoded_chunk, mut encoded_chunk_used)| {
-            // Last byte's bits all set to 1 represents missing proof, see above
-            if maybe_encoded_chunk[31] == u8::MAX {
+            // All bits set means no proof, see above
+            if maybe_encoded_chunk == [u8::MAX; Scalar::FULL_BYTES] {
                 None
             } else {
                 *encoded_chunk_used = true;


### PR DESCRIPTION
In some of the refactorings a check was done incorrectly in the plotting code that resulted in some sectors being plotted incorrectly.

The reason is that only one byte was checked even though the source was the result of XOR and it was possible for valid chunk to have all bits set in the last byte as well.

To smooth the impact of this I implemented scheduling of the sector for replotting when proving error is detected, such that farmer will slowly start fixing itself over time.

This issue was discovered as part of GPU plotting implementation when some of the plotting outputs were not matching expectations.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
