### PR TITLE
Extract object mappings for remark_with_event and seed_history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13127,6 +13127,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "pallet-balances",
  "pallet-domains",
+ "pallet-history-seeding",
  "pallet-messenger",
  "pallet-mmr",
  "pallet-offences-subspace",

--- a/crates/subspace-runtime/src/object_mapping.rs
+++ b/crates/subspace-runtime/src/object_mapping.rs
@@ -85,6 +85,21 @@ pub(crate) fn extract_call_block_object_mapping(
                 offset: base_offset + 1,
             });
         }
+        RuntimeCall::System(frame_system::Call::remark_with_event { remark }) => {
+            objects.push(BlockObject {
+                hash: crypto::blake3_hash(remark),
+                // Add frame_system::Call enum variant to the base offset.
+                offset: base_offset + 1,
+            });
+        }
+        RuntimeCall::HistorySeeding(pallet_history_seeding::Call::seed_history { remark }) => {
+            objects.push(BlockObject {
+                hash: crypto::blake3_hash(remark),
+                // Add pallet_history_seeding::Call enum variant to the base offset.
+                offset: base_offset + 1,
+            });
+        }
+
         // Recursively extract object mappings for the call.
         RuntimeCall::Utility(call) => {
             extract_utility_block_object_mapping(base_offset, objects, call, recursion_depth_left)

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -7,8 +7,9 @@ use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use subspace_runtime_primitives::{AccountId, Balance, Signature};
 use subspace_test_runtime::{
-    AllowAuthoringBy, BalancesConfig, DomainsConfig, EnableRewardsAt, RewardsConfig,
-    RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, SSC, WASM_BINARY,
+    AllowAuthoringBy, BalancesConfig, DomainsConfig, EnableRewardsAt, HistorySeedingConfig,
+    RewardsConfig, RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, SSC,
+    WASM_BINARY,
 };
 
 /// Generate a crypto pair from seed.
@@ -90,9 +91,12 @@ fn create_genesis_config(
             genesis_domains: vec![
                 crate::evm_domain_chain_spec::get_genesis_domain(sudo_account.clone())
                     .expect("Must success"),
-                crate::auto_id_domain_chain_spec::get_genesis_domain(sudo_account)
+                crate::auto_id_domain_chain_spec::get_genesis_domain(sudo_account.clone())
                     .expect("Must success"),
             ],
+        },
+        history_seeding: HistorySeedingConfig {
+            history_seeder: Some(sudo_account),
         },
         runtime_configs: Default::default(),
     })

--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -23,6 +23,7 @@ frame-support = { default-features = false, git = "https://github.com/subspace/p
 frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 pallet-balances = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 pallet-domains = { version = "0.1.0", default-features = false, path = "../../crates/pallet-domains" }
+pallet-history-seeding = { version = "0.1.0", default-features = false, path = "../../crates/pallet-history-seeding" }
 pallet-messenger = { version = "0.1.0", path = "../../domains/pallets/messenger", default-features = false }
 pallet-mmr = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 pallet-offences-subspace = { version = "0.1.0", default-features = false, path = "../../crates/pallet-offences-subspace" }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -293,6 +293,10 @@ parameter_types! {
     pub TransactionWeightFee: Balance = 100_000 * SHANNON;
 }
 
+impl pallet_history_seeding::Config for Runtime {
+    type WeightInfo = pallet_history_seeding::weights::SubstrateWeight<Runtime>;
+}
+
 impl pallet_subspace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type BlockAuthoringDelay = BlockAuthoringDelay;
@@ -860,6 +864,8 @@ construct_runtime!(
         // Note: Indexes should match with indexes on other chains and domains
         Messenger: pallet_messenger exclude_parts { Inherent } = 60,
         Transporter: pallet_transporter = 61,
+
+        HistorySeeding: pallet_history_seeding = 91,
 
         // Reserve some room for other pallets as we'll remove sudo pallet eventually.
         Sudo: pallet_sudo = 100,

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1019,6 +1019,21 @@ fn extract_call_block_object_mapping(
                 offset: base_offset + 1,
             });
         }
+        RuntimeCall::System(frame_system::Call::remark_with_event { remark }) => {
+            objects.push(BlockObject {
+                hash: crypto::blake3_hash(remark),
+                // Add frame_system::Call enum variant to the base offset.
+                offset: base_offset + 1,
+            });
+        }
+        RuntimeCall::HistorySeeding(pallet_history_seeding::Call::seed_history { remark }) => {
+            objects.push(BlockObject {
+                hash: crypto::blake3_hash(remark),
+                // Add pallet_history_seeding::Call enum variant to the base offset.
+                offset: base_offset + 1,
+            });
+        }
+
         // Recursively extract object mappings for the call.
         RuntimeCall::Utility(call) => {
             extract_utility_block_object_mapping(base_offset, objects, call, recursion_depth_left)


### PR DESCRIPTION
Jeremy asked if we could extract object mappings for remark_with_event and history seeding. This PR extracts those mappings.

It also adds test runtime support for those mappings.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
