### PR TITLE
Restore support for CPUs without AES-NI support

### DIFF
--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -106,9 +106,13 @@ jobs:
           ARTIFACT="${{ matrix.build.base-artifact }}"
           
           docker run --rm --platform linux/amd64 --entrypoint /bin/cat $IMAGE /$ARTIFACT > $ARTIFACT-ubuntu-x86_64-skylake-${{ github.ref_name }}
+          # TODO: Pull is a workaround for https://github.com/moby/moby/issues/48197#issuecomment-2472265028
+          docker pull --platform linux/amd64/v2 $IMAGE
           docker run --rm --platform linux/amd64/v2 --entrypoint /bin/cat $IMAGE /$ARTIFACT > $ARTIFACT-ubuntu-x86_64-v2-${{ github.ref_name }}
           if [ "${{ matrix.build.image }}" == "farmer" ]; then
             docker run --rm --platform linux/amd64 --entrypoint /bin/cat $IMAGE /$ARTIFACT-rocm > $ARTIFACT-rocm-ubuntu-x86_64-skylake-${{ github.ref_name }}
+            # TODO: Pull is a workaround for https://github.com/moby/moby/issues/48197#issuecomment-2472265028
+            docker pull --platform linux/amd64/v2 $IMAGE
             docker run --rm --platform linux/amd64/v2 --entrypoint /bin/cat $IMAGE /$ARTIFACT-rocm > $ARTIFACT-rocm-ubuntu-x86_64-v2-${{ github.ref_name }}
           fi
           docker run --rm --platform linux/arm64 --entrypoint /bin/cat $IMAGE /$ARTIFACT > $ARTIFACT-ubuntu-aarch64-${{ github.ref_name }}

--- a/docker/bootstrap-node.Dockerfile
+++ b/docker/bootstrap-node.Dockerfile
@@ -78,7 +78,7 @@ RUN \
     if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
-        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2 -C target-feature=+aes" ;; \
+        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \
         # x86-64-v3 with AES-NI
         "v3") export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+aes" ;; \
         # v4 is compiled for Zen 4+

--- a/docker/farmer.Dockerfile
+++ b/docker/farmer.Dockerfile
@@ -117,7 +117,7 @@ RUN \
     if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = "" ]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
-        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2 -C target-feature=+aes" ;; \
+        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \
         # x86-64-v3 with AES-NI
         "v3") export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+aes" ;; \
         # v4 is compiled for Zen 4+

--- a/docker/node.Dockerfile
+++ b/docker/node.Dockerfile
@@ -79,7 +79,7 @@ RUN \
     if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
-        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2 -C target-feature=+aes" ;; \
+        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \
         # x86-64-v3 with AES-NI
         "v3") export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+aes" ;; \
         # v4 is compiled for Zen 4+

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -78,7 +78,7 @@ RUN \
     if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
-        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2 -C target-feature=+aes" ;; \
+        "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \
         # x86-64-v3 with AES-NI
         "v3") export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+aes" ;; \
         # v4 is compiled for Zen 4+


### PR DESCRIPTION
We didn't require AES-NI before, so let's allow it to continue working.

Will merge after user confirmation.

https://github.com/moby/moby/issues/48197 surprised me and not in a good way :confused: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
