### PR TITLE
Add MMR-sync to consensus chain snap sync.

### DIFF
--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -905,7 +905,7 @@ where
 
     if let Some(offchain_storage) = backend.offchain_storage() {
         // Allow both outgoing and incoming requests.
-        let (handler, protocol_config) = MmrRequestHandler::new::<NetworkWorker<_, _>, _>(
+        let (handler, protocol_config) = MmrRequestHandler::new::<NetworkWorker<_, _>>(
             &protocol_id,
             fork_id,
             client.clone(),

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1088,6 +1088,8 @@ where
         sync_service.clone(),
         network_service_handle,
         subspace_link.erasure_coding().clone(),
+        backend.offchain_storage(),
+        network_service.clone(),
     );
 
     let (observer, worker) = sync_from_dsn::create_observer_and_worker(

--- a/crates/subspace-service/src/mmr.rs
+++ b/crates/subspace-service/src/mmr.rs
@@ -1,9 +1,15 @@
+use sp_core::H256;
 use sp_mmr_primitives::utils::NodesUtils;
 use sp_mmr_primitives::{NodeIndex, INDEXING_PREFIX};
+use subspace_runtime_primitives::opaque::Header;
 
 pub(crate) mod request_handler;
 pub(crate) mod sync;
 
 pub(crate) fn get_offchain_key(index: NodeIndex) -> Vec<u8> {
     NodesUtils::node_canon_offchain_key(INDEXING_PREFIX, index)
+}
+
+pub(crate) fn get_temp_key(index: NodeIndex, hash: H256) -> Vec<u8> {
+    NodesUtils::node_temp_offchain_key::<Header>(INDEXING_PREFIX, index, hash)
 }

--- a/crates/subspace-service/src/mmr/request_handler.rs
+++ b/crates/subspace-service/src/mmr/request_handler.rs
@@ -249,7 +249,10 @@ where
                 if let Some(storage_value) = storage_value {
                     mmr_data.insert(position, storage_value);
                 } else {
-                    if let Ok(Some(hash)) = self.client.hash((block_number as u32).into()) {
+                    if let Ok(Some(hash)) = self
+                        .client
+                        .hash((u32::try_from(block_number).expect("Block number is u32")).into())
+                    {
                         let temp_key = get_temp_key(position.into(), hash);
                         let storage_value = self
                             .offchain_db

--- a/crates/subspace-service/src/mmr/request_handler.rs
+++ b/crates/subspace-service/src/mmr/request_handler.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::mmr::get_offchain_key;
+use crate::mmr::sync::decode_mmr_data;
+use crate::mmr::{get_offchain_key, get_temp_key};
 use futures::channel::oneshot;
 use futures::stream::StreamExt;
 use parity_scale_codec::{Decode, Encode};
@@ -23,8 +24,10 @@ use sc_network::config::ProtocolId;
 use sc_network::request_responses::{IncomingRequest, OutgoingResponse};
 use sc_network::{NetworkBackend, PeerId};
 use schnellru::{ByLength, LruMap};
+use sp_blockchain::HeaderBackend;
 use sp_core::offchain::storage::OffchainDb;
 use sp_core::offchain::{DbExternalities, OffchainStorage, StorageKind};
+use sp_mmr_primitives::utils::NodesUtils;
 use sp_runtime::codec;
 use sp_runtime::traits::Block as BlockT;
 use std::collections::BTreeMap;
@@ -111,7 +114,10 @@ enum SeenRequestsValue {
 }
 
 /// Handler for incoming block requests from a remote peer.
-pub struct MmrRequestHandler<Block: BlockT, OS> {
+pub struct MmrRequestHandler<Block, OS, Client>
+where
+    Block: BlockT,
+{
     request_receiver: async_channel::Receiver<IncomingRequest>,
     /// Maps from request to number of times we have seen this request.
     ///
@@ -120,17 +126,20 @@ pub struct MmrRequestHandler<Block: BlockT, OS> {
 
     offchain_db: OffchainDb<OS>,
 
+    client: Arc<Client>,
+
     _phantom: PhantomData<Block>,
 }
 
-impl<Block, OS> MmrRequestHandler<Block, OS>
+impl<Block, OS, Client> MmrRequestHandler<Block, OS, Client>
 where
-    Block: BlockT,
-
+    Block: BlockT<Hash = sp_core::H256>,
+    Client:
+        HeaderBackend<Block> + BlockBackend<Block> + ProofProvider<Block> + Send + Sync + 'static,
     OS: OffchainStorage,
 {
     /// Create a new [`MmrRequestHandler`].
-    pub fn new<NB, Client>(
+    pub fn new<NB>(
         protocol_id: &ProtocolId,
         fork_id: Option<&str>,
         client: Arc<Client>,
@@ -138,8 +147,7 @@ where
         offchain_storage: OS,
     ) -> (Self, NB::RequestResponseProtocolConfig)
     where
-        NB: NetworkBackend<Block, Block::Hash>,
-        Client: BlockBackend<Block> + ProofProvider<Block> + Send + Sync + 'static,
+        NB: NetworkBackend<Block, <Block as BlockT>::Hash>,
     {
         // Reserve enough request slots for one request per peer when we are at the maximum
         // number of peers.
@@ -162,6 +170,7 @@ where
 
         (
             Self {
+                client,
                 request_receiver,
                 seen_requests,
                 offchain_db: OffchainDb::new(offchain_storage),
@@ -228,17 +237,35 @@ where
             Err(())
         } else {
             let mut mmr_data = BTreeMap::new();
-            for block_number in
-                request.starting_position..(request.starting_position + request.limit)
-            {
-                let canon_key = get_offchain_key(block_number.into());
+            for position in request.starting_position..(request.starting_position + request.limit) {
+                let canon_key = get_offchain_key(position.into());
                 let storage_value = self
                     .offchain_db
                     .local_storage_get(StorageKind::PERSISTENT, &canon_key);
 
+                let block_number = NodesUtils::leaf_index_that_added_node(position.into());
+                trace!(%position, %block_number, "Storage data present: {}", storage_value.is_some());
+
                 if let Some(storage_value) = storage_value {
-                    mmr_data.insert(block_number, storage_value);
+                    mmr_data.insert(position, storage_value);
                 } else {
+                    if let Ok(Some(hash)) = self.client.hash((block_number as u32).into()) {
+                        let temp_key = get_temp_key(position.into(), hash);
+                        let storage_value = self
+                            .offchain_db
+                            .local_storage_get(StorageKind::PERSISTENT, &temp_key);
+
+                        if let Some(storage_value) = storage_value {
+                            let data = decode_mmr_data(&storage_value);
+                            trace!(%position, %block_number,"MMR node: {data:?}");
+                            mmr_data.insert(position, storage_value);
+                            continue;
+                        } else {
+                            debug!(%position, %block_number, ?hash, "Didn't find value in storage.")
+                        }
+                    } else {
+                        debug!(%position, %block_number, "Didn't find hash.")
+                    }
                     break; // No more storage values
                 }
             }

--- a/crates/subspace-service/src/mmr/request_handler/tests.rs
+++ b/crates/subspace-service/src/mmr/request_handler/tests.rs
@@ -1,0 +1,7 @@
+use subspace_core_primitives::BlockNumber;
+
+#[test]
+fn leaf_index_that_added_node_fits_block_number() {
+    // Must not panic
+    super::leaf_index_that_added_node(BlockNumber::MAX);
+}

--- a/crates/subspace-service/src/mmr/sync.rs
+++ b/crates/subspace-service/src/mmr/sync.rs
@@ -110,6 +110,7 @@ impl mmr_lib::Merge for MmrHasher {
 
 const SYNC_PAUSE: Duration = Duration::from_secs(5);
 
+// TODO: Add support for MMR-sync reruns from non-zero starting point.
 /// Synchronize MMR-leafs from remote offchain storage of the synced peer.
 pub async fn mmr_sync<Block, Client, NR, OS>(
     fork_id: Option<String>,
@@ -242,6 +243,14 @@ where
 
                 // Should we request a new portion of the data from the last peer?
                 if target_position <= starting_position.into() {
+                    if let Err(err) = mmr.commit() {
+                        error!(?err, "MMR commit failed.");
+
+                        return Err(sp_blockchain::Error::Application(
+                            "Failed to commit MMR data.".into(),
+                        ));
+                    }
+
                     // Actual MMR-nodes may exceed this number, however, we will catch up with the rest
                     // when we sync the remaining data (consensus and domain chains).
                     debug!("Target position reached: {target_position}");

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -416,6 +416,12 @@ where
     // TODO: Replace this hack with actual watching of block import
     wait_for_block_import(client.as_ref(), last_block_number.into()).await;
 
+    let mmr_target_block = if let Some(target_block) = target_block {
+        target_block
+    } else {
+        last_block_number
+    };
+
     if let Some(offchain_storage) = offchain_storage {
         mmr_sync(
             fork_id.map(|v| v.into()),
@@ -423,7 +429,7 @@ where
             network_request,
             sync_service.clone(),
             offchain_storage,
-            target_block,
+            mmr_target_block,
         )
         .await?;
     }

--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -19,6 +19,8 @@ use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockOrigin;
 use sp_consensus_subspace::SubspaceApi;
 use sp_core::offchain::OffchainStorage;
+use sp_core::H256;
+use sp_mmr_primitives::MmrApi;
 use sp_objects::ObjectsApi;
 use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::collections::{HashSet, VecDeque};
@@ -87,7 +89,8 @@ where
         + Send
         + Sync
         + 'static,
-    Client::Api: SubspaceApi<Block, PublicKey> + ObjectsApi<Block>,
+    Client::Api:
+        SubspaceApi<Block, PublicKey> + ObjectsApi<Block> + MmrApi<Block, H256, NumberFor<Block>>,
     PG: DsnSyncPieceGetter,
     OS: OffchainStorage,
 {
@@ -298,7 +301,8 @@ where
         + Send
         + Sync
         + 'static,
-    Client::Api: SubspaceApi<Block, PublicKey> + ObjectsApi<Block>,
+    Client::Api:
+        SubspaceApi<Block, PublicKey> + ObjectsApi<Block> + MmrApi<Block, H256, NumberFor<Block>>,
     IQS: ImportQueueService<Block> + ?Sized,
     OS: OffchainStorage,
     NR: NetworkRequest + Sync + Send,


### PR DESCRIPTION
This PR adds MMR-sync as part of the consensus snap sync. It will simplify future domain snap sync because the consensus chain network will contain proper local MMR data storage.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
