### PR TITLE
Move cluster maintenance utilities from binary to library code

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -69,6 +69,8 @@ const MAX_SPACE_PLEDGED_FOR_PLOT_CACHE_ON_WINDOWS: u64 = 7 * 1024 * 1024 * 1024 
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);
 const PLOTTING_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
+type FarmIndex = u8;
+
 #[derive(Debug, Parser)]
 struct CpuPlottingOptions {
     /// How many sectors a farmer will download concurrently. Limits memory usage of
@@ -757,7 +759,7 @@ where
 
     info!("Finished collecting already plotted pieces successfully");
 
-    let mut farms_stream = (0u8..)
+    let mut farms_stream = (FarmIndex::MIN..)
         .zip(farms)
         .map(|(farm_index, farm)| {
             let plotted_pieces = Arc::clone(&plotted_pieces);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/main.rs
@@ -1,10 +1,4 @@
-#![feature(
-    duration_constructors,
-    extract_if,
-    hash_extract_if,
-    let_chains,
-    type_changing_struct_update
-)]
+#![feature(duration_constructors, type_changing_struct_update)]
 
 mod commands;
 mod utils;

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -6,6 +6,9 @@
 //! client implementations designed to work with cluster controller and a service function to drive
 //! the backend part of the controller.
 
+pub mod caches;
+pub mod farms;
+
 use crate::cluster::cache::{ClusterCacheReadPieceRequest, ClusterCacheReadPiecesRequest};
 use crate::cluster::nats_client::{
     GenericBroadcast, GenericNotification, GenericRequest, GenericStreamRequest, NatsClient,

--- a/crates/subspace-farmer/src/lib.rs
+++ b/crates/subspace-farmer/src/lib.rs
@@ -4,6 +4,7 @@
     assert_matches,
     btree_extract_if,
     duration_constructors,
+    extract_if,
     exact_size_is_empty,
     fmt_helpers_for_derive,
     future_join,


### PR DESCRIPTION
Previous attempt was painful, but now with https://github.com/autonomys/subspace/pull/3213 and not exposing farm index generic from maintenance functions this is easy. We can make `FarmIndex` there generic in the future if someone needs more than 2^16 farms per controller.

The changes here are all trivial.

Will help adding cluster support into Space Acres or similar software.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
