### PR TITLE
Stay at v3 Cargo.lock file format

### DIFF
--- a/crates/subspace-node/Cargo.toml
+++ b/crates/subspace-node/Cargo.toml
@@ -15,6 +15,11 @@ include = [
     "/README.md"
 ]
 
+# TODO: remove when cargo-audit supports v4 lock files
+# https://github.com/rustsec/rustsec/issues/1249
+# This setting applies to the workspace lockfile, even though it's in a crate.
+rust-version = "1.81" # ensure we stay at lockfile v3
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 


### PR DESCRIPTION
We’ve been getting some cargo-audit failures in CI because it’s missing support for v4 lock files.

This workaround prevents upgrades by fixing the lowest supported rust (and cargo) version at a version which doesn’t have v4 lock file support.

Here’s where the workaround is from:
https://github.com/rustsec/rustsec/pull/1206#issuecomment-2402411088

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
