### PR TITLE
Download pieces in batches for piece cache sync

### DIFF
--- a/crates/subspace-farmer/src/farmer_cache/piece_cache_state.rs
+++ b/crates/subspace-farmer/src/farmer_cache/piece_cache_state.rs
@@ -46,6 +46,8 @@ where
                 Some(free_offset)
             }
             None => {
+                // TODO: Use simple round robin for uniform filling instead of re-sorting all the
+                //  time
                 // Sort piece caches by number of stored pieces to fill those that are less
                 // populated first
                 let mut sorted_backends = self


### PR DESCRIPTION
One more thing remained, the thing users complained about: piece cache sync.

This implements batched downloads, but only for initial sync. I was lazy to do it for keep-up sync right now and keep-up sync is much less critical.

Hit another one of the sub-issues of https://github.com/rust-lang/rust/issues/110338 that I don't think I hit before, so had to waste a bit of time and do some unfortunate allocations to make it compile.

A lot of changes here are simply due to code being offset to the right.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
