### PR TITLE
Increase state sync retries

### DIFF
--- a/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -517,8 +517,8 @@ where
 {
     let block_number = *header.number();
 
-    const STATE_SYNC_RETRIES: u32 = 5;
-    const LOOP_PAUSE: Duration = Duration::from_secs(20);
+    const STATE_SYNC_RETRIES: u32 = 10;
+    const LOOP_PAUSE: Duration = Duration::from_secs(10);
 
     for attempt in 1..=STATE_SYNC_RETRIES {
         debug!(%attempt, "Starting state sync...");


### PR DESCRIPTION
It wouldn't hurt doing more attempts, but might help some users. Looks like large genesis state makes it difficult for some users to download it an situation will only get worse over time.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
