### PR TITLE
Batches in `ClusterPieceGetter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7468,6 +7474,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944fa20996a25aded6b4795c6d63f10014a7a83f8be9828a11860b08c5fc4a67"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd"
+dependencies = [
+ "heck 0.4.1",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8660,6 +8691,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -12507,6 +12551,7 @@ dependencies = [
  "jsonrpsee",
  "mimalloc",
  "num_cpus",
+ "ouroboros",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
@@ -15045,6 +15090,12 @@ dependencies = [
  "static_assertions",
  "web-time",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/crates/subspace-farmer-components/src/lib.rs
+++ b/crates/subspace-farmer-components/src/lib.rs
@@ -54,19 +54,7 @@ pub trait PieceGetter {
         Box<dyn Stream<Item = (PieceIndex, anyhow::Result<Option<Piece>>)> + Send + Unpin + 'a>,
     >
     where
-        PieceIndices: IntoIterator<Item = PieceIndex, IntoIter: Send> + Send + 'a,
-    {
-        // TODO: Remove default impl here
-        Ok(Box::new(
-            piece_indices
-                .into_iter()
-                .map(|piece_index| async move {
-                    let result = self.get_piece(piece_index).await;
-                    (piece_index, result)
-                })
-                .collect::<FuturesUnordered<_>>(),
-        ) as Box<_>)
-    }
+        PieceIndices: IntoIterator<Item = PieceIndex, IntoIter: Send> + Send + 'a;
 }
 
 #[async_trait]

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -39,6 +39,7 @@ hwlocality = { version = "1.0.0-alpha.6", features = ["vendored"], optional = tr
 jsonrpsee = { version = "0.24.5", features = ["ws-client"] }
 mimalloc = { version = "0.1.43", optional = true }
 num_cpus = "1.16.0"
+ouroboros = "0.18.4"
 parity-scale-codec = "3.6.12"
 parking_lot = "0.12.2"
 pin-project = "1.1.5"

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -125,8 +125,8 @@ struct RocmPlottingOptions {
 pub(super) struct PlotterArgs {
     /// Piece getter concurrency.
     ///
-    /// Increasing this value can cause NATS communication issues if too many messages arrive via NATS, but
-    /// are not processed quickly enough.
+    /// Increasing this value can cause NATS communication issues if too many messages arrive via
+    /// NATS, but are not processed quickly enough.
     #[arg(long, default_value = "32")]
     piece_getter_concurrency: NonZeroUsize,
     /// Plotting options only used by CPU plotter

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -132,7 +132,7 @@ impl PieceCache for ClusterPieceCache {
     > {
         Ok(Box::new(
             self.nats_client
-                .stream_request(ClusterCacheContentsRequest, Some(&self.cache_id_string))
+                .stream_request(&ClusterCacheContentsRequest, Some(&self.cache_id_string))
                 .await?
                 .map(|response| response.map_err(FarmError::from)),
         ))
@@ -200,7 +200,7 @@ impl PieceCache for ClusterPieceCache {
         let mut stream = self
             .nats_client
             .stream_request(
-                ClusterCacheReadPiecesRequest { offsets },
+                &ClusterCacheReadPiecesRequest { offsets },
                 Some(&self.cache_id_string),
             )
             .await?

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -90,7 +90,7 @@ impl GenericStreamRequest for ClusterCacheReadPiecesRequest {
     type Response = Result<(PieceCacheOffset, Option<(PieceIndex, Piece)>), String>;
 }
 
-/// Request plotted from farmer, request
+/// Collect plotted pieces from farmer
 #[derive(Debug, Clone, Encode, Decode)]
 struct ClusterCacheContentsRequest;
 

--- a/crates/subspace-farmer/src/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/cluster/farmer.rs
@@ -134,7 +134,7 @@ impl PlottedSectors for ClusterPlottedSectors {
         Ok(Box::new(
             self.nats_client
                 .stream_request(
-                    ClusterFarmerPlottedSectorsRequest,
+                    &ClusterFarmerPlottedSectorsRequest,
                     Some(&self.farm_id_string),
                 )
                 .await?

--- a/crates/subspace-farmer/src/cluster/nats_client.rs
+++ b/crates/subspace-farmer/src/cluster/nats_client.rs
@@ -21,7 +21,6 @@ use async_nats::{
 };
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use derive_more::{Deref, DerefMut};
 use futures::channel::mpsc;
 use futures::stream::FuturesUnordered;
 use futures::{select, FutureExt, Stream, StreamExt};
@@ -30,6 +29,7 @@ use std::any::type_name;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -146,12 +146,10 @@ pub enum StreamRequestError {
 
 /// Wrapper around subscription that transforms stream of wrapped response messages into a normal
 /// `Response` stream.
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug)]
 #[pin_project::pin_project]
 pub struct StreamResponseSubscriber<Response> {
     #[pin]
-    #[deref]
-    #[deref_mut]
     subscriber: Subscriber,
     response_subject: String,
     buffered_responses: Option<GenericStreamResponses<Response>>,
@@ -314,12 +312,10 @@ pub trait GenericBroadcast: Encode + Decode + fmt::Debug + Send + Sync + 'static
 }
 
 /// Subscriber wrapper that decodes messages automatically and skips messages that can't be decoded
-#[derive(Debug, Deref, DerefMut)]
+#[derive(Debug)]
 #[pin_project::pin_project]
 pub struct SubscriberWrapper<Message> {
     #[pin]
-    #[deref]
-    #[deref_mut]
     subscriber: Subscriber,
     _phantom: PhantomData<Message>,
 }
@@ -624,7 +620,7 @@ impl NatsClient {
     /// Make request that expects stream response
     pub async fn stream_request<Request>(
         &self,
-        request: Request,
+        request: &Request,
         instance: Option<&str>,
     ) -> Result<StreamResponseSubscriber<Request::Response>, StreamRequestError>
     where

--- a/crates/subspace-farmer/src/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/cluster/plotter.rs
@@ -353,7 +353,7 @@ impl ClusterPlotter {
 
                 let response_stream_result = nats_client
                     .stream_request(
-                        ClusterPlotterPlotSectorRequest {
+                        &ClusterPlotterPlotSectorRequest {
                             public_key,
                             sector_index,
                             farmer_protocol_info,


### PR DESCRIPTION
Builds on https://github.com/autonomys/subspace/pull/3147 and basically completes faster piece retrieval for farmer.

Streaming versions of two requests were added: checking for cached piece indices and getting pieces from controller.

Mostly similar boilerplate to previous PRs.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
