### PR TITLE
Remove `serde_arrays` to make `serde` support in `subspace-core-primitives` `no_std`-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11131,15 +11131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_arrays"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12555,7 +12546,6 @@ name = "subspace-core-primitives"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "blst",
  "bytes",
  "criterion",
  "derive_more 1.0.0",
@@ -12570,7 +12560,6 @@ dependencies = [
  "rust-kzg-blst",
  "scale-info",
  "serde",
- "serde_arrays",
  "spin 0.9.8",
  "static_assertions",
  "tracing",

--- a/crates/subspace-core-primitives/Cargo.toml
+++ b/crates/subspace-core-primitives/Cargo.toml
@@ -17,8 +17,6 @@ bench = false
 
 [dependencies]
 blake3 = { version = "1.5.3", default-features = false }
-# TODO: Remove once we switch to big-endian
-blst = "0.3.13"
 bytes = { version = "1.7.1", default-features = false }
 derive_more = { version = "1.0.0", default-features = false, features = ["full"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
@@ -30,7 +28,6 @@ rayon = { version = "1.10.0", optional = true }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }
 scale-info = { version = "2.11.2", default-features = false, features = ["derive"] }
 serde = { version = "1.0.206", optional = true, features = ["alloc", "derive"] }
-serde_arrays = { version = "0.1.0", optional = true }
 # Replacement for `parking_lot` in `no_std` environment
 spin = "0.9.7"
 static_assertions = "1.1.0"
@@ -58,8 +55,6 @@ parallel = [
 ]
 serde = [
     "dep:serde",
-    # TODO: `serde_arrays` doesn't support `no_std` right now: https://github.com/Kromey/serde_arrays/issues/8
-    "dep:serde_arrays",
     "hex/serde",
 ]
 std = [

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -525,7 +525,7 @@ impl PublicKey {
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RewardSignature(
-    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))] [u8; REWARD_SIGNATURE_LENGTH],
+    #[cfg_attr(feature = "serde", serde(with = "hex"))] [u8; REWARD_SIGNATURE_LENGTH],
 );
 
 impl AsRef<[u8]> for RewardSignature {


### PR DESCRIPTION
Forgot to remove `blst` in https://github.com/autonomys/subspace/pull/3035

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
