### PR TITLE
Add riscv64 support

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -64,6 +64,8 @@ jobs:
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: Dockerfile-${{ matrix.image }}
+          # TODO: Add `linux/riscv64` once https://github.com/paritytech/polkadot-sdk/issues/5996 is resolved and ring
+          #  0.16.x is no longer in dependencies
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -36,6 +36,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-riscv64-linux-gnu \
+          gcc-riscv64-linux-gnu \
+          libc6-dev-riscv64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -54,10 +62,13 @@ RUN \
     if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=aarch64-linux-gnu-gcc" \
     ; fi && \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
+    ; fi && \
     if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
-    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g") && \
+    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -36,6 +36,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-riscv64-linux-gnu \
+          gcc-riscv64-linux-gnu \
+          libc6-dev-riscv64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -96,11 +104,14 @@ RUN \
     if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=aarch64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
+    ; fi && \
+    if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = "" ]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
     export PATH=/usr/local/cuda/bin${PATH:+:${PATH}} && \
-    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g") && \
+    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     if [ $BUILDARCH = "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
       NVCC=off /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
           --locked \
@@ -111,13 +122,22 @@ RUN \
           --target $RUSTC_TARGET_ARCH-unknown-linux-gnu && \
       mv target/*/*/subspace-farmer subspace-farmer-rocm \
     ; fi && \
-    /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
-        --locked \
-        -Z build-std \
-        --profile $PROFILE \
-        --bin subspace-farmer \
-        --features cuda \
-        --target $RUSTC_TARGET_ARCH-unknown-linux-gnu && \
+    if [ $(which nvcc) ]; then \
+      /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
+          --locked \
+          -Z build-std \
+          --profile $PROFILE \
+          --bin subspace-farmer \
+          --features cuda \
+          --target $RUSTC_TARGET_ARCH-unknown-linux-gnu \
+    ; else \
+      /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
+          --locked \
+          -Z build-std \
+          --profile $PROFILE \
+          --bin subspace-farmer \
+          --target $RUSTC_TARGET_ARCH-unknown-linux-gnu \
+    ; fi && \
     mv target/*/*/subspace-farmer subspace-farmer && \
     rm -rf target
 

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -143,6 +143,9 @@ RUN \
 
 FROM ubuntu:22.04
 
+ARG BUILDARCH
+ARG TARGETARCH
+
 # Next block is for ROCm support
 # ROCm is only used on x86-64 since they don't have other packages
 ARG ROCM_VERSION=6.2.2

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -36,6 +36,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-riscv64-linux-gnu \
+          gcc-riscv64-linux-gnu \
+          libc6-dev-riscv64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -56,10 +64,13 @@ RUN \
     if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=aarch64-linux-gnu-gcc" \
     ; fi && \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
+    ; fi && \
     if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
-    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g") && \
+    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -36,6 +36,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-riscv64-linux-gnu \
+          gcc-riscv64-linux-gnu \
+          libc6-dev-riscv64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -54,10 +62,13 @@ RUN \
     if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=aarch64-linux-gnu-gcc" \
     ; fi && \
+    if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
+    ; fi && \
     if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
-    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g") && \
+    RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
         --locked \
         -Z build-std \


### PR DESCRIPTION
Tried for fun, took just a few minutes, but then node failed to compile in CI due to https://github.com/briansmith/ring/issues/2148, which resulted in:
* https://github.com/libp2p/rust-libp2p/issues/5629 that caused `quic` feature being enabled that in turn pulled old version of `ring` among other things
* https://github.com/paritytech/polkadot-sdk/issues/5996 because if Substrate used current version of libp2p then modern version of `ring` would be pulled in, such that compiles on `riscv64gc` without issues

If at least one of those two were not the case it'd work fine, but as is node fails to compile unfortunately. So it took a bit more than a few minutes overall, but still time well spend IMO as both of reported issues should be fixed regardless.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
