### PR TITLE
Make serde hex attributes shorter

### DIFF
--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -156,7 +156,7 @@ mod scalar_serde {
 
     // Custom wrapper so we don't have to write serialization/deserialization code manually
     #[derive(Serialize, Deserialize)]
-    struct Scalar(#[serde(with = "hex::serde")] pub(super) [u8; super::Scalar::FULL_BYTES]);
+    struct Scalar(#[serde(with = "hex")] pub(super) [u8; super::Scalar::FULL_BYTES]);
 
     impl Serialize for super::Scalar {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -124,9 +124,7 @@ pub struct Blake3HashHex(#[cfg_attr(feature = "serde", serde(with = "hex"))] Bla
     MaxEncodedLen,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Randomness(
-    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; RANDOMNESS_LENGTH],
-);
+pub struct Randomness(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; RANDOMNESS_LENGTH]);
 
 impl AsRef<[u8]> for Randomness {
     #[inline]
@@ -481,9 +479,7 @@ impl PotCheckpoints {
     Into,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PublicKey(
-    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; PUBLIC_KEY_LENGTH],
-);
+pub struct PublicKey(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; PUBLIC_KEY_LENGTH]);
 
 impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -125,7 +125,7 @@ pub struct Blake3HashHex(#[cfg_attr(feature = "serde", serde(with = "hex"))] Bla
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Randomness(
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; RANDOMNESS_LENGTH],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; RANDOMNESS_LENGTH],
 );
 
 impl AsRef<[u8]> for Randomness {
@@ -304,7 +304,7 @@ impl PosProof {
     MaxEncodedLen,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PotKey(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; Self::SIZE]);
+pub struct PotKey(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; Self::SIZE]);
 
 impl fmt::Display for PotKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -349,7 +349,7 @@ impl PotKey {
     MaxEncodedLen,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PotSeed(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; Self::SIZE]);
+pub struct PotSeed(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; Self::SIZE]);
 
 impl fmt::Display for PotSeed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -399,7 +399,7 @@ impl PotSeed {
     MaxEncodedLen,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PotOutput(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; Self::SIZE]);
+pub struct PotOutput(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; Self::SIZE]);
 
 impl fmt::Display for PotOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -482,7 +482,7 @@ impl PotCheckpoints {
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PublicKey(
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; PUBLIC_KEY_LENGTH],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; PUBLIC_KEY_LENGTH],
 );
 
 impl fmt::Display for PublicKey {
@@ -1006,7 +1006,7 @@ impl SectorSlotChallenge {
 /// Data structure representing sector ID in farmer's plot
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct SectorId(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] Blake3Hash);
+pub struct SectorId(#[cfg_attr(feature = "serde", serde(with = "hex"))] Blake3Hash);
 
 impl AsRef<[u8]> for SectorId {
     #[inline]

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -681,7 +681,7 @@ impl Record {
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RecordCommitment(
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; RecordCommitment::SIZE],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; RecordCommitment::SIZE],
 );
 
 impl Default for RecordCommitment {
@@ -800,7 +800,7 @@ impl TryFrom<RecordCommitment> for Commitment {
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RecordWitness(
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; RecordWitness::SIZE],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; RecordWitness::SIZE],
 );
 
 impl Default for RecordWitness {
@@ -919,7 +919,7 @@ impl TryFrom<RecordWitness> for Witness {
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ChunkWitness(
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; ChunkWitness::SIZE],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; ChunkWitness::SIZE],
 );
 
 impl Default for ChunkWitness {

--- a/crates/subspace-core-primitives/src/segments.rs
+++ b/crates/subspace-core-primitives/src/segments.rs
@@ -144,7 +144,7 @@ impl SegmentIndex {
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SegmentCommitment(
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] [u8; SegmentCommitment::SIZE],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; SegmentCommitment::SIZE],
 );
 
 impl Default for SegmentCommitment {

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -120,7 +120,7 @@ pub enum SingleDiskFarmInfo {
         /// ID of the farm
         id: FarmId,
         /// Genesis hash of the chain used for farm creation
-        #[serde(with = "hex::serde")]
+        #[serde(with = "hex")]
         genesis_hash: [u8; 32],
         /// Public key of identity used for farm creation
         public_key: PublicKey,
@@ -135,7 +135,7 @@ pub enum SingleDiskFarmInfo {
         /// ID of the farm
         id: FarmId,
         /// Genesis hash of the chain used for farm creation
-        #[serde(with = "hex::serde")]
+        #[serde(with = "hex")]
         genesis_hash: [u8; 32],
         /// Public key of identity used for farm creation
         public_key: PublicKey,

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -32,7 +32,7 @@ pub const MAX_SEGMENT_HEADERS_PER_REQUEST: usize = 1000;
 #[serde(rename_all = "camelCase")]
 pub struct FarmerAppInfo {
     /// Genesis hash of the chain
-    #[serde(with = "hex::serde")]
+    #[serde(with = "hex")]
     pub genesis_hash: [u8; 32],
     /// Bootstrap nodes for DSN
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
@@ -138,10 +138,10 @@ pub struct SolutionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct RewardSigningInfo {
     /// Hash to be signed.
-    #[serde(with = "hex::serde")]
+    #[serde(with = "hex")]
     pub hash: [u8; 32],
     /// Public key of the plot identity that should create signature.
-    #[serde(with = "hex::serde")]
+    #[serde(with = "hex")]
     pub public_key: [u8; 32],
 }
 
@@ -150,7 +150,7 @@ pub struct RewardSigningInfo {
 #[serde(rename_all = "camelCase")]
 pub struct RewardSignatureResponse {
     /// Hash that was signed.
-    #[serde(with = "hex::serde")]
+    #[serde(with = "hex")]
     pub hash: [u8; 32],
     /// Pre-header or vote hash signature.
     pub signature: Option<RewardSignature>,


### PR DESCRIPTION
This PR refactors serde hex attributes to use a shorter alias.

Auto-generated code change using:
```sh
fastmod --fixed-strings 'serde(with = "hex::serde")' 'serde(with = "hex")'
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
