### PR TITLE
prepare mainnet chainspec

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -9,7 +9,7 @@ on:
   push:
     tags:
       - 'chain-spec-snapshot-*'
-      - 'chain-spec-taurus-*'
+      - 'chain-spec-mainnet-*'
 
 jobs:
   chains-spec:
@@ -28,16 +28,16 @@ jobs:
 
       - name: Generate testnet chain specifications
         run: |
-          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain taurus-compiled --disable-default-bootnode > chain-spec-taurus.json
-          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain taurus-compiled --disable-default-bootnode --raw > chain-spec-raw-taurus.json
+          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain mainnet-compiled --disable-default-bootnode > chain-spec-mainnet.json
+          docker run --rm -u root ${{ steps.build.outputs.digest }} build-spec --chain mainnet-compiled --disable-default-bootnode --raw > chain-spec-raw-mainnet.json
 
       - name: Upload chain specifications to artifacts
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.1.3
         with:
           name: chain-specifications
           path: |
-            chain-spec-taurus.json
-            chain-spec-raw-taurus.json
+            chain-spec-mainnet.json
+            chain-spec-raw-mainnet.json
           if-no-files-found: error
 
       - name: Upload chain specifications to assets
@@ -45,6 +45,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["chain-spec-taurus.json", "chain-spec-raw-taurus.json"]'
+          asset_paths: '["chain-spec-mainnet.json", "chain-spec-raw-mainnet.json"]'
         # Only run for releases
         if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -10,6 +10,7 @@ on:
     tags:
       - "runtime-snapshot-*"
       - "runtime-taurus-*"
+      - "runtime-mainnet-*"
 
 jobs:
   runtime:

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -11,6 +11,7 @@ on:
     tags:
       - "snapshot-*"
       - "taurus-*"
+      - "mainnet-*"
 
 # Incremental compilation here isn't helpful
 env:

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -31,6 +31,7 @@ use sp_runtime::{BoundedVec, Percent};
 use std::marker::PhantomData;
 use std::num::{NonZeroU128, NonZeroU32};
 use subspace_core_primitives::pot::PotKey;
+use subspace_core_primitives::PublicKey;
 use subspace_runtime::{
     AllowAuthoringBy, BalancesConfig, CouncilConfig, DemocracyConfig, DomainsConfig,
     EnableRewardsAt, HistorySeedingConfig, RewardPoint, RewardsConfig, RuntimeConfigsConfig,
@@ -75,20 +76,20 @@ fn get_genesis_allocations(contents: &str) -> Vec<(AccountId, Balance)> {
         .collect()
 }
 
-pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
+pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
     Ok(GenericChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Wasm binary must be built for Taurus".to_string())?,
         None,
     )
-    .with_name("Autonomys Taurus Testnet")
+    .with_name("Autonomys Mainnet")
     // ID
-    .with_id("autonomys_taurus")
-    .with_chain_type(ChainType::Custom("Autonomys Taurus Testnet".to_string()))
+    .with_id("autonomys_mainnet")
+    .with_chain_type(ChainType::Custom("Autonomys Mainnet".to_string()))
     .with_telemetry_endpoints(
         TelemetryEndpoints::new(vec![(SUBSPACE_TELEMETRY_URL.into(), 1)])
             .map_err(|error| error.to_string())?,
     )
-    .with_protocol_id("autonomys-taurus")
+    .with_protocol_id("autonomys-mainnet")
     .with_properties({
         let mut properties = chain_spec_properties();
         properties.insert(
@@ -99,7 +100,7 @@ pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
     })
     .with_genesis_config({
         let sudo_account =
-            AccountId::from_ss58check("5F1XZHUSixAq58W8fstCUNtP1WDGoRpCEuLzGRDmJo32sbGc")
+            AccountId::from_ss58check("5EHHtxGtDEPFX2x2PCVg8uhhg6kDdt9znQLr2oqUA9sYL5n6")
                 .expect("Wrong root account address");
         let history_seeder =
             AccountId::from_ss58check("5EXKjeN6GXua85mHygsS95UwwrnNwTTEbzeAj9nqkXrgqQp6")
@@ -129,7 +130,11 @@ pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
             balances,
             GenesisParams {
                 enable_rewards_at: EnableRewardsAt::Manually,
-                allow_authoring_by: AllowAuthoringBy::FirstFarmer,
+                allow_authoring_by: AllowAuthoringBy::RootFarmer(PublicKey::from(
+                    hex_literal::hex!(
+                        "e6a489dab63b650cf475431fc46649f4256167443fea241fca0bb3f86b29837a"
+                    ),
+                )),
                 // TODO: Adjust once we bench PoT on faster hardware
                 // About 1s on 6.2 GHz Raptor Lake CPU (14900KS)
                 pot_slot_iterations: NonZeroU32::new(206_557_520).expect("Not zero; qed"),
@@ -240,10 +245,7 @@ pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
                 permissioned_action_allowed_by: PermissionedActionAllowedBy::Accounts(vec![
                     sudo_account.clone(),
                 ]),
-                genesis_domains: vec![
-                    evm_chain_spec::get_genesis_domain(SpecId::Taurus, sudo_account.clone())?,
-                    auto_id_chain_spec::get_genesis_domain(SpecId::Taurus, sudo_account.clone())?,
-                ],
+                genesis_domains: vec![],
             },
             CouncilDemocracyConfigParams::<BlockNumber>::production_params(),
             council_config,
@@ -252,6 +254,10 @@ pub fn taurus_compiled() -> Result<GenericChainSpec, String> {
         .map_err(|error| format!("Failed to serialize genesis config: {error}"))?
     })
     .build())
+}
+
+pub fn mainnet_config() -> Result<GenericChainSpec, String> {
+    Err("Mainnet is not supported".to_string())
 }
 
 pub fn taurus_config() -> Result<GenericChainSpec, String> {

--- a/crates/subspace-node/src/cli.rs
+++ b/crates/subspace-node/src/cli.rs
@@ -98,7 +98,8 @@ impl SubstrateCli for SubspaceCliPlaceholder {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn ChainSpec>, String> {
         let chain_spec = match id {
-            "taurus-compiled" => chain_spec::taurus_compiled()?,
+            "mainnet-compiled" => chain_spec::mainnet_compiled()?,
+            "mainnet" => chain_spec::mainnet_config()?,
             "taurus" => chain_spec::taurus_config()?,
             "devnet" => chain_spec::devnet_config()?,
             "devnet-compiled" => chain_spec::devnet_config_compiled()?,

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -506,7 +506,8 @@ pub(super) fn create_consensus_chain_configuration(
     let sync = sync.unwrap_or(ChainSyncMode::Snap);
 
     let chain_spec = match chain.as_deref() {
-        Some("taurus-compiled") => chain_spec::taurus_compiled()?,
+        Some("mainnet-compiled") => chain_spec::mainnet_compiled()?,
+        Some("mainnet") => chain_spec::mainnet_config()?,
         Some("taurus") => chain_spec::taurus_config()?,
         Some("devnet") => chain_spec::devnet_config()?,
         Some("devnet-compiled") => chain_spec::devnet_config_compiled()?,


### PR DESCRIPTION
I have modified `taurus-compiled` to `mainnet-compiled` to build the spec, removed genesis domains and included the bootstrap nodes we prepared on infra side. 
Effectively, by including the JSON we now carry 2 copies of genesis allocations information, which is not ideal. I would like to keep it as is for the next days, however.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
