### PR TITLE
Make the minimum mapping block 1, not genesis

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -383,9 +383,6 @@ pub enum CreateObjectMappings {
 }
 
 impl CreateObjectMappings {
-    /// The minimum mapping block number.
-    pub const MIN_BLOCK: CreateObjectMappings = CreateObjectMappings::Block(NonZeroU32::MIN);
-
     /// The fixed block number to start creating object mappings from.
     /// If there is no fixed block number, or mappings are disabled, returns None.
     fn block(&self) -> Option<BlockNumber> {

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), Error> {
                 base: consensus_chain_config,
                 // Domain node needs slots notifications for bundle production.
                 force_new_slot_notifications: true,
-                create_object_mappings: CreateObjectMappings::MIN_BLOCK,
+                create_object_mappings: CreateObjectMappings::No,
                 subspace_networking: SubspaceNetworking::Create { config: dsn_config },
                 dsn_piece_getter: None,
                 sync: Default::default(),

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), Error> {
                 base: consensus_chain_config,
                 // Domain node needs slots notifications for bundle production.
                 force_new_slot_notifications: true,
-                create_object_mappings: CreateObjectMappings::Block(0),
+                create_object_mappings: CreateObjectMappings::MIN_BLOCK,
                 subspace_networking: SubspaceNetworking::Create { config: dsn_config },
                 dsn_piece_getter: None,
                 sync: Default::default(),

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -362,12 +362,6 @@ impl fmt::Display for CreateObjectMappingConfig {
     }
 }
 
-impl CreateObjectMappingConfig {
-    /// The minimum mapping block number.
-    pub const MIN_BLOCK: CreateObjectMappingConfig =
-        CreateObjectMappingConfig::Block(NonZeroU32::MIN);
-}
-
 /// Options for running a node
 #[derive(Debug, Parser)]
 pub(super) struct ConsensusChainOptions {
@@ -548,7 +542,7 @@ pub(super) fn create_consensus_chain_configuration(
             timekeeper_options.timekeeper = true;
 
             if create_object_mappings.is_none() {
-                create_object_mappings = Some(CreateObjectMappingConfig::MIN_BLOCK);
+                create_object_mappings = Some(CreateObjectMappingConfig::Block(NonZeroU32::MIN));
             }
 
             if sync.is_none() {


### PR DESCRIPTION
This PR makes the minimum mapping block 1, rather than genesis.

During snap sync we don’t store the genesis block data, which was leading to errors when the archiver couldn’t find the genesis data to start mapping from. For background see https://github.com/paritytech/polkadot-sdk/issues/5366

There are no mappings in the genesis block, so starting at 1 doesn’t change the mappings created by the node.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
