### PR TITLE
Prepare `subspace-farmer-components` to retrieve pieces in batches

### DIFF
--- a/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -212,6 +212,7 @@ impl PiecesReconstructor {
             return Err(ReconstructorError::IncorrectPiecePosition);
         }
 
+        // TODO: Early exit if position already exists and doesn't need reconstruction
         let (reconstructed_records, polynomial) = self.reconstruct_shards(segment_pieces)?;
 
         let mut piece = Piece::from(&reconstructed_records[piece_position]);

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -6,6 +6,7 @@
     array_chunks,
     const_option,
     const_trait_impl,
+    exact_size_is_empty,
     int_roundings,
     iter_collect_into,
     never_type,


### PR DESCRIPTION
This introduces `PieceGetter::get_pieces()` (with dummy implementation that just calls `PieceGetter::get_piece()` internally) and prepares `subspace-farmer-components` to use it.

This prepares lower-level part of the farmer implementation, next steps include properly implementing `PieceGetter::get_pieces()` in `FarmerPieceGetter` and `ClusterPieceGetter` to fully utilize new capabilities and then switching piece cache sync to `PieceGetter::get_pieces()`.

Eventually we'll make similar changes in `subspace-service` and upcoming data retrieval application.

I'm also considering optimizing `PieceGetter::get_piece()` to take advantage of already connected peers if there remains a use case for it after all this, though I'll need to check how much sense there is since we can just call with a single piece index, though I realize we'll have a bunch of extra bookkeeping there that might be too heavy for the use case.

Note that in `recover_missing_piece` implementation is not of the highest possible efficiency (it waits for one batch to complete before starting to download more pieces), but that is a conscious decision to simplify implementation given that requiring reconstruction is an exceptional situation to begin with and should be a very cold code path overall, it really shouldn't happen on any real network in practice.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
