### PR TITLE
Add max object size and DSN listen on address arguments to gateway

### DIFF
--- a/crates/subspace-gateway/src/commands/run/network.rs
+++ b/crates/subspace-gateway/src/commands/run/network.rs
@@ -40,6 +40,12 @@ pub(crate) struct NetworkArgs {
     /// Maximum pending outgoing swarm connection limit.
     #[arg(long, default_value_t = 100)]
     pending_out_connections: u32,
+
+    /// Multiaddrs to listen on for DSN connections, multiple are supported.
+    ///
+    /// This is mainly for debugging.
+    #[arg(long)]
+    listen_on: Vec<Multiaddr>,
 }
 
 /// Create a DSN network client with the supplied configuration.
@@ -54,6 +60,7 @@ pub async fn configure_network(
         allow_private_ips,
         out_connections,
         pending_out_connections,
+        listen_on,
     }: NetworkArgs,
 ) -> anyhow::Result<(Node, NodeRunner<()>, RpcNodeClient)> {
     // TODO:
@@ -92,6 +99,7 @@ pub async fn configure_network(
         max_established_outgoing_connections: out_connections,
         max_pending_outgoing_connections: pending_out_connections,
         kademlia_mode: KademliaMode::Static(Mode::Client),
+        listen_on,
         ..default_config
     };
 

--- a/crates/subspace-gateway/src/commands/run/rpc.rs
+++ b/crates/subspace-gateway/src/commands/run/rpc.rs
@@ -12,7 +12,7 @@ pub const RPC_DEFAULT_PORT: u16 = 9955;
 /// Options for the RPC server.
 #[derive(Debug, Parser)]
 pub(crate) struct RpcOptions<const DEFAULT_PORT: u16> {
-    /// IP and port (TCP) on which to listen for RPC requests.
+    /// IP and port (TCP) to listen for RPC requests.
     ///
     /// This RPC method is not safe to be exposed on a public IP address.
     #[arg(long, default_value_t = SocketAddr::new(


### PR DESCRIPTION
This PR adds two command line arguments to the gateway:
- the maximum object size to fetch
- DSN listen addresses, for debugging

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
