### PR TITLE
CPU plotting CLI refactoring

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -60,6 +60,77 @@ const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);
 
 type CacheIndex = u8;
 
+#[derive(Debug, Parser)]
+struct CpuPlottingOptions {
+    /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
+    /// the plotting process, defaults to `--sector-encoding-concurrency` + 1 to download future
+    /// sector ahead of time.
+    ///
+    /// Increase will result in higher memory usage.
+    #[arg(long)]
+    sector_downloading_concurrency: Option<NonZeroUsize>,
+    /// Defines how many sectors farmer will encode concurrently, defaults to 1 on UMA system and
+    /// number of NUMA nodes on NUMA system or L3 cache groups on large CPUs. It is further
+    /// restricted by
+    /// `--sector-downloading-concurrency` and setting this option higher than
+    /// `--sector-downloading-concurrency` will have no effect.
+    ///
+    /// Increase will result in higher memory usage.
+    #[arg(long)]
+    sector_encoding_concurrency: Option<NonZeroUsize>,
+    /// Defines how many records farmer will encode in a single sector concurrently, defaults to one
+    /// record per 2 cores, but not more than 8 in total. Higher concurrency means higher memory
+    /// usage and typically more efficient CPU utilization.
+    #[arg(long)]
+    record_encoding_concurrency: Option<NonZeroUsize>,
+    /// Size of one thread pool used for plotting, defaults to number of logical CPUs available
+    /// on UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
+    /// groups on large CPUs.
+    ///
+    /// Number of thread pools is defined by `--sector-encoding-concurrency` option, different
+    /// thread pools might have different number of threads if NUMA nodes do not have the same size.
+    ///
+    /// Threads will be pinned to corresponding CPU cores at creation.
+    #[arg(long)]
+    plotting_thread_pool_size: Option<NonZeroUsize>,
+    /// Specify exact CPU cores to be used for plotting bypassing any custom logic farmer might use
+    /// otherwise. It replaces both `--sector-encoding-concurrency` and
+    /// `--plotting-thread-pool-size` options if specified. Requires `--replotting-cpu-cores` to be
+    /// specified with the same number of CPU cores groups (or not specified at all, in which case
+    /// it'll use the same thread pool as plotting).
+    ///
+    /// Cores are coma-separated, with whitespace separating different thread pools/encoding
+    /// instances. For example "0,1 2,3" will result in two sectors being encoded at the same time,
+    /// each with a pair of CPU cores.
+    #[arg(long, conflicts_with_all = & ["sector_encoding_concurrency", "plotting_thread_pool_size"])]
+    plotting_cpu_cores: Option<String>,
+    /// Size of one thread pool used for replotting, typically smaller pool than for plotting
+    /// to not affect farming as much, defaults to half of the number of logical CPUs available on
+    /// UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
+    /// groups on large CPUs.
+    ///
+    /// Number of thread pools is defined by `--sector-encoding-concurrency` option, different
+    /// thread pools might have different number of threads if NUMA nodes do not have the same size.
+    ///
+    /// Threads will be pinned to corresponding CPU cores at creation.
+    #[arg(long)]
+    replotting_thread_pool_size: Option<NonZeroUsize>,
+    /// Specify exact CPU cores to be used for replotting bypassing any custom logic farmer might
+    /// use otherwise. It replaces `--replotting-thread_pool_size` options if specified. Requires
+    /// `--plotting-cpu-cores` to be specified with the same number of CPU cores groups.
+    ///
+    /// Cores are coma-separated, with whitespace separating different thread pools/encoding
+    /// instances. For example "0,1 2,3" will result in two sectors being encoded at the same time,
+    /// each with a pair of CPU cores.
+    #[arg(long, conflicts_with_all = & ["sector_encoding_concurrency", "replotting_thread_pool_size"])]
+    replotting_cpu_cores: Option<String>,
+    /// Plotting thread priority, by default de-prioritizes plotting threads in order to make sure
+    /// farming is successful and computer can be used comfortably for other things.  Can be set to
+    /// "min", "max" or "default".
+    #[arg(long, default_value_t = PlottingThreadPriority::Min)]
+    plotting_thread_priority: PlottingThreadPriority,
+}
+
 /// Arguments for farmer
 #[derive(Debug, Parser)]
 pub(crate) struct FarmingArgs {
@@ -120,79 +191,15 @@ pub(crate) struct FarmingArgs {
     /// Increase will result in higher memory usage.
     #[arg(long, default_value = "128")]
     piece_getter_concurrency: NonZeroUsize,
-    /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
-    /// the plotting process, defaults to `--sector-encoding-concurrency` + 1 to download future
-    /// sector ahead of time.
-    ///
-    /// Increase will result in higher memory usage.
-    #[arg(long)]
-    sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Defines how many sectors farmer will encode concurrently, defaults to 1 on UMA system and
-    /// number of NUMA nodes on NUMA system or L3 cache groups on large CPUs. It is further
-    /// restricted by
-    /// `--sector-downloading-concurrency` and setting this option higher than
-    /// `--sector-downloading-concurrency` will have no effect.
-    ///
-    /// Increase will result in higher memory usage.
-    #[arg(long)]
-    sector_encoding_concurrency: Option<NonZeroUsize>,
-    /// Defines how many records farmer will encode in a single sector concurrently, defaults to one
-    /// record per 2 cores, but not more than 8 in total. Higher concurrency means higher memory
-    /// usage and typically more efficient CPU utilization.
-    #[arg(long)]
-    record_encoding_concurrency: Option<NonZeroUsize>,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
     /// compute-intensive operations during proving), defaults to number of logical CPUs
     /// available on UMA system and number of logical CPUs in first NUMA node on NUMA system, but
     /// not more than 32 threads
     #[arg(long)]
     farming_thread_pool_size: Option<NonZeroUsize>,
-    /// Size of one thread pool used for plotting, defaults to number of logical CPUs available
-    /// on UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
-    /// groups on large CPUs.
-    ///
-    /// Number of thread pools is defined by `--sector-encoding-concurrency` option, different
-    /// thread pools might have different number of threads if NUMA nodes do not have the same size.
-    ///
-    /// Threads will be pinned to corresponding CPU cores at creation.
-    #[arg(long)]
-    plotting_thread_pool_size: Option<NonZeroUsize>,
-    /// Specify exact CPU cores to be used for plotting bypassing any custom logic farmer might use
-    /// otherwise. It replaces both `--sector-encoding-concurrency` and
-    /// `--plotting-thread-pool-size` options if specified. Requires `--replotting-cpu-cores` to be
-    /// specified with the same number of CPU cores groups (or not specified at all, in which case
-    /// it'll use the same thread pool as plotting).
-    ///
-    /// Cores are coma-separated, with whitespace separating different thread pools/encoding
-    /// instances. For example "0,1 2,3" will result in two sectors being encoded at the same time,
-    /// each with a pair of CPU cores.
-    #[arg(long, conflicts_with_all = & ["sector_encoding_concurrency", "plotting_thread_pool_size"])]
-    plotting_cpu_cores: Option<String>,
-    /// Size of one thread pool used for replotting, typically smaller pool than for plotting
-    /// to not affect farming as much, defaults to half of the number of logical CPUs available on
-    /// UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
-    /// groups on large CPUs.
-    ///
-    /// Number of thread pools is defined by `--sector-encoding-concurrency` option, different
-    /// thread pools might have different number of threads if NUMA nodes do not have the same size.
-    ///
-    /// Threads will be pinned to corresponding CPU cores at creation.
-    #[arg(long)]
-    replotting_thread_pool_size: Option<NonZeroUsize>,
-    /// Specify exact CPU cores to be used for replotting bypassing any custom logic farmer might
-    /// use otherwise. It replaces `--replotting-thread_pool_size` options if specified. Requires
-    /// `--plotting-cpu-cores` to be specified with the same number of CPU cores groups.
-    ///
-    /// Cores are coma-separated, with whitespace separating different thread pools/encoding
-    /// instances. For example "0,1 2,3" will result in two sectors being encoded at the same time,
-    /// each with a pair of CPU cores.
-    #[arg(long, conflicts_with_all = & ["sector_encoding_concurrency", "replotting_thread_pool_size"])]
-    replotting_cpu_cores: Option<String>,
-    /// Plotting thread priority, by default de-prioritizes plotting threads in order to make sure
-    /// farming is successful and computer can be used comfortably for other things.  Can be set to
-    /// "min", "max" or "default".
-    #[arg(long, default_value_t = PlottingThreadPriority::Min)]
-    plotting_thread_priority: PlottingThreadPriority,
+    /// Plotting options only used by CPU plotter
+    #[clap(flatten)]
+    cpu_plotting_options: CpuPlottingOptions,
     /// Enable plot cache.
     ///
     /// Plot cache uses unplotted space as additional cache improving plotting speeds, especially
@@ -248,20 +255,24 @@ where
         mut disk_farms,
         prometheus_listen_on,
         piece_getter_concurrency,
-        sector_downloading_concurrency,
-        sector_encoding_concurrency,
-        record_encoding_concurrency,
         farming_thread_pool_size,
-        plotting_thread_pool_size,
-        plotting_cpu_cores,
-        replotting_thread_pool_size,
-        replotting_cpu_cores,
-        plotting_thread_priority,
+        cpu_plotting_options,
         plot_cache,
         disable_farm_locking,
         create,
         exit_on_farm_error,
     } = farming_args;
+
+    let CpuPlottingOptions {
+        sector_downloading_concurrency,
+        sector_encoding_concurrency,
+        record_encoding_concurrency,
+        plotting_thread_pool_size,
+        plotting_cpu_cores,
+        replotting_thread_pool_size,
+        replotting_cpu_cores,
+        plotting_thread_priority,
+    } = cpu_plotting_options;
 
     let plot_cache = plot_cache.unwrap_or_else(|| {
         !cfg!(windows)

--- a/crates/subspace-farmer/src/plotter/pool.rs
+++ b/crates/subspace-farmer/src/plotter/pool.rs
@@ -14,13 +14,13 @@ use tracing::{error, trace};
 /// This plotter implementation relies on retries and should only be used with local plotter
 /// implementations (like CPU and GPU).
 #[derive(Debug)]
-pub struct AggregatePlotter {
+pub struct PoolPlotter {
     plotters: Vec<Box<dyn Plotter + Send + Sync>>,
     retry_interval: Duration,
 }
 
 #[async_trait]
-impl Plotter for AggregatePlotter {
+impl Plotter for PoolPlotter {
     async fn has_free_capacity(&self) -> Result<bool, String> {
         for (index, plotter) in self.plotters.iter().enumerate() {
             match plotter.has_free_capacity().await {
@@ -106,7 +106,7 @@ impl Plotter for AggregatePlotter {
     }
 }
 
-impl AggregatePlotter {
+impl PoolPlotter {
     /// Create new instance
     pub fn new(plotters: Vec<Box<dyn Plotter + Send + Sync>>, retry_interval: Duration) -> Self {
         Self {


### PR DESCRIPTION
This changes CLI interface of the farmer when it comes to plotting options.

All CPU-specific plotting options in CLI are moved into a separate data structure and prefixed with `--cpu` to distinguish them from GPU plotting options that will be introduced later.

Also CPU plotting initialization was extracted into a separate function so it is easier to compose it later. Most of the commits simply move code around with no other changes.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
