### PR TITLE
Switch from `async-lock` to `tokio` primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12631,7 +12631,6 @@ name = "subspace-farmer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-lock 3.4.0",
  "async-nats",
  "async-trait",
  "backoff",
@@ -12691,7 +12690,6 @@ dependencies = [
 name = "subspace-farmer-components"
 version = "0.1.0"
 dependencies = [
- "async-lock 3.4.0",
  "async-trait",
  "backoff",
  "bitvec",

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -16,7 +16,6 @@ include = [
 bench = false
 
 [dependencies]
-async-lock = "3.3.0"
 async-trait = "0.1.81"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bitvec = "1.0.1"

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -17,7 +17,6 @@ required-features = ["binary"]
 
 [dependencies]
 anyhow = "1.0.86"
-async-lock = "3.3.0"
 async-nats = { version = "0.35.1", optional = true }
 async-trait = "0.1.81"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
@@ -65,7 +64,7 @@ supports-color = { version = "3.0.0", optional = true }
 tempfile = "3.12.0"
 thiserror = "1.0.63"
 thread-priority = "1.1.0"
-tokio = { version = "1.39.2", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.39.2", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -6,7 +6,6 @@ use crate::commands::cluster::controller::farms::{maintain_farms, FarmIndex};
 use crate::commands::shared::derive_libp2p_keypair;
 use crate::commands::shared::network::{configure_network, NetworkArgs};
 use anyhow::anyhow;
-use async_lock::RwLock as AsyncRwLock;
 use backoff::ExponentialBackoff;
 use clap::{Parser, ValueHint};
 use futures::stream::FuturesUnordered;
@@ -31,6 +30,7 @@ use subspace_farmer::node_client::NodeClient;
 use subspace_farmer::single_disk_farm::identity::Identity;
 use subspace_farmer::utils::{run_future_in_dedicated_thread, AsyncJoinOnDrop};
 use subspace_networking::utils::piece_provider::PieceProvider;
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::info;
 
 /// Get piece retry attempts number.

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -2,7 +2,6 @@
 
 use crate::commands::shared::DiskFarm;
 use anyhow::anyhow;
-use async_lock::Mutex as AsyncMutex;
 use backoff::ExponentialBackoff;
 use bytesize::ByteSize;
 use clap::Parser;
@@ -35,7 +34,7 @@ use subspace_farmer::utils::{
 };
 use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_proof_of_space::Table;
-use tokio::sync::{Barrier, Semaphore};
+use tokio::sync::{Barrier, Mutex as AsyncMutex, Semaphore};
 use tracing::{error, info, info_span, warn, Instrument};
 
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -1,6 +1,5 @@
 use crate::commands::shared::PlottingThreadPriority;
 use anyhow::anyhow;
-use async_lock::Mutex as AsyncMutex;
 use clap::Parser;
 use futures::{select, FutureExt};
 use prometheus_client::registry::Registry;
@@ -27,7 +26,7 @@ use subspace_farmer::utils::{
 };
 use subspace_farmer_components::PieceGetter;
 use subspace_proof_of_space::Table;
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex as AsyncMutex, Semaphore};
 use tracing::info;
 
 const PLOTTING_RETRY_INTERVAL: Duration = Duration::from_secs(5);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -1,4 +1,3 @@
-use async_lock::RwLock as AsyncRwLock;
 use clap::Parser;
 use prometheus_client::registry::Registry;
 use std::collections::HashSet;
@@ -22,6 +21,7 @@ use subspace_networking::{
     SegmentHeaderBySegmentIndexesRequestHandler, SegmentHeaderRequest, SegmentHeaderResponse,
 };
 use subspace_rpc_primitives::MAX_SEGMENT_HEADERS_PER_REQUEST;
+use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{debug, error, info, Instrument};
 
 /// How many segment headers can be requested at a time.
@@ -139,7 +139,8 @@ where
 
                         let read_piece_fut = match weak_plotted_pieces.upgrade() {
                             Some(plotted_pieces) => plotted_pieces
-                                .try_read()?
+                                .try_read()
+                                .ok()?
                                 .read_piece(piece_index)?
                                 .in_current_span(),
                             None => {

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -14,7 +14,6 @@ use crate::farm::{PieceCacheId, PieceCacheOffset};
 use crate::farmer_cache::FarmerCache;
 use crate::node_client::{Error as NodeClientError, NodeClient};
 use anyhow::anyhow;
-use async_lock::Semaphore;
 use async_nats::HeaderValue;
 use async_trait::async_trait;
 use futures::{select, FutureExt, Stream, StreamExt};
@@ -29,6 +28,7 @@ use subspace_farmer_components::PieceGetter;
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
+use tokio::sync::Semaphore;
 use tracing::{debug, trace, warn};
 
 /// Broadcast sent by controllers requesting farmers to identify themselves

--- a/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -3,7 +3,6 @@
 
 use crate::node_client::{Error as RpcError, Error, NodeClient, NodeClientExt};
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use async_trait::async_trait;
 use futures::{select, FutureExt, Stream, StreamExt};
 use std::pin::Pin;
@@ -14,7 +13,7 @@ use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
     MAX_SEGMENT_HEADERS_PER_REQUEST,
 };
-use tokio::sync::watch;
+use tokio::sync::{watch, Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use tokio_stream::wrappers::WatchStream;
 use tracing::{info, trace, warn};
 

--- a/crates/subspace-farmer/src/node_client/rpc_node_client.rs
+++ b/crates/subspace-farmer/src/node_client/rpc_node_client.rs
@@ -1,7 +1,6 @@
 //! Node client implementation that connects to node via RPC (WebSockets)
 
 use crate::node_client::{Error as RpcError, Error, NodeClient, NodeClientExt};
-use async_lock::Semaphore;
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 use jsonrpsee::core::client::{ClientT, Error as JsonError, SubscriptionClientT};
@@ -13,6 +12,7 @@ use subspace_core_primitives::{Piece, PieceIndex, SegmentHeader, SegmentIndex};
 use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
+use tokio::sync::Semaphore;
 
 /// TODO: Node is having a hard time responding for many piece requests, specifically this results
 ///  in subscriptions become broken on the node: https://github.com/paritytech/jsonrpsee/issues/1409

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -6,7 +6,6 @@ use crate::plotter::cpu::metrics::CpuPlotterMetrics;
 use crate::plotter::{Plotter, SectorPlottingProgress};
 use crate::thread_pool_manager::PlottingThreadPoolManager;
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::mpsc;
@@ -32,7 +31,7 @@ use subspace_farmer_components::plotting::{
 };
 use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_proof_of_space::Table;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore};
 use tokio::task::yield_now;
 use tracing::{warn, Instrument};
 
@@ -302,7 +301,7 @@ where
                     }
 
                     // Take mutex briefly to make sure plotting is allowed right now
-                    global_mutex.lock().await;
+                    let _ = global_mutex.lock().await;
 
                     let downloading_start = Instant::now();
 

--- a/crates/subspace-farmer/src/plotter/gpu.rs
+++ b/crates/subspace-farmer/src/plotter/gpu.rs
@@ -9,7 +9,6 @@ use crate::plotter::gpu::gpu_encoders_manager::GpuRecordsEncoderManager;
 use crate::plotter::gpu::metrics::GpuPlotterMetrics;
 use crate::plotter::{Plotter, SectorPlottingProgress};
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::mpsc;
@@ -32,7 +31,7 @@ use subspace_farmer_components::plotting::{
     PlottingError, RecordsEncoder,
 };
 use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore};
 use tokio::task::yield_now;
 use tracing::{warn, Instrument};
 
@@ -305,7 +304,7 @@ where
                     }
 
                     // Take mutex briefly to make sure plotting is allowed right now
-                    global_mutex.lock().await;
+                    let _ = global_mutex.lock().await;
 
                     let downloading_start = Instant::now();
 

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -42,7 +42,6 @@ use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows
 use crate::single_disk_farm::unbuffered_io_file_windows::DISK_SECTOR_SIZE;
 use crate::utils::{tokio_rayon_spawn_handler, AsyncJoinOnDrop};
 use crate::{farm, KNOWN_PEERS_CACHE_SIZE};
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use async_trait::async_trait;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::{mpsc, oneshot};
@@ -85,7 +84,7 @@ use subspace_proof_of_space::Table;
 use subspace_rpc_primitives::{FarmerAppInfo, SolutionResponse};
 use thiserror::Error;
 use tokio::runtime::Handle;
-use tokio::sync::{broadcast, Barrier, Semaphore};
+use tokio::sync::{broadcast, Barrier, Mutex as AsyncMutex, RwLock as AsyncRwLock, Semaphore};
 use tokio::task;
 use tracing::{debug, error, info, trace, warn, Instrument, Span};
 
@@ -958,7 +957,7 @@ impl SingleDiskFarm {
                 *registry.lock(),
                 single_disk_farm_info.id(),
                 target_sector_count,
-                sectors_metadata.read_blocking().len() as SectorIndex,
+                task::block_in_place(|| sectors_metadata.blocking_read()).len() as SectorIndex,
             ))
         });
 

--- a/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -11,7 +11,6 @@ use crate::farm::{
 use crate::node_client::NodeClient;
 use crate::single_disk_farm::metrics::SingleDiskFarmMetrics;
 use crate::single_disk_farm::Handlers;
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use futures::channel::mpsc;
 use futures::StreamExt;
 use parking_lot::Mutex;
@@ -31,6 +30,7 @@ use subspace_farmer_components::sector::{SectorMetadata, SectorMetadataChecksumm
 use subspace_farmer_components::ReadAtSync;
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
+use tokio::sync::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use tracing::{debug, error, info, trace, warn, Span};
 
 /// How many non-fatal errors should happen in a row before farm is considered non-operational
@@ -257,7 +257,7 @@ where
         let slot = slot_info.slot_number;
 
         // Take mutex briefly to make sure farming is allowed right now
-        global_mutex.lock().await;
+        let _ = global_mutex.lock().await;
 
         let mut problematic_sectors = Vec::new();
         let result: Result<(), FarmingError> = try {

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
@@ -7,7 +7,6 @@ use crate::farm::{FarmError, MaybePieceStoredResult, PlotCache};
 #[cfg(windows)]
 use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows;
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::RwLock as AsyncRwLock;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use parking_lot::RwLock;
@@ -23,6 +22,7 @@ use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_networking::libp2p::kad::RecordKey;
 use subspace_networking::utils::multihash::ToMultihash;
 use thiserror::Error;
+use tokio::sync::RwLock as AsyncRwLock;
 use tokio::task;
 use tracing::{debug, info, warn};
 
@@ -92,7 +92,7 @@ impl DiskPlotCache {
     ) -> Self {
         info!("Checking plot cache contents, this can take a while");
         let cached_pieces = {
-            let sectors_metadata = sectors_metadata.read_blocking();
+            let sectors_metadata = task::block_in_place(|| sectors_metadata.blocking_read());
             let mut element = vec![0; Self::element_size() as usize];
             // Clippy complains about `RecordKey`, but it is not changing here, so it is fine
             #[allow(clippy::mutable_key_type)]
@@ -170,7 +170,8 @@ impl DiskPlotCache {
 
         let element_offset = u64::from(offset) * u64::from(Self::element_size());
         // Blocking read is fine because writes in farmer are very rare and very brief
-        let plotted_bytes = self.sector_size * sectors_metadata.read_blocking().len() as u64;
+        let plotted_bytes = self.sector_size
+            * task::block_in_place(|| sectors_metadata.blocking_read()).len() as u64;
 
         // Make sure offset is after anything that is already plotted
         if element_offset < plotted_bytes {

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -92,7 +92,7 @@ async fn basic() {
     );
 
     // Can't store pieces when all sectors are plotted
-    sectors_metadata.write_blocking().resize(
+    sectors_metadata.write().await.resize(
         usize::from(TARGET_SECTOR_COUNT),
         dummy_sector_metadata.clone(),
     );
@@ -106,7 +106,7 @@ async fn basic() {
     );
 
     // Clear plotted sectors and reopen
-    sectors_metadata.write_blocking().clear();
+    sectors_metadata.write().await.clear();
     let disk_plot_cache = DiskPlotCache::new(
         &file,
         &sectors_metadata,
@@ -177,7 +177,8 @@ async fn basic() {
         MaybePieceStoredResult::Yes
     );
     sectors_metadata
-        .write_blocking()
+        .write()
+        .await
         .resize(usize::from(TARGET_SECTOR_COUNT - 1), dummy_sector_metadata);
     assert_matches!(
         disk_plot_cache.is_piece_maybe_stored(&record_key_1),

--- a/crates/subspace-farmer/src/single_disk_farm/plotted_sectors.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotted_sectors.rs
@@ -1,5 +1,4 @@
 use crate::farm::{FarmError, PlottedSectors};
-use async_lock::RwLock as AsyncRwLock;
 use async_trait::async_trait;
 use futures::{stream, Stream};
 use std::sync::Arc;
@@ -7,6 +6,7 @@ use subspace_core_primitives::{PieceOffset, PublicKey, SectorId};
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use subspace_farmer_components::FarmerProtocolInfo;
+use tokio::sync::RwLock as AsyncRwLock;
 
 /// Getter for single disk plotted sectors
 #[derive(Debug)]

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -7,7 +7,6 @@ use crate::single_disk_farm::unbuffered_io_file_windows::UnbufferedIoFileWindows
 use crate::single_disk_farm::{
     BackgroundTaskError, Handlers, PlotMetadataHeader, RESERVED_PLOT_METADATA,
 };
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use futures::channel::{mpsc, oneshot};
 use futures::stream::FuturesOrdered;
 use futures::{select, FutureExt, SinkExt, StreamExt};
@@ -29,7 +28,7 @@ use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
 use thiserror::Error;
-use tokio::sync::watch;
+use tokio::sync::{watch, Mutex as AsyncMutex, RwLock as AsyncRwLock};
 use tokio::task;
 use tracing::{debug, info, info_span, trace, warn, Instrument};
 
@@ -588,7 +587,7 @@ async fn plot_single_sector_internal(
 
     {
         // Take mutex briefly to make sure writing is allowed right now
-        global_mutex.lock().await;
+        let _ = global_mutex.lock().await;
 
         if let Some(metrics) = metrics {
             metrics.sector_writing.inc();


### PR DESCRIPTION
I discovered that https://github.com/smol-rs/async-lock/issues/91 not only affects RwLock, but also `Mutex` and possibly other primitives (we used `Semaphore` too in some case). So I decided to move away from it completely (though I did like API of `async-lock` more).

We still use `async-lock` in our fork of Substrate for parallel block verification implementation, I'll take care of it when we update Substrate again (should be soon, they're polishing September's release at the moment).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
