### PR TITLE
Create mappings from a specified block number

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -385,6 +385,13 @@ where
         .rev()
         .filter_map(|segment_index| segment_headers_store.get_segment_header(segment_index))
     {
+        // If we're re-creating mappings for existing segments, ignore those segments. This
+        // archives them again, and creates their mappings.
+        // TODO: create historic mappings without doing expensive re-archiving operations
+        if create_object_mappings {
+            continue;
+        }
+
         let last_archived_block_number = segment_header.last_archived_block().number;
         if NumberFor::<Block>::from(last_archived_block_number) > best_block_to_archive {
             // Last archived block in segment header is too high for current state of the chain

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -360,18 +360,20 @@ pub struct ObjectMappingNotification {
     // TODO: add an acknowledgement_sender for backpressure if needed
 }
 
-/// When to start creating object mappings.
+/// Whether to create object mappings.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum CreateObjectMappings {
     /// Start creating object mappings from this block number.
+    ///
+    /// This can be lower than the latest archived block.
     Block(BlockNumber),
 
-    /// Start creating object mappings from the locally archived tip.
-    Continue,
+    /// Create object mappings as archiving is happening.
+    Yes,
 
     /// Don't create object mappings.
     #[default]
-    Disabled,
+    No,
 }
 
 impl CreateObjectMappings {
@@ -380,14 +382,14 @@ impl CreateObjectMappings {
     fn block(&self) -> Option<BlockNumber> {
         match self {
             CreateObjectMappings::Block(block) => Some(*block),
-            CreateObjectMappings::Continue => None,
-            CreateObjectMappings::Disabled => None,
+            CreateObjectMappings::Yes => None,
+            CreateObjectMappings::No => None,
         }
     }
 
     /// Returns true if object mappings will be created from a past or future block.
     pub fn is_enabled(&self) -> bool {
-        !matches!(self, CreateObjectMappings::Disabled)
+        !matches!(self, CreateObjectMappings::No)
     }
 
     /// Does the supplied block number need object mappings?

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -372,6 +372,11 @@ pub enum CreateObjectMappings {
 }
 
 impl CreateObjectMappings {
+    /// Returns true if object mappings will be created from a past or future block.
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, CreateObjectMappings::Block(_))
+    }
+
     /// The block number to start creating object mappings from.
     pub fn block(&self) -> Option<BlockNumber> {
         match self {
@@ -862,6 +867,15 @@ where
     AS: AuxStore + Send + Sync + 'static,
     SO: SyncOracle + Send + Sync + 'static,
 {
+    if create_object_mappings.is_enabled() {
+        info!(
+            ?create_object_mappings,
+            "Creating object mappings from the configured block onwards"
+        );
+    } else {
+        info!("Not creating object mappings");
+    }
+
     let maybe_archiver = if segment_headers_store.max_segment_index().is_none() {
         Some(initialize_archiver(
             &segment_headers_store,

--- a/crates/subspace-gateway-rpc/README.md
+++ b/crates/subspace-gateway-rpc/README.md
@@ -6,10 +6,15 @@ RPC API for Subspace Gateway.
 
 The gateway RPCs can fetch data using object mappings supplied by a node.
 
-Launch a node with `--create-object-mappings`, and wait for mappings from the node RPCs:
-(See the node README for more details.)
-```bash
-$ subspace-node --create-object-mappings ...
+Launch a node with `--create-object-mappings blockNumber --sync full`, and wait for mappings from
+the node RPCs. (See the node README for more details.)
+
+The `blockNumber` should be taken from the last full block mappings received by the client.
+Blocks with lots of mappings can be split into multiple batches, so the client can only be sure it
+has received all the mappings when it sees the next block number.
+
+```sh
+$ subspace-node --create-object-mappings *blockNumber* --sync full ...
 $ websocat --jsonrpc ws://127.0.0.1:9944
 subspace_subscribeObjectMappings
 ```
@@ -37,7 +42,7 @@ subspace_subscribeObjectMappings
 ```
 
 Then use those mappings to get object data from the gateway RPCs:
-```bash
+```sh
 $ websocat --jsonrpc ws://127.0.0.1:9955
 subspace_fetchObject ["v0": { "objects": [["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]]}]
 ```
@@ -48,3 +53,18 @@ subspace_fetchObject ["v0": { "objects": [["000000000000000000000000000000000000
   "result": ["00000000"]
 }
 ```
+
+#### Missed Mappings
+
+The node doesn't make sure the client has processed the previous mapping before generating the next
+one. And any mappings generated while the client is disconnected are silently dropped.
+
+So mappings can be missed if the client is slow to connect, disconnects, or lags.
+To avoid dropping mappings, do the equivalent of:
+```sh
+$ websocat -t - autoreconnect:jsonrpc:ws://127.0.0.1:9944
+$ subspace-node --create-object-mappings blockNumber --sync full ...
+```
+
+This makes sure the websocket will connect as soon as the node opens its RPC port.
+For example, the [`reconnecting-websocket` library](https://github.com/joewalnes/reconnecting-websocket).

--- a/crates/subspace-gateway-rpc/README.md
+++ b/crates/subspace-gateway-rpc/README.md
@@ -68,3 +68,13 @@ $ subspace-node --create-object-mappings blockNumber --sync full ...
 
 This makes sure the websocket will connect as soon as the node opens its RPC port.
 For example, the [`reconnecting-websocket` library](https://github.com/joewalnes/reconnecting-websocket).
+
+#### Live Mappings Only
+
+If the client is only interested in live updates, and can tolerate missing some mappings, the node
+can use snap sync, and launch with `--create-object-mappings continue`:
+```sh
+$ subspace-node --create-object-mappings continue --sync snap ...
+$ websocat --jsonrpc ws://127.0.0.1:9944
+subspace_subscribeObjectMappings
+```

--- a/crates/subspace-gateway-rpc/README.md
+++ b/crates/subspace-gateway-rpc/README.md
@@ -44,7 +44,7 @@ subspace_subscribeObjectMappings
 Then use those mappings to get object data from the gateway RPCs:
 ```sh
 $ websocat --jsonrpc ws://127.0.0.1:9955
-subspace_fetchObject ["v0": { "objects": [["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]]}]
+subspace_fetchObject {"mappings": {"v0": {"objects": [["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]]}}}
 ```
 
 ```json

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -23,6 +23,7 @@ use domain_client_operator::fetch_domain_bootstrap_info;
 use domain_runtime_primitives::opaque::Block as DomainBlock;
 use sc_cli::{ChainSpec, SubstrateCli};
 use sc_consensus_slots::SlotProportion;
+use sc_consensus_subspace::archiver::CreateObjectMappings;
 use sc_network::config::MultiaddrWithPeerId;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sc_utils::mpsc::tracing_unbounded;
@@ -199,7 +200,7 @@ fn main() -> Result<(), Error> {
                 base: consensus_chain_config,
                 // Domain node needs slots notifications for bundle production.
                 force_new_slot_notifications: true,
-                create_object_mappings: true,
+                create_object_mappings: CreateObjectMappings::Block(0),
                 subspace_networking: SubspaceNetworking::Create { config: dsn_config },
                 dsn_piece_getter: None,
                 sync: Default::default(),

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -309,6 +309,9 @@ pub enum CreateObjectMappingConfig {
     /// Start creating object mappings from this block number.
     Block(BlockNumber),
 
+    /// Start creating object mappings from the locally archived tip.
+    Continue,
+
     /// Don't create object mappings.
     #[default]
     Disabled,
@@ -318,6 +321,7 @@ impl From<CreateObjectMappingConfig> for CreateObjectMappings {
     fn from(config: CreateObjectMappingConfig) -> Self {
         match config {
             CreateObjectMappingConfig::Block(block) => CreateObjectMappings::Block(block),
+            CreateObjectMappingConfig::Continue => CreateObjectMappings::Continue,
             CreateObjectMappingConfig::Disabled => CreateObjectMappings::Disabled,
         }
     }
@@ -329,6 +333,7 @@ impl FromStr for CreateObjectMappingConfig {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match input {
             "disabled" => Ok(Self::Disabled),
+            "continue" => Ok(Self::Continue),
             block => block.parse().map(Self::Block).map_err(|_| {
                 "Unsupported create object mappings setting: use a block number, or 'disabled'"
                     .to_string()
@@ -341,6 +346,7 @@ impl fmt::Display for CreateObjectMappingConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Block(block) => write!(f, "{}", block),
+            Self::Continue => f.write_str("continue"),
             Self::Disabled => f.write_str("disabled"),
         }
     }
@@ -433,8 +439,9 @@ pub(super) struct ConsensusChainOptions {
     #[arg(long)]
     force_authoring: bool,
 
-    /// Create object mappings from the supplied block number, or genesis if no block number is
-    /// specified. By default, mappings are disabled.
+    /// Create object mappings from the locally archived tip using `continue`, or from the supplied
+    /// block number. Creates mappings from genesis if no block number is specified. By default,
+    /// mappings are disabled.
     ///
     /// --dev mode enables mappings from genesis automatically, unless another height is supplied.
     /// Use `disabled` to disable mappings in --dev mode.

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -1,6 +1,7 @@
 use crate::dsn::DsnConfig;
 use crate::sync_from_dsn::DsnSyncPieceGetter;
 use sc_chain_spec::ChainSpec;
+use sc_consensus_subspace::archiver::CreateObjectMappings;
 use sc_network::config::{
     MultiaddrWithPeerId, NetworkBackendType, NetworkConfiguration, NodeKeyConfig, SetConfig,
     SyncMode, TransportConfig, DEFAULT_KADEMLIA_REPLICATION_FACTOR,
@@ -302,8 +303,8 @@ pub struct SubspaceConfiguration {
     /// Whether slot notifications need to be present even if node is not responsible for block
     /// authoring.
     pub force_new_slot_notifications: bool,
-    /// Create object mappings for new blocks, and blocks that have already been archived.
-    pub create_object_mappings: bool,
+    /// Create object mappings from a specified segment index, or disable object mapping creation.
+    pub create_object_mappings: CreateObjectMappings,
     /// Subspace networking (DSN).
     pub subspace_networking: SubspaceNetworking,
     /// DSN piece getter


### PR DESCRIPTION
### Partial mapping re-creation feature

This PR allows the user to specify a block number to start creating object mappings from. Can be enabled, disabled or continue from a specified block number.

This allows clients to restart a node from their last *completed* block number after a downtime. Since the mappings between genesis and that block number don't need to be re-created, this increases recovery speed on long chains.

Internally, mappings are created starting at that block. Re-archiving the block can cause duplicate mappings. But if the client didn't receive and persist all the mappings that were queued by the archiver, those duplicates are needed to fill in the gaps.

Users can also say `--create-object-mappings yes`, and mappings will be created from the last locally archived block.

### Mapping re-creation bug fix

This PR also fixes a bug where mappings were skipped up until the last archived segment. `--create-object-mappings` was supposed to re-create mappings from genesis, but instead it was creating them from the first segment that the node didn't have available locally.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
