### PR TITLE
Remove CFLAGS workaround for C dependencies

### DIFF
--- a/crates/subspace-runtime/build.rs
+++ b/crates/subspace-runtime/build.rs
@@ -17,8 +17,6 @@
 fn main() {
     #[cfg(feature = "std")]
     {
-        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
-        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/runtime/auto-id/build.rs
+++ b/domains/runtime/auto-id/build.rs
@@ -1,8 +1,6 @@
 fn main() {
     #[cfg(feature = "std")]
     {
-        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
-        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/runtime/evm/build.rs
+++ b/domains/runtime/evm/build.rs
@@ -1,8 +1,6 @@
 fn main() {
     #[cfg(feature = "std")]
     {
-        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
-        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()

--- a/domains/test/runtime/auto-id/build.rs
+++ b/domains/test/runtime/auto-id/build.rs
@@ -1,8 +1,6 @@
 fn main() {
     #[cfg(feature = "std")]
     {
-        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
-        std::env::set_var("CFLAGS", "-mcpu=mvp");
         std::env::set_var("WASM_BUILD_TYPE", "release");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()

--- a/domains/test/runtime/evm/build.rs
+++ b/domains/test/runtime/evm/build.rs
@@ -1,8 +1,6 @@
 fn main() {
     #[cfg(feature = "std")]
     {
-        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
-        std::env::set_var("CFLAGS", "-mcpu=mvp");
         std::env::set_var("WASM_BUILD_TYPE", "release");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()

--- a/test/subspace-test-runtime/build.rs
+++ b/test/subspace-test-runtime/build.rs
@@ -17,8 +17,6 @@
 fn main() {
     #[cfg(feature = "std")]
     {
-        // TODO: Workaround for https://github.com/paritytech/polkadot-sdk/issues/3192
-        std::env::set_var("CFLAGS", "-mcpu=mvp");
         substrate_wasm_builder::WasmBuilder::new()
             .with_current_project()
             .export_heap_base()


### PR DESCRIPTION
After https://github.com/autonomys/subspace/pull/3088 we no longer have C dependencies in the runtime, so we don't need the workaround anymore

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
