### PR TITLE
Remove OperatorSigningKey pallet storage

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -231,7 +231,7 @@ mod pallet {
     use sp_domains::{
         BundleDigest, DomainBundleSubmitted, DomainId, DomainSudoCall, DomainsTransfersTracker,
         EpochIndex, GenesisDomain, OnChainRewards, OnDomainInstantiated, OperatorAllowList,
-        OperatorId, OperatorPublicKey, OperatorRewardSource, RuntimeId, RuntimeObject, RuntimeType,
+        OperatorId, OperatorRewardSource, RuntimeId, RuntimeObject, RuntimeType,
     };
     use sp_domains_fraud_proof::fraud_proof_runtime_interface::domain_runtime_call;
     use sp_domains_fraud_proof::storage_proof::{self, FraudProofStorageKeyProvider};
@@ -483,12 +483,6 @@ mod pallet {
     #[pallet::storage]
     pub(super) type OperatorIdOwner<T: Config> =
         StorageMap<_, Identity, OperatorId, T::AccountId, OptionQuery>;
-
-    /// Indexes operator signing key against OperatorId.
-    #[pallet::storage]
-    #[pallet::getter(fn operator_signing_key)]
-    pub(super) type OperatorSigningKey<T: Config> =
-        StorageMap<_, Identity, OperatorPublicKey, OperatorId, OptionQuery>;
 
     #[pallet::storage]
     #[pallet::getter(fn domain_staking_summary)]

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -493,7 +493,7 @@ pub(crate) fn do_slash_operator<T: Config>(
             nominator_count == 0 && !Deposits::<T>::contains_key(operator_id, operator_owner);
 
         if cleanup_operator {
-            do_cleanup_operator::<T>(operator_id, total_stake, operator.signing_key)?;
+            do_cleanup_operator::<T>(operator_id, total_stake)?;
             if slashed_operators.is_empty() {
                 PendingSlashes::<T>::remove(domain_id);
             } else {
@@ -516,7 +516,7 @@ mod tests {
     use crate::bundle_storage_fund::STORAGE_FEE_RESERVE;
     use crate::pallet::{
         Deposits, DomainStakingSummary, HeadDomainNumber, LastEpochStakingDistribution,
-        NominatorCount, OperatorIdOwner, OperatorSigningKey, Operators, Withdrawals,
+        NominatorCount, OperatorIdOwner, Operators, Withdrawals,
     };
     use crate::staking::tests::{register_operator, Share};
     use crate::staking::{
@@ -641,7 +641,6 @@ mod tests {
 
             assert_eq!(Operators::<Test>::get(operator_id), None);
             assert_eq!(OperatorIdOwner::<Test>::get(operator_id), None);
-            assert_eq!(OperatorSigningKey::<Test>::get(pair.public()), None);
             assert_eq!(NominatorCount::<Test>::get(operator_id), 0);
         });
     }

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1532,9 +1532,6 @@ sp_api::decl_runtime_apis! {
         /// Returns the current epoch and the next epoch operators of the given domain
         fn domain_operators(domain_id: DomainId) -> Option<(BTreeMap<OperatorId, Balance>, Vec<OperatorId>)>;
 
-        /// Get operator id by signing key
-        fn operator_id_by_signing_key(signing_key: OperatorPublicKey) -> Option<OperatorId>;
-
         /// Returns the execution receipt hash of the given domain and domain block number
         fn receipt_hash(domain_id: DomainId, domain_number: HeaderNumberFor<DomainHeader>) -> Option<HeaderHashFor<DomainHeader>>;
 

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -253,10 +253,6 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn operator_id_by_signing_key(_signing_key: OperatorPublicKey) -> Option<OperatorId> {
-            unreachable!()
-        }
-
         fn receipt_hash(_domain_id: DomainId, _domain_number: DomainNumber) -> Option<DomainHash> {
             unreachable!()
         }

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1325,10 +1325,6 @@ impl_runtime_apis! {
             })
         }
 
-        fn operator_id_by_signing_key(signing_key: OperatorPublicKey) -> Option<OperatorId> {
-            Domains::operator_signing_key(signing_key)
-        }
-
         fn receipt_hash(domain_id: DomainId, domain_number: DomainNumber) -> Option<DomainHash> {
             Domains::receipt_hash(domain_id, domain_number)
         }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1386,10 +1386,6 @@ impl_runtime_apis! {
             })
         }
 
-        fn operator_id_by_signing_key(signing_key: OperatorPublicKey) -> Option<OperatorId> {
-            Domains::operator_signing_key(signing_key)
-        }
-
         fn receipt_hash(domain_id: DomainId, domain_number: DomainNumber) -> Option<DomainHash> {
             Domains::receipt_hash(domain_id, domain_number)
         }


### PR DESCRIPTION
This PR removes the storage for the `OperatorSigningKey` map.

It replaces the usage in the malicious operator with a search though all operator IDs.

Close #3261.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
