### PR TITLE
Rewrite README intros to be clearer

### DIFF
--- a/crates/subspace-farmer/README.md
+++ b/crates/subspace-farmer/README.md
@@ -4,11 +4,11 @@ Reference implementation of Subspace Farmer for Subspace Network Blockchain.
 
 ## Running
 
-It is recommended to follow general farming instructions that explain how to run both farmer and node together.
+We recommend following the general farming instructions that explain how to run both the farmer and node together.
 
 ## Build from source
 
-Rust toolchain is expected to be installed for anything in this repository to compile, but there are some extra dependencies for farmer specifically.
+A Rust toolchain is required to compile this repository, but there are some extra dependencies for the farmer.
 
 `protoc` is required for `libp2p`.
 `automake`,`libtool` and `pkg-config` on Linux/macOS or CMake on Windows for `hwlocality-sys` (if `numa` features is
@@ -65,7 +65,9 @@ target/production/subspace-farmer --help
 
 ### Start the farmer
 ```
-target/production/subspace-farmer farm --reward-address st... path=/path/to/farm,size=100G
+target/production/subspace-farmer farm \
+    --reward-address st... \
+    path=/path/to/farm,size=100G
 ```
 
 `st...` should be replaced with the reward address taken from [Polkadot.js wallet](https://polkadot.js.org/extension/) (or similar), `/path/to/farm` with location where you want to store plot and `100G` replaced with desired plot size.

--- a/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/utils.rs
@@ -11,7 +11,7 @@ pub(crate) fn raise_fd_limit() {
             );
         }
         Ok(fdlimit::Outcome::Unsupported) => {
-            // Unsupported platform (non-Linux)
+            // Unsupported platform (a platform other than Linux or macOS)
         }
         Err(error) => {
             tracing::warn!(

--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 homepage = "https://subspace.network"
 repository = "https://github.com/autonomys/subspace"
 include = [
-    "/res",
     "/src",
     "/build.rs",
     "/Cargo.toml",

--- a/crates/subspace-node/README.md
+++ b/crates/subspace-node/README.md
@@ -8,11 +8,11 @@ Follow these steps to get started with the Subspace Node :hammer_and_wrench:
 
 ## Running
 
-It is recommended to follow general farming instructions that explain how to run both farmer and node together.
+We recommend following the general farming instructions that explain how to run both the farmer and node together.
 
 ## Build from source
 
-Rust toolchain is expected to be installed for anything in this repository to compile, but there are some extra dependencies for farmer specifically.
+A Rust toolchain is required to compile this repository, but there are some extra dependencies for the node.
 
 `protoc` is required for `libp2p`.
 
@@ -71,7 +71,7 @@ By default, node data are written to `subspace-node` subdirectory of the OS-spec
 ```
 Linux
 $XDG_DATA_HOME or                   /home/alice/.local/share
-$HOME/.local/share 
+$HOME/.local/share
 
 macOS
 $HOME/Library/Application Support   /Users/Alice/Library/Application Support

--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -62,7 +62,7 @@ fn raise_fd_limit() {
             );
         }
         Ok(fdlimit::Outcome::Unsupported) => {
-            // Unsupported platform (non-Linux)
+            // Unsupported platform (a platform other than Linux or macOS)
         }
         Err(error) => {
             warn!(


### PR DESCRIPTION
This PR rewrites some intro docs in the README, fixes some outdated comments, and removes an outdated path from a Cargo.toml.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
