### PR TITLE
Change snap-sync UX for early history.

### DIFF
--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -493,8 +493,8 @@ pub(super) fn create_consensus_chain_configuration(
         });
     }
 
-    // Full sync is the default mode.
-    let sync = sync.unwrap_or(ChainSyncMode::Full);
+    // Snap sync is the default mode.
+    let sync = sync.unwrap_or(ChainSyncMode::Snap);
 
     let chain_spec = match chain.as_deref() {
         Some("gemini-3h-compiled") => chain_spec::gemini_3h_compiled()?,

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -493,8 +493,8 @@ pub(super) fn create_consensus_chain_configuration(
         });
     }
 
-    // Snap sync is the default mode.
-    let sync = sync.unwrap_or(ChainSyncMode::Snap);
+    // Full sync is the default mode.
+    let sync = sync.unwrap_or(ChainSyncMode::Full);
 
     let chain_spec = match chain.as_deref() {
         Some("gemini-3h-compiled") => chain_spec::gemini_3h_compiled()?,

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -167,12 +167,12 @@ where
         }
     };
 
-    // Skip the snap sync if there is just one segment header built on top of genesis, it is
-    // more efficient to sync it regularly
+    // We don't have the genesis state when we choose to snap sync.
     if target_segment_index <= SegmentIndex::ONE {
-        debug!("Snap sync was skipped due to too early chain history");
-
-        return Ok(None);
+        panic!(
+            "Snap sync is impossible - not enough archived history: \
+          wipe the DB folder and rerun with --sync=full"
+        );
     }
 
     // Identify all segment headers that would need to be reconstructed in order to get first

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -171,7 +171,7 @@ where
     if target_segment_index <= SegmentIndex::ONE {
         panic!(
             "Snap sync is impossible - not enough archived history: \
-          wipe the DB folder and rerun with --sync=full"
+            wipe the DB folder and rerun with --sync=full"
         );
     }
 


### PR DESCRIPTION
This PR adds a hard error for the attempt of snap-sync during the early history and makes the full snap sync mode default. Previously, snap sync attempts continued with errors: we don't have genesis state on snap sync and new blocks were unexpected because snap sync was skipped along with new state downloading.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
