### PR TITLE
Update domain config items

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use super::*;
 use crate::block_tree::{prune_receipt, BlockTreeNode};
 use crate::bundle_storage_fund::refund_storage_fee;
-use crate::domain_registry::DomainConfig;
+use crate::domain_registry::{into_domain_config, DomainConfigParams};
 use crate::staking::{
     do_convert_previous_epoch_withdrawal, do_mark_operators_as_slashed, do_reward_operators,
     Error as StakingError, OperatorConfig, OperatorStatus, WithdrawStake,
@@ -23,7 +23,6 @@ use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
 use frame_support::traits::fungible::{Inspect, Mutate};
 use frame_support::traits::Hooks;
-use frame_support::weights::Weight;
 use frame_system::{Pallet as System, RawOrigin};
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_core::ByteArray;
@@ -528,11 +527,10 @@ mod benchmarks {
 
         let runtime_id = register_runtime::<T>();
         let domain_id = NextDomainId::<T>::get();
-        let domain_config = DomainConfig {
+        let domain_config_params = DomainConfigParams {
             domain_name: "evm-domain".to_owned(),
             runtime_id,
-            max_bundle_size: 1024,
-            max_bundle_weight: Weight::from_parts(1, 0),
+            maybe_bundle_limit: None,
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
@@ -544,10 +542,16 @@ mod benchmarks {
         ));
 
         #[extrinsic_call]
-        _(RawOrigin::Signed(creator.clone()), domain_config.clone());
+        _(
+            RawOrigin::Signed(creator.clone()),
+            domain_config_params.clone(),
+        );
 
         let domain_obj = DomainRegistry::<T>::get(domain_id).expect("domain object must exist");
-        assert_eq!(domain_obj.domain_config, domain_config);
+        assert_eq!(
+            domain_obj.domain_config,
+            into_domain_config::<T>(domain_config_params).expect("Must success")
+        );
         assert_eq!(domain_obj.owner_account_id, creator);
         assert!(DomainStakingSummary::<T>::get(domain_id).is_some());
         assert!(
@@ -945,11 +949,10 @@ mod benchmarks {
 
         let runtime_id = register_runtime::<T>();
         let domain_id = NextDomainId::<T>::get();
-        let domain_config = DomainConfig {
+        let domain_config_params = DomainConfigParams {
             domain_name: "evm-domain".to_owned(),
             runtime_id,
-            max_bundle_size: 1024,
-            max_bundle_weight: Weight::from_parts(1, 0),
+            maybe_bundle_limit: None,
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
@@ -962,11 +965,14 @@ mod benchmarks {
 
         assert_ok!(Domains::<T>::instantiate_domain(
             RawOrigin::Signed(creator.clone()).into(),
-            domain_config.clone(),
+            domain_config_params.clone(),
         ));
 
         let domain_obj = DomainRegistry::<T>::get(domain_id).expect("domain object must exist");
-        assert_eq!(domain_obj.domain_config, domain_config);
+        assert_eq!(
+            domain_obj.domain_config,
+            into_domain_config::<T>(domain_config_params).expect("Must success")
+        );
         assert_eq!(domain_obj.owner_account_id, creator);
 
         domain_id

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -531,8 +531,8 @@ mod benchmarks {
         let domain_config = DomainConfig {
             domain_name: "evm-domain".to_owned(),
             runtime_id,
-            max_block_size: 1024,
-            max_block_weight: Weight::from_parts(1, 0),
+            max_bundle_size: 1024,
+            max_bundle_weight: Weight::from_parts(1, 0),
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
@@ -948,8 +948,8 @@ mod benchmarks {
         let domain_config = DomainConfig {
             domain_name: "evm-domain".to_owned(),
             runtime_id,
-            max_block_size: 1024,
-            max_block_weight: Weight::from_parts(1, 0),
+            max_bundle_size: 1024,
+            max_bundle_weight: Weight::from_parts(1, 0),
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -534,7 +534,6 @@ mod benchmarks {
             max_block_size: 1024,
             max_block_weight: Weight::from_parts(1, 0),
             bundle_slot_probability: (1, 1),
-            target_bundles_per_block: 10,
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
         };
@@ -952,7 +951,6 @@ mod benchmarks {
             max_block_size: 1024,
             max_block_weight: Weight::from_parts(1, 0),
             bundle_slot_probability: (1, 1),
-            target_bundles_per_block: 10,
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
         };

--- a/crates/pallet-domains/src/domain_registry.rs
+++ b/crates/pallet-domains/src/domain_registry.rs
@@ -33,7 +33,6 @@ use sp_runtime::traits::{CheckedAdd, Zero};
 use sp_runtime::DigestItem;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
-use subspace_runtime_primitives::SLOT_PROBABILITY;
 
 /// Domain registry specific errors
 #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
@@ -113,7 +112,7 @@ pub fn into_domain_config<T: Config>(
         None => calculate_max_bundle_weight_and_size(
             T::MaxDomainBlockSize::get(),
             T::MaxDomainBlockWeight::get(),
-            SLOT_PROBABILITY,
+            T::ConsensusSlotProbability::get(),
             bundle_slot_probability,
         )
         .ok_or(Error::BundleLimitCalculationOverflow)?,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -335,10 +335,6 @@ mod pallet {
         #[pallet::constant]
         type MaxDomainBlockWeight: Get<Weight>;
 
-        /// The maximum bundle per block limit for all domain.
-        #[pallet::constant]
-        type MaxBundlesPerBlock: Get<u32>;
-
         /// The maximum domain name length limit for all domain.
         #[pallet::constant]
         type MaxDomainNameLength: Get<u32>;
@@ -1829,7 +1825,6 @@ mod pallet {
                         max_block_size: genesis_domain.max_block_size,
                         max_block_weight: genesis_domain.max_block_weight,
                         bundle_slot_probability: genesis_domain.bundle_slot_probability,
-                        target_bundles_per_block: genesis_domain.target_bundles_per_block,
                         operator_allow_list: genesis_domain.operator_allow_list,
                         initial_balances: genesis_domain.initial_balances,
                     };

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -181,7 +181,7 @@ mod pallet {
     use crate::bundle_storage_fund::refund_storage_fee;
     use crate::bundle_storage_fund::Error as BundleStorageFundError;
     use crate::domain_registry::{
-        do_instantiate_domain, do_update_domain_allow_list, DomainConfig, DomainObject,
+        do_instantiate_domain, do_update_domain_allow_list, DomainConfigParams, DomainObject,
         Error as DomainRegistryError,
     };
     use crate::runtime_registry::{
@@ -1397,7 +1397,7 @@ mod pallet {
         #[pallet::weight(T::WeightInfo::instantiate_domain())]
         pub fn instantiate_domain(
             origin: OriginFor<T>,
-            domain_config: DomainConfig<T::AccountId, BalanceOf<T>>,
+            domain_config_params: DomainConfigParams<T::AccountId, BalanceOf<T>>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
             ensure!(
@@ -1409,7 +1409,7 @@ mod pallet {
 
             let created_at = frame_system::Pallet::<T>::current_block_number();
 
-            let domain_id = do_instantiate_domain::<T>(domain_config, who, created_at)
+            let domain_id = do_instantiate_domain::<T>(domain_config_params, who, created_at)
                 .map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::DomainInstantiated { domain_id });
@@ -1817,18 +1817,17 @@ mod pallet {
                     .expect("Genesis runtime registration must always succeed");
 
                     // Instantiate the genesis domain
-                    let domain_config = DomainConfig {
+                    let domain_config_params = DomainConfigParams {
                         domain_name: genesis_domain.domain_name,
                         runtime_id,
-                        max_bundle_size: genesis_domain.max_bundle_size,
-                        max_bundle_weight: genesis_domain.max_bundle_weight,
+                        maybe_bundle_limit: None,
                         bundle_slot_probability: genesis_domain.bundle_slot_probability,
                         operator_allow_list: genesis_domain.operator_allow_list,
                         initial_balances: genesis_domain.initial_balances,
                     };
                     let domain_owner = genesis_domain.owner_account_id;
                     let domain_id = do_instantiate_domain::<T>(
-                        domain_config,
+                        domain_config_params,
                         domain_owner.clone(),
                         Zero::zero(),
                     )

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1508,7 +1508,6 @@ pub(crate) mod tests {
                 max_block_size: u32::MAX,
                 max_block_weight: Weight::MAX,
                 bundle_slot_probability: (0, 0),
-                target_bundles_per_block: 0,
                 operator_allow_list: OperatorAllowList::Anyone,
                 initial_balances: Default::default(),
             };
@@ -1905,7 +1904,6 @@ pub(crate) mod tests {
                 max_block_size: u32::MAX,
                 max_block_weight: Weight::MAX,
                 bundle_slot_probability: (0, 0),
-                target_bundles_per_block: 0,
                 operator_allow_list: OperatorAllowList::Anyone,
                 initial_balances: Default::default(),
             };

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1505,8 +1505,8 @@ pub(crate) mod tests {
             let domain_config = DomainConfig {
                 domain_name: String::from_utf8(vec![0; 1024]).unwrap(),
                 runtime_id: 0,
-                max_block_size: u32::MAX,
-                max_block_weight: Weight::MAX,
+                max_bundle_size: u32::MAX,
+                max_bundle_weight: Weight::MAX,
                 bundle_slot_probability: (0, 0),
                 operator_allow_list: OperatorAllowList::Anyone,
                 initial_balances: Default::default(),
@@ -1901,8 +1901,8 @@ pub(crate) mod tests {
             let domain_config = DomainConfig {
                 domain_name: String::from_utf8(vec![0; 1024]).unwrap(),
                 runtime_id: 0,
-                max_block_size: u32::MAX,
-                max_block_weight: Weight::MAX,
+                max_bundle_size: u32::MAX,
+                max_bundle_weight: Weight::MAX,
                 bundle_slot_probability: (0, 0),
                 operator_allow_list: OperatorAllowList::Anyone,
                 initial_balances: Default::default(),

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::block_tree::{verify_execution_receipt, BlockTreeNode};
-use crate::domain_registry::{DomainConfig, DomainObject};
+use crate::domain_registry::{DomainConfig, DomainConfigParams, DomainObject};
 use crate::pallet::OperatorIdOwner;
 use crate::runtime_registry::ScheduledRuntimeUpgrade;
 use crate::staking::Operator;
@@ -461,11 +461,10 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorI
     );
     crate::Pallet::<Test>::instantiate_domain(
         RawOrigin::Signed(creator).into(),
-        DomainConfig {
+        DomainConfigParams {
             domain_name: "evm-domain".to_owned(),
             runtime_id: 0,
-            max_bundle_size: 1u32,
-            max_bundle_weight: Weight::from_parts(1, 0),
+            maybe_bundle_limit: None,
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -464,8 +464,8 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorI
         DomainConfig {
             domain_name: "evm-domain".to_owned(),
             runtime_id: 0,
-            max_block_size: 1u32,
-            max_block_weight: Weight::from_parts(1, 0),
+            max_bundle_size: 1u32,
+            max_bundle_weight: Weight::from_parts(1, 0),
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
@@ -619,12 +619,12 @@ fn test_bundle_fromat_verification() {
     new_test_ext().execute_with(|| {
         let domain_id = DomainId::new(0);
         let max_extrincis_count = 10;
-        let max_block_size = opaque_extrinsic(0, 0).encoded_size() as u32 * max_extrincis_count;
+        let max_bundle_size = opaque_extrinsic(0, 0).encoded_size() as u32 * max_extrincis_count;
         let domain_config = DomainConfig {
             domain_name: "test-domain".to_owned(),
             runtime_id: 0u32,
-            max_block_size,
-            max_block_weight: Weight::MAX,
+            max_bundle_size,
+            max_bundle_weight: Weight::MAX,
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
@@ -661,7 +661,7 @@ fn test_bundle_fromat_verification() {
                 .extrinsics
                 .push(opaque_extrinsic(i as u128, i as u128));
         }
-        assert!(too_large_bundle.size() > max_block_size);
+        assert!(too_large_bundle.size() > max_bundle_size);
 
         // Bundle with wrong value of `bundle_extrinsics_root`
         let mut invalid_extrinsic_root_bundle = valid_bundle.clone();

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -81,7 +81,6 @@ parameter_types! {
     pub const InitialDomainTxRange: u64 = 3;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
     pub const DomainRuntimeUpgradeDelay: BlockNumber = 100;
-    pub const MaxBundlesPerBlock: u32 = 10;
     pub const MaxDomainBlockSize: u32 = 1024 * 1024;
     pub const MaxDomainBlockWeight: Weight = Weight::from_parts(1024 * 1024, 0);
     pub const DomainInstantiationDeposit: Balance = 100;
@@ -253,7 +252,6 @@ impl pallet_domains::Config for Test {
     type MinNominatorStake = MinNominatorStake;
     type MaxDomainBlockSize = MaxDomainBlockSize;
     type MaxDomainBlockWeight = MaxDomainBlockWeight;
-    type MaxBundlesPerBlock = MaxBundlesPerBlock;
     type DomainInstantiationDeposit = DomainInstantiationDeposit;
     type MaxDomainNameLength = MaxDomainNameLength;
     type Share = Balance;
@@ -469,7 +467,6 @@ pub(crate) fn register_genesis_domain(creator: u128, operator_ids: Vec<OperatorI
             max_block_size: 1u32,
             max_block_weight: Weight::from_parts(1, 0),
             bundle_slot_probability: (1, 1),
-            target_bundles_per_block: 1,
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
         },
@@ -629,7 +626,6 @@ fn test_bundle_fromat_verification() {
             max_block_size,
             max_block_weight: Weight::MAX,
             bundle_slot_probability: (1, 1),
-            target_bundles_per_block: 1,
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
         };

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -604,7 +604,7 @@ fn test_calculate_tx_range() {
 }
 
 #[test]
-fn test_bundle_fromat_verification() {
+fn test_bundle_format_verification() {
     let opaque_extrinsic = |dest: u128, value: u128| -> OpaqueExtrinsic {
         UncheckedExtrinsic {
             signature: None,
@@ -617,8 +617,8 @@ fn test_bundle_fromat_verification() {
     };
     new_test_ext().execute_with(|| {
         let domain_id = DomainId::new(0);
-        let max_extrincis_count = 10;
-        let max_bundle_size = opaque_extrinsic(0, 0).encoded_size() as u32 * max_extrincis_count;
+        let max_extrinsics_count = 10;
+        let max_bundle_size = opaque_extrinsic(0, 0).encoded_size() as u32 * max_extrinsics_count;
         let domain_config = DomainConfig {
             domain_name: "test-domain".to_owned(),
             runtime_id: 0u32,
@@ -655,7 +655,7 @@ fn test_bundle_fromat_verification() {
 
         // Bundle exceed max size
         let mut too_large_bundle = valid_bundle.clone();
-        for i in 0..max_extrincis_count {
+        for i in 0..max_extrinsics_count {
             too_large_bundle
                 .extrinsics
                 .push(opaque_extrinsic(i as u128, i as u128));

--- a/crates/sp-domains-fraud-proof/src/tests.rs
+++ b/crates/sp-domains-fraud-proof/src/tests.rs
@@ -93,7 +93,7 @@ fn generate_eip2930_tx(
         <TestRuntime as frame_system::Config>::BlockWeights::get();
     // `limits.get(DispatchClass::Normal).max_extrinsic` is too large to use as `gas_limit`
     // thus use `base_extrinsic`
-    let max_extrinsic = limits.get(DispatchClass::Normal).base_extrinsic * 1000;
+    let max_extrinsic = limits.get(DispatchClass::Normal).base_extrinsic * 100;
     let max_extrinsic_gas =
         <TestRuntime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(max_extrinsic);
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -908,7 +908,6 @@ pub struct GenesisDomain<AccountId: Ord, Balance> {
     pub max_block_size: u32,
     pub max_block_weight: Weight,
     pub bundle_slot_probability: (u64, u64),
-    pub target_bundles_per_block: u32,
     pub operator_allow_list: OperatorAllowList<AccountId>,
 
     // Genesis operator

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -905,8 +905,8 @@ pub struct GenesisDomain<AccountId: Ord, Balance> {
     // Domain config items
     pub owner_account_id: AccountId,
     pub domain_name: String,
-    pub max_block_size: u32,
-    pub max_block_weight: Weight,
+    pub max_bundle_size: u32,
+    pub max_bundle_weight: Weight,
     pub bundle_slot_probability: (u64, u64),
     pub operator_allow_list: OperatorAllowList<AccountId>,
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -905,8 +905,6 @@ pub struct GenesisDomain<AccountId: Ord, Balance> {
     // Domain config items
     pub owner_account_id: AccountId,
     pub domain_name: String,
-    pub max_bundle_size: u32,
-    pub max_bundle_weight: Weight,
     pub bundle_slot_probability: (u64, u64),
     pub operator_allow_list: OperatorAllowList<AccountId>,
 
@@ -1060,7 +1058,7 @@ pub struct DomainInstanceData {
     pub raw_genesis: RawGenesis,
 }
 
-#[derive(Debug, Decode, Encode, TypeInfo, Clone)]
+#[derive(Debug, Decode, Encode, TypeInfo, Clone, PartialEq, Eq)]
 pub struct DomainBundleLimit {
     /// The max bundle size for the domain.
     pub max_bundle_size: u32,

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -258,7 +258,6 @@ fn subspace_genesis_config(
                 max_block_size: MaxDomainBlockSize::get(),
                 max_block_weight: MaxDomainBlockWeight::get(),
                 bundle_slot_probability: (1, 1),
-                target_bundles_per_block: 10,
                 operator_allow_list: genesis_domain_params.operator_allow_list,
                 signing_key: genesis_domain_params.operator_signing_key,
                 nomination_tax: Percent::from_percent(5),

--- a/crates/subspace-malicious-operator/src/chain_spec.rs
+++ b/crates/subspace-malicious-operator/src/chain_spec.rs
@@ -7,21 +7,17 @@ use sc_service::{ChainSpec, ChainType};
 use sp_core::crypto::AccountId32;
 use sp_core::{sr25519, Pair, Public};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{
-    calculate_max_bundle_weight_and_size, DomainBundleLimit, OperatorAllowList, OperatorPublicKey,
-    PermissionedActionAllowedBy, RuntimeType,
-};
+use sp_domains::{OperatorAllowList, OperatorPublicKey, PermissionedActionAllowedBy, RuntimeType};
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use subspace_runtime::{
     AllowAuthoringBy, CouncilConfig, DemocracyConfig, DomainsConfig, EnableRewardsAt,
-    HistorySeedingConfig, MaxDomainBlockSize, MaxDomainBlockWeight, RewardsConfig,
-    RuntimeConfigsConfig, SubspaceConfig,
+    HistorySeedingConfig, RewardsConfig, RuntimeConfigsConfig, SubspaceConfig,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SLOT_PROBABILITY, SSC,
+    AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SSC,
 };
 
 fn endowed_accounts() -> Vec<(MultiAccountId, Balance)> {
@@ -220,19 +216,6 @@ fn subspace_genesis_config(
         rewards_config,
     } = genesis_params;
 
-    let bundle_slot_probability = (1, 1);
-
-    let DomainBundleLimit {
-        max_bundle_size,
-        max_bundle_weight,
-    } = calculate_max_bundle_weight_and_size(
-        MaxDomainBlockSize::get(),
-        MaxDomainBlockWeight::get(),
-        SLOT_PROBABILITY,
-        bundle_slot_probability,
-    )
-    .expect("No arithmetic error");
-
     subspace_runtime::RuntimeGenesisConfig {
         system: subspace_runtime::SystemConfig::default(),
         balances: subspace_runtime::BalancesConfig { balances },
@@ -271,9 +254,7 @@ fn subspace_genesis_config(
                 // Domain config, mainly for placeholder the concrete value TBD
                 owner_account_id: sudo_account.clone(),
                 domain_name: genesis_domain_params.domain_name,
-                max_bundle_size,
-                max_bundle_weight,
-                bundle_slot_probability,
+                bundle_slot_probability: (1, 1),
                 operator_allow_list: genesis_domain_params.operator_allow_list,
                 signing_key: genesis_domain_params.operator_signing_key,
                 nomination_tax: Percent::from_percent(5),

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -396,7 +396,6 @@ fn subspace_genesis_config(
                     max_block_size: MaxDomainBlockSize::get(),
                     max_block_weight: MaxDomainBlockWeight::get(),
                     bundle_slot_probability: (1, 1),
-                    target_bundles_per_block: 10,
                     operator_allow_list: genesis_domain.operator_allow_list.clone(),
                     signing_key: genesis_domain.operator_signing_key.clone(),
                     nomination_tax: Percent::from_percent(5),

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -25,21 +25,18 @@ use sc_service::ChainType;
 use sc_subspace_chain_specs::DEVNET_CHAIN_SPEC;
 use sc_telemetry::TelemetryEndpoints;
 use sp_core::crypto::Ss58Codec;
-use sp_domains::{
-    calculate_max_bundle_weight_and_size, DomainBundleLimit, PermissionedActionAllowedBy,
-};
+use sp_domains::PermissionedActionAllowedBy;
 use sp_runtime::{BoundedVec, Percent};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use subspace_core_primitives::{PotKey, PublicKey};
 use subspace_runtime::{
     AllowAuthoringBy, BalancesConfig, CouncilConfig, DemocracyConfig, DomainsConfig,
-    EnableRewardsAt, HistorySeedingConfig, MaxDomainBlockSize, MaxDomainBlockWeight, RewardPoint,
-    RewardsConfig, RuntimeConfigsConfig, RuntimeGenesisConfig, SubspaceConfig, SudoConfig,
-    SystemConfig, WASM_BINARY,
+    EnableRewardsAt, HistorySeedingConfig, RewardPoint, RewardsConfig, RuntimeConfigsConfig,
+    RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 use subspace_runtime_primitives::{
-    AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SLOT_PROBABILITY, SSC,
+    AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SSC,
 };
 
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.network/submit/";
@@ -382,19 +379,6 @@ fn subspace_genesis_config(
     } = genesis_params;
 
     let genesis_domains = if enable_domains {
-        let bundle_slot_probability = (1, 1);
-
-        let DomainBundleLimit {
-            max_bundle_size,
-            max_bundle_weight,
-        } = calculate_max_bundle_weight_and_size(
-            MaxDomainBlockSize::get(),
-            MaxDomainBlockWeight::get(),
-            SLOT_PROBABILITY,
-            bundle_slot_probability,
-        )
-        .expect("No arithmetic error");
-
         genesis_domain_params
             .genesis_domains
             .into_iter()
@@ -408,9 +392,7 @@ fn subspace_genesis_config(
                     // Domain config, mainly for placeholder the concrete value TBD
                     owner_account_id: sudo_account.clone(),
                     domain_name: genesis_domain.domain_name,
-                    max_bundle_size,
-                    max_bundle_weight,
-                    bundle_slot_probability,
+                    bundle_slot_probability: (1, 1),
                     operator_allow_list: genesis_domain.operator_allow_list.clone(),
                     signing_key: genesis_domain.operator_signing_key.clone(),
                     nomination_tax: Percent::from_percent(5),

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -743,7 +743,6 @@ parameter_types! {
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
     pub MaxDomainBlockWeight: Weight = maximum_domain_block_weight();
-    pub const MaxBundlesPerBlock: u32 = 10;
     pub const DomainInstantiationDeposit: Balance = 100 * SSC;
     pub const MaxDomainNameLength: u32 = 32;
     pub const BlockTreePruningDepth: u32 = 14_400;
@@ -825,7 +824,6 @@ impl pallet_domains::Config for Runtime {
     type MinNominatorStake = MinNominatorStake;
     type MaxDomainBlockSize = MaxDomainBlockSize;
     type MaxDomainBlockWeight = MaxDomainBlockWeight;
-    type MaxBundlesPerBlock = MaxBundlesPerBlock;
     type DomainInstantiationDeposit = DomainInstantiationDeposit;
     type MaxDomainNameLength = MaxDomainNameLength;
     type Share = Balance;

--- a/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
@@ -87,7 +87,6 @@ pub fn get_genesis_domain(
         max_block_size: MaxDomainBlockSize::get(),
         max_block_weight: MaxDomainBlockWeight::get(),
         bundle_slot_probability: (1, 1),
-        target_bundles_per_block: 10,
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Bob"),

--- a/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
@@ -8,14 +8,10 @@ use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
 use sp_core::crypto::AccountId32;
 use sp_core::{sr25519, Pair, Public};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{
-    calculate_max_bundle_weight_and_size, DomainBundleLimit, GenesisDomain, OperatorAllowList,
-    OperatorPublicKey, RuntimeType,
-};
+use sp_domains::{GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
-use subspace_runtime_primitives::{AccountId, Balance, SLOT_PROBABILITY, SSC};
-use subspace_test_runtime::{MaxDomainBlockSize, MaxDomainBlockWeight};
+use subspace_runtime_primitives::{AccountId, Balance, SSC};
 
 /// Get public key from keypair seed.
 pub(crate) fn get_public_key_from_seed<TPublic: Public>(
@@ -78,19 +74,6 @@ pub fn get_genesis_domain(
         raw_genesis.encode()
     };
 
-    let bundle_slot_probability = (1, 1);
-
-    let DomainBundleLimit {
-        max_bundle_size,
-        max_bundle_weight,
-    } = calculate_max_bundle_weight_and_size(
-        MaxDomainBlockSize::get(),
-        MaxDomainBlockWeight::get(),
-        SLOT_PROBABILITY,
-        bundle_slot_probability,
-    )
-    .expect("No arithmetic error");
-
     Ok(GenesisDomain {
         runtime_name: "auto-id".to_owned(),
         runtime_type: RuntimeType::AutoId,
@@ -100,9 +83,7 @@ pub fn get_genesis_domain(
         // Domain config, mainly for placeholder the concrete value TBD
         owner_account_id: sudo_account,
         domain_name: "auto-id-domain".to_owned(),
-        max_bundle_size,
-        max_bundle_weight,
-        bundle_slot_probability,
+        bundle_slot_probability: (1, 1),
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Bob"),

--- a/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/auto_id_domain_chain_spec.rs
@@ -8,10 +8,13 @@ use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
 use sp_core::crypto::AccountId32;
 use sp_core::{sr25519, Pair, Public};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_domains::{
+    calculate_max_bundle_weight_and_size, DomainBundleLimit, GenesisDomain, OperatorAllowList,
+    OperatorPublicKey, RuntimeType,
+};
 use sp_runtime::traits::{Convert, IdentifyAccount};
 use sp_runtime::{BuildStorage, MultiSigner, Percent};
-use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_runtime_primitives::{AccountId, Balance, SLOT_PROBABILITY, SSC};
 use subspace_test_runtime::{MaxDomainBlockSize, MaxDomainBlockWeight};
 
 /// Get public key from keypair seed.
@@ -75,6 +78,19 @@ pub fn get_genesis_domain(
         raw_genesis.encode()
     };
 
+    let bundle_slot_probability = (1, 1);
+
+    let DomainBundleLimit {
+        max_bundle_size,
+        max_bundle_weight,
+    } = calculate_max_bundle_weight_and_size(
+        MaxDomainBlockSize::get(),
+        MaxDomainBlockWeight::get(),
+        SLOT_PROBABILITY,
+        bundle_slot_probability,
+    )
+    .expect("No arithmetic error");
+
     Ok(GenesisDomain {
         runtime_name: "auto-id".to_owned(),
         runtime_type: RuntimeType::AutoId,
@@ -84,9 +100,9 @@ pub fn get_genesis_domain(
         // Domain config, mainly for placeholder the concrete value TBD
         owner_account_id: sudo_account,
         domain_name: "auto-id-domain".to_owned(),
-        max_block_size: MaxDomainBlockSize::get(),
-        max_block_weight: MaxDomainBlockWeight::get(),
-        bundle_slot_probability: (1, 1),
+        max_bundle_size,
+        max_bundle_weight,
+        bundle_slot_probability,
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Bob"),

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -9,14 +9,10 @@ use evm_domain_test_runtime::{
 use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
 use sp_core::{ecdsa, Pair, Public};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{
-    calculate_max_bundle_weight_and_size, DomainBundleLimit, DomainId, GenesisDomain,
-    OperatorAllowList, OperatorPublicKey, RuntimeType,
-};
+use sp_domains::{DomainId, GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
 use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
 use sp_runtime::{BuildStorage, Percent};
-use subspace_runtime_primitives::{AccountId, Balance, SLOT_PROBABILITY, SSC};
-use subspace_test_runtime::{MaxDomainBlockSize, MaxDomainBlockWeight};
+use subspace_runtime_primitives::{AccountId, Balance, SSC};
 
 type AccountPublic = <Signature as Verify>::Signer;
 
@@ -116,19 +112,6 @@ pub fn get_genesis_domain(
         raw_genesis.encode()
     };
 
-    let bundle_slot_probability = (1, 1);
-
-    let DomainBundleLimit {
-        max_bundle_size,
-        max_bundle_weight,
-    } = calculate_max_bundle_weight_and_size(
-        MaxDomainBlockSize::get(),
-        MaxDomainBlockWeight::get(),
-        SLOT_PROBABILITY,
-        bundle_slot_probability,
-    )
-    .expect("No arithmetic error");
-
     Ok(GenesisDomain {
         runtime_name: "evm".to_owned(),
         runtime_type: RuntimeType::Evm,
@@ -138,9 +121,7 @@ pub fn get_genesis_domain(
         // Domain config, mainly for placeholder the concrete value TBD
         owner_account_id: sudo_account,
         domain_name: "evm-domain".to_owned(),
-        max_bundle_size,
-        max_bundle_weight,
-        bundle_slot_probability,
+        bundle_slot_probability: (1, 1),
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Alice"),

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -9,10 +9,13 @@ use evm_domain_test_runtime::{
 use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
 use sp_core::{ecdsa, Pair, Public};
 use sp_domains::storage::RawGenesis;
-use sp_domains::{DomainId, GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_domains::{
+    calculate_max_bundle_weight_and_size, DomainBundleLimit, DomainId, GenesisDomain,
+    OperatorAllowList, OperatorPublicKey, RuntimeType,
+};
 use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
 use sp_runtime::{BuildStorage, Percent};
-use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_runtime_primitives::{AccountId, Balance, SLOT_PROBABILITY, SSC};
 use subspace_test_runtime::{MaxDomainBlockSize, MaxDomainBlockWeight};
 
 type AccountPublic = <Signature as Verify>::Signer;
@@ -113,6 +116,19 @@ pub fn get_genesis_domain(
         raw_genesis.encode()
     };
 
+    let bundle_slot_probability = (1, 1);
+
+    let DomainBundleLimit {
+        max_bundle_size,
+        max_bundle_weight,
+    } = calculate_max_bundle_weight_and_size(
+        MaxDomainBlockSize::get(),
+        MaxDomainBlockWeight::get(),
+        SLOT_PROBABILITY,
+        bundle_slot_probability,
+    )
+    .expect("No arithmetic error");
+
     Ok(GenesisDomain {
         runtime_name: "evm".to_owned(),
         runtime_type: RuntimeType::Evm,
@@ -122,9 +138,9 @@ pub fn get_genesis_domain(
         // Domain config, mainly for placeholder the concrete value TBD
         owner_account_id: sudo_account,
         domain_name: "evm-domain".to_owned(),
-        max_block_size: MaxDomainBlockSize::get(),
-        max_block_weight: MaxDomainBlockWeight::get(),
-        bundle_slot_probability: (1, 1),
+        max_bundle_size,
+        max_bundle_weight,
+        bundle_slot_probability,
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Alice"),

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -125,7 +125,6 @@ pub fn get_genesis_domain(
         max_block_size: MaxDomainBlockSize::get(),
         max_block_weight: MaxDomainBlockWeight::get(),
         bundle_slot_probability: (1, 1),
-        target_bundles_per_block: 10,
         operator_allow_list: OperatorAllowList::Anyone,
 
         signing_key: get_from_seed::<OperatorPublicKey>("Alice"),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -672,7 +672,6 @@ parameter_types! {
     pub MaxDomainBlockSize: u32 = NORMAL_DISPATCH_RATIO * MAX_BLOCK_LENGTH;
     /// Use the consensus chain's `Normal` extrinsics block weight limit as the domain block weight limit
     pub MaxDomainBlockWeight: Weight = NORMAL_DISPATCH_RATIO * BLOCK_WEIGHT_FOR_2_SEC;
-    pub const MaxBundlesPerBlock: u32 = 10;
     pub const DomainInstantiationDeposit: Balance = 100 * SSC;
     pub const MaxDomainNameLength: u32 = 32;
     pub const BlockTreePruningDepth: u32 = 10;
@@ -748,7 +747,6 @@ impl pallet_domains::Config for Runtime {
     type MinOperatorStake = MinOperatorStake;
     type MaxDomainBlockSize = MaxDomainBlockSize;
     type MaxDomainBlockWeight = MaxDomainBlockWeight;
-    type MaxBundlesPerBlock = MaxBundlesPerBlock;
     type DomainInstantiationDeposit = DomainInstantiationDeposit;
     type MaxDomainNameLength = MaxDomainNameLength;
     type Share = Balance;


### PR DESCRIPTION
This PR implements https://github.com/subspace/protocol-specs/pull/22, includes changes of:
- Remove the unused `DomainConfig::target_bundles_per_block` field 
- Replace `DomainConfig::max_block_size/weight` with `DomainConfig::max_bundle_size/weight`
- Recorrect the max domain extrinsic weight in the domain runtime 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
