### PR TITLE
Generate object mappings incrementally

### DIFF
--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -61,6 +61,12 @@ pub enum Segment {
     },
 }
 
+impl Default for Segment {
+    fn default() -> Self {
+        Segment::V0 { items: Vec::new() }
+    }
+}
+
 impl Encode for Segment {
     fn size_hint(&self) -> usize {
         RecordedHistorySegment::SIZE
@@ -278,7 +284,7 @@ impl Archiver {
 
     /// Create a new instance of the archiver with initial state in case of restart.
     ///
-    /// `block` corresponds to `last_archived_block` and will be processed accordingly to its state.
+    /// `block` corresponds to `last_archived_block` and will be processed according to its state.
     pub fn with_initial_state(
         kzg: Kzg,
         erasure_coding: ErasureCoding,
@@ -315,7 +321,7 @@ impl Archiver {
                 }
                 Ordering::Greater => {
                     // Take part of the encoded block that wasn't archived yet and push to the
-                    // buffer and block continuation
+                    // buffer as a block continuation
                     object_mapping
                         .objects_mut()
                         .retain_mut(|block_object: &mut BlockObject| {
@@ -346,7 +352,8 @@ impl Archiver {
         }
     }
 
-    /// Adds new block to internal buffer, potentially producing pieces and segment header headers.
+    /// Adds new block to internal buffer, potentially producing pieces, segment headers, and
+    /// object mappings.
     ///
     /// Incremental archiving can be enabled if amortized block addition cost is preferred over
     /// throughput.
@@ -365,10 +372,18 @@ impl Archiver {
         let mut archived_segments = Vec::new();
         let mut object_mapping = Vec::new();
 
-        while let Some(segment) = self.produce_segment(incremental) {
-            object_mapping.extend(self.produce_object_mappings(&segment));
+        // Add completed segments and their mappings for this block.
+        while let Some(mut segment) = self.produce_segment(incremental) {
+            // Produce any segment mappings that haven't already been produced.
+            object_mapping.extend(Self::produce_object_mappings(
+                self.segment_index,
+                segment.items_mut().iter_mut(),
+            ));
             archived_segments.push(self.produce_archived_segment(segment));
         }
+
+        // Produce any next segment buffer mappings that haven't already been produced.
+        object_mapping.extend(self.produce_next_segment_mappings());
 
         ArchiveBlockOutcome {
             archived_segments,
@@ -614,16 +629,29 @@ impl Archiver {
         Some(segment)
     }
 
-    /// Take segment as an input, apply necessary transformations and produce archived object mappings.
-    /// Must be called before `produce_archived_segment()`.
-    fn produce_object_mappings(&self, segment: &Segment) -> Vec<GlobalObject> {
-        let source_piece_indexes = &self.segment_index.segment_piece_indexes_source_first()
+    /// Produce object mappings for the buffered items for the next segment. Then remove the
+    /// mappings in those items.
+    ///
+    /// Must only be called after all complete segments for a block have been produced. Before
+    /// that, the buffer can contain a `BlockContinuation` which spans multiple segments.
+    fn produce_next_segment_mappings(&mut self) -> Vec<GlobalObject> {
+        Self::produce_object_mappings(self.segment_index, self.buffer.iter_mut())
+    }
+
+    /// Produce object mappings for `items` in `segment_index`. Then remove the mappings from those
+    /// items.
+    ///
+    /// This method can be called on a `Segment`’s items, or on the `Archiver`'s internal buffer.
+    fn produce_object_mappings<'a>(
+        segment_index: SegmentIndex,
+        items: impl Iterator<Item = &'a mut SegmentItem>,
+    ) -> Vec<GlobalObject> {
+        let source_piece_indexes = &segment_index.segment_piece_indexes_source_first()
             [..RecordedHistorySegment::NUM_RAW_RECORDS];
 
         let mut corrected_object_mapping = Vec::new();
-        // `+1` corresponds to enum variant encoding
-        let mut base_offset_in_segment = 1;
-        for segment_item in segment.items() {
+        let mut base_offset_in_segment = Segment::default().encoded_size();
+        for segment_item in items {
             match segment_item {
                 SegmentItem::Padding => {
                     unreachable!(
@@ -642,7 +670,7 @@ impl Archiver {
                     bytes,
                     object_mapping,
                 } => {
-                    for block_object in object_mapping.objects() {
+                    for block_object in object_mapping.objects_mut().drain(..) {
                         // `+1` corresponds to `SegmentItem::X {}` enum variant encoding
                         let offset_in_segment = base_offset_in_segment
                             + 1
@@ -659,7 +687,7 @@ impl Archiver {
                     }
                 }
                 SegmentItem::ParentSegmentHeader(_) => {
-                    // Ignore, no objects mappings here
+                    // Ignore, no object mappings here
                 }
             }
 

--- a/crates/subspace-archiving/src/reconstructor.rs
+++ b/crates/subspace-archiving/src/reconstructor.rs
@@ -168,7 +168,7 @@ impl Reconstructor {
         &mut self,
         segment_pieces: &[Option<Piece>],
     ) -> Result<ReconstructedContents, ReconstructorError> {
-        let Segment::V0 { items } = self.reconstruct_segment(segment_pieces)?;
+        let items = self.reconstruct_segment(segment_pieces)?.into_items();
 
         let mut reconstructed_contents = ReconstructedContents::default();
         let mut next_block_number = 0;

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -389,7 +389,7 @@ impl ObjectFetcher {
         );
 
         let mut data = {
-            let Segment::V0 { items } = self.read_segment(segment_index).await?;
+            let items = self.read_segment(segment_index).await?.into_items();
             // Go through the segment until we reach the offset.
             // Unconditional progress is enum variant + compact encoding of number of elements
             let mut progress = 1 + Compact::compact_len(&(items.len() as u64));
@@ -495,7 +495,7 @@ impl ObjectFetcher {
         // headers and optional padding.
         loop {
             segment_index += SegmentIndex::ONE;
-            let Segment::V0 { items } = self.read_segment(segment_index).await?;
+            let items = self.read_segment(segment_index).await?.into_items();
             for segment_item in items {
                 match segment_item {
                     SegmentItem::BlockContinuation { bytes, .. } => {


### PR DESCRIPTION
This PR generates object mapping when each block is added to the archiver, rather than only at the end of a full segment. When a part of a block added in `Archiver::with_initial_state()`, those mappings are generated when the next block is added.

This reduces load bursts on the mapping indexer, and reduces object submission to mapping latency.

Piece generation still requires a full segment.

#### Cleanups
* Simplify segment item access

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
