### PR TITLE
Replace panic with error in snap sync

### DIFF
--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -1302,7 +1302,7 @@ where
                 result_sender,
             } => {
                 if !self.swarm.behaviour().gossipsub.is_enabled() {
-                    panic!("Gossibsub protocol is disabled.");
+                    panic!("Gossipsub protocol is disabled.");
                 }
 
                 let topic_hash = topic.hash();
@@ -1354,7 +1354,7 @@ where
                 subscription_id,
             } => {
                 if !self.swarm.behaviour().gossipsub.is_enabled() {
-                    panic!("Gossibsub protocol is disabled.");
+                    panic!("Gossipsub protocol is disabled.");
                 }
 
                 if let Entry::Occupied(mut entry) =
@@ -1385,7 +1385,7 @@ where
                 result_sender,
             } => {
                 if !self.swarm.behaviour().gossipsub.is_enabled() {
-                    panic!("Gossibsub protocol is disabled.");
+                    panic!("Gossipsub protocol is disabled.");
                 }
 
                 if let Some(gossipsub) = self.swarm.behaviour_mut().gossipsub.as_mut() {

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -166,10 +166,11 @@ where
 
     // We don't have the genesis state when we choose to snap sync.
     if target_segment_index <= SegmentIndex::ONE {
-        panic!(
+        error!(
             "Snap sync is impossible - not enough archived history: \
             wipe the DB folder and rerun with --sync=full"
         );
+        return Err("Snap sync is impossible - not enough archived history".into());
     }
 
     // Identify all segment headers that would need to be reconstructed in order to get first


### PR DESCRIPTION
Panicking in async code causes a race condition which hangs the node roughly half the time on my machine. (The other half it exits with an error.)

As part of this race, the Ctrl-C handler is dropped, because it is an async future running in the same executor. So the user can't use Ctrl-C to exit.

The only way I found to exit the process was `kill -KILL`. A SIGTERM was ignored.

Close #3175.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
