### PR TITLE
Avoid allocation in `CowBytes` if possible

### DIFF
--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -822,7 +822,7 @@ impl AsMut<[u8]> for CowBytes {
     fn as_mut(&mut self) -> &mut [u8] {
         match self {
             CowBytes::Shared(bytes) => {
-                *self = CowBytes::Owned(BytesMut::from(bytes.as_ref()));
+                *self = CowBytes::Owned(BytesMut::from(mem::take(bytes)));
 
                 let CowBytes::Owned(bytes) = self else {
                     unreachable!("Just replaced; qed");


### PR DESCRIPTION
Instead of allocating unconditionally try to reuse original allocation if possible. `BytesMut::from()` tries to reuse allocation if possible.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
