### PR TITLE
Remove unnecessary re-export of `jsonrpsee`

### DIFF
--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -65,7 +65,5 @@ pub mod single_disk_farm;
 pub mod thread_pool_manager;
 pub mod utils;
 
-pub use jsonrpsee;
-
 /// Size of the LRU cache for peers.
 pub const KNOWN_PEERS_CACHE_SIZE: u32 = 100;


### PR DESCRIPTION
Probably a historical artifact of the node client implementation

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
