### PR TITLE
Fix the max domain block weight usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
 name = "auto-id-domain-runtime"
 version = "0.1.0"
 dependencies = [
+ "domain-check-weight",
  "domain-pallet-executive",
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -1009,6 +1010,7 @@ dependencies = [
 name = "auto-id-domain-test-runtime"
 version = "0.1.0"
 dependencies = [
+ "domain-check-weight",
  "domain-pallet-executive",
  "domain-runtime-primitives",
  "domain-test-primitives",
@@ -2547,6 +2549,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "domain-check-weight"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-weights",
+]
+
+[[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
 dependencies = [
@@ -2792,6 +2806,7 @@ version = "0.1.0"
 dependencies = [
  "auto-id-domain-test-runtime",
  "cross-domain-message-gossip",
+ "domain-check-weight",
  "domain-client-operator",
  "domain-runtime-primitives",
  "domain-service",
@@ -3208,6 +3223,7 @@ dependencies = [
 name = "evm-domain-runtime"
 version = "0.1.0"
 dependencies = [
+ "domain-check-weight",
  "domain-pallet-executive",
  "domain-runtime-primitives",
  "fp-account",
@@ -3265,6 +3281,7 @@ dependencies = [
 name = "evm-domain-test-runtime"
 version = "0.1.0"
 dependencies = [
+ "domain-check-weight",
  "domain-pallet-executive",
  "domain-runtime-primitives",
  "domain-test-primitives",

--- a/domains/pallets/domain-check-weight/Cargo.toml
+++ b/domains/pallets/domain-check-weight/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "domain-check-weight"
+version = "0.1.0"
+authors = ["Subspace Labs <https://subspace.network>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/autonomys/subspace"
+description = "Subspace domain check_weight extension"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+frame-support = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
+frame-system = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
+scale-info = { version = "2.11.2", default-features = false, features = ["derive"] }
+sp-runtime = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
+sp-weights = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "scale-info/std",
+    "sp-runtime/std",
+    "sp-weights/std",
+]

--- a/domains/pallets/domain-check-weight/src/lib.rs
+++ b/domains/pallets/domain-check-weight/src/lib.rs
@@ -1,0 +1,168 @@
+// Copyright (C) 2024 Subspace Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+use frame_support::dispatch::{DispatchInfo, PostDispatchInfo};
+use frame_support::traits::Get;
+use frame_system::limits::BlockWeights;
+use frame_system::{Config, ConsumedWeight};
+use scale_info::TypeInfo;
+use sp_runtime::traits::{DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension};
+use sp_runtime::transaction_validity::{TransactionValidity, TransactionValidityError};
+use sp_runtime::DispatchResult;
+use sp_weights::Weight;
+
+/// Wrapper of [`frame_system::CheckWeight`]
+///
+/// It performs the same check as [`frame_system::CheckWeight`] except the `max_total/max_block` weight limit
+/// check is removed from the `pre_dispatch/pre_dispatch_unsigned` because the total weight of a domain block
+/// is based on probability instead of a hard limit.
+#[derive(Encode, Decode, Clone, Eq, PartialEq, Default, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct CheckWeight<T: Config + Send + Sync>(core::marker::PhantomData<T>);
+
+impl<T: Config + Send + Sync> CheckWeight<T>
+where
+    T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+{
+    /// Creates new `SignedExtension` to check weight of the extrinsic.
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+
+    /// Check the block lenght and the max extrinsic weight and notes the new weight and length value.
+    ///
+    /// It is same as the [`frame_system::CheckWeight::do_pre_dispatch`] except the `max_total/max_block`
+    /// weight limit check is removed.
+    pub fn do_pre_dispatch(
+        info: &DispatchInfoOf<T::RuntimeCall>,
+        len: usize,
+    ) -> Result<(), TransactionValidityError> {
+        // Check the block lenght and the max extrinsic weight
+        frame_system::CheckWeight::<T>::do_validate(info, len)?;
+
+        let next_len = frame_system::Pallet::<T>::all_extrinsics_len().saturating_add(len as u32);
+
+        let next_weight = {
+            let all_weight = frame_system::Pallet::<T>::block_weight();
+            let maximum_weight = T::BlockWeights::get();
+            calculate_consumed_weight::<T::RuntimeCall>(&maximum_weight, all_weight, info, len)
+        };
+
+        frame_system::AllExtrinsicsLen::<T>::put(next_len);
+        frame_system::BlockWeight::<T>::put(next_weight);
+
+        Ok(())
+    }
+}
+
+/// Calculate the new block weight value with the given extrinsic
+fn calculate_consumed_weight<Call>(
+    maximum_weight: &BlockWeights,
+    mut all_weight: ConsumedWeight,
+    info: &DispatchInfoOf<Call>,
+    len: usize,
+) -> ConsumedWeight
+where
+    Call: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+{
+    // Also Consider extrinsic length as proof weight.
+    let extrinsic_weight = info
+        .weight
+        .saturating_add(maximum_weight.get(info.class).base_extrinsic)
+        .saturating_add(Weight::from_parts(0, len as u64));
+
+    // Saturating add the weight
+    all_weight.accrue(extrinsic_weight, info.class);
+
+    all_weight
+}
+
+impl<T: Config + Send + Sync> SignedExtension for CheckWeight<T>
+where
+    T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+{
+    type AccountId = T::AccountId;
+    type Call = T::RuntimeCall;
+    type AdditionalSigned = ();
+    type Pre = ();
+    const IDENTIFIER: &'static str = "CheckWeight";
+
+    fn additional_signed(&self) -> core::result::Result<(), TransactionValidityError> {
+        Ok(())
+    }
+
+    fn pre_dispatch(
+        self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> Result<(), TransactionValidityError> {
+        Self::do_pre_dispatch(info, len)
+    }
+
+    fn validate(
+        &self,
+        _who: &Self::AccountId,
+        _call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> TransactionValidity {
+        frame_system::CheckWeight::<T>::do_validate(info, len)
+    }
+
+    fn pre_dispatch_unsigned(
+        _call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> Result<(), TransactionValidityError> {
+        Self::do_pre_dispatch(info, len)
+    }
+
+    fn validate_unsigned(
+        _call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> TransactionValidity {
+        frame_system::CheckWeight::<T>::do_validate(info, len)
+    }
+
+    fn post_dispatch(
+        pre: Option<Self::Pre>,
+        info: &DispatchInfoOf<Self::Call>,
+        post_info: &PostDispatchInfoOf<Self::Call>,
+        len: usize,
+        result: &DispatchResult,
+    ) -> Result<(), TransactionValidityError> {
+        <frame_system::CheckWeight<T> as SignedExtension>::post_dispatch(
+            pre, info, post_info, len, result,
+        )
+    }
+}
+
+impl<T: Config + Send + Sync> core::fmt::Debug for CheckWeight<T> {
+    #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "CheckWeight")
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn fmt(&self, _: &mut core::fmt::Formatter) -> core::fmt::Result {
+        Ok(())
+    }
+}

--- a/domains/pallets/domain-check-weight/src/lib.rs
+++ b/domains/pallets/domain-check-weight/src/lib.rs
@@ -44,7 +44,7 @@ where
         Self(Default::default())
     }
 
-    /// Check the block lenght and the max extrinsic weight and notes the new weight and length value.
+    /// Check the block length and the max extrinsic weight and notes the new weight and length value.
     ///
     /// It is same as the [`frame_system::CheckWeight::do_pre_dispatch`] except the `max_total/max_block`
     /// weight limit check is removed.

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -113,7 +113,7 @@ pub fn block_weights() -> BlockWeights {
     // If the bundle slot probability is the same as the consensus slot probability then
     // there is one bundle per block, such a bundle is allowed to consume the whole domain
     // block weight
-    let max_extrinsic_weight = maximum_block_weight;
+    let max_extrinsic_weight = maximum_block_weight - ExtrinsicBaseWeight::get();
 
     BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -101,13 +101,19 @@ pub const EXISTENTIAL_DEPOSIT: Balance = 500 * SHANNON;
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 
 pub fn block_weights() -> BlockWeights {
-    // Allow u64::MAX for ref_time and proof size for total domain weight
-    let maximum_block_weight = Weight::from_parts(u64::MAX, u64::MAX);
+    // NOTE: this value is used in many places as the `max_block` weight (e.g. `used_weight / max_block`
+    // is used in tx fee adjustment), but it does not serve as a limit of the total weight of a domain block,
+    // which is `max_bundle_weight * number_of_bundle` and bundle production is probabilistic.
+    // See [`domain-check-weight::CheckWeight`] for more detail about the domain block weight check.
+    //
+    // TODO: instead of using a constant weight value for all the domain runtimes, perhaps derive and use the
+    // target domain block weight bases on `max_bundle_weight` and `bundle_slot_probability`.
+    let maximum_block_weight = maximum_domain_block_weight();
 
     // If the bundle slot probability is the same as the consensus slot probability then
-    // there is one bundle per block, such bundle is allowed to contains the whole domain
+    // there is one bundle per block, such a bundle is allowed to consume the whole domain
     // block weight
-    let max_extrinsic_weight = maximum_domain_block_weight();
+    let max_extrinsic_weight = maximum_block_weight;
 
     BlockWeights::builder()
         .base_block(BlockExecutionWeight::get())

--- a/domains/runtime/auto-id/Cargo.toml
+++ b/domains/runtime/auto-id/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+domain-check-weight = { version = "0.1.0", path = "../../pallets/domain-check-weight", default-features = false }
 domain-pallet-executive = { version = "0.1.0", path = "../../pallets/executive", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/subspace/polkadot-sdk", rev = "5871818e1d736f1843eb9078f886290695165c42" }
@@ -70,6 +71,7 @@ default = [
 ]
 std = [
     "codec/std",
+    "domain-check-weight/std",
     "domain-pallet-executive/std",
     "domain-runtime-primitives/std",
     "frame-benchmarking?/std",

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -831,7 +831,11 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
-            ext.get_dispatch_info().weight
+            let len = ext.encoded_size() as u64;
+            let info = ext.get_dispatch_info();
+            info.weight
+                .saturating_add(<Runtime as frame_system::Config>::BlockWeights::get().get(info.class).base_extrinsic)
+                .saturating_add(Weight::from_parts(0, len))
         }
 
         fn block_fees() -> sp_domains::BlockFees<Balance> {

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -87,7 +87,7 @@ pub type SignedExtra = (
     frame_system::CheckGenesis<Runtime>,
     frame_system::CheckMortality<Runtime>,
     frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
+    domain_check_weight::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+domain-check-weight = { version = "0.1.0", path = "../../pallets/domain-check-weight", default-features = false }
 domain-pallet-executive = { version = "0.1.0", path = "../../pallets/executive", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../primitives/runtime", default-features = false }
 fp-account = { version = "1.0.0-dev", default-features = false, features = ["serde"], git = "https://github.com/autonomys/frontier", rev = "f80f9e2bad338f3bf3854b256b3c4edea23e5968" }
@@ -80,6 +81,7 @@ default = [
 ]
 std = [
     "codec/std",
+    "domain-check-weight/std",
     "domain-pallet-executive/std",
     "domain-runtime-primitives/std",
     "fp-account/std",

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -215,8 +215,8 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
                     Err(_) => return Some(Err(InvalidTransaction::Payment.into())),
                 }
 
-                // Copy from [`pallet_ethereum::Call::pre_dispatch_self_contained`] with `frame_system::CheckWeight`
-                // replaced to `domain_check_weight::CheckWeight`
+                // Copied from [`pallet_ethereum::Call::pre_dispatch_self_contained`] with `frame_system::CheckWeight`
+                // replaced with `domain_check_weight::CheckWeight`
                 if let pallet_ethereum::Call::transact { transaction } = call {
                     if let Err(e) = domain_check_weight::CheckWeight::<Runtime>::do_pre_dispatch(
                         dispatch_info,

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -1242,7 +1242,11 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
-            ext.get_dispatch_info().weight
+            let len = ext.encoded_size() as u64;
+            let info = ext.get_dispatch_info();
+            info.weight
+                .saturating_add(<Runtime as frame_system::Config>::BlockWeights::get().get(info.class).base_extrinsic)
+                .saturating_add(Weight::from_parts(0, len))
         }
 
         fn block_fees() -> sp_domains::BlockFees<Balance> {

--- a/domains/test/runtime/auto-id/Cargo.toml
+++ b/domains/test/runtime/auto-id/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+domain-check-weight = { version = "0.1.0", path = "../../../pallets/domain-check-weight", default-features = false }
 domain-pallet-executive = { version = "0.1.0", path = "../../../pallets/executive", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../../primitives/runtime", default-features = false }
 domain-test-primitives = { version = "0.1.0", path = "../../primitives", default-features = false }
@@ -70,6 +71,7 @@ default = [
 ]
 std = [
     "codec/std",
+    "domain-check-weight/std",
     "domain-pallet-executive/std",
     "domain-runtime-primitives/std",
     "domain-test-primitives/std",

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -822,7 +822,11 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
-            ext.get_dispatch_info().weight
+            let len = ext.encoded_size() as u64;
+            let info = ext.get_dispatch_info();
+            info.weight
+                .saturating_add(<Runtime as frame_system::Config>::BlockWeights::get().get(info.class).base_extrinsic)
+                .saturating_add(Weight::from_parts(0, len))
         }
 
         fn block_fees() -> sp_domains::BlockFees<Balance> {

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -87,7 +87,7 @@ pub type SignedExtra = (
     frame_system::CheckGenesis<Runtime>,
     frame_system::CheckMortality<Runtime>,
     frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
+    domain_check_weight::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 

--- a/domains/test/runtime/evm/Cargo.toml
+++ b/domains/test/runtime/evm/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+domain-check-weight = { version = "0.1.0", path = "../../../pallets/domain-check-weight", default-features = false }
 domain-pallet-executive = { version = "0.1.0", path = "../../../pallets/executive", default-features = false }
 domain-test-primitives = { version = "0.1.0", path = "../../primitives", default-features = false }
 domain-runtime-primitives = { version = "0.1.0", path = "../../../primitives/runtime", default-features = false }
@@ -74,6 +75,7 @@ default = [
 ]
 std = [
     "codec/std",
+    "domain-check-weight/std",
     "domain-pallet-executive/std",
     "domain-runtime-primitives/std",
     "domain-test-primitives/std",

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -1205,7 +1205,11 @@ impl_runtime_apis! {
         }
 
         fn extrinsic_weight(ext: &<Block as BlockT>::Extrinsic) -> Weight {
-            ext.get_dispatch_info().weight
+            let len = ext.encoded_size() as u64;
+            let info = ext.get_dispatch_info();
+            info.weight
+                .saturating_add(<Runtime as frame_system::Config>::BlockWeights::get().get(info.class).base_extrinsic)
+                .saturating_add(Weight::from_parts(0, len))
         }
 
         fn block_fees() -> sp_domains::BlockFees<Balance> {

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -117,7 +117,7 @@ pub type SignedExtra = (
     frame_system::CheckGenesis<Runtime>,
     frame_system::CheckMortality<Runtime>,
     frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
+    domain_check_weight::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 
@@ -130,7 +130,7 @@ type CustomSignedExtra = (
     frame_system::CheckGenesis<Runtime>,
     frame_system::CheckMortality<Runtime>,
     pallet_evm_nonce_tracker::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
+    domain_check_weight::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 
@@ -214,7 +214,20 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
                     Err(_) => return Some(Err(InvalidTransaction::Payment.into())),
                 }
 
-                call.pre_dispatch_self_contained(info, dispatch_info, len)
+                // Copy from [`pallet_ethereum::Call::pre_dispatch_self_contained`] with `frame_system::CheckWeight`
+                // replaced to `domain_check_weight::CheckWeight`
+                if let pallet_ethereum::Call::transact { transaction } = call {
+                    if let Err(e) = domain_check_weight::CheckWeight::<Runtime>::do_pre_dispatch(
+                        dispatch_info,
+                        len,
+                    ) {
+                        return Some(Err(e));
+                    }
+
+                    Some(Ethereum::validate_transaction_in_block(*info, transaction))
+                } else {
+                    None
+                }
             }
             _ => None,
         }
@@ -896,7 +909,7 @@ fn pre_dispatch_evm_transaction(
                 transaction_validity.map(|_| ())?;
 
                 let Call::transact { transaction } = call;
-                frame_system::CheckWeight::<Runtime>::do_pre_dispatch(dispatch_info, len)?;
+                domain_check_weight::CheckWeight::<Runtime>::do_pre_dispatch(dispatch_info, len)?;
 
                 let transaction_data: TransactionData = (&transaction).into();
                 let transaction_nonce = transaction_data.nonce;

--- a/domains/test/service/Cargo.toml
+++ b/domains/test/service/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+domain-check-weight = { version = "0.1.0", path = "../../../domains/pallets/domain-check-weight" }
 auto-id-domain-test-runtime = { version = "0.1.0", path = "../runtime/auto-id" }
 cross-domain-message-gossip = { version = "0.1.0", path = "../../client/cross-domain-message-gossip" }
 domain-client-operator = { version = "0.1.0", path = "../../client/domain-operator" }

--- a/domains/test/service/src/lib.rs
+++ b/domains/test/service/src/lib.rs
@@ -170,7 +170,7 @@ type SignedExtraFor<Runtime> = (
     frame_system::CheckGenesis<Runtime>,
     frame_system::CheckMortality<Runtime>,
     frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
+    domain_check_weight::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 
@@ -219,7 +219,7 @@ where
             generic::Era::mortal(period, current_block)
         }),
         frame_system::CheckNonce::<Runtime>::from(nonce.into()),
-        frame_system::CheckWeight::<Runtime>::new(),
+        domain_check_weight::CheckWeight::<Runtime>::new(),
         pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
     );
     (


### PR DESCRIPTION
close #3193 

In main, the domain runtime uses a MAX value as the max block weight because even though we have a target max domain block weight the actual total domain block weight is probabilistic, which causes issues when calculating the weight usage and remaining weight in block, etc, see #3193 for more detail.

This PR fixes the issue by using a realistic value as the max block weight in the domain runtime instead of the MAX value. To workaround the probabilistic domain block weight, it introduces a customized `check_weight` extension, which is the same as the upstream one except the `max_block` weight limit check is removed (the alternative is to continue using the MAX value in the `check_weight` extension but a realistic value in other places but it is too hack and a lot of redundant code).

Note this PR replaces the upstream `check_weight` extension with the customized one in a few more places in the EVM domain runtime, and it also fixes a minor issue about accounting the `base_extrinsic` weight in the bundle weight check.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
