### PR TITLE
Big-endian Scalar/KZG

### DIFF
--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -686,7 +686,7 @@ impl Archiver {
             let mut tmp_source_shards_scalars =
                 Vec::<Scalar>::with_capacity(RecordedHistorySegment::NUM_RAW_RECORDS);
             // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
-            for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
+            for record_offset in 0..RawRecord::NUM_CHUNKS {
                 // Collect chunks of each record at the same offset
                 raw_record_shards
                     .array_chunks::<{ RawRecord::SIZE }>()

--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -62,7 +62,7 @@ impl PiecesReconstructor {
         let mut tmp_shards_scalars =
             Vec::<Option<Scalar>>::with_capacity(ArchivedHistorySegment::NUM_PIECES);
         // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
-        for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
+        for record_offset in 0..RawRecord::NUM_CHUNKS {
             // Collect chunks of each record at the same offset
             for maybe_piece in input_pieces.iter() {
                 let maybe_scalar = maybe_piece

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -110,7 +110,7 @@ impl Reconstructor {
             let mut tmp_shards_scalars =
                 Vec::<Option<Scalar>>::with_capacity(ArchivedHistorySegment::NUM_PIECES);
             // Iterate over the chunks of `Scalar::SAFE_BYTES` bytes of all records
-            for record_offset in 0..RawRecord::SIZE / Scalar::SAFE_BYTES {
+            for record_offset in 0..RawRecord::NUM_CHUNKS {
                 // Collect chunks of each record at the same offset
                 for maybe_piece in segment_pieces.iter() {
                     let maybe_scalar = maybe_piece

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -26,7 +26,9 @@ fn extract_data_from_source_record<O: Into<u64>>(record: &Record, offset: O) -> 
     let offset: u64 = offset.into();
     let Compact(size) = Compact::<u64>::decode(
         &mut record
-            .to_raw_record_bytes()
+            .to_raw_record_chunks()
+            .flatten()
+            .copied()
             .skip(offset as usize)
             .take(8)
             .collect::<Vec<_>>()
@@ -34,7 +36,9 @@ fn extract_data_from_source_record<O: Into<u64>>(record: &Record, offset: O) -> 
     )
     .unwrap();
     record
-        .to_raw_record_bytes()
+        .to_raw_record_chunks()
+        .flatten()
+        .copied()
         .skip(offset as usize + Compact::compact_len(&size))
         .take(size as usize)
         .collect()
@@ -680,7 +684,9 @@ fn object_on_the_edge_of_segment() {
     assert_eq!(
         archived_segments[1].pieces[0]
             .record()
-            .to_raw_record_bytes()
+            .to_raw_record_chunks()
+            .flatten()
+            .copied()
             .skip(archived_segments[1].object_mapping[0].objects[0].offset() as usize)
             .take(mapped_bytes.len())
             .collect::<Vec<_>>(),

--- a/crates/subspace-core-primitives/benches/kzg.rs
+++ b/crates/subspace-core-primitives/benches/kzg.rs
@@ -4,7 +4,7 @@ use subspace_core_primitives::crypto::Scalar;
 use subspace_core_primitives::RawRecord;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let values = (0..RawRecord::SIZE / Scalar::SAFE_BYTES)
+    let values = (0..RawRecord::NUM_CHUNKS)
         .map(|_| Scalar::from(rand::random::<[u8; Scalar::SAFE_BYTES]>()))
         .collect::<Vec<_>>();
 

--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -651,13 +651,14 @@ impl Record {
         unsafe { mem::transmute(value) }
     }
 
-    /// Convert from a record to its raw bytes. Used for object reconstruction.
-    pub fn to_raw_record_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+    /// Convert from a record to its raw bytes, assumes dealing with source record that only stores
+    /// safe bytes in its chunks.
+    #[inline]
+    pub fn to_raw_record_chunks(&self) -> impl Iterator<Item = &'_ [u8; Scalar::SAFE_BYTES]> + '_ {
         // We have zero byte padding from [`Scalar::SAFE_BYTES`] to [`Scalar::FULL_BYTES`] that we need
         // to skip
         self.iter()
-            .flat_map(|bytes| &bytes[..Scalar::SAFE_BYTES])
-            .copied()
+            .map(|bytes| bytes[1..].try_into().expect("Correct length; qed"))
     }
 }
 

--- a/crates/subspace-core-primitives/src/tests.rs
+++ b/crates/subspace-core-primitives/src/tests.rs
@@ -30,7 +30,7 @@ fn bytes_scalars_conversion() {
                 .chunks_exact_mut(Scalar::SAFE_BYTES)
                 .zip(scalars.iter())
                 .for_each(|(bytes, scalar)| {
-                    bytes.copy_from_slice(&scalar.to_bytes()[..Scalar::SAFE_BYTES]);
+                    bytes.copy_from_slice(&scalar.to_bytes()[1..]);
                 });
 
             assert_eq!(bytes, decoded_bytes);
@@ -42,7 +42,7 @@ fn bytes_scalars_conversion() {
                 .chunks_exact_mut(Scalar::SAFE_BYTES)
                 .zip(scalars.iter())
                 .for_each(|(bytes, scalar)| {
-                    bytes.copy_from_slice(&scalar.to_bytes()[..Scalar::SAFE_BYTES]);
+                    bytes.copy_from_slice(&scalar.to_bytes()[1..]);
                 });
 
             assert_eq!(bytes, decoded_bytes);
@@ -52,8 +52,7 @@ fn bytes_scalars_conversion() {
     {
         let bytes = {
             let mut bytes = [0u8; Scalar::FULL_BYTES];
-            bytes[..Scalar::SAFE_BYTES]
-                .copy_from_slice(&rand::random::<[u8; Scalar::SAFE_BYTES]>());
+            bytes[1..].copy_from_slice(&rand::random::<[u8; Scalar::SAFE_BYTES]>());
             bytes
         };
 


### PR DESCRIPTION
As discussed in https://github.com/autonomys/subspace/pull/3004 we're switching to big-endian after Ethereum.

I also refactored `Record::to_raw_record_bytes()` into `Record::to_raw_record_chunks()`, that way it is useful in more contexts.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
