### PR TITLE
Remove piece getter concurrency option

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -43,11 +43,6 @@ const GET_PIECE_MAX_INTERVAL: Duration = Duration::from_secs(40);
 /// Arguments for controller
 #[derive(Debug, Parser)]
 pub(super) struct ControllerArgs {
-    /// Piece getter concurrency.
-    ///
-    /// Increasing this value will cause higher memory usage.
-    #[arg(long, default_value = "128")]
-    piece_getter_concurrency: NonZeroUsize,
     /// Base path where to store P2P network identity
     #[arg(long, value_hint = ValueHint::DirPath)]
     base_path: Option<PathBuf>,
@@ -88,7 +83,6 @@ pub(super) async fn controller(
     controller_args: ControllerArgs,
 ) -> anyhow::Result<Pin<Box<dyn Future<Output = anyhow::Result<()>>>>> {
     let ControllerArgs {
-        piece_getter_concurrency,
         base_path,
         node_rpc_url,
         cache_group,
@@ -186,7 +180,6 @@ pub(super) async fn controller(
                 ..ExponentialBackoff::default()
             },
         },
-        piece_getter_concurrency,
     );
 
     let farmer_cache_worker_fut = run_future_in_dedicated_thread(

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -123,12 +123,6 @@ struct RocmPlottingOptions {
 /// Arguments for plotter
 #[derive(Debug, Parser)]
 pub(super) struct PlotterArgs {
-    /// Piece getter concurrency.
-    ///
-    /// Increasing this value can cause NATS communication issues if too many messages arrive via
-    /// NATS, but are not processed quickly enough.
-    #[arg(long, default_value = "32")]
-    piece_getter_concurrency: NonZeroUsize,
     /// Plotting options only used by CPU plotter
     #[clap(flatten)]
     cpu_plotting_options: CpuPlottingOptions,
@@ -154,7 +148,6 @@ where
     PosTable: Table,
 {
     let PlotterArgs {
-        piece_getter_concurrency,
         cpu_plotting_options,
         #[cfg(feature = "cuda")]
         cuda_plotting_options,
@@ -169,7 +162,7 @@ where
             .expect("Not zero; qed"),
     )
     .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
-    let piece_getter = ClusterPieceGetter::new(nats_client.clone(), piece_getter_concurrency);
+    let piece_getter = ClusterPieceGetter::new(nats_client.clone());
 
     let global_mutex = Arc::default();
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -235,11 +235,6 @@ pub(crate) struct FarmingArgs {
     /// one specified endpoint. Format: 127.0.0.1:8080
     #[arg(long, aliases = ["metrics-endpoint", "metrics-endpoints"])]
     prometheus_listen_on: Vec<SocketAddr>,
-    /// Piece getter concurrency.
-    ///
-    /// Increasing this value will cause higher memory usage.
-    #[arg(long, default_value = "128")]
-    piece_getter_concurrency: NonZeroUsize,
     /// Size of PER FARM thread pool used for farming (mostly for blocking I/O, but also for some
     /// compute-intensive operations during proving). Defaults to the number of logical CPUs
     /// on UMA systems, or the number of logical CPUs in first NUMA node on NUMA systems, but
@@ -310,7 +305,6 @@ where
         tmp,
         mut disk_farms,
         prometheus_listen_on,
-        piece_getter_concurrency,
         farming_thread_pool_size,
         cpu_plotting_options,
         #[cfg(feature = "cuda")]
@@ -457,7 +451,6 @@ where
                 ..ExponentialBackoff::default()
             },
         },
-        piece_getter_concurrency,
     );
 
     let farmer_cache_worker_fut = run_future_in_dedicated_thread(


### PR DESCRIPTION
Introduced in https://github.com/autonomys/subspace/pull/2830 it was supposed to help with large numbers of concurrent requests.

This is no longer necessary after https://github.com/autonomys/subspace/pull/3149 due to much more limited number of stream requests that have internal backpressure, similarly DSN requests also have network-level backpressure and we shouldn't really need to constrain concurrency in most cases at all.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
