### PR TITLE
Improve piece downloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,7 +4227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "rustls-pki-types",
 ]
 
@@ -5273,7 +5273,7 @@ dependencies = [
  "http 1.1.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
@@ -6081,7 +6081,7 @@ dependencies = [
  "quinn 0.11.5",
  "rand",
  "ring 0.17.8",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "socket2 0.5.7",
  "thiserror 1.0.64",
  "tokio",
@@ -6278,7 +6278,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen 0.11.3",
  "ring 0.17.8",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.64",
  "x509-parser 0.16.0",
@@ -8991,7 +8991,7 @@ dependencies = [
  "quinn-proto 0.11.8",
  "quinn-udp 0.5.5",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "socket2 0.5.7",
  "thiserror 1.0.64",
  "tokio",
@@ -9043,7 +9043,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "slab",
  "thiserror 1.0.64",
  "tinyvec",
@@ -9606,9 +9606,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",
@@ -9664,9 +9664,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -9679,7 +9679,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -13732,7 +13732,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,15 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
 name = "async-nats"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12675,6 +12666,7 @@ name = "subspace-gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-lock 3.4.0",
  "async-trait",
  "clap",
  "fdlimit",
@@ -12682,7 +12674,6 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "mimalloc",
- "parking_lot 0.12.3",
  "subspace-core-primitives",
  "subspace-data-retrieval",
  "subspace-erasure-coding",
@@ -12692,7 +12683,6 @@ dependencies = [
  "subspace-rpc-primitives",
  "subspace-verification",
  "supports-color",
- "thiserror 2.0.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -12808,13 +12798,12 @@ dependencies = [
 name = "subspace-networking"
 version = "0.1.0"
 dependencies = [
- "async-mutex",
+ "async-lock 3.4.0",
  "async-trait",
  "backoff",
  "bytes",
  "clap",
  "derive_more 1.0.0",
- "either",
  "event-listener-primitives",
  "fs2",
  "futures",
@@ -13056,6 +13045,7 @@ version = "0.1.0"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
+ "async-lock 3.4.0",
  "async-trait",
  "cross-domain-message-gossip",
  "domain-runtime-primitives",
@@ -13083,9 +13073,7 @@ dependencies = [
  "sc-executor",
  "sc-informant",
  "sc-network",
- "sc-network-light",
  "sc-network-sync",
- "sc-network-transactions",
  "sc-offchain",
  "sc-proof-of-time",
  "sc-rpc",
@@ -13098,7 +13086,6 @@ dependencies = [
  "sc-tracing",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
- "sc-utils",
  "schnellru",
  "schnorrkel",
  "sp-api",

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::shared::DiskFarm;
 use anyhow::anyhow;
-use async_lock::Mutex as AsyncMutex;
+use async_lock::{Mutex as AsyncMutex, Semaphore};
 use backoff::ExponentialBackoff;
 use bytesize::ByteSize;
 use clap::Parser;
@@ -36,7 +36,7 @@ use subspace_farmer::utils::{
 use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::Table;
-use tokio::sync::{Barrier, Semaphore};
+use tokio::sync::Barrier;
 use tracing::{error, info, info_span, warn, Instrument};
 
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -1,6 +1,6 @@
 use crate::commands::shared::PlottingThreadPriority;
 use anyhow::anyhow;
-use async_lock::Mutex as AsyncMutex;
+use async_lock::{Mutex as AsyncMutex, Semaphore};
 use clap::Parser;
 use prometheus_client::registry::Registry;
 use std::future::Future;
@@ -28,7 +28,6 @@ use subspace_farmer::utils::{
 use subspace_farmer_components::PieceGetter;
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::Table;
-use tokio::sync::Semaphore;
 use tracing::info;
 
 const PLOTTING_RETRY_INTERVAL: Duration = Duration::from_secs(5);

--- a/crates/subspace-farmer/src/farmer_cache.rs
+++ b/crates/subspace-farmer/src/farmer_cache.rs
@@ -654,7 +654,7 @@ where
         downloading_pieces_stream
             // This allows to schedule new batch while previous batches partially completed, but
             // avoids excessive memory usage like when all futures are created upfront
-            .buffer_unordered(SYNC_CONCURRENT_BATCHES * 2)
+            .buffer_unordered(SYNC_CONCURRENT_BATCHES * 10)
             // Simply drain everything
             .for_each(|()| async {})
             .await;

--- a/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/crates/subspace-farmer/src/plotter/cpu.rs
@@ -6,7 +6,7 @@ use crate::plotter::cpu::metrics::CpuPlotterMetrics;
 use crate::plotter::{Plotter, SectorPlottingProgress};
 use crate::thread_pool_manager::PlottingThreadPoolManager;
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::Mutex as AsyncMutex;
+use async_lock::{Mutex as AsyncMutex, Semaphore, SemaphoreGuardArc};
 use async_trait::async_trait;
 use bytes::Bytes;
 use event_listener_primitives::{Bag, HandlerId};
@@ -35,7 +35,6 @@ use subspace_farmer_components::plotting::{
 use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_kzg::Kzg;
 use subspace_proof_of_space::Table;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::yield_now;
 use tracing::{warn, Instrument};
 
@@ -87,7 +86,7 @@ where
     PosTable: Table,
 {
     async fn has_free_capacity(&self) -> Result<bool, String> {
-        Ok(self.downloading_semaphore.available_permits() > 0)
+        Ok(self.downloading_semaphore.try_acquire().is_some())
     }
 
     async fn plot_sector(
@@ -97,39 +96,13 @@ where
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
         replotting: bool,
-        mut progress_sender: mpsc::Sender<SectorPlottingProgress>,
+        progress_sender: mpsc::Sender<SectorPlottingProgress>,
     ) {
         let start = Instant::now();
 
         // Done outside the future below as a backpressure, ensuring that it is not possible to
         // schedule unbounded number of plotting tasks
-        let downloading_permit = match Arc::clone(&self.downloading_semaphore)
-            .acquire_owned()
-            .await
-        {
-            Ok(downloading_permit) => downloading_permit,
-            Err(error) => {
-                warn!(%error, "Failed to acquire downloading permit");
-
-                let progress_updater = ProgressUpdater {
-                    public_key,
-                    sector_index,
-                    handlers: Arc::clone(&self.handlers),
-                    metrics: self.metrics.clone(),
-                };
-
-                progress_updater
-                    .update_progress_and_events(
-                        &mut progress_sender,
-                        SectorPlottingProgress::Error {
-                            error: format!("Failed to acquire downloading permit: {error}"),
-                        },
-                    )
-                    .await;
-
-                return;
-            }
-        };
+        let downloading_permit = self.downloading_semaphore.acquire_arc().await;
 
         self.plot_sector_internal(
             start,
@@ -155,8 +128,7 @@ where
     ) -> bool {
         let start = Instant::now();
 
-        let Ok(downloading_permit) = Arc::clone(&self.downloading_semaphore).try_acquire_owned()
-        else {
+        let Some(downloading_permit) = self.downloading_semaphore.try_acquire_arc() else {
             return false;
         };
 
@@ -259,7 +231,7 @@ where
     async fn plot_sector_internal<PS>(
         &self,
         start: Instant,
-        downloading_permit: OwnedSemaphorePermit,
+        downloading_permit: SemaphoreGuardArc,
         public_key: PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,

--- a/crates/subspace-farmer/src/plotter/gpu.rs
+++ b/crates/subspace-farmer/src/plotter/gpu.rs
@@ -11,7 +11,7 @@ use crate::plotter::gpu::gpu_encoders_manager::GpuRecordsEncoderManager;
 use crate::plotter::gpu::metrics::GpuPlotterMetrics;
 use crate::plotter::{Plotter, SectorPlottingProgress};
 use crate::utils::AsyncJoinOnDrop;
-use async_lock::Mutex as AsyncMutex;
+use async_lock::{Mutex as AsyncMutex, Semaphore, SemaphoreGuardArc};
 use async_trait::async_trait;
 use bytes::Bytes;
 use event_listener_primitives::{Bag, HandlerId};
@@ -37,7 +37,6 @@ use subspace_farmer_components::plotting::{
 };
 use subspace_farmer_components::{FarmerProtocolInfo, PieceGetter};
 use subspace_kzg::Kzg;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::yield_now;
 use tracing::{warn, Instrument};
 
@@ -97,7 +96,7 @@ where
     GRE: GpuRecordsEncoder + 'static,
 {
     async fn has_free_capacity(&self) -> Result<bool, String> {
-        Ok(self.downloading_semaphore.available_permits() > 0)
+        Ok(self.downloading_semaphore.try_acquire().is_some())
     }
 
     async fn plot_sector(
@@ -107,39 +106,13 @@ where
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
         _replotting: bool,
-        mut progress_sender: mpsc::Sender<SectorPlottingProgress>,
+        progress_sender: mpsc::Sender<SectorPlottingProgress>,
     ) {
         let start = Instant::now();
 
         // Done outside the future below as a backpressure, ensuring that it is not possible to
         // schedule unbounded number of plotting tasks
-        let downloading_permit = match Arc::clone(&self.downloading_semaphore)
-            .acquire_owned()
-            .await
-        {
-            Ok(downloading_permit) => downloading_permit,
-            Err(error) => {
-                warn!(%error, "Failed to acquire downloading permit");
-
-                let progress_updater = ProgressUpdater {
-                    public_key,
-                    sector_index,
-                    handlers: Arc::clone(&self.handlers),
-                    metrics: self.metrics.clone(),
-                };
-
-                progress_updater
-                    .update_progress_and_events(
-                        &mut progress_sender,
-                        SectorPlottingProgress::Error {
-                            error: format!("Failed to acquire downloading permit: {error}"),
-                        },
-                    )
-                    .await;
-
-                return;
-            }
-        };
+        let downloading_permit = self.downloading_semaphore.acquire_arc().await;
 
         self.plot_sector_internal(
             start,
@@ -164,8 +137,7 @@ where
     ) -> bool {
         let start = Instant::now();
 
-        let Ok(downloading_permit) = Arc::clone(&self.downloading_semaphore).try_acquire_owned()
-        else {
+        let Some(downloading_permit) = self.downloading_semaphore.try_acquire_arc() else {
             return false;
         };
 
@@ -266,7 +238,7 @@ where
     async fn plot_sector_internal<PS>(
         &self,
         start: Instant,
-        downloading_permit: OwnedSemaphorePermit,
+        downloading_permit: SemaphoreGuardArc,
         public_key: PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,

--- a/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/crates/subspace-farmer/src/single_disk_farm.rs
@@ -40,7 +40,7 @@ use crate::single_disk_farm::plotting::{
 use crate::single_disk_farm::reward_signing::reward_signing;
 use crate::utils::{tokio_rayon_spawn_handler, AsyncJoinOnDrop};
 use crate::{farm, KNOWN_PEERS_CACHE_SIZE};
-use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
+use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock, Semaphore};
 use async_trait::async_trait;
 use event_listener_primitives::{Bag, HandlerId};
 use futures::channel::{mpsc, oneshot};
@@ -82,7 +82,7 @@ use subspace_proof_of_space::Table;
 use subspace_rpc_primitives::{FarmerAppInfo, SolutionResponse};
 use thiserror::Error;
 use tokio::runtime::Handle;
-use tokio::sync::{broadcast, Barrier, Semaphore};
+use tokio::sync::{broadcast, Barrier};
 use tokio::task;
 use tracing::{debug, error, info, trace, warn, Instrument, Span};
 

--- a/crates/subspace-gateway/Cargo.toml
+++ b/crates/subspace-gateway/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+async-lock = "3.4.0"
 anyhow = "1.0.89"
 async-trait = "0.1.83"
 clap = { version = "4.5.18", features = ["derive"] }
@@ -25,7 +26,6 @@ futures = "0.3.31"
 hex = "0.4.3"
 jsonrpsee = { version = "0.24.5", features = ["server"] }
 mimalloc = "0.1.43"
-parking_lot = "0.12.2"
 subspace-core-primitives = { version = "0.1.0", path = "../subspace-core-primitives" }
 subspace-data-retrieval = { version = "0.1.0", path = "../../shared/subspace-data-retrieval" }
 subspace-erasure-coding = { version = "0.1.0", path = "../subspace-erasure-coding" }
@@ -35,7 +35,6 @@ subspace-networking = { version = "0.1.0", path = "../subspace-networking" }
 subspace-rpc-primitives = { version = "0.1.0", path = "../subspace-rpc-primitives" }
 subspace-verification = { version = "0.1.0", path = "../subspace-verification", default-features = false }
 supports-color = "3.0.1"
-thiserror = "2.0.0"
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "signal", "macros"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/subspace-gateway/src/commands/run/network.rs
+++ b/crates/subspace-gateway/src/commands/run/network.rs
@@ -37,7 +37,7 @@ pub(crate) struct NetworkArgs {
 
     /// Maximum established outgoing swarm connection limit.
     #[arg(long, default_value_t = 100)]
-    out_connections: u32,
+    pub(crate) out_connections: u32,
 
     /// Maximum pending outgoing swarm connection limit.
     #[arg(long, default_value_t = 100)]

--- a/crates/subspace-gateway/src/piece_getter.rs
+++ b/crates/subspace-gateway/src/piece_getter.rs
@@ -7,7 +7,6 @@ use std::ops::{Deref, DerefMut};
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use subspace_data_retrieval::piece_getter::{BoxError, ObjectPieceGetter};
 use subspace_networking::utils::piece_provider::{PieceProvider, PieceValidator};
-use subspace_networking::Node;
 
 /// The maximum number of peer-to-peer walking rounds for L1 archival storage.
 const MAX_RANDOM_WALK_ROUNDS: usize = 15;
@@ -76,7 +75,7 @@ where
     PV: PieceValidator,
 {
     /// Creates new DSN piece getter.
-    pub fn new(node: Node, piece_validator: PV) -> Self {
-        Self(PieceProvider::new(node, piece_validator))
+    pub fn new(piece_provider: PieceProvider<PV>) -> Self {
+        Self(piece_provider)
     }
 }

--- a/crates/subspace-networking/Cargo.toml
+++ b/crates/subspace-networking/Cargo.toml
@@ -16,13 +16,12 @@ include = [
 ]
 
 [dependencies]
-async-mutex = "1.4.0"
+async-lock = "3.4.0"
 async-trait = "0.1.83"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = "1.7.2"
 clap = { version = "4.5.18", features = ["color", "derive"] }
 derive_more = { version = "1.0.0", features = ["full"] }
-either = "1.13.0"
 event-listener-primitives = "2.0.1"
 # TODO: Switch to fs4 once https://github.com/al8n/fs4-rs/issues/15 is resolved
 fs2 = "0.4.3"

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -16,7 +16,7 @@
 //! Networking functionality of Subspace Network, primarily used for DSN (Distributed Storage
 //! Network).
 
-#![feature(impl_trait_in_assoc_type, ip, try_blocks)]
+#![feature(exact_size_is_empty, impl_trait_in_assoc_type, ip, try_blocks)]
 #![warn(missing_docs)]
 
 mod behavior;

--- a/crates/subspace-networking/src/node.rs
+++ b/crates/subspace-networking/src/node.rs
@@ -571,7 +571,7 @@ impl Node {
     pub async fn connected_peers(&self) -> Result<Vec<PeerId>, ConnectedPeersError> {
         let (result_sender, result_receiver) = oneshot::channel();
 
-        trace!("Starting 'connected_peers' request.");
+        trace!("Starting `connected_peers` request");
 
         self.shared
             .command_sender
@@ -584,11 +584,28 @@ impl Node {
             .map_err(|_| ConnectedPeersError::ConnectedPeers)
     }
 
+    /// Returns a collection of currently connected servers (typically farmers).
+    pub async fn connected_servers(&self) -> Result<Vec<PeerId>, ConnectedPeersError> {
+        let (result_sender, result_receiver) = oneshot::channel();
+
+        trace!("Starting `connected_servers` request.");
+
+        self.shared
+            .command_sender
+            .clone()
+            .send(Command::ConnectedServers { result_sender })
+            .await?;
+
+        result_receiver
+            .await
+            .map_err(|_| ConnectedPeersError::ConnectedPeers)
+    }
+
     /// Bootstraps Kademlia network
     pub async fn bootstrap(&self) -> Result<(), BootstrapError> {
         let (result_sender, mut result_receiver) = mpsc::unbounded();
 
-        debug!("Starting 'bootstrap' request.");
+        debug!("Starting `bootstrap` request");
 
         self.shared
             .command_sender

--- a/crates/subspace-networking/src/node_runner.rs
+++ b/crates/subspace-networking/src/node_runner.rs
@@ -10,7 +10,7 @@ use crate::protocols::request_response::request_response_factory::{
 };
 use crate::shared::{Command, CreatedSubscription, PeerDiscovered, Shared};
 use crate::utils::{is_global_address_or_dns, strip_peer_id, SubspaceMetrics};
-use async_mutex::Mutex as AsyncMutex;
+use async_lock::Mutex as AsyncMutex;
 use bytes::Bytes;
 use event_listener_primitives::HandlerId;
 use futures::channel::mpsc;

--- a/crates/subspace-networking/src/shared.rs
+++ b/crates/subspace-networking/src/shared.rs
@@ -108,6 +108,9 @@ pub(crate) enum Command {
     ConnectedPeers {
         result_sender: oneshot::Sender<Vec<PeerId>>,
     },
+    ConnectedServers {
+        result_sender: oneshot::Sender<Vec<PeerId>>,
+    },
     Bootstrap {
         // No result sender means background async bootstrapping
         result_sender: Option<mpsc::UnboundedSender<()>>,

--- a/crates/subspace-service/Cargo.toml
+++ b/crates/subspace-service/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.2.3"
 async-channel = "1.8.0"
+async-lock = "3.4.0"
 async-trait = "0.1.83"
 cross-domain-message-gossip = { version = "0.1.0", path = "../../domains/client/cross-domain-message-gossip" }
 domain-runtime-primitives = { version = "0.1.0", path = "../../domains/primitives/runtime" }
@@ -43,9 +44,7 @@ sc-domains = { version = "0.1.0", path = "../sc-domains" }
 sc-executor = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-sc-network-light = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-network-sync = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-sc-network-transactions = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-offchain = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-proof-of-time = { version = "0.1.0", path = "../sc-proof-of-time" }
 sc-rpc = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
@@ -57,7 +56,6 @@ sc-telemetry = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8
 sc-tracing = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-transaction-pool = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sc-transaction-pool-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
-sc-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 schnellru = "0.2.1"
 schnorrkel = "0.11.4"
 sp-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -287,6 +287,8 @@ pub enum SubspaceNetworking {
         node: Node,
         /// Bootstrap nodes used (that can be also sent to the farmer over RPC)
         bootstrap_nodes: Vec<Multiaddr>,
+        /// Sum of incoming and outgoing connection limits
+        max_connections: u32,
     },
     /// Networking must be instantiated internally
     Create {


### PR DESCRIPTION
There is some reafactoring here, but the primary goal is to accelerate `PieceProvider`.

Previously it had somewhat optimized implementation for downloading from connected peers and non-optimized implementation for closest peers downloads.

This new implementation is actually a bit simpler and unifies both mechanisms under single uniform logic. It does so by querying closest peers to convert them into connected and continue from there.

Together with piece cache tweaks from my testing this helps with both peak and sustained downloading speed. I'll be looking into avoiding making requests to connected peers that are not able to serve pieces and generally to non-farmers, but that will be a separate PR.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
