### PR TITLE
Use head domain number to count for the unlocking period

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -27,9 +27,9 @@ use frame_system::{Pallet as System, RawOrigin};
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
 use sp_core::ByteArray;
 use sp_domains::{
-    dummy_opaque_bundle, BlockFees, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
+    dummy_opaque_bundle, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
     OperatorPublicKey, OperatorRewardSource, OperatorSignature, PermissionedActionAllowedBy,
-    ProofOfElection, RuntimeType, SealedSingletonReceipt, SingletonReceipt, Transfers,
+    ProofOfElection, RuntimeType, SealedSingletonReceipt, SingletonReceipt,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_runtime::traits::{CheckedAdd, One, Zero};
@@ -777,28 +777,11 @@ mod benchmarks {
         })
         .unwrap();
 
-        // Update the `LatestConfirmedDomainExecutionReceipt` so unlock can success
-        let confirmed_domain_block_number =
-            Pallet::<T>::latest_confirmed_domain_block_number(domain_id)
-                + T::StakeWithdrawalLockingPeriod::get()
-                + One::one();
-        LatestConfirmedDomainExecutionReceipt::<T>::insert(
-            domain_id,
-            ExecutionReceiptOf::<T> {
-                domain_block_number: confirmed_domain_block_number,
-                domain_block_hash: Default::default(),
-                domain_block_extrinsic_root: Default::default(),
-                parent_domain_block_receipt_hash: Default::default(),
-                consensus_block_number: Default::default(),
-                consensus_block_hash: Default::default(),
-                inboxed_bundles: vec![],
-                final_state_root: Default::default(),
-                execution_trace: vec![],
-                execution_trace_root: Default::default(),
-                block_fees: BlockFees::default(),
-                transfers: Transfers::default(),
-            },
-        );
+        // Update the `HeadDomainNumber` so unlock can success
+        let next_head_domain_number = HeadDomainNumber::<T>::get(domain_id)
+            + T::StakeWithdrawalLockingPeriod::get()
+            + One::one();
+        HeadDomainNumber::<T>::set(domain_id, next_head_domain_number);
 
         #[extrinsic_call]
         _(RawOrigin::Signed(nominator.clone()), operator_id);
@@ -828,28 +811,11 @@ mod benchmarks {
             operator_id,
         ));
 
-        // Update the `LatestConfirmedDomainExecutionReceipt` so unlock can success
-        let confirmed_domain_block_number =
-            Pallet::<T>::latest_confirmed_domain_block_number(domain_id)
-                + T::StakeWithdrawalLockingPeriod::get()
-                + One::one();
-        LatestConfirmedDomainExecutionReceipt::<T>::insert(
-            domain_id,
-            ExecutionReceiptOf::<T> {
-                domain_block_number: confirmed_domain_block_number,
-                domain_block_hash: Default::default(),
-                domain_block_extrinsic_root: Default::default(),
-                parent_domain_block_receipt_hash: Default::default(),
-                consensus_block_number: Default::default(),
-                consensus_block_hash: Default::default(),
-                inboxed_bundles: vec![],
-                final_state_root: Default::default(),
-                execution_trace: vec![],
-                execution_trace_root: Default::default(),
-                block_fees: BlockFees::default(),
-                transfers: Transfers::default(),
-            },
-        );
+        // Update the `HeadDomainNumber` so unlock can success
+        let next_head_domain_number = HeadDomainNumber::<T>::get(domain_id)
+            + T::StakeWithdrawalLockingPeriod::get()
+            + One::one();
+        HeadDomainNumber::<T>::set(domain_id, next_head_domain_number);
 
         #[extrinsic_call]
         _(RawOrigin::Signed(operator_owner), operator_id);

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -515,9 +515,8 @@ pub(crate) fn do_slash_operator<T: Config>(
 mod tests {
     use crate::bundle_storage_fund::STORAGE_FEE_RESERVE;
     use crate::pallet::{
-        Deposits, DomainStakingSummary, LastEpochStakingDistribution,
-        LatestConfirmedDomainExecutionReceipt, NominatorCount, OperatorIdOwner, OperatorSigningKey,
-        Operators, Withdrawals,
+        Deposits, DomainStakingSummary, HeadDomainNumber, LastEpochStakingDistribution,
+        NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators, Withdrawals,
     };
     use crate::staking::tests::{register_operator, Share};
     use crate::staking::{
@@ -528,7 +527,7 @@ mod tests {
         do_finalize_domain_current_epoch, operator_take_reward_tax_and_stake,
     };
     use crate::tests::{new_test_ext, Test};
-    use crate::{BalanceOf, Config, ExecutionReceiptOf, HoldIdentifier, NominatorId};
+    use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
     #[cfg(not(feature = "std"))]
     use alloc::vec;
     use codec::Encode;
@@ -536,8 +535,7 @@ mod tests {
     use frame_support::traits::fungible::InspectHold;
     use sp_core::{Pair, U256};
     use sp_domains::{
-        BlockFees, DomainId, OperatorPair, OperatorRewardSource,
-        OperatorSigningKeyProofOfOwnershipData, Transfers,
+        DomainId, OperatorPair, OperatorRewardSource, OperatorSigningKeyProofOfOwnershipData,
     };
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
@@ -616,48 +614,16 @@ mod tests {
             }
 
             // de-register operator
-            let domain_block_number = 100;
-            LatestConfirmedDomainExecutionReceipt::<Test>::insert(
-                domain_id,
-                ExecutionReceiptOf::<Test> {
-                    domain_block_number,
-                    domain_block_hash: Default::default(),
-                    domain_block_extrinsic_root: Default::default(),
-                    parent_domain_block_receipt_hash: Default::default(),
-                    consensus_block_number: Default::default(),
-                    consensus_block_hash: Default::default(),
-                    inboxed_bundles: vec![],
-                    final_state_root: Default::default(),
-                    execution_trace: vec![],
-                    execution_trace_root: Default::default(),
-                    block_fees: BlockFees::default(),
-                    transfers: Transfers::default(),
-                },
-            );
+            let head_domain_number = HeadDomainNumber::<Test>::get(domain_id);
             do_deregister_operator::<Test>(operator_account, operator_id).unwrap();
 
             // finalize and add to pending operator unlocks
             do_finalize_domain_current_epoch::<Test>(domain_id).unwrap();
 
-            // staking withdrawal is 5 blocks,
-            // to unlock funds, confirmed block should be atleast 105
-            let domain_block_number = 105;
-            LatestConfirmedDomainExecutionReceipt::<Test>::insert(
+            // Update `HeadDomainNumber` to ensure unlock success
+            HeadDomainNumber::<Test>::set(
                 domain_id,
-                ExecutionReceiptOf::<Test> {
-                    domain_block_number,
-                    domain_block_hash: Default::default(),
-                    domain_block_extrinsic_root: Default::default(),
-                    parent_domain_block_receipt_hash: Default::default(),
-                    consensus_block_number: Default::default(),
-                    consensus_block_hash: Default::default(),
-                    inboxed_bundles: vec![],
-                    final_state_root: Default::default(),
-                    execution_trace: vec![],
-                    execution_trace_root: Default::default(),
-                    block_fees: BlockFees::default(),
-                    transfers: Transfers::default(),
-                },
+                head_domain_number + <Test as crate::Config>::StakeWithdrawalLockingPeriod::get(),
             );
 
             for (nominator_id, _) in nominators {


### PR DESCRIPTION
close #2971 

This PR uses the `HeadDomainNumber` instead of the `latest_confirmed_domain_block_number` to count for the unlocking period to ensure the withdrawal requested in the first challenge period also needs to wait `StakeWithdrawalLockingPeriod` number of the domain block before being able to unlock. See #2971 for more details about the issue.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
