### PR TITLE
Pallet subspace cleanup

### DIFF
--- a/crates/pallet-subspace/src/benchmarking.rs
+++ b/crates/pallet-subspace/src/benchmarking.rs
@@ -10,7 +10,7 @@ mod benchmarks {
     use crate::{
         AllowAuthoringByAnyone, Call, Config, EnableRewards, EnableRewardsAt,
         NextSolutionRangeOverride, Pallet, PotSlotIterations, PotSlotIterationsUpdate,
-        PotSlotIterationsUpdateValue, SegmentCommitment, ShouldAdjustSolutionRange, SolutionRanges,
+        PotSlotIterationsValue, SegmentCommitment, ShouldAdjustSolutionRange, SolutionRanges,
     };
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
@@ -156,16 +156,22 @@ mod benchmarks {
             .checked_mul(NonZeroU32::new(2).expect("2 is non-zero"))
             .expect("Not overflow");
 
-        PotSlotIterations::<T>::set(Some(slot_iterations));
+        PotSlotIterations::<T>::put(PotSlotIterationsValue {
+            slot_iterations,
+            update: None,
+        });
 
         #[extrinsic_call]
         _(RawOrigin::Root, next_slot_iterations);
 
         assert_eq!(
-            PotSlotIterationsUpdate::<T>::get(),
-            Some(PotSlotIterationsUpdateValue {
-                target_slot: None,
-                slot_iterations: next_slot_iterations,
+            PotSlotIterations::<T>::get(),
+            Some(PotSlotIterationsValue {
+                slot_iterations,
+                update: Some(PotSlotIterationsUpdate {
+                    target_slot: None,
+                    slot_iterations: next_slot_iterations,
+                }),
             })
         );
     }

--- a/crates/pallet-subspace/src/benchmarking.rs
+++ b/crates/pallet-subspace/src/benchmarking.rs
@@ -8,7 +8,7 @@ use frame_benchmarking::v2::*;
 #[benchmarks]
 mod benchmarks {
     use crate::{
-        AllowAuthoringByAnyone, Call, Config, CurrentSlot, EnableRewards, EnableRewardsAt,
+        AllowAuthoringByAnyone, Call, Config, EnableRewards, EnableRewardsAt,
         NextSolutionRangeOverride, Pallet, PotSlotIterations, PotSlotIterationsUpdate,
         PotSlotIterationsUpdateValue, SegmentCommitment, ShouldAdjustSolutionRange, SolutionRanges,
     };
@@ -45,7 +45,7 @@ mod benchmarks {
             Default::default(),
         );
         let proof = EquivocationProof {
-            slot: CurrentSlot::<T>::get(),
+            slot: Pallet::<T>::current_slot(),
             offender,
             first_header: header.clone(),
             second_header: header,
@@ -108,7 +108,7 @@ mod benchmarks {
         let unsigned_vote: Vote<BlockNumberFor<T>, T::Hash, T::AccountId> = Vote::V0 {
             height: System::<T>::block_number(),
             parent_hash: System::<T>::parent_hash(),
-            slot: CurrentSlot::<T>::get(),
+            slot: Pallet::<T>::current_slot(),
             solution: Solution::genesis_solution(
                 FarmerPublicKey::unchecked_from([1u8; 32]),
                 account("user1", 1, SEED),

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -144,11 +144,11 @@ pub mod pallet {
 
     /// Override for next solution range adjustment
     #[derive(Debug, Encode, Decode, TypeInfo)]
-    pub struct SolutionRangeOverride {
+    pub(super) struct SolutionRangeOverride {
         /// Value that should be set as solution range
-        pub solution_range: SolutionRange,
+        pub(super) solution_range: SolutionRange,
         /// Value that should be set as voting solution range
-        pub voting_solution_range: SolutionRange,
+        pub(super) voting_solution_range: SolutionRange,
     }
 
     /// The Subspace Pallet
@@ -387,7 +387,7 @@ pub mod pallet {
     /// Bounded mapping from block number to slot
     #[pallet::storage]
     #[pallet::getter(fn block_slots)]
-    pub type BlockSlots<T: Config> =
+    pub(super) type BlockSlots<T: Config> =
         StorageValue<_, BoundedBTreeMap<BlockNumberFor<T>, Slot, T::BlockSlotCount>, ValueQuery>;
 
     /// Solution ranges used for challenges.
@@ -403,16 +403,16 @@ pub mod pallet {
     /// Storage to check if the solution range is to be adjusted for next era
     #[pallet::storage]
     #[pallet::getter(fn should_adjust_solution_range)]
-    pub type ShouldAdjustSolutionRange<T: Config> =
+    pub(super) type ShouldAdjustSolutionRange<T: Config> =
         StorageValue<_, bool, ValueQuery, T::ShouldAdjustSolutionRange>;
 
     /// Override solution range during next update
     #[pallet::storage]
-    pub type NextSolutionRangeOverride<T> = StorageValue<_, SolutionRangeOverride>;
+    pub(super) type NextSolutionRangeOverride<T> = StorageValue<_, SolutionRangeOverride>;
 
     /// Slot at which current era started.
     #[pallet::storage]
-    pub type EraStartSlot<T> = StorageValue<_, Slot>;
+    pub(super) type EraStartSlot<T> = StorageValue<_, Slot>;
 
     /// A set of blocked farmers keyed by their public key.
     #[pallet::storage]

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -18,8 +18,8 @@
 
 use crate::equivocation::EquivocationHandler;
 use crate::{
-    self as pallet_subspace, AllowAuthoringBy, Config, CurrentSlot, EnableRewardsAt,
-    FarmerPublicKey, NormalEraChange,
+    self as pallet_subspace, AllowAuthoringBy, Config, EnableRewardsAt, FarmerPublicKey,
+    NormalEraChange,
 };
 use frame_support::traits::{ConstU128, ConstU16, OnInitialize};
 use frame_support::{derive_impl, parameter_types};
@@ -284,7 +284,7 @@ pub fn generate_equivocation_proof(
     slot: Slot,
 ) -> sp_consensus_subspace::EquivocationProof<Header> {
     let current_block = System::block_number();
-    let current_slot = CurrentSlot::<Test>::get();
+    let current_slot = Subspace::current_slot();
 
     let chunk = {
         let mut chunk_bytes = [0; Scalar::SAFE_BYTES];

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -51,17 +51,6 @@ use subspace_core_primitives::{PieceOffset, PotOutput, SegmentIndex, SolutionRan
 use subspace_runtime_primitives::{FindBlockRewardAddress, FindVotingRewardAddresses};
 
 #[test]
-fn genesis_slot_is_correct() {
-    new_test_ext(allow_all_pot_extension()).execute_with(|| {
-        let keypair = Keypair::generate();
-
-        // this sets the genesis slot to 6;
-        go_to_block(&keypair, 1, 6, 1);
-        assert_eq!(*Subspace::genesis_slot(), 6);
-    })
-}
-
-#[test]
 fn can_update_solution_range_on_era_change() {
     new_test_ext(allow_all_pot_extension()).execute_with(|| {
         let keypair = Keypair::generate();

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -24,9 +24,8 @@ use crate::mock::{
 };
 use crate::{
     pallet, AllowAuthoringByAnyone, BlockList, Call, CheckVoteError, Config,
-    CurrentBlockAuthorInfo, CurrentBlockVoters, CurrentSlot, EnableRewardsAt,
-    ParentBlockAuthorInfo, ParentBlockVoters, PotSlotIterations, SegmentCommitment,
-    SubspaceEquivocationOffence,
+    CurrentBlockAuthorInfo, CurrentBlockVoters, EnableRewardsAt, ParentBlockAuthorInfo,
+    ParentBlockVoters, PotSlotIterations, SegmentCommitment, SubspaceEquivocationOffence,
 };
 use codec::Encode;
 use frame_support::dispatch::{GetDispatchInfo, Pays};
@@ -249,7 +248,7 @@ fn report_equivocation_current_session_works() {
 
         // generate an equivocation proof. it creates two headers at the given
         // slot with different block hashes and signed by the given key
-        let equivocation_proof = generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+        let equivocation_proof = generate_equivocation_proof(&keypair, Subspace::current_slot());
 
         assert!(!Subspace::is_in_block_list(&farmer_public_key));
 
@@ -273,7 +272,7 @@ fn report_equivocation_old_session_works() {
         let farmer_public_key = FarmerPublicKey::unchecked_from(keypair.public.to_bytes());
 
         // generate an equivocation proof at the current slot
-        let equivocation_proof = generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+        let equivocation_proof = generate_equivocation_proof(&keypair, Subspace::current_slot());
 
         // create new block and report the equivocation
         // from the previous block
@@ -312,32 +311,32 @@ fn report_equivocation_invalid_equivocation_proof() {
 
         // both headers have the same hash, no equivocation.
         let mut equivocation_proof =
-            generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+            generate_equivocation_proof(&keypair, Subspace::current_slot());
         equivocation_proof.second_header = equivocation_proof.first_header.clone();
         assert_invalid_equivocation(equivocation_proof);
 
         // missing preruntime digest from one header
         let mut equivocation_proof =
-            generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+            generate_equivocation_proof(&keypair, Subspace::current_slot());
         equivocation_proof.first_header.digest_mut().logs.remove(0);
         assert_invalid_equivocation(equivocation_proof);
 
         // missing seal from one header
         let mut equivocation_proof =
-            generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+            generate_equivocation_proof(&keypair, Subspace::current_slot());
         equivocation_proof.first_header.digest_mut().logs.remove(1);
         assert_invalid_equivocation(equivocation_proof);
 
         // invalid slot number in proof compared to runtime digest
         let mut equivocation_proof =
-            generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+            generate_equivocation_proof(&keypair, Subspace::current_slot());
         equivocation_proof.slot = Slot::from(0);
         assert_invalid_equivocation(equivocation_proof.clone());
 
         // different slot numbers in headers
         let h1 = equivocation_proof.first_header;
         let mut equivocation_proof =
-            generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get() + 1);
+            generate_equivocation_proof(&keypair, Subspace::current_slot() + 1);
 
         // use the header from the previous equivocation generated
         // at the previous slot
@@ -347,7 +346,7 @@ fn report_equivocation_invalid_equivocation_proof() {
 
         // invalid seal signature
         let mut equivocation_proof =
-            generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get() + 1);
+            generate_equivocation_proof(&keypair, Subspace::current_slot() + 1);
 
         // replace the seal digest with the digest from the
         // previous header at the previous slot
@@ -370,7 +369,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 
         let farmer_public_key = FarmerPublicKey::unchecked_from(keypair.public.to_bytes());
 
-        let equivocation_proof = generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+        let equivocation_proof = generate_equivocation_proof(&keypair, Subspace::current_slot());
 
         let inner = Call::report_equivocation {
             equivocation_proof: Box::new(equivocation_proof.clone()),
@@ -386,7 +385,7 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
         );
 
         // The transaction is valid when passed as local
-        let tx_tag = (farmer_public_key, CurrentSlot::<Test>::get());
+        let tx_tag = (farmer_public_key, Subspace::current_slot());
         assert_eq!(
             <Subspace as sp_runtime::traits::ValidateUnsigned>::validate_unsigned(
                 TransactionSource::Local,
@@ -432,7 +431,7 @@ fn valid_equivocation_reports_dont_pay_fees() {
         progress_to_block(&keypair, 1, 1);
 
         // generate an equivocation proof.
-        let equivocation_proof = generate_equivocation_proof(&keypair, CurrentSlot::<Test>::get());
+        let equivocation_proof = generate_equivocation_proof(&keypair, Subspace::current_slot());
 
         // check the dispatch info for the call.
         let info = Call::<Test>::report_equivocation {


### PR DESCRIPTION
There were a few fields that either were not necessary or needed to be refactored. This cleaned up all TODOs in `pallet-subspace` library code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
