### PR TITLE
Limit CI to 2 hours when a test hangs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -198,6 +198,8 @@ jobs:
         os: ${{ fromJson(github.repository_owner == 'autonomys' && '[["self-hosted", "ubuntu-20.04-x86-64"], ["self-hosted", "macos-14-arm64"], ["self-hosted", "windows-server-2022-x86-64"]]' || '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
 
     runs-on: ${{ matrix.os }}
+    # Don't use the full 6 hours if a test hangs
+    timeout-minutes: 120
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR limits tests to 2 hours in CI, rather than GitHub's default 6 hour limit.

See the docs here:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

And previous conversation here:
https://github.com/autonomys/subspace/pull/3100#pullrequestreview-2361344531

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
