### PR TITLE
Improve GPU support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -154,15 +154,12 @@ jobs:
         if: runner.os == 'Linux' || runner.os == 'Windows'
 
       - name: cargo clippy (ROCm)
-        env:
-          NVCC: off
         run: |
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features rocm -- -D warnings
         if: runner.os == 'Linux'
 
       - name: cargo clippy (ROCm)
         env:
-          NVCC: off
           # Why `PROGRA~1` instead of `Program Files`? Because Windows!
           HIPCC: C:\PROGRA~1\AMD\ROCm\6.1\bin\hipcc.bin.exe
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,14 +104,13 @@ jobs:
           sub-packages: '["nvcc", "cudart"]'
         if: runner.os == 'Linux' || runner.os == 'Windows'
 
-      # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-      # - name: Configure ROCm cache (Windows)
-      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      #   id: rocm-cache
-      #   with:
-      #     path: C:\Program Files\AMD\ROCm
-      #     key: ${{ runner.os }}-rocm
-      #   if: runner.os == 'Windows'
+      - name: Configure ROCm cache (Windows)
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        id: rocm-cache
+        with:
+          path: C:\Program Files\AMD\ROCm
+          key: ${{ runner.os }}-rocm
+        if: runner.os == 'Windows'
 
       - name: ROCm toolchain
         run: |
@@ -126,19 +125,13 @@ jobs:
           sudo ldconfig
         if: runner.os == 'Linux'
 
-      # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-      # - name: ROCm toolchain
-      #   run: |
-      #     $ErrorActionPreference = "Stop"
-      #     Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q3-WinSvr2022-For-HIP.exe -OutFile "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
-      #     Start-Process "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe" -ArgumentList '-install' -NoNewWindow -Wait
-      #     Remove-Item "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
-      #   if: runner.os == 'Windows' && steps.rocm-cache.outputs.cache-hit != 'true'
-      #
-      # - name: ROCm toolchain environment (Windows)
-      #   run: |
-      #     Add-Content $env:GITHUB_PATH "C:\Program Files\AMD\ROCm\6.1\bin"
-      #   if: runner.os == 'Windows'
+      - name: ROCm toolchain
+        run: |
+          $ErrorActionPreference = "Stop"
+          Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q3-WinSvr2022-For-HIP.exe -OutFile "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
+          Start-Process "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe" -ArgumentList '-install' -NoNewWindow -Wait
+          Remove-Item "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
+        if: runner.os == 'Windows' && steps.rocm-cache.outputs.cache-hit != 'true'
 
       - name: Configure cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -167,14 +160,14 @@ jobs:
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features rocm -- -D warnings
         if: runner.os == 'Linux'
 
-      # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-      # - name: cargo clippy (ROCm)
-      #   env:
-      #     NVCC: off
-      #     HIPCC: hipcc.bin.exe
-      #   run: |
-      #     cargo -Zgitoxide -Zgit clippy --locked --all-targets --features rocm -- -D warnings
-      #   if: runner.os == 'Windows'
+      - name: cargo clippy (ROCm)
+        env:
+          NVCC: off
+          # Why `PROGRA~1` instead of `Program Files`? Because Windows!
+          HIPCC: C:\PROGRA~1\AMD\ROCm\6.1\bin\hipcc.bin.exe
+        run: |
+          cargo -Zgitoxide -Zgit clippy --locked --all-targets --features rocm -- -D warnings
+        if: runner.os == 'Windows'
 
   cargo-docs:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-20.04-x86-64"]' || '"ubuntu-22.04"') }}

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -170,14 +170,13 @@ jobs:
           sub-packages: '["nvcc", "cudart"]'
         if: runner.os == 'Linux' || runner.os == 'Windows'
 
-      # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-      # - name: Configure ROCm cache (Windows)
-      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      #   id: rocm-cache
-      #   with:
-      #     path: C:\Program Files\AMD\ROCm
-      #     key: ${{ runner.os }}-rocm
-      #   if: runner.os == 'Windows'
+      - name: Configure ROCm cache (Windows)
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        id: rocm-cache
+        with:
+          path: C:\Program Files\AMD\ROCm
+          key: ${{ runner.os }}-rocm
+        if: runner.os == 'Windows'
 
       - name: ROCm toolchain
         run: |
@@ -193,19 +192,13 @@ jobs:
         # TODO: ROCm packages are only available for x86-64 for now
         if: runner.os == 'Linux' && startsWith(matrix.build.target, 'x86_64')
 
-      # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-      # - name: ROCm toolchain
-      #   run: |
-      #     $ErrorActionPreference = "Stop"
-      #     Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q3-WinSvr2022-For-HIP.exe -OutFile "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
-      #     Start-Process "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe" -ArgumentList '-install' -NoNewWindow -Wait
-      #     Remove-Item "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
-      #   if: runner.os == 'Windows' && steps.rocm-cache.outputs.cache-hit != 'true'
-      #
-      # - name: ROCm toolchain environment (Windows)
-      #   run: |
-      #     Add-Content $env:GITHUB_PATH "C:\Program Files\AMD\ROCm\6.1\bin"
-      #   if: runner.os == 'Windows'
+      - name: ROCm toolchain
+        run: |
+          $ErrorActionPreference = "Stop"
+          Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q3-WinSvr2022-For-HIP.exe -OutFile "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
+          Start-Process "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe" -ArgumentList '-install' -NoNewWindow -Wait
+          Remove-Item "${env:RUNNER_TEMP}\HIP-SDK-Installer.exe"
+        if: runner.os == 'Windows' && steps.rocm-cache.outputs.cache-hit != 'true'
 
       - name: Configure cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -222,17 +215,16 @@ jobs:
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer
         if: runner.os == 'macOS' || !startsWith(matrix.build.target, 'x86_64')
 
-      # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-      # # ROCm can't be enabled together with CUDA for now
-      # - name: Build farmer (ROCm, Windows)
-      #   env:
-      #     NVCC: off
-      #     HIPCC: hipcc.bin.exe
-      #   run: |
-      #     cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features rocm
-      #     move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe
-      #   # TODO: ROCm packages are only available for x86-64 for now
-      #   if: runner.os == 'Windows' && startsWith(matrix.build.target, 'x86_64')
+      # ROCm can't be enabled together with CUDA for now
+      - name: Build farmer (ROCm, Windows)
+        env:
+          NVCC: off
+          # Why `PROGRA~1` instead of `Program Files`? Because Windows!
+          HIPCC: C:\PROGRA~1\AMD\ROCm\6.1\bin\hipcc.bin.exe
+        run: |
+          cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features rocm
+          move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe
+        if: runner.os == 'Windows' && startsWith(matrix.build.target, 'x86_64')
 
       # ROCm can't be enabled together with CUDA for now
       - name: Build farmer (ROCm, Ubuntu)
@@ -241,7 +233,6 @@ jobs:
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features rocm
           mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm
-        # TODO: ROCm packages are only available for x86-64 for now
         if: runner.os == 'Linux' && startsWith(matrix.build.target, 'x86_64')
 
       - name: Build farmer
@@ -291,8 +282,7 @@ jobs:
       - name: Sign Application (Windows)
         run: |
           AzureSignTool sign --azure-key-vault-url "${{ secrets.AZURE_KEY_VAULT_URI }}" --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" --azure-key-vault-certificate "${{ secrets.AZURE_CERT_NAME }}" --file-digest sha512 --timestamp-rfc3161 http://timestamp.digicert.com -v "${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe"
-          # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-          # AzureSignTool sign --azure-key-vault-url "${{ secrets.AZURE_KEY_VAULT_URI }}" --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" --azure-key-vault-certificate "${{ secrets.AZURE_CERT_NAME }}" --file-digest sha512 --timestamp-rfc3161 http://timestamp.digicert.com -v "${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe"
+          AzureSignTool sign --azure-key-vault-url "${{ secrets.AZURE_KEY_VAULT_URI }}" --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" --azure-key-vault-certificate "${{ secrets.AZURE_CERT_NAME }}" --file-digest sha512 --timestamp-rfc3161 http://timestamp.digicert.com -v "${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe"
           AzureSignTool sign --azure-key-vault-url "${{ secrets.AZURE_KEY_VAULT_URI }}" --azure-key-vault-client-id "${{ secrets.AZURE_CLIENT_ID }}" --azure-key-vault-client-secret "${{ secrets.AZURE_CLIENT_SECRET }}" --azure-key-vault-tenant-id "${{ secrets.AZURE_TENANT_ID }}" --azure-key-vault-certificate "${{ secrets.AZURE_CERT_NAME }}" --file-digest sha512 --timestamp-rfc3161 http://timestamp.digicert.com -v "${{ env.PRODUCTION_TARGET }}/subspace-node.exe"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
         continue-on-error: ${{ github.repository_owner != 'autonomys' || github.event_name != 'push' || github.ref_type != 'tag' }}
@@ -308,7 +298,6 @@ jobs:
       - name: Prepare executables for uploading (Ubuntu, ROCm)
         run: |
           mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm executables/subspace-farmer-rocm-${{ matrix.build.suffix }}
-        # TODO: ROCm packages are only available for x86-64 for now
         if: runner.os == 'Linux' && startsWith(matrix.build.target, 'x86_64')
 
       - name: Prepare executables for uploading (macOS)
@@ -327,8 +316,7 @@ jobs:
         run: |
           mkdir executables
           move ${{ env.PRODUCTION_TARGET }}/subspace-farmer.exe executables/subspace-farmer-${{ matrix.build.suffix }}.exe
-          # TODO: ROCm compilation doesn't work in CI right now, good luck fixing it
-          # move ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe executables/subspace-farmer-rocm-${{ matrix.build.suffix }}.exe
+          move ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm.exe executables/subspace-farmer-rocm-${{ matrix.build.suffix }}.exe
           move ${{ env.PRODUCTION_TARGET }}/subspace-node.exe executables/subspace-node-${{ matrix.build.suffix }}.exe
         if: runner.os == 'Windows'
 

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -218,7 +218,6 @@ jobs:
       # ROCm can't be enabled together with CUDA for now
       - name: Build farmer (ROCm, Windows)
         env:
-          NVCC: off
           # Why `PROGRA~1` instead of `Program Files`? Because Windows!
           HIPCC: C:\PROGRA~1\AMD\ROCm\6.1\bin\hipcc.bin.exe
         run: |
@@ -228,8 +227,6 @@ jobs:
 
       # ROCm can't be enabled together with CUDA for now
       - name: Build farmer (ROCm, Ubuntu)
-        env:
-          NVCC: off
         run: |
           cargo -Zgitoxide -Zgit build --locked -Z build-std --target ${{ matrix.build.target }} --profile production --bin subspace-farmer --features rocm
           mv ${{ env.PRODUCTION_TARGET }}/subspace-farmer ${{ env.PRODUCTION_TARGET }}/subspace-farmer-rocm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12260,7 +12260,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.8"
-source = "git+https://github.com/autonomys/sppark?rev=71c49160d7aa24f92c20592d2d26ef16f5400a04#71c49160d7aa24f92c20592d2d26ef16f5400a04"
+source = "git+https://github.com/autonomys/sppark?rev=b2a181eb99c8200f1a604f04122551ea39fbf63f#b2a181eb99c8200f1a604f04122551ea39fbf63f"
 dependencies = [
  "cc",
  "which",

--- a/Dockerfile-bootstrap-node
+++ b/Dockerfile-bootstrap-node
@@ -65,7 +65,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -107,7 +107,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = "" ]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = "" ]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
     export PATH=/usr/local/cuda/bin${PATH:+:${PATH}} && \

--- a/Dockerfile-farmer
+++ b/Dockerfile-farmer
@@ -98,7 +98,6 @@ RUN \
       ldconfig \
     ; fi
 
-# TODO: Remove `NVCC=off` hack once `sppark` has proper features for CUDA and ROCm
 # ROCm is only used on x86-64 since they don't have other packages
 RUN \
     if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
@@ -113,7 +112,7 @@ RUN \
     export PATH=/usr/local/cuda/bin${PATH:+:${PATH}} && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     if [ $BUILDARCH = "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
-      NVCC=off /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
+      /root/.cargo/bin/cargo -Zgitoxide -Zgit build \
           --locked \
           -Z build-std \
           --profile $PROFILE \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -67,7 +67,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -65,7 +65,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ $RUSTFLAGS = ""]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
       export RUSTFLAGS="-C target-cpu=skylake" \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \

--- a/shared/subspace-proof-of-space-gpu/Cargo.toml
+++ b/shared/subspace-proof-of-space-gpu/Cargo.toml
@@ -15,8 +15,8 @@ include = [
 [dependencies]
 blst = { version = "0.3.13", optional = true }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false, optional = true }
-# TODO: Fork with ROCm support, switch to upstream once `rocm` branch from `https://github.com/dot-asm/sppark` is upstreamed
-sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "71c49160d7aa24f92c20592d2d26ef16f5400a04", optional = true }
+# TODO: Fork with ROCm support, switch to upstream once `rocm` branch from `https://github.com/dot-asm/sppark` + https://github.com/dot-asm/sppark/pull/2 are upstreamed
+sppark = { version = "0.1.8", git = "https://github.com/autonomys/sppark", rev = "b2a181eb99c8200f1a604f04122551ea39fbf63f", optional = true }
 subspace-core-primitives = { version = "0.1.0", path = "../../crates/subspace-core-primitives", default-features = false, optional = true }
 subspace-kzg = { version = "0.1.0", path = "../subspace-kzg", optional = true }
 
@@ -30,15 +30,14 @@ cc = "1.1.23"
 
 [features]
 # Only Volta+ architectures are supported (GeForce RTX 16xx consumer GPUs and newer)
-cuda = ["_gpu"]
+cuda = ["_gpu", "sppark/cuda"]
 # TODO: ROCm can't be enabled at the same time as `cuda` feature at the moment
 # Seems to support RDNA 2+, at least on Linux
-rocm = ["_gpu"]
+rocm = ["_gpu", "sppark/rocm"]
 # Internal feature, shouldn't be used directly
 _gpu = [
     "dep:blst",
     "dep:rust-kzg-blst",
-    "dep:sppark",
     "dep:subspace-core-primitives",
     "dep:subspace-kzg",
 ]

--- a/shared/subspace-proof-of-space-gpu/README.md
+++ b/shared/subspace-proof-of-space-gpu/README.md
@@ -24,8 +24,3 @@ For other operating systems/platforms check official documentation: <https://doc
 ### ROCm
 
 For AMD/ROCm support follow their official documentation: <https://rocm.docs.amd.com/en/latest/>
-
-For compilation `NVCC=off` environment variable must be additionally used:
-```bash
-NVCC=off cargo build
-```

--- a/shared/subspace-proof-of-space-gpu/build.rs
+++ b/shared/subspace-proof-of-space-gpu/build.rs
@@ -18,6 +18,8 @@ fn main() {
     }
 
     if cfg!(feature = "rocm") {
+        println!("cargo::rerun-if-env-changed=HIPCC");
+
         let mut hipcc = cc::Build::new();
         hipcc.compiler(env::var("HIPCC").unwrap_or("hipcc".to_string()));
         hipcc.cpp(true);
@@ -88,5 +90,4 @@ fn main() {
     }
 
     println!("cargo::rerun-if-changed=src");
-    println!("cargo::rerun-if-env-changed=CXXFLAGS");
 }


### PR DESCRIPTION
Two key fixes here: Windows and linking.

Windows support is fixed (ignore whitespaces, the diff is very small), the solution is described in https://x.com/nazarpc/status/1844098745857667412

Linking was problematic after ROCm introduction because sppark seemed to always link `amdhip64`, even if only CUDA support was built (and I don't really see why), but https://github.com/dot-asm/sppark/pull/2 fixed it alongside with DX improvements, so I pulled it into our fork at https://github.com/autonomys/sppark/tree/subspace-v1 and now it is good:
```
nobody@0ee4c112cfe9:/$ ldd /subspace-farmer*
/subspace-farmer:
	linux-vdso.so.1 (0x000078597b6dd000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000785979b19000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000785979800000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000078597b6b4000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000785979400000)
	/lib64/ld-linux-x86-64.so.2 (0x000078597b6df000)
/subspace-farmer-rocm:
	linux-vdso.so.1 (0x0000772350bf2000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000772350b02000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x000077234e400000)
	libamdhip64.so.6 => /opt/rocm/lib/libamdhip64.so.6 (0x000077234ca00000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000772350ae2000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000077234c600000)
	/lib64/ld-linux-x86-64.so.2 (0x0000772350bf4000)
	librocprofiler-register.so.0 => /opt/rocm/lib/librocprofiler-register.so.0 (0x000077234e77e000)
	libamd_comgr.so.2 => /opt/rocm/lib/libamd_comgr.so.2 (0x0000772343800000)
	libhsa-runtime64.so.1 => /opt/rocm/lib/libhsa-runtime64.so.1 (0x0000772343400000)
	libnuma.so.1 => /lib/x86_64-linux-gnu/libnuma.so.1 (0x0000772350ad3000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x000077234e762000)
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x000077234e730000)
	libelf.so.1 => /lib/x86_64-linux-gnu/libelf.so.1 (0x000077234e712000)
	libdrm.so.2 => /lib/x86_64-linux-gnu/libdrm.so.2 (0x000077234e6fc000)
	libdrm_amdgpu.so.1 => /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1 (0x0000772350ac5000)
```

I think the next simplification for CI would be to only build containers and then simply extract executables from then instead of building them on the host again.

Still thinking whether it would be a good idea to simply package into `zip` archive AMD libraries so user doesn't need to install their runtime through a custom repo manually, any opinion?

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
