### PR TITLE
Add `PieceCache::read_pieces()` method for more efficient piece cache reads in batches

### DIFF
--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -44,7 +44,9 @@ pub trait PieceGetter {
     /// Get piece by index
     async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>>;
 
-    /// Get pieces with provided indices
+    /// Get pieces with provided indices.
+    ///
+    /// Number of elements in returned stream is the same as number of unique `piece_indices`.
     async fn get_pieces<'a, PieceIndices>(
         &'a self,
         piece_indices: PieceIndices,

--- a/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/piece_cache.rs
@@ -81,6 +81,27 @@ impl farm::PieceCache for SingleDiskPieceCache {
             Ok(None)
         }
     }
+
+    async fn read_pieces(
+        &self,
+        offsets: Box<dyn Iterator<Item = PieceCacheOffset> + Send>,
+    ) -> Result<
+        Box<
+            dyn Stream<Item = Result<(PieceCacheOffset, Option<(PieceIndex, Piece)>), FarmError>>
+                + Send
+                + Unpin
+                + '_,
+        >,
+        FarmError,
+    > {
+        if let Some(piece_cache) = &self.maybe_piece_cache {
+            farm::PieceCache::read_pieces(piece_cache, offsets).await
+        } else {
+            Ok(Box::new(stream::iter(
+                offsets.map(|offset| Ok((offset, None))),
+            )))
+        }
+    }
 }
 
 impl SingleDiskPieceCache {

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -81,7 +81,7 @@ where
 
     /// Get pieces with provided indices from cache.
     ///
-    /// Number of elements in returned stream is the same as in `piece_indices`.
+    /// Number of elements in returned stream is the same as number of unique `piece_indices`.
     pub async fn get_from_cache<'a, PieceIndices>(
         &'a self,
         piece_indices: PieceIndices,


### PR DESCRIPTION
This builds on https://github.com/autonomys/subspace/pull/3135 and https://github.com/autonomys/subspace/pull/3141 to implement more efficient piece reading.

For local cache we now have a pool of open files. `DirectIoFile` has mutex internally due to need to manage its read/write buffer for aligned I/O and without pool concurrent reads are not actually happening despite `&self` of the `FileExt` trait it implements. Also it is from our experience with farmer faster to read from multiple handles in general, especially on Windows (though due to memory usage issues Windows is still doing blocking non-concurrent reads).

For cluster cache we now have stream request for faster retrieval of pieces, which was much easier to implement after refactoring done in https://github.com/autonomys/subspace/pull/3141

I also clarified guarantees about returned values in a few places.

The biggest remaining topic is implementing `PieceGetter::get_pieces()` for `ClusterPieceGetter` and remove dummy implementation from `PieceGetter`.

Not particularly happy with number of hashmaps required in piece cache handling, but I didn't want to force all results being returned in-order either and without guaranteed order we need an efficient way to track pieces, hence hashmaps :disappointed: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
