### PR TITLE
Remove unused register_operator(signing_key_proof_of_ownership) argument

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -576,9 +576,6 @@ mod benchmarks {
 
         let domain_id = register_domain::<T>();
         let operator_id = NextOperatorId::<T>::get();
-
-        // TODO: the `(key, signature)` is failed to verify in `cargo test --features runtime-benchmarks` but it
-        // will pass when doing the actual benchmark with `subspace-node benchmark pallet ...`, need more investigations.
         let key =
             OperatorPublicKey::from_ss58check("5Gv1Uopoqo1k7125oDtFSCmxH4DzuCiBU7HBKu2bF1GZFsEb")
                 .unwrap();

--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -25,7 +25,6 @@ use frame_support::traits::fungible::{Inspect, Mutate};
 use frame_support::traits::Hooks;
 use frame_system::{Pallet as System, RawOrigin};
 use sp_core::crypto::{Ss58Codec, UncheckedFrom};
-use sp_core::ByteArray;
 use sp_domains::{
     dummy_opaque_bundle, DomainId, ExecutionReceipt, OperatorAllowList, OperatorId,
     OperatorPublicKey, OperatorRewardSource, OperatorSignature, PermissionedActionAllowedBy,
@@ -580,23 +579,9 @@ mod benchmarks {
 
         // TODO: the `(key, signature)` is failed to verify in `cargo test --features runtime-benchmarks` but it
         // will pass when doing the actual benchmark with `subspace-node benchmark pallet ...`, need more investigations.
-        let (key, signature) = {
-            let key = OperatorPublicKey::from_ss58check(
-                "5Gv1Uopoqo1k7125oDtFSCmxH4DzuCiBU7HBKu2bF1GZFsEb",
-            )
-            .unwrap();
-
-            // signature data included operator_account since result from `account` with same
-            // input is always deterministic
-            let sig = OperatorSignature::from_slice(&[
-                88, 91, 154, 118, 137, 117, 109, 164, 232, 186, 101, 199, 94, 12, 91, 47, 228, 198,
-                61, 146, 200, 227, 152, 191, 205, 114, 81, 127, 192, 158, 48, 96, 211, 199, 237,
-                121, 170, 38, 118, 109, 3, 44, 198, 54, 155, 133, 240, 77, 200, 117, 107, 34, 248,
-                238, 144, 101, 200, 146, 20, 94, 180, 98, 40, 134,
-            ])
-            .unwrap();
-            (key, sig)
-        };
+        let key =
+            OperatorPublicKey::from_ss58check("5Gv1Uopoqo1k7125oDtFSCmxH4DzuCiBU7HBKu2bF1GZFsEb")
+                .unwrap();
         let operator_config = OperatorConfig {
             signing_key: key,
             minimum_nominator_stake: T::MinNominatorStake::get(),
@@ -609,7 +594,6 @@ mod benchmarks {
             domain_id,
             T::MinOperatorStake::get(),
             operator_config.clone(),
-            signature,
         );
 
         assert_eq!(NextOperatorId::<T>::get(), operator_id + 1);

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -231,8 +231,7 @@ mod pallet {
     use sp_domains::{
         BundleDigest, DomainBundleSubmitted, DomainId, DomainSudoCall, DomainsTransfersTracker,
         EpochIndex, GenesisDomain, OnChainRewards, OnDomainInstantiated, OperatorAllowList,
-        OperatorId, OperatorPublicKey, OperatorRewardSource, OperatorSignature, RuntimeId,
-        RuntimeObject, RuntimeType,
+        OperatorId, OperatorPublicKey, OperatorRewardSource, RuntimeId, RuntimeObject, RuntimeType,
     };
     use sp_domains_fraud_proof::fraud_proof_runtime_interface::domain_runtime_call;
     use sp_domains_fraud_proof::storage_proof::{self, FraudProofStorageKeyProvider};
@@ -1357,7 +1356,6 @@ mod pallet {
             domain_id: DomainId,
             amount: BalanceOf<T>,
             config: OperatorConfig<BalanceOf<T>>,
-            _signing_key_proof_of_ownership: OperatorSignature,
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
 

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -530,13 +530,10 @@ mod tests {
     use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
     #[cfg(not(feature = "std"))]
     use alloc::vec;
-    use codec::Encode;
     use frame_support::assert_ok;
     use frame_support::traits::fungible::InspectHold;
     use sp_core::{Pair, U256};
-    use sp_domains::{
-        DomainId, OperatorPair, OperatorRewardSource, OperatorSigningKeyProofOfOwnershipData,
-    };
+    use sp_domains::{DomainId, OperatorPair, OperatorRewardSource};
     use sp_runtime::traits::Zero;
     use sp_runtime::{PerThing, Percent};
     use std::collections::BTreeMap;
@@ -554,10 +551,6 @@ mod tests {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
         let pair = OperatorPair::from_seed(&U256::from(0u32).into());
-        let data = OperatorSigningKeyProofOfOwnershipData {
-            operator_owner: operator_account,
-        };
-        let signature = pair.sign(&data.encode());
         let minimum_free_balance = 10 * SSC;
         let mut nominators = BTreeMap::from_iter(
             nominators
@@ -586,7 +579,6 @@ mod tests {
                 operator_stake,
                 10 * SSC,
                 pair.public(),
-                signature,
                 BTreeMap::from_iter(nominators.clone()),
             );
 
@@ -692,10 +684,6 @@ mod tests {
         let domain_id = DomainId::new(0);
         let operator_account = 0;
         let pair = OperatorPair::from_seed(&U256::from(0u32).into());
-        let data = OperatorSigningKeyProofOfOwnershipData {
-            operator_owner: operator_account,
-        };
-        let signature = pair.sign(&data.encode());
         let FinalizeDomainParams {
             total_deposit,
             rewards,
@@ -729,7 +717,6 @@ mod tests {
                 operator_stake,
                 10 * SSC,
                 pair.public(),
-                signature,
                 BTreeMap::from_iter(nominators),
             );
 
@@ -808,10 +795,6 @@ mod tests {
         let domain_id = DomainId::new(0);
         let operator_account = 1;
         let pair = OperatorPair::from_seed(&U256::from(0u32).into());
-        let data = OperatorSigningKeyProofOfOwnershipData {
-            operator_owner: operator_account,
-        };
-        let signature = pair.sign(&data.encode());
         let operator_rewards = 10 * SSC;
         let mut nominators =
             BTreeMap::from_iter(vec![(1, (110 * SSC, 100 * SSC)), (2, (60 * SSC, 50 * SSC))]);
@@ -827,7 +810,6 @@ mod tests {
                 operator_stake,
                 10 * SSC,
                 pair.public(),
-                signature,
                 BTreeMap::from_iter(nominators),
             );
 

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1456,14 +1456,6 @@ pub fn operator_block_fees_final_key() -> Vec<u8> {
         .to_vec()
 }
 
-/// Preimage to verify the proof of ownership of Operator Signing key.
-/// Operator owner is used to ensure the signature is used by anyone except
-/// the owner of the Signing key pair.
-#[derive(Debug, Encode)]
-pub struct OperatorSigningKeyProofOfOwnershipData<AccountId> {
-    pub operator_owner: AccountId,
-}
-
 /// Hook to handle chain rewards.
 pub trait OnChainRewards<Balance> {
     fn on_chain_rewards(chain_id: ChainId, reward: Balance);

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -32,7 +32,7 @@ use sp_domains::core_api::DomainCoreApi;
 use sp_domains::merkle_tree::MerkleTree;
 use sp_domains::{
     Bundle, BundleValidity, ChainId, ChannelId, DomainsApi, HeaderHashingFor, InboxedBundle,
-    InvalidBundleType, OperatorSignature, OperatorSigningKeyProofOfOwnershipData, Transfers,
+    InvalidBundleType, Transfers,
 };
 use sp_domains_fraud_proof::fraud_proof::{
     ApplyExtrinsicMismatch, ExecutionPhase, FinalizeBlockMismatch, FraudProofVariant,
@@ -4535,12 +4535,6 @@ async fn test_bad_receipt_chain() {
                 minimum_nominator_stake: Balance::MAX,
                 nomination_tax: Default::default(),
             },
-            signing_key_proof_of_ownership: OperatorSignature::from(
-                OperatorSigningKeyProofOfOwnershipData {
-                    operator_owner: Sr25519Alice.to_account_id(),
-                }
-                .using_encoded(|e| Sr25519Keyring::Charlie.sign(e)),
-            ),
         })
         .await
         .unwrap();


### PR DESCRIPTION
PR #3263 removed the actual check, this PR removes the unused arguments, data types, and test setup code.

Part of #3261.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
