### PR TITLE
Cluster cache improvements

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -200,6 +200,7 @@ pub(super) async fn controller(
             let node_client = node_client.clone();
             let piece_getter = piece_getter.clone();
             let farmer_cache = farmer_cache.clone();
+            let cache_group = cache_group.clone();
             let instance = instance.clone();
 
             AsyncJoinOnDrop::new(
@@ -210,6 +211,7 @@ pub(super) async fn controller(
                         &piece_getter,
                         &farmer_cache,
                         &instance,
+                        &cache_group,
                         index == 0,
                     )
                     .await

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -20,7 +20,7 @@ use subspace_farmer::cluster::controller::controller_service;
 use subspace_farmer::cluster::controller::farms::{maintain_farms, FarmIndex};
 use subspace_farmer::cluster::nats_client::NatsClient;
 use subspace_farmer::farm::plotted_pieces::PlottedPieces;
-use subspace_farmer::farmer_cache::FarmerCache;
+use subspace_farmer::farmer_cache::{FarmerCache, FarmerCaches};
 use subspace_farmer::farmer_piece_getter::piece_validator::SegmentCommitmentPieceValidator;
 use subspace_farmer::farmer_piece_getter::{DsnCacheRetryPolicy, FarmerPieceGetter};
 use subspace_farmer::node_client::caching_proxy_node_client::CachingProxyNodeClient;
@@ -57,7 +57,7 @@ pub(super) struct ControllerArgs {
     /// It is strongly recommended to use alphanumeric values for cache group, the same cache group
     /// must be also specified on corresponding caches.
     #[arg(long, default_value = "default")]
-    cache_group: String,
+    cache_groups: Vec<String>,
     /// Number of service instances.
     ///
     /// Increasing number of services allows to process more concurrent requests, but increasing
@@ -86,7 +86,7 @@ pub(super) async fn controller(
     let ControllerArgs {
         base_path,
         node_rpc_url,
-        cache_group,
+        cache_groups,
         service_instances,
         mut network_args,
         dev,
@@ -130,8 +130,11 @@ pub(super) async fn controller(
     let peer_id = keypair.public().to_peer_id();
     let instance = peer_id.to_string();
 
-    let (farmer_cache, farmer_cache_worker) =
-        FarmerCache::new(node_client.clone(), peer_id, Some(registry));
+    let (farmer_caches, farmer_cache_workers) = cache_groups
+        .iter()
+        .map(|_cache_group| FarmerCache::new(node_client.clone(), peer_id, Some(registry)))
+        .unzip::<_, _, Vec<_>, Vec<_>>();
+    let farmer_caches = Arc::from(farmer_caches.into_boxed_slice());
 
     // TODO: Metrics
 
@@ -154,7 +157,7 @@ pub(super) async fn controller(
             network_args,
             Arc::downgrade(&plotted_pieces),
             node_client.clone(),
-            farmer_cache.clone(),
+            FarmerCaches::from(Arc::clone(&farmer_caches)),
             Some(registry),
         )
         .map_err(|error| anyhow!("Failed to configure networking: {error}"))?
@@ -164,12 +167,55 @@ pub(super) async fn controller(
     let piece_provider = PieceProvider::new(
         node.clone(),
         SegmentCommitmentPieceValidator::new(node.clone(), node_client.clone(), kzg.clone()),
-        Semaphore::new(out_connections as usize * PIECE_PROVIDER_MULTIPLIER),
+        Arc::new(Semaphore::new(
+            out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
+        )),
     );
+
+    let farmer_cache_workers_fut = farmer_cache_workers
+        .into_iter()
+        .enumerate()
+        .map(|(index, farmer_cache_worker)| {
+            // Each farmer cache worker gets a customized piece getter that can leverage other
+            // caches than itself for sync purposes
+            let piece_getter = FarmerPieceGetter::new(
+                piece_provider.clone(),
+                FarmerCaches::from(Arc::from(
+                    farmer_caches
+                        .iter()
+                        .enumerate()
+                        .filter(|&(filter_index, _farmer_cache)| (filter_index != index))
+                        .map(|(_filter_index, farmer_cache)| farmer_cache.clone())
+                        .collect::<Box<_>>(),
+                )),
+                node_client.clone(),
+                Arc::clone(&plotted_pieces),
+                DsnCacheRetryPolicy {
+                    max_retries: PIECE_GETTER_MAX_RETRIES,
+                    backoff: ExponentialBackoff {
+                        initial_interval: GET_PIECE_INITIAL_INTERVAL,
+                        max_interval: GET_PIECE_MAX_INTERVAL,
+                        // Try until we get a valid piece
+                        max_elapsed_time: None,
+                        multiplier: 1.75,
+                        ..ExponentialBackoff::default()
+                    },
+                },
+            );
+
+            let fut = farmer_cache_worker.run(piece_getter.downgrade());
+
+            async move {
+                let fut =
+                    run_future_in_dedicated_thread(move || fut, format!("cache-worker-{index}"));
+                anyhow::Ok(fut?.await?)
+            }
+        })
+        .collect::<FuturesUnordered<_>>();
 
     let piece_getter = FarmerPieceGetter::new(
         piece_provider,
-        farmer_cache.clone(),
+        FarmerCaches::from(Arc::clone(&farmer_caches)),
         node_client.clone(),
         Arc::clone(&plotted_pieces),
         DsnCacheRetryPolicy {
@@ -185,33 +231,29 @@ pub(super) async fn controller(
         },
     );
 
-    let farmer_cache_worker_fut = run_future_in_dedicated_thread(
-        {
-            let future = farmer_cache_worker.run(piece_getter.downgrade());
-
-            move || future
-        },
-        "controller-cache-worker".to_string(),
-    )?;
-
     let mut controller_services = (0..service_instances.get())
         .map(|index| {
             let nats_client = nats_client.clone();
             let node_client = node_client.clone();
             let piece_getter = piece_getter.clone();
-            let farmer_cache = farmer_cache.clone();
-            let cache_group = cache_group.clone();
+            let farmer_caches = Arc::clone(&farmer_caches);
+            let cache_groups = cache_groups.clone();
             let instance = instance.clone();
 
             AsyncJoinOnDrop::new(
                 tokio::spawn(async move {
+                    let farmer_caches = cache_groups
+                        .iter()
+                        .zip(farmer_caches.as_ref())
+                        .map(|(cache_group, farmer_cache)| (cache_group.as_str(), farmer_cache))
+                        .collect::<Vec<_>>();
+
                     controller_service(
                         &nats_client,
                         &node_client,
                         &piece_getter,
-                        &farmer_cache,
+                        &farmer_caches,
                         &instance,
-                        &cache_group,
                         index == 0,
                     )
                     .await
@@ -244,39 +286,56 @@ pub(super) async fn controller(
                 .await
             }
         },
-        "controller-farms".to_string(),
+        "farms".to_string(),
     )?;
 
-    let caches_fut = run_future_in_dedicated_thread(
-        move || async move {
-            maintain_caches(
-                &cache_group,
-                &nats_client,
-                farmer_cache,
-                CACHE_IDENTIFICATION_BROADCAST_INTERVAL,
-            )
-            .await
-        },
-        "controller-caches".to_string(),
-    )?;
+    let caches_fut = farmer_caches
+        .iter()
+        .cloned()
+        .zip(cache_groups)
+        .enumerate()
+        .map(|(index, (farmer_cache, cache_group))| {
+            let nats_client = nats_client.clone();
+
+            async move {
+                let fut = run_future_in_dedicated_thread(
+                    move || async move {
+                        maintain_caches(
+                            &cache_group,
+                            &nats_client,
+                            &farmer_cache,
+                            CACHE_IDENTIFICATION_BROADCAST_INTERVAL,
+                        )
+                        .await
+                    },
+                    format!("caches-{index}"),
+                );
+                anyhow::Ok(fut?.await?)
+            }
+        })
+        .collect::<FuturesUnordered<_>>();
 
     let networking_fut = run_future_in_dedicated_thread(
         move || async move { node_runner.run().await },
-        "controller-networking".to_string(),
+        "networking".to_string(),
     )?;
 
     Ok(Box::pin(async move {
         // This defines order in which things are dropped
         let networking_fut = networking_fut;
         let farms_fut = farms_fut;
-        let caches_fut = caches_fut;
-        let farmer_cache_worker_fut = farmer_cache_worker_fut;
+        let mut caches_fut = caches_fut;
+        let caches_fut = caches_fut.next().map(|result| result.unwrap_or(Ok(Ok(()))));
+        let mut farmer_cache_workers_fut = farmer_cache_workers_fut;
+        let farmer_cache_workers_fut = farmer_cache_workers_fut
+            .next()
+            .map(|result| result.unwrap_or(Ok(())));
         let controller_service_fut = controller_service_fut;
 
         let networking_fut = pin!(networking_fut);
         let farms_fut = pin!(farms_fut);
         let caches_fut = pin!(caches_fut);
-        let farmer_cache_worker_fut = pin!(farmer_cache_worker_fut);
+        let farmer_cache_workers_fut = pin!(farmer_cache_workers_fut);
         let controller_service_fut = pin!(controller_service_fut);
 
         select! {
@@ -296,7 +355,7 @@ pub(super) async fn controller(
             },
 
             // Piece cache worker future
-            _ = farmer_cache_worker_fut.fuse() => {
+            _ = farmer_cache_workers_fut.fuse() => {
                 info!("Farmer cache worker exited.")
             },
 

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/plotter.rs
@@ -133,6 +133,9 @@ pub(super) struct PlotterArgs {
     #[cfg(feature = "rocm")]
     #[clap(flatten)]
     rocm_plotting_options: RocmPlottingOptions,
+    /// Cache group to use if specified, otherwise all caches are usable by this plotter
+    #[arg(long)]
+    cache_group: Option<String>,
     /// Additional cluster components
     #[clap(raw = true)]
     pub(super) additional_components: Vec<String>,
@@ -152,6 +155,7 @@ where
         cuda_plotting_options,
         #[cfg(feature = "rocm")]
         rocm_plotting_options,
+        cache_group,
         additional_components: _,
     } = plotter_args;
 
@@ -161,7 +165,7 @@ where
             .expect("Not zero; qed"),
     )
     .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
-    let piece_getter = ClusterPieceGetter::new(nats_client.clone());
+    let piece_getter = ClusterPieceGetter::new(nats_client.clone(), cache_group);
 
     let global_mutex = Arc::default();
 

--- a/crates/subspace-farmer/src/cluster/controller.rs
+++ b/crates/subspace-farmer/src/cluster/controller.rs
@@ -38,8 +38,8 @@ use subspace_rpc_primitives::{
 };
 use tracing::{debug, error, trace, warn};
 
-/// Special "cache group" that all controllers subscribe to and that can be used to query all cache
-/// groups
+/// Special "cache group" that all controllers subscribe to and that can be used to query any cache
+/// group. The cache group for each query is chosen at random.
 const GLOBAL_CACHE_GROUP: &str = "_";
 
 /// Broadcast sent by controllers requesting farmers to identify themselves

--- a/crates/subspace-farmer/src/cluster/controller/caches.rs
+++ b/crates/subspace-farmer/src/cluster/controller/caches.rs
@@ -94,7 +94,7 @@ impl KnownCaches {
 pub async fn maintain_caches(
     cache_group: &str,
     nats_client: &NatsClient,
-    farmer_cache: FarmerCache,
+    farmer_cache: &FarmerCache,
     identification_broadcast_interval: Duration,
 ) -> anyhow::Result<()> {
     let mut known_caches = KnownCaches::new(identification_broadcast_interval);

--- a/crates/subspace-gateway/src/commands/run.rs
+++ b/crates/subspace-gateway/src/commands/run.rs
@@ -16,6 +16,7 @@ use futures::{select, FutureExt};
 use std::env;
 use std::num::NonZeroUsize;
 use std::pin::pin;
+use std::sync::Arc;
 use subspace_core_primitives::pieces::Record;
 use subspace_data_retrieval::object_fetcher::ObjectFetcher;
 use subspace_erasure_coding::ErasureCoding;
@@ -99,7 +100,9 @@ pub async fn run(run_options: RunOptions) -> anyhow::Result<()> {
     let piece_provider = PieceProvider::new(
         dsn_node.clone(),
         SegmentCommitmentPieceValidator::new(dsn_node, node_client, kzg),
-        Semaphore::new(out_connections as usize * PIECE_PROVIDER_MULTIPLIER),
+        Arc::new(Semaphore::new(
+            out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
+        )),
     );
     let piece_getter = DsnPieceGetter::new(piece_provider);
     let object_fetcher = ObjectFetcher::new(piece_getter.into(), erasure_coding, Some(max_size));

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -214,7 +214,7 @@ async fn simple_benchmark(node: Node, max_pieces: usize, start_with: usize, retr
         return;
     }
 
-    let piece_provider = PieceProvider::new(node, NoPieceValidator, Semaphore::new(100));
+    let piece_provider = PieceProvider::new(node, NoPieceValidator, Arc::new(Semaphore::new(100)));
     let mut total_duration = Duration::default();
     for i in start_with..(start_with + max_pieces) {
         let piece_index = PieceIndex::from(i as u64);
@@ -269,7 +269,7 @@ async fn parallel_benchmark(
     let piece_provider = &PieceProvider::new(
         node,
         NoPieceValidator,
-        Semaphore::new(parallelism_level.into()),
+        Arc::new(Semaphore::new(parallelism_level.into())),
     );
     let mut total_duration = Duration::default();
     let mut pure_total_duration = Duration::default();

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -57,10 +57,11 @@ impl PieceValidator for NoPieceValidator {
 
 /// Piece provider with cancellation and piece validator.
 /// Use `NoPieceValidator` to disable validation.
+#[derive(Clone)]
 pub struct PieceProvider<PV> {
     node: Node,
     piece_validator: PV,
-    piece_downloading_semaphore: Semaphore,
+    piece_downloading_semaphore: Arc<Semaphore>,
 }
 
 impl<PV> fmt::Debug for PieceProvider<PV> {
@@ -76,7 +77,11 @@ where
     PV: PieceValidator,
 {
     /// Creates new piece provider.
-    pub fn new(node: Node, piece_validator: PV, piece_downloading_semaphore: Semaphore) -> Self {
+    pub fn new(
+        node: Node,
+        piece_validator: PV,
+        piece_downloading_semaphore: Arc<Semaphore>,
+    ) -> Self {
         Self {
             node,
             piece_validator,

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -1062,7 +1062,9 @@ where
                 subspace_link.kzg().clone(),
                 segment_headers_store.clone(),
             ),
-            Semaphore::new(max_connections as usize * PIECE_PROVIDER_MULTIPLIER),
+            Arc::new(Semaphore::new(
+                max_connections as usize * PIECE_PROVIDER_MULTIPLIER,
+            )),
         ))
     });
 


### PR DESCRIPTION
This introduces two changes for cluster farmers:
* `--cache-group` is now optionally supported on plotter to localize downloads
* `--cache-group` can be specified multiple times on controller to manage multiple cache groups at once (and yes, adding second cache group will allow it to sync from the first)

It is expected that caches will either be of the same size or all larger than cached pieces in the network.

To implement this I introduced `FarmerChaches` wrapper and pseudo-cache group `_` that corresponds to getting pieces from any cache group (and implicitly used internally by plotter by default).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
