### PR TITLE
Fix incorrect `stream::poll_fn` implementation

### DIFF
--- a/crates/subspace-farmer-components/src/plotting.rs
+++ b/crates/subspace-farmer-components/src/plotting.rs
@@ -279,7 +279,7 @@ where
             pieces_to_download
                 .entry(piece_index)
                 .or_default()
-                .push((record, metadata))
+                .push((record, metadata));
         }
         // This map will be mutated, removing piece indices we have already processed
         let pieces_to_download = AsyncMutex::new(pieces_to_download);
@@ -786,6 +786,15 @@ where
                 }
             }
         }
+    }
+
+    if final_result.is_ok() && !pieces_to_download.is_empty() {
+        return Err(PlottingError::FailedToRetrievePieces {
+            error: anyhow::anyhow!(
+                "Successful result, but not all pieces were downloaded, this is likely a piece \
+                getter implementation bug"
+            ),
+        });
     }
 
     final_result

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1490,7 +1490,11 @@ where
                             .condition(PeerCondition::DisconnectedAndNotDialing)
                             .build(),
                     ) {
-                        warn!(%error, "Failed to dial disconnected peer on generic request");
+                        warn!(
+                            %error,
+                            %peer_id,
+                            "Failed to dial disconnected peer on generic request"
+                        );
                     }
                 } else {
                     self.swarm.behaviour_mut().request_response.send_request(

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -10,6 +10,7 @@ use crate::utils::multihash::ToMultihash;
 use crate::{Multihash, Node};
 use async_trait::async_trait;
 use futures::channel::mpsc;
+use futures::future::FusedFuture;
 use futures::stream::FuturesUnordered;
 use futures::task::noop_waker_ref;
 use futures::{stream, FutureExt, Stream, StreamExt};
@@ -89,20 +90,27 @@ where
         PieceIndices: IntoIterator<Item = PieceIndex> + 'a,
     {
         let (tx, mut rx) = mpsc::unbounded();
-        let mut fut = Box::pin(get_from_cache_inner(
+        let fut = get_from_cache_inner(
             piece_indices.into_iter(),
             &self.node,
             &self.piece_validator,
             tx,
-        ));
+        );
+        let mut fut = Box::pin(fut.fuse());
 
         // Drive above future and stream back any pieces that were downloaded so far
         stream::poll_fn(move |cx| {
+            if !fut.is_terminated() {
+                // Result doesn't matter, we'll need to poll stream below anyway
+                let _ = fut.poll_unpin(cx);
+            }
+
             if let Poll::Ready(maybe_result) = rx.poll_next_unpin(cx) {
                 return Poll::Ready(maybe_result);
             }
 
-            fut.poll_unpin(cx).map(|()| None)
+            // Exit will be done by the stream above
+            Poll::Pending
         })
     }
 


### PR DESCRIPTION
https://github.com/autonomys/subspace/pull/3142 was not a 100% correct fix, it was dropping the very last element of the stream :upside_down_face: 

A simpler and easier to understand solution is to simply create a fused future and check whether it ended or not explicitly.

The consequence of buggy implementation was silent creation of broken sectors, so I have added additional check for this in the implementation to make sure we catch potentially buggy piece getters that don't satisfy expected invariants in the future.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
