### PR TITLE
Include the std feature of pallet-history-seeding in subspace-test-runtime

### DIFF
--- a/test/subspace-test-runtime/Cargo.toml
+++ b/test/subspace-test-runtime/Cargo.toml
@@ -80,6 +80,7 @@ std = [
     "frame-system-rpc-runtime-api/std",
     "pallet-balances/std",
     "pallet-domains/std",
+    "pallet-history-seeding/std",
     "pallet-messenger/std",
     "pallet-mmr/std",
     "pallet-rewards/std",


### PR DESCRIPTION
Otherwise `cargo test -p domain-client-operator` will fail, not sure why CI doesn't fail due to this though.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
