### PR TITLE
Refactor archiver public API to return ArchiveBlockOutcome

### DIFF
--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -289,6 +289,7 @@ pub fn create_archived_segment() -> &'static NewArchivedSegment {
         rand::thread_rng().fill(block.as_mut_slice());
         archiver
             .add_block(block, Default::default(), true)
+            .archived_segments
             .into_iter()
             .next()
             .unwrap()

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -36,7 +36,7 @@ pub mod slot_worker;
 mod tests;
 pub mod verifier;
 
-use crate::archiver::ArchivedSegmentNotification;
+use crate::archiver::{ArchivedSegmentNotification, ObjectMappingNotification};
 use crate::block_import::BlockImportingNotification;
 use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream};
 use crate::slot_worker::{NewSlotNotification, RewardSigningNotification};
@@ -52,6 +52,8 @@ pub struct SubspaceLink<Block: BlockT> {
     new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     reward_signing_notification_sender: SubspaceNotificationSender<RewardSigningNotification>,
     reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
+    object_mapping_notification_sender: SubspaceNotificationSender<ObjectMappingNotification>,
+    object_mapping_notification_stream: SubspaceNotificationStream<ObjectMappingNotification>,
     archived_segment_notification_sender: SubspaceNotificationSender<ArchivedSegmentNotification>,
     archived_segment_notification_stream: SubspaceNotificationStream<ArchivedSegmentNotification>,
     block_importing_notification_sender:
@@ -70,6 +72,8 @@ impl<Block: BlockT> SubspaceLink<Block> {
             notification::channel("subspace_new_slot_notification_stream");
         let (reward_signing_notification_sender, reward_signing_notification_stream) =
             notification::channel("subspace_reward_signing_notification_stream");
+        let (object_mapping_notification_sender, object_mapping_notification_stream) =
+            notification::channel("subspace_object_mapping_notification_stream");
         let (archived_segment_notification_sender, archived_segment_notification_stream) =
             notification::channel("subspace_archived_segment_notification_stream");
         let (block_importing_notification_sender, block_importing_notification_stream) =
@@ -80,6 +84,8 @@ impl<Block: BlockT> SubspaceLink<Block> {
             new_slot_notification_stream,
             reward_signing_notification_sender,
             reward_signing_notification_stream,
+            object_mapping_notification_sender,
+            object_mapping_notification_stream,
             archived_segment_notification_sender,
             archived_segment_notification_stream,
             block_importing_notification_sender,
@@ -101,6 +107,13 @@ impl<Block: BlockT> SubspaceLink<Block> {
         &self,
     ) -> SubspaceNotificationStream<RewardSigningNotification> {
         self.reward_signing_notification_stream.clone()
+    }
+
+    /// Get stream with notifications about object mappings
+    pub fn object_mapping_notification_stream(
+        &self,
+    ) -> SubspaceNotificationStream<ObjectMappingNotification> {
+        self.object_mapping_notification_stream.clone()
     }
 
     /// Get stream with notifications about archived segment creation

--- a/crates/sc-consensus-subspace/src/tests.rs
+++ b/crates/sc-consensus-subspace/src/tests.rs
@@ -453,7 +453,8 @@
 //
 //     let genesis_block = client.block(client.info().genesis_hash).unwrap().unwrap();
 //     archiver
-//         .add_block(genesis_block.encode(), BlockObjectMapping::default())
+//         .add_block(genesis_block.encode(), BlockObjectMapping::default(), true)
+//         .archived_segments
 //         .into_iter()
 //         .map(|archived_segment| archived_segment.pieces)
 //         .collect()

--- a/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -33,7 +33,9 @@ fn segment_reconstruction_works() {
 
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
+    let archived_segments = archiver
+        .add_block(block, BlockObjectMapping::default(), true)
+        .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
 
@@ -79,7 +81,9 @@ fn piece_reconstruction_works() {
     // Block that fits into the segment fully
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
+    let archived_segments = archiver
+        .add_block(block, BlockObjectMapping::default(), true)
+        .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
 
@@ -143,7 +147,9 @@ fn segment_reconstruction_fails() {
     // Block that fits into the segment fully
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
+    let archived_segments = archiver
+        .add_block(block, BlockObjectMapping::default(), true)
+        .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
 
@@ -184,7 +190,9 @@ fn piece_reconstruction_fails() {
     // Block that fits into the segment fully
     let block = get_random_block();
 
-    let archived_segments = archiver.add_block(block, BlockObjectMapping::default(), true);
+    let archived_segments = archiver
+        .add_block(block, BlockObjectMapping::default(), true)
+        .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
 

--- a/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -58,11 +58,28 @@ fn basic() {
     };
     let archived_segments = archiver
         .add_block(block_0.clone(), BlockObjectMapping::default(), true)
+        .archived_segments
         .into_iter()
-        .chain(archiver.add_block(block_1.clone(), BlockObjectMapping::default(), true))
-        .chain(archiver.add_block(block_2.clone(), BlockObjectMapping::default(), true))
-        .chain(archiver.add_block(block_3.clone(), BlockObjectMapping::default(), true))
-        .chain(archiver.add_block(block_4, BlockObjectMapping::default(), true))
+        .chain(
+            archiver
+                .add_block(block_1.clone(), BlockObjectMapping::default(), true)
+                .archived_segments,
+        )
+        .chain(
+            archiver
+                .add_block(block_2.clone(), BlockObjectMapping::default(), true)
+                .archived_segments,
+        )
+        .chain(
+            archiver
+                .add_block(block_3.clone(), BlockObjectMapping::default(), true)
+                .archived_segments,
+        )
+        .chain(
+            archiver
+                .add_block(block_4, BlockObjectMapping::default(), true)
+                .archived_segments,
+        )
         .collect::<Vec<_>>();
 
     assert_eq!(archived_segments.len(), 5);
@@ -271,8 +288,13 @@ fn partial_data() {
     };
     let archived_segments = archiver
         .add_block(block_0.clone(), BlockObjectMapping::default(), true)
+        .archived_segments
         .into_iter()
-        .chain(archiver.add_block(block_1, BlockObjectMapping::default(), true))
+        .chain(
+            archiver
+                .add_block(block_1, BlockObjectMapping::default(), true)
+                .archived_segments,
+        )
         .collect::<Vec<_>>();
 
     assert_eq!(archived_segments.len(), 1);
@@ -347,7 +369,9 @@ fn invalid_usage() {
         block
     };
 
-    let archived_segments = archiver.add_block(block_0, BlockObjectMapping::default(), true);
+    let archived_segments = archiver
+        .add_block(block_0, BlockObjectMapping::default(), true)
+        .archived_segments;
 
     assert_eq!(archived_segments.len(), 4);
 

--- a/crates/subspace-farmer-components/benches/auditing.rs
+++ b/crates/subspace-farmer-components/benches/auditing.rs
@@ -64,6 +64,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             Default::default(),
             true,
         )
+        .archived_segments
         .into_iter()
         .next()
         .unwrap()

--- a/crates/subspace-farmer-components/benches/plotting.rs
+++ b/crates/subspace-farmer-components/benches/plotting.rs
@@ -52,6 +52,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             Default::default(),
             true,
         )
+        .archived_segments
         .into_iter()
         .next()
         .unwrap()

--- a/crates/subspace-farmer-components/benches/proving.rs
+++ b/crates/subspace-farmer-components/benches/proving.rs
@@ -72,6 +72,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             Default::default(),
             true,
         )
+        .archived_segments
         .into_iter()
         .next()
         .unwrap()

--- a/crates/subspace-farmer-components/benches/reading.rs
+++ b/crates/subspace-farmer-components/benches/reading.rs
@@ -63,6 +63,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             Default::default(),
             true,
         )
+        .archived_segments
         .into_iter()
         .next()
         .unwrap()

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -66,7 +66,8 @@ use sc_consensus::{
 };
 use sc_consensus_slots::SlotProportion;
 use sc_consensus_subspace::archiver::{
-    create_subspace_archiver, ArchivedSegmentNotification, SegmentHeadersStore,
+    create_subspace_archiver, ArchivedSegmentNotification, ObjectMappingNotification,
+    SegmentHeadersStore,
 };
 use sc_consensus_subspace::block_import::{BlockImportingNotification, SubspaceBlockImport};
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
@@ -713,6 +714,8 @@ where
     /// Stream of notifications about blocks about to be imported.
     pub block_importing_notification_stream:
         SubspaceNotificationStream<BlockImportingNotification<Block>>,
+    /// Archived object mapping stream.
+    pub object_mapping_notification_stream: SubspaceNotificationStream<ObjectMappingNotification>,
     /// Archived segment stream.
     pub archived_segment_notification_stream:
         SubspaceNotificationStream<ArchivedSegmentNotification>,
@@ -1179,6 +1182,7 @@ where
     let new_slot_notification_stream = subspace_link.new_slot_notification_stream();
     let reward_signing_notification_stream = subspace_link.reward_signing_notification_stream();
     let block_importing_notification_stream = subspace_link.block_importing_notification_stream();
+    let object_mapping_notification_stream = subspace_link.object_mapping_notification_stream();
     let archived_segment_notification_stream = subspace_link.archived_segment_notification_stream();
 
     let (pot_source_worker, pot_gossip_worker, pot_slot_info_stream) = PotSourceWorker::new(
@@ -1290,6 +1294,7 @@ where
             let client = client.clone();
             let new_slot_notification_stream = new_slot_notification_stream.clone();
             let reward_signing_notification_stream = reward_signing_notification_stream.clone();
+            let object_mapping_notification_stream = object_mapping_notification_stream.clone();
             let archived_segment_notification_stream = archived_segment_notification_stream.clone();
             let transaction_pool = transaction_pool.clone();
             let backend = backend.clone();
@@ -1301,6 +1306,7 @@ where
                     subscription_executor,
                     new_slot_notification_stream: new_slot_notification_stream.clone(),
                     reward_signing_notification_stream: reward_signing_notification_stream.clone(),
+                    object_mapping_notification_stream: object_mapping_notification_stream.clone(),
                     archived_segment_notification_stream: archived_segment_notification_stream
                         .clone(),
                     dsn_bootstrap_nodes: dsn_bootstrap_nodes.clone(),
@@ -1337,6 +1343,7 @@ where
         new_slot_notification_stream,
         reward_signing_notification_stream,
         block_importing_notification_stream,
+        object_mapping_notification_stream,
         archived_segment_notification_stream,
         network_starter,
         transaction_pool,

--- a/crates/subspace-service/src/rpc.rs
+++ b/crates/subspace-service/src/rpc.rs
@@ -26,7 +26,9 @@ use jsonrpsee::RpcModule;
 use mmr_rpc::{Mmr, MmrApiServer};
 use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 use sc_client_api::{AuxStore, BlockBackend};
-use sc_consensus_subspace::archiver::{ArchivedSegmentNotification, SegmentHeadersStore};
+use sc_consensus_subspace::archiver::{
+    ArchivedSegmentNotification, ObjectMappingNotification, SegmentHeadersStore,
+};
 use sc_consensus_subspace::notification::SubspaceNotificationStream;
 use sc_consensus_subspace::slot_worker::{
     NewSlotNotification, RewardSigningNotification, SubspaceSyncOracle,
@@ -65,6 +67,8 @@ where
     /// A stream with notifications about headers that need to be signed with ability to send
     /// signature back.
     pub reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
+    /// A stream with notifications about mappings.
+    pub object_mapping_notification_stream: SubspaceNotificationStream<ObjectMappingNotification>,
     /// A stream with notifications about archived segment creation.
     pub archived_segment_notification_stream:
         SubspaceNotificationStream<ArchivedSegmentNotification>,
@@ -113,6 +117,7 @@ where
         subscription_executor,
         new_slot_notification_stream,
         reward_signing_notification_stream,
+        object_mapping_notification_stream,
         archived_segment_notification_stream,
         dsn_bootstrap_nodes,
         segment_headers_store,
@@ -131,6 +136,7 @@ where
             subscription_executor,
             new_slot_notification_stream,
             reward_signing_notification_stream,
+            object_mapping_notification_stream,
             archived_segment_notification_stream,
             dsn_bootstrap_nodes,
             segment_headers_store,

--- a/test/subspace-test-client/src/lib.rs
+++ b/test/subspace-test-client/src/lib.rs
@@ -217,6 +217,7 @@ where
             BlockObjectMapping::default(),
             true,
         )
+        .archived_segments
         .into_iter()
         .next()
         .expect("First block is always producing one segment; qed");


### PR DESCRIPTION
This PR prepares for PR #3100 by moving piece mappings from `NewArchivedSegment` into a new `ArchiveBlockOutcome` return type. It also updates the RPCs with a notification channel for these separate mappings.

As part of this change, the archiver creates `GlobalObject`s directly, which significantly simplifies the code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
