### PR TITLE
More x86-64 variants of container images

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -65,7 +65,8 @@ jobs:
           file: docker/${{ matrix.image }}.Dockerfile
           # TODO: Add `linux/riscv64` once https://github.com/paritytech/polkadot-sdk/issues/5996 is resolved and ring
           #  0.16.x is no longer in dependencies
-          platforms: linux/amd64,linux/arm64
+          # TODO: Add linux/amd64/v4 when runner supports it
+          platforms: linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/bootstrap-node.Dockerfile
+++ b/docker/bootstrap-node.Dockerfile
@@ -1,4 +1,4 @@
-# This Dockerfile supports both native building and cross-compilation to aarch64 on x86-64
+# This Dockerfile supports both native building and cross-compilation to x86-64, aarch64 and riscv64
 FROM --platform=$BUILDPLATFORM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2024-10-22
@@ -44,6 +44,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-x86-64-linux-gnu \
+          gcc-x86-64-linux-gnu \
+          libc6-dev-amd64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -78,6 +86,9 @@ RUN \
         # Default build is for Skylake
         *) export RUSTFLAGS="-C target-cpu=skylake" ;; \
       esac \
+    ; fi && \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=x86_64-linux-gnu-gcc" \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \

--- a/docker/node.Dockerfile
+++ b/docker/node.Dockerfile
@@ -1,4 +1,4 @@
-# This Dockerfile supports both native building and cross-compilation to aarch64 on x86-64
+# This Dockerfile supports both native building and cross-compilation to x86-64, aarch64 and riscv64
 FROM --platform=$BUILDPLATFORM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2024-10-22
@@ -44,6 +44,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-x86-64-linux-gnu \
+          gcc-x86-64-linux-gnu \
+          libc6-dev-amd64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -79,6 +87,9 @@ RUN \
         # Default build is for Skylake
         *) export RUSTFLAGS="-C target-cpu=skylake" ;; \
       esac \
+    ; fi && \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=x86_64-linux-gnu-gcc" \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \

--- a/docker/node.Dockerfile
+++ b/docker/node.Dockerfile
@@ -59,6 +59,7 @@ COPY test /code/test
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
+ARG TARGETVARIANT
 
 RUN \
     if [ $BUILDARCH != "arm64" ] && [ $TARGETARCH = "arm64" ]; then \
@@ -68,7 +69,16 @@ RUN \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
     if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
-      export RUSTFLAGS="-C target-cpu=skylake" \
+      case "$TARGETVARIANT" in \
+        # x86-64-v2 with AES-NI
+        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2 -C target-feature=+aes" ;; \
+        # x86-64-v3 with AES-NI
+        "v3") export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+aes" ;; \
+        # v4 is compiled for Zen 4+
+        "v4") export RUSTFLAGS="-C target-cpu=znver4" ;; \
+        # Default build is for Skylake
+        *) export RUSTFLAGS="-C target-cpu=skylake" ;; \
+      esac \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -1,4 +1,4 @@
-# This Dockerfile supports both native building and cross-compilation to aarch64 on x86-64
+# This Dockerfile supports both native building and cross-compilation to x86-64, aarch64 and riscv64
 FROM --platform=$BUILDPLATFORM ubuntu:22.04
 
 ARG RUSTC_VERSION=nightly-2024-10-22
@@ -44,6 +44,14 @@ RUN \
     ; fi
 
 RUN \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+          g++-x86-64-linux-gnu \
+          gcc-x86-64-linux-gnu \
+          libc6-dev-amd64-cross \
+    ; fi
+
+RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
@@ -78,6 +86,9 @@ RUN \
         # Default build is for Skylake
         *) export RUSTFLAGS="-C target-cpu=skylake" ;; \
       esac \
+    ; fi && \
+    if [ $BUILDARCH != "amd64" ] && [ $TARGETARCH = "amd64" ]; then \
+      export RUSTFLAGS="$RUSTFLAGS -C linker=x86_64-linux-gnu-gcc" \
     ; fi && \
     RUSTC_TARGET_ARCH=$(echo $TARGETARCH | sed "s/amd64/x86_64/g" | sed "s/arm64/aarch64/g" | sed "s/riscv64/riscv64gc/g") && \
     /root/.cargo/bin/cargo -Zgitoxide -Zgit build \


### PR DESCRIPTION
This way we have not just Skylake build, but also x86-64-v2, x86-64-v3 and can have Zen4+ optimized builds (if runner would support it).

Follow-up to this will replace building of executables on host OS with extraction from container images, which will simplify CI pipeline and even reduce the time it takes to build everything (with a small caveat that we technically build more variants now, but we do it concurrently, but it should at least not be slower overall).

As a bonus it is now possible to cross-compile to x86-64, not just from. Not very practical without non-x86-64 runners, but hey, at least we have it.

CI run confirming successful operation: https://github.com/autonomys/subspace/actions/runs/11725994004/job/32663591077

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
