### PR TITLE
Fix request/response with addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.54.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "bytes",
  "either",
@@ -5526,7 +5526,7 @@ dependencies = [
  "libp2p-yamux 0.46.0",
  "multiaddr 0.18.2",
  "pin-project",
- "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0)",
+ "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8)",
  "thiserror",
 ]
 
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "libp2p-core 0.42.0",
  "libp2p-identity",
@@ -5556,7 +5556,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "libp2p-core 0.42.0",
  "libp2p-identity",
@@ -5633,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "either",
  "fnv",
@@ -5642,13 +5642,13 @@ dependencies = [
  "libp2p-identity",
  "multiaddr 0.18.2",
  "multihash 0.19.1",
- "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0)",
+ "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8)",
  "once_cell",
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
  "rand",
- "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0)",
+ "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8)",
  "serde",
  "smallvec",
  "thiserror",
@@ -5677,7 +5677,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "async-trait",
  "futures",
@@ -5692,7 +5692,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.47.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "base64 0.22.1",
@@ -5746,7 +5746,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "either",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.46.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "arrayvec",
  "asynchronous-codec 0.7.0",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "data-encoding",
  "futures",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.15.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "futures",
  "libp2p-core 0.42.0",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -5989,7 +5989,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.45.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "either",
  "futures",
@@ -6006,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.11.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "bytes",
  "futures",
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.27.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "async-trait",
  "futures",
@@ -6128,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.45.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "async-std",
  "either",
@@ -6139,7 +6139,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive 0.35.0",
  "lru",
- "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0)",
+ "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8)",
  "once_cell",
  "rand",
  "smallvec",
@@ -6165,7 +6165,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6176,7 +6176,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "async-trait",
  "futures",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "async-io 2.3.4",
  "futures",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "futures",
  "futures-rustls 0.26.0",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.3.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.46.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "either",
  "futures",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "bytes",
  "futures",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=458d22ef382641a6f42f7baddff99b70f33cdcc0#458d22ef382641a6f42f7baddff99b70f33cdcc0"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=ae7527453146df24aff6afed5f5b9efdffbc15b8#ae7527453146df24aff6afed5f5b9efdffbc15b8"
 dependencies = [
  "futures",
  "pin-project",

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -51,9 +51,10 @@ unsigned-varint = { version = "0.8.0", features = ["futures", "asynchronous_code
 void = "1.0.2"
 
 [dependencies.libp2p]
-# TODO: Replace with upstream once https://github.com/libp2p/rust-libp2p/issues/5626 is resolved
+# TODO: Replace with upstream once https://github.com/libp2p/rust-libp2p/issues/5626 and
+#  https://github.com/libp2p/rust-libp2p/issues/5634 are resolved
 git = "https://github.com/autonomys/rust-libp2p"
-rev = "458d22ef382641a6f42f7baddff99b70f33cdcc0"
+rev = "ae7527453146df24aff6afed5f5b9efdffbc15b8"
 version = "0.54.1"
 default-features = false
 features = [
@@ -77,4 +78,4 @@ features = [
 [dev-dependencies]
 rand = "0.8.5"
 # TODO: Replace with upstream once https://github.com/libp2p/rust-libp2p/issues/5626 is resolved
-libp2p-swarm-test = { version = "0.4.0", git = "https://github.com/autonomys/rust-libp2p", rev = "458d22ef382641a6f42f7baddff99b70f33cdcc0" }
+libp2p-swarm-test = { version = "0.4.0", git = "https://github.com/autonomys/rust-libp2p", rev = "ae7527453146df24aff6afed5f5b9efdffbc15b8" }

--- a/crates/subspace-networking/src/protocols/request_response/request_response_factory.rs
+++ b/crates/subspace-networking/src/protocols/request_response/request_response_factory.rs
@@ -379,10 +379,11 @@ impl RequestResponseFactoryBehaviour {
         request: Vec<u8>,
         pending_response: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
         connect: IfDisconnected,
+        addresses: Vec<Multiaddr>,
     ) {
         if let Some((protocol, _)) = self.protocols.get_mut(protocol_name) {
             if protocol.is_connected(target) || connect.should_connect() {
-                let request_id = protocol.send_request(target, request);
+                let request_id = protocol.send_request(target, request, addresses);
                 let prev_req_id = self.pending_requests.insert(
                     (protocol_name.to_string().into(), request_id).into(),
                     (Instant::now(), pending_response),

--- a/crates/subspace-networking/src/protocols/request_response/request_response_factory/tests.rs
+++ b/crates/subspace-networking/src/protocols/request_response/request_response_factory/tests.rs
@@ -132,6 +132,7 @@ async fn basic_request_response_works() {
         b"this is a request".to_vec(),
         sender,
         IfDisconnected::ImmediateError,
+        Vec::new(),
     );
     // Wait for request to finish
     loop {
@@ -209,6 +210,7 @@ async fn max_response_size_exceeded() {
         b"this is a request".to_vec(),
         sender,
         IfDisconnected::ImmediateError,
+        Vec::new(),
     );
     // Wait for request to finish
     loop {
@@ -349,6 +351,7 @@ async fn request_id_collision() {
         b"this is a request 1".to_vec(),
         sender_1,
         IfDisconnected::ImmediateError,
+        Vec::new(),
     );
     swarm_1.behaviour_mut().send_request(
         &peer_id_2,
@@ -356,6 +359,7 @@ async fn request_id_collision() {
         b"this is a request 2".to_vec(),
         sender_2,
         IfDisconnected::ImmediateError,
+        Vec::new(),
     );
     // Expect both to finish
     loop {


### PR DESCRIPTION
While previous version worked, it didn't behave nicely during concurrent requests to the same peer due to lack of awareness of pending requests, resulting in this:
> 2024-10-17T16:55:57.396088Z  WARN subspace_networking::node_runner: Failed to dial disconnected peer on generic request error=Dial error: dial condition was configured to only happen when both disconnected (`PeerCondition::Disconnected`) and there is currently no ongoing dialing attempt (`PeerCondition::NotDialing`), but node is already connected or dial is in progress, thus cancelling new dial.

While I could fix that with more hacks, I decided to simply patch libp2p while we're discussing it in https://github.com/libp2p/rust-libp2p/issues/5634, here is the patch (`subspace-v8` branch): https://github.com/autonomys/rust-libp2p/commit/ae7527453146df24aff6afed5f5b9efdffbc15b8

Patch adds `addresses` argument to `send_request` method, fixing this issue.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
