### PR TITLE
opt: optimize cluster identification

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -2,7 +2,7 @@ mod caches;
 mod farms;
 
 use crate::commands::cluster::controller::caches::maintain_caches;
-use crate::commands::cluster::controller::farms::{maintain_farms, FarmIndex};
+use crate::commands::cluster::controller::farms::maintain_farms;
 use crate::commands::shared::derive_libp2p_keypair;
 use crate::commands::shared::network::{configure_network, NetworkArgs};
 use anyhow::anyhow;
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_farmer::cluster::controller::controller_service;
+use subspace_farmer::cluster::farmer::FarmIndex;
 use subspace_farmer::cluster::nats_client::NatsClient;
 use subspace_farmer::farm::plotted_pieces::PlottedPieces;
 use subspace_farmer::farmer_cache::FarmerCache;

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
@@ -65,6 +65,7 @@ impl KnownCaches {
                 self.known_single_caches
                     .iter_mut()
                     .for_each(|known_single_cache| {
+                        debug!(single_cache_id = %known_single_cache.single_cache_id, "Updating last identification for single cache");
                         known_single_cache.last_identification = last_identification;
                     });
                 true

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
@@ -9,23 +9,31 @@ use crate::commands::cluster::cache::CACHE_IDENTIFICATION_BROADCAST_INTERVAL;
 use anyhow::anyhow;
 use futures::channel::oneshot;
 use futures::future::FusedFuture;
-use futures::{select, FutureExt, StreamExt};
+use futures::{select, stream, FutureExt, StreamExt};
 use parking_lot::Mutex;
 use std::future::{ready, Future};
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use subspace_farmer::cluster::cache::{
+    ClusterCacheDetailsRequest, ClusterCacheIdentifyBroadcast,
     ClusterCacheIdentifySignalCacheBroadcast, ClusterCacheIndex, ClusterPieceCache,
+    ClusterSingleCacheDetails,
 };
 use subspace_farmer::cluster::controller::ClusterControllerCacheIdentifyBroadcast;
 use subspace_farmer::cluster::nats_client::NatsClient;
 use subspace_farmer::farm::{PieceCache, PieceCacheId};
 use subspace_farmer::farmer_cache::FarmerCache;
 use tokio::time::MissedTickBehavior;
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 const SCHEDULE_REINITIALIZATION_DELAY: Duration = Duration::from_secs(3);
+
+#[derive(Debug)]
+struct KnownCache {
+    cache_id: PieceCacheId,
+    last_identification: Instant,
+}
 
 #[derive(Debug)]
 struct KnownSingleCache {
@@ -36,6 +44,7 @@ struct KnownSingleCache {
 
 #[derive(Debug, Default)]
 struct KnownCaches {
+    known_caches: Vec<KnownCache>,
     known_single_caches: Vec<KnownSingleCache>,
 }
 
@@ -45,6 +54,33 @@ impl KnownCaches {
             .iter()
             .map(|known_cache| Arc::clone(&known_cache.piece_cache) as Arc<_>)
             .collect()
+    }
+
+    /// Return `true` if farmer cache reinitialization is required
+    fn update(&mut self, cache_id: PieceCacheId) -> bool {
+        let last_identification = Instant::now();
+        if self.known_caches.iter_mut().any(|known_cache| {
+            if known_cache.cache_id == cache_id {
+                known_cache.last_identification = last_identification;
+                self.known_single_caches
+                    .iter_mut()
+                    .for_each(|known_single_cache| {
+                        known_single_cache.last_identification = last_identification;
+                    });
+                true
+            } else {
+                false
+            }
+        }) {
+            return false;
+        }
+
+        self.known_caches.push(KnownCache {
+            cache_id,
+            last_identification,
+        });
+
+        true
     }
 
     /// Return `true` if farmer cache reinitialization is required
@@ -84,6 +120,9 @@ impl KnownCaches {
 
     fn remove_expired(&mut self) -> impl Iterator<Item = KnownSingleCache> + '_ {
         let elapsed = CACHE_IDENTIFICATION_BROADCAST_INTERVAL * 2;
+        self.known_caches
+            .retain(move |known_cache| known_cache.last_identification.elapsed() <= elapsed);
+
         self.known_single_caches
             .extract_if(move |known_single_cache| {
                 known_single_cache.last_identification.elapsed() > elapsed
@@ -104,12 +143,19 @@ pub(super) async fn maintain_caches(
         (Box::pin(ready(())) as Pin<Box<dyn Future<Output = ()>>>).fuse();
 
     let cache_identify_subscription = pin!(nats_client
+        .subscribe_to_broadcasts::<ClusterCacheIdentifyBroadcast>(None, None)
+        .await
+        .map_err(|error| anyhow!("Failed to subscribe to cache identify broadcast: {error}"))?);
+
+    let single_cache_identify_subscription = pin!(nats_client
         .subscribe_to_broadcasts::<ClusterCacheIdentifySignalCacheBroadcast>(
             Some(cache_group),
             None
         )
         .await
-        .map_err(|error| anyhow!("Failed to subscribe to cache identify broadcast: {error}"))?);
+        .map_err(|error| anyhow!(
+            "Failed to subscribe to single cache identify broadcast: {error}"
+        ))?);
 
     // Request cache to identify themselves
     if let Err(error) = nats_client
@@ -120,6 +166,7 @@ pub(super) async fn maintain_caches(
     }
 
     let mut cache_identify_subscription = cache_identify_subscription.fuse();
+    let mut single_cache_identify_subscription = single_cache_identify_subscription.fuse();
     let mut cache_pruning_interval = tokio::time::interval_at(
         (Instant::now() + CACHE_IDENTIFICATION_BROADCAST_INTERVAL * 2).into(),
         CACHE_IDENTIFICATION_BROADCAST_INTERVAL * 2,
@@ -161,7 +208,7 @@ pub(super) async fn maintain_caches(
         }
 
         select! {
-            maybe_identify_message = cache_identify_subscription.next() => {
+            maybe_identify_message = single_cache_identify_subscription.next() => {
                 let Some(identify_message) = maybe_identify_message else {
                     return Err(anyhow!("Cache identify stream ended"));
                 };
@@ -170,20 +217,55 @@ pub(super) async fn maintain_caches(
                     cache_id,
                     max_num_elements,
                 } = identify_message;
-                if known_caches.update_single(cache_id, max_num_elements, nats_client) {
-                    info!(
-                        %cache_id,
-                        "New cache discovered, scheduling reinitialization"
-                    );
-                    scheduled_reinitialization_for.replace(
-                        Instant::now() + SCHEDULE_REINITIALIZATION_DELAY,
-                    );
-                } else {
-                    trace!(
-                        %cache_id,
-                        "Received identification for already known cache"
-                    );
+                process_cache_identify_message(
+                    nats_client,
+                    cache_id,
+                    max_num_elements,
+                    &mut known_caches,
+                    &mut scheduled_reinitialization_for,
+                )
+            }
+            maybe_identify_message = cache_identify_subscription.next() => {
+                let Some(identify_message) = maybe_identify_message else {
+                    return Err(anyhow!("Cache identify stream ended"));
+                };
+
+                let ClusterCacheIdentifyBroadcast { cache_id, cache_count } = identify_message;
+
+                if !known_caches.update(cache_id) {
+                    // Cache already known, nothing to do
+                    debug!(%cache_id, "Cache already known, nothing to do");
+                    continue
                 }
+
+                let cache_ids = cache_id.derive_sub_ids(cache_count.into());
+                match nats_client
+                .stream_request(
+                    ClusterCacheDetailsRequest,
+                    Some(&cache_id.to_string()),
+                )
+                .await
+            {
+                Ok(caches_details) => {
+                    let mut caches_details = caches_details.zip(stream::iter(cache_ids));
+                    while let Some((cache_details, single_cache_id)) = caches_details.next().await {
+                        let ClusterSingleCacheDetails { max_num_elements } = cache_details;
+
+                        process_cache_identify_message(
+                            nats_client,
+                            single_cache_id,
+                            max_num_elements,
+                            &mut known_caches,
+                            &mut scheduled_reinitialization_for,
+                        )
+                    }
+                }
+                Err(error) => warn!(
+                    %error,
+                    %cache_id,
+                    "Failed to request farmer farm details"
+                ),
+            }
             }
             _ = cache_pruning_interval.tick().fuse() => {
                 let mut reinit = false;
@@ -191,7 +273,7 @@ pub(super) async fn maintain_caches(
                     reinit = true;
 
                     warn!(
-                        cache_id = %removed_cache.cache_id,
+                        cache_id = %removed_cache.single_cache_id,
                         "Cache expired and removed, scheduling reinitialization"
                     );
                 }
@@ -205,6 +287,28 @@ pub(super) async fn maintain_caches(
             _ = cache_reinitialization => {
                 // Nothing left to do
             }
+        }
+    }
+
+    fn process_cache_identify_message(
+        nats_client: &NatsClient,
+        cache_id: PieceCacheId,
+        max_num_elements: u32,
+        known_caches: &mut KnownCaches,
+        scheduled_reinitialization_for: &mut Option<Instant>,
+    ) {
+        if known_caches.update_single(cache_id, max_num_elements, nats_client) {
+            info!(
+                %cache_id,
+                "New cache discovered, scheduling reinitialization"
+            );
+            scheduled_reinitialization_for
+                .replace(Instant::now() + SCHEDULE_REINITIALIZATION_DELAY);
+        } else {
+            trace!(
+                %cache_id,
+                "Received identification for already known cache"
+            );
         }
     }
 }

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/farms.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/farms.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 use std::time::Instant;
 use subspace_core_primitives::{Blake3Hash, SectorIndex};
 use subspace_farmer::cluster::controller::ClusterControllerFarmerIdentifyBroadcast;
-use subspace_farmer::cluster::farmer::{ClusterFarm, ClusterFarmerIdentifyFarmBroadcast};
+use subspace_farmer::cluster::farmer::{
+    ClusterFarm, ClusterFarmerIdentifyFarmBroadcast, FarmIndex,
+};
 use subspace_farmer::cluster::nats_client::NatsClient;
 use subspace_farmer::farm::plotted_pieces::PlottedPieces;
 use subspace_farmer::farm::{Farm, FarmId, SectorPlottingDetails, SectorUpdate};
@@ -31,8 +33,6 @@ use tracing::{error, info, trace, warn};
 
 type AddRemoveFuture<'a> =
     Pin<Box<dyn Future<Output = Option<(FarmIndex, oneshot::Receiver<()>, ClusterFarm)>> + 'a>>;
-
-pub(super) type FarmIndex = u16;
 
 #[derive(Debug)]
 struct KnownFarm {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/farms.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/farms.rs
@@ -77,6 +77,7 @@ impl KnownFarms {
                 self.known_farms.iter_mut().for_each(|(_, known_farm)| {
                     // All farms in farmer use the same fingerprint
                     if known_farm.fingerprint == fingerprint {
+                        debug!(farm_id = %known_farm.farm_id, "Updating last identification for farm");
                         known_farm.last_identification = last_identification;
                     }
                 });

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -439,7 +439,7 @@ where
                 };
 
                 // Create background task for concurrent processing
-                processing.push(Box::pin(process_caches_deatils_request(
+                processing.push(Box::pin(process_caches_details_request(
                     nats_client,
                     caches_details,
                     message,
@@ -454,7 +454,7 @@ where
     Ok(())
 }
 
-async fn process_caches_deatils_request<C>(
+async fn process_caches_details_request<C>(
     nats_client: &NatsClient,
     caches_details: &[CacheDetails<'_, C>],
     request: StreamRequest<ClusterCacheDetailsRequest>,

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -691,7 +691,7 @@ async fn farms_details_responder(
                 };
 
                 // Create background task for concurrent processing
-                processing.push(Box::pin(process_farms_deatils_request(
+                processing.push(Box::pin(process_farms_details_request(
                     nats_client,
                     farms_details,
                     message,
@@ -706,7 +706,7 @@ async fn farms_details_responder(
     Ok(())
 }
 
-async fn process_farms_deatils_request(
+async fn process_farms_details_request(
     nats_client: &NatsClient,
     farms_details: &[FarmDetails],
     request: StreamRequest<ClusterFarmerFarmDetailsRequest>,

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -37,6 +37,8 @@ use tracing::{debug, error, trace, warn};
 const BROADCAST_NOTIFICATIONS_BUFFER: usize = 1000;
 const MIN_FARMER_IDENTIFICATION_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Type alias for farm index used by cluster.
+pub type FarmIndex = u16;
 type Handler<A> = Bag<HandlerFn<A>, A>;
 
 /// Broadcast with identification details by farmers

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -102,6 +102,19 @@ impl PieceCacheId {
     pub fn new() -> Self {
         Self::Ulid(Ulid::new())
     }
+
+    /// Derive sub IDs
+    #[inline]
+    pub fn derive_sub_ids(&self, n: usize) -> Vec<Self> {
+        match self {
+            PieceCacheId::Ulid(ulid) => {
+                let ulid = ulid.0;
+                (0..n as u128)
+                    .map(|i| PieceCacheId::Ulid(Ulid(ulid + i)))
+                    .collect()
+            }
+        }
+    }
 }
 
 /// Offset wrapper for pieces in [`PieceCache`]

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -28,6 +28,8 @@ use thiserror::Error;
 use ulid::Ulid;
 
 pub mod plotted_pieces;
+#[cfg(test)]
+mod tests;
 
 /// Erased error type
 pub type FarmError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -498,6 +500,19 @@ impl FarmId {
     #[inline]
     pub fn new() -> Self {
         Self::Ulid(Ulid::new())
+    }
+
+    /// Derive sub IDs
+    #[inline]
+    pub fn derive_sub_ids(&self, n: usize) -> Vec<Self> {
+        match self {
+            FarmId::Ulid(ulid) => {
+                let ulid = ulid.0;
+                (0..n as u128)
+                    .map(|i| FarmId::Ulid(Ulid(ulid + i)))
+                    .collect()
+            }
+        }
     }
 }
 

--- a/crates/subspace-farmer/src/farm/tests.rs
+++ b/crates/subspace-farmer/src/farm/tests.rs
@@ -1,0 +1,19 @@
+use crate::farm::FarmId;
+
+#[test]
+fn derive_sub_farm_ids_test() {
+    let id = FarmId::new();
+    let sub_ids = id.derive_sub_ids(128);
+    assert_eq!(sub_ids.len(), 128);
+
+    match id {
+        FarmId::Ulid(id) => {
+            let id: u128 = id.into();
+            sub_ids.into_iter().zip(0..128u128).for_each(|(sub_id, i)| {
+                let FarmId::Ulid(sub_id) = sub_id;
+                let sub_id: u128 = sub_id.into();
+                assert_eq!(sub_id, id + i);
+            });
+        }
+    };
+}

--- a/crates/subspace-farmer/src/farm/tests.rs
+++ b/crates/subspace-farmer/src/farm/tests.rs
@@ -1,4 +1,4 @@
-use crate::farm::FarmId;
+use crate::farm::{FarmId, PieceCacheId};
 
 #[test]
 fn derive_sub_farm_ids_test() {
@@ -11,6 +11,24 @@ fn derive_sub_farm_ids_test() {
             let id: u128 = id.into();
             sub_ids.into_iter().zip(0..128u128).for_each(|(sub_id, i)| {
                 let FarmId::Ulid(sub_id) = sub_id;
+                let sub_id: u128 = sub_id.into();
+                assert_eq!(sub_id, id + i);
+            });
+        }
+    };
+}
+
+#[test]
+fn derive_sub_cache_ids_test() {
+    let id = PieceCacheId::new();
+    let sub_ids = id.derive_sub_ids(128);
+    assert_eq!(sub_ids.len(), 128);
+
+    match id {
+        PieceCacheId::Ulid(id) => {
+            let id: u128 = id.into();
+            sub_ids.into_iter().zip(0..128u128).for_each(|(sub_id, i)| {
+                let PieceCacheId::Ulid(sub_id) = sub_id;
                 let sub_id: u128 = sub_id.into();
                 assert_eq!(sub_id, id + i);
             });


### PR DESCRIPTION
close #2900 

For the cache, the modification is quite simple — just generate a random Cache ID each time and derive sub-IDs from it.

However, it's a bit different for the farmer. Currently, the logic for deriving the farmer's fingerprint is almost the same as that for the farm's fingerprint, but the information included is insufficient to fully describe whether the farm's state has changed between two restarts.

As a result, the current implementation does not support fast restarts. However, we have still achieved our initial goal: reducing identification messages to one per farmer and retrieving farm details in a steady stream.

Therefore, I will submit this PR first and implement the fast restart feature in a subsequent PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
