### PR TITLE
Mainnet chainspec json

### DIFF
--- a/crates/sc-subspace-chain-specs/src/lib.rs
+++ b/crates/sc-subspace-chain-specs/src/lib.rs
@@ -19,3 +19,4 @@
 /// Devnet chain spec
 pub const DEVNET_CHAIN_SPEC: &str = include_str!("../res/chain-spec-raw-devnet.json");
 pub const TAURUS_CHAIN_SPEC: &str = include_str!("../res/chain-spec-raw-taurus.json");
+pub const MAINNET_CHAIN_SPEC: &str = include_str!("../res/chain-spec-raw-mainnet.json");

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -22,7 +22,7 @@ use crate::domain::cli::{GenesisDomain, SpecId};
 use crate::domain::evm_chain_spec::{self};
 use sc_chain_spec::GenericChainSpec;
 use sc_service::ChainType;
-use sc_subspace_chain_specs::{DEVNET_CHAIN_SPEC, TAURUS_CHAIN_SPEC};
+use sc_subspace_chain_specs::{DEVNET_CHAIN_SPEC, MAINNET_CHAIN_SPEC, TAURUS_CHAIN_SPEC};
 use sc_telemetry::TelemetryEndpoints;
 use serde::Deserialize;
 use sp_core::crypto::Ss58Codec;
@@ -257,7 +257,7 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
 }
 
 pub fn mainnet_config() -> Result<GenericChainSpec, String> {
-    Err("Mainnet is not supported".to_string())
+    GenericChainSpec::from_json_bytes(MAINNET_CHAIN_SPEC.as_bytes())
 }
 
 pub fn taurus_config() -> Result<GenericChainSpec, String> {


### PR DESCRIPTION
The first commit contains the CI-built raw chainspec as in https://github.com/autonomys/subspace/releases/tag/chain-spec-mainnet-2024-nov-04 
2nd ingests it into the node
3rd adds correct bootstrap addresses 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
