### PR TITLE
Remove msys64 workaround

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,12 +90,6 @@ jobs:
         run: brew install automake
         if: runner.os == 'macOS'
 
-      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
-      - name: Remove msys64
-        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        # Doesn't exist on self-hosted runners
-        if: matrix.os == 'windows-2022'
-
       - name: CUDA toolchain
         uses: Jimver/cuda-toolkit@9b295696791d75d658d8de64c4a85097ad8abeaf # v0.2.16
         with:
@@ -232,12 +226,6 @@ jobs:
       - name: Install automake (macOS)
         run: brew install automake
         if: runner.os == 'macOS'
-
-      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
-      - name: Remove msys64
-        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        # Doesn't exist on self-hosted runners
-        if: matrix.os == 'windows-2022'
 
       - name: Configure cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -143,12 +143,6 @@ jobs:
         run: brew install automake
         if: runner.os == 'macOS'
 
-      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
-      - name: Remove msys64
-        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        # Doesn't exist on self-hosted runners
-        if: matrix.os == 'windows-2022'
-
       - name: AArch64 cross-compile packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
It was taking over a minute of CI time and after testing it again today it worked fine without workaround, which is finally good news, last time a few months ago it didn't.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
