### PR TITLE
Fix farmer memory usage during plotting

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -94,6 +94,15 @@ pub(super) struct FarmerArgs {
     /// limited to 32 threads.
     #[arg(long)]
     farming_thread_pool_size: Option<NonZeroUsize>,
+    /// How many sectors a will be plotted concurrently per farm.
+    ///
+    /// Defaults to 4, but can be decreased if there is a large number of farms available to
+    /// decrease peak memory usage, especially with slow disks.
+    ///
+    /// Increasing this value is not recommended and can result in excessive RAM usage due to more
+    /// sectors being stuck in-flight if writes to farm disk are too slow.
+    #[arg(long, default_value = "4")]
+    max_plotting_sectors_per_farm: NonZeroUsize,
     /// Disable farm locking, for example if file system doesn't support it
     #[arg(long)]
     disable_farm_locking: bool,
@@ -134,6 +143,7 @@ where
         no_info,
         sector_encoding_concurrency,
         farming_thread_pool_size,
+        max_plotting_sectors_per_farm,
         disable_farm_locking,
         create,
         exit_on_farm_error,
@@ -262,6 +272,7 @@ where
                             farming_thread_pool_size,
                             plotting_delay: None,
                             global_mutex,
+                            max_plotting_sectors_per_farm,
                             disable_farm_locking,
                             read_sector_record_chunks_mode: disk_farm
                                 .read_sector_record_chunks_mode,

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -252,6 +252,15 @@ pub(crate) struct FarmingArgs {
     #[cfg(feature = "rocm")]
     #[clap(flatten)]
     rocm_plotting_options: RocmPlottingOptions,
+    /// How many sectors a will be plotted concurrently per farm.
+    ///
+    /// Defaults to 4, but can be decreased if there is a large number of farms available to
+    /// decrease peak memory usage, especially with slow disks.
+    ///
+    /// Increasing this value is not recommended and can result in excessive RAM usage due to more
+    /// sectors being stuck in-flight if writes to farm disk are too slow.
+    #[arg(long, default_value = "4")]
+    max_plotting_sectors_per_farm: NonZeroUsize,
     /// Enable plot cache.
     ///
     /// Plot cache uses unplotted space as additional cache improving plotting speeds, especially
@@ -311,6 +320,7 @@ where
         cuda_plotting_options,
         #[cfg(feature = "rocm")]
         rocm_plotting_options,
+        max_plotting_sectors_per_farm,
         plot_cache,
         disable_farm_locking,
         create,
@@ -581,6 +591,7 @@ where
                             farming_thread_pool_size,
                             plotting_delay: Some(plotting_delay_receiver),
                             global_mutex,
+                            max_plotting_sectors_per_farm,
                             disable_farm_locking,
                             read_sector_record_chunks_mode: disk_farm
                                 .read_sector_record_chunks_mode,

--- a/crates/subspace-farmer/src/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/cluster/plotter.rs
@@ -934,8 +934,6 @@ async fn send_publish_progress(
                 }
             }
 
-            response_sender.close_channel();
-
             return;
         }
         SectorPlottingProgress::Error { error } => ClusterSectorPlottingProgress::Error { error },

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -23,6 +23,7 @@ use std::num::NonZeroUsize;
 use std::pin::pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Instant;
 use subspace_core_primitives::sectors::SectorIndex;
 use subspace_core_primitives::PublicKey;
@@ -456,12 +457,19 @@ where
                         SectorPlottingProgress::Finished {
                             plotted_sector,
                             time: start.elapsed(),
-                            sector: Box::pin(stream::once(async move { Ok(Bytes::from(sector)) })),
+                            sector: Box::pin({
+                                let mut sector = Some(Ok(Bytes::from(sector)));
+
+                                stream::poll_fn(move |_cx| {
+                                    // Just so that permit is dropped with stream itself
+                                    let _downloading_permit = &downloading_permit;
+
+                                    Poll::Ready(sector.take())
+                                })
+                            }),
                         },
                     )
                     .await;
-
-                drop(downloading_permit);
             }
         };
 

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -58,6 +58,7 @@ use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::future::Future;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -301,6 +302,8 @@ where
     /// that those operations that are very sensitive (like proving) have all the resources
     /// available to them for the highest probability of success
     pub global_mutex: Arc<AsyncMutex<()>>,
+    /// How many sectors a will be plotted concurrently per farm
+    pub max_plotting_sectors_per_farm: NonZeroUsize,
     /// Disable farm locking, for example if file system doesn't support it
     pub disable_farm_locking: bool,
     /// Explicit mode to use for reading of sector record chunks instead of doing internal
@@ -845,6 +848,7 @@ impl SingleDiskFarm {
             farming_thread_pool_size,
             plotting_delay,
             global_mutex,
+            max_plotting_sectors_per_farm,
             disable_farm_locking,
             read_sector_record_chunks_mode,
             faster_read_sector_record_chunks_mode_barrier,
@@ -1031,6 +1035,7 @@ impl SingleDiskFarm {
                         plotter,
                         metrics,
                     },
+                    max_plotting_sectors_per_farm,
                 };
 
                 let plotting_fut = async {


### PR DESCRIPTION
There are two commits here that address two related issues as described in https://github.com/autonomys/subspace/issues/3107

First commit addresses a situation when there farm is on slow disk and plotting is happening faster than disk writes. Previously this would simply accumulate sectors in memory with memory usage growing indefinitely since disk is physically is not able to process the pipeline of already produced sectors. This is fixed by limiting how many sectors can be plotted per farm. Default value of 4 is sufficient to saturate plotting capacity with a single farm on most consumer systems including Threadripper CPUs, for higher concurrency value can be increased or more farms can be added. New `--max-plotting-sectors-per-farm` is introduced to control this behavior.

Second commit addresses a similar issue, but in cluster setup where plotting is much faster than available network bandwith, resulting in runaway memory usage as well. This is because plotting ends with ~1G sector being created and then streamed as chunks to the farmer. The permit for plotting resources was released once sector was produced, allowing for more and more sectors being produced without any hard limits. Dropping the permit only when the sector is consumed (first `stream.next()` will yield sector that will be streamed as chunks and only after this is done stream will be polled again just to realize realize it has ended, resulting in stream being dropped and permit being released).

`close_channel()` call was simply redundant.

Fixes https://github.com/autonomys/subspace/issues/3107

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
