### PR TITLE
Always pull fresh container base

### DIFF
--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - name: Build node image
         id: build
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: docker/node.Dockerfile
+          pull: true
           push: false
 
       - name: Generate testnet chain specifications

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -20,9 +20,10 @@ jobs:
     steps:
       - name: Build node image
         id: build
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: docker/node.Dockerfile
+          pull: true
           push: false
 
       - name: Generate testnet domain genesis storages

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -25,9 +25,10 @@ jobs:
 
       - name: Build runtime
         id: build
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: docker/runtime.Dockerfile
+          pull: true
           push: false
 
       - name: Extract runtime

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -74,6 +74,7 @@ jobs:
           #  0.16.x is no longer in dependencies
           # TODO: Add linux/amd64/v4 when runner supports it
           platforms: linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64
+          pull: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Since our runners are still not ephemeral we may build container images based on older base image with security vulnerabilities.

We also used outdated `docker/build-push-action` everywhere except snapshot action :thinking: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
