### PR TITLE
Keep our customized executive pallet up-to-date with the upstream

### DIFF
--- a/crates/pallet-domains/Cargo.toml
+++ b/crates/pallet-domains/Cargo.toml
@@ -64,7 +64,6 @@ std = [
     "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-support/runtime-benchmarks",
     "frame-system/runtime-benchmarks",

--- a/crates/pallet-history-seeding/Cargo.toml
+++ b/crates/pallet-history-seeding/Cargo.toml
@@ -37,7 +37,6 @@ std = [
     "scale-info/std",
     "sp-std/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/crates/pallet-rewards/Cargo.toml
+++ b/crates/pallet-rewards/Cargo.toml
@@ -47,7 +47,6 @@ std = [
     "sp-runtime/std",
     "subspace-runtime-primitives/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/crates/pallet-runtime-configs/Cargo.toml
+++ b/crates/pallet-runtime-configs/Cargo.toml
@@ -38,7 +38,6 @@ std = [
     "sp-std?/std",
     "subspace-runtime-primitives/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/crates/pallet-subspace-mmr/Cargo.toml
+++ b/crates/pallet-subspace-mmr/Cargo.toml
@@ -39,8 +39,3 @@ std = [
     "sp-std/std",
     "sp-subspace-mmr/std"
 ]
-try-runtime = [
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "sp-runtime/try-runtime",
-]

--- a/crates/pallet-subspace/Cargo.toml
+++ b/crates/pallet-subspace/Cargo.toml
@@ -67,7 +67,6 @@ std = [
     "subspace-runtime-primitives/std",
     "subspace-verification/std"
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/crates/pallet-transaction-fees/Cargo.toml
+++ b/crates/pallet-transaction-fees/Cargo.toml
@@ -33,4 +33,3 @@ std = [
     "scale-info/std",
     "subspace-runtime-primitives/std",
 ]
-try-runtime = ["frame-support/try-runtime"]

--- a/domains/pallets/auto-id/Cargo.toml
+++ b/domains/pallets/auto-id/Cargo.toml
@@ -44,7 +44,6 @@ std = [
     "sp-runtime/std",
     "subspace-runtime-primitives/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/domains/pallets/block-fees/Cargo.toml
+++ b/domains/pallets/block-fees/Cargo.toml
@@ -37,8 +37,3 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
 ]
-try-runtime = [
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "sp-runtime/try-runtime",
-]

--- a/domains/pallets/domain-id/Cargo.toml
+++ b/domains/pallets/domain-id/Cargo.toml
@@ -36,8 +36,3 @@ std = [
 ]
 
 runtime-benchmarks = []
-try-runtime = [
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "sp-runtime/try-runtime",
-]

--- a/domains/pallets/domain-sudo/Cargo.toml
+++ b/domains/pallets/domain-sudo/Cargo.toml
@@ -32,8 +32,3 @@ std = [
     "sp-runtime/std",
     "sp-domain-sudo/std"
 ]
-try-runtime = [
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "sp-runtime/try-runtime",
-]

--- a/domains/pallets/evm_nonce_tracker/Cargo.toml
+++ b/domains/pallets/evm_nonce_tracker/Cargo.toml
@@ -30,8 +30,3 @@ std = [
     "sp-core/std",
     "sp-runtime/std",
 ]
-try-runtime = [
-    "frame-support/try-runtime",
-    "frame-system/try-runtime",
-    "sp-runtime/try-runtime",
-]

--- a/domains/pallets/executive/Cargo.toml
+++ b/domains/pallets/executive/Cargo.toml
@@ -48,7 +48,6 @@ std = [
     "sp-std/std",
     "sp-tracing/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -301,32 +301,6 @@ where
         >::execute_on_runtime_upgrade()
     }
 
-    /// Wrapped `frame_executive::Executive::execute_block_no_check`.
-    #[cfg(feature = "try-runtime")]
-    pub fn execute_block_no_check(block: BlockOf<ExecutiveConfig>) -> Weight {
-        frame_executive::Executive::<
-            ExecutiveConfig,
-            BlockOf<ExecutiveConfig>,
-            Context,
-            UnsignedValidator,
-            AllPalletsWithSystem,
-            COnRuntimeUpgrade,
-        >::execute_block_no_check(block)
-    }
-
-    /// Wrapped `frame_executive::Executive::try_runtime_upgrade`.
-    #[cfg(feature = "try-runtime")]
-    pub fn try_runtime_upgrade() -> Result<Weight, &'static str> {
-        frame_executive::Executive::<
-            ExecutiveConfig,
-            BlockOf<ExecutiveConfig>,
-            Context,
-            UnsignedValidator,
-            AllPalletsWithSystem,
-            COnRuntimeUpgrade,
-        >::try_runtime_upgrade()
-    }
-
     /// Wrapped `frame_executive::Executive::initialize_block`.
     ///
     /// Note the storage root in the end.

--- a/domains/pallets/executive/src/lib.rs
+++ b/domains/pallets/executive/src/lib.rs
@@ -18,6 +18,7 @@
 //! # Domain Executive Module
 //!
 //! This module is derived from frame_executive with some custom modifications for
+//! including the failed extrinsic during `pre/post_dispatch` in the block and
 //! collecting the intermediate storage roots in the block execution required for
 //! the fraud proof of decoupled execution in Subspace.
 
@@ -35,6 +36,7 @@ pub mod weights;
 extern crate alloc;
 
 use codec::{Codec, Encode};
+use frame_support::defensive_assert;
 use frame_support::dispatch::{
     DispatchClass, DispatchErrorWithPostInfo, DispatchInfo, GetDispatchInfo, Pays, PostDispatchInfo,
 };
@@ -43,7 +45,7 @@ use frame_support::traits::fungible::{Inspect, Mutate};
 use frame_support::traits::tokens::{Fortitude, Precision, Preservation};
 use frame_support::traits::{
     BeforeAllRuntimeMigrations, EnsureInherentsAreFirst, ExecuteBlock, Get, OffchainWorker,
-    OnFinalize, OnIdle, OnInitialize, OnPoll, OnRuntimeUpgrade,
+    OnFinalize, OnIdle, OnInitialize, OnPoll, OnRuntimeUpgrade, PostTransactions,
 };
 use frame_support::weights::{Weight, WeightToFee};
 use frame_system::pallet_prelude::*;
@@ -316,7 +318,7 @@ where
     }
 
     // TODO: https://github.com/paritytech/substrate/issues/10711
-    fn initial_checks(block: &BlockOf<ExecutiveConfig>) {
+    fn initial_checks(block: &BlockOf<ExecutiveConfig>) -> u32 {
         sp_tracing::enter_span!(sp_tracing::Level::TRACE, "initial_checks");
         let header = block.header();
 
@@ -330,37 +332,56 @@ where
             "Parent hash should be valid.",
         );
 
-        if let Err(i) = ExecutiveConfig::ensure_inherents_are_first(block) {
-            panic!("Invalid inherent position for extrinsic at index {i}");
+        match ExecutiveConfig::ensure_inherents_are_first(block) {
+            Ok(num) => num,
+            Err(i) => panic!("Invalid inherent position for extrinsic at index {}", i),
         }
     }
 
     /// Wrapped `frame_executive::Executive::execute_block`.
     ///
-    /// The purpose is to use our custom [`Executive::initialize_block`] and
-    /// [`Executive::apply_extrinsic`].
+    /// The purpose is to use our custom [`Executive::apply_extrinsic`] and
+    /// the [`Executive::finalize_block`] logic.
     pub fn execute_block(block: BlockOf<ExecutiveConfig>) {
         sp_io::init_tracing();
         sp_tracing::within_span! {
             sp_tracing::info_span!("execute_block", ?block);
-
-            Self::initialize_block(block.header());
-
-            Self::initial_checks(&block);
-
-            // execute extrinsics
+            // Execute `on_runtime_upgrade` and `on_initialize`.
+            let mode = Self::initialize_block(block.header());
+            let num_inherents = Self::initial_checks(&block) as usize;
             let (header, extrinsics) = block.deconstruct();
-            Self::execute_extrinsics_with_book_keeping(extrinsics, *header.number());
+            let num_extrinsics = extrinsics.len();
 
+            if mode == ExtrinsicInclusionMode::OnlyInherents && num_extrinsics > num_inherents {
+                // Invalid block
+                panic!("Only inherents are allowed in this block")
+            }
+
+            Self::apply_extrinsics(extrinsics.into_iter());
+
+            // In this case there were no transactions to trigger this state transition:
+            if !<frame_system::Pallet<ExecutiveConfig>>::inherents_applied() {
+                defensive_assert!(num_inherents == num_extrinsics);
+                frame_executive::Executive::<
+                    ExecutiveConfig,
+                    BlockOf<ExecutiveConfig>,
+                    Context,
+                    UnsignedValidator,
+                    AllPalletsWithSystem,
+                    COnRuntimeUpgrade,
+                >::inherents_applied();
+            }
+
+            <frame_system::Pallet<ExecutiveConfig>>::note_finished_extrinsics();
+            <ExecutiveConfig as frame_system::Config>::PostTransactions::post_transactions();
+
+            Self::idle_and_finalize_hook(*header.number());
             Self::final_checks(&header);
         }
     }
 
-    /// Exactly same with `frame_executive::executive::execute_extrinsics_with_book_keeping`.
-    fn execute_extrinsics_with_book_keeping(
-        extrinsics: Vec<ExtrinsicOf<ExecutiveConfig>>,
-        block_number: NumberFor<BlockOf<ExecutiveConfig>>,
-    ) {
+    /// Wrapped `frame_executive::Executive::apply_extrinsics`.
+    fn apply_extrinsics(extrinsics: impl Iterator<Item = ExtrinsicOf<ExecutiveConfig>>) {
         extrinsics.into_iter().for_each(|e| {
             if let Err(e) = Self::apply_extrinsic(e) {
                 let err: &'static str = e.into();
@@ -372,11 +393,6 @@ where
         // syncing process produces the same storage root with the one processed based on
         // the consensus block.
         Pallet::<ExecutiveConfig>::push_root(Self::storage_root());
-
-        // post-extrinsics book-keeping
-        <frame_system::Pallet<ExecutiveConfig>>::note_finished_extrinsics();
-
-        Self::idle_and_finalize_hook(block_number);
     }
 
     /// Wrapped `frame_executive::Executive::finalize_block`.
@@ -392,7 +408,7 @@ where
         >::finalize_block()
     }
 
-    // TODO: https://github.com/paritytech/substrate/issues/10711
+    /// Wrapped `frame_executive::Executive::on_idle_hook` and `frame_executive::Executive::on_finalize_hook`
     fn idle_and_finalize_hook(block_number: NumberFor<BlockOf<ExecutiveConfig>>) {
         let weight = <frame_system::Pallet<ExecutiveConfig>>::block_weight();
         let max_weight = <<ExecutiveConfig as frame_system::Config>::BlockWeights as frame_support::traits::Get<_>>::get().max_block;
@@ -411,7 +427,7 @@ where
 
     /// Wrapped `frame_executive::Executive::apply_extrinsic`.
     ///
-    /// Note the storage root in the end.
+    /// Note the storage root in the beginning.
     pub fn apply_extrinsic(uxt: ExtrinsicOf<ExecutiveConfig>) -> ApplyExtrinsicResult {
         Pallet::<ExecutiveConfig>::push_root(Self::storage_root());
 

--- a/domains/pallets/messenger/Cargo.toml
+++ b/domains/pallets/messenger/Cargo.toml
@@ -51,7 +51,6 @@ std = [
     "sp-trie/std",
     "sp-subspace-mmr/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",

--- a/domains/pallets/transporter/Cargo.toml
+++ b/domains/pallets/transporter/Cargo.toml
@@ -46,7 +46,6 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
 ]
-try-runtime = ["frame-support/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking",
     "frame-benchmarking/runtime-benchmarks",


### PR DESCRIPTION
This PR brings some changes to our customized executive pallet to keep it up-to-date with the upstream, this fixes the `state_traceBlock` RPC service cc @DaMandal0rian. Note these changes don't affect the actual domain block execution but only the cli and RPC because all the domain blocks are derived locally with the domain block builder whose logic is untouched.

Ideally, we should proceed with https://github.com/paritytech/substrate/issues/10711 to remove the need of maintaining our  customized executive pallet but things get more complicated now because we do not just need a hook to collect the intermediate storage root but also some customized behavior of `apply_extrinsic` (introduced in #2343).

This PR also removes the `try-runtime` feature which is broken, incomplete, and unused, we can add it back when we have a use case.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
