### PR TITLE
Switch async `RwLock` from `async-lock` to `tokio`

### DIFF
--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -65,7 +65,7 @@ supports-color = { version = "3.0.0", optional = true }
 tempfile = "3.12.0"
 thiserror = "1.0.63"
 thread-priority = "1.1.0"
-tokio = { version = "1.39.2", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.39.2", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -6,7 +6,6 @@ use crate::commands::cluster::controller::farms::{maintain_farms, FarmIndex};
 use crate::commands::shared::derive_libp2p_keypair;
 use crate::commands::shared::network::{configure_network, NetworkArgs};
 use anyhow::anyhow;
-use async_lock::RwLock as AsyncRwLock;
 use backoff::ExponentialBackoff;
 use clap::{Parser, ValueHint};
 use futures::stream::FuturesUnordered;
@@ -31,6 +30,7 @@ use subspace_farmer::node_client::NodeClient;
 use subspace_farmer::single_disk_farm::identity::Identity;
 use subspace_farmer::utils::{run_future_in_dedicated_thread, AsyncJoinOnDrop};
 use subspace_networking::utils::piece_provider::PieceProvider;
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::info;
 
 /// Get piece retry attempts number.

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -1,4 +1,3 @@
-use async_lock::RwLock as AsyncRwLock;
 use clap::Parser;
 use prometheus_client::registry::Registry;
 use std::collections::HashSet;
@@ -22,6 +21,7 @@ use subspace_networking::{
     SegmentHeaderBySegmentIndexesRequestHandler, SegmentHeaderRequest, SegmentHeaderResponse,
 };
 use subspace_rpc_primitives::MAX_SEGMENT_HEADERS_PER_REQUEST;
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{debug, error, info, Instrument};
 
 /// How many segment headers can be requested at a time.
@@ -139,7 +139,8 @@ where
 
                         let read_piece_fut = match weak_plotted_pieces.upgrade() {
                             Some(plotted_pieces) => plotted_pieces
-                                .try_read()?
+                                .try_read()
+                                .ok()?
                                 .read_piece(piece_index)?
                                 .in_current_span(),
                             None => {

--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -3,9 +3,7 @@
 use crate::farm::plotted_pieces::PlottedPieces;
 use crate::farmer_cache::FarmerCache;
 use crate::node_client::NodeClient;
-use async_lock::{
-    Mutex as AsyncMutex, MutexGuardArc as AsyncMutexGuardArc, RwLock as AsyncRwLock, Semaphore,
-};
+use async_lock::{Mutex as AsyncMutex, MutexGuardArc as AsyncMutexGuardArc, Semaphore};
 use async_trait::async_trait;
 use backoff::backoff::Backoff;
 use backoff::future::retry;
@@ -22,6 +20,7 @@ use subspace_core_primitives::{Piece, PieceIndex};
 use subspace_farmer_components::PieceGetter;
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{debug, error, trace};
 
 pub mod piece_validator;
@@ -282,6 +281,7 @@ where
         let maybe_read_piece_fut = inner
             .plotted_pieces
             .try_read()
+            .ok()
             .and_then(|plotted_pieces| plotted_pieces.read_piece(piece_index));
 
         if let Some(read_piece_fut) = maybe_read_piece_fut {

--- a/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -3,7 +3,7 @@
 
 use crate::node_client::{Error as RpcError, Error, NodeClient, NodeClientExt};
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
 use futures::{select, FutureExt, Stream, StreamExt};
 use std::pin::Pin;
@@ -14,7 +14,7 @@ use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
     MAX_SEGMENT_HEADERS_PER_REQUEST,
 };
-use tokio::sync::watch;
+use tokio::sync::{watch, RwLock as AsyncRwLock};
 use tokio_stream::wrappers::WatchStream;
 use tracing::{info, trace, warn};
 

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -11,7 +11,7 @@ use crate::farm::{
 use crate::node_client::NodeClient;
 use crate::single_disk_farm::metrics::SingleDiskFarmMetrics;
 use crate::single_disk_farm::Handlers;
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use async_lock::Mutex as AsyncMutex;
 use futures::channel::mpsc;
 use futures::StreamExt;
 use parking_lot::Mutex;
@@ -31,6 +31,7 @@ use subspace_farmer_components::sector::{SectorMetadata, SectorMetadataChecksumm
 use subspace_farmer_components::ReadAtSync;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{debug, error, info, trace, warn, Span};
 
 /// How many non-fatal errors should happen in a row before farm is considered non-operational

--- a/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
@@ -3,7 +3,7 @@
 use crate::farm::{FarmError, PieceReader};
 #[cfg(windows)]
 use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows;
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
@@ -18,6 +18,7 @@ use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_farmer_components::sector::{sector_size, SectorMetadataChecksummed};
 use subspace_farmer_components::{reading, ReadAt, ReadAtAsync, ReadAtSync};
 use subspace_proof_of_space::Table;
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{error, warn};
 
 #[derive(Debug)]

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -92,7 +92,7 @@ async fn basic() {
     );
 
     // Can't store pieces when all sectors are plotted
-    sectors_metadata.write_blocking().resize(
+    sectors_metadata.write().await.resize(
         usize::from(TARGET_SECTOR_COUNT),
         dummy_sector_metadata.clone(),
     );
@@ -106,7 +106,7 @@ async fn basic() {
     );
 
     // Clear plotted sectors and reopen
-    sectors_metadata.write_blocking().clear();
+    sectors_metadata.write().await.clear();
     let disk_plot_cache = DiskPlotCache::new(
         &file,
         &sectors_metadata,
@@ -177,7 +177,8 @@ async fn basic() {
         MaybePieceStoredResult::Yes
     );
     sectors_metadata
-        .write_blocking()
+        .write()
+        .await
         .resize(usize::from(TARGET_SECTOR_COUNT - 1), dummy_sector_metadata);
     assert_matches!(
         disk_plot_cache.is_piece_maybe_stored(&record_key_1),

--- a/crates/subspace-farmer/src/single_disk_farm/plotted_sectors.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotted_sectors.rs
@@ -1,5 +1,4 @@
 use crate::farm::{FarmError, PlottedSectors};
-use async_lock::RwLock as AsyncRwLock;
 use async_trait::async_trait;
 use futures::{stream, Stream};
 use std::sync::Arc;
@@ -7,6 +6,7 @@ use subspace_core_primitives::{PieceOffset, PublicKey, SectorId};
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_farmer_components::FarmerProtocolInfo;
+use tokio::sync::RwLock as AsyncRwLock;
 
 /// Getter for single disk plotted sectors
 #[derive(Debug)]

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -7,7 +7,7 @@ use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows
 use crate::single_disk_farm::{
     BackgroundTaskError, Handlers, PlotMetadataHeader, RESERVED_PLOT_METADATA,
 };
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use async_lock::Mutex as AsyncMutex;
 use futures::channel::{mpsc, oneshot};
 use futures::stream::FuturesOrdered;
 use futures::{select, FutureExt, SinkExt, StreamExt};
@@ -29,7 +29,7 @@ use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use thiserror::Error;
-use tokio::sync::watch;
+use tokio::sync::{watch, RwLock as AsyncRwLock};
 use tokio::task;
 use tracing::{debug, info, info_span, trace, warn, Instrument};
 


### PR DESCRIPTION
The reason is https://github.com/smol-rs/async-lock/issues/91

Will switch back once fixed, the API in `async-lock` is nicer.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
