### PR TITLE
Update MMR sync.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,7 +2626,6 @@ dependencies = [
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-subspace",
  "sc-domains",
  "sc-network",
  "sc-network-common",

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -96,7 +96,7 @@ const ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_mins(2);
 /// Ideally, we'd decouple pruning from finalization, but it may require invasive changes in
 /// Substrate and is not worth it right now.
 /// https://github.com/paritytech/substrate/discussions/14359
-pub const FINALIZATION_DEPTH_IN_SEGMENTS: SegmentIndex = SegmentIndex::new(5);
+const FINALIZATION_DEPTH_IN_SEGMENTS: SegmentIndex = SegmentIndex::new(5);
 
 #[derive(Debug)]
 struct SegmentHeadersStoreInner<AS> {

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -893,7 +893,7 @@ where
     if let Some(offchain_storage) = backend.offchain_storage() {
         // Allow both outgoing and incoming requests.
         let (handler, protocol_config) =
-            MmrRequestHandler::new::<NetworkWorker<Block, <Block as BlockT>::Hash>, _>(
+            MmrRequestHandler::new::<NetworkWorker<Block, <Block as BlockT>::Hash>>(
                 &config.base.protocol_id(),
                 fork_id.as_deref(),
                 client.clone(),

--- a/crates/subspace-service/src/mmr.rs
+++ b/crates/subspace-service/src/mmr.rs
@@ -1,9 +1,15 @@
+use sp_core::H256;
 use sp_mmr_primitives::utils::NodesUtils;
 use sp_mmr_primitives::{NodeIndex, INDEXING_PREFIX};
+use subspace_runtime_primitives::opaque::Header;
 
 pub(crate) mod request_handler;
 pub(crate) mod sync;
 
 pub(crate) fn get_offchain_key(index: NodeIndex) -> Vec<u8> {
     NodesUtils::node_canon_offchain_key(INDEXING_PREFIX, index)
+}
+
+pub(crate) fn get_temp_key(index: NodeIndex, hash: H256) -> Vec<u8> {
+    NodesUtils::node_temp_offchain_key::<Header>(INDEXING_PREFIX, index, hash)
 }

--- a/crates/subspace-service/src/mmr/request_handler.rs
+++ b/crates/subspace-service/src/mmr/request_handler.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::mmr::get_offchain_key;
+use crate::mmr::sync::decode_mmr_data;
+use crate::mmr::{get_offchain_key, get_temp_key};
 use futures::channel::oneshot;
 use futures::stream::StreamExt;
 use parity_scale_codec::{Decode, Encode};
@@ -23,8 +24,10 @@ use sc_network::config::ProtocolId;
 use sc_network::request_responses::{IncomingRequest, OutgoingResponse};
 use sc_network::{NetworkBackend, PeerId};
 use schnellru::{ByLength, LruMap};
+use sp_blockchain::HeaderBackend;
 use sp_core::offchain::storage::OffchainDb;
 use sp_core::offchain::{DbExternalities, OffchainStorage, StorageKind};
+use sp_mmr_primitives::utils::NodesUtils;
 use sp_runtime::codec;
 use sp_runtime::traits::Block as BlockT;
 use std::collections::BTreeMap;
@@ -115,7 +118,10 @@ enum SeenRequestsValue {
 }
 
 /// Handler for incoming block requests from a remote peer.
-pub struct MmrRequestHandler<Block: BlockT, OS> {
+pub struct MmrRequestHandler<Block, OS, Client>
+where
+    Block: BlockT,
+{
     request_receiver: async_channel::Receiver<IncomingRequest>,
     /// Maps from request to number of times we have seen this request.
     ///
@@ -124,17 +130,20 @@ pub struct MmrRequestHandler<Block: BlockT, OS> {
 
     offchain_db: OffchainDb<OS>,
 
+    client: Arc<Client>,
+
     _phantom: PhantomData<Block>,
 }
 
-impl<Block, OS> MmrRequestHandler<Block, OS>
+impl<Block, OS, Client> MmrRequestHandler<Block, OS, Client>
 where
-    Block: BlockT,
-
+    Block: BlockT<Hash = sp_core::H256>,
+    Client:
+        HeaderBackend<Block> + BlockBackend<Block> + ProofProvider<Block> + Send + Sync + 'static,
     OS: OffchainStorage,
 {
     /// Create a new [`MmrRequestHandler`].
-    pub fn new<NB, Client>(
+    pub fn new<NB>(
         protocol_id: &ProtocolId,
         fork_id: Option<&str>,
         client: Arc<Client>,
@@ -143,7 +152,6 @@ where
     ) -> (Self, NB::RequestResponseProtocolConfig)
     where
         NB: NetworkBackend<Block, <Block as BlockT>::Hash>,
-        Client: BlockBackend<Block> + ProofProvider<Block> + Send + Sync + 'static,
     {
         // Reserve enough request slots for one request per peer when we are at the maximum
         // number of peers.
@@ -166,6 +174,7 @@ where
 
         (
             Self {
+                client,
                 request_receiver,
                 seen_requests,
                 offchain_db: OffchainDb::new(offchain_storage),
@@ -232,17 +241,35 @@ where
             Err(())
         } else {
             let mut mmr_data = BTreeMap::new();
-            for block_number in
-                request.starting_position..(request.starting_position + request.limit)
-            {
-                let canon_key = get_offchain_key(block_number.into());
+            for position in request.starting_position..(request.starting_position + request.limit) {
+                let canon_key = get_offchain_key(position.into());
                 let storage_value = self
                     .offchain_db
                     .local_storage_get(StorageKind::PERSISTENT, &canon_key);
 
+                let block_number = NodesUtils::leaf_index_that_added_node(position.into());
+                trace!(%position, %block_number, "Storage data present: {}", storage_value.is_some());
+
                 if let Some(storage_value) = storage_value {
-                    mmr_data.insert(block_number, storage_value);
+                    mmr_data.insert(position, storage_value);
                 } else {
+                    if let Ok(Some(hash)) = self.client.hash((block_number as u32).into()) {
+                        let temp_key = get_temp_key(position.into(), hash);
+                        let storage_value = self
+                            .offchain_db
+                            .local_storage_get(StorageKind::PERSISTENT, &temp_key);
+
+                        if let Some(storage_value) = storage_value {
+                            let data = decode_mmr_data(&storage_value);
+                            trace!(%position, %block_number,"MMR node: {data:?}");
+                            mmr_data.insert(position, storage_value);
+                            continue;
+                        } else {
+                            debug!(%position, %block_number, ?hash, "Didn't find value in storage.")
+                        }
+                    } else {
+                        debug!(%position, %block_number, "Didn't find hash.")
+                    }
                     break; // No more storage values
                 }
             }

--- a/domains/client/domain-operator/Cargo.toml
+++ b/domains/client/domain-operator/Cargo.toml
@@ -14,7 +14,6 @@ futures-timer = "3.0.3"
 parking_lot = "0.12.2"
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 sc-consensus = { git = "https://github.com/subspace/polkadot-sdk", rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
-sc-consensus-subspace = { version = "0.1.0", default-features = false, path = "../../../crates/sc-consensus-subspace" }
 sc-domains = { version = "0.1.0", path = "../../../crates/sc-domains" }
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", default-features = false, rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }
 sc-network-common = { git = "https://github.com/subspace/polkadot-sdk", default-features = false, rev = "5626154d0781ac9a6ffd5a6207ed237f425ae631" }

--- a/domains/client/domain-operator/src/snap_sync.rs
+++ b/domains/client/domain-operator/src/snap_sync.rs
@@ -5,7 +5,6 @@ use sc_client_api::{AuxStore, Backend, ProofProvider};
 use sc_consensus::{
     BlockImport, BlockImportParams, ForkChoiceStrategy, ImportedState, StateAction, StorageChanges,
 };
-use sc_consensus_subspace::archiver::FINALIZATION_DEPTH_IN_SEGMENTS;
 use sc_network::{NetworkRequest, PeerId};
 use sc_network_common::sync::message::{
     BlockAttributes, BlockData, BlockRequest, Direction, FromBlock,
@@ -346,27 +345,7 @@ where
         .backend
         .offchain_storage()
     {
-        // let target_block = sync_params
-        //     .consensus_chain_sync_params
-        //     .segment_headers_store
-        //     .last_segment_header()
-        //     .map(|header| header.last_archived_block().number);
-
-        let target_block = sync_params
-            .consensus_chain_sync_params
-            .segment_headers_store
-            .max_segment_index()
-            // Skip last `FINALIZATION_DEPTH_IN_SEGMENTS` archived segments
-            .and_then(|max_segment_index| {
-                max_segment_index.checked_sub(FINALIZATION_DEPTH_IN_SEGMENTS)
-            })
-            .and_then(|segment_index| {
-                sync_params
-                    .consensus_chain_sync_params
-                    .segment_headers_store
-                    .get_segment_header(segment_index)
-            })
-            .map(|segment_header| segment_header.last_archived_block().number);
+        let target_block = Some(consensus_block_number);
 
         mmr_sync(
             sync_params.consensus_chain_sync_params.fork_id,


### PR DESCRIPTION
This PR updates MMR-sync. It removes the existing limitation of using `FINALIZATION_DEPTH_IN_SEGMENTS` lag by calculating the proper temporary key by the block number and saving the MMR-node with a canon key in advance. This change allows us to snap sync to the confirmed domain block instead of to the block within `FINALIZATION_DEPTH_IN_SEGMENTS` blocks lag and sync several segments after that.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
