### PR TITLE
change telemetry endpoint to foundation

### DIFF
--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -39,7 +39,7 @@ use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, CouncilDemocracyConfigParams, SSC,
 };
 
-const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.network/submit/";
+const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.foundation/submit/";
 
 /// Additional subspace specific genesis parameters.
 struct GenesisParams {


### PR DESCRIPTION
Makes more sense for Foundation to host it. The link is already live.
### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
