### PR TITLE
remove gon and use native xcode tools for notarizing

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -227,8 +227,9 @@ jobs:
           echo "Notarizing ZIP archive file"
           xcrun notarytool submit subspace-binaries.zip --apple-id "${{ secrets.MACOS_APPLE_ID }}" --password "${{ secrets.MACOS_APP_PW }}" --team-id "${{ secrets.MACOS_TEAM_ID }}" --wait
 
-          echo "Stapling notarization to ZIP file"
-          xcrun stapler staple subspace-binaries.zip
+          # stapling does not work for .zip archives only .app bundles and .dmg files. Commenting this for now!
+          # echo "Stapling notarization to ZIP file"
+          # xcrun stapler staple subspace-binaries.zip
 
           echo "Done!"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -212,41 +212,29 @@ jobs:
           security unlock-keychain -p "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
           security import certificate.p12 -k build.keychain -P "${{ secrets.MACOS_CERTIFICATE_PW }}" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
+
           echo "Signing farmer"
           codesign --force --options=runtime --entitlements .github/workflows/Entitlements.plist -s "${{ secrets.MACOS_IDENTITY }}" --timestamp ${{ env.PRODUCTION_TARGET }}/subspace-farmer
+
           echo "Signing node"
           codesign --force --options=runtime --entitlements .github/workflows/Entitlements.plist -s "${{ secrets.MACOS_IDENTITY }}" --timestamp ${{ env.PRODUCTION_TARGET }}/subspace-node
-          echo "Creating an archive"
-          mkdir ${{ env.PRODUCTION_TARGET }}/macos-binaries
+
+          echo "Creating a ZIP archive"
+          mkdir -p ${{ env.PRODUCTION_TARGET }}/macos-binaries
           cp ${{ env.PRODUCTION_TARGET }}/subspace-farmer ${{ env.PRODUCTION_TARGET }}/subspace-node ${{ env.PRODUCTION_TARGET }}/macos-binaries
           ditto -c -k --rsrc ${{ env.PRODUCTION_TARGET }}/macos-binaries subspace-binaries.zip
-          echo "Notarizing"
-          brew update
-          brew install mitchellh/gon/gon
-          cat << EOF > gon.hcl
-          source = ["subspace-binaries.zip"]
-          bundle_id = "${{ secrets.MACOS_BUNDLE_ID }}"
-          sign {
-            application_identity = "${{ secrets.MACOS_IDENTITY }}"
-          }
-          apple_id {
-              username = "${{ secrets.MACOS_APPLE_ID }}"
-              password = "${{ secrets.MACOS_APP_PW }}"
-          }
-          EOF
-          gon -log-level=info -log-json gon.hcl
 
-          # Notarize the ZIP using notarytool
+          echo "Notarizing ZIP archive file"
           xcrun notarytool submit subspace-binaries.zip --apple-id "${{ secrets.MACOS_APPLE_ID }}" --password "${{ secrets.MACOS_APP_PW }}" --team-id "${{ secrets.MACOS_TEAM_ID }}" --wait
 
-          # // todo stapling for macOS artifacts
-          # Staple the zip package
-          # xcrun stapler staple subspace-binaries.zip
+          echo "Stapling notarization to ZIP file"
+          xcrun stapler staple subspace-binaries.zip
 
           echo "Done!"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
         continue-on-error: ${{ github.repository_owner != 'autonomys' || github.event_name != 'push' || github.ref_type != 'tag' }}
         if: runner.os == 'macOS'
+
 
       - name: Sign Application (Windows)
         run: |


### PR DESCRIPTION
This PR updates the macOS codesigning and notarization workflow for .zip binaries, transitioning from using the gon package to Xcode native tools. It ensures that the .zip file generated for distribution is signed and notarized correctly using Apple’s standard processes.

In order to achieve this, the full xcode application was required to be installed since xcode command-line tools does not have some of the required libraries, and with headless macOS it was not possible to install xcode from the app store. Xcode releases are now available for download through apple developer portal.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
