### PR TITLE
XDM: Update the verification error values to be distinct from the value used in Domain verifcation

### DIFF
--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -47,9 +47,9 @@ use sp_runtime::traits::{Extrinsic, Hash};
 use sp_runtime::DispatchError;
 
 pub(crate) mod verification_errors {
-    pub(crate) const INVALID_CHANNEL: u8 = 100;
-    pub(crate) const INVALID_NONCE: u8 = 101;
-    pub(crate) const NONCE_OVERFLOW: u8 = 102;
+    pub(crate) const INVALID_CHANNEL: u8 = 200;
+    pub(crate) const INVALID_NONCE: u8 = 201;
+    pub(crate) const NONCE_OVERFLOW: u8 = 202;
 }
 
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo, Copy)]


### PR DESCRIPTION
We use `InvalidTransaction::Custom` variant in Domains and Messenger in the unsigned validate functionality. We ended using same error number for both of them and as a result its actually difficult  to distinguish in the logs.

Useful once we start re-doing the tests for XDM

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
