### PR TITLE
Revert "Do not enable CUDA on Windows because compilation fails for now"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,13 +117,12 @@ jobs:
       - name: cargo clippy
         run: |
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features runtime-benchmarks -- -D warnings
-        # TODO: Windows should be compiled with CUDA as well once compilation succeeds
-        if: runner.os == 'macOS' || runner.os == 'Windows'
+        if: runner.os == 'macOS'
 
       - name: cargo clippy
         run: |
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features runtime-benchmarks,cuda -- -D warnings
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'Windows'
 
   cargo-docs:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-20.04-x86-64"]' || '"ubuntu-22.04"') }}

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -210,14 +210,13 @@ jobs:
       - name: Build farmer
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
-        # TODO: Windows should be compiled with CUDA as well once compilation succeeds
-        if: runner.os == 'macOS' || runner.os == 'Windows' || !startsWith(matrix.build.target, 'x86_64')
+        if: runner.os == 'macOS' || !startsWith(matrix.build.target, 'x86_64')
 
       - name: Build farmer
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features cuda
         # TODO: We don't configure CUDA for cross-compilation purposes, hence only x86-64 for now
-        if: (runner.os == 'Linux') && startsWith(matrix.build.target, 'x86_64')
+        if: (runner.os == 'Linux' || runner.os == 'Windows') && startsWith(matrix.build.target, 'x86_64')
 
       - name: Build node
         run: |


### PR DESCRIPTION
It compiles on Windows now, so d42735d299339b9bb32711111ebfcd1e1ee9d36c is reverted here

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
