### PR TITLE
Use correct DSN protocols in gateway

### DIFF
--- a/crates/subspace-gateway/src/commands/run/network.rs
+++ b/crates/subspace-gateway/src/commands/run/network.rs
@@ -5,6 +5,8 @@ use anyhow::anyhow;
 use clap::{Parser, ValueHint};
 use subspace_networking::libp2p::kad::Mode;
 use subspace_networking::libp2p::{identity, Multiaddr};
+use subspace_networking::protocols::request_response::handlers::cached_piece_by_index::CachedPieceByIndexRequestHandler;
+use subspace_networking::protocols::request_response::handlers::piece_by_index::PieceByIndexRequestHandler;
 use subspace_networking::{construct, Config, KademliaMode, Node, NodeRunner};
 use tracing::{debug, info};
 
@@ -98,6 +100,12 @@ pub async fn configure_network(
         bootstrap_addresses: bootstrap_nodes,
         reserved_peers,
         allow_non_global_addresses_in_dht: allow_private_ips,
+        request_response_protocols: vec![
+            // We need to enable protocol to request pieces
+            CachedPieceByIndexRequestHandler::create(|_, _| async { None }),
+            // We need to enable protocol to request pieces
+            PieceByIndexRequestHandler::create(|_, _| async { None }),
+        ],
         max_established_outgoing_connections: out_connections,
         max_pending_outgoing_connections: pending_out_connections,
         kademlia_mode: KademliaMode::Static(Mode::Client),

--- a/crates/subspace-gateway/src/piece_getter.rs
+++ b/crates/subspace-gateway/src/piece_getter.rs
@@ -9,6 +9,9 @@ use subspace_data_retrieval::piece_getter::{BoxError, ObjectPieceGetter};
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
 use subspace_networking::Node;
 
+/// The maximum number of peer-to-peer walking rounds for L1 archival storage.
+const MAX_RANDOM_WALK_ROUNDS: usize = 15;
+
 /// Wrapper type for PieceProvider, so it can implement ObjectPieceGetter.
 pub struct DsnPieceGetter<PV: PieceValidator>(pub PieceProvider<PV>);
 
@@ -62,7 +65,9 @@ where
             }
         }
 
-        Ok(None)
+        Ok(self
+            .get_piece_from_archival_storage(piece_index, MAX_RANDOM_WALK_ROUNDS)
+            .await)
     }
 }
 

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -255,6 +255,8 @@ impl<LocalRecordProvider> fmt::Debug for Config<LocalRecordProvider> {
     }
 }
 
+/// This default can only be used for `dev` networks.
+/// Other networks should use `Config::new()` to apply the correct prefix to the protocol version.
 impl Default for Config<()> {
     #[inline]
     fn default() -> Self {
@@ -275,6 +277,7 @@ where
     LocalRecordProvider: self::LocalRecordProvider,
 {
     /// Creates a new [`Config`].
+    /// Applies a subspace-specific version prefix to the `protocol_version`.
     pub fn new(
         protocol_version: String,
         keypair: identity::Keypair,


### PR DESCRIPTION
In a recent refactor, I used the wrong gateway node config. The protocol version is missing a `/subspace/2/` prefix, and the piece fetching protocols weren't enabled.

As part of this change, I also added a fallback from the farmer cache (L2) to archival storage (L1).

In the current implementation, all the DSN connections fail:

```sh
$ subspace-node run --chain mainnet --tmp
$ RUST_LOG=subspace=debug,subspace_networking=info,subspace_networking::utils::piece_provider=debug,info subspace-gateway run
$ websocat --jsonrpc ws://127.0.0.1:9955 | jq .
subspace_fetchObject {"mappings": {"v0": {"objects": [["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]]}}}
```

> 2024-11-07T22:28:00.703640Z DEBUG subspace_networking::node_runner: Peer has different protocol version, banning temporarily local_peer_id=12D3KooWB9bHyw97AcEzCGDabL1dgaFU4K2q5a3DopQU9F4jaWs8 peer_id=12D3KooW9sMSK3i9pkPQaQJgWkVVeN7gzrgHD6kAGQKuycqUAWVY local_protocol_version=66455a580aabff303720aa83adbe6c44502922251c03ba73686d5245da9e21bd peer_protocol_version=/subspace/2/66455a580aabff303720aa83adbe6c44502922251c03ba73686d5245da9e21bd

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": 9001,
    "message": "ObjectFetcherError(PieceNotFound { piece_index: PieceIndex(0) })"
  }
}
```

After these fixes, it works:
```
subspace_fetchObject {"mappings": {"v0": {"objects": [["0000000000000000000000000000000000000000000000000000000000000000", 0, 0]]}}}
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": 9001,
    "message": "InvalidObjectHash { mapping_hash: 0000000000000000000000000000000000000000000000000000000000000000, data_hash: af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262 }"
  }
}
subspace_fetchObject {"mappings": {"v0": {"objects": [["af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262", 0, 0]]}}}
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": [
    ""
  ]
}
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
