### PR TITLE
Fix libp2p request response warning

### DIFF
--- a/crates/subspace-networking/src/behavior.rs
+++ b/crates/subspace-networking/src/behavior.rs
@@ -42,6 +42,9 @@ pub(crate) struct BehaviorConfig<RecordStore> {
     pub(crate) record_store: RecordStore,
     /// The configuration for the [`RequestResponsesBehaviour`] protocol.
     pub(crate) request_response_protocols: Vec<Box<dyn RequestHandler>>,
+    /// The upper bound for the number of concurrent inbound + outbound streams for request/response
+    /// protocols.
+    pub(crate) request_response_max_concurrent_streams: usize,
     /// Connection limits for the swarm.
     pub(crate) connection_limits: ConnectionLimits,
     /// The configuration for the [`ReservedPeersBehaviour`].
@@ -97,6 +100,7 @@ where
             ping: Ping::default(),
             request_response: RequestResponseFactoryBehaviour::new(
                 config.request_response_protocols,
+                config.request_response_max_concurrent_streams,
             )
             //TODO: Convert to an error.
             .expect("RequestResponse protocols registration failed."),

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -62,6 +62,7 @@ const SWARM_MAX_PENDING_INCOMING_CONNECTIONS: u32 = 80;
 const SWARM_MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 80;
 const KADEMLIA_QUERY_TIMEOUT: Duration = Duration::from_secs(40);
 const SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER: u32 = 3;
+const MAX_CONCURRENT_STREAMS_PER_CONNECTION: usize = 10;
 // TODO: Consider moving this constant to configuration or removing `Toggle` wrapper when we find a
 //  use-case for gossipsub protocol.
 const ENABLE_GOSSIP_PROTOCOL: bool = false;
@@ -472,7 +473,7 @@ where
         request_response_max_concurrent_streams: {
             let max_num_connections = max_established_incoming_connections as usize
                 + max_established_outgoing_connections as usize;
-            max_num_connections * SWARM_MAX_ESTABLISHED_CONNECTIONS_PER_PEER as usize
+            max_num_connections * MAX_CONCURRENT_STREAMS_PER_CONNECTION
         },
         connection_limits,
         reserved_peers: ReservedPeersConfig {

--- a/crates/subspace-networking/src/protocols/request_response/request_response_factory.rs
+++ b/crates/subspace-networking/src/protocols/request_response/request_response_factory.rs
@@ -323,6 +323,7 @@ impl RequestResponseFactoryBehaviour {
     /// the same protocol is passed twice.
     pub fn new(
         list: impl IntoIterator<Item = Box<dyn RequestHandler>>,
+        max_concurrent_streams: usize,
     ) -> Result<Self, RegisterError> {
         let mut protocols = HashMap::new();
         let mut request_handlers = Vec::new();
@@ -341,7 +342,9 @@ impl RequestResponseFactoryBehaviour {
                     max_response_size: config.max_response_size,
                 },
                 iter::once(StreamProtocol::new(config.name)).zip(iter::repeat(protocol_support)),
-                RequestResponseConfig::default().with_request_timeout(config.request_timeout),
+                RequestResponseConfig::default()
+                    .with_request_timeout(config.request_timeout)
+                    .with_max_concurrent_streams(max_concurrent_streams),
             );
 
             match protocols.entry(Cow::Borrowed(config.name)) {

--- a/crates/subspace-networking/src/protocols/request_response/request_response_factory/tests.rs
+++ b/crates/subspace-networking/src/protocols/request_response/request_response_factory/tests.rs
@@ -41,7 +41,7 @@ async fn build_swarm(
         .into_iter()
         .map(|config| Box::new(MockRunner(config)) as Box<dyn RequestHandler>)
         .collect::<Vec<_>>();
-    let behaviour = RequestResponseFactoryBehaviour::new(configs).unwrap();
+    let behaviour = RequestResponseFactoryBehaviour::new(configs, 100).unwrap();
 
     let mut swarm = SwarmBuilder::with_new_identity()
         .with_tokio()


### PR DESCRIPTION
Without specifying it explicitly, the default is 100, which sometimes can result in this:
> 2024-11-19T13:27:47.261956Z  WARN libp2p_request_response::handler: Dropping inbound stream because we are at capacity

I believe by setting the limit to the actual value we should be able to avoid it and improve request/response success rate.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
