### PR TITLE
Remove signing key proof of ownership check

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -986,7 +986,6 @@ mod benchmarks {
             domain_id,
             T::MinOperatorStake::get(),
             operator_config.clone(),
-            None,
         ));
         assert_eq!(
             OperatorIdOwner::<T>::get(operator_id),

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -1357,18 +1357,13 @@ mod pallet {
             domain_id: DomainId,
             amount: BalanceOf<T>,
             config: OperatorConfig<BalanceOf<T>>,
-            signing_key_proof_of_ownership: OperatorSignature,
+            _signing_key_proof_of_ownership: OperatorSignature,
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
 
-            let (operator_id, current_epoch_index) = do_register_operator::<T>(
-                owner,
-                domain_id,
-                amount,
-                config,
-                Some(signing_key_proof_of_ownership),
-            )
-            .map_err(Error::<T>::from)?;
+            let (operator_id, current_epoch_index) =
+                do_register_operator::<T>(owner, domain_id, amount, config)
+                    .map_err(Error::<T>::from)?;
 
             Self::deposit_event(Event::OperatorRegistered {
                 operator_id,
@@ -1854,8 +1849,6 @@ mod pallet {
                         domain_id,
                         operator_stake,
                         operator_config,
-                        // safe to not check the signing key ownership during genesis
-                        None,
                     )
                     .expect("Genesis operator registration must succeed");
 


### PR DESCRIPTION
This PR removes the operator signing key proof of ownership check.

My next PR will remove the argument from register_operator, and the OperatorSigningKeyProofOfOwnershipData type.

Part of #3261.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
