### PR TITLE
Update `rustsec/audit-check` action

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || '"ubuntu-22.04"') }}
     steps:
       - uses: actions/checkout@v3
-      - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 #v1.4.1
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 #v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # TODO: Remove once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies


### PR DESCRIPTION
Started failing, probably after Rust upgrade with new lock file version, maybe new version will fix that

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
