### PR TITLE
Simplify command-line help phrasing

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -34,9 +34,9 @@ pub(crate) struct AuditOptions {
     #[arg(long)]
     with_single: bool,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
-    /// compute-intensive operations during proving), defaults to number of logical CPUs
-    /// available on UMA system and number of logical CPUs in first NUMA node on NUMA system, but
-    /// not more than 32 threads
+    /// compute-intensive operations during proving). Defaults to the number of logical CPUs
+    /// on UMA systems, or the number of logical CPUs in the first NUMA node on NUMA systems, but
+    /// limited to 32 threads.
     #[arg(long)]
     farming_thread_pool_size: Option<NonZeroUsize>,
     /// Disk farm to audit
@@ -57,9 +57,9 @@ pub(crate) struct ProveOptions {
     #[arg(long)]
     with_single: bool,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
-    /// compute-intensive operations during proving), defaults to number of logical CPUs
-    /// available on UMA system and number of logical CPUs in first NUMA node on NUMA system, but
-    /// not more than 32 threads
+    /// compute-intensive operations during proving). Defaults to the number of logical CPUs
+    /// on UMA systems, or the number of logical CPUs in the first NUMA node on NUMA systems, but
+    /// limited to 32 threads.
     #[arg(long)]
     farming_thread_pool_size: Option<NonZeroUsize>,
     /// Disk farm to prove

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster.rs
@@ -52,7 +52,7 @@ struct SharedArgs {
     /// which can be done by starting NATS server with config file containing `max_payload = 2MB`.
     #[arg(long = "nats-server", required = true)]
     nats_servers: Vec<ServerAddr>,
-    /// Defines endpoints for the prometheus metrics server. It doesn't start without at least
+    /// Endpoints for the prometheus metrics server. It doesn't start without at least
     /// one specified endpoint. Format: 127.0.0.1:8080
     #[arg(long, aliases = ["metrics-endpoint", "metrics-endpoints"])]
     prometheus_listen_on: Vec<SocketAddr>,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -45,7 +45,7 @@ const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(40);
 pub(super) struct ControllerArgs {
     /// Piece getter concurrency.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long, default_value = "128")]
     piece_getter_concurrency: NonZeroUsize,
     /// Base path where to store P2P network identity

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -46,13 +46,13 @@ pub(super) const FARMER_IDENTIFICATION_BROADCAST_INTERVAL: Duration = Duration::
 /// Arguments for farmer
 #[derive(Debug, Parser)]
 pub(super) struct FarmerArgs {
-    /// One or more farm located at specified path, each with its own allocated space.
+    /// One or more farms located at specified paths, each with its own allocated space.
     ///
     /// In case of multiple disks, it is recommended to specify them individually rather than using
     /// RAID 0, that way farmer will be able to better take advantage of concurrency of individual
     /// drives.
     ///
-    /// Format for each farm is coma-separated list of strings like this:
+    /// The format for each farm is a coma-separated list of strings like this:
     ///
     ///   path=/path/to/directory,size=5T
     ///
@@ -65,33 +65,33 @@ pub(super) struct FarmerArgs {
     /// Address for farming rewards
     #[arg(long, value_parser = parse_ss58_reward_address)]
     reward_address: PublicKey,
-    /// Run temporary farmer with specified farm size in human-readable format (e.g. 10GB, 2TiB) or
+    /// Run a temporary farmer with a farm size in human-readable format (e.g. 10GB, 2TiB) or
     /// just bytes (e.g. 4096), this will create a temporary directory that will be deleted at the
     /// end of the process.
     #[arg(long, conflicts_with = "disk_farms")]
     tmp: Option<ByteSize>,
-    /// Maximum number of pieces in sector (can override protocol value to something lower).
+    /// Maximum number of pieces in a sector (can override protocol value to something lower).
     ///
     /// This will make plotting of individual sectors faster, decrease load on CPU proving, but also
     /// proportionally increase amount of disk reads during audits since every sector needs to be
     /// audited and there will be more of them.
     ///
-    /// This is primarily for development and not recommended to use by regular users.
+    /// This is primarily for development and not recommended for regular users.
     #[arg(long)]
     max_pieces_in_sector: Option<u16>,
     /// Do not print info about configured farms on startup
     #[arg(long)]
     no_info: bool,
-    /// Defines max number sectors farmer will encode concurrently, defaults to 50. Might be limited
+    /// The maximum number sectors a farmer will encode concurrently, defaults to 50. Might be limited
     /// by plotting capacity available in the cluster.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long, default_value = "50")]
     sector_encoding_concurrency: NonZeroUsize,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
-    /// compute-intensive operations during proving), defaults to number of logical CPUs
-    /// available on UMA system and number of logical CPUs in first NUMA node on NUMA system, but
-    /// not more than 32 threads
+    /// compute-intensive operations during proving). Defaults to the number of logical CPUs
+    /// on UMA systems, or the number of logical CPUs in the first NUMA node on NUMA systems, but
+    /// limited to 32 threads.
     #[arg(long)]
     farming_thread_pool_size: Option<NonZeroUsize>,
     /// Disable farm locking, for example if file system doesn't support it

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -35,14 +35,14 @@ const PLOTTING_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Parser)]
 struct CpuPlottingOptions {
-    /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
-    /// the plotting process, defaults to `--cpu-sector-encoding-concurrency` + 1 to download future
+    /// How many sectors the farmer will download concurrently. Limits the memory usage of
+    /// the plotting process. Defaults to `--cpu-sector-encoding-concurrency` + 1 to download future
     /// sector ahead of time.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long)]
     cpu_sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Defines how many sectors farmer will encode concurrently, defaults to 1 on UMA system and
+    /// How many sectors the farmer will encode concurrently. Defaults to 1 on UMA system and the
     /// number of NUMA nodes on NUMA system or L3 cache groups on large CPUs. It is further
     /// restricted by
     /// `--cpu-sector-downloading-concurrency` and setting this option higher than
@@ -50,27 +50,27 @@ struct CpuPlottingOptions {
     ///
     /// CPU plotting is disabled by default if GPU plotting is detected.
     ///
-    /// Increase will result in higher memory usage, setting to 0 will disable CPU plotting.
+    /// Increasing this value will cause higher memory usage. Set to 0 to disable CPU plotting.
     #[arg(long)]
     cpu_sector_encoding_concurrency: Option<usize>,
-    /// Defines how many records farmer will encode in a single sector concurrently, defaults to one
+    /// How many records the farmer will encode in a single sector concurrently. Defaults to one
     /// record per 2 cores, but not more than 8 in total. Higher concurrency means higher memory
-    /// usage and typically more efficient CPU utilization.
+    /// usage, and typically more efficient CPU utilization.
     #[arg(long)]
     cpu_record_encoding_concurrency: Option<NonZeroUsize>,
-    /// Size of one thread pool used for plotting, defaults to number of logical CPUs available
+    /// Size of one thread pool used for plotting. Defaults to number of logical CPUs available
     /// on UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
     /// groups on large CPUs.
     ///
-    /// Number of thread pools is defined by `--cpu-sector-encoding-concurrency` option, different
-    /// thread pools might have different number of threads if NUMA nodes do not have the same size.
+    /// The number of thread pools is defined by `--cpu-sector-encoding-concurrency` option. Different
+    /// thread pools might have different numbers of threads if NUMA nodes do not have the same size.
     ///
     /// Threads will be pinned to corresponding CPU cores at creation.
     #[arg(long)]
     cpu_plotting_thread_pool_size: Option<NonZeroUsize>,
-    /// Specify exact CPU cores to be used for plotting bypassing any custom logic farmer might use
-    /// otherwise. It replaces both `--cpu-sector-encoding-concurrency` and
-    /// `--cpu-plotting-thread-pool-size` options if specified.
+    /// Set the exact CPU cores to be used for plotting, bypassing any custom logic in the farmer.
+    /// Replaces both `--cpu-sector-encoding-concurrency` and
+    /// `--cpu-plotting-thread-pool-size` options.
     ///
     /// Cores are coma-separated, with whitespace separating different thread pools/encoding
     /// instances. For example "0,1 2,3" will result in two sectors being encoded at the same time,
@@ -87,17 +87,17 @@ struct CpuPlottingOptions {
 #[cfg(feature = "cuda")]
 #[derive(Debug, Parser)]
 struct CudaPlottingOptions {
-    /// Defines how many sectors farmer will download concurrently during plotting with CUDA GPU,
-    /// allows to limit memory usage of the plotting process, defaults to number of CUDA GPUs found
-    /// + 1 to download future sector ahead of time.
+    /// How many sectors farmer will download concurrently during plotting with CUDA GPUs.
+    /// Limits memory usage of the plotting process. Defaults to the number of CUDA GPUs + 1,
+    /// to download future sectors ahead of time.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long)]
     cuda_sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Specify exact GPUs to be used for plotting instead of using all GPUs (default behavior).
+    /// Set the exact GPUs to be used for plotting, instead of using all GPUs (default behavior).
     ///
-    /// GPUs are coma-separated: `--cuda-gpus 0,1,3`. Empty string can be specified to disable CUDA
-    /// GPU usage.
+    /// GPUs are coma-separated: `--cuda-gpus 0,1,3`. Use an empty string to disable CUDA
+    /// GPUs.
     #[arg(long)]
     cuda_gpus: Option<String>,
 }
@@ -105,17 +105,17 @@ struct CudaPlottingOptions {
 #[cfg(feature = "rocm")]
 #[derive(Debug, Parser)]
 struct RocmPlottingOptions {
-    /// Defines how many sectors farmer will download concurrently during plotting with ROCm GPU,
-    /// allows to limit memory usage of the plotting process, defaults to number of ROCm GPUs found
-    /// + 1 to download future sector ahead of time.
+    /// How many sectors the farmer will download concurrently during plotting with ROCm GPUs.
+    /// Limits memory usage of the plotting process. Defaults to number of ROCm GPUs + 1,
+    /// to download future sectors ahead of time.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long)]
     rocm_sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Specify exact GPUs to be used for plotting instead of using all GPUs (default behavior).
+    /// Set the exact GPUs to be used for plotting, instead of using all GPUs (default behavior).
     ///
-    /// GPUs are coma-separated: `--rocm-gpus 0,1,3`. Empty string can be specified to disable ROCm
-    /// GPU usage.
+    /// GPUs are coma-separated: `--rocm-gpus 0,1,3`. Use an empty string to disable ROCm
+    /// GPUs.
     #[arg(long)]
     rocm_gpus: Option<String>,
 }
@@ -125,8 +125,8 @@ struct RocmPlottingOptions {
 pub(super) struct PlotterArgs {
     /// Piece getter concurrency.
     ///
-    /// Increase can result in NATS communication issues if too many messages arrive via NATS, but
-    /// are not processed quickly enough for some reason.
+    /// Increasing this value can cause NATS communication issues if too many messages arrive via NATS, but
+    /// are not processed quickly enough.
     #[arg(long, default_value = "32")]
     piece_getter_concurrency: NonZeroUsize,
     /// Plotting options only used by CPU plotter

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -73,14 +73,14 @@ type CacheIndex = u8;
 
 #[derive(Debug, Parser)]
 struct CpuPlottingOptions {
-    /// Defines how many sectors farmer will download concurrently, allows to limit memory usage of
-    /// the plotting process, defaults to `--cpu-sector-encoding-concurrency` + 1 to download future
+    /// How many sectors a farmer will download concurrently. Limits memory usage of
+    /// the plotting process. Defaults to `--cpu-sector-encoding-concurrency` + 1 to download future
     /// sector ahead of time.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long)]
     cpu_sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Defines how many sectors farmer will encode concurrently, defaults to 1 on UMA system and
+    /// How many sectors a farmer will encode concurrently. Defaults to 1 on UMA system and
     /// number of NUMA nodes on NUMA system or L3 cache groups on large CPUs. It is further
     /// restricted by
     /// `--cpu-sector-downloading-concurrency` and setting this option higher than
@@ -88,15 +88,15 @@ struct CpuPlottingOptions {
     ///
     /// CPU plotting is disabled by default if GPU plotting is detected.
     ///
-    /// Increase will result in higher memory usage, setting to 0 will disable CPU plotting.
+    /// Increasing this value will cause higher memory usage. Set to 0 to disable CPU plotting.
     #[arg(long)]
     cpu_sector_encoding_concurrency: Option<usize>,
-    /// Defines how many records farmer will encode in a single sector concurrently, defaults to one
+    /// How many records a farmer will encode in a single sector concurrently. Defaults to one
     /// record per 2 cores, but not more than 8 in total. Higher concurrency means higher memory
     /// usage and typically more efficient CPU utilization.
     #[arg(long)]
     cpu_record_encoding_concurrency: Option<NonZeroUsize>,
-    /// Size of one thread pool used for plotting, defaults to number of logical CPUs available
+    /// Size of one thread pool used for plotting. Defaults to the number of logical CPUs available
     /// on UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
     /// groups on large CPUs.
     ///
@@ -106,9 +106,9 @@ struct CpuPlottingOptions {
     /// Threads will be pinned to corresponding CPU cores at creation.
     #[arg(long)]
     cpu_plotting_thread_pool_size: Option<NonZeroUsize>,
-    /// Specify exact CPU cores to be used for plotting bypassing any custom logic farmer might use
-    /// otherwise. It replaces both `--cpu-sector-encoding-concurrency` and
-    /// `--cpu-plotting-thread-pool-size` options if specified. Requires `--cpu-replotting-cores` to
+    /// Set the exact CPU cores to be used for plotting bypassing any custom farmer logic.
+    /// Replaces both `--cpu-sector-encoding-concurrency` and
+    /// `--cpu-plotting-thread-pool-size` options. Requires `--cpu-replotting-cores` to
     /// be specified with the same number of CPU cores groups (or not specified at all, in which
     /// case it'll use the same thread pool as plotting).
     ///
@@ -118,9 +118,9 @@ struct CpuPlottingOptions {
     #[arg(long, conflicts_with_all = & ["cpu_sector_encoding_concurrency", "cpu_plotting_thread_pool_size"])]
     cpu_plotting_cores: Option<String>,
     /// Size of one thread pool used for replotting, typically smaller pool than for plotting
-    /// to not affect farming as much, defaults to half of the number of logical CPUs available on
-    /// UMA system and number of logical CPUs available in NUMA node on NUMA system or L3 cache
-    /// groups on large CPUs.
+    /// to not affect farming as much. Defaults to half the number of logical CPUs on UMA systems,
+    /// half the number of logical CPUs in the local NUMA node on NUMA systems, or half the L3
+    /// cache group on large CPUs.
     ///
     /// Number of thread pools is defined by `--cpu-sector-encoding-concurrency` option, different
     /// thread pools might have different number of threads if NUMA nodes do not have the same size.
@@ -128,8 +128,8 @@ struct CpuPlottingOptions {
     /// Threads will be pinned to corresponding CPU cores at creation.
     #[arg(long)]
     cpu_replotting_thread_pool_size: Option<NonZeroUsize>,
-    /// Specify exact CPU cores to be used for replotting bypassing any custom logic farmer might
-    /// use otherwise. It replaces `--cpu-replotting-thread-pool-size` options if specified.
+    /// Set the exact CPU cores to be used for replotting, bypassing any custom farmer logic.
+    /// Replaces `--cpu-replotting-thread-pool-size` option if specified.
     /// Requires `--cpu-plotting-cores` to be specified with the same number of CPU cores groups.
     ///
     /// Cores are coma-separated, with whitespace separating different thread pools/encoding
@@ -147,17 +147,17 @@ struct CpuPlottingOptions {
 #[cfg(feature = "cuda")]
 #[derive(Debug, Parser)]
 struct CudaPlottingOptions {
-    /// Defines how many sectors farmer will download concurrently during plotting with CUDA GPU,
-    /// allows to limit memory usage of the plotting process, defaults to number of CUDA GPUs found
+    /// How many sectors a farmer will download concurrently during plotting with a CUDA GPU.
+    /// Limits memory usage of the plotting process. Defaults to the number of CUDA GPUs found
     /// + 1 to download future sector ahead of time.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long)]
     cuda_sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Specify exact GPUs to be used for plotting instead of using all GPUs (default behavior).
+    /// Set the exact GPUs to be used for plotting instead of using all GPUs (default behavior).
     ///
-    /// GPUs are coma-separated: `--cuda-gpus 0,1,3`. Empty string can be specified to disable CUDA
-    /// GPU usage.
+    /// GPUs are coma-separated: `--cuda-gpus 0,1,3`. Use an empty string to disable CUDA
+    /// GPUs.
     #[arg(long)]
     cuda_gpus: Option<String>,
 }
@@ -165,17 +165,17 @@ struct CudaPlottingOptions {
 #[cfg(feature = "rocm")]
 #[derive(Debug, Parser)]
 struct RocmPlottingOptions {
-    /// Defines how many sectors farmer will download concurrently during plotting with ROCm GPU,
-    /// allows to limit memory usage of the plotting process, defaults to number of ROCm GPUs found
+    /// How many sectors a farmer will download concurrently during plotting with a ROCm GPU.
+    /// Limits memory usage of the plotting process. Defaults to the number of ROCm GPUs found
     /// + 1 to download future sector ahead of time.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long)]
     rocm_sector_downloading_concurrency: Option<NonZeroUsize>,
-    /// Specify exact GPUs to be used for plotting instead of using all GPUs (default behavior).
+    /// Set the exact GPUs to be used for plotting instead of using all GPUs (default behavior).
     ///
-    /// GPUs are coma-separated: `--rocm-gpus 0,1,3`. Empty string can be specified to disable ROCm
-    /// GPU usage.
+    /// GPUs are coma-separated: `--rocm-gpus 0,1,3`. Use an empty string to disable ROCm
+    /// GPUs.
     #[arg(long)]
     rocm_gpus: Option<String>,
 }
@@ -183,13 +183,13 @@ struct RocmPlottingOptions {
 /// Arguments for farmer
 #[derive(Debug, Parser)]
 pub(crate) struct FarmingArgs {
-    /// One or more farm located at specified path, each with its own allocated space.
+    /// One or more farms located at specified paths, each with its own allocated space.
     ///
     /// In case of multiple disks, it is recommended to specify them individually rather than using
     /// RAID 0, that way farmer will be able to better take advantage of concurrency of individual
     /// drives.
     ///
-    /// Format for each farm is coma-separated list of strings like this:
+    /// The format for each farm is coma-separated list of strings like this:
     ///
     ///   path=/path/to/directory,size=5T
     ///
@@ -211,18 +211,18 @@ pub(crate) struct FarmingArgs {
     /// Sets some flags that are convenient during development, currently `--allow-private-ips`
     #[arg(long)]
     dev: bool,
-    /// Run temporary farmer with specified plot size in human-readable format (e.g. 10GB, 2TiB) or
-    /// just bytes (e.g. 4096), this will create a temporary directory that will be deleted at the
+    /// Run a temporary farmer with a plot size in human-readable format (e.g. 10GB, 2TiB) or
+    /// just bytes (e.g. 4096). This will create a temporary directory that will be deleted at the
     /// end of the process.
     #[arg(long, conflicts_with = "disk_farms")]
     tmp: Option<ByteSize>,
-    /// Maximum number of pieces in sector (can override protocol value to something lower).
+    /// Maximum number of pieces in a sector (can override protocol value to something lower).
     ///
     /// This will make plotting of individual sectors faster, decrease load on CPU proving, but also
     /// proportionally increase amount of disk reads during audits since every sector needs to be
     /// audited and there will be more of them.
     ///
-    /// This is primarily for development and not recommended to use by regular users.
+    /// This is primarily for development and not recommended for regular users.
     #[arg(long)]
     max_pieces_in_sector: Option<u16>,
     /// Network parameters
@@ -231,19 +231,19 @@ pub(crate) struct FarmingArgs {
     /// Do not print info about configured farms on startup
     #[arg(long)]
     no_info: bool,
-    /// Defines endpoints for the prometheus metrics server. It doesn't start without at least
+    /// Endpoints for the prometheus metrics server. It doesn't start without at least
     /// one specified endpoint. Format: 127.0.0.1:8080
     #[arg(long, aliases = ["metrics-endpoint", "metrics-endpoints"])]
     prometheus_listen_on: Vec<SocketAddr>,
     /// Piece getter concurrency.
     ///
-    /// Increase will result in higher memory usage.
+    /// Increasing this value will cause higher memory usage.
     #[arg(long, default_value = "128")]
     piece_getter_concurrency: NonZeroUsize,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
-    /// compute-intensive operations during proving), defaults to number of logical CPUs
-    /// available on UMA system and number of logical CPUs in first NUMA node on NUMA system, but
-    /// not more than 32 threads
+    /// compute-intensive operations during proving). Defaults to the number of logical CPUs
+    /// on UMA systems, or the number of logical CPUs in first NUMA node on NUMA systems, but
+    /// limited to 32 threads.
     #[arg(long)]
     farming_thread_pool_size: Option<NonZeroUsize>,
     /// Plotting options only used by CPU plotter

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -45,7 +45,7 @@ pub(in super::super) struct NetworkArgs {
     /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
     #[arg(long)]
     pub(in super::super) bootstrap_nodes: Vec<Multiaddr>,
-    /// Multiaddr to listen on for subspace networking, for instance `/ip4/0.0.0.0/tcp/0`,
+    /// Multiaddrs to listen on for subspace networking, for instance `/ip4/0.0.0.0/tcp/0`,
     /// multiple are supported.
     #[arg(long, default_values_t = [
         Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
@@ -54,26 +54,26 @@ pub(in super::super) struct NetworkArgs {
             .with(Protocol::Tcp(30533))
     ])]
     pub(in super::super) listen_on: Vec<Multiaddr>,
-    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in
-    /// Kademlia DHT.
+    /// Enable non-global (private, shared, loopback..) addresses in Kademlia DHT.
+    /// By default, these addresses are excluded from the DHT.
     #[arg(long, default_value_t = false)]
     pub(in super::super) allow_private_ips: bool,
     /// Multiaddrs of reserved nodes to maintain a connection to, multiple are supported
     #[arg(long)]
     pub(in super::super) reserved_peers: Vec<Multiaddr>,
-    /// Defines max established incoming connection limit.
+    /// Maximum established incoming connection limit.
     #[arg(long, default_value_t = 300)]
     pub(in super::super) in_connections: u32,
-    /// Defines max established outgoing swarm connection limit.
+    /// Maximum established outgoing swarm connection limit.
     #[arg(long, default_value_t = 100)]
     pub(in super::super) out_connections: u32,
-    /// Defines max pending incoming connection limit.
+    /// Maximum pending incoming connection limit.
     #[arg(long, default_value_t = 100)]
     pub(in super::super) pending_in_connections: u32,
-    /// Defines max pending outgoing swarm connection limit.
+    /// Maximum pending outgoing swarm connection limit.
     #[arg(long, default_value_t = 100)]
     pub(in super::super) pending_out_connections: u32,
-    /// Known external addresses
+    /// Known external addresses.
     #[arg(long = "external-address")]
     pub(in super::super) external_addresses: Vec<Multiaddr>,
 }

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -98,10 +98,10 @@ struct Args {
     /// production use.
     #[arg(long, required = true)]
     protocol_version: String,
-    /// Defines max established outgoing connections limit for the peer.
+    /// Maximum established outgoing connections limit for the peer.
     #[arg(long, default_value_t = 100)]
     out_peers: u32,
-    /// Defines max pending outgoing connections limit for the peer.
+    /// Maximum pending outgoing connections limit for the peer.
     #[arg(long, default_value_t = 100)]
     pending_out_peers: u32,
     #[clap(subcommand)]

--- a/crates/subspace-networking/examples/random-walker.rs
+++ b/crates/subspace-networking/examples/random-walker.rs
@@ -37,10 +37,10 @@ struct Args {
     /// production use.
     #[arg(long, required = true)]
     protocol_version: String,
-    /// Defines max established outgoing connections limit for the peer.
+    /// Maximum established outgoing connections limit for the peer.
     #[arg(long, default_value_t = 100)]
     out_peers: u32,
-    /// Defines max pending outgoing connections limit for the peer.
+    /// Maximum pending outgoing connections limit for the peer.
     #[arg(long, default_value_t = 100)]
     pending_out_peers: u32,
     /// Enable piece retrieval retries on unsuccessful requests.

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -52,19 +52,20 @@ enum Command {
         /// Multiaddresses of reserved peers to maintain connections to, multiple are supported
         #[arg(long = "reserved-peer")]
         reserved_peers: Vec<Multiaddr>,
-        /// Defines max established incoming connections limit for the peer.
+        /// Maximum established incoming connections limit for the peer.
         #[arg(long, default_value_t = 300)]
         in_peers: u32,
-        /// Defines max established outgoing connections limit for the peer.
+        /// Maximum established outgoing connections limit for the peer.
         #[arg(long, default_value_t = 300)]
         out_peers: u32,
-        /// Defines max pending incoming connections limit for the peer.
+        /// Maximum pending incoming connections limit for the peer.
         #[arg(long, default_value_t = 300)]
         pending_in_peers: u32,
-        /// Defines max pending outgoing connections limit for the peer.
+        /// Maximum pending outgoing connections limit for the peer.
         #[arg(long, default_value_t = 300)]
         pending_out_peers: u32,
-        /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses in Kademlia DHT.
+        /// Enable non-global (private, shared, loopback..) addresses in the Kademlia DHT.
+        /// By default these addresses are excluded from the DHT.
         #[arg(long, default_value_t = false)]
         allow_private_ips: bool,
         /// Protocol version for libp2p stack, should be set as genesis hash of the blockchain for
@@ -74,14 +75,14 @@ enum Command {
         /// Known external addresses
         #[arg(long = "external-address")]
         external_addresses: Vec<Multiaddr>,
-        /// Defines endpoints for the prometheus metrics server. It doesn't start without at least
-        /// one specified endpoint. Format: 127.0.0.1:8080
+        /// Endpoints for the prometheus metrics server. It doesn't start without at least one
+        /// specified endpoint. Format: 127.0.0.1:8080
         #[arg(long, aliases = ["metrics-endpoint", "metrics-endpoints"])]
         prometheus_listen_on: Vec<SocketAddr>,
     },
     /// Generate a new keypair
     GenerateKeypair {
-        /// Produce an output in JSON format when enabled.
+        /// Produce output in JSON format.
         #[arg(long, default_value_t = false)]
         json: bool,
     },

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -431,7 +431,7 @@ impl Node {
     /// Get closest peers by multihash key using Kademlia DHT's local view without any network
     /// requests.
     ///
-    /// Optional `source` is peer for which results will be sent as a response, defaults to local
+    /// Optional `source` is peer for which results will be sent as a response. Defaults to local
     /// peer ID.
     pub async fn get_closest_local_peers(
         &self,

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -60,15 +60,15 @@ fn parse_timekeeper_cpu_cores(
 /// Options for Substrate networking
 #[derive(Debug, Parser)]
 struct SubstrateNetworkOptions {
-    /// Specify a list of bootstrap nodes for Substrate networking stack.
+    /// A list of bootstrap nodes for the Substrate networking stack.
     #[arg(long)]
     bootstrap_nodes: Vec<MultiaddrWithPeerId>,
 
-    /// Specify a list of reserved node addresses.
+    /// A list of reserved node addresses, which are prioritised for connections.
     #[arg(long)]
     reserved_nodes: Vec<MultiaddrWithPeerId>,
 
-    /// Whether to only synchronize the chain with reserved nodes.
+    /// Only synchronize the chain with reserved nodes.
     ///
     /// TCP connections might still be established with non-reserved nodes.
     /// In particular, if you are a farmer your node might still connect to other farmer nodes
@@ -76,14 +76,14 @@ struct SubstrateNetworkOptions {
     #[arg(long)]
     reserved_only: bool,
 
-    /// The public address that other nodes will use to connect to it.
+    /// The public address that other nodes will use to connect to this node.
     ///
     /// This can be used if there's a proxy in front of this node or if address is known beforehand
     /// and less reliable auto-discovery can be avoided.
     #[arg(long)]
     public_addr: Vec<sc_network::Multiaddr>,
 
-    /// Listen on this multiaddress
+    /// Listen for incoming Substrate connections on these multiaddresses.
     #[arg(long, default_values_t = [
         sc_network::Multiaddr::from(sc_network::multiaddr::Protocol::Ip4(Ipv4Addr::UNSPECIFIED))
             .with(sc_network::multiaddr::Protocol::Tcp(30333)),
@@ -92,12 +92,12 @@ struct SubstrateNetworkOptions {
     ])]
     listen_on: Vec<sc_network::Multiaddr>,
 
-    /// Determines whether we allow keeping non-global (private, shared, loopback..) addresses
-    /// in Kademlia DHT.
+    /// Enable non-global (private, shared, loopback..) addresses in the Kademlia DHT.
+    /// By default these addresses are excluded from the DHT.
     #[arg(long, default_value_t = false)]
     allow_private_ips: bool,
 
-    /// Specify the number of outgoing connections we're trying to maintain.
+    /// The number of outgoing connections we will try to maintain.
     #[arg(long, default_value_t = 8)]
     out_peers: u32,
 
@@ -119,7 +119,7 @@ struct SubstrateNetworkOptions {
 /// Options for DSN
 #[derive(Debug, Parser)]
 struct DsnOptions {
-    /// Where local DSN node will listen for incoming connections.
+    /// Listen for incoming DSN connections on these multiaddresses.
     #[arg(long, default_values_t = [
         Multiaddr::from(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
             .with(Protocol::Tcp(30433)),
@@ -136,23 +136,23 @@ struct DsnOptions {
     #[arg(long)]
     dsn_reserved_peers: Vec<Multiaddr>,
 
-    /// Defines max established incoming connection limit for DSN.
+    /// Maximum established incoming connection limit for DSN.
     #[arg(long, default_value_t = 50)]
     dsn_in_connections: u32,
 
-    /// Defines max established outgoing swarm connection limit for DSN.
+    /// Maximum established outgoing swarm connection limit for DSN.
     #[arg(long, default_value_t = 150)]
     dsn_out_connections: u32,
 
-    /// Defines max pending incoming connection limit for DSN.
+    /// Maximum pending incoming connection limit for DSN.
     #[arg(long, default_value_t = 100)]
     dsn_pending_in_connections: u32,
 
-    /// Defines max pending outgoing swarm connection limit for DSN.
+    /// Maximum pending outgoing swarm connection limit for DSN.
     #[arg(long, default_value_t = 150)]
     dsn_pending_out_connections: u32,
 
-    /// Known external addresses
+    /// Known external addresses.
     #[arg(long = "dsn-external-address")]
     dsn_external_addresses: Vec<Multiaddr>,
 }
@@ -234,7 +234,7 @@ impl fmt::Display for BlocksPruningMode {
 /// Parameters to define the pruning mode
 #[derive(Debug, Clone, Parser)]
 struct PruningOptions {
-    /// Specify the state pruning mode.
+    /// The state pruning mode.
     ///
     /// This mode specifies when the block's state (ie, storage) should be pruned (ie, removed)
     /// from the database.
@@ -247,7 +247,7 @@ struct PruningOptions {
     #[arg(long, default_value_t = StatePruningMode::Number(MIN_STATE_PRUNING))]
     state_pruning: StatePruningMode,
 
-    /// Specify the blocks pruning mode.
+    /// The blocks pruning mode.
     ///
     /// This mode specifies when the block's body (including justifications)
     /// should be pruned (ie, removed) from the database.
@@ -305,13 +305,13 @@ struct TimekeeperOptions {
 /// Options for running a node
 #[derive(Debug, Parser)]
 pub(super) struct ConsensusChainOptions {
-    /// Base path where to store node files.
+    /// Base path to store node files.
     ///
     /// Required unless --dev mode is used.
     #[arg(long)]
     base_path: Option<PathBuf>,
 
-    /// Specify the chain specification.
+    /// The chain specification.
     ///
     /// It can be one of the predefined ones (dev) or it can be a path to a file with the chainspec
     /// (such as one exported by the `build-spec` subcommand).
@@ -378,9 +378,8 @@ pub(super) struct ConsensusChainOptions {
     #[clap(flatten)]
     pool_config: TransactionPoolParams,
 
-    /// Parameter that allows node to forcefully assume it is synced, needed for network
-    /// bootstrapping only, as long as two synced nodes remain on the network at any time, this
-    /// doesn't need to be used.
+    /// Make the node forcefully assume it is synced, needed for network bootstrapping only. As
+    /// long as two synced nodes remain on the network at any time, this doesn't need to be used.
     ///
     /// --dev mode enables this option automatically.
     #[clap(long)]

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -50,16 +50,16 @@ pub struct DsnConfig {
     /// System base path.
     pub network_path: PathBuf,
 
-    /// Defines max established incoming swarm connection limit.
+    /// Maximum established incoming swarm connection limit.
     pub max_in_connections: u32,
 
-    /// Defines max established outgoing swarm connection limit.
+    /// Maximum established outgoing swarm connection limit.
     pub max_out_connections: u32,
 
-    /// Defines max pending incoming swarm connection limit.
+    /// Maximum pending incoming swarm connection limit.
     pub max_pending_in_connections: u32,
 
-    /// Defines max pending outgoing swarm connection limit.
+    /// Maximum pending outgoing swarm connection limit.
     pub max_pending_out_connections: u32,
 
     /// Known external addresses


### PR DESCRIPTION
This PR simplifies the phrasing of command-line help, to make it easier to read.

To minimise the diff, I have avoided reformatting too many lines.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
