### PR TITLE
Piece cache fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12609,7 +12609,6 @@ dependencies = [
  "prometheus-client 0.22.3",
  "rand",
  "rayon",
- "schnellru",
  "schnorrkel",
  "serde",
  "serde_json",

--- a/crates/subspace-farmer/Cargo.toml
+++ b/crates/subspace-farmer/Cargo.toml
@@ -46,7 +46,6 @@ pin-project = "1.1.5"
 prometheus-client = "0.22.3"
 rand = "0.8.5"
 rayon = "1.10.0"
-schnellru = "0.2.3"
 schnorrkel = "0.11.4"
 serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.128"
@@ -67,7 +66,7 @@ supports-color = { version = "3.0.1", optional = true }
 tempfile = "3.13.0"
 thiserror = "2.0.0"
 thread-priority = "1.1.0"
-tokio = { version = "1.40.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.40.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = { version = "0.1.16", features = ["sync"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"], optional = true }

--- a/crates/subspace-farmer/src/disk_piece_cache/tests.rs
+++ b/crates/subspace-farmer/src/disk_piece_cache/tests.rs
@@ -1,6 +1,7 @@
 use crate::disk_piece_cache::{DiskPieceCache, DiskPieceCacheError, PieceCacheOffset};
 use rand::prelude::*;
 use std::assert_matches::assert_matches;
+use std::num::NonZeroU32;
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use tempfile::tempdir;
 
@@ -8,7 +9,8 @@ use tempfile::tempdir;
 fn basic() {
     let path = tempdir().unwrap();
     {
-        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2, None, None).unwrap();
+        let disk_piece_cache =
+            DiskPieceCache::open(path.as_ref(), NonZeroU32::new(2).unwrap(), None, None).unwrap();
 
         // Initially empty
         assert_eq!(
@@ -115,7 +117,8 @@ fn basic() {
 
     // Reopening works
     {
-        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2, None, None).unwrap();
+        let disk_piece_cache =
+            DiskPieceCache::open(path.as_ref(), NonZeroU32::new(2).unwrap(), None, None).unwrap();
         // Two pieces stored
         assert_eq!(
             disk_piece_cache
@@ -130,7 +133,8 @@ fn basic() {
     {
         DiskPieceCache::wipe(path.as_ref()).unwrap();
 
-        let disk_piece_cache = DiskPieceCache::open(path.as_ref(), 2, None, None).unwrap();
+        let disk_piece_cache =
+            DiskPieceCache::open(path.as_ref(), NonZeroU32::new(2).unwrap(), None, None).unwrap();
         // Wiped successfully
         assert_eq!(
             disk_piece_cache

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -410,7 +410,11 @@ where
             match maybe_cache {
                 Ok(cache) => {
                     let backend = cache.backend;
-                    stored_pieces.extend(cache.cache_stored_pieces.into_iter());
+                    for (key, cache_offset) in cache.cache_stored_pieces {
+                        if let Some(old_cache_offset) = stored_pieces.insert(key, cache_offset) {
+                            dangling_free_offsets.push_front(old_cache_offset);
+                        }
+                    }
                     dangling_free_offsets.extend(
                         cache.cache_free_offsets.into_iter().filter(|free_offset| {
                             free_offset.piece_offset.0 < backend.used_capacity

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -38,6 +38,7 @@ use subspace_networking::libp2p::PeerId;
 use subspace_networking::utils::multihash::ToMultihash;
 use subspace_networking::{KeyWithDistance, LocalRecordProvider};
 use tokio::runtime::Handle;
+use tokio::sync::Semaphore;
 use tokio::task::{block_in_place, yield_now};
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 
@@ -539,12 +540,18 @@ where
         self.handlers.progress.call_simple(&0.0);
         let piece_indices_to_store = piece_indices_to_store.into_iter().enumerate();
 
+        let downloading_semaphore = &Semaphore::new(SYNC_BATCH_SIZE * SYNC_CONCURRENT_BATCHES);
+
         let downloading_pieces_stream =
             stream::iter(piece_indices_to_store.map(|(batch, piece_indices)| {
                 let downloaded_pieces_count = &downloaded_pieces_count;
                 let caches = &caches;
 
                 async move {
+                    let mut permit = downloading_semaphore
+                        .acquire_many(SYNC_BATCH_SIZE as u32)
+                        .await
+                        .expect("Semaphore is never closed; qed");
                     debug!(%batch, num_pieces = %piece_indices.len(), "Downloading pieces");
 
                     let pieces_stream = match piece_getter.get_pieces(piece_indices).await {
@@ -580,6 +587,8 @@ where
                                 continue;
                             }
                         };
+                        // Release slot for future batches
+                        permit.split(1);
 
                         let (offset, maybe_backend) = {
                             let mut caches = caches.lock();
@@ -639,10 +648,13 @@ where
                     }
                 }
             }));
+
         // Download several batches concurrently to make sure slow tail of one is compensated by
         // another
         downloading_pieces_stream
-            .buffer_unordered(SYNC_CONCURRENT_BATCHES)
+            // This allows to schedule new batch while previous batches partially completed, but
+            // avoids excessive memory usage like when all futures are created upfront
+            .buffer_unordered(SYNC_CONCURRENT_BATCHES * 2)
             // Simply drain everything
             .for_each(|()| async {})
             .await;

--- a/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -8,7 +8,7 @@ use futures::{SinkExt, Stream, StreamExt};
 use parking_lot::Mutex;
 use rand::prelude::*;
 use std::collections::HashMap;
-use std::num::NonZeroU64;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -226,8 +226,24 @@ async fn basic() {
         farmer_cache
             .replace_backing_caches(
                 vec![
-                    Arc::new(DiskPieceCache::open(path1.as_ref(), 1, None, None).unwrap()),
-                    Arc::new(DiskPieceCache::open(path2.as_ref(), 1, None, None).unwrap()),
+                    Arc::new(
+                        DiskPieceCache::open(
+                            path1.as_ref(),
+                            NonZeroU32::new(1).unwrap(),
+                            None,
+                            None,
+                        )
+                        .unwrap(),
+                    ),
+                    Arc::new(
+                        DiskPieceCache::open(
+                            path2.as_ref(),
+                            NonZeroU32::new(1).unwrap(),
+                            None,
+                            None,
+                        )
+                        .unwrap(),
+                    ),
                 ],
                 vec![],
             )
@@ -426,8 +442,24 @@ async fn basic() {
         farmer_cache
             .replace_backing_caches(
                 vec![
-                    Arc::new(DiskPieceCache::open(path1.as_ref(), 1, None, None).unwrap()),
-                    Arc::new(DiskPieceCache::open(path2.as_ref(), 1, None, None).unwrap()),
+                    Arc::new(
+                        DiskPieceCache::open(
+                            path1.as_ref(),
+                            NonZeroU32::new(1).unwrap(),
+                            None,
+                            None,
+                        )
+                        .unwrap(),
+                    ),
+                    Arc::new(
+                        DiskPieceCache::open(
+                            path2.as_ref(),
+                            NonZeroU32::new(1).unwrap(),
+                            None,
+                            None,
+                        )
+                        .unwrap(),
+                    ),
                 ],
                 vec![],
             )

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -29,7 +29,7 @@ use std::task::{Context, Poll};
 use std::{fmt, iter, mem};
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use tokio_stream::StreamMap;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace, warn, Instrument};
 
 /// Validates piece against using its commitment.
 #[async_trait]
@@ -493,18 +493,38 @@ async fn get_from_cache_inner<PV, PieceIndices>(
     PV: PieceValidator,
     PieceIndices: Iterator<Item = PieceIndex>,
 {
-    // Download from connected peers first
-    let pieces_to_download =
-        download_cached_pieces_from_connected_peers(piece_indices, node, piece_validator, &results)
-            .await;
+    let download_id = random::<u64>();
 
-    if pieces_to_download.is_empty() {
-        return;
-    }
-
-    // Download from iteratively closer peers according to Kademlia rules
-    download_cached_pieces_from_closest_peers(pieces_to_download, node, piece_validator, &results)
+    // TODO: It'd be nice to combine downloading from connected peers with downloading from closest
+    //  peers concurrently
+    let fut = async move {
+        // Download from connected peers first
+        let pieces_to_download = download_cached_pieces_from_connected_peers(
+            piece_indices,
+            node,
+            piece_validator,
+            &results,
+        )
         .await;
+
+        if pieces_to_download.is_empty() {
+            debug!("Done");
+            return;
+        }
+
+        // Download from iteratively closer peers according to Kademlia rules
+        download_cached_pieces_from_closest_peers(
+            pieces_to_download,
+            node,
+            piece_validator,
+            &results,
+        )
+        .await;
+
+        debug!("Done #2");
+    };
+
+    fut.instrument(tracing::info_span!("", %download_id)).await;
 }
 
 /// Takes pieces to download as an input, sends results with pieces that were downloaded
@@ -528,15 +548,24 @@ where
     let mut pieces_to_download = piece_indices
         .map(|piece_index| (piece_index, HashMap::new()))
         .collect::<HashMap<PieceIndex, HashMap<PeerId, Vec<Multiaddr>>>>();
+
+    debug!(num_pieces = %pieces_to_download.len(), "Starting");
+
     let mut checked_connected_peers = HashSet::new();
 
     // The loop is in order to check peers that might be connected after the initial loop has
     // started.
     loop {
         let Ok(connected_peers) = node.connected_peers().await else {
+            trace!("Connected peers error");
             break;
         };
 
+        debug!(
+            connected_peers = %connected_peers.len(),
+            pieces_to_download = %pieces_to_download.len(),
+            "Loop"
+        );
         if connected_peers.is_empty() || pieces_to_download.is_empty() {
             break;
         }
@@ -589,6 +618,7 @@ where
                 mut cached_pieces,
                 not_cached_pieces,
             } = result;
+            trace!(%piece_index, %peer_id, result = %result.is_some(), "Piece response");
 
             let Some(result) = result else {
                 // Downloading failed, ignore peer
@@ -597,6 +627,8 @@ where
 
             match result {
                 PieceResult::Piece(piece) => {
+                    trace!(%piece_index, %peer_id, "Got piece");
+
                     // Downloaded successfully
                     pieces_to_download.remove(&piece_index);
 
@@ -609,6 +641,8 @@ where
                     }
                 }
                 PieceResult::ClosestPeers(closest_peers) => {
+                    trace!(%piece_index, %peer_id, "Got closest peers");
+
                     // Store closer peers in case piece index was not downloaded yet
                     if let Some(peers) = pieces_to_download.get_mut(&piece_index) {
                         peers.extend(Vec::from(closest_peers));
@@ -639,8 +673,10 @@ where
 
             let piece_index_to_download_next =
                 if let Some(piece_index) = maybe_piece_index_to_download_next {
+                    trace!(%piece_index, %peer_id, "Next piece to download from peer");
                     piece_index
                 } else {
+                    trace!(%peer_id, "Peer doesn't have anything else");
                     // Nothing left to do with this peer
                     continue;
                 };
@@ -680,6 +716,7 @@ where
         }
 
         if pieces_to_download.len() == num_pieces {
+            debug!(%num_pieces, "Finished downloading from connected peers");
             // Nothing was downloaded, we're done here
             break;
         }

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -647,6 +647,10 @@ where
                     if let Some(peers) = pieces_to_download.get_mut(&piece_index) {
                         peers.extend(Vec::from(closest_peers));
                     }
+
+                    // No need to ask this peer again if they didn't have the piece we expected, or
+                    // they claimed to have earlier
+                    continue;
                 }
             }
 


### PR DESCRIPTION
This both fixes and significantly improves piece cache sync and piece downloading more generally.

One bug was not storing free offset in case more than one cache stores the same piece index (usually caused by user manipulation with farms), test case was added to check this.

Significant slowdown was caused by faulty peers that initially claim to have a bunch of pieces, but then not returning them and instead returning closes peers, which in pathological cases meant farmer was sending thousands of individual requests to get pieces to a single peer one at a time, but was only getting closest peers back, meaning it was wasting a lot of time and to user that looked like downloading hanged even though it technically didn't.

I also improved piece cache sync performance by allowing to schedule more batches after previous batches partially completed, which helps with bandwidth saturation, this allowed me to download pieces as 100-250 Mbps speed most of the time, with higher limits can push closer to 800 Mbps. For higher utilization we'll need to introduce CLI option to increase memory usage by piece cache sync (right now constrained to use around 1GB).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
