### PR TITLE
Add MMR data verification.

### DIFF
--- a/domains/client/domain-operator/src/snap_sync.rs
+++ b/domains/client/domain-operator/src/snap_sync.rs
@@ -13,8 +13,11 @@ use sc_network_common::sync::message::{
 use sc_network_sync::block_relay_protocol::BlockDownloader;
 use sc_network_sync::SyncingService;
 use sc_service::ClientExt;
+use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockOrigin;
+use sp_core::H256;
+use sp_mmr_primitives::MmrApi;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -28,6 +31,8 @@ use tracing::{debug, error, trace};
 
 pub struct SyncParams<DomainClient, CClient, NR, Block, CBlock, CNR, AS>
 where
+    CClient: ProvideRuntimeApi<CBlock> + HeaderBackend<CBlock>,
+    CClient::Api: MmrApi<CBlock, H256, NumberFor<CBlock>>,
     NR: NetworkRequest + Send + Sync,
     CNR: NetworkRequest + Send + Sync + 'static,
     Block: BlockT,
@@ -200,7 +205,13 @@ where
     NR: NetworkRequest + Send + Sync,
     CNR: NetworkRequest + Send + Sync,
     CBlock: BlockT,
-    CClient: HeaderBackend<CBlock> + ProofProvider<CBlock> + Send + Sync + 'static,
+    CClient: ProvideRuntimeApi<CBlock>
+        + HeaderBackend<CBlock>
+        + ProofProvider<CBlock>
+        + Send
+        + Sync
+        + 'static,
+    CClient::Api: MmrApi<CBlock, H256, NumberFor<CBlock>>,
     AS: AuxStore,
 {
     let execution_receipt_result = sync_params


### PR DESCRIPTION
This PR adds verification to the MMR data acquired during the domain snap sync. The idea is to collect the received data in a similar structure `MMR` as the actual pallet does and compare calculated root with the MMR root from the downloaded state using the runtime API call. The block number for the runtime API call is the target block number for the state download. 

The code worked in the local tests when all domain snap-sync components are enabled.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
