### PR TITLE
Exit when snap sync needs user intervention

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1113,7 +1113,10 @@ where
             Box::pin(async move {
                 // Run snap-sync before DSN-sync.
                 if config.sync == ChainSyncMode::Snap {
-                    snap_sync_task.await;
+                    if let Err(error) = snap_sync_task.await {
+                        error!(%error, "Snap sync exited with a fatal error");
+                        return;
+                    }
                 }
 
                 if let Err(error) = worker.await {


### PR DESCRIPTION
This PR is a follow-up to #3176, which restores the previous behaviour of exiting when snap sync needs user intervention. (But instead of exiting using a panic, it exits by logging the error and returning from an essential task.)

See the discussion here:
https://github.com/autonomys/subspace/pull/3176#issuecomment-2441596987

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
