### PR TITLE
Use `anyhow` more widely in farmer code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12546,6 +12546,7 @@ dependencies = [
 name = "subspace-farmer-components"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-lock 3.4.0",
  "async-trait",
  "backoff",

--- a/crates/subspace-farmer-components/Cargo.toml
+++ b/crates/subspace-farmer-components/Cargo.toml
@@ -16,6 +16,7 @@ include = [
 bench = false
 
 [dependencies]
+anyhow = "1.0.89"
 async-lock = "3.4.0"
 async-trait = "0.1.83"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -28,7 +28,6 @@ use async_trait::async_trait;
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
-use std::error::Error;
 use std::fs::File;
 use std::future::Future;
 use std::io;
@@ -40,10 +39,7 @@ use subspace_core_primitives::segments::{ArchivedHistorySegment, HistorySize};
 #[async_trait]
 pub trait PieceGetter {
     /// Get piece by index
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>>;
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>>;
 }
 
 #[async_trait]
@@ -51,20 +47,14 @@ impl<T> PieceGetter for Arc<T>
 where
     T: PieceGetter + Send + Sync,
 {
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         self.as_ref().get_piece(piece_index).await
     }
 }
 
 #[async_trait]
 impl PieceGetter for ArchivedHistorySegment {
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         let position = usize::try_from(u64::from(piece_index))?;
 
         Ok(self.pieces().nth(position))

--- a/crates/subspace-farmer/src/farm.rs
+++ b/crates/subspace-farmer/src/farm.rs
@@ -7,7 +7,6 @@
 //! way). This crate provides a few of such implementations, but more can be created externally as
 //! well if needed without modifying the library itself.
 
-use crate::node_client;
 use async_trait::async_trait;
 use derive_more::{Display, From};
 use futures::Stream;
@@ -278,13 +277,13 @@ pub enum FarmingError {
     #[error("Failed to subscribe to slot info notifications: {error}")]
     FailedToSubscribeSlotInfo {
         /// Lower-level error
-        error: node_client::Error,
+        error: anyhow::Error,
     },
     /// Failed to retrieve farmer info
     #[error("Failed to retrieve farmer info: {error}")]
     FailedToGetFarmerInfo {
         /// Lower-level error
-        error: node_client::Error,
+        error: anyhow::Error,
     },
     /// Slot info notification stream ended
     #[error("Slot info notification stream ended")]

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -6,7 +6,7 @@
 
 use crate::disk_piece_cache::DiskPieceCache;
 use crate::farmer_cache::{decode_piece_index_from_record_key, FarmerCache};
-use crate::node_client::{Error, NodeClient};
+use crate::node_client::NodeClient;
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, Stream, StreamExt};
@@ -44,7 +44,7 @@ struct MockNodeClient {
 
 #[async_trait]
 impl NodeClient for MockNodeClient {
-    async fn farmer_app_info(&self) -> Result<FarmerAppInfo, Error> {
+    async fn farmer_app_info(&self) -> anyhow::Result<FarmerAppInfo> {
         // Most of these values make no sense, but they are not used by piece cache anyway
         Ok(FarmerAppInfo {
             genesis_hash: [0; 32],
@@ -68,33 +68,33 @@ impl NodeClient for MockNodeClient {
 
     async fn subscribe_slot_info(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, Error> {
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>> {
         unimplemented!()
     }
 
     async fn submit_solution_response(
         &self,
         _solution_response: SolutionResponse,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         unimplemented!()
     }
 
     async fn subscribe_reward_signing(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, Error> {
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>> {
         unimplemented!()
     }
 
     async fn submit_reward_signature(
         &self,
         _reward_signature: RewardSignatureResponse,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         unimplemented!()
     }
 
     async fn subscribe_archived_segment_headers(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = SegmentHeader> + Send + 'static>>, Error> {
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = SegmentHeader> + Send + 'static>>> {
         let (tx, rx) = oneshot::channel();
         self.archived_segment_headers_stream_request_sender
             .clone()
@@ -109,11 +109,11 @@ impl NodeClient for MockNodeClient {
     async fn segment_headers(
         &self,
         _segment_indexes: Vec<SegmentIndex>,
-    ) -> Result<Vec<Option<SegmentHeader>>, Error> {
+    ) -> anyhow::Result<Vec<Option<SegmentHeader>>> {
         unimplemented!()
     }
 
-    async fn piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, Error> {
+    async fn piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         Ok(Some(
             self.pieces
                 .lock()
@@ -130,7 +130,7 @@ impl NodeClient for MockNodeClient {
     async fn acknowledge_archived_segment_header(
         &self,
         segment_index: SegmentIndex,
-    ) -> Result<(), Error> {
+    ) -> anyhow::Result<()> {
         self.acknowledge_archived_segment_header_sender
             .clone()
             .send(segment_index)
@@ -147,10 +147,7 @@ struct MockPieceGetter {
 
 #[async_trait]
 impl PieceGetter for MockPieceGetter {
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         Ok(Some(
             self.pieces
                 .lock()

--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -12,7 +12,6 @@ use backoff::future::retry;
 use backoff::ExponentialBackoff;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::error::Error;
 use std::fmt;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
@@ -383,10 +382,7 @@ where
     PV: PieceValidator + Send + 'static,
     NC: NodeClient,
 {
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         let _guard = self.inner.request_semaphore.acquire().await;
 
         match InProgressPiece::new(piece_index, &self.inner.in_progress_pieces) {
@@ -453,10 +449,7 @@ where
     PV: PieceValidator + Send + 'static,
     NC: NodeClient,
 {
-    async fn get_piece(
-        &self,
-        piece_index: PieceIndex,
-    ) -> Result<Option<Piece>, Box<dyn Error + Send + Sync + 'static>> {
+    async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         let Some(piece_getter) = self.upgrade() else {
             debug!("Farmer piece getter upgrade didn't succeed");
             return Ok(None);

--- a/crates/subspace-farmer/src/node_client.rs
+++ b/crates/subspace-farmer/src/node_client.rs
@@ -21,61 +21,58 @@ use subspace_rpc_primitives::{
     FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
 };
 
-/// Erased error type
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
 /// Abstraction of the Node Client
 #[async_trait]
 pub trait NodeClient: fmt::Debug + Send + Sync + 'static {
     /// Get farmer app info
-    async fn farmer_app_info(&self) -> Result<FarmerAppInfo, Error>;
+    async fn farmer_app_info(&self) -> anyhow::Result<FarmerAppInfo>;
 
     /// Subscribe to slot
     async fn subscribe_slot_info(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>, Error>;
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = SlotInfo> + Send + 'static>>>;
 
     /// Submit a slot solution
     async fn submit_solution_response(
         &self,
         solution_response: SolutionResponse,
-    ) -> Result<(), Error>;
+    ) -> anyhow::Result<()>;
 
     /// Subscribe to block signing request
     async fn subscribe_reward_signing(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>, Error>;
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = RewardSigningInfo> + Send + 'static>>>;
 
     /// Submit a block signature
     async fn submit_reward_signature(
         &self,
         reward_signature: RewardSignatureResponse,
-    ) -> Result<(), Error>;
+    ) -> anyhow::Result<()>;
 
     /// Subscribe to archived segment headers
     async fn subscribe_archived_segment_headers(
         &self,
-    ) -> Result<Pin<Box<dyn Stream<Item = SegmentHeader> + Send + 'static>>, Error>;
+    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = SegmentHeader> + Send + 'static>>>;
 
     /// Get segment headers for the segments
     async fn segment_headers(
         &self,
         segment_indices: Vec<SegmentIndex>,
-    ) -> Result<Vec<Option<SegmentHeader>>, Error>;
+    ) -> anyhow::Result<Vec<Option<SegmentHeader>>>;
 
     /// Get piece by index.
-    async fn piece(&self, piece_index: PieceIndex) -> Result<Option<Piece>, Error>;
+    async fn piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>>;
 
     /// Acknowledge segment header.
     async fn acknowledge_archived_segment_header(
         &self,
         segment_index: SegmentIndex,
-    ) -> Result<(), Error>;
+    ) -> anyhow::Result<()>;
 }
 
 /// Node Client extension methods that are not necessary for farmer as a library, but might be useful for an app
 #[async_trait]
 pub trait NodeClientExt: NodeClient {
     /// Get the last segment headers.
-    async fn last_segment_headers(&self, limit: u32) -> Result<Vec<Option<SegmentHeader>>, Error>;
+    async fn last_segment_headers(&self, limit: u32) -> anyhow::Result<Vec<Option<SegmentHeader>>>;
 }

--- a/crates/subspace-farmer/src/plotter/gpu/cuda.rs
+++ b/crates/subspace-farmer/src/plotter/gpu/cuda.rs
@@ -30,11 +30,11 @@ impl RecordsEncoder for CudaRecordsEncoder {
         sector_id: &SectorId,
         records: &mut [Record],
         abort_early: &AtomicBool,
-    ) -> Result<SectorContentsMap, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> anyhow::Result<SectorContentsMap> {
         let pieces_in_sector = records
             .len()
             .try_into()
-            .map_err(|error| format!("Failed to convert pieces in sector: {error}"))?;
+            .map_err(|error| anyhow::anyhow!("Failed to convert pieces in sector: {error}"))?;
         let mut sector_contents_map = SectorContentsMap::new(pieces_in_sector);
 
         self.thread_pool.install(|| {
@@ -76,7 +76,7 @@ impl RecordsEncoder for CudaRecordsEncoder {
 
             let plotting_error = plotting_error.lock().take();
             if let Some(error) = plotting_error {
-                return Err(error);
+                return Err(anyhow::Error::msg(error));
             }
 
             Ok(())

--- a/crates/subspace-farmer/src/plotter/gpu/rocm.rs
+++ b/crates/subspace-farmer/src/plotter/gpu/rocm.rs
@@ -30,11 +30,11 @@ impl RecordsEncoder for RocmRecordsEncoder {
         sector_id: &SectorId,
         records: &mut [Record],
         abort_early: &AtomicBool,
-    ) -> Result<SectorContentsMap, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> anyhow::Result<SectorContentsMap> {
         let pieces_in_sector = records
             .len()
             .try_into()
-            .map_err(|error| format!("Failed to convert pieces in sector: {error}"))?;
+            .map_err(|error| anyhow::anyhow!("Failed to convert pieces in sector: {error}"))?;
         let mut sector_contents_map = SectorContentsMap::new(pieces_in_sector);
 
         self.thread_pool.install(|| {
@@ -76,7 +76,7 @@ impl RecordsEncoder for RocmRecordsEncoder {
 
             let plotting_error = plotting_error.lock().take();
             if let Some(error) = plotting_error {
-                return Err(error);
+                return Err(anyhow::Error::msg(error));
             }
 
             Ok(())

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -55,7 +55,6 @@ use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
 use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
 use std::collections::HashSet;
-use std::error::Error;
 use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::Write;
@@ -550,7 +549,7 @@ pub enum BackgroundTaskError {
     Farming(#[from] FarmingError),
     /// Reward signing
     #[error(transparent)]
-    RewardSigning(#[from] Box<dyn Error + Send + Sync + 'static>),
+    RewardSigning(#[from] anyhow::Error),
     /// Background task panicked
     #[error("Background task {task} panicked")]
     BackgroundTaskPanicked {
@@ -1227,10 +1226,9 @@ impl SingleDiskFarm {
                     reward_signing_fut.await;
                 }
                 Err(error) => {
-                    return Err(BackgroundTaskError::RewardSigning(
-                        format!("Failed to subscribe to reward signing notifications: {error}")
-                            .into(),
-                    ));
+                    return Err(BackgroundTaskError::RewardSigning(anyhow::anyhow!(
+                        "Failed to subscribe to reward signing notifications: {error}"
+                    )));
                 }
             }
 

--- a/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -1,5 +1,5 @@
 use crate::farm::{SectorExpirationDetails, SectorPlottingDetails, SectorUpdate};
-use crate::node_client::{Error as NodeClientError, NodeClient};
+use crate::node_client::NodeClient;
 use crate::plotter::{Plotter, SectorPlottingProgress};
 use crate::single_disk_farm::direct_io_file::DirectIoFile;
 use crate::single_disk_farm::metrics::{SectorState, SingleDiskFarmMetrics};
@@ -50,13 +50,13 @@ pub enum PlottingError {
     #[error("Failed to retrieve farmer info: {error}")]
     FailedToGetFarmerInfo {
         /// Lower-level error
-        error: NodeClientError,
+        error: anyhow::Error,
     },
     /// Failed to get segment header
     #[error("Failed to get segment header: {error}")]
     FailedToGetSegmentHeader {
         /// Lower-level error
-        error: NodeClientError,
+        error: anyhow::Error,
     },
     /// Missing archived segment header
     #[error("Missing archived segment header: {segment_index}")]
@@ -68,7 +68,7 @@ pub enum PlottingError {
     #[error("Failed to subscribe to archived segments: {error}")]
     FailedToSubscribeArchivedSegments {
         /// Lower-level error
-        error: NodeClientError,
+        error: anyhow::Error,
     },
     /// Low-level plotting error
     #[error("Low-level plotting error: {0}")]

--- a/crates/subspace-farmer/src/single_disk_farm/reward_signing.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/reward_signing.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 pub(super) async fn reward_signing<NC>(
     node_client: NC,
     identity: Identity,
-) -> Result<impl Future<Output = ()>, Box<dyn std::error::Error + Send + Sync>>
+) -> anyhow::Result<impl Future<Output = ()>>
 where
     NC: NodeClient,
 {

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -78,7 +78,7 @@ where
         }
     }
 
-    /// Get a pieces with provided indices from cache
+    /// Get pieces with provided indices from cache
     pub async fn get_from_cache<'a, PieceIndices>(
         &'a self,
         piece_indices: PieceIndices,


### PR DESCRIPTION
It is better than `Box<dyn std::error::Error + Send + Sync + 'static>` in almost every way.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
