### PR TITLE
Gemini to taurus testnet changes

### DIFF
--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -59,20 +59,20 @@ struct GenesisDomainParams {
     genesis_domains: Vec<GenesisDomain>,
 }
 
-pub fn gemini_3h_compiled() -> Result<GenericChainSpec, String> {
+pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
     Ok(GenericChainSpec::builder(
-        WASM_BINARY.ok_or_else(|| "Wasm binary must be built for Gemini".to_string())?,
+        WASM_BINARY.ok_or_else(|| "Wasm binary must be built for Taurus".to_string())?,
         None,
     )
-    .with_name("Subspace Gemini 3h")
+    .with_name("Autonomys Taurus Testnet")
     // ID
-    .with_id("subspace_gemini_3h")
-    .with_chain_type(ChainType::Custom("Subspace Gemini 3h".to_string()))
+    .with_id("autonomys_taurus")
+    .with_chain_type(ChainType::Custom("Autonomys Taurus Testnet".to_string()))
     .with_telemetry_endpoints(
         TelemetryEndpoints::new(vec![(SUBSPACE_TELEMETRY_URL.into(), 1)])
             .map_err(|error| error.to_string())?,
     )
-    .with_protocol_id("subspace-gemini-3h")
+    .with_protocol_id("autonomys-taurus")
     .with_properties({
         let mut properties = chain_spec_properties();
         properties.insert(
@@ -105,7 +105,6 @@ pub fn gemini_3h_compiled() -> Result<GenericChainSpec, String> {
                 enable_balance_transfers: true,
                 // TODO: Proper value here
                 confirmation_depth_k: 100,
-                // TODO: Proper value here
                 rewards_config: RewardsConfig {
                     remaining_issuance: 360_000_000 * SSC,
                     proposer_subsidy_points: BoundedVec::try_from(vec![
@@ -209,8 +208,8 @@ pub fn gemini_3h_compiled() -> Result<GenericChainSpec, String> {
                     sudo_account.clone(),
                 ]),
                 genesis_domains: vec![
-                    evm_chain_spec::get_genesis_domain(SpecId::Gemini, sudo_account.clone())?,
-                    auto_id_chain_spec::get_genesis_domain(SpecId::Gemini, sudo_account.clone())?,
+                    evm_chain_spec::get_genesis_domain(SpecId::Taurus, sudo_account.clone())?,
+                    auto_id_chain_spec::get_genesis_domain(SpecId::Taurus, sudo_account.clone())?,
                 ],
             },
             CouncilDemocracyConfigParams::<BlockNumber>::production_params(),
@@ -222,8 +221,8 @@ pub fn gemini_3h_compiled() -> Result<GenericChainSpec, String> {
     .build())
 }
 
-pub fn gemini_3h_config() -> Result<GenericChainSpec, String> {
-    Err("Gemini 3h is not supported".to_string())
+pub fn taurus_config() -> Result<GenericChainSpec, String> {
+    Err("Taurus is not supported".to_string())
 }
 
 pub fn devnet_config() -> Result<GenericChainSpec, String> {

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -83,7 +83,7 @@ pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
     })
     .with_genesis_config({
         let sudo_account =
-            AccountId::from_ss58check("5DNwQTHfARgKoa2NdiUM51ZUow7ve5xG9S2yYdSbVQcnYxBA")
+            AccountId::from_ss58check("5F1XZHUSixAq58W8fstCUNtP1WDGoRpCEuLzGRDmJo32sbGc")
                 .expect("Wrong root account address");
 
         let balances = vec![(sudo_account.clone(), 1_000 * SSC)];

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -102,7 +102,7 @@ pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
                 pot_slot_iterations: NonZeroU32::new(200_032_000).expect("Not zero; qed"),
                 enable_domains: false,
                 enable_dynamic_cost_of_storage: false,
-                enable_balance_transfers: true,
+                enable_balance_transfers: false,
                 // TODO: Proper value here
                 confirmation_depth_k: 100,
                 rewards_config: RewardsConfig {

--- a/crates/subspace-node/src/cli.rs
+++ b/crates/subspace-node/src/cli.rs
@@ -98,8 +98,8 @@ impl SubstrateCli for SubspaceCliPlaceholder {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
         let chain_spec = match id {
-            "gemini-3h-compiled" => chain_spec::gemini_3h_compiled()?,
-            "gemini-3h" => chain_spec::gemini_3h_config()?,
+            "taurus-compiled" => chain_spec::taurus_compiled()?,
+            "taurus" => chain_spec::taurus_config()?,
             "devnet" => chain_spec::devnet_config()?,
             "devnet-compiled" => chain_spec::devnet_config_compiled()?,
             "dev" => chain_spec::dev_config()?,

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -495,8 +495,8 @@ pub(super) fn create_consensus_chain_configuration(
     let sync = sync.unwrap_or(ChainSyncMode::Snap);
 
     let chain_spec = match chain.as_deref() {
-        Some("gemini-3h-compiled") => chain_spec::gemini_3h_compiled()?,
-        Some("gemini-3h") => chain_spec::gemini_3h_config()?,
+        Some("taurus-compiled") => chain_spec::taurus_compiled()?,
+        Some("taurus") => chain_spec::taurus_config()?,
         Some("devnet") => chain_spec::devnet_config()?,
         Some("devnet-compiled") => chain_spec::devnet_config_compiled()?,
         Some("dev") => chain_spec::dev_config()?,

--- a/crates/subspace-node/src/domain/auto_id_chain_spec.rs
+++ b/crates/subspace-node/src/domain/auto_id_chain_spec.rs
@@ -62,21 +62,21 @@ pub fn development_config(
     .build())
 }
 
-pub fn gemini_3h_config(
+pub fn taurus_config(
     runtime_genesis_config: RuntimeGenesisConfig,
 ) -> Result<GenericChainSpec, String> {
     Ok(GenericChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "WASM binary was not build, please build it!".to_string())?,
         None,
     )
-    .with_name("Subspace Gemini 3h AutoId Domain")
-    .with_id("subspace_gemini_3h_auto_id_domain")
+    .with_name("Autonomys Taurus AutoId Domain")
+    .with_id("autonomys_taurus_auto_id_domain")
     .with_chain_type(ChainType::Live)
     .with_genesis_config(
         serde_json::to_value(runtime_genesis_config)
             .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
     )
-    .with_protocol_id("subspace-gemini-3h-auto-id-domain")
+    .with_protocol_id("autonomys-taurus-auto-id-domain")
     .with_properties(chain_spec_properties())
     .build())
 }
@@ -102,7 +102,7 @@ pub fn devnet_config(
 
 pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
     let chain_spec = match spec_id {
-        "gemini-3h" => gemini_3h_config(get_testnet_genesis_by_spec_id(SpecId::Gemini))?,
+        "taurus" => taurus_config(get_testnet_genesis_by_spec_id(SpecId::Taurus))?,
         "devnet" => devnet_config(get_testnet_genesis_by_spec_id(SpecId::DevNet))?,
         "dev" => development_config(get_testnet_genesis_by_spec_id(SpecId::Dev))?,
         path => GenericChainSpec::from_json_file(std::path::PathBuf::from(path))?,
@@ -113,7 +113,7 @@ pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, Stri
 pub fn get_testnet_genesis_by_spec_id(spec_id: SpecId) -> RuntimeGenesisConfig {
     match spec_id {
         SpecId::Dev => testnet_genesis(),
-        SpecId::Gemini => testnet_genesis(),
+        SpecId::Taurus => testnet_genesis(),
         SpecId::DevNet => testnet_genesis(),
     }
 }
@@ -129,7 +129,7 @@ pub fn get_testnet_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAcc
             let alice_account = accounts[0].clone();
             vec![(AccountIdConverter::convert(alice_account), 1_000_000 * SSC)]
         }
-        SpecId::Gemini => vec![],
+        SpecId::Taurus => vec![],
     }
 }
 
@@ -150,7 +150,7 @@ fn get_operator_params(
             operator_allow_list: OperatorAllowList::Anyone,
             operator_signing_key: get_public_key_from_seed::<OperatorPublicKey>("Alice"),
         },
-        SpecId::Gemini => GenesisOperatorParams {
+        SpecId::Taurus => GenesisOperatorParams {
             operator_allow_list: OperatorAllowList::Operators(BTreeSet::from_iter(vec![
                 sudo_account.clone(),
             ])),
@@ -173,7 +173,7 @@ pub fn get_genesis_domain(
 ) -> Result<GenesisDomain, String> {
     let chain_spec = match spec_id {
         SpecId::Dev => development_config(get_testnet_genesis_by_spec_id(spec_id))?,
-        SpecId::Gemini => gemini_3h_config(get_testnet_genesis_by_spec_id(spec_id))?,
+        SpecId::Taurus => taurus_config(get_testnet_genesis_by_spec_id(spec_id))?,
         SpecId::DevNet => devnet_config(get_testnet_genesis_by_spec_id(spec_id))?,
     };
 

--- a/crates/subspace-node/src/domain/cli.rs
+++ b/crates/subspace-node/src/domain/cli.rs
@@ -91,7 +91,7 @@ pub struct DomainCli {
 #[derive(Debug, Copy, Clone)]
 pub enum SpecId {
     Dev,
-    Gemini,
+    Taurus,
     DevNet,
 }
 

--- a/crates/subspace-node/src/domain/evm_chain_spec.rs
+++ b/crates/subspace-node/src/domain/evm_chain_spec.rs
@@ -67,21 +67,21 @@ pub fn development_config(
     .build())
 }
 
-pub fn gemini_3h_config(
+pub fn taurus_config(
     runtime_genesis_config: RuntimeGenesisConfig,
 ) -> Result<GenericChainSpec, String> {
     Ok(GenericChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "WASM binary was not build, please build it!".to_string())?,
         None,
     )
-    .with_name("Subspace Gemini 3h EVM Domain")
-    .with_id("subspace_gemini_3h_evm_domain")
+    .with_name("Autonomys Taurus EVM Domain")
+    .with_id("autonomys_taurus_evm_domain")
     .with_chain_type(ChainType::Live)
     .with_genesis_config(
         serde_json::to_value(runtime_genesis_config)
             .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
     )
-    .with_protocol_id("subspace-gemini-3h-evm-domain")
+    .with_protocol_id("autonomys-taurus-evm-domain")
     .with_properties(chain_spec_properties())
     .build())
 }
@@ -107,7 +107,7 @@ pub fn devnet_config(
 
 pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, String> {
     let chain_spec = match spec_id {
-        "gemini-3h" => gemini_3h_config(get_testnet_genesis_by_spec_id(SpecId::Gemini))?,
+        "taurus" => taurus_config(get_testnet_genesis_by_spec_id(SpecId::Taurus))?,
         "devnet" => devnet_config(get_testnet_genesis_by_spec_id(SpecId::DevNet))?,
         "dev" => development_config(get_testnet_genesis_by_spec_id(SpecId::Dev))?,
         path => GenericChainSpec::from_json_file(std::path::PathBuf::from(path))?,
@@ -118,7 +118,7 @@ pub fn load_chain_spec(spec_id: &str) -> Result<Box<dyn sc_cli::ChainSpec>, Stri
 pub fn get_testnet_genesis_by_spec_id(spec_id: SpecId) -> RuntimeGenesisConfig {
     match spec_id {
         SpecId::Dev => testnet_genesis(),
-        SpecId::Gemini => testnet_genesis(),
+        SpecId::Taurus => testnet_genesis(),
         SpecId::DevNet => testnet_genesis(),
     }
 }
@@ -129,7 +129,7 @@ pub fn get_testnet_endowed_accounts_by_spec_id(spec_id: SpecId) -> Vec<(MultiAcc
             .into_iter()
             .map(|acc| (AccountId20Converter::convert(acc), 1_000_000 * SSC))
             .collect(),
-        SpecId::DevNet | SpecId::Gemini => vec![],
+        SpecId::DevNet | SpecId::Taurus => vec![],
     }
 }
 
@@ -178,7 +178,7 @@ fn get_operator_params(
             operator_allow_list: OperatorAllowList::Anyone,
             operator_signing_key: get_public_key_from_seed::<OperatorPublicKey>("Bob"),
         },
-        SpecId::Gemini => GenesisOperatorParams {
+        SpecId::Taurus => GenesisOperatorParams {
             operator_allow_list: OperatorAllowList::Operators(BTreeSet::from_iter(vec![
                 sudo_account.clone(),
             ])),
@@ -201,7 +201,7 @@ pub fn get_genesis_domain(
 ) -> Result<GenesisDomain, String> {
     let chain_spec = match spec_id {
         SpecId::Dev => development_config(get_testnet_genesis_by_spec_id(spec_id))?,
-        SpecId::Gemini => gemini_3h_config(get_testnet_genesis_by_spec_id(spec_id))?,
+        SpecId::Taurus => taurus_config(get_testnet_genesis_by_spec_id(spec_id))?,
         SpecId::DevNet => devnet_config(get_testnet_genesis_by_spec_id(spec_id))?,
     };
 


### PR DESCRIPTION
The current PR:
- renames `gemini-3h` related functions to `taurus`
- updates sudo key 
- disables transfers
What's missing:
- democracy council (can be set by sudo later)
- history seeder (can be set by sudo later)
- genesis farmer public key will probably change
- balances other than sudo

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
