### PR TITLE
Improve cluster plotting GPU utilization

### DIFF
--- a/crates/subspace-farmer/src/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/cluster/plotter.rs
@@ -384,7 +384,8 @@ impl ClusterPlotter {
                 // Allow to buffer up to the whole sector in memory to not block plotter on the
                 // other side
                 let (mut sector_sender, sector_receiver) = mpsc::channel(
-                    sector_size(pieces_in_sector) / nats_client.approximate_max_message_size(),
+                    (sector_size(pieces_in_sector) / nats_client.approximate_max_message_size())
+                        .max(1),
                 );
                 let mut maybe_sector_receiver = Some(sector_receiver);
                 loop {

--- a/crates/subspace-farmer/src/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/cluster/plotter.rs
@@ -31,6 +31,7 @@ use std::time::{Duration, Instant};
 use subspace_core_primitives::sectors::SectorIndex;
 use subspace_core_primitives::PublicKey;
 use subspace_farmer_components::plotting::PlottedSector;
+use subspace_farmer_components::sector::sector_size;
 use subspace_farmer_components::FarmerProtocolInfo;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::MissedTickBehavior;
@@ -380,7 +381,11 @@ impl ClusterPlotter {
                     }
                 };
 
-                let (mut sector_sender, sector_receiver) = mpsc::channel(1);
+                // Allow to buffer up to the whole sector in memory to not block plotter on the
+                // other side
+                let (mut sector_sender, sector_receiver) = mpsc::channel(
+                    sector_size(pieces_in_sector) / nats_client.approximate_max_message_size(),
+                );
                 let mut maybe_sector_receiver = Some(sector_receiver);
                 loop {
                     match tokio::time::timeout(PING_TIMEOUT, response_stream.next()).await {


### PR DESCRIPTION
This allows farmer to buffer the whole sector in memory in case disk is not fast enough to write, which will release plotting resources on the other end and allow plotter to start plotting other sectors, potentially for a completely different machine.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
