### PR TITLE
Rename CLI options (part 2)

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -43,7 +43,7 @@ const SEGMENT_HEADERS_LIMIT: u32 = MAX_SEGMENT_HEADERS_PER_REQUEST as u32;
 #[derive(Debug, Parser)]
 pub(in super::super) struct NetworkArgs {
     /// Multiaddrs of bootstrap nodes to connect to on startup, multiple are supported
-    #[arg(long)]
+    #[arg(long = "bootstrap-node")]
     pub(in super::super) bootstrap_nodes: Vec<Multiaddr>,
     /// Multiaddrs to listen on for subspace networking, for instance `/ip4/0.0.0.0/tcp/0`,
     /// multiple are supported.

--- a/crates/subspace-gateway/src/commands/run/dsn.rs
+++ b/crates/subspace-gateway/src/commands/run/dsn.rs
@@ -21,7 +21,7 @@ pub(crate) struct NetworkArgs {
     /// Multiaddrs of DSN bootstrap nodes to connect to on startup, multiple are supported.
     ///
     /// The default bootstrap nodes are fetched from the node RPC connection.
-    #[arg(long)]
+    #[arg(long = "bootstrap-node")]
     pub(crate) dsn_bootstrap_nodes: Vec<Multiaddr>,
 
     /// Multiaddrs of DSN reserved nodes to maintain a connection to, multiple are supported.

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -61,12 +61,12 @@ fn parse_timekeeper_cpu_cores(
 #[derive(Debug, Parser)]
 struct SubstrateNetworkOptions {
     /// A list of bootstrap nodes for the Substrate networking stack.
-    #[arg(long)]
+    #[arg(long = "bootstrap-node")]
     bootstrap_nodes: Vec<MultiaddrWithPeerId>,
 
     /// A list of reserved node addresses, which are prioritised for connections.
-    #[arg(long)]
-    reserved_nodes: Vec<MultiaddrWithPeerId>,
+    #[arg(long = "reserved-peer")]
+    reserved_peers: Vec<MultiaddrWithPeerId>,
 
     /// Only synchronize the chain with reserved nodes.
     ///
@@ -80,8 +80,8 @@ struct SubstrateNetworkOptions {
     ///
     /// This can be used if there's a proxy in front of this node or if address is known beforehand
     /// and less reliable auto-discovery can be avoided.
-    #[arg(long)]
-    public_addr: Vec<sc_network::Multiaddr>,
+    #[arg(long = "external-address")]
+    external_addresses: Vec<sc_network::Multiaddr>,
 
     /// Listen for incoming Substrate connections on these multiaddresses.
     #[arg(long, default_values_t = [
@@ -93,7 +93,7 @@ struct SubstrateNetworkOptions {
     listen_on: Vec<sc_network::Multiaddr>,
 
     /// Enable non-global (private, shared, loopback..) addresses in the Kademlia DHT.
-    /// By default these addresses are excluded from the DHT.
+    /// By default, these addresses are excluded from the DHT.
     #[arg(long, default_value_t = false)]
     allow_private_ips: bool,
 
@@ -129,11 +129,11 @@ struct DsnOptions {
     dsn_listen_on: Vec<Multiaddr>,
 
     /// Bootstrap nodes for DSN.
-    #[arg(long)]
+    #[arg(long = "dsn-bootstrap-node")]
     dsn_bootstrap_nodes: Vec<Multiaddr>,
 
     /// Reserved peers for DSN.
-    #[arg(long)]
+    #[arg(long = "dsn-reserved-peer")]
     dsn_reserved_peers: Vec<Multiaddr>,
 
     /// Maximum established incoming connection limit for DSN.
@@ -561,7 +561,7 @@ pub(super) fn create_consensus_chain_configuration(
         transaction_pool,
         network: SubstrateNetworkConfiguration {
             listen_on: network_options.listen_on,
-            public_addresses: network_options.public_addr,
+            public_addresses: network_options.external_addresses,
             bootstrap_nodes: network_options.bootstrap_nodes,
             node_key: {
                 let node_key_params = NodeKeyParams {
@@ -576,7 +576,7 @@ pub(super) fn create_consensus_chain_configuration(
             default_peers_set: SetConfig {
                 in_peers: network_options.in_peers,
                 out_peers: network_options.out_peers,
-                reserved_nodes: network_options.reserved_nodes,
+                reserved_nodes: network_options.reserved_peers,
                 non_reserved_mode: if network_options.reserved_only {
                     NonReservedPeerMode::Deny
                 } else {

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -46,12 +46,12 @@ use tracing::warn;
 #[derive(Debug, Parser)]
 struct SubstrateNetworkOptions {
     /// Specify a list of bootstrap nodes for Substrate networking stack.
-    #[arg(long)]
+    #[arg(long = "bootstrap-node")]
     bootstrap_nodes: Vec<MultiaddrWithPeerId>,
 
     /// Specify a list of reserved node addresses.
-    #[arg(long)]
-    reserved_nodes: Vec<MultiaddrWithPeerId>,
+    #[arg(long = "reserved-peer")]
+    reserved_peers: Vec<MultiaddrWithPeerId>,
 
     /// Whether to only synchronize the chain with reserved nodes.
     ///
@@ -310,7 +310,7 @@ pub(super) fn create_domain_configuration(
             default_peers_set: SetConfig {
                 in_peers: network_options.in_peers,
                 out_peers: network_options.out_peers,
-                reserved_nodes: network_options.reserved_nodes,
+                reserved_nodes: network_options.reserved_peers,
                 non_reserved_mode: if network_options.reserved_only {
                     NonReservedPeerMode::Deny
                 } else {


### PR DESCRIPTION
This is done for consistency and is a continuation of https://github.com/autonomys/subspace/pull/3051

Farmer:
* `--bootstrap-nodes` -> `--bootstrap-node`

Node:
* `--bootstrap-nodes` -> `--bootstrap-node`
* `--reserved-nodes` -> `--reserved-peer`
* `--public-addr` -> `--external-address`
* `--dsn-bootstrap-nodes` -> `--dsn-bootstrap-node`
* `--dsn-reserved-peers` -> `--dsn-reserved-peer`

Bootstrap node:
* `--bootstrap-nodes` -> `--bootstrap-node`
* `--reserved-peers` -> `--reserved-peer`

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
