### PR TITLE
Use only 4096 bytes sectors for Direct I/O

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -212,10 +212,9 @@ where
             });
         }
         {
-            let plot = RayonFiles::open_with(
-                &disk_farm.join(SingleDiskFarm::PLOT_FILE),
-                DirectIoFile::open,
-            )
+            let plot = RayonFiles::open_with(disk_farm.join(SingleDiskFarm::PLOT_FILE), |path| {
+                DirectIoFile::open(path)
+            })
             .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
 
@@ -250,7 +249,7 @@ where
             });
         }
         {
-            let plot = RayonFiles::open(&disk_farm.join(SingleDiskFarm::PLOT_FILE))
+            let plot = RayonFiles::open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
 
@@ -429,10 +428,9 @@ where
             });
         }
         {
-            let plot = RayonFiles::open_with(
-                &disk_farm.join(SingleDiskFarm::PLOT_FILE),
-                DirectIoFile::open,
-            )
+            let plot = RayonFiles::open_with(disk_farm.join(SingleDiskFarm::PLOT_FILE), |path| {
+                DirectIoFile::open(path)
+            })
             .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
             let mut options = PlotAuditOptions::<PosTable> {
@@ -504,7 +502,7 @@ where
             });
         }
         {
-            let plot = RayonFiles::open(&disk_farm.join(SingleDiskFarm::PLOT_FILE))
+            let plot = RayonFiles::open(disk_farm.join(SingleDiskFarm::PLOT_FILE))
                 .map_err(|error| anyhow::anyhow!("Failed to open plot: {error}"))?;
             let plot_audit = PlotAudit::new(&plot);
             let mut options = PlotAuditOptions::<PosTable> {

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -962,7 +962,9 @@ impl SingleDiskFarm {
         let farming_plot_fut = task::spawn_blocking(|| {
             farming_thread_pool
                 .install(move || {
-                    RayonFiles::open_with(&directory.join(Self::PLOT_FILE), DirectIoFile::open)
+                    RayonFiles::open_with(directory.join(Self::PLOT_FILE), |path| {
+                        DirectIoFile::open(path)
+                    })
                 })
                 .map(|farming_plot| (farming_plot, farming_thread_pool))
         });
@@ -1466,7 +1468,7 @@ impl SingleDiskFarm {
             Arc::new(AsyncRwLock::new(sectors_metadata))
         };
 
-        let plot_file = DirectIoFile::open(&directory.join(Self::PLOT_FILE))?;
+        let plot_file = DirectIoFile::open(directory.join(Self::PLOT_FILE))?;
 
         if plot_file.size()? != allocated_space_distribution.plot_file_size {
             // Allocating the whole file (`set_len` below can create a sparse file, which will cause
@@ -1609,7 +1611,7 @@ impl SingleDiskFarm {
     pub fn read_all_sectors_metadata(
         directory: &Path,
     ) -> io::Result<Vec<SectorMetadataChecksummed>> {
-        let metadata_file = DirectIoFile::open(&directory.join(Self::METADATA_FILE))?;
+        let metadata_file = DirectIoFile::open(directory.join(Self::METADATA_FILE))?;
 
         let metadata_size = metadata_file.size()?;
         let sector_metadata_size = SectorMetadataChecksummed::encoded_size();

--- a/crates/subspace-farmer/src/single_disk_farm/direct_io_file.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/direct_io_file.rs
@@ -155,7 +155,10 @@ impl DirectIoFile {
     /// will be created).
     ///
     /// This is especially important on Windows to prevent huge memory usage.
-    pub fn open(path: &Path) -> io::Result<Self> {
+    pub fn open<P>(path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
         let mut open_options = OpenOptions::new();
         open_options.use_direct_io();
         let file = open_options

--- a/crates/subspace-farmer/src/single_disk_farm/farming/rayon_files.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/farming/rayon_files.rs
@@ -40,13 +40,16 @@ where
 impl RayonFiles<File> {
     /// Open file at specified path as many times as there is number of threads in current [`rayon`]
     /// thread pool.
-    pub fn open(path: &Path) -> io::Result<Self> {
+    pub fn open<P>(path: P) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
         let files = (0..rayon::current_num_threads())
             .map(|_| {
                 let file = OpenOptions::new()
                     .read(true)
                     .advise_random_access()
-                    .open(path)?;
+                    .open(path.as_ref())?;
                 file.advise_random_access()?;
 
                 Ok::<_, io::Error>(file)
@@ -63,9 +66,12 @@ where
 {
     /// Open file at specified path as many times as there is number of threads in current [`rayon`]
     /// thread pool with a provided function
-    pub fn open_with(path: &Path, open: fn(&Path) -> io::Result<File>) -> io::Result<Self> {
+    pub fn open_with<P>(path: P, open: fn(&Path) -> io::Result<File>) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
         let files = (0..rayon::current_num_threads())
-            .map(|_| open(path))
+            .map(|_| open(path.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self { files })

--- a/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/subspace-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -27,7 +27,7 @@ async fn basic() {
     });
 
     let tempdir = tempdir().unwrap();
-    let file = DirectIoFile::open(&tempdir.path().join("plot.bin")).unwrap();
+    let file = DirectIoFile::open(tempdir.path().join("plot.bin")).unwrap();
 
     // Align plot file size for disk sector size
     file.preallocate(


### PR DESCRIPTION
512 bytes was supposed to save some bandwidth during reads when disk is able to emulate it (physically all SSDs are at least 4096). This caused issues on Linux with SSDs that are formatted to not emulate 512.

The behavior is somewhat bizarre, for example for 0 bytes file reading even unaligned 512 bytes at 512 offset succeeds. It also succeeds for pre-allocated file that wasn't written to. But then write of the same size and at the same offset fails.

This confusingly results in first farmer start to error, but then succeed on subsequent restart:
```
2024-10-29T12:40:10.257523Z ERROR {farm_index=0}: subspace_farmer::commands::farm: Farm creation failed error=Single disk farm I/O error: Invalid argument (os error 22)
Error: Single disk farm I/O error: Invalid argument (os error 22)

Caused by:
    Invalid argument (os error 22)
```

I waned to avoid writing to the file just to test what is possible, but this wasn't really possible. `fs4` has some APIs, but they expose file system level information, not of the physical disk. Querying the low-level properties of the physical disk in cross-platform way is too annoying to deal with, so I decided to simply abandon the idea of supporting 512 bytes emulated sectors.

This will work fine until someone uses SSD with physical sector sizes that are larger than 4096, which can hypothetically exist, but we are yet to see them in the wild among other farmers (and I'll be surprised if those didn't support formatting to 4096 bytes sector sizes even if this ever happens).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
