### PR TITLE
Remove cache index generic

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller/caches.rs
@@ -15,9 +15,7 @@ use std::future::{ready, Future};
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use subspace_farmer::cluster::cache::{
-    ClusterCacheIdentifyBroadcast, ClusterCacheIndex, ClusterPieceCache,
-};
+use subspace_farmer::cluster::cache::{ClusterCacheIdentifyBroadcast, ClusterPieceCache};
 use subspace_farmer::cluster::controller::ClusterControllerCacheIdentifyBroadcast;
 use subspace_farmer::cluster::nats_client::NatsClient;
 use subspace_farmer::farm::{PieceCache, PieceCacheId};
@@ -88,7 +86,7 @@ impl KnownCaches {
 pub(super) async fn maintain_caches(
     cache_group: &str,
     nats_client: &NatsClient,
-    farmer_cache: FarmerCache<ClusterCacheIndex>,
+    farmer_cache: FarmerCache,
 ) -> anyhow::Result<()> {
     let mut known_caches = KnownCaches::default();
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -69,8 +69,6 @@ const MAX_SPACE_PLEDGED_FOR_PLOT_CACHE_ON_WINDOWS: u64 = 7 * 1024 * 1024 * 1024 
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);
 const PLOTTING_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
-type CacheIndex = u8;
-
 #[derive(Debug, Parser)]
 struct CpuPlottingOptions {
     /// How many sectors a farmer will download concurrently. Limits memory usage of
@@ -424,7 +422,7 @@ where
     let should_start_prometheus_server = !prometheus_listen_on.is_empty();
 
     let (farmer_cache, farmer_cache_worker) =
-        FarmerCache::<CacheIndex>::new(node_client.clone(), peer_id, Some(&mut registry));
+        FarmerCache::new(node_client.clone(), peer_id, Some(&mut registry));
 
     let node_client = CachingProxyNodeClient::new(node_client)
         .await

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -79,7 +79,7 @@ pub(in super::super) struct NetworkArgs {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(in super::super) fn configure_network<FarmIndex, CacheIndex, NC>(
+pub(in super::super) fn configure_network<FarmIndex, NC>(
     protocol_prefix: String,
     base_path: &Path,
     keypair: Keypair,
@@ -96,15 +96,12 @@ pub(in super::super) fn configure_network<FarmIndex, CacheIndex, NC>(
     }: NetworkArgs,
     weak_plotted_pieces: Weak<AsyncRwLock<PlottedPieces<FarmIndex>>>,
     node_client: NC,
-    farmer_cache: FarmerCache<CacheIndex>,
+    farmer_cache: FarmerCache,
     prometheus_metrics_registry: Option<&mut Registry>,
-) -> Result<(Node, NodeRunner<FarmerCache<CacheIndex>>), anyhow::Error>
+) -> Result<(Node, NodeRunner<FarmerCache>), anyhow::Error>
 where
     FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + Sync + 'static,
     usize: From<FarmIndex>,
-    CacheIndex: Hash + Eq + Copy + fmt::Debug + fmt::Display + Send + Sync + 'static,
-    usize: From<CacheIndex>,
-    CacheIndex: TryFrom<usize>,
     NC: NodeClientExt + Clone,
 {
     let known_peers_registry = KnownPeersManager::new(KnownPeersManagerConfig {

--- a/crates/subspace-farmer/src/cluster/cache.rs
+++ b/crates/subspace-farmer/src/cluster/cache.rs
@@ -27,9 +27,6 @@ use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 
 const MIN_CACHE_IDENTIFICATION_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Type alias for cache index used by cluster.
-pub type ClusterCacheIndex = u16;
-
 /// Broadcast with identification details by caches
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ClusterCacheIdentifyBroadcast {

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -6,9 +6,7 @@
 //! client implementations designed to work with cluster controller and a service function to drive
 //! the backend part of the controller.
 
-use crate::cluster::cache::{
-    ClusterCacheIndex, ClusterCacheReadPieceRequest, ClusterCacheReadPiecesRequest,
-};
+use crate::cluster::cache::{ClusterCacheReadPieceRequest, ClusterCacheReadPiecesRequest};
 use crate::cluster::nats_client::{
     GenericBroadcast, GenericNotification, GenericRequest, GenericStreamRequest, NatsClient,
 };
@@ -608,7 +606,7 @@ pub async fn controller_service<NC, PG>(
     nats_client: &NatsClient,
     node_client: &NC,
     piece_getter: &PG,
-    farmer_cache: &FarmerCache<ClusterCacheIndex>,
+    farmer_cache: &FarmerCache,
     instance: &str,
     primary_instance: bool,
 ) -> anyhow::Result<()>
@@ -906,7 +904,7 @@ where
 
 async fn find_piece_responder(
     nats_client: &NatsClient,
-    farmer_cache: &FarmerCache<ClusterCacheIndex>,
+    farmer_cache: &FarmerCache,
 ) -> anyhow::Result<()> {
     nats_client
         .request_responder(
@@ -921,7 +919,7 @@ async fn find_piece_responder(
 
 async fn find_pieces_responder(
     nats_client: &NatsClient,
-    farmer_cache: &FarmerCache<ClusterCacheIndex>,
+    farmer_cache: &FarmerCache,
 ) -> anyhow::Result<()> {
     nats_client
         .stream_request_responder(

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -26,8 +26,6 @@ use subspace_rpc_primitives::{
 };
 use tempfile::tempdir;
 
-type TestCacheIndex = u8;
-
 #[derive(Debug, Clone)]
 struct MockNodeClient {
     current_segment_index: Arc<AtomicU64>,
@@ -206,7 +204,7 @@ async fn basic() {
 
     {
         let (farmer_cache, farmer_cache_worker) =
-            FarmerCache::<TestCacheIndex>::new(node_client.clone(), public_key.to_peer_id(), None);
+            FarmerCache::new(node_client.clone(), public_key.to_peer_id(), None);
 
         let farmer_cache_worker_exited =
             tokio::spawn(farmer_cache_worker.run(piece_getter.clone()));
@@ -406,7 +404,7 @@ async fn basic() {
         pieces.lock().clear();
 
         let (farmer_cache, farmer_cache_worker) =
-            FarmerCache::<TestCacheIndex>::new(node_client.clone(), public_key.to_peer_id(), None);
+            FarmerCache::new(node_client.clone(), public_key.to_peer_id(), None);
 
         let farmer_cache_worker_exited = tokio::spawn(farmer_cache_worker.run(piece_getter));
 


### PR DESCRIPTION
After thinking about it some more I no longer think there is any practical value to support more than 256 caches per controller/farmer. It is unlikely that it will be beneficial and if desired more controllers or RAID can be used to fit into this limit.

Removing this generic simplifies code quite and reduces memory usage on cluster controller a bit.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
