### PR TITLE
Remove farmer piece getter deduplication

### DIFF
--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -3,15 +3,11 @@
 use crate::farm::plotted_pieces::PlottedPieces;
 use crate::farmer_cache::FarmerCache;
 use crate::node_client::NodeClient;
-use async_lock::{
-    Mutex as AsyncMutex, MutexGuardArc as AsyncMutexGuardArc, RwLock as AsyncRwLock, Semaphore,
-};
+use async_lock::{RwLock as AsyncRwLock, Semaphore};
 use async_trait::async_trait;
 use backoff::backoff::Backoff;
 use backoff::future::retry;
 use backoff::ExponentialBackoff;
-use parking_lot::Mutex;
-use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
@@ -26,71 +22,6 @@ use tracing::{debug, error, trace};
 pub mod piece_validator;
 
 const MAX_RANDOM_WALK_ROUNDS: usize = 15;
-
-struct InProgressPieceGetting<'a> {
-    piece_index: PieceIndex,
-    in_progress_piece: AsyncMutexGuardArc<Option<Piece>>,
-    in_progress_pieces: &'a Mutex<HashMap<PieceIndex, Arc<AsyncMutex<Option<Piece>>>>>,
-}
-
-impl<'a> Drop for InProgressPieceGetting<'a> {
-    fn drop(&mut self) {
-        self.in_progress_pieces.lock().remove(&self.piece_index);
-    }
-}
-
-impl<'a> InProgressPieceGetting<'a> {
-    fn store_piece_getting_result(mut self, maybe_piece: &Option<Piece>) {
-        self.in_progress_piece.clone_from(maybe_piece);
-    }
-}
-
-enum InProgressPiece<'a> {
-    Getting(InProgressPieceGetting<'a>),
-    // If piece is already in progress, just wait for it
-    Waiting {
-        in_progress_piece_mutex: Arc<AsyncMutex<Option<Piece>>>,
-    },
-}
-
-impl<'a> InProgressPiece<'a> {
-    fn new(
-        piece_index: PieceIndex,
-        in_progress_pieces: &'a Mutex<HashMap<PieceIndex, Arc<AsyncMutex<Option<Piece>>>>>,
-    ) -> Self {
-        let in_progress_piece_mutex = Arc::new(AsyncMutex::new(None));
-        // Take lock before anything else, set to `None` when another piece getting is already in
-        // progress
-        let mut local_in_progress_piece_guard = Some(
-            in_progress_piece_mutex
-                .try_lock_arc()
-                .expect("Just created; qed"),
-        );
-        let in_progress_piece_mutex = in_progress_pieces
-            .lock()
-            .entry(piece_index)
-            .and_modify(|_mutex| {
-                local_in_progress_piece_guard.take();
-            })
-            .or_insert_with(|| Arc::clone(&in_progress_piece_mutex))
-            .clone();
-
-        if let Some(in_progress_piece) = local_in_progress_piece_guard {
-            // Store guard and details necessary to remove entry from `in_progress_pieces` after
-            // piece getting is complete (in `Drop` impl)
-            Self::Getting(InProgressPieceGetting {
-                piece_index,
-                in_progress_piece,
-                in_progress_pieces,
-            })
-        } else {
-            // Piece getting is already in progress, only mutex is needed to wait for its result
-            Self::Waiting {
-                in_progress_piece_mutex,
-            }
-        }
-    }
-}
 
 /// Retry policy for getting pieces from DSN cache
 #[derive(Debug)]
@@ -107,7 +38,6 @@ struct Inner<FarmIndex, CacheIndex, PV, NC> {
     node_client: NC,
     plotted_pieces: Arc<AsyncRwLock<PlottedPieces<FarmIndex>>>,
     dsn_cache_retry_policy: DsnCacheRetryPolicy,
-    in_progress_pieces: Mutex<HashMap<PieceIndex, Arc<AsyncMutex<Option<Piece>>>>>,
     request_semaphore: Arc<Semaphore>,
 }
 
@@ -163,7 +93,6 @@ where
                 node_client,
                 plotted_pieces,
                 dsn_cache_retry_policy,
-                in_progress_pieces: Mutex::default(),
                 request_semaphore,
             }),
         }
@@ -173,23 +102,7 @@ where
     pub async fn get_piece_fast(&self, piece_index: PieceIndex) -> Option<Piece> {
         let _guard = self.inner.request_semaphore.acquire().await;
 
-        match InProgressPiece::new(piece_index, &self.inner.in_progress_pieces) {
-            InProgressPiece::Getting(in_progress_piece_getting) => {
-                // Try to get the piece without releasing lock to make sure successfully
-                // downloaded piece gets stored
-                let maybe_piece = self.get_piece_fast_internal(piece_index).await;
-                // Store the result for others to observe
-                in_progress_piece_getting.store_piece_getting_result(&maybe_piece);
-                maybe_piece
-            }
-            InProgressPiece::Waiting {
-                in_progress_piece_mutex,
-            } => {
-                trace!(%piece_index, "Piece is already in progress, waiting for result #1");
-                // Doesn't matter if it was successful or not here
-                in_progress_piece_mutex.lock().await.clone()
-            }
-        }
+        self.get_piece_fast_internal(piece_index).await
     }
 
     async fn get_piece_fast_internal(&self, piece_index: PieceIndex) -> Option<Piece> {
@@ -246,31 +159,7 @@ where
     pub async fn get_piece_slow(&self, piece_index: PieceIndex) -> Option<Piece> {
         let _guard = self.inner.request_semaphore.acquire().await;
 
-        match InProgressPiece::new(piece_index, &self.inner.in_progress_pieces) {
-            InProgressPiece::Getting(in_progress_piece_getting) => {
-                // Try to get the piece without releasing lock to make sure successfully
-                // downloaded piece gets stored
-                let maybe_piece = self.get_piece_slow_internal(piece_index).await;
-                // Store the result for others to observe
-                in_progress_piece_getting.store_piece_getting_result(&maybe_piece);
-                maybe_piece
-            }
-            InProgressPiece::Waiting {
-                in_progress_piece_mutex,
-            } => {
-                trace!(%piece_index, "Piece is already in progress, waiting for result #2");
-                if let Some(piece) = in_progress_piece_mutex.lock().await.clone() {
-                    trace!(
-                        %piece_index,
-                        "Piece was already in progress and downloaded successfully #1"
-                    );
-                    return Some(piece);
-                }
-
-                // Try again just in case
-                self.get_piece_slow_internal(piece_index).await
-            }
-        }
+        self.get_piece_slow_internal(piece_index).await
     }
 
     /// Slow way to get piece using archival storage
@@ -385,31 +274,7 @@ where
     async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
         let _guard = self.inner.request_semaphore.acquire().await;
 
-        match InProgressPiece::new(piece_index, &self.inner.in_progress_pieces) {
-            InProgressPiece::Getting(in_progress_piece_getting) => {
-                // Try to get the piece without releasing lock to make sure successfully
-                // downloaded piece gets stored
-                let maybe_piece = self.get_piece_internal(piece_index).await;
-                // Store the result for others to observe
-                in_progress_piece_getting.store_piece_getting_result(&maybe_piece);
-                Ok(maybe_piece)
-            }
-            InProgressPiece::Waiting {
-                in_progress_piece_mutex,
-            } => {
-                trace!(%piece_index, "Piece is already in progress, waiting for result #3");
-                if let Some(piece) = in_progress_piece_mutex.lock().await.clone() {
-                    trace!(
-                        %piece_index,
-                        "Piece was already in progress and downloaded successfully #2"
-                    );
-                    return Ok(Some(piece));
-                }
-
-                // Try again just in case
-                Ok(self.get_piece_internal(piece_index).await)
-            }
-        }
+        Ok(self.get_piece_internal(piece_index).await)
     }
 }
 


### PR DESCRIPTION
The feature was introduced as part of https://github.com/autonomys/subspace/pull/2565 and later refactored in https://github.com/autonomys/subspace/pull/2793 to de-duplicate in-flight piece requests.

While it helped at the time, with growing network size (meaning larger selection of pieces) and Snap sync (meaning little to no overlap between node sync, piece cache sync and plotting) its assumptions no longer hold and it just adds a bunch of complexity for very little benefit. As such I think we should remove it.

Moreover, with https://github.com/autonomys/subspace/pull/3132 and other upcoming PRs many simple cases like plotting right after genesis where out of 1000 unique pieces there are just 256 unique pieces will be internally de-duplicated (see https://github.com/autonomys/subspace/pull/3132/commits/29b86e3e559b3b313c3f5d950bd3faf8983ecdaa#diff-765c2c9791b623384f826fa8f02a4e4c4c78735e85b42a3533537cb58d3df116R278-R289).

First commit is the actual change, second simply inlines the function which only has a trivial call from a single place.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
