### PR TITLE
Fix non-Skylake Ubuntu builds

### DIFF
--- a/docker/bootstrap-node.Dockerfile
+++ b/docker/bootstrap-node.Dockerfile
@@ -75,7 +75,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = "" ]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
         "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \

--- a/docker/node.Dockerfile
+++ b/docker/node.Dockerfile
@@ -76,7 +76,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = "" ]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
         "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -75,7 +75,7 @@ RUN \
     if [ $BUILDARCH != "riscv64" ] && [ $TARGETARCH = "riscv64" ]; then \
       export RUSTFLAGS="$RUSTFLAGS -C linker=riscv64-linux-gnu-gcc" \
     ; fi && \
-    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = ""]; then \
+    if [ $TARGETARCH = "amd64" ] && [ "$RUSTFLAGS" = "" ]; then \
       case "$TARGETVARIANT" in \
         # x86-64-v2 with AES-NI
         "v2") export RUSTFLAGS="-C target-cpu=x86-64-v2" ;; \


### PR DESCRIPTION
I hate such programming languages.

It literally printed this and moved on like nothing happened:
```
#20 0.474 /bin/sh: 1: [: =: argument expected
```

But the logic was completely different! It somehow ended up compiling for Skylake processors by the looks of it :exploding_head: 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
