### PR TITLE
Add source to the OperatorRewarded event

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -28,8 +28,8 @@ use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_core::ByteArray;
 use sp_domains::{
     dummy_opaque_bundle, BlockFees, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
-    OperatorPublicKey, OperatorSignature, PermissionedActionAllowedBy, ProofOfElection,
-    RuntimeType, SealedSingletonReceipt, SingletonReceipt, Transfers,
+    OperatorPublicKey, OperatorRewardSource, OperatorSignature, PermissionedActionAllowedBy,
+    ProofOfElection, RuntimeType, SealedSingletonReceipt, SingletonReceipt, Transfers,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{CheckedAdd, One, Zero};
@@ -286,6 +286,7 @@ mod benchmarks {
 
             do_reward_operators::<T>(
                 domain_id,
+                OperatorRewardSource::Dummy,
                 operator_ids[..n as usize].to_vec().into_iter(),
                 operator_rewards,
             )
@@ -337,6 +338,7 @@ mod benchmarks {
 
         do_reward_operators::<T>(
             domain_id,
+            OperatorRewardSource::Dummy,
             operator_ids.clone().into_iter(),
             operator_rewards,
         )
@@ -449,8 +451,13 @@ mod benchmarks {
         }
         assert_eq!(PendingStakingOperationCount::<T>::get(domain_id), p);
 
-        do_reward_operators::<T>(domain_id, operator_ids.into_iter(), operator_rewards)
-            .expect("reward operator should success");
+        do_reward_operators::<T>(
+            domain_id,
+            OperatorRewardSource::Dummy,
+            operator_ids.into_iter(),
+            operator_rewards,
+        )
+        .expect("reward operator should success");
 
         let epoch_index = DomainStakingSummary::<T>::get(domain_id)
             .expect("staking summary must exist")

--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -318,7 +318,8 @@ pub(crate) fn verify_execution_receipt<T: Config>(
 
 /// Details of the confirmed domain block such as operators, rewards they would receive.
 #[derive(Debug, PartialEq)]
-pub(crate) struct ConfirmedDomainBlockInfo<DomainNumber, Balance> {
+pub(crate) struct ConfirmedDomainBlockInfo<ConsensusNumber, DomainNumber, Balance> {
+    pub consensus_block_number: ConsensusNumber,
     pub domain_block_number: DomainNumber,
     pub operator_ids: Vec<OperatorId>,
     pub rewards: Balance,
@@ -327,8 +328,10 @@ pub(crate) struct ConfirmedDomainBlockInfo<DomainNumber, Balance> {
     pub paid_bundle_storage_fees: BTreeMap<OperatorId, u32>,
 }
 
-pub(crate) type ProcessExecutionReceiptResult<T> =
-    Result<Option<ConfirmedDomainBlockInfo<DomainBlockNumberFor<T>, BalanceOf<T>>>, Error>;
+pub(crate) type ProcessExecutionReceiptResult<T> = Result<
+    Option<ConfirmedDomainBlockInfo<BlockNumberFor<T>, DomainBlockNumberFor<T>, BalanceOf<T>>>,
+    Error,
+>;
 
 /// Process the execution receipt to add it to the block tree
 /// Returns the domain block number that was pruned, if any
@@ -429,6 +432,7 @@ pub(crate) fn process_execution_receipt<T: Config>(
                     });
 
                 return Ok(Some(ConfirmedDomainBlockInfo {
+                    consensus_block_number: execution_receipt.consensus_block_number,
                     domain_block_number: to_prune,
                     operator_ids,
                     rewards: execution_receipt.block_fees.domain_execution_fee,

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -536,7 +536,8 @@ mod tests {
     use frame_support::traits::fungible::InspectHold;
     use sp_core::{Pair, U256};
     use sp_domains::{
-        BlockFees, DomainId, OperatorPair, OperatorSigningKeyProofOfOwnershipData, Transfers,
+        BlockFees, DomainId, OperatorPair, OperatorRewardSource,
+        OperatorSigningKeyProofOfOwnershipData, Transfers,
     };
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
@@ -605,8 +606,13 @@ mod tests {
             }
 
             if !rewards.is_zero() {
-                do_reward_operators::<Test>(domain_id, vec![operator_id].into_iter(), rewards)
-                    .unwrap()
+                do_reward_operators::<Test>(
+                    domain_id,
+                    OperatorRewardSource::Dummy,
+                    vec![operator_id].into_iter(),
+                    rewards,
+                )
+                .unwrap()
             }
 
             // de-register operator
@@ -770,8 +776,13 @@ mod tests {
             }
 
             if !rewards.is_zero() {
-                do_reward_operators::<Test>(domain_id, vec![operator_id].into_iter(), rewards)
-                    .unwrap();
+                do_reward_operators::<Test>(
+                    domain_id,
+                    OperatorRewardSource::Dummy,
+                    vec![operator_id].into_iter(),
+                    rewards,
+                )
+                .unwrap();
             }
 
             do_finalize_domain_current_epoch::<Test>(domain_id).unwrap();
@@ -864,8 +875,13 @@ mod tests {
             Operators::<Test>::insert(operator_id, operator);
             let expected_operator_tax = nomination_tax.mul_ceil(operator_rewards);
 
-            do_reward_operators::<Test>(domain_id, vec![operator_id].into_iter(), operator_rewards)
-                .unwrap();
+            do_reward_operators::<Test>(
+                domain_id,
+                OperatorRewardSource::Dummy,
+                vec![operator_id].into_iter(),
+                operator_rewards,
+            )
+            .unwrap();
 
             operator_take_reward_tax_and_stake::<Test>(domain_id).unwrap();
             let operator = Operators::<Test>::get(operator_id).unwrap();

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1473,6 +1473,16 @@ impl<Balance> OnChainRewards<Balance> for () {
     fn on_chain_rewards(_chain_id: ChainId, _reward: Balance) {}
 }
 
+#[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
+pub enum OperatorRewardSource<Number> {
+    Bundle {
+        at_block_number: Number,
+    },
+    XDMProtocolFees,
+    #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
+    Dummy,
+}
+
 sp_api::decl_runtime_apis! {
     /// API necessary for domains pallet.
     pub trait DomainsApi<DomainHeader: HeaderT> {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -72,7 +72,8 @@ use sp_core::{ConstBool, OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     ChannelId, DomainAllowlistUpdates, DomainId, DomainInstanceData, ExecutionReceiptFor,
-    OperatorId, OperatorPublicKey, DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
+    OperatorId, OperatorPublicKey, OperatorRewardSource, DOMAIN_STORAGE_FEE_MULTIPLIER,
+    INITIAL_DOMAIN_TX_RANGE,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::{
@@ -590,7 +591,7 @@ impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
         // on consensus chain, reward the domain operators
         // balance is already on this consensus runtime
         if let ChainId::Domain(domain_id) = chain_id {
-            Domains::reward_domain_operators(domain_id, fees)
+            Domains::reward_domain_operators(domain_id, OperatorRewardSource::XDMProtocolFees, fees)
         }
     }
 }
@@ -793,7 +794,11 @@ impl sp_domains::OnChainRewards<Balance> for OnChainRewards {
                     let _ = Balances::deposit_creating(&block_author, reward);
                 }
             }
-            ChainId::Domain(domain_id) => Domains::reward_domain_operators(domain_id, reward),
+            ChainId::Domain(domain_id) => Domains::reward_domain_operators(
+                domain_id,
+                OperatorRewardSource::XDMProtocolFees,
+                reward,
+            ),
         }
     }
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -603,6 +603,24 @@ parameter_types! {
     pub const ChannelFeeModel: FeeModel<Balance> = FeeModel{relay_fee: SSC};
 }
 
+pub struct OnXDMRewards;
+
+impl sp_messenger::OnXDMRewards<Balance> for OnXDMRewards {
+    fn on_xdm_rewards(reward: Balance) {
+        if let Some(block_author) = Subspace::find_block_reward_address() {
+            let _ = Balances::deposit_creating(&block_author, reward);
+        }
+    }
+
+    fn on_chain_protocol_fees(chain_id: ChainId, fees: Balance) {
+        // on consensus chain, reward the domain operators
+        // balance is already on this consensus runtime
+        if let ChainId::Domain(domain_id) = chain_id {
+            Domains::reward_domain_operators(domain_id, OperatorRewardSource::XDMProtocolFees, fees)
+        }
+    }
+}
+
 impl pallet_messenger::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SelfChainId = SelfChainId;
@@ -618,7 +636,7 @@ impl pallet_messenger::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_messenger::weights::SubstrateWeight<Runtime>;
     type WeightToFee = ConstantMultiplier<Balance, TransactionWeightFee>;
-    type OnXDMRewards = ();
+    type OnXDMRewards = OnXDMRewards;
     type MmrHash = mmr::Hash;
     type MmrProofVerifier = MmrProofVerifier;
     type StorageKeys = StorageKeys;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -61,8 +61,8 @@ use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainAllowlistUpdates, DomainId, DomainInstanceData, ExecutionReceiptFor, OpaqueBundle,
-    OpaqueBundles, OperatorId, OperatorPublicKey, DOMAIN_STORAGE_FEE_MULTIPLIER,
-    INITIAL_DOMAIN_TX_RANGE,
+    OpaqueBundles, OperatorId, OperatorPublicKey, OperatorRewardSource,
+    DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::{
@@ -719,7 +719,11 @@ impl sp_domains::OnChainRewards<Balance> for OnChainRewards {
                     let _ = Balances::deposit_creating(&block_author, reward);
                 }
             }
-            ChainId::Domain(domain_id) => Domains::reward_domain_operators(domain_id, reward),
+            ChainId::Domain(domain_id) => Domains::reward_domain_operators(
+                domain_id,
+                OperatorRewardSource::XDMProtocolFees,
+                reward,
+            ),
         }
     }
 }


### PR DESCRIPTION
This PR adds source to the `OperatorRewarded` event (e.g. which consensus block the bundle fee comes from) along with a minor fix to the consensus test runtime.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
