### PR TITLE
Minimise features used by RPC servers, support IPv6 CORS

### DIFF
--- a/crates/sc-consensus-subspace-rpc/Cargo.toml
+++ b/crates/sc-consensus-subspace-rpc/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 async-oneshot = "0.5.9"
 futures = "0.3.31"
 futures-timer = "3.0.3"
-jsonrpsee = { version = "0.24.5", features = ["server", "macros"] }
+jsonrpsee = { version = "0.24.5", features = ["server-core", "macros"] }
 parking_lot = "0.12.2"
 schnellru = "0.2.3"
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }

--- a/crates/subspace-gateway-rpc/Cargo.toml
+++ b/crates/subspace-gateway-rpc/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 hex = "0.4.3"
-jsonrpsee = { version = "0.24.5", features = ["server", "macros"] }
+jsonrpsee = { version = "0.24.5", features = ["client-core", "server-core", "macros"] }
 serde = { version = "1.0.110", default-features = false, features = ["alloc", "derive"] }
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-data-retrieval = { version = "0.1.0", path = "../../shared/subspace-data-retrieval" }

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -24,6 +24,6 @@ futures = "0.3.31"
 mimalloc = "0.1.43"
 supports-color = "3.0.1"
 thiserror = "1.0.64"
-tokio = { version = "1.40.0", features = ["macros"] }
+tokio = { version = "1.40.0", features = ["rt-multi-thread", "signal", "macros"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -492,8 +492,10 @@ pub(super) fn create_consensus_chain_configuration(
                 Cors::List(vec![
                     "http://localhost:*".into(),
                     "http://127.0.0.1:*".into(),
+                    "http://[::1]:*".into(),
                     "https://localhost:*".into(),
                     "https://127.0.0.1:*".into(),
+                    "https://[::1]:*".into(),
                     "https://polkadot.js.org".into(),
                 ])
             }

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -190,8 +190,10 @@ pub(super) fn create_domain_configuration(
                 Cors::List(vec![
                     "http://localhost:*".into(),
                     "http://127.0.0.1:*".into(),
+                    "http://[::1]:*".into(),
                     "https://localhost:*".into(),
                     "https://127.0.0.1:*".into(),
+                    "https://[::1]:*".into(),
                     "https://polkadot.js.org".into(),
                 ])
             }

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -24,7 +24,7 @@ domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitive
 frame-benchmarking = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42", optional = true }
 futures = "0.3.31"
 hex = "0.4.3"
-jsonrpsee = { version = "0.24.5", features = ["server"] }
+jsonrpsee = { version = "0.24.5", features = ["server-core"] }
 mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 mmr-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }

--- a/domains/client/eth-service/Cargo.toml
+++ b/domains/client/eth-service/Cargo.toml
@@ -23,7 +23,7 @@ fc-rpc-core = { version = "1.1.0-dev", git = "https://github.com/autonomys/front
 fc-storage = { version = "1.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "f80f9e2bad338f3bf3854b256b3c4edea23e5968" }
 fp-rpc = { version = "3.0.0-dev", git = "https://github.com/autonomys/frontier", rev = "f80f9e2bad338f3bf3854b256b3c4edea23e5968", features = ['default'] }
 futures = "0.3.31"
-jsonrpsee = { version = "0.24.5", features = ["server"] }
+jsonrpsee = { version = "0.24.5", features = ["server-core"] }
 pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 parity-scale-codec = "3.6.12"
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }

--- a/domains/service/Cargo.toml
+++ b/domains/service/Cargo.toml
@@ -22,7 +22,7 @@ domain-client-operator = { version = "0.1.0", path = "../client/domain-operator"
 domain-runtime-primitives = { version = "0.1.0", path = "../primitives/runtime" }
 frame-benchmarking = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42", optional = true }
 futures = "0.3.31"
-jsonrpsee = { version = "0.24.5", features = ["server"] }
+jsonrpsee = { version = "0.24.5", features = ["server-core"] }
 log = "0.4.22"
 pallet-transaction-payment-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 parity-scale-codec = "3.6.12"

--- a/test/subspace-test-service/Cargo.toml
+++ b/test/subspace-test-service/Cargo.toml
@@ -22,7 +22,7 @@ domain-client-message-relayer = { version = "0.1.0", path = "../../domains/clien
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
 frame-system = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 futures = "0.3.31"
-jsonrpsee = { version = "0.24.5", features = ["server"] }
+jsonrpsee = { version = "0.24.5", features = ["server-core"] }
 pallet-transaction-payment = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 mmr-gadget = { git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
 rand = "0.8.5"


### PR DESCRIPTION
This PR makes two changes to RPC servers:
- add IPv6 localhost address to default CORS rules: sometimes `localhost` will resolve to IPv4, IPv6, or both, depending on the local C library and DNS server
- minimise features used by RPC server crates: I tested this by compiling each RPC server crate by itself
    - this also requires a fix to the gateway `tokio` features

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
