### PR TITLE
Remove `zlib1g-dev:arm64` from cross-compilation to aarch64

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -161,30 +161,11 @@ jobs:
 
       - name: AArch64 cross-compile packages
         run: |
-          FLAVOR="$(lsb_release -sc)"
-
-          sudo tee /etc/apt/sources.list.d/arm64.list <<LIST
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR} main restricted
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR}-updates main restricted
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR} universe
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR}-updates universe
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR} multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR}-updates multiverse
-            deb [arch=arm64] http://ports.ubuntu.com/ ${FLAVOR}-backports main restricted universe multiverse
-          LIST
-          sudo sed -i 's/deb http/deb [arch=amd64] http/' /etc/apt/sources.list
-          # GitHub runners use mirror file
-          sudo sed -i 's/deb mirror/deb [arch=amd64] mirror/' /etc/apt/sources.list
-
-          sudo dpkg --add-architecture arm64
           sudo apt-get update
-          # zlib1g-dev:arm64 is only necessary because amd64 version is present on the host and cross-compilation of
-          # hwlocality-sys fails otherwise
           sudo apt-get install -y --no-install-recommends \
             g++-aarch64-linux-gnu \
             gcc-aarch64-linux-gnu \
-            libc6-dev-arm64-cross \
-            zlib1g-dev:arm64
+            libc6-dev-arm64-cross
 
           echo "PKG_CONFIG_ALLOW_CROSS=true" >> $GITHUB_ENV
         if: matrix.build.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
Our environment is not clean, but I tested in my fork and it succeeds without the library, so I think we don't need it anymore

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
