### PR TITLE
Publish docs with a single commit

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -51,7 +51,8 @@ jobs:
           RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
 
       - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
+        uses: JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29 # v4.6.8
         with:
           branch: gh-pages
+          single-commit: true
           folder: target/doc


### PR DESCRIPTION
Our `gh-pages` branch contains 1753 commits, which we will never actually need. This changes the strategy to have a single commit in `gh-pages` that is updated, decreasing repo size for clones. I also bumped action version while at it.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
