### PR TITLE
Introduce withdrawal limit

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -431,6 +431,12 @@ mod pallet {
 
         /// Hook to handle chain rewards.
         type OnChainRewards: OnChainRewards<BalanceOf<Self>>;
+
+        /// The max number of withdrawal of a given nominator exist in the same time,
+        /// after this limit is met, the nominator need to unlock the withdrawal before
+        /// requesting new withdrawal.
+        #[pallet::constant]
+        type WithdrawalLimit: Get<u32>;
     }
 
     #[pallet::pallet]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -432,9 +432,9 @@ mod pallet {
         /// Hook to handle chain rewards.
         type OnChainRewards: OnChainRewards<BalanceOf<Self>>;
 
-        /// The max number of withdrawal of a given nominator exist in the same time,
-        /// after this limit is met, the nominator need to unlock the withdrawal before
-        /// requesting new withdrawal.
+        /// The max number of withdrawals per nominator that may exist at any time,
+        /// once this limit is reached, the nominator need to unlock the withdrawal
+        /// before requesting new withdrawal.
         #[pallet::constant]
         type WithdrawalLimit: Get<u32>;
     }

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -980,8 +980,8 @@ pub(crate) fn do_unlock_funds<T: Config>(
         let latest_confirmed_block_number =
             Pallet::<T>::latest_confirmed_domain_block_number(operator.current_domain_id);
 
-        let mut total_unlocked_amount: BalanceOf<T> = Zero::zero();
-        let mut total_storage_fee_refund: BalanceOf<T> = Zero::zero();
+        let mut total_unlocked_amount = BalanceOf::<T>::zero();
+        let mut total_storage_fee_refund = BalanceOf::<T>::zero();
         loop {
             if withdrawal
                 .withdrawals

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -800,7 +800,7 @@ pub(crate) fn do_withdraw_stake<T: Config>(
             if let Some(withdrawal) = maybe_withdrawal {
                 do_convert_previous_epoch_withdrawal::<T>(operator_id, withdrawal)?;
                 if withdrawal.withdrawals.len() as u32 >= T::WithdrawalLimit::get() {
-                    return Err(Error::TooManayWithdrawal);
+                    return Err(Error::TooManyWithdrawals);
                 }
             }
             Ok(())
@@ -2723,7 +2723,7 @@ pub(crate) mod tests {
                     nominator_account,
                     WithdrawStake::Stake(amount_per_withdraw),
                 ),
-                StakingError::TooManayWithdrawal
+                StakingError::TooManyWithdrawals
             );
             Withdrawals::<Test>::try_mutate(operator_id, nominator_account, |maybe_withdrawal| {
                 let withdrawal = maybe_withdrawal.as_mut().unwrap();

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1016,7 +1016,7 @@ pub(crate) fn do_unlock_funds<T: Config>(
                 .ok_or(Error::BalanceOverflow)?;
         }
 
-        // There is withdrawal but none being processed meaning the first withdrawal's unlocke period
+        // There is withdrawal but none being processed meaning the first withdrawal's unlock period has
         // not completed yet
         ensure!(
             !total_unlocked_amount.is_zero() || !total_storage_fee_refund.is_zero(),

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -544,7 +544,7 @@ pub(crate) fn do_convert_previous_epoch_withdrawal<T: Config>(
         unlock_at_confirmed_domain_block_number,
         shares,
         storage_fee_refund,
-        ..
+        domain_epoch: _,
     }) = withdrawal.withdrawal_in_shares.take()
     {
         let withdrawal_amount = epoch_share_price.shares_to_stake::<T>(shares);
@@ -1009,11 +1009,11 @@ pub(crate) fn do_unlock_funds<T: Config>(
 
             total_unlocked_amount = total_unlocked_amount
                 .checked_add(&amount_to_unlock)
-                .ok_or(Error::BalanceUnderflow)?;
+                .ok_or(Error::BalanceOverflow)?;
 
             total_storage_fee_refund = total_storage_fee_refund
                 .checked_add(&storage_fee_refund)
-                .ok_or(Error::BalanceUnderflow)?;
+                .ok_or(Error::BalanceOverflow)?;
         }
 
         // There is withdrawal but none being processed meaning the first withdrawal's unlocke period

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -297,6 +297,7 @@ pub enum Error {
     UnconfirmedER,
     /// Invalid signature from Signing key owner.
     InvalidSigningKeySignature,
+    TooManayWithdrawal,
 }
 
 // Increase `PendingStakingOperationCount` by one and check if the `MaxPendingStakingOperation`
@@ -801,8 +802,10 @@ pub(crate) fn do_withdraw_stake<T: Config>(
         Withdrawals::<T>::try_mutate(operator_id, nominator_id.clone(), |maybe_withdrawal| {
             if let Some(withdrawal) = maybe_withdrawal {
                 do_convert_previous_epoch_withdrawal::<T>(operator_id, withdrawal)?;
+                if withdrawal.withdrawals.len() as u32 >= T::WithdrawalLimit::get() {
+                    return Err(Error::TooManayWithdrawal);
+                }
             }
-
             Ok(())
         })?;
 

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -296,7 +296,7 @@ pub enum Error {
     UnconfirmedER,
     /// Invalid signature from Signing key owner.
     InvalidSigningKeySignature,
-    TooManayWithdrawal,
+    TooManyWithdrawals,
 }
 
 // Increase `PendingStakingOperationCount` by one and check if the `MaxPendingStakingOperation`

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -153,6 +153,7 @@ parameter_types! {
     pub const MaxInitialDomainAccounts: u32 = 5;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
     pub const BundleLongevity: u32 = 5;
+    pub const WithdrawalLimit: u32 = 10;
 }
 
 pub struct MockRandomness;
@@ -283,6 +284,7 @@ impl pallet_domains::Config for Test {
     type MmrProofVerifier = ();
     type FraudProofStorageKeyProvider = ();
     type OnChainRewards = ();
+    type WithdrawalLimit = WithdrawalLimit;
 }
 
 pub struct ExtrinsicStorageFees;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -769,6 +769,7 @@ parameter_types! {
     pub const MaxInitialDomainAccounts: u32 = 10;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
     pub const BundleLongevity: u32 = 5;
+    pub const WithdrawalLimit: u32 = 32;
 }
 
 // `BlockSlotCount` must at least keep the slot for the current and the parent block, it also need to
@@ -861,6 +862,7 @@ impl pallet_domains::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type FraudProofStorageKeyProvider = StorageKeyProvider;
     type OnChainRewards = OnChainRewards;
+    type WithdrawalLimit = WithdrawalLimit;
 }
 
 parameter_types! {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -688,6 +688,7 @@ parameter_types! {
     pub const MaxInitialDomainAccounts: u32 = 20;
     pub const MinInitialDomainAccountBalance: Balance = SSC;
     pub const BundleLongevity: u32 = 5;
+    pub const WithdrawalLimit: u32 = 32;
 }
 
 // `BlockSlotCount` must at least keep the slot for the current and the parent block, it also need to
@@ -777,6 +778,7 @@ impl pallet_domains::Config for Runtime {
     type MmrProofVerifier = MmrProofVerifier;
     type FraudProofStorageKeyProvider = StorageKeyProvider;
     type OnChainRewards = OnChainRewards;
+    type WithdrawalLimit = WithdrawalLimit;
 }
 
 parameter_types! {


### PR DESCRIPTION
In main, there is no limit on the number of withdrawals a nominator can request at the same time, and the withdrawals can only removed by `unlock_funds` extrinsic one by one. If the nominator just requests many numbers of withdrawals but no `unlock_funds` after the unlocking period (either forget or intentionally, especially since there is no limit on the minimum of funds of each withdrawal), the consensus state can bloat without limit.

In this PR:
- Introduce withdrawal limit (set to 32 currently), which is the number of withdrawals allowed to exist at the same time for a given nominator, after the limit is met the nominator will have to call `unlock_funds` to free the slot.
    - Withdrawal requested in the same epoch will still merge into one as it is
- Unlock all the ready withdrawals within one `unlock_funds` call
    - In main, the nominator will have to send the same number of `unlock_funds` as the withdrawal to get all the funds unlocked, but with the withdrawal limit the weight is bunded so we can unlock all ready withdrawals at once
- Add test and update benchmark

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
