### PR TITLE
Optimize cluster memory allocations

### DIFF
--- a/crates/subspace-farmer/src/plotter.rs
+++ b/crates/subspace-farmer/src/plotter.rs
@@ -11,6 +11,7 @@ pub mod gpu;
 pub mod pool;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::channel::mpsc;
 use futures::Stream;
 use std::fmt;
@@ -39,7 +40,7 @@ pub enum SectorPlottingProgress {
         /// How much time it took to plot a sector
         time: Duration,
         /// Stream of all plotted sector bytes
-        sector: Pin<Box<dyn Stream<Item = Result<Vec<u8>, String>> + Send + Sync>>,
+        sector: Pin<Box<dyn Stream<Item = Result<Bytes, String>> + Send + Sync>>,
     },
     /// Plotting failed
     Error {

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -8,6 +8,7 @@ use crate::thread_pool_manager::PlottingThreadPoolManager;
 use crate::utils::AsyncJoinOnDrop;
 use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
+use bytes::Bytes;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::mpsc;
 use futures::stream::FuturesUnordered;
@@ -455,7 +456,7 @@ where
                         SectorPlottingProgress::Finished {
                             plotted_sector,
                             time: start.elapsed(),
-                            sector: Box::pin(stream::once(async move { Ok(sector) })),
+                            sector: Box::pin(stream::once(async move { Ok(Bytes::from(sector)) })),
                         },
                     )
                     .await;

--- a/crates/subspace-farmer/src/plotter/gpu.rs
+++ b/crates/subspace-farmer/src/plotter/gpu.rs
@@ -11,6 +11,7 @@ use crate::plotter::{Plotter, SectorPlottingProgress};
 use crate::utils::AsyncJoinOnDrop;
 use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
+use bytes::Bytes;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::mpsc;
 use futures::stream::FuturesUnordered;
@@ -441,7 +442,7 @@ where
                         SectorPlottingProgress::Finished {
                             plotted_sector,
                             time: start.elapsed(),
-                            sector: Box::pin(stream::once(async move { Ok(sector) })),
+                            sector: Box::pin(stream::once(async move { Ok(Bytes::from(sector)) })),
                         },
                     )
                     .await;


### PR DESCRIPTION
Both CPU and GPU plotters produce a ~1G sector as a vector. For cluster purposes we need to send it over the network in chunks.

Previously vector was chunked into slices and then slices were allocated into separate smaller vectors. This is unnecessary though and with https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.slice_ref we can reuse the same large allocation (that will not be dropped until the whole sector is sent over anyway) for sub-slices. It would have been nice if there was a `.chunks()` method that produces `Bytes` instances directly, but we have what we have.

Just something I noticed while re-reading code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
