### PR TITLE
Update gateway README for new format

### DIFF
--- a/crates/subspace-gateway-rpc/README.md
+++ b/crates/subspace-gateway-rpc/README.md
@@ -6,8 +6,10 @@ RPC API for Subspace Gateway.
 
 The gateway RPCs can fetch data using object mappings supplied by a node.
 
-Launch a node using the instructions in its README, and wait for mappings from the node RPCs:
+Launch a node with `--create-object-mappings`, and wait for mappings from the node RPCs:
+(See the node README for more details.)
 ```bash
+$ subspace-node --create-object-mappings ...
 $ websocat --jsonrpc ws://127.0.0.1:9944
 subspace_subscribeObjectMappings
 ```
@@ -15,13 +17,18 @@ subspace_subscribeObjectMappings
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "subspace_archived_object_mappings",
+  "method": "subspace_object_mappings",
   "params": {
     "subscription": "o7M85uu9ir39R5PJ",
     "result": {
+      "blockNumber": 0,
       "v0": {
         "objects": [
-          ["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]
+          [
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            0,
+            0
+          ]
         ]
       }
     }


### PR DESCRIPTION
Just a README update for the format change in PR #3204.

#### Test Details

Here's how I tested it:

Test branch: https://github.com/autonomys/subspace/tree/obj-block-num-test

Commands (I also piped through `jq .` for pretty formatting):
```sh
$ ./subspace-node run --dev
$ websocat --jsonrpc ws://127.0.0.1:9944
subspace_subscribeObjectMappings
```

Old format:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": "0x0P1Mr0PBkk060v"
}
{
  "jsonrpc": "2.0",
  "method": "subspace_object_mappings",
  "params": {
    "subscription": "0x0P1Mr0PBkk060v",
    "result": {
      "v0": {
        "objects": [
          [
            "0000000000000000000000000000000000000000000000000000000000000000",
            0,
            0
          ]
        ]
      }
    }
  }
}
```

New format:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": "iPmA4xBUikkbFFrh"
}
{
  "jsonrpc": "2.0",
  "method": "subspace_object_mappings",
  "params": {
    "subscription": "iPmA4xBUikkbFFrh",
    "result": {
      "blockNumber": 0,
      "v0": {
        "objects": [
          [
            "0000000000000000000000000000000000000000000000000000000000000000",
            0,
            0
          ]
        ]
      }
    }
  }
}
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
