### PR TITLE
Fix offset calculation bugs in ObjectFetcher

### DIFF
--- a/crates/subspace-core-primitives/src/pieces.rs
+++ b/crates/subspace-core-primitives/src/pieces.rs
@@ -125,6 +125,14 @@ impl PieceIndex {
         (self.0 % ArchivedHistorySegment::NUM_PIECES as u64) as u32
     }
 
+    /// Position of a source piece in the source pieces for a segment.
+    /// Panics if the piece is not a source piece.
+    #[inline]
+    pub const fn source_position(&self) -> u32 {
+        assert!(self.is_source());
+        self.position() / (Self::source_ratio() as u32)
+    }
+
     /// Is this piece index a source piece?
     #[inline]
     pub const fn is_source(&self) -> bool {


### PR DESCRIPTION
There are multiple bugs in the ObjectFetcher’s piece and segment offset calculations:
- we’re using segment piece positions (including parity pieces) in calculations with source piece counts and lengths
- we subtract 2 for optional padding, but if the mapping is right at the end of the segment, and the padding isn’t there (or the mapping is malicious), that calculation can underflow

I think this previously worked in automated and manual tests because the mappings were all in the first source piece, and never in the last 2 bytes of the segment. I’ll follow up with a PR containing tests for those situations.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
