### PR TITLE
Move piece getter option to `SubspaceNetworking::Reuse`

### DIFF
--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -202,7 +202,6 @@ fn main() -> Result<(), Error> {
                 force_new_slot_notifications: true,
                 create_object_mappings: CreateObjectMappings::No,
                 subspace_networking: SubspaceNetworking::Create { config: dsn_config },
-                dsn_piece_getter: None,
                 sync: Default::default(),
                 is_timekeeper: false,
                 timekeeper_cpu_cores: Default::default(),

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -758,7 +758,6 @@ pub(super) fn create_consensus_chain_configuration(
             force_new_slot_notifications: domains_enabled,
             create_object_mappings: create_object_mappings.unwrap_or_default().into(),
             subspace_networking: SubspaceNetworking::Create { config: dsn_config },
-            dsn_piece_getter: None,
             sync,
             is_timekeeper: timekeeper_options.timekeeper,
             timekeeper_cpu_cores: timekeeper_options.timekeeper_cpu_cores,

--- a/crates/subspace-service/src/config.rs
+++ b/crates/subspace-service/src/config.rs
@@ -287,8 +287,8 @@ pub enum SubspaceNetworking {
         node: Node,
         /// Bootstrap nodes used (that can be also sent to the farmer over RPC)
         bootstrap_nodes: Vec<Multiaddr>,
-        /// Sum of incoming and outgoing connection limits
-        max_connections: u32,
+        /// Piece getter
+        piece_getter: Arc<dyn DsnSyncPieceGetter + Send + Sync + 'static>,
     },
     /// Networking must be instantiated internally
     Create {
@@ -309,8 +309,6 @@ pub struct SubspaceConfiguration {
     pub create_object_mappings: CreateObjectMappings,
     /// Subspace networking (DSN).
     pub subspace_networking: SubspaceNetworking,
-    /// DSN piece getter
-    pub dsn_piece_getter: Option<Arc<dyn DsnSyncPieceGetter + Send + Sync + 'static>>,
     /// Is this node a Timekeeper
     pub is_timekeeper: bool,
     /// CPU cores that timekeeper can use

--- a/crates/subspace-service/src/lib.rs
+++ b/crates/subspace-service/src/lib.rs
@@ -778,12 +778,12 @@ where
     } = other;
 
     let offchain_indexing_enabled = config.base.offchain_worker.indexing_enabled;
-    let (node, bootstrap_nodes, max_connections) = match config.subspace_networking {
+    let (node, bootstrap_nodes, piece_getter) = match config.subspace_networking {
         SubspaceNetworking::Reuse {
             node,
             bootstrap_nodes,
-            max_connections,
-        } => (node, bootstrap_nodes, max_connections),
+            piece_getter,
+        } => (node, bootstrap_nodes, piece_getter),
         SubspaceNetworking::Create { config: dsn_config } => {
             let dsn_protocol_version = hex::encode(client.chain_info().genesis_hash);
 
@@ -827,7 +827,17 @@ where
                     ),
                 );
 
-            (node, dsn_config.bootstrap_nodes, out_connections)
+            let piece_getter = Arc::new(PieceProvider::new(
+                node.clone(),
+                SegmentCommitmentPieceValidator::new(
+                    node.clone(),
+                    subspace_link.kzg().clone(),
+                    segment_headers_store.clone(),
+                ),
+                Semaphore::new(out_connections as usize * PIECE_PROVIDER_MULTIPLIER),
+            ));
+
+            (node, dsn_config.bootstrap_nodes, piece_getter as _)
         }
     };
 
@@ -1054,18 +1064,6 @@ where
 
     network_wrapper.set(network_service.clone());
 
-    let dsn_sync_piece_getter = config.dsn_piece_getter.unwrap_or_else(|| {
-        Arc::new(PieceProvider::new(
-            node.clone(),
-            SegmentCommitmentPieceValidator::new(
-                node.clone(),
-                subspace_link.kzg().clone(),
-                segment_headers_store.clone(),
-            ),
-            Semaphore::new(max_connections as usize * PIECE_PROVIDER_MULTIPLIER),
-        ))
-    });
-
     if !config.base.network.force_synced {
         // Start with DSN sync in this case
         pause_sync.store(true, Ordering::Release);
@@ -1078,7 +1076,7 @@ where
         Arc::clone(&client),
         import_queue_service1,
         pause_sync.clone(),
-        dsn_sync_piece_getter.clone(),
+        piece_getter.clone(),
         sync_service.clone(),
         network_service_handle,
         subspace_link.erasure_coding().clone(),
@@ -1096,7 +1094,7 @@ where
         sync_service.clone(),
         sync_target_block_number,
         pause_sync,
-        dsn_sync_piece_getter,
+        piece_getter,
         subspace_link.erasure_coding().clone(),
     );
     task_manager


### PR DESCRIPTION
It became clear to me that it was at the wrong place when `max_connections` was introduced, this way it it much more logical and reduces number of branches.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
