### PR TITLE
Make Blake3Hash always encode as Hex in JSON

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -469,7 +469,7 @@ pub fn create_signed_vote(
         );
         let sector_slot_challenge = sector_id.derive_sector_slot_challenge(&global_challenge);
         let masked_chunk = (Simd::from(solution.chunk.to_bytes())
-            ^ Simd::from(solution.proof_of_space.hash()))
+            ^ Simd::from(*solution.proof_of_space.hash()))
         .to_array();
 
         // Check that solution quality is not too high

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -56,8 +56,8 @@ use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::crypto::kzg::Kzg;
 use subspace_core_primitives::objects::GlobalObjectMapping;
 use subspace_core_primitives::{
-    Blake3Hash, Blake3HashHex, BlockHash, HistorySize, Piece, PieceIndex, PublicKey, SegmentHeader,
-    SegmentIndex, SlotNumber, Solution,
+    Blake3Hash, BlockHash, HistorySize, Piece, PieceIndex, PublicKey, SegmentHeader, SegmentIndex,
+    SlotNumber, Solution,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::FarmerProtocolInfo;
@@ -181,7 +181,7 @@ pub trait SubspaceRpcApi {
         unsubscribe = "subspace_unsubscribeFilteredObjectMappings",
         item = GlobalObjectMapping,
     )]
-    fn subscribe_filtered_object_mappings(&self, hashes: Vec<Blake3HashHex>);
+    fn subscribe_filtered_object_mappings(&self, hashes: Vec<Blake3Hash>);
 }
 
 #[derive(Default)]
@@ -850,7 +850,7 @@ where
     fn subscribe_filtered_object_mappings(
         &self,
         pending: PendingSubscriptionSink,
-        hashes: Vec<Blake3HashHex>,
+        hashes: Vec<Blake3Hash>,
     ) {
         // TODO: deny unsafe subscriptions?
 
@@ -876,7 +876,7 @@ where
             return;
         };
 
-        let mut hashes = HashSet::<Blake3Hash>::from_iter(hashes.into_iter().map(|hash| *hash));
+        let mut hashes = HashSet::<Blake3Hash>::from_iter(hashes);
         let hash_count = hashes.len();
 
         // The genesis segment isn't included in this stream, see
@@ -888,7 +888,7 @@ where
                 let objects = archived_segment_notification
                     .archived_segment
                     .global_object_mappings()
-                    .filter(|object| hashes.remove(&*object.hash))
+                    .filter(|object| hashes.remove(&object.hash))
                     .collect::<Vec<_>>();
 
                 stream::iter(objects)

--- a/crates/sc-proof-of-time/src/verifier/tests.rs
+++ b/crates/sc-proof-of-time/src/verifier/tests.rs
@@ -128,7 +128,7 @@ fn test_basic() {
 fn parameters_change() {
     let genesis_seed = PotSeed::from(SEED);
     let slot_iterations_1 = NonZeroU32::new(512).unwrap();
-    let entropy = [1; mem::size_of::<Blake3Hash>()];
+    let entropy: Blake3Hash = [1; mem::size_of::<Blake3Hash>()].into();
     let checkpoints_1 = subspace_proof_of_time::prove(genesis_seed, slot_iterations_1).unwrap();
     let slot_iterations_2 = slot_iterations_1.saturating_mul(NonZeroU32::new(2).unwrap());
     let checkpoints_2 = subspace_proof_of_time::prove(

--- a/crates/sc-proof-of-time/src/verifier/tests.rs
+++ b/crates/sc-proof-of-time/src/verifier/tests.rs
@@ -128,7 +128,7 @@ fn test_basic() {
 fn parameters_change() {
     let genesis_seed = PotSeed::from(SEED);
     let slot_iterations_1 = NonZeroU32::new(512).unwrap();
-    let entropy: Blake3Hash = [1; mem::size_of::<Blake3Hash>()].into();
+    let entropy = Blake3Hash::from([1; Blake3Hash::SIZE]);
     let checkpoints_1 = subspace_proof_of_time::prove(genesis_seed, slot_iterations_1).unwrap();
     let slot_iterations_2 = slot_iterations_1.saturating_mul(NonZeroU32::new(2).unwrap());
     let checkpoints_2 = subspace_proof_of_time::prove(

--- a/crates/sc-proof-of-time/src/verifier/tests.rs
+++ b/crates/sc-proof-of-time/src/verifier/tests.rs
@@ -1,7 +1,6 @@
 use crate::verifier::PotVerifier;
 use sp_consensus_slots::Slot;
 use sp_consensus_subspace::{PotNextSlotInput, PotParametersChange};
-use std::mem;
 use std::num::NonZeroU32;
 use subspace_core_primitives::{Blake3Hash, PotSeed};
 

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -345,7 +345,7 @@ where
 
         let bundle = bundles.get(bundle_index as usize)?;
         let bundle_vrf_hash =
-            U256::from_be_bytes(bundle.sealed_header.header.proof_of_election.vrf_hash());
+            U256::from_be_bytes(*bundle.sealed_header.header.proof_of_election.vrf_hash());
 
         self.domain_runtime_call(
             runtime_code,

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -608,7 +608,7 @@ where
 
             let domain_tx_range = U256::MAX / INITIAL_DOMAIN_TX_RANGE;
             let bundle_vrf_hash =
-                U256::from_be_bytes(bundle.sealed_header.header.proof_of_election.vrf_hash());
+                U256::from_be_bytes(*bundle.sealed_header.header.proof_of_election.vrf_hash());
 
             let is_tx_in_range = fraud_proof_runtime_interface::domain_runtime_call(
                 domain_runtime_code,

--- a/crates/sp-domains/src/merkle_tree.rs
+++ b/crates/sp-domains/src/merkle_tree.rs
@@ -10,7 +10,6 @@ use parity_scale_codec::{Decode, Encode};
 use rs_merkle::Hasher;
 use scale_info::TypeInfo;
 use sp_runtime::traits::{BlakeTwo256, Hash};
-use subspace_core_primitives::Blake3Hash;
 
 /// Merkle tree using [`Blake2b256Algorithm`].
 pub type MerkleTree = rs_merkle::MerkleTree<Blake2b256Algorithm>;
@@ -40,9 +39,9 @@ impl Default for Blake2b256Algorithm {
 }
 
 impl Hasher for Blake2b256Algorithm {
-    type Hash = Blake3Hash;
+    type Hash = [u8; 32];
 
-    fn hash(data: &[u8]) -> Blake3Hash {
+    fn hash(data: &[u8]) -> Self::Hash {
         let mut hasher = Blake2b::new();
         hasher.update(data);
         hasher.finalize_fixed().into()

--- a/crates/subspace-core-primitives/src/checksum.rs
+++ b/crates/subspace-core-primitives/src/checksum.rs
@@ -4,7 +4,6 @@
 mod tests;
 
 use crate::Blake3Hash;
-use core::mem;
 use parity_scale_codec::{Decode, Encode, EncodeLike, Error, Input, Output};
 
 /// Output wrapper for SCALE codec that will write Blake3 checksum at the end of the encoding

--- a/crates/subspace-core-primitives/src/checksum.rs
+++ b/crates/subspace-core-primitives/src/checksum.rs
@@ -105,7 +105,7 @@ where
 {
     #[inline]
     fn size_hint(&self) -> usize {
-        self.0.size_hint() + mem::size_of::<Blake3Hash>()
+        self.0.size_hint() + Blake3Hash::SIZE
     }
 
     #[inline]
@@ -118,7 +118,7 @@ where
 
     #[inline]
     fn encoded_size(&self) -> usize {
-        self.0.encoded_size() + mem::size_of::<Blake3Hash>()
+        self.0.encoded_size() + Blake3Hash::SIZE
     }
 }
 

--- a/crates/subspace-core-primitives/src/checksum.rs
+++ b/crates/subspace-core-primitives/src/checksum.rs
@@ -91,7 +91,7 @@ where
     fn finish(self) -> (Blake3Hash, &'a mut I) {
         // Compute checksum at the very end of decoding
         let hash = *self.hasher.finalize().as_bytes();
-        (hash, self.input)
+        (hash.into(), self.input)
     }
 }
 

--- a/crates/subspace-core-primitives/src/checksum/tests.rs
+++ b/crates/subspace-core-primitives/src/checksum/tests.rs
@@ -13,7 +13,7 @@ fn basic() {
 
     // Encoding is extended with checksum
     assert_eq!(
-        plain_encoding.len() + mem::size_of::<Blake3Hash>(),
+        plain_encoding.len() + Blake3Hash::SIZE,
         checksummed_encoding.len()
     );
 

--- a/crates/subspace-core-primitives/src/checksum/tests.rs
+++ b/crates/subspace-core-primitives/src/checksum/tests.rs
@@ -2,7 +2,6 @@ use super::Blake3Checksummed;
 use crate::Blake3Hash;
 use parity_scale_codec::{Decode, Encode};
 use rand::prelude::*;
-use std::mem;
 
 #[test]
 fn basic() {

--- a/crates/subspace-core-primitives/src/crypto.rs
+++ b/crates/subspace-core-primitives/src/crypto.rs
@@ -38,7 +38,7 @@ use scale_info::{Type, TypeInfo};
 
 /// BLAKE3 hashing of a single value.
 pub fn blake3_hash(data: &[u8]) -> Blake3Hash {
-    *blake3::hash(data).as_bytes()
+    blake3::hash(data).as_bytes().into()
 }
 
 /// BLAKE3 hashing of a single value in parallel (only useful for large values well above 128kiB).
@@ -46,12 +46,12 @@ pub fn blake3_hash(data: &[u8]) -> Blake3Hash {
 pub fn blake3_hash_parallel(data: &[u8]) -> Blake3Hash {
     let mut state = blake3::Hasher::new();
     state.update_rayon(data);
-    *state.finalize().as_bytes()
+    state.finalize().as_bytes().into()
 }
 
 /// BLAKE3 keyed hashing of a single value.
 pub fn blake3_hash_with_key(key: &[u8; 32], data: &[u8]) -> Blake3Hash {
-    *blake3::keyed_hash(key, data).as_bytes()
+    blake3::keyed_hash(key, data).as_bytes().into()
 }
 
 /// BLAKE3 hashing of a list of values.
@@ -60,7 +60,7 @@ pub fn blake3_hash_list(data: &[&[u8]]) -> Blake3Hash {
     for d in data {
         state.update(d);
     }
-    *state.finalize().as_bytes()
+    state.finalize().as_bytes().into()
 }
 
 /// BLAKE3 hashing of a single value truncated to 254 bits as Scalar for usage with KZG.
@@ -68,7 +68,7 @@ pub fn blake3_254_hash_to_scalar(data: &[u8]) -> Scalar {
     let mut hash = blake3_hash(data);
     // Erase first 2 bits to effectively truncate the hash (number is interpreted as big-endian)
     hash[0] &= 0b00111111;
-    Scalar::try_from(hash)
+    Scalar::try_from(*hash)
         .expect("Last bit erased, thus hash is guaranteed to fit into scalar; qed")
 }
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -78,9 +78,6 @@ pub const REWARD_SIGNING_CONTEXT: &[u8] = b"subspace_reward";
 /// Byte length of a randomness type.
 pub const RANDOMNESS_LENGTH: usize = 32;
 
-/// Size of BLAKE3 hash output (in bytes).
-pub const BLAKE3_HASH_SIZE: usize = 32;
-
 /// BLAKE3 hash output transparent wrapper
 #[derive(
     Default,
@@ -92,7 +89,6 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
     PartialOrd,
     Hash,
     From,
-    Into,
     AsRef,
     AsMut,
     Deref,
@@ -104,7 +100,7 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Blake3Hash(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; BLAKE3_HASH_SIZE]);
+pub struct Blake3Hash(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; Self::SIZE]);
 
 impl fmt::Debug for Blake3Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -138,9 +134,9 @@ impl FromHex for Blake3Hash {
     }
 }
 
-impl From<&[u8; BLAKE3_HASH_SIZE]> for Blake3Hash {
+impl From<&[u8; Self::SIZE]> for Blake3Hash {
     #[inline]
-    fn from(value: &[u8; BLAKE3_HASH_SIZE]) -> Self {
+    fn from(value: &[u8; Self::SIZE]) -> Self {
         Self(*value)
     }
 }
@@ -152,6 +148,18 @@ impl TryFrom<&[u8]> for Blake3Hash {
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into()?))
     }
+}
+
+impl From<Blake3Hash> for [u8; Blake3Hash::SIZE] {
+    #[inline]
+    fn from(value: Blake3Hash) -> Self {
+        value.0
+    }
+}
+
+impl Blake3Hash {
+    /// Size of BLAKE3 hash output (in bytes).
+    pub const SIZE: usize = 32;
 }
 
 /// Type of randomness.

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -50,11 +50,13 @@ use alloc::boxed::Box;
 use alloc::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::array::TryFromSliceError;
 use core::fmt;
 use core::num::{NonZeroU64, NonZeroU8};
 use core::simd::Simd;
 use core::str::FromStr;
 use derive_more::{Add, AsMut, AsRef, Deref, DerefMut, Display, Div, From, Into, Mul, Rem, Sub};
+use hex::FromHex;
 use num_traits::{WrappingAdd, WrappingSub};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 pub use pieces::{
@@ -79,11 +81,7 @@ pub const RANDOMNESS_LENGTH: usize = 32;
 /// Size of BLAKE3 hash output (in bytes).
 pub const BLAKE3_HASH_SIZE: usize = 32;
 
-/// BLAKE3 hash output
-pub type Blake3Hash = [u8; BLAKE3_HASH_SIZE];
-
-/// BLAKE3 hash output wrapper, which serializes it as a hex string
-// TODO: rename this type to Blake3Hash into a newtype, after checking for any breaking changes
+/// BLAKE3 hash output transparent wrapper
 #[derive(
     Default,
     Copy,
@@ -95,6 +93,8 @@ pub type Blake3Hash = [u8; BLAKE3_HASH_SIZE];
     Hash,
     From,
     Into,
+    AsRef,
+    AsMut,
     Deref,
     DerefMut,
     Encode,
@@ -102,13 +102,43 @@ pub type Blake3Hash = [u8; BLAKE3_HASH_SIZE];
     TypeInfo,
     MaxEncodedLen,
 )]
+#[as_ref(forward)]
+#[as_mut(forward)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Blake3HashHex(#[cfg_attr(feature = "serde", serde(with = "hex"))] Blake3Hash);
+pub struct Blake3Hash(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; BLAKE3_HASH_SIZE]);
 
-impl fmt::Debug for Blake3HashHex {
+impl fmt::Debug for Blake3Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl FromHex for Blake3Hash {
+    type Error = hex::FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let data = hex::decode(hex)?
+            .try_into()
+            .map_err(|_| hex::FromHexError::InvalidStringLength)?;
+
+        Ok(Self(data))
+    }
+}
+
+impl From<&[u8; BLAKE3_HASH_SIZE]> for Blake3Hash {
+    #[inline]
+    fn from(value: &[u8; BLAKE3_HASH_SIZE]) -> Self {
+        Self(*value)
+    }
+}
+
+impl TryFrom<&[u8]> for Blake3Hash {
+    type Error = TryFromSliceError;
+
+    #[inline]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
     }
 }
 
@@ -411,7 +441,7 @@ impl PotOutput {
     /// Derives the global randomness from the output
     #[inline]
     pub fn derive_global_randomness(&self) -> Randomness {
-        Randomness::from(blake3_hash(&self.0))
+        Randomness::from(*blake3_hash(&self.0))
     }
 
     /// Derive seed from proof of time in case entropy injection is not needed
@@ -423,7 +453,7 @@ impl PotOutput {
     /// Derive seed from proof of time with entropy injection
     #[inline]
     pub fn seed_with_entropy(&self, entropy: &Blake3Hash) -> PotSeed {
-        let hash = blake3_hash_list(&[entropy, &self.0]);
+        let hash = blake3_hash_list(&[entropy.as_ref(), &self.0]);
         let mut seed = PotSeed::default();
         seed.copy_from_slice(&hash[..Self::SIZE]);
         seed
@@ -1009,7 +1039,7 @@ pub struct SectorId(#[cfg_attr(feature = "serde", serde(with = "hex"))] Blake3Ha
 impl AsRef<[u8]> for SectorId {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self.0.as_ref()
     }
 }
 
@@ -1042,7 +1072,7 @@ impl SectorId {
             let piece_offset_bytes = piece_offset.to_bytes();
             let mut key = [0; 32];
             key[..piece_offset_bytes.len()].copy_from_slice(&piece_offset_bytes);
-            U256::from_le_bytes(blake3_hash_with_key(&key, &self.0))
+            U256::from_le_bytes(*blake3_hash_with_key(&key, self.as_ref()))
         };
         let history_size_in_pieces = history_size.in_pieces().get();
         let num_interleaved_pieces = 1.max(
@@ -1073,8 +1103,8 @@ impl SectorId {
         &self,
         global_challenge: &Blake3Hash,
     ) -> SectorSlotChallenge {
-        let sector_slot_challenge = Simd::from(self.0) ^ Simd::from(*global_challenge);
-        SectorSlotChallenge(sector_slot_challenge.to_array())
+        let sector_slot_challenge = Simd::from(*self.0) ^ Simd::from(**global_challenge);
+        SectorSlotChallenge(sector_slot_challenge.to_array().into())
     }
 
     /// Derive evaluation seed
@@ -1084,12 +1114,12 @@ impl SectorId {
         history_size: HistorySize,
     ) -> PosSeed {
         let evaluation_seed = blake3_hash_list(&[
-            &self.0,
+            self.as_ref(),
             &piece_offset.to_bytes(),
             &history_size.get().to_le_bytes(),
         ]);
 
-        PosSeed::from(evaluation_seed)
+        PosSeed::from(*evaluation_seed)
     }
 
     /// Derive history size when sector created at `history_size` expires.
@@ -1104,8 +1134,8 @@ impl SectorId {
         let sector_expiration_check_history_size =
             history_size.sector_expiration_check(min_sector_lifetime)?;
 
-        let input_hash = U256::from_le_bytes(blake3_hash_list(&[
-            &self.0,
+        let input_hash = U256::from_le_bytes(*blake3_hash_list(&[
+            self.as_ref(),
             sector_expiration_check_segment_commitment.as_ref(),
         ]));
 

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -102,8 +102,6 @@ pub const BLAKE3_HASH_SIZE: usize = 32;
     TypeInfo,
     MaxEncodedLen,
 )]
-#[as_ref(forward)]
-#[as_mut(forward)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Blake3Hash(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; BLAKE3_HASH_SIZE]);
@@ -111,6 +109,20 @@ pub struct Blake3Hash(#[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; B
 impl fmt::Debug for Blake3Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl AsRef<[u8]> for Blake3Hash {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsMut<[u8]> for Blake3Hash {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
     }
 }
 

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -23,7 +23,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::{Blake3Hash, Blake3HashHex, PieceIndex};
+use crate::{Blake3Hash, PieceIndex};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::default::Default;
@@ -158,7 +158,7 @@ impl PieceObjectMapping {
 pub struct GlobalObject {
     /// Object hash.
     /// We order by hash, so object hash lookups can be performed efficiently.
-    pub hash: Blake3HashHex,
+    pub hash: Blake3Hash,
     /// Piece index where object is contained (at least its beginning, might not fit fully)
     pub piece_index: PieceIndex,
     /// Raw record offset of the object in that piece, for use with `Record::to_raw_record_bytes`
@@ -185,7 +185,7 @@ impl GlobalObject {
     /// Returns a newly created GlobalObject from a piece index and object.
     pub fn new(piece_index: PieceIndex, piece_object: &PieceObject) -> Self {
         Self {
-            hash: piece_object.hash.into(),
+            hash: piece_object.hash,
             piece_index,
             offset: piece_object.offset,
         }
@@ -195,7 +195,7 @@ impl GlobalObject {
 /// Space-saving serialization of an object stored in the history of the blockchain
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct CompactGlobalObject(Blake3HashHex, PieceIndex, u32);
+pub struct CompactGlobalObject(Blake3Hash, PieceIndex, u32);
 
 /// Mapping of objects stored in the history of the blockchain
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -161,7 +161,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     println!("Searching for solutions");
     let (global_challenge, solution_candidates) = &loop {
         let mut global_challenge = Blake3Hash::default();
-        rng.fill_bytes(&mut global_challenge);
+        rng.fill_bytes(global_challenge.as_mut());
 
         let audit_results = audit_plot_sync(
             public_key,

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -616,7 +616,7 @@ pub fn write_sector(
         // It would be more efficient to not re-read the whole sector again, but it makes above code
         // significantly more convoluted and most likely not worth it
         let (sector_contents, sector_checksum) =
-            sector_output.split_at_mut(sector_size - mem::size_of::<Blake3Hash>());
+            sector_output.split_at_mut(sector_size - Blake3Hash::SIZE);
         sector_checksum.copy_from_slice(blake3_hash_parallel(sector_contents).as_ref());
     }
 

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -617,7 +617,7 @@ pub fn write_sector(
         // significantly more convoluted and most likely not worth it
         let (sector_contents, sector_checksum) =
             sector_output.split_at_mut(sector_size - mem::size_of::<Blake3Hash>());
-        sector_checksum.copy_from_slice(&blake3_hash_parallel(sector_contents));
+        sector_checksum.copy_from_slice(blake3_hash_parallel(sector_contents).as_ref());
     }
 
     Ok(())
@@ -668,7 +668,7 @@ fn record_encoding<PosTable>(
         )
         .map(|(s_bucket, record_chunk)| {
             if let Some(proof) = pos_table.find_proof(s_bucket.into()) {
-                (Simd::from(*record_chunk) ^ Simd::from(proof.hash())).to_array()
+                (Simd::from(*record_chunk) ^ Simd::from(*proof.hash())).to_array()
             } else {
                 // Dummy value indicating no proof
                 [0; Scalar::FULL_BYTES]

--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -20,7 +20,6 @@ use futures::StreamExt;
 use parity_scale_codec::{Decode, Encode};
 use parking_lot::Mutex;
 use rayon::prelude::*;
-use std::mem;
 use std::simd::Simd;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/crates/subspace-farmer-components/src/reading.rs
+++ b/crates/subspace-farmer-components/src/reading.rs
@@ -238,7 +238,7 @@ where
                             .ok_or(ReadingError::MissingPosProof { s_bucket })?;
 
                         record_chunk =
-                            Simd::to_array(Simd::from(record_chunk) ^ Simd::from(proof.hash()));
+                            Simd::to_array(Simd::from(record_chunk) ^ Simd::from(*proof.hash()));
                     }
 
                     maybe_record_chunk.replace(Scalar::try_from(record_chunk).map_err(
@@ -296,7 +296,7 @@ where
                                 .ok_or(ReadingError::MissingPosProof { s_bucket })?;
 
                             record_chunk = Simd::to_array(
-                                Simd::from(record_chunk) ^ Simd::from(proof.hash()),
+                                Simd::from(record_chunk) ^ Simd::from(*proof.hash()),
                             );
                         }
 

--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -313,7 +313,7 @@ impl SectorContentsMap {
             bytes.split_at(bytes.len() - mem::size_of::<Blake3Hash>());
         // Verify checksum
         let actual_checksum = blake3_hash(single_records_bit_arrays);
-        if actual_checksum != expected_checksum {
+        if actual_checksum.as_ref() != expected_checksum {
             debug!(
                 actual_checksum = %hex::encode(actual_checksum),
                 expected_checksum = %hex::encode(expected_checksum),
@@ -378,7 +378,7 @@ impl SectorContentsMap {
 
         // Write data and checksum
         output[..slice.len()].copy_from_slice(slice);
-        output[slice.len()..].copy_from_slice(&blake3_hash(slice));
+        output[slice.len()..].copy_from_slice(blake3_hash(slice).as_ref());
 
         Ok(())
     }

--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -313,7 +313,7 @@ impl SectorContentsMap {
             bytes.split_at(bytes.len() - mem::size_of::<Blake3Hash>());
         // Verify checksum
         let actual_checksum = blake3_hash(single_records_bit_arrays);
-        if actual_checksum.as_ref() != expected_checksum {
+        if *actual_checksum != *expected_checksum {
             debug!(
                 actual_checksum = %hex::encode(actual_checksum),
                 expected_checksum = %hex::encode(expected_checksum),

--- a/crates/subspace-farmer-components/src/sector.rs
+++ b/crates/subspace-farmer-components/src/sector.rs
@@ -49,7 +49,7 @@ pub const fn sector_size(pieces_in_sector: u16) -> usize {
     sector_record_chunks_size(pieces_in_sector)
         + sector_record_metadata_size(pieces_in_sector)
         + SectorContentsMap::encoded_size(pieces_in_sector)
-        + mem::size_of::<Blake3Hash>()
+        + Blake3Hash::SIZE
 }
 
 /// Metadata of the plotted sector
@@ -148,7 +148,7 @@ pub(crate) struct RecordMetadata {
 
 impl RecordMetadata {
     pub(crate) const fn encoded_size() -> usize {
-        RecordWitness::SIZE + RecordCommitment::SIZE + mem::size_of::<Blake3Hash>()
+        RecordWitness::SIZE + RecordCommitment::SIZE + Blake3Hash::SIZE
     }
 }
 
@@ -310,7 +310,7 @@ impl SectorContentsMap {
         }
 
         let (single_records_bit_arrays, expected_checksum) =
-            bytes.split_at(bytes.len() - mem::size_of::<Blake3Hash>());
+            bytes.split_at(bytes.len() - Blake3Hash::SIZE);
         // Verify checksum
         let actual_checksum = blake3_hash(single_records_bit_arrays);
         if *actual_checksum != *expected_checksum {
@@ -355,7 +355,7 @@ impl SectorContentsMap {
     /// Size of sector contents map when encoded and stored in the plot for specified number of
     /// pieces in sector
     pub const fn encoded_size(pieces_in_sector: u16) -> usize {
-        SINGLE_RECORD_BIT_ARRAY_SIZE * pieces_in_sector as usize + mem::size_of::<Blake3Hash>()
+        SINGLE_RECORD_BIT_ARRAY_SIZE * pieces_in_sector as usize + Blake3Hash::SIZE
     }
 
     /// Encode internal contents into `output`

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -9,7 +9,7 @@ use std::fs::OpenOptions;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
-use subspace_core_primitives::{Record, SolutionRange};
+use subspace_core_primitives::{Blake3Hash, Record, SolutionRange};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer::single_disk_farm::farming::rayon_files::RayonFiles;
 use subspace_farmer::single_disk_farm::farming::{PlotAudit, PlotAuditOptions};
@@ -181,14 +181,14 @@ where
 
             group.bench_function("plot/single", |b| {
                 b.iter_batched(
-                    rand::random,
+                    rand::random::<[u8; 32]>,
                     |global_challenge| {
                         let options = PlotAuditOptions::<PosTable> {
                             public_key: single_disk_farm_info.public_key(),
                             reward_address: single_disk_farm_info.public_key(),
                             slot_info: SlotInfo {
                                 slot_number: 0,
-                                global_challenge,
+                                global_challenge: Blake3Hash::from(global_challenge),
                                 // No solution will be found, pure audit
                                 solution_range: SolutionRange::MIN,
                                 // No solution will be found, pure audit
@@ -219,14 +219,14 @@ where
 
             group.bench_function("plot/rayon/unbuffered", |b| {
                 b.iter_batched(
-                    rand::random,
+                    rand::random::<[u8; 32]>,
                     |global_challenge| {
                         let options = PlotAuditOptions::<PosTable> {
                             public_key: single_disk_farm_info.public_key(),
                             reward_address: single_disk_farm_info.public_key(),
                             slot_info: SlotInfo {
                                 slot_number: 0,
-                                global_challenge,
+                                global_challenge: Blake3Hash::from(global_challenge),
                                 // No solution will be found, pure audit
                                 solution_range: SolutionRange::MIN,
                                 // No solution will be found, pure audit
@@ -254,14 +254,14 @@ where
 
             group.bench_function("plot/rayon/regular", |b| {
                 b.iter_batched(
-                    rand::random,
+                    rand::random::<[u8; 32]>,
                     |global_challenge| {
                         let options = PlotAuditOptions::<PosTable> {
                             public_key: single_disk_farm_info.public_key(),
                             reward_address: single_disk_farm_info.public_key(),
                             slot_info: SlotInfo {
                                 slot_number: 0,
-                                global_challenge,
+                                global_challenge: Blake3Hash::from(global_challenge),
                                 // No solution will be found, pure audit
                                 solution_range: SolutionRange::MIN,
                                 // No solution will be found, pure audit
@@ -363,7 +363,7 @@ where
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
                     slot_number: 0,
-                    global_challenge: rand::random(),
+                    global_challenge: Blake3Hash::from(rand::random::<[u8; 32]>()),
                     // Solution is guaranteed to be found
                     solution_range: SolutionRange::MAX,
                     // Solution is guaranteed to be found
@@ -386,7 +386,8 @@ where
                             return result;
                         }
 
-                        options.slot_info.global_challenge = rand::random();
+                        options.slot_info.global_challenge =
+                            Blake3Hash::from(rand::random::<[u8; 32]>());
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
@@ -410,7 +411,8 @@ where
                             return result;
                         }
 
-                        options.slot_info.global_challenge = rand::random();
+                        options.slot_info.global_challenge =
+                            Blake3Hash::from(rand::random::<[u8; 32]>());
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
@@ -436,7 +438,7 @@ where
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
                     slot_number: 0,
-                    global_challenge: rand::random(),
+                    global_challenge: Blake3Hash::from(rand::random::<[u8; 32]>()),
                     // Solution is guaranteed to be found
                     solution_range: SolutionRange::MAX,
                     // Solution is guaranteed to be found
@@ -459,7 +461,8 @@ where
                             return result;
                         }
 
-                        options.slot_info.global_challenge = rand::random();
+                        options.slot_info.global_challenge =
+                            Blake3Hash::from(rand::random::<[u8; 32]>());
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
@@ -483,7 +486,8 @@ where
                             return result;
                         }
 
-                        options.slot_info.global_challenge = rand::random();
+                        options.slot_info.global_challenge =
+                            Blake3Hash::from(rand::random::<[u8; 32]>());
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
@@ -506,7 +510,7 @@ where
                 reward_address: single_disk_farm_info.public_key(),
                 slot_info: SlotInfo {
                     slot_number: 0,
-                    global_challenge: rand::random(),
+                    global_challenge: Blake3Hash::from(rand::random::<[u8; 32]>()),
                     // Solution is guaranteed to be found
                     solution_range: SolutionRange::MAX,
                     // Solution is guaranteed to be found
@@ -529,7 +533,8 @@ where
                             return result;
                         }
 
-                        options.slot_info.global_challenge = rand::random();
+                        options.slot_info.global_challenge =
+                            Blake3Hash::from(rand::random::<[u8; 32]>());
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()
@@ -553,7 +558,8 @@ where
                             return result;
                         }
 
-                        options.slot_info.global_challenge = rand::random();
+                        options.slot_info.global_challenge =
+                            Blake3Hash::from(rand::random::<[u8; 32]>());
                         audit_results = plot_audit.audit(options).unwrap();
 
                         audit_results.pop().unwrap()

--- a/crates/subspace-farmer/src/disk_piece_cache.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache.rs
@@ -406,7 +406,7 @@ impl DiskPieceCache {
 
         // Verify checksum
         let actual_checksum = blake3_hash_list(&[piece_index_bytes, piece_bytes]);
-        if actual_checksum.as_ref() != expected_checksum {
+        if *actual_checksum != *expected_checksum {
             if element.iter().all(|&byte| byte == 0) {
                 return Ok(None);
             }

--- a/crates/subspace-farmer/src/disk_piece_cache.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache.rs
@@ -22,7 +22,7 @@ use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::sync::Arc;
 use std::task::Poll;
-use std::{fs, io, mem};
+use std::{fs, io};
 use subspace_core_primitives::crypto::blake3_hash_list;
 use subspace_core_primitives::{Blake3Hash, Piece, PieceIndex};
 use subspace_farmer_components::file_ext::FileExt;

--- a/crates/subspace-farmer/src/disk_piece_cache.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache.rs
@@ -239,7 +239,7 @@ impl DiskPieceCache {
 
     /// Size of a single piece cache element
     pub const fn element_size() -> u32 {
-        (PieceIndex::SIZE + Piece::SIZE + mem::size_of::<Blake3Hash>()) as u32
+        (PieceIndex::SIZE + Piece::SIZE + Blake3Hash::SIZE) as u32
     }
 
     /// Contents of this piece cache

--- a/crates/subspace-farmer/src/disk_piece_cache.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache.rs
@@ -326,7 +326,7 @@ impl DiskPieceCache {
             .file
             .write_all_at(piece.as_ref(), element_offset + PieceIndex::SIZE as u64)?;
         self.inner.file.write_all_at(
-            &blake3_hash_list(&[&piece_index_bytes, piece.as_ref()]),
+            blake3_hash_list(&[&piece_index_bytes, piece.as_ref()]).as_ref(),
             element_offset + PieceIndex::SIZE as u64 + Piece::SIZE as u64,
         )?;
 
@@ -406,7 +406,7 @@ impl DiskPieceCache {
 
         // Verify checksum
         let actual_checksum = blake3_hash_list(&[piece_index_bytes, piece_bytes]);
-        if actual_checksum != expected_checksum {
+        if actual_checksum.as_ref() != expected_checksum {
             if element.iter().all(|&byte| byte == 0) {
                 return Ok(None);
             }

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -259,7 +259,7 @@ async fn basic() {
             let segment_header = SegmentHeader::V0 {
                 segment_index: SegmentIndex::ONE,
                 segment_commitment: Default::default(),
-                prev_segment_header_hash: [0; 32],
+                prev_segment_header_hash: [0; 32].into(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
                     archived_progress: Default::default(),
@@ -317,7 +317,7 @@ async fn basic() {
             let segment_header = SegmentHeader::V0 {
                 segment_index: SegmentIndex::from(segment_index),
                 segment_commitment: Default::default(),
-                prev_segment_header_hash: [0; 32],
+                prev_segment_header_hash: [0; 32].into(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
                     archived_progress: Default::default(),

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -2384,7 +2384,7 @@ impl SingleDiskFarm {
                 let (index_and_piece_bytes, expected_checksum) =
                     element.split_at(element_size as usize - mem::size_of::<Blake3Hash>());
                 let actual_checksum = blake3_hash(index_and_piece_bytes);
-                if actual_checksum != expected_checksum && element != &dummy_element {
+                if actual_checksum.as_ref() != expected_checksum && element != &dummy_element {
                     warn!(
                         %cache_offset,
                         actual_checksum = %hex::encode(actual_checksum),

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -2384,7 +2384,7 @@ impl SingleDiskFarm {
                 let (index_and_piece_bytes, expected_checksum) =
                     element.split_at(element_size as usize - mem::size_of::<Blake3Hash>());
                 let actual_checksum = blake3_hash(index_and_piece_bytes);
-                if actual_checksum.as_ref() != expected_checksum && element != &dummy_element {
+                if *actual_checksum != *expected_checksum && element != &dummy_element {
                     warn!(
                         %cache_offset,
                         actual_checksum = %hex::encode(actual_checksum),

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -2058,7 +2058,7 @@ impl SingleDiskFarm {
                 plot_file
             };
 
-            let sector_bytes_range = 0..(sector_size as usize - mem::size_of::<Blake3Hash>());
+            let sector_bytes_range = 0..(sector_size as usize - Blake3Hash::SIZE);
 
             info!("Checking sectors and corresponding metadata");
             (0..metadata_header.plotted_sector_count)
@@ -2191,7 +2191,7 @@ impl SingleDiskFarm {
                             }
 
                             let actual_checksum = *hasher.finalize().as_bytes();
-                            let mut expected_checksum = [0; mem::size_of::<Blake3Hash>()];
+                            let mut expected_checksum = [0; Blake3Hash::SIZE];
                             {
                                 let offset = u64::from(sector_index) * sector_size
                                     + sector_bytes_range.end as u64;
@@ -2382,7 +2382,7 @@ impl SingleDiskFarm {
                 }
 
                 let (index_and_piece_bytes, expected_checksum) =
-                    element.split_at(element_size as usize - mem::size_of::<Blake3Hash>());
+                    element.split_at(element_size as usize - Blake3Hash::SIZE);
                 let actual_checksum = blake3_hash(index_and_piece_bytes);
                 if *actual_checksum != *expected_checksum && element != &dummy_element {
                     warn!(

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
@@ -320,7 +320,7 @@ impl DiskPlotCache {
 
         // Verify checksum
         let actual_checksum = blake3_hash_list(&[piece_index_bytes, piece_bytes]);
-        if actual_checksum.as_ref() != expected_checksum {
+        if *actual_checksum != *expected_checksum {
             if element.iter().all(|&byte| byte == 0) {
                 return Ok(None);
             }

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
@@ -234,7 +234,7 @@ impl DiskPlotCache {
                 file.write_all_at(&piece_index_bytes, element_offset)?;
                 file.write_all_at(piece.as_ref(), element_offset + PieceIndex::SIZE as u64)?;
                 file.write_all_at(
-                    &blake3_hash_list(&[&piece_index_bytes, piece.as_ref()]),
+                    blake3_hash_list(&[&piece_index_bytes, piece.as_ref()]).as_ref(),
                     element_offset + PieceIndex::SIZE as u64 + Piece::SIZE as u64,
                 )
             }
@@ -320,7 +320,7 @@ impl DiskPlotCache {
 
         // Verify checksum
         let actual_checksum = blake3_hash_list(&[piece_index_bytes, piece_bytes]);
-        if actual_checksum != expected_checksum {
+        if actual_checksum.as_ref() != expected_checksum {
             if element.iter().all(|&byte| byte == 0) {
                 return Ok(None);
             }

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache.rs
@@ -144,7 +144,7 @@ impl DiskPlotCache {
 
     /// Size of a single plot cache element
     pub(crate) const fn element_size() -> u32 {
-        (PieceIndex::SIZE + Piece::SIZE + mem::size_of::<Blake3Hash>()) as u32
+        (PieceIndex::SIZE + Piece::SIZE + Blake3Hash::SIZE) as u32
     }
 
     /// Check if piece is potentially stored in this cache (not guaranteed to be because it might be

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -176,7 +176,7 @@ impl KnownPeersSlots {
         let (encoded_bytes, remaining_bytes) = self.a.split_at_mut(known_peers_bytes.len());
         encoded_bytes.copy_from_slice(&known_peers_bytes);
         // Write checksum
-        remaining_bytes[..mem::size_of::<Blake3Hash>()]
+        remaining_bytes[..Blake3Hash::SIZE]
             .copy_from_slice(blake3_hash(&known_peers_bytes).as_ref());
         if let Err(error) = self.a.flush() {
             warn!(%error, "Failed to flush known peers to disk");
@@ -362,7 +362,7 @@ impl KnownPeersManager {
 
                     let (encoded_bytes, remaining_bytes) =
                         known_addresses_bytes.split_at(known_addresses.encoded_size());
-                    if remaining_bytes.len() < mem::size_of::<Blake3Hash>() {
+                    if remaining_bytes.len() < Blake3Hash::SIZE {
                         debug!(
                             remaining_bytes = %remaining_bytes.len(),
                             "Not enough bytes to decode checksum, file was likely corrupted"
@@ -372,7 +372,7 @@ impl KnownPeersManager {
 
                     // Verify checksum
                     let actual_checksum = blake3_hash(encoded_bytes);
-                    let expected_checksum = &remaining_bytes[..mem::size_of::<Blake3Hash>()];
+                    let expected_checksum = &remaining_bytes[..Blake3Hash::SIZE];
                     if *actual_checksum != *expected_checksum {
                         debug!(
                             encoded_bytes_len = %encoded_bytes.len(),
@@ -521,7 +521,7 @@ impl KnownPeersManager {
         mem::size_of::<u64>()
             + Compact::compact_len(&(cache_size))
             + Self::single_peer_encoded_size() * cache_size as usize
-            + mem::size_of::<Blake3Hash>()
+            + Blake3Hash::SIZE
     }
 
     fn persistent_enabled(&self) -> bool {

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -373,7 +373,7 @@ impl KnownPeersManager {
                     // Verify checksum
                     let actual_checksum = blake3_hash(encoded_bytes);
                     let expected_checksum = &remaining_bytes[..mem::size_of::<Blake3Hash>()];
-                    if actual_checksum.as_ref() != expected_checksum {
+                    if *actual_checksum != *expected_checksum {
                         debug!(
                             encoded_bytes_len = %encoded_bytes.len(),
                             actual_checksum = %hex::encode(actual_checksum),

--- a/crates/subspace-networking/src/behavior/persistent_parameters.rs
+++ b/crates/subspace-networking/src/behavior/persistent_parameters.rs
@@ -177,7 +177,7 @@ impl KnownPeersSlots {
         encoded_bytes.copy_from_slice(&known_peers_bytes);
         // Write checksum
         remaining_bytes[..mem::size_of::<Blake3Hash>()]
-            .copy_from_slice(&blake3_hash(&known_peers_bytes));
+            .copy_from_slice(blake3_hash(&known_peers_bytes).as_ref());
         if let Err(error) = self.a.flush() {
             warn!(%error, "Failed to flush known peers to disk");
         }
@@ -373,7 +373,7 @@ impl KnownPeersManager {
                     // Verify checksum
                     let actual_checksum = blake3_hash(encoded_bytes);
                     let expected_checksum = &remaining_bytes[..mem::size_of::<Blake3Hash>()];
-                    if actual_checksum != expected_checksum {
+                    if actual_checksum.as_ref() != expected_checksum {
                         debug!(
                             encoded_bytes_len = %encoded_bytes.len(),
                             actual_checksum = %hex::encode(actual_checksum),

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -309,7 +309,7 @@ where
                 .validation_mode(ValidationMode::None)
                 // To content-address message, we can take the hash of message and use it as an ID.
                 .message_id_fn(|message: &GossipsubMessage| {
-                    MessageId::from(crypto::blake3_hash(&message.data))
+                    MessageId::from(*crypto::blake3_hash(&message.data))
                 })
                 .max_transmit_size(2 * 1024 * 1024) // 2MB
                 .build()

--- a/crates/subspace-proof-of-space/src/shim.rs
+++ b/crates/subspace-proof-of-space/src/shim.rs
@@ -48,7 +48,7 @@ impl Table for ShimTable {
 
 fn find_proof(seed: &PosSeed, challenge_index: u32) -> Option<PosProof> {
     let quality = blake3_hash(&challenge_index.to_le_bytes());
-    if U256::from_le_bytes(quality) % U256::from(3u32) > U256::zero() {
+    if U256::from_le_bytes(*quality) % U256::from(3u32) > U256::zero() {
         let mut proof = PosProof::default();
         proof
             .iter_mut()

--- a/crates/subspace-verification/src/lib.rs
+++ b/crates/subspace-verification/src/lib.rs
@@ -210,7 +210,7 @@ where
     };
 
     let masked_chunk = (Simd::from(solution.chunk.to_bytes())
-        ^ Simd::from(solution.proof_of_space.hash()))
+        ^ Simd::from(*solution.proof_of_space.hash()))
     .to_array();
 
     let solution_distance =

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -320,7 +320,7 @@ where
         at_consensus_hash: CBlock::Hash,
     ) -> sp_blockchain::Result<BundleValidity<Block::Extrinsic>> {
         let bundle_vrf_hash =
-            U256::from_be_bytes(bundle.sealed_header.header.proof_of_election.vrf_hash());
+            U256::from_be_bytes(*bundle.sealed_header.header.proof_of_election.vrf_hash());
 
         let mut extrinsics = Vec::with_capacity(bundle.extrinsics.len());
         let mut estimated_bundle_weight = Weight::default();

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -233,7 +233,7 @@ where
         self.previous_bundled_tx
             .maybe_clear(self.consensus_client.info().best_hash);
 
-        let bundle_vrf_hash = U256::from_be_bytes(proof_of_election.vrf_hash());
+        let bundle_vrf_hash = U256::from_be_bytes(*proof_of_election.vrf_hash());
 
         let domain_bundle_limit = self.fetch_domain_bundle_limit()?;
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -761,7 +761,7 @@ impl_runtime_apis! {
                     account_result.ok().map(|account_id| account_id.encode())
                 }) {
                 // Check if the signer Id hash is within the tx range
-                let signer_id_hash = U256::from_be_bytes(blake3_hash(&signer.encode()));
+                let signer_id_hash = U256::from_be_bytes(*blake3_hash(&signer.encode()));
                 sp_domains::signer_in_tx_range(bundle_vrf_hash, &signer_id_hash, tx_range)
             } else {
                 // Unsigned transactions are always in the range.

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -1158,7 +1158,7 @@ impl_runtime_apis! {
                     account_result.ok().map(|account_id| account_id.encode())
                 }) {
                 // Check if the signer Id hash is within the tx range
-                let signer_id_hash = U256::from_be_bytes(blake3_hash(&signer.encode()));
+                let signer_id_hash = U256::from_be_bytes(*blake3_hash(&signer.encode()));
                 sp_domains::signer_in_tx_range(bundle_vrf_hash, &signer_id_hash, tx_range)
             } else {
                 // Unsigned transactions are always in the range.

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -751,7 +751,7 @@ impl_runtime_apis! {
                     account_result.ok().map(|account_id| account_id.encode())
                 }) {
                 // Check if the signer Id hash is within the tx range
-                let signer_id_hash = U256::from_be_bytes(blake3_hash(&signer.encode()));
+                let signer_id_hash = U256::from_be_bytes(*blake3_hash(&signer.encode()));
                 sp_domains::signer_in_tx_range(bundle_vrf_hash, &signer_id_hash, tx_range)
             } else {
                 // Unsigned transactions are always in the range.

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -1109,7 +1109,7 @@ impl_runtime_apis! {
             if let Some(signer) = extract_signer_inner(extrinsic, &lookup).and_then(|account_result| {
                     account_result.ok().map(|account_id| account_id.encode())
                 }) {
-                let signer_id_hash = U256::from_be_bytes(blake3_hash(&signer.encode()));
+                let signer_id_hash = U256::from_be_bytes(*blake3_hash(&signer.encode()));
                 sp_domains::signer_in_tx_range(bundle_vrf_hash, &signer_id_hash, tx_range)
             } else {
                 true


### PR DESCRIPTION
This PR makes sure `Blake3Hash` is always hex-encoded in JSON and debug contexts.

It replaces the type alias to `[u8; 32]` with a wrapper type, with appropriate trait impls and methods. ~~This is slightly tricky due to Rust's trait coherence rules: arrays and slices are always foreign types.~~

I'm happy to add or change trait impls to reduce the other code changes, but I've tried a lot of alternatives already. So significant changes might be better as a PR on top of this one.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
