### PR TITLE
Support building container image in forks

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -44,6 +44,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        if: github.repository_owner == 'autonomys'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        with:
+          # Limit concurrency so it can complete with small official runners
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+        if: github.repository_owner != 'autonomys'
 
       - name: Log into registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0


### PR DESCRIPTION
By default all platforms are built concurrently (see line 86), this makes them build sequentially in forks where we don't have as much RAM (it was crashing with OOM).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
