### PR TITLE
Improve cache logging by including cache index

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -34,7 +34,7 @@ use subspace_networking::{KeyWithDistance, LocalRecordProvider};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use tokio::task::{block_in_place, yield_now};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 
 const WORKER_CHANNEL_CAPACITY: usize = 100;
 const CONCURRENT_PIECES_TO_DOWNLOAD: usize = 1_000;
@@ -330,7 +330,7 @@ where
                     let mut maybe_contents = match backend.backend.contents().await {
                         Ok(contents) => Some(contents),
                         Err(error) => {
-                            warn!(%cache_index, %error, "Failed to get cache contents");
+                            warn!(%error, "Failed to get cache contents");
 
                             None
                         }
@@ -354,11 +354,7 @@ where
                         let (piece_offset, maybe_piece_index) = match maybe_element_details {
                             Ok(element_details) => element_details,
                             Err(error) => {
-                                warn!(
-                                    %cache_index,
-                                    %error,
-                                    "Failed to get cache contents element details"
-                                );
+                                warn!(%error, "Failed to get cache contents element details");
                                 break;
                             }
                         };
@@ -392,7 +388,7 @@ where
                 };
 
                 Some(run_future_in_dedicated_thread(
-                    move || init_fut,
+                    move || init_fut.instrument(info_span!("", %cache_index)),
                     format!("piece-cache.{cache_index}"),
                 ))
             })


### PR DESCRIPTION
Without this users were complaining about not super helpful errors that looked like this:
> 2024-08-17T06:01:49.780775Z  WARN subspace_farmer::disk_piece_cache: Failed to read cache element error=Disk piece cache I/O error: Input/output error (os error 5) offset=1148

Inclusion of cache index makes it more useful and actionable.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
