### PR TITLE
Refactor `sectors_to_solution_range` to `pieces_to_solution_range` and `solution_range_to_sectors` to `solution_range_to_pieces`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ sha3 = { opt-level = 3 }
 smallvec = { opt-level = 3 }
 snow = { opt-level = 3 }
 subspace-archiving = { opt-level = 3 }
-subspace-chiapos = { opt-level = 3 }
 subspace-core-primitives = { opt-level = 3 }
 subspace-erasure-coding = { opt-level = 3 }
 subspace-farmer-components = { opt-level = 3 }

--- a/crates/subspace-core-primitives/src/lib.rs
+++ b/crates/subspace-core-primitives/src/lib.rs
@@ -212,52 +212,43 @@ pub type SolutionRange = u64;
 
 /// Computes the following:
 /// ```text
-/// MAX * slot_probability / (pieces_in_sector * chunks / s_buckets) / sectors
+/// MAX * slot_probability / chunks * s_buckets / sectors
 /// ```
-pub const fn sectors_to_solution_range(
-    sectors: u64,
-    slot_probability: (u64, u64),
-    pieces_in_sector: u16,
-) -> SolutionRange {
+pub const fn pieces_to_solution_range(pieces: u64, slot_probability: (u64, u64)) -> SolutionRange {
     let solution_range = SolutionRange::MAX
         // Account for slot probability
         / slot_probability.1 * slot_probability.0
-        // Now take sector size and probability of hitting occupied s-bucket in sector into account
-        / (pieces_in_sector as u64 * Record::NUM_CHUNKS as u64 / Record::NUM_S_BUCKETS as u64);
+        // Now take probability of hitting occupied s-bucket in a piece into account
+        / Record::NUM_CHUNKS as u64
+        * Record::NUM_S_BUCKETS as u64;
 
-    // Take number of sectors into account
-    solution_range / sectors
+    // Take number of pieces into account
+    solution_range / pieces
 }
 
 /// Computes the following:
 /// ```text
-/// MAX * slot_probability / (pieces_in_sector * chunks / s_buckets) / solution_range
+/// MAX * slot_probability / chunks * s_buckets / solution_range
 /// ```
-pub const fn solution_range_to_sectors(
+pub const fn solution_range_to_pieces(
     solution_range: SolutionRange,
     slot_probability: (u64, u64),
-    pieces_in_sector: u16,
 ) -> u64 {
-    let sectors = SolutionRange::MAX
+    let pieces = SolutionRange::MAX
         // Account for slot probability
         / slot_probability.1 * slot_probability.0
-        // Now take sector size and probability of hitting occupied s-bucket in sector into account
-        / (pieces_in_sector as u64 * Record::NUM_CHUNKS as u64 / Record::NUM_S_BUCKETS as u64);
+        // Now take probability of hitting occupied s-bucket in sector into account
+        / Record::NUM_CHUNKS as u64
+        * Record::NUM_S_BUCKETS as u64;
 
     // Take solution range into account
-    sectors / solution_range
+    pieces / solution_range
 }
 
 // Quick test to ensure functions above are the inverse of each other
-const_assert!(
-    solution_range_to_sectors(sectors_to_solution_range(1, (1, 6), 1000), (1, 6), 1000) == 1
-);
-const_assert!(
-    solution_range_to_sectors(sectors_to_solution_range(3, (1, 6), 1000), (1, 6), 1000) == 3
-);
-const_assert!(
-    solution_range_to_sectors(sectors_to_solution_range(5, (1, 6), 1000), (1, 6), 1000) == 5
-);
+const_assert!(solution_range_to_pieces(pieces_to_solution_range(1, (1, 6)), (1, 6)) == 1);
+const_assert!(solution_range_to_pieces(pieces_to_solution_range(3, (1, 6)), (1, 6)) == 3);
+const_assert!(solution_range_to_pieces(pieces_to_solution_range(5, (1, 6)), (1, 6)) == 5);
 
 /// BlockWeight type for fork choice rules.
 ///

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -100,8 +100,8 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::{
-    sectors_to_solution_range, solution_range_to_sectors, HistorySize, Piece, PublicKey,
-    Randomness, SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, SolutionRange, U256,
+    pieces_to_solution_range, solution_range_to_pieces, HistorySize, Piece, PublicKey, Randomness,
+    SegmentCommitment, SegmentHeader, SegmentIndex, SlotNumber, SolutionRange, U256,
 };
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash,
@@ -164,9 +164,9 @@ const ERA_DURATION_IN_BLOCKS: BlockNumber = 2016;
 /// Tx range is adjusted every DOMAIN_TX_RANGE_ADJUSTMENT_INTERVAL blocks.
 const TX_RANGE_ADJUSTMENT_INTERVAL_BLOCKS: u64 = 100;
 
-// We assume initial plot size starts with the a single sector.
+// We assume initial plot size starts with a single sector.
 const INITIAL_SOLUTION_RANGE: SolutionRange =
-    sectors_to_solution_range(1, SLOT_PROBABILITY, MAX_PIECES_IN_SECTOR);
+    pieces_to_solution_range(MAX_PIECES_IN_SECTOR as u64, SLOT_PROBABILITY);
 
 /// Number of votes expected per block.
 ///
@@ -366,8 +366,8 @@ impl pallet_balances::Config for Runtime {
 parameter_types! {
     pub CreditSupply: Balance = Balances::total_issuance();
     pub TotalSpacePledged: u128 = {
-        let sectors = solution_range_to_sectors(Subspace::solution_ranges().current, SLOT_PROBABILITY, MAX_PIECES_IN_SECTOR);
-        sectors as u128 * MAX_PIECES_IN_SECTOR as u128 * Piece::SIZE as u128
+        let pieces = solution_range_to_pieces(Subspace::solution_ranges().current, SLOT_PROBABILITY);
+        pieces as u128 * Piece::SIZE as u128
     };
     pub BlockchainHistorySize: u128 = u128::from(Subspace::archived_history_size());
     pub DynamicCostOfStorage: bool = RuntimeConfigs::enable_dynamic_cost_of_storage();


### PR DESCRIPTION
It bothered me for a while that those functions have sectors in them despite sectors being actually not a fixed sized thing. Replacing calculations to pieces instead fixes that and even simplifies code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
