### PR TITLE
Remove internal proving benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/autonomys/subspace?display_name=tag&style=flat-square)](https://github.com/autonomys/subspace/releases)
 [![Downloads Latest](https://img.shields.io/github/downloads/autonomys/subspace/latest/total?style=flat-square)](https://github.com/autonomys/subspace/releases/latest)
-[![Rust](https://img.shields.io/github/actions/workflow/status/autonomys/subspace/rust.yml?branch=main)](https://github.com/autonomys/subspace/actions/workflows/rust.yaml)
+[![Rust](https://img.shields.io/github/actions/workflow/status/autonomys/subspace/rust.yml?branch=main)](https://github.com/autonomys/subspace/actions/workflows/rust.yml)
 [![Rust Docs](https://img.shields.io/github/actions/workflow/status/autonomys/subspace/rustdoc.yml?branch=main)](https://autonomys.github.io/subspace)
 
 This is a mono repository for [Subspace Network](https://subspace.network/) implementation, primarily containing


### PR DESCRIPTION
Majority of user reports seem to indicate that concurrent chunks is the optimal way to go.

This PR makes it the default, but retains ability to specify `WholeSector` explicitly. Unless there will be reports of proving issues going forward that are solved by `WholeSector`, we'll remove support for changing this and simply keep one version in the codebase (which will allow to simplify code in `subspace-farmer-components`).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
