### PR TITLE
Skip empty object mapping notifications

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -1064,6 +1064,10 @@ fn send_object_mapping_notification(
     object_mapping_notification_sender: &SubspaceNotificationSender<ObjectMappingNotification>,
     object_mapping: Vec<GlobalObject>,
 ) {
+    if object_mapping.is_empty() {
+        return;
+    }
+
     let object_mapping_notification = ObjectMappingNotification { object_mapping };
 
     object_mapping_notification_sender.notify(move || object_mapping_notification);


### PR DESCRIPTION
If we don't have any object mappings for a block, don't send a notification to the RPC subscriptions.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
