### PR TITLE
Exit on panics, rather than unwinding

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -10,8 +10,9 @@ mod commands;
 mod utils;
 
 use clap::Parser;
-use std::fs;
 use std::path::PathBuf;
+use std::process::exit;
+use std::{fs, panic};
 use subspace_farmer::single_disk_farm::{ScrubTarget, SingleDiskFarm};
 use subspace_proof_of_space::chia::ChiaTable;
 use tracing::info;
@@ -74,6 +75,14 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Exit on panics, rather than unwinding. Unwinding can hang the tokio runtime waiting for
+    // stuck tasks or threads.
+    let default_panic_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+        default_panic_hook(panic_info);
+        exit(1);
+    }));
+
     tracing_subscriber::registry()
         .with(
             fmt::layer()

--- a/crates/subspace-gateway/src/commands.rs
+++ b/crates/subspace-gateway/src/commands.rs
@@ -4,6 +4,8 @@ pub(crate) mod run;
 
 use crate::commands::run::RunOptions;
 use clap::Parser;
+use std::panic;
+use std::process::exit;
 use tokio::signal;
 use tracing::level_filters::LevelFilter;
 use tracing::{debug, warn};
@@ -18,6 +20,16 @@ pub enum Command {
     /// Run data gateway
     Run(RunOptions),
     // TODO: subcommand to run various benchmarks
+}
+
+/// Install a panic handler which exits on panics, rather than unwinding. Unwinding can hang the
+/// tokio runtime waiting for stuck tasks or threads.
+pub(crate) fn set_exit_on_panic() {
+    let default_panic_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+        default_panic_hook(panic_info);
+        exit(1);
+    }));
 }
 
 pub(crate) fn init_logger() {

--- a/crates/subspace-gateway/src/main.rs
+++ b/crates/subspace-gateway/src/main.rs
@@ -5,7 +5,7 @@ mod node_client;
 mod piece_getter;
 mod piece_validator;
 
-use crate::commands::{init_logger, raise_fd_limit, Command};
+use crate::commands::{init_logger, raise_fd_limit, set_exit_on_panic, Command};
 use clap::Parser;
 
 #[global_allocator]
@@ -13,6 +13,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    set_exit_on_panic();
     init_logger();
     raise_fd_limit();
 

--- a/crates/subspace-node/src/commands.rs
+++ b/crates/subspace-node/src/commands.rs
@@ -7,4 +7,5 @@ pub use domain_key::{
     create_domain_key, insert_domain_key, CreateDomainKeyOptions, InsertDomainKeyOptions,
 };
 pub use run::{run, RunOptions};
+pub(crate) use shared::set_exit_on_panic;
 pub use wipe::{wipe, WipeOptions};

--- a/crates/subspace-node/src/commands/shared.rs
+++ b/crates/subspace-node/src/commands/shared.rs
@@ -6,7 +6,9 @@ use sp_core::sr25519::Pair;
 use sp_core::Pair as PairT;
 use sp_domains::KEY_TYPE;
 use sp_keystore::Keystore;
+use std::panic;
 use std::path::PathBuf;
+use std::process::exit;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -50,6 +52,16 @@ pub(super) fn store_key_in_keystore(
     LocalKeystore::open(keystore_path, password)?
         .insert(KEY_TYPE, suri.expose_secret(), &keypair.public())
         .map_err(|()| Error::Application("Failed to insert key into keystore".to_string().into()))
+}
+
+/// Install a panic handler which exits on panics, rather than unwinding. Unwinding can hang the
+/// tokio runtime waiting for stuck tasks or threads.
+pub(crate) fn set_exit_on_panic() {
+    let default_panic_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+        default_panic_hook(panic_info);
+        exit(1);
+    }));
 }
 
 pub(super) fn init_logger() {

--- a/crates/subspace-node/src/main.rs
+++ b/crates/subspace-node/src/main.rs
@@ -26,6 +26,7 @@ mod cli;
 mod domain;
 
 use crate::cli::{Cli, SubspaceCliPlaceholder};
+use crate::commands::set_exit_on_panic;
 use crate::domain::cli::DomainKey;
 use crate::domain::{DomainCli, DomainSubcommand};
 use clap::Parser;
@@ -130,6 +131,8 @@ fn derive_pot_external_entropy(
 }
 
 fn main() -> Result<(), Error> {
+    set_exit_on_panic();
+
     match Cli::parse() {
         Cli::Run(run_options) => {
             commands::run(run_options)?;


### PR DESCRIPTION
This PR makes the node, farmer, gateway, and boostrap node exit immediately when there is a panic.

Previously, the Rust panic handler would unwind the stack, and drop the tokio runtime. This could lead to a hang if tasks were deadlocked, livelocked, or otherwise running forever without yielding.

Close #3175.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)

