### PR TITLE
Rename CLI options

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster.rs
@@ -50,7 +50,7 @@ struct SharedArgs {
     ///
     /// NOTE: NATS must be configured for message sizes of 2MiB or larger (1MiB is the default),
     /// which can be done by starting NATS server with config file containing `max_payload = 2MB`.
-    #[arg(long, alias = "nats-server", required = true)]
+    #[arg(long = "nats-server", required = true)]
     nats_servers: Vec<ServerAddr>,
     /// Defines endpoints for the prometheus metrics server. It doesn't start without at least
     /// one specified endpoint. Format: 127.0.0.1:8080

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -64,7 +64,7 @@ pub(in super::super) struct NetworkArgs {
     #[arg(long, default_value_t = 100)]
     pub(in super::super) pending_out_connections: u32,
     /// Known external addresses
-    #[arg(long, alias = "external-address")]
+    #[arg(long = "external-address")]
     pub(in super::super) external_addresses: Vec<Multiaddr>,
 }
 

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -82,7 +82,7 @@ where
 #[derive(Debug, Parser)]
 struct Args {
     /// Multiaddresses of bootstrap nodes to connect to on startup, multiple are supported
-    #[arg(long, alias = "bootstrap-node", required = true)]
+    #[arg(long = "bootstrap-node", required = true)]
     bootstrap_nodes: Vec<Multiaddr>,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
     #[arg(long, default_value_t = false)]

--- a/crates/subspace-networking/examples/random-walker.rs
+++ b/crates/subspace-networking/examples/random-walker.rs
@@ -22,7 +22,7 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Parser)]
 struct Args {
     /// Multiaddresses of bootstrap nodes to connect to on startup, multiple are supported
-    #[arg(long, alias = "bootstrap-node", required = true)]
+    #[arg(long = "bootstrap-node", required = true)]
     bootstrap_nodes: Vec<Multiaddr>,
     /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
     #[arg(long, default_value_t = false)]

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -30,7 +30,7 @@ enum Command {
     /// Start bootstrap node
     Start {
         /// Multiaddresses of bootstrap nodes to connect to on startup, multiple are supported
-        #[arg(long, alias = "bootstrap-node")]
+        #[arg(long = "bootstrap-node")]
         bootstrap_nodes: Vec<Multiaddr>,
         /// Keypair for node identity, can be obtained with `generate-keypair` command
         #[clap(long)]
@@ -44,7 +44,7 @@ enum Command {
         ])]
         listen_on: Vec<Multiaddr>,
         /// Multiaddresses of reserved peers to maintain connections to, multiple are supported
-        #[arg(long, alias = "reserved-peer")]
+        #[arg(long = "reserved-peer")]
         reserved_peers: Vec<Multiaddr>,
         /// Defines max established incoming connections limit for the peer.
         #[arg(long, default_value_t = 300)]
@@ -66,7 +66,7 @@ enum Command {
         #[arg(long)]
         protocol_version: String,
         /// Known external addresses
-        #[arg(long, alias = "external-address")]
+        #[arg(long = "external-address")]
         external_addresses: Vec<Multiaddr>,
         /// Defines endpoints for the prometheus metrics server. It doesn't start without at least
         /// one specified endpoint. Format: 127.0.0.1:8080

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -154,7 +154,7 @@ struct DsnOptions {
     dsn_pending_out_connections: u32,
 
     /// Known external addresses
-    #[arg(long, alias = "dsn-external-address")]
+    #[arg(long = "dsn-external-address")]
     dsn_external_addresses: Vec<Multiaddr>,
 }
 


### PR DESCRIPTION
Following CLI options were renamed, such that in CLI help they look like in docs:
* `--nats-servers` -> `--nats-server`
* `--bootstrap-nodes` -> `--bootstrap-node`
* `--external-addresses` -> `--external-address`
* `--reserved-peers` -> `--reserved-peer`
* `--dsn-external-addresses` -> `--dsn-external-address`

While both options were previously accepted by CLI, only singular will be supported going forward.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
