### PR TITLE
Fix the consensus chain benchmark command

### DIFF
--- a/crates/pallet-subspace/src/benchmarking.rs
+++ b/crates/pallet-subspace/src/benchmarking.rs
@@ -107,10 +107,7 @@ mod benchmarks {
         EnableRewards::<T>::take();
 
         #[extrinsic_call]
-        _(
-            RawOrigin::Root,
-            EnableRewardsAt::Height(Some(100u32.into())),
-        );
+        _(RawOrigin::Root, EnableRewardsAt::Height(100u32.into()));
 
         assert_eq!(EnableRewards::<T>::get(), Some(100u32.into()));
     }

--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -108,6 +108,7 @@ pub mod pallet {
     use sp_consensus_subspace::digests::CompatibleDigestItem;
     use sp_consensus_subspace::inherents::{InherentError, InherentType, INHERENT_IDENTIFIER};
     use sp_consensus_subspace::SignedVote;
+    use sp_runtime::traits::One;
     use sp_runtime::DigestItem;
     use sp_std::collections::btree_map::BTreeMap;
     use sp_std::num::NonZeroU32;
@@ -278,7 +279,7 @@ pub mod pallet {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub enum EnableRewardsAt<BlockNumber> {
         /// At specified height or next block if `None`
-        Height(Option<BlockNumber>),
+        Height(BlockNumber),
         /// When solution range is below specified threshold
         SolutionRange(u64),
         /// Manually with an explicit extrinsic
@@ -307,7 +308,7 @@ pub mod pallet {
         #[inline]
         fn default() -> Self {
             Self {
-                enable_rewards_at: EnableRewardsAt::Height(None),
+                enable_rewards_at: EnableRewardsAt::Height(BlockNumberFor::<T>::one()),
                 allow_authoring_by: AllowAuthoringBy::Anyone,
                 pot_slot_iterations: NonZeroU32::MIN,
                 phantom: PhantomData,
@@ -322,10 +323,8 @@ pub mod pallet {
     {
         fn build(&self) {
             match self.enable_rewards_at {
-                EnableRewardsAt::Height(maybe_block_number) => {
-                    EnableRewards::<T>::put(
-                        maybe_block_number.unwrap_or_else(sp_runtime::traits::One::one),
-                    );
+                EnableRewardsAt::Height(block_number) => {
+                    EnableRewards::<T>::put(block_number);
                 }
                 EnableRewardsAt::SolutionRange(solution_range) => {
                     EnableRewardsBelowSolutionRange::<T>::put(solution_range);
@@ -1122,16 +1121,12 @@ impl<T: Config> Pallet<T> {
         }
 
         match enable_rewards_at {
-            EnableRewardsAt::Height(maybe_block_number) => {
+            EnableRewardsAt::Height(block_number) => {
                 // Enable rewards at a particular block height (default to the next block after
                 // this)
                 let next_block_number =
                     frame_system::Pallet::<T>::current_block_number() + One::one();
-                EnableRewards::<T>::put(
-                    maybe_block_number
-                        .unwrap_or(next_block_number)
-                        .max(next_block_number),
-                );
+                EnableRewards::<T>::put(block_number.max(next_block_number));
             }
             EnableRewardsAt::SolutionRange(solution_range) => {
                 EnableRewardsBelowSolutionRange::<T>::put(solution_range);

--- a/crates/pallet-subspace/src/mock.rs
+++ b/crates/pallet-subspace/src/mock.rs
@@ -250,7 +250,7 @@ pub fn new_test_ext(pot_extension: PotExtension) -> TestExternalities {
         .unwrap();
 
     pallet_subspace::GenesisConfig::<Test> {
-        enable_rewards_at: EnableRewardsAt::Height(Some(1)),
+        enable_rewards_at: EnableRewardsAt::Height(1),
         allow_authoring_by: AllowAuthoringBy::Anyone,
         pot_slot_iterations: NonZeroU32::new(100_000).unwrap(),
         phantom: PhantomData,

--- a/crates/pallet-subspace/src/tests.rs
+++ b/crates/pallet-subspace/src/tests.rs
@@ -1316,9 +1316,7 @@ fn enabling_block_rewards_works() {
         // Enable since next block only rewards
         assert_ok!(Subspace::enable_rewards_at(
             RuntimeOrigin::root(),
-            EnableRewardsAt::Height(Some(
-                frame_system::Pallet::<Test>::current_block_number() + 1,
-            )),
+            EnableRewardsAt::Height(frame_system::Pallet::<Test>::current_block_number() + 1,),
         ));
         // No rewards yet
         assert_matches!(Subspace::find_block_reward_address(), None);

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1534,8 +1534,9 @@ impl_runtime_apis! {
             build_state::<RuntimeGenesisConfig>(config)
         }
 
-        fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-            get_preset::<RuntimeGenesisConfig>(id, |_| None)
+        fn get_preset(_id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
+            // By passing `None` the upstream `get_preset` will return the default value of `RuntimeGenesisConfig`
+            get_preset::<RuntimeGenesisConfig>(&None, |_| None)
         }
 
         fn preset_names() -> Vec<sp_genesis_builder::PresetId> {


### PR DESCRIPTION
The benchmark command now requires the `--genesis-builder-preset` arg, which is a spec id that is used to load a JSON-encoded `RuntimeGenesisConfig`, if not specified "development" will be used. In our case, it will fail because we always return `None` despite the input:
https://github.com/autonomys/subspace/blob/82e8e0a5047619e8209b3d3a49d764fa99ab265d/crates/subspace-runtime/src/lib.rs#L1537-L1539

Ideally, we should follow the upstream practice of using spec id to load the responding `RuntimeGenesisConfig` for benchmark:
https://github.com/paritytech/polkadot-sdk/blob/cc4fe1ec1eee5d2141e8d6160d89bda2a9cf34b0/polkadot/runtime/westend/src/genesis_config_presets.rs#L412-L425
But because the domain runtime is also part of the consensus chain spec, which means the `subspace-runtime` will depend on all the domain runtime crates, doing so will increase the compile time a lot. cc @nazar-pc 

This PR instead uses the default value of `RuntimeGenesisConfig` since each benchmark is coded for the worst scenario regardless of the `RuntimeGenesisConfig` value. The first commit is used to fix a deserialize issue about the default `enable_rewards_at` value because `enable_rewards_at: EnableRewardsAt::Height(None)` will encode as `enable_rewards_at: {}` and fail during decode.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
