### PR TITLE
Fix resuming future after completion

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -1304,13 +1304,11 @@ where
 
         // Drive above future and stream back any pieces that were downloaded so far
         stream::poll_fn(move |cx| {
-            let end_result = fut.poll_unpin(cx);
-
-            if let Ok(maybe_result) = rx.try_next() {
+            if let Poll::Ready(maybe_result) = rx.poll_next_unpin(cx) {
                 return Poll::Ready(maybe_result);
             }
 
-            end_result.map(|((), ())| None)
+            fut.poll_unpin(cx).map(|((), ())| None)
         })
     }
 

--- a/crates/subspace-farmer/src/farmer_piece_getter.rs
+++ b/crates/subspace-farmer/src/farmer_piece_getter.rs
@@ -393,13 +393,11 @@ where
 
         // Drive above future and stream back any pieces that were downloaded so far
         Ok(Box::new(stream::poll_fn(move |cx| {
-            let end_result = fut.poll_unpin(cx);
-
-            if let Ok(maybe_result) = rx.try_next() {
+            if let Poll::Ready(maybe_result) = rx.poll_next_unpin(cx) {
                 return Poll::Ready(maybe_result);
             }
 
-            end_result.map(|()| None)
+            fut.poll_unpin(cx).map(|()| None)
         })))
     }
 }

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -98,13 +98,11 @@ where
 
         // Drive above future and stream back any pieces that were downloaded so far
         stream::poll_fn(move |cx| {
-            let end_result = fut.poll_unpin(cx);
-
-            if let Ok(maybe_result) = rx.try_next() {
+            if let Poll::Ready(maybe_result) = rx.poll_next_unpin(cx) {
                 return Poll::Ready(maybe_result);
             }
 
-            end_result.map(|()| None)
+            fut.poll_unpin(cx).map(|()| None)
         })
     }
 


### PR DESCRIPTION
By draining stream first we avoid unnecessary polling of the future and avoid calling it after completion.

Without this we could get this in some cases:
```
thread 'tokio-runtime-worker' panicked at subspace/crates/subspace-farmer/src/farmer_cache.rs:1191:32:
`async fn` resumed after completion
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
