### PR TITLE
Fix fresh node start with Snap sync failing

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -631,28 +631,38 @@ where
     }
 
     // If the user chooses an object mapping start block we don't have data or state for, we can't
-    // create mappings for it, so the node must exit with an error.
-    let best_block_to_archive_hash = client
-        .hash(best_block_to_archive.into())?
-        .expect("just checked above; qed");
-    let Some(best_block_data) = client.block(best_block_to_archive_hash)? else {
-        let error = format!(
-                "Missing data for mapping block {best_block_to_archive} hash {best_block_to_archive_hash}, \
-                try a higher block number, or wipe your node and restart with `--sync full`"
+    // create mappings for it, so the node must exit with an error
+    if create_object_mappings.is_enabled() {
+        let best_block_to_archive_hash = client
+            .hash(best_block_to_archive.into())?
+            .expect("just checked above; qed");
+        let Some(best_block_data) = client.block(best_block_to_archive_hash)? else {
+            let error = format!(
+                "Missing data for mapping block {best_block_to_archive} hash \
+                {best_block_to_archive_hash}, try a higher block number, or wipe your node and \
+                restart with `--sync full`"
             );
-        return Err(sp_blockchain::Error::Application(error.into()));
-    };
+            return Err(sp_blockchain::Error::Application(error.into()));
+        };
 
-    // Similarly, state can be pruned, even if the data is present.
-    client
-        .runtime_api()
-        .extract_block_object_mapping(*best_block_data.block.header().parent_hash(), best_block_data.block.clone())
+        // Similarly, state can be pruned, even if the data is present
+        client
+            .runtime_api()
+            .extract_block_object_mapping(
+                *best_block_data.block.header().parent_hash(),
+                best_block_data.block.clone(),
+            )
             .map_err(|error| {
                 sp_blockchain::Error::Application(
-                    format!("Missing state for mapping block {best_block_to_archive} hash {best_block_to_archive_hash}: {error}, \
-                            try a higher block number, or wipe your node and restart with `--sync full`").into(),
+                    format!(
+                        "Missing state for mapping block {best_block_to_archive} hash \
+                        {best_block_to_archive_hash}: {error}, try a higher block number, or wipe \
+                        your node and restart with `--sync full`"
+                    )
+                    .into(),
                 )
             })?;
+    }
 
     let maybe_last_archived_block = find_last_archived_block(
         client,


### PR DESCRIPTION
Regression from recent object mappings changes. For regular node operation it doesn't matter if state exists, which it will not for parent of genesis block anyway since there can't be state for genesis block anyway.

Without this node with regular Snap sync (including Space Acres) fails like this:
> Error: SubstrateService(Other("Failed to build a full subspace node 3: Sub(Client(Application(\"Missing state for mapping block 0 hash 0x6645…21bd: Api called for an unknown Block: Header was not found in the database: 0x0000000000000000000000000000000000000000000000000000000000000000, try a higher block number, or wipe your node and restart with `--sync full`\")))"))


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
