### PR TITLE
Improve PoS performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12900,6 +12900,7 @@ dependencies = [
  "seq-macro",
  "sha2 0.10.8",
  "spin 0.9.8",
+ "static_assertions",
  "subspace-chiapos",
  "subspace-core-primitives",
 ]

--- a/crates/subspace-proof-of-space/Cargo.toml
+++ b/crates/subspace-proof-of-space/Cargo.toml
@@ -24,6 +24,7 @@ seq-macro = "0.3.5"
 sha2 = { version = "0.10.7", default-features = false }
 # Replacement for `parking_lot` in `no_std` environment
 spin = "0.9.7"
+static_assertions = "1.1.0"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives", default-features = false }
 
 [dev-dependencies]

--- a/crates/subspace-proof-of-space/src/chiapos/table.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table.rs
@@ -151,7 +151,7 @@ impl<const K: u8> Default for TablesCache<K> {
 }
 
 #[derive(Debug)]
-pub(super) struct Match {
+struct Match {
     left_position: Position,
     left_y: Y,
     right_position: Position,

--- a/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/tests.rs
@@ -139,15 +139,18 @@ fn test_matches() {
         right_bucket_ys.sort_unstable();
         right_bucket_ys.reverse();
 
-        let matches = find_matches(
+        let mut matches = Vec::new();
+        find_matches(
             &left_bucket_ys,
             Position::ZERO,
             &right_bucket_ys,
             Position::ZERO,
             &mut rmap_scratch,
             &left_targets,
+            |m| m,
+            &mut matches,
         );
-        for m in matches.unwrap() {
+        for m in matches {
             let yl = usize::from(*left_bucket_ys.get(usize::from(m.left_position)).unwrap());
             let yr = usize::from(*right_bucket_ys.get(usize::from(m.right_position)).unwrap());
 

--- a/crates/subspace-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/subspace-proof-of-space/src/chiapos/table/types.rs
@@ -12,32 +12,38 @@ use derive_more::{Add, AddAssign, From, Into};
 pub(in super::super) struct X(u32);
 
 impl Step for X {
+    #[inline(always)]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u32::steps_between(&start.0, &end.0)
     }
 
+    #[inline(always)]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u32::forward_checked(start.0, count).map(Self)
     }
 
+    #[inline(always)]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u32::backward_checked(start.0, count).map(Self)
     }
 }
 
 impl From<X> for u64 {
+    #[inline(always)]
     fn from(value: X) -> Self {
         Self::from(value.0)
     }
 }
 
 impl From<X> for u128 {
+    #[inline(always)]
     fn from(value: X) -> Self {
         Self::from(value.0)
     }
 }
 
 impl From<X> for usize {
+    #[inline(always)]
     fn from(value: X) -> Self {
         value.0 as Self
     }
@@ -56,12 +62,14 @@ impl X {
 pub(in super::super) struct Y(u32);
 
 impl From<Y> for u128 {
+    #[inline(always)]
     fn from(value: Y) -> Self {
         Self::from(value.0)
     }
 }
 
 impl From<Y> for usize {
+    #[inline(always)]
     fn from(value: Y) -> Self {
         value.0 as Self
     }
@@ -80,20 +88,24 @@ impl Y {
 pub(in super::super) struct Position(u32);
 
 impl Step for Position {
+    #[inline(always)]
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u32::steps_between(&start.0, &end.0)
     }
 
+    #[inline(always)]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u32::forward_checked(start.0, count).map(Self)
     }
 
+    #[inline(always)]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u32::backward_checked(start.0, count).map(Self)
     }
 }
 
 impl From<Position> for usize {
+    #[inline(always)]
     fn from(value: Position) -> Self {
         value.0 as Self
     }
@@ -117,6 +129,7 @@ impl<const K: u8, const TABLE_NUMBER: u8> Default for Metadata<K, TABLE_NUMBER>
 where
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
 {
+    #[inline(always)]
     fn default() -> Self {
         Self([0; metadata_size_bytes(K, TABLE_NUMBER)])
     }
@@ -154,6 +167,7 @@ impl<const K: u8, const TABLE_NUMBER: u8> From<X> for Metadata<K, TABLE_NUMBER>
 where
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
 {
+    #[inline(always)]
     fn from(value: X) -> Self {
         Self::from(u128::from(value))
     }


### PR DESCRIPTION
Found a few more optimizations that speed up both proving and verification.

Before:
```
chia/table/parallel/8x  time:   [1.2842 s 1.2958 s 1.3070 s]
chia/verification       time:   [11.420 µs 11.438 µs 11.461 µs]
```

After:
```
chia/table/parallel/8x  time:   [1.0766 s 1.0850 s 1.0932 s]
chia/verification       time:   [11.215 µs 11.220 µs 11.226 µs]
```

Each commit introduces a non-negligible performance improvement.

Proving improvement is thanks to simpler code that is very favorable for modern CPUs with very long internal pipelines.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
