### PR TITLE
Fix domain genesis storage snapshot build CI workflow

### DIFF
--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -18,6 +18,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Build node image
         id: build
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0


### PR DESCRIPTION
The domain genesis storage snapshot build CI workflow is not working see https://github.com/autonomys/subspace/actions/runs/12018841722, not sure when this CI workflow starts failing but adding a `checkout` step fixes the issue see https://github.com/autonomys/subspace/actions/runs/12019619951.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
