### PR TITLE
Support shared hold id to have constant number of hold id

### DIFF
--- a/crates/pallet-domains/src/bundle_storage_fund.rs
+++ b/crates/pallet-domains/src/bundle_storage_fund.rs
@@ -27,6 +27,7 @@ pub enum Error {
     FailToDeposit,
     WithdrawAndHold,
     BalanceTransfer,
+    FailToWithdraw,
 }
 
 /// The type of system account being created.
@@ -184,7 +185,7 @@ pub fn withdraw_and_hold<T: Config>(
     }
 
     let storage_fund_acc = storage_fund_account::<T>(operator_id);
-    let storage_fund_hold_id = T::HoldIdentifier::storage_fund_withdrawal(operator_id);
+    let storage_fund_hold_id = T::HoldIdentifier::storage_fund_withdrawal();
     T::Currency::transfer_and_hold(
         &storage_fund_hold_id,
         &storage_fund_acc,

--- a/crates/pallet-domains/src/bundle_storage_fund.rs
+++ b/crates/pallet-domains/src/bundle_storage_fund.rs
@@ -197,6 +197,27 @@ pub fn withdraw_and_hold<T: Config>(
     .map_err(|_| Error::WithdrawAndHold)
 }
 
+/// Transfer the given `withdraw_amount` of balance from the bundle storage fund to the
+/// given `dest_account`
+pub fn withdraw_to<T: Config>(
+    operator_id: OperatorId,
+    dest_account: &T::AccountId,
+    withdraw_amount: BalanceOf<T>,
+) -> Result<BalanceOf<T>, Error> {
+    if withdraw_amount.is_zero() {
+        return Ok(Zero::zero());
+    }
+
+    let storage_fund_acc = storage_fund_account::<T>(operator_id);
+    T::Currency::transfer(
+        &storage_fund_acc,
+        dest_account,
+        withdraw_amount,
+        Preservation::Expendable,
+    )
+    .map_err(|_| Error::FailToWithdraw)
+}
+
 /// Return the total balance of the bundle storage fund the given `operator_id`
 pub fn total_balance<T: Config>(operator_id: OperatorId) -> BalanceOf<T> {
     let storage_fund_acc = storage_fund_account::<T>(operator_id);

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -97,7 +97,7 @@ pub(crate) type FungibleHoldId<T> =
 pub(crate) type NominatorId<T> = <T as frame_system::Config>::AccountId;
 
 pub trait HoldIdentifier<T: Config> {
-    fn staking_staked(operator_id: OperatorId) -> FungibleHoldId<T>;
+    fn staking_staked() -> FungibleHoldId<T>;
     fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<T>;
     fn storage_fund_withdrawal() -> FungibleHoldId<T>;
 }
@@ -544,6 +544,11 @@ mod pallet {
         Withdrawal<BalanceOf<T>, T::Share, DomainBlockNumberFor<T>>,
         OptionQuery,
     >;
+
+    /// The amount of balance the nominator hold for a given operator
+    #[pallet::storage]
+    pub(super) type DepositOnHold<T: Config> =
+        StorageMap<_, Identity, (OperatorId, NominatorId<T>), BalanceOf<T>, ValueQuery>;
 
     /// Tracks the nominator count under given operator.
     /// This storage is necessary since CountedStorageNMap does not support prefix key count, so

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -98,7 +98,7 @@ pub(crate) type NominatorId<T> = <T as frame_system::Config>::AccountId;
 
 pub trait HoldIdentifier<T: Config> {
     fn staking_staked() -> FungibleHoldId<T>;
-    fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<T>;
+    fn domain_instantiation_id() -> FungibleHoldId<T>;
     fn storage_fund_withdrawal() -> FungibleHoldId<T>;
 }
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -99,7 +99,7 @@ pub(crate) type NominatorId<T> = <T as frame_system::Config>::AccountId;
 pub trait HoldIdentifier<T: Config> {
     fn staking_staked(operator_id: OperatorId) -> FungibleHoldId<T>;
     fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<T>;
-    fn storage_fund_withdrawal(operator_id: OperatorId) -> FungibleHoldId<T>;
+    fn storage_fund_withdrawal() -> FungibleHoldId<T>;
 }
 
 pub trait BlockSlot<T: frame_system::Config> {

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1184,7 +1184,7 @@ pub(crate) fn do_unlock_nominator<T: Config>(
             .checked_add(&deposit.known.storage_fee_deposit)
             .ok_or(Error::BalanceOverflow)?;
 
-        bundle_storage_fund::withdraw_and_hold::<T>(
+        bundle_storage_fund::withdraw_to::<T>(
             operator_id,
             &nominator_id,
             storage_fund_redeem_price.redeem(nominator_total_storage_fee_deposit),

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1495,6 +1495,7 @@ pub(crate) mod tests {
                 genesis_receipt_hash: Default::default(),
                 domain_config,
                 domain_runtime_info: Default::default(),
+                domain_instantiation_deposit: Default::default(),
             };
 
             DomainRegistry::<Test>::insert(domain_id, domain_obj);
@@ -1891,6 +1892,7 @@ pub(crate) mod tests {
                 genesis_receipt_hash: Default::default(),
                 domain_config,
                 domain_runtime_info: Default::default(),
+                domain_instantiation_deposit: Default::default(),
             };
 
             DomainRegistry::<Test>::insert(new_domain_id, domain_obj);

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -660,7 +660,7 @@ mod tests {
 
             assert_ok!(do_unlock_nominator::<Test>(operator_id, operator_account));
 
-            let hold_id = crate::tests::HoldIdentifier::staking_staked();
+            let hold_id = crate::tests::HoldIdentifierWrapper::staking_staked();
             for (nominator_id, mut expected_usable_balance) in expected_usable_balances {
                 expected_usable_balance += minimum_free_balance;
                 assert_eq!(Deposits::<Test>::get(operator_id, nominator_id), None);

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -10,13 +10,13 @@ use crate::staking::{
     DomainEpoch, Error as TransitionError, OperatorStatus, SharePrice, WithdrawalInShares,
 };
 use crate::{
-    bundle_storage_fund, BalanceOf, Config, ElectionVerificationParams, Event, HoldIdentifier,
-    OperatorEpochSharePrice, Pallet,
+    bundle_storage_fund, BalanceOf, Config, DepositOnHold, ElectionVerificationParams, Event,
+    HoldIdentifier, OperatorEpochSharePrice, Pallet,
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec;
 use codec::{Decode, Encode};
-use frame_support::traits::fungible::{Inspect, InspectHold, Mutate, MutateHold};
+use frame_support::traits::fungible::{Inspect, Mutate, MutateHold};
 use frame_support::traits::tokens::{
     DepositConsequence, Fortitude, Precision, Provenance, Restriction,
 };
@@ -333,7 +333,7 @@ pub(crate) fn do_slash_operator<T: Config>(
     domain_id: DomainId,
     max_nominator_count: u32,
 ) -> Result<u32, TransitionError> {
-    let mut slashed_nominators = vec![];
+    let mut slashed_nominator_count = 0u32;
     let (operator_id, slashed_operators) = match PendingSlashes::<T>::get(domain_id) {
         None => return Ok(0),
         Some(mut slashed_operators) => match slashed_operators.pop_first() {
@@ -354,7 +354,7 @@ pub(crate) fn do_slash_operator<T: Config>(
         let operator_owner =
             OperatorIdOwner::<T>::get(operator_id).ok_or(TransitionError::UnknownOperator)?;
 
-        let staked_hold_id = T::HoldIdentifier::staking_staked(operator_id);
+        let staked_hold_id = T::HoldIdentifier::staking_staked();
 
         let mut total_stake = operator
             .current_total_stake
@@ -369,8 +369,8 @@ pub(crate) fn do_slash_operator<T: Config>(
 
         // transfer all the staked funds to the treasury account
         // any gains will be minted to treasury account
-        for (nominator_id, mut deposit) in Deposits::<T>::iter_prefix(operator_id) {
-            let locked_amount = T::Currency::balance_on_hold(&staked_hold_id, &nominator_id);
+        for (nominator_id, mut deposit) in Deposits::<T>::drain_prefix(operator_id) {
+            let locked_amount = DepositOnHold::<T>::take((operator_id, nominator_id.clone()));
 
             // convert any previous epoch deposits
             do_convert_previous_epoch_deposits::<T>(operator_id, &mut deposit)?;
@@ -405,14 +405,14 @@ pub(crate) fn do_slash_operator<T: Config>(
             // current staked amount
             let nominator_staked_amount = share_price.shares_to_stake::<T>(nominator_shares);
 
+            let pedning_deposit = deposit
+                .pending
+                .map(|pending_deposit| pending_deposit.amount)
+                .unwrap_or_default();
+
             // do not slash the deposit that is not staked yet
             let amount_to_slash_in_holding = locked_amount
-                .checked_sub(
-                    &deposit
-                        .pending
-                        .map(|pending_deposit| pending_deposit.amount)
-                        .unwrap_or_default(),
-                )
+                .checked_sub(&pedning_deposit)
                 .ok_or(TransitionError::BalanceUnderflow)?;
 
             T::Currency::transfer_on_hold(
@@ -423,6 +423,15 @@ pub(crate) fn do_slash_operator<T: Config>(
                 Precision::Exact,
                 Restriction::Free,
                 Fortitude::Force,
+            )
+            .map_err(|_| TransitionError::RemoveLock)?;
+
+            // release rest of the deposited un staked amount back to nominator
+            T::Currency::release(
+                &staked_hold_id,
+                &nominator_id,
+                pedning_deposit,
+                Precision::BestEffort,
             )
             .map_err(|_| TransitionError::RemoveLock)?;
 
@@ -438,10 +447,6 @@ pub(crate) fn do_slash_operator<T: Config>(
 
             total_stake = total_stake.saturating_sub(nominator_staked_amount);
             total_shares = total_shares.saturating_sub(nominator_shares);
-
-            // release rest of the deposited un staked amount back to nominator
-            T::Currency::release_all(&staked_hold_id, &nominator_id, Precision::BestEffort)
-                .map_err(|_| TransitionError::RemoveLock)?;
 
             // Transfer the deposited non-staked storage fee back to nominator
             if let Some(pending_deposit) = deposit.pending {
@@ -479,17 +484,11 @@ pub(crate) fn do_slash_operator<T: Config>(
                 NominatorCount::<T>::set(operator_id, nominator_count - 1);
             }
 
-            slashed_nominators.push(nominator_id);
-            if slashed_nominators.len() as u32 >= max_nominator_count {
+            slashed_nominator_count += 1;
+            if slashed_nominator_count >= max_nominator_count {
                 break;
             }
         }
-
-        // for all slashed nominators, remove their deposits
-        let slashed_nominator_count = slashed_nominators.len() as u32;
-        slashed_nominators.into_iter().for_each(|nominator_id| {
-            Deposits::<T>::remove(operator_id, nominator_id);
-        });
 
         let nominator_count = NominatorCount::<T>::get(operator_id);
         let cleanup_operator =
@@ -661,7 +660,7 @@ mod tests {
 
             assert_ok!(do_unlock_nominator::<Test>(operator_id, operator_account));
 
-            let hold_id = crate::tests::HoldIdentifier::staking_staked(operator_id);
+            let hold_id = crate::tests::HoldIdentifier::staking_staked();
             for (nominator_id, mut expected_usable_balance) in expected_usable_balances {
                 expected_usable_balance += minimum_free_balance;
                 assert_eq!(Deposits::<Test>::get(operator_id, nominator_id), None);

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -405,14 +405,14 @@ pub(crate) fn do_slash_operator<T: Config>(
             // current staked amount
             let nominator_staked_amount = share_price.shares_to_stake::<T>(nominator_shares);
 
-            let pedning_deposit = deposit
+            let pending_deposit = deposit
                 .pending
                 .map(|pending_deposit| pending_deposit.amount)
                 .unwrap_or_default();
 
             // do not slash the deposit that is not staked yet
             let amount_to_slash_in_holding = locked_amount
-                .checked_sub(&pedning_deposit)
+                .checked_sub(&pending_deposit)
                 .ok_or(TransitionError::BalanceUnderflow)?;
 
             T::Currency::transfer_on_hold(
@@ -430,7 +430,7 @@ pub(crate) fn do_slash_operator<T: Config>(
             T::Currency::release(
                 &staked_hold_id,
                 &nominator_id,
-                pedning_deposit,
+                pending_deposit,
                 Precision::BestEffort,
             )
             .map_err(|_| TransitionError::RemoveLock)?;

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -447,20 +447,12 @@ pub(crate) fn do_slash_operator<T: Config>(
                     total_storage_fee_deposit,
                 );
 
-                let storage_fee_deposit = bundle_storage_fund::withdraw_and_hold::<T>(
+                bundle_storage_fund::withdraw_to::<T>(
                     operator_id,
                     &nominator_id,
                     storage_fund_redeem_price.redeem(pending_deposit.storage_fee_deposit),
                 )
                 .map_err(TransitionError::BundleStorageFund)?;
-
-                T::Currency::release(
-                    &storage_fund_hold_id,
-                    &nominator_id,
-                    storage_fee_deposit,
-                    Precision::Exact,
-                )
-                .map_err(|_| TransitionError::RemoveLock)?;
 
                 total_storage_fee_deposit =
                     total_storage_fee_deposit.saturating_sub(pending_deposit.storage_fee_deposit);

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -115,8 +115,8 @@ impl pallet_domains::HoldIdentifier<Test> for HoldIdentifier {
         Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
     }
 
-    fn storage_fund_withdrawal(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::StorageFund(operator_id))
+    fn storage_fund_withdrawal() -> Self {
+        Self::Domains(DomainsHoldIdentifier::StorageFund)
     }
 }
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -109,8 +109,8 @@ impl pallet_domains::HoldIdentifier<Test> for HoldIdentifier {
         Self::Domains(DomainsHoldIdentifier::Staking)
     }
 
-    fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<Test> {
-        Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
+    fn domain_instantiation_id() -> FungibleHoldId<Test> {
+        Self::Domains(DomainsHoldIdentifier::DomainInstantiation)
     }
 
     fn storage_fund_withdrawal() -> Self {
@@ -643,6 +643,7 @@ fn test_bundle_fromat_verification() {
             genesis_receipt_hash: Default::default(),
             domain_config,
             domain_runtime_info: Default::default(),
+            domain_instantiation_deposit: Default::default(),
         };
         DomainRegistry::<Test>::insert(domain_id, domain_obj);
 

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -11,6 +11,7 @@ use crate::{
     RuntimeRegistry, ScheduledRuntimeUpgrades,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::BlockNumber as DomainBlockNumber;
 use frame_support::dispatch::{DispatchInfo, RawOrigin};
@@ -26,9 +27,9 @@ use sp_core::{Get, H256, U256};
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
-    BundleHeader, ChainId, DomainId, DomainsHoldIdentifier, ExecutionReceipt, InboxedBundle,
-    OpaqueBundle, OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, RuntimeId,
-    RuntimeType, SealedBundleHeader,
+    BundleHeader, ChainId, DomainId, ExecutionReceipt, InboxedBundle, OpaqueBundle,
+    OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, RuntimeId, RuntimeType,
+    SealedBundleHeader,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{
@@ -38,7 +39,7 @@ use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_runtime::{BuildStorage, OpaqueExtrinsic, Saturating};
 use sp_version::RuntimeVersion;
 use subspace_core_primitives::U256 as P256;
-use subspace_runtime_primitives::{Moment, StorageFee, SSC};
+use subspace_runtime_primitives::{HoldIdentifier, Moment, StorageFee, SSC};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -100,29 +101,24 @@ impl Get<BlockNumber> for ConfirmationDepthK {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum HoldIdentifier {
-    Domains(DomainsHoldIdentifier),
-}
+pub struct HoldIdentifierWrapper(HoldIdentifier);
 
-impl pallet_domains::HoldIdentifier<Test> for HoldIdentifier {
+impl pallet_domains::HoldIdentifier<Test> for HoldIdentifierWrapper {
     fn staking_staked() -> FungibleHoldId<Test> {
-        Self::Domains(DomainsHoldIdentifier::Staking)
+        Self(HoldIdentifier::DomainStaking)
     }
 
     fn domain_instantiation_id() -> FungibleHoldId<Test> {
-        Self::Domains(DomainsHoldIdentifier::DomainInstantiation)
+        Self(HoldIdentifier::DomainInstantiation)
     }
 
     fn storage_fund_withdrawal() -> Self {
-        Self::Domains(DomainsHoldIdentifier::StorageFund)
+        Self(HoldIdentifier::DomainStorageFund)
     }
 }
 
-impl VariantCount for HoldIdentifier {
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 10;
+impl VariantCount for HoldIdentifierWrapper {
+    const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
 }
 
 parameter_types! {
@@ -134,7 +130,7 @@ impl pallet_balances::Config for Test {
     type Balance = Balance;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
-    type RuntimeHoldReason = HoldIdentifier;
+    type RuntimeHoldReason = HoldIdentifierWrapper;
     type DustRemoval = ();
 }
 
@@ -248,7 +244,7 @@ impl pallet_domains::Config for Test {
     type ConfirmationDepthK = ConfirmationDepthK;
     type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
     type Currency = Balances;
-    type HoldIdentifier = HoldIdentifier;
+    type HoldIdentifier = HoldIdentifierWrapper;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Test>;
     type InitialDomainTxRange = InitialDomainTxRange;
     type DomainTxRangeAdjustmentInterval = DomainTxRangeAdjustmentInterval;

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -28,7 +28,7 @@ use sp_domains::storage::RawGenesis;
 use sp_domains::{
     BundleHeader, ChainId, DomainId, DomainsHoldIdentifier, ExecutionReceipt, InboxedBundle,
     OpaqueBundle, OperatorAllowList, OperatorId, OperatorPair, ProofOfElection, RuntimeId,
-    RuntimeType, SealedBundleHeader, StakingHoldIdentifier,
+    RuntimeType, SealedBundleHeader,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{
@@ -105,10 +105,8 @@ pub enum HoldIdentifier {
 }
 
 impl pallet_domains::HoldIdentifier<Test> for HoldIdentifier {
-    fn staking_staked(operator_id: OperatorId) -> FungibleHoldId<Test> {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::Staked(operator_id),
-        ))
+    fn staking_staked() -> FungibleHoldId<Test> {
+        Self::Domains(DomainsHoldIdentifier::Staking)
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> FungibleHoldId<Test> {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -966,7 +966,7 @@ pub enum MessengerHoldIdentifier {
 )]
 pub enum DomainsHoldIdentifier {
     Staking,
-    DomainInstantiation(DomainId),
+    DomainInstantiation,
     StorageFund,
 }
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -957,7 +957,7 @@ pub type ChannelId = sp_core::U256;
 )]
 pub enum MessengerHoldIdentifier {
     /// Holds the current reserved balance for channel opening
-    Channel((ChainId, ChannelId)),
+    Channel,
 }
 
 /// Domains specific Identifier for Balances holds.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -951,25 +951,6 @@ pub type OperatorId = u64;
 /// Channel identity.
 pub type ChannelId = sp_core::U256;
 
-/// Messenger specific hold identifier
-#[derive(
-    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
-)]
-pub enum MessengerHoldIdentifier {
-    /// Holds the current reserved balance for channel opening
-    Channel,
-}
-
-/// Domains specific Identifier for Balances holds.
-#[derive(
-    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
-)]
-pub enum DomainsHoldIdentifier {
-    Staking,
-    DomainInstantiation,
-    StorageFund,
-}
-
 /// Domains specific digest item.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
 pub enum DomainDigestItem {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -976,7 +976,7 @@ pub enum MessengerHoldIdentifier {
 pub enum DomainsHoldIdentifier {
     Staking(StakingHoldIdentifier),
     DomainInstantiation(DomainId),
-    StorageFund(OperatorId),
+    StorageFund,
 }
 
 /// Domains specific digest item.

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -948,15 +948,6 @@ pub type EpochIndex = u32;
 /// Type representing operator ID
 pub type OperatorId = u64;
 
-/// Staking specific hold identifier
-#[derive(
-    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
-)]
-pub enum StakingHoldIdentifier {
-    /// Holds all the currently staked funds to an Operator.
-    Staked(OperatorId),
-}
-
 /// Channel identity.
 pub type ChannelId = sp_core::U256;
 
@@ -974,7 +965,7 @@ pub enum MessengerHoldIdentifier {
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
 pub enum DomainsHoldIdentifier {
-    Staking(StakingHoldIdentifier),
+    Staking,
     DomainInstantiation(DomainId),
     StorageFund,
 }

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -243,6 +243,17 @@ impl<Balance: Codec + tokens::Balance> Default for BlockTransactionByteFee<Balan
     }
 }
 
+#[derive(
+    PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
+)]
+pub enum HoldIdentifier {
+    DomainStaking,
+    DomainInstantiation,
+    DomainStorageFund,
+    MessengerChannel,
+    Preimage,
+}
+
 #[cfg(feature = "testing")]
 pub mod tests_utils {
     use frame_support::dispatch::DispatchClass;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -35,6 +35,7 @@ use crate::fees::{OnChargeTransaction, TransactionByteFee};
 use crate::object_mapping::extract_block_object_mapping;
 pub use crate::signed_extensions::{CheckStorageAccess, DisablePallets};
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 use core::num::NonZeroU64;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::{
@@ -354,15 +355,9 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 }
 
 impl VariantCount for HoldIdentifier {
-    // TODO: revist this value, it is used as the max number of hold an account can
-    // create. Currently, nomination an operator will create 2 holds and opening an
-    // XDM channel will create 1 hold, so this value also used as the limit of how
-    // many operator/channel an account can nominate/open.
-    //
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 100;
+    const VARIANT_COUNT: u32 = 1
+        + mem::variant_count::<DomainsHoldIdentifier>() as u32
+        + mem::variant_count::<MessengerHoldIdentifier>() as u32;
 }
 
 impl pallet_balances::Config for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -338,8 +338,8 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
         Self::Domains(DomainsHoldIdentifier::Staking)
     }
 
-    fn domain_instantiation_id(domain_id: DomainId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
+    fn domain_instantiation_id() -> Self {
+        Self::Domains(DomainsHoldIdentifier::DomainInstantiation)
     }
 
     fn storage_fund_withdrawal() -> Self {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -348,8 +348,8 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
 }
 
 impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -344,8 +344,8 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
         Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
     }
 
-    fn storage_fund_withdrawal(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::StorageFund(operator_id))
+    fn storage_fund_withdrawal() -> Self {
+        Self::Domains(DomainsHoldIdentifier::StorageFund)
     }
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -70,7 +70,7 @@ use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     ChannelId, DomainAllowlistUpdates, DomainId, DomainInstanceData, DomainsHoldIdentifier,
     ExecutionReceiptFor, MessengerHoldIdentifier, OpaqueBundle, OperatorId, OperatorPublicKey,
-    StakingHoldIdentifier, DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
+    DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::{
@@ -334,10 +334,8 @@ pub enum HoldIdentifier {
 }
 
 impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn staking_staked(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::Staked(operator_id),
-        ))
+    fn staking_staked() -> Self {
+        Self::Domains(DomainsHoldIdentifier::Staking)
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> Self {

--- a/domains/pallets/messenger/src/benchmarking.rs
+++ b/domains/pallets/messenger/src/benchmarking.rs
@@ -19,6 +19,7 @@ use sp_messenger::messages::{
     RequestResponse, VersionedPayload,
 };
 use sp_mmr_primitives::{EncodableOpaqueLeaf, LeafProof as MmrProof};
+use sp_runtime::traits::Zero;
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_trie::StorageProof;
 #[cfg(feature = "std")]
@@ -87,6 +88,7 @@ mod benchmarks {
             dummy_channel_params::<T>(),
             None,
             true,
+            Zero::zero(),
         ));
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
         assert_eq!(channel.state, ChannelState::Initiated);
@@ -255,7 +257,8 @@ mod benchmarks {
             dst_chain_id,
             params,
             None,
-            true
+            true,
+            Zero::zero(),
         ));
         let channel = Channels::<T>::get(dst_chain_id, channel_id).expect("channel should exist");
         assert_eq!(channel.state, ChannelState::Initiated);

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -106,7 +106,7 @@ pub struct InitiateChannelParams {
 
 /// Hold identifier trait for messenger specific balance holds
 pub trait HoldIdentifier<T: Config> {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> FungibleHoldId<T>;
+    fn messenger_channel() -> FungibleHoldId<T>;
 }
 
 #[frame_support::pallet]
@@ -142,6 +142,7 @@ mod pallet {
         DomainRegistration, InherentError, InherentType, OnXDMRewards, StorageKeys,
         INHERENT_IDENTIFIER,
     };
+    use sp_runtime::traits::Zero;
     use sp_runtime::{ArithmeticError, Perbill, Saturating};
     use sp_subspace_mmr::MmrProofVerifier;
     #[cfg(feature = "std")]
@@ -541,6 +542,9 @@ mod pallet {
 
         /// Failed to unlock the balance
         BalanceUnlock,
+
+        /// Invalid channel reserve fee
+        InvalidChannelReserveFee,
     }
 
     #[pallet::call]
@@ -556,21 +560,9 @@ mod pallet {
             params: InitiateChannelParams,
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
-            let channel_open_params = ChannelOpenParams {
-                max_outgoing_messages: params.max_outgoing_messages,
-                fee_model: T::ChannelFeeModel::get(),
-            };
-
-            // initiate the channel config
-            let channel_id = Self::do_init_channel(
-                dst_chain_id,
-                channel_open_params,
-                Some(owner.clone()),
-                true,
-            )?;
 
             // reserve channel open fees
-            let hold_id = T::HoldIdentifier::messenger_channel(dst_chain_id, channel_id);
+            let hold_id = T::HoldIdentifier::messenger_channel();
             let amount = T::ChannelReserveFee::get();
 
             // ensure there is enough free balance to lock
@@ -580,6 +572,19 @@ mod pallet {
                 Error::<T>::InsufficientBalance
             );
             T::Currency::hold(&hold_id, &owner, amount).map_err(|_| Error::<T>::BalanceHold)?;
+
+            // initiate the channel config
+            let channel_open_params = ChannelOpenParams {
+                max_outgoing_messages: params.max_outgoing_messages,
+                fee_model: T::ChannelFeeModel::get(),
+            };
+            let channel_id = Self::do_init_channel(
+                dst_chain_id,
+                channel_open_params,
+                Some(owner.clone()),
+                true,
+                amount,
+            )?;
 
             // send message to dst_chain
             Self::new_outbox_message(
@@ -864,7 +869,8 @@ mod pallet {
                 fee_model,
             };
             ChainAllowlist::<T>::mutate(|list| list.insert(dst_chain_id));
-            let channel_id = Self::do_init_channel(dst_chain_id, init_params, None, true)?;
+            let channel_id =
+                Self::do_init_channel(dst_chain_id, init_params, None, true, Zero::zero())?;
             Self::do_open_channel(dst_chain_id, channel_id)?;
             Ok(())
         }
@@ -953,8 +959,8 @@ mod pallet {
                 }
 
                 if let Some(owner) = &channel.maybe_owner {
-                    let hold_id = T::HoldIdentifier::messenger_channel(chain_id, channel_id);
-                    let locked_amount = T::Currency::balance_on_hold(&hold_id, owner);
+                    let hold_id = T::HoldIdentifier::messenger_channel();
+                    let locked_amount = channel.channel_reserve_fee;
                     let amount_to_release = {
                         if channel.state == ChannelState::Open {
                             locked_amount
@@ -993,10 +999,18 @@ mod pallet {
             init_params: ChannelOpenParams<BalanceOf<T>>,
             maybe_owner: Option<T::AccountId>,
             check_allowlist: bool,
+            channel_reserve_fee: BalanceOf<T>,
         ) -> Result<ChannelId, DispatchError> {
             ensure!(
                 T::SelfChainId::get() != dst_chain_id,
                 Error::<T>::InvalidChain,
+            );
+
+            // If the channel owner is in this chain then the channel reserve fee
+            // must not be empty
+            ensure!(
+                maybe_owner.is_none() || !channel_reserve_fee.is_zero(),
+                Error::<T>::InvalidChannelReserveFee,
             );
 
             if check_allowlist {
@@ -1024,6 +1038,7 @@ mod pallet {
                     max_outgoing_messages: init_params.max_outgoing_messages,
                     fee: init_params.fee_model,
                     maybe_owner,
+                    channel_reserve_fee,
                 },
             );
 
@@ -1144,8 +1159,8 @@ mod pallet {
                     // channel is being opened without an owner since this is a relay message
                     // from other chain
                     // we do not check the allowlist to finish the end to end flow
-                    Self::do_init_channel(msg.src_chain_id, params, None, false).map_err(
-                        |err| {
+                    Self::do_init_channel(msg.src_chain_id, params, None, false, Zero::zero())
+                        .map_err(|err| {
                             log::error!(
                                 "Error initiating channel: {:?} with chain: {:?}: {:?}",
                                 msg.channel_id,
@@ -1153,8 +1168,7 @@ mod pallet {
                                 err
                             );
                             InvalidTransaction::Call
-                        },
-                    )?;
+                        })?;
                 } else {
                     log::error!("Unexpected call instead of channel open request: {:?}", msg,);
                     return Err(InvalidTransaction::Call.into());

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -21,7 +21,7 @@ macro_rules! impl_runtime {
         use crate::mock::MockEndpoint;
         use crate::mock::{AccountId, Balance, MessageId, TestExternalities};
         use codec::{Decode, Encode};
-        use domain_runtime_primitives::{MultiAccountId, TryConvertBack};
+        use domain_runtime_primitives::{MultiAccountId, TryConvertBack, HoldIdentifier};
         #[cfg(not(feature = "runtime-benchmarks"))]
         use frame_support::pallet_prelude::*;
         use frame_support::{derive_impl, parameter_types};
@@ -31,10 +31,8 @@ macro_rules! impl_runtime {
         use sp_messenger::messages::{ChainId, FeeModel};
         use sp_runtime::traits::Convert;
         use sp_runtime::BuildStorage;
-        use crate::HoldIdentifier;
         use scale_info::TypeInfo;
         use codec::MaxEncodedLen;
-        use sp_domains::MessengerHoldIdentifier;
         use frame_support::traits::VariantCount;
         use core::mem;
         use sp_runtime::Perbill;
@@ -68,16 +66,16 @@ macro_rules! impl_runtime {
             PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
         )]
         pub enum MockHoldIdentifer {
-            Messenger(MessengerHoldIdentifier)
+            Messenger(HoldIdentifier)
         }
 
         impl VariantCount for MockHoldIdentifer {
-            const VARIANT_COUNT: u32 = mem::variant_count::<Self>() as u32;
+            const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
         }
 
-        impl HoldIdentifier<$runtime> for MockHoldIdentifer {
+        impl crate::HoldIdentifier<$runtime> for MockHoldIdentifer {
             fn messenger_channel() -> Self {
-                MockHoldIdentifer::Messenger(MessengerHoldIdentifier::Channel)
+                MockHoldIdentifer::Messenger(HoldIdentifier::MessengerChannel)
             }
         }
 

--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -32,7 +32,6 @@ macro_rules! impl_runtime {
         use sp_runtime::traits::Convert;
         use sp_runtime::BuildStorage;
         use crate::HoldIdentifier;
-        use sp_domains::ChannelId;
         use scale_info::TypeInfo;
         use codec::MaxEncodedLen;
         use sp_domains::MessengerHoldIdentifier;
@@ -77,8 +76,8 @@ macro_rules! impl_runtime {
         }
 
         impl HoldIdentifier<$runtime> for MockHoldIdentifer {
-            fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-                MockHoldIdentifer::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+            fn messenger_channel() -> Self {
+                MockHoldIdentifer::Messenger(MessengerHoldIdentifier::Channel)
             }
         }
 

--- a/domains/pallets/messenger/src/tests.rs
+++ b/domains/pallets/messenger/src/tests.rs
@@ -25,7 +25,7 @@ use sp_messenger::messages::{
     ProtocolMessageRequest, RequestResponse, VersionedPayload,
 };
 use sp_mmr_primitives::{EncodableOpaqueLeaf, LeafProof as MmrProof};
-use sp_runtime::traits::Convert;
+use sp_runtime::traits::{Convert, Zero};
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 use sp_trie::StorageProof;
 use std::collections::BTreeSet;
@@ -490,8 +490,14 @@ fn force_toggle_channel_state<Runtime: crate::Config>(
         if add_to_allow_list {
             ChainAllowlist::<Runtime>::put(list);
         }
-        Pallet::<Runtime>::do_init_channel(dst_chain_id, init_params, None, add_to_allow_list)
-            .unwrap();
+        Pallet::<Runtime>::do_init_channel(
+            dst_chain_id,
+            init_params,
+            None,
+            add_to_allow_list,
+            Zero::zero(),
+        )
+        .unwrap();
         Pallet::<Runtime>::channels(dst_chain_id, channel_id).unwrap()
     });
 
@@ -765,6 +771,7 @@ fn test_update_consensus_channel_allowlist() {
                     relay_fee: Default::default(),
                 },
                 maybe_owner: None,
+                channel_reserve_fee: Default::default(),
             }),
         );
     });

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -10,7 +10,7 @@ use pallet_messenger::HoldIdentifier;
 use sp_core::U256;
 use sp_domains::{DomainId, MessengerHoldIdentifier};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler, EndpointId, EndpointRequest, Sender};
-use sp_messenger::messages::{ChainId, ChannelId, FeeModel, MessageId};
+use sp_messenger::messages::{ChainId, FeeModel, MessageId};
 use sp_runtime::traits::{Convert, IdentityLookup};
 use sp_runtime::{BuildStorage, DispatchError, Perbill};
 
@@ -77,8 +77,8 @@ impl sp_messenger::DomainRegistration for DomainRegistration {
 }
 
 impl HoldIdentifier<MockRuntime> for MockHoldIdentifer {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        MockHoldIdentifer::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        MockHoldIdentifer::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -1,14 +1,13 @@
 use crate as pallet_transporter;
 use crate::{Config, TryConvertBack};
 use codec::{Decode, Encode};
-use domain_runtime_primitives::MultiAccountId;
+use domain_runtime_primitives::{HoldIdentifier, MultiAccountId};
 use frame_support::pallet_prelude::{MaxEncodedLen, TypeInfo};
 use frame_support::traits::VariantCount;
 use frame_support::{derive_impl, parameter_types};
 use pallet_balances::AccountData;
-use pallet_messenger::HoldIdentifier;
 use sp_core::U256;
-use sp_domains::{DomainId, MessengerHoldIdentifier};
+use sp_domains::DomainId;
 use sp_messenger::endpoint::{Endpoint, EndpointHandler, EndpointId, EndpointRequest, Sender};
 use sp_messenger::messages::{ChainId, FeeModel, MessageId};
 use sp_runtime::traits::{Convert, IdentityLookup};
@@ -61,7 +60,7 @@ parameter_types! {
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
 pub enum MockHoldIdentifer {
-    Messenger(MessengerHoldIdentifier),
+    Messenger(HoldIdentifier),
 }
 
 impl VariantCount for MockHoldIdentifer {
@@ -76,9 +75,9 @@ impl sp_messenger::DomainRegistration for DomainRegistration {
     }
 }
 
-impl HoldIdentifier<MockRuntime> for MockHoldIdentifer {
+impl pallet_messenger::HoldIdentifier<MockRuntime> for MockHoldIdentifer {
     fn messenger_channel() -> Self {
-        MockHoldIdentifer::Messenger(MessengerHoldIdentifier::Channel)
+        MockHoldIdentifer::Messenger(HoldIdentifier::MessengerChannel)
     }
 }
 

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -61,7 +61,7 @@ pub struct Channel<Balance, AccountId> {
     /// Owner of the channel
     /// Owner maybe None if the channel was initiated on the other chain.
     pub maybe_owner: Option<AccountId>,
-    /// The amount of fund hold on the owner account for this channel
+    /// The amount of funds put on hold by the owner account for this channel
     pub channel_reserve_fee: Balance,
 }
 

--- a/domains/primitives/messenger/src/messages.rs
+++ b/domains/primitives/messenger/src/messages.rs
@@ -61,6 +61,8 @@ pub struct Channel<Balance, AccountId> {
     /// Owner of the channel
     /// Owner maybe None if the channel was initiated on the other chain.
     pub maybe_owner: Option<AccountId>,
+    /// The amount of fund hold on the owner account for this channel
+    pub channel_reserve_fee: Balance,
 }
 
 /// Channel open parameters

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -37,6 +37,7 @@ use sp_runtime::transaction_validity::TransactionValidityError;
 use sp_runtime::{MultiAddress, MultiSignature, Perbill};
 use sp_weights::constants::WEIGHT_REF_TIME_PER_SECOND;
 use sp_weights::Weight;
+pub use subspace_runtime_primitives::HoldIdentifier;
 use subspace_runtime_primitives::{MAX_BLOCK_LENGTH, SHANNON, SLOT_PROBABILITY};
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -13,14 +13,15 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
     block_weights, maximum_block_length, opaque, Balance, BlockNumber, Hash, Nonce,
     EXISTENTIAL_DEPOSIT,
 };
 use domain_runtime_primitives::{
-    AccountId, Address, CheckExtrinsicsValidityError, DecodeExtrinsicError, Signature,
-    ERR_BALANCE_OVERFLOW, SLOT_DURATION,
+    AccountId, Address, CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier,
+    Signature, ERR_BALANCE_OVERFLOW, SLOT_DURATION,
 };
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
 use frame_support::genesis_builder_helper::{build_state, get_preset};
@@ -39,7 +40,7 @@ use pallet_transporter::EndpointHandler;
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata};
-use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
+use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
@@ -227,7 +228,7 @@ impl pallet_balances::Config for Runtime {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type MaxFreezes = ();
-    type RuntimeHoldReason = HoldIdentifier;
+    type RuntimeHoldReason = HoldIdentifierWrapper;
 }
 
 parameter_types! {
@@ -374,24 +375,15 @@ impl sp_messenger::StorageKeys for StorageKeys {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum HoldIdentifier {
-    Messenger(MessengerHoldIdentifier),
+pub struct HoldIdentifierWrapper(HoldIdentifier);
+
+impl VariantCount for HoldIdentifierWrapper {
+    const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
 }
 
-impl VariantCount for HoldIdentifier {
-    // TODO: revist this value, it is used as the max number of hold an account can
-    // create. Currently, opening an XDM channel will create 1 hold, so this value
-    // also used as the limit of how many channel an account can open.
-    //
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 100;
-}
-
-impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
     fn messenger_channel() -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel)
+        Self(HoldIdentifier::MessengerChannel)
     }
 }
 
@@ -422,7 +414,7 @@ impl pallet_messenger::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;
     type DomainOwner = ();
-    type HoldIdentifier = HoldIdentifier;
+    type HoldIdentifier = HoldIdentifierWrapper;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -390,8 +390,8 @@ impl VariantCount for HoldIdentifier {
 }
 
 impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -519,8 +519,8 @@ impl VariantCount for HoldIdentifier {
 }
 
 impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -15,14 +15,15 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
     block_weights, maximum_block_length, maximum_domain_block_weight, opaque, Balance, BlockNumber,
     Hash, Nonce, EXISTENTIAL_DEPOSIT,
 };
 use domain_runtime_primitives::{
-    CheckExtrinsicsValidityError, DecodeExtrinsicError, ERR_BALANCE_OVERFLOW, ERR_NONCE_OVERFLOW,
-    SLOT_DURATION,
+    CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier, ERR_BALANCE_OVERFLOW,
+    ERR_NONCE_OVERFLOW, SLOT_DURATION,
 };
 use fp_account::EthereumSignature;
 use fp_self_contained::{CheckedSignature, SelfContainedCall};
@@ -52,7 +53,7 @@ use pallet_transporter::EndpointHandler;
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
-use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
+use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
@@ -359,7 +360,7 @@ impl pallet_balances::Config for Runtime {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type MaxFreezes = ();
-    type RuntimeHoldReason = HoldIdentifier;
+    type RuntimeHoldReason = HoldIdentifierWrapper;
 }
 
 parameter_types! {
@@ -503,24 +504,15 @@ impl sp_messenger::StorageKeys for StorageKeys {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum HoldIdentifier {
-    Messenger(MessengerHoldIdentifier),
+pub struct HoldIdentifierWrapper(HoldIdentifier);
+
+impl VariantCount for HoldIdentifierWrapper {
+    const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
 }
 
-impl VariantCount for HoldIdentifier {
-    // TODO: revist this value, it is used as the max number of hold an account can
-    // create. Currently, opening an XDM channel will create 1 hold, so this value
-    // also used as the limit of how many channel an account can open.
-    //
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 100;
-}
-
-impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
     fn messenger_channel() -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel)
+        Self(HoldIdentifier::MessengerChannel)
     }
 }
 
@@ -551,7 +543,7 @@ impl pallet_messenger::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;
     type DomainOwner = ();
-    type HoldIdentifier = HoldIdentifier;
+    type HoldIdentifier = HoldIdentifierWrapper;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -13,13 +13,15 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 use domain_runtime_primitives::opaque::Header;
 pub use domain_runtime_primitives::{
     block_weights, maximum_block_length, opaque, AccountId, Address, Balance, BlockNumber, Hash,
     Nonce, Signature, EXISTENTIAL_DEPOSIT,
 };
 use domain_runtime_primitives::{
-    CheckExtrinsicsValidityError, DecodeExtrinsicError, ERR_BALANCE_OVERFLOW, SLOT_DURATION,
+    CheckExtrinsicsValidityError, DecodeExtrinsicError, HoldIdentifier, ERR_BALANCE_OVERFLOW,
+    SLOT_DURATION,
 };
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo};
 use frame_support::genesis_builder_helper::{build_state, get_preset};
@@ -38,7 +40,7 @@ use pallet_transporter::EndpointHandler;
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata};
-use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
+use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
@@ -226,7 +228,7 @@ impl pallet_balances::Config for Runtime {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type MaxFreezes = ();
-    type RuntimeHoldReason = HoldIdentifier;
+    type RuntimeHoldReason = HoldIdentifierWrapper;
 }
 
 parameter_types! {
@@ -372,24 +374,15 @@ impl sp_messenger::StorageKeys for StorageKeys {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum HoldIdentifier {
-    Messenger(MessengerHoldIdentifier),
+pub struct HoldIdentifierWrapper(HoldIdentifier);
+
+impl VariantCount for HoldIdentifierWrapper {
+    const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
 }
 
-impl VariantCount for HoldIdentifier {
-    // TODO: revist this value, it is used as the max number of hold an account can
-    // create. Currently, opening an XDM channel will create 1 hold, so this value
-    // also used as the limit of how many channel an account can open.
-    //
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 100;
-}
-
-impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
     fn messenger_channel() -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel)
+        Self(HoldIdentifier::MessengerChannel)
     }
 }
 
@@ -420,7 +413,7 @@ impl pallet_messenger::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;
     type DomainOwner = ();
-    type HoldIdentifier = HoldIdentifier;
+    type HoldIdentifier = HoldIdentifierWrapper;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -388,8 +388,8 @@ impl VariantCount for HoldIdentifier {
 }
 
 impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -15,13 +15,15 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::mem;
 pub use domain_runtime_primitives::opaque::Header;
 use domain_runtime_primitives::{
     block_weights, maximum_block_length, maximum_domain_block_weight, ERR_BALANCE_OVERFLOW,
     ERR_NONCE_OVERFLOW, EXISTENTIAL_DEPOSIT, SLOT_DURATION,
 };
 pub use domain_runtime_primitives::{
-    opaque, Balance, BlockNumber, CheckExtrinsicsValidityError, DecodeExtrinsicError, Hash, Nonce,
+    opaque, Balance, BlockNumber, CheckExtrinsicsValidityError, DecodeExtrinsicError, Hash,
+    HoldIdentifier, Nonce,
 };
 use fp_account::EthereumSignature;
 use fp_self_contained::{CheckedSignature, SelfContainedCall};
@@ -50,7 +52,7 @@ use pallet_transporter::EndpointHandler;
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
-use sp_domains::{DomainAllowlistUpdates, DomainId, MessengerHoldIdentifier, Transfers};
+use sp_domains::{DomainAllowlistUpdates, DomainId, Transfers};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
@@ -348,7 +350,7 @@ impl pallet_balances::Config for Runtime {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type MaxFreezes = ();
-    type RuntimeHoldReason = HoldIdentifier;
+    type RuntimeHoldReason = HoldIdentifierWrapper;
 }
 
 parameter_types! {
@@ -467,20 +469,15 @@ impl sp_subspace_mmr::MmrProofVerifier<MmrHash, NumberFor<Block>, Hash> for MmrP
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum HoldIdentifier {
-    Messenger(MessengerHoldIdentifier),
+pub struct HoldIdentifierWrapper(HoldIdentifier);
+
+impl VariantCount for HoldIdentifierWrapper {
+    const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
 }
 
-impl VariantCount for HoldIdentifier {
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 10;
-}
-
-impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
+impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifierWrapper {
     fn messenger_channel() -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel)
+        Self(HoldIdentifier::MessengerChannel)
     }
 }
 
@@ -532,7 +529,7 @@ impl pallet_messenger::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;
     type DomainOwner = ();
-    type HoldIdentifier = HoldIdentifier;
+    type HoldIdentifier = HoldIdentifierWrapper;
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
     type DomainRegistration = ();

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -479,8 +479,8 @@ impl VariantCount for HoldIdentifier {
 }
 
 impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -27,6 +27,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Compact, CompactLen, Decode, Encode, MaxEncodedLen};
+use core::mem;
 use core::num::NonZeroU64;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::{
@@ -355,10 +356,9 @@ impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
 }
 
 impl VariantCount for HoldIdentifier {
-    // TODO: HACK this is not the actual variant count but it is required see
-    // https://github.com/autonomys/subspace/issues/2674 for more details. It
-    // will be resolved as https://github.com/paritytech/polkadot-sdk/issues/4033.
-    const VARIANT_COUNT: u32 = 10;
+    const VARIANT_COUNT: u32 = 1
+        + mem::variant_count::<DomainsHoldIdentifier>() as u32
+        + mem::variant_count::<MessengerHoldIdentifier>() as u32;
 }
 
 impl pallet_balances::Config for Runtime {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -349,8 +349,8 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
 }
 
 impl pallet_messenger::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn messenger_channel(dst_chain_id: ChainId, channel_id: ChannelId) -> Self {
-        Self::Messenger(MessengerHoldIdentifier::Channel((dst_chain_id, channel_id)))
+    fn messenger_channel() -> Self {
+        Self::Messenger(MessengerHoldIdentifier::Channel)
     }
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -339,8 +339,8 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
         Self::Domains(DomainsHoldIdentifier::Staking)
     }
 
-    fn domain_instantiation_id(domain_id: DomainId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
+    fn domain_instantiation_id() -> Self {
+        Self::Domains(DomainsHoldIdentifier::DomainInstantiation)
     }
 
     fn storage_fund_withdrawal() -> Self {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -346,8 +346,8 @@ impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
         Self::Domains(DomainsHoldIdentifier::DomainInstantiation(domain_id))
     }
 
-    fn storage_fund_withdrawal(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::StorageFund(operator_id))
+    fn storage_fund_withdrawal() -> Self {
+        Self::Domains(DomainsHoldIdentifier::StorageFund)
     }
 }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -60,8 +60,7 @@ use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainAllowlistUpdates, DomainId, DomainInstanceData, DomainsHoldIdentifier,
     ExecutionReceiptFor, MessengerHoldIdentifier, OpaqueBundle, OpaqueBundles, OperatorId,
-    OperatorPublicKey, StakingHoldIdentifier, DOMAIN_STORAGE_FEE_MULTIPLIER,
-    INITIAL_DOMAIN_TX_RANGE,
+    OperatorPublicKey, DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::{
@@ -336,10 +335,8 @@ pub enum HoldIdentifier {
 }
 
 impl pallet_domains::HoldIdentifier<Runtime> for HoldIdentifier {
-    fn staking_staked(operator_id: OperatorId) -> Self {
-        Self::Domains(DomainsHoldIdentifier::Staking(
-            StakingHoldIdentifier::Staked(operator_id),
-        ))
+    fn staking_staked() -> Self {
+        Self::Domains(DomainsHoldIdentifier::Staking)
     }
 
     fn domain_instantiation_id(domain_id: DomainId) -> Self {


### PR DESCRIPTION
close #2674

This PR supports shared hold id that is used in staking, domain instantiation, and XDM channel, such that we can have a constant number of hold id variants and extrinsic that require creating hold won't fail due to the fixed hold id limit.

Because we also support the nomination of multiple different operators, opening multiple channel, and instantiating multiple domains so we have to add storage keep tracking of the hold balance.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
