### PR TITLE
Move test-only code to TestBundleProducer

### DIFF
--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -1,5 +1,5 @@
 use crate::malicious_bundle_tamper::MaliciousBundleTamper;
-use domain_client_operator::domain_bundle_producer::{BundleProducer, DomainBundleProducer};
+use domain_client_operator::domain_bundle_producer::{BundleProducer, TestBundleProducer};
 use domain_client_operator::domain_bundle_proposer::DomainBundleProposer;
 use domain_client_operator::{OpaqueBundleFor, OperatorSlotInfo};
 use domain_runtime_primitives::opaque::Block as DomainBlock;
@@ -86,7 +86,7 @@ pub struct MaliciousBundleProducer<Client, CClient, TransactionPool> {
     operator_keystore: KeystorePtr,
     consensus_client: Arc<CClient>,
     consensus_offchain_tx_pool_factory: OffchainTransactionPoolFactory<CBlock>,
-    bundle_producer: DomainBundleProducer<DomainBlock, CBlock, Client, CClient, TransactionPool>,
+    bundle_producer: TestBundleProducer<DomainBlock, CBlock, Client, CClient, TransactionPool>,
     malicious_bundle_tamper: MaliciousBundleTamper<DomainBlock, CBlock, Client>,
     malicious_operator_status: MaliciousOperatorStatus,
 }
@@ -132,7 +132,7 @@ where
         );
 
         let (bundle_sender, _bundle_receiver) = tracing_unbounded("domain_bundle_stream", 100);
-        let bundle_producer = DomainBundleProducer::new(
+        let bundle_producer = TestBundleProducer::new(
             domain_id,
             consensus_client.clone(),
             domain_client.clone(),

--- a/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
+++ b/crates/subspace-malicious-operator/src/malicious_bundle_producer.rs
@@ -1,5 +1,5 @@
 use crate::malicious_bundle_tamper::MaliciousBundleTamper;
-use domain_client_operator::domain_bundle_producer::DomainBundleProducer;
+use domain_client_operator::domain_bundle_producer::{BundleProducer, DomainBundleProducer};
 use domain_client_operator::domain_bundle_proposer::DomainBundleProposer;
 use domain_client_operator::{OpaqueBundleFor, OperatorSlotInfo};
 use domain_runtime_primitives::opaque::Block as DomainBlock;

--- a/domains/client/domain-operator/src/domain_bundle_producer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_producer.rs
@@ -184,7 +184,7 @@ where
     }
 
     #[expect(clippy::type_complexity)]
-    pub fn claim_bundle_slot(
+    fn claim_bundle_slot(
         &self,
         operator_id: OperatorId,
         slot_info: &OperatorSlotInfo,
@@ -258,7 +258,7 @@ where
         }
     }
 
-    pub fn prepare_receipt(
+    fn prepare_receipt(
         &self,
         slot_info: &OperatorSlotInfo,
         domain_best_number_onchain: NumberFor<Block>,
@@ -302,7 +302,7 @@ where
         }
     }
 
-    pub async fn prepare_bundle(
+    async fn prepare_bundle(
         &mut self,
         operator_id: OperatorId,
         consensus_chain_best_hash: BlockHashFor<CBlock>,
@@ -346,7 +346,7 @@ where
         Ok(is_empty)
     }
 
-    pub fn seal_bundle(
+    fn seal_bundle(
         &self,
         bundle_header: BundleHeaderFor<Block, CBlock>,
         operator_signing_key: &OperatorPublicKey,

--- a/domains/client/domain-operator/src/domain_worker.rs
+++ b/domains/client/domain-operator/src/domain_worker.rs
@@ -15,7 +15,7 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::bundle_processor::BundleProcessor;
-use crate::domain_bundle_producer::{DomainBundleProducer, DomainProposal};
+use crate::domain_bundle_producer::{BundleProducer, DomainBundleProducer, DomainProposal};
 use crate::utils::{BlockInfo, OperatorSlotInfo};
 use crate::{NewSlotNotification, OperatorStreams};
 use futures::channel::mpsc;

--- a/domains/client/domain-operator/src/operator.rs
+++ b/domains/client/domain-operator/src/operator.rs
@@ -141,7 +141,7 @@ where
             params.transaction_pool.clone(),
         );
 
-        let bundle_producer = DomainBundleProducer::new(
+        let bundle_producer = Box::new(DomainBundleProducer::new(
             params.domain_id,
             params.consensus_client.clone(),
             params.client.clone(),
@@ -150,7 +150,7 @@ where
             params.keystore.clone(),
             params.skip_empty_bundle_production,
             params.skip_out_of_order_slot,
-        );
+        ));
 
         let fraud_proof_generator = FraudProofGenerator::new(
             params.client.clone(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::domain_block_processor::{DomainBlockProcessor, PendingConsensusBlocks};
-use crate::domain_bundle_producer::{BundleProducer, DomainBundleProducer};
+use crate::domain_bundle_producer::{BundleProducer, TestBundleProducer};
 use crate::domain_bundle_proposer::DomainBundleProposer;
 use crate::fraud_proof::{FraudProofGenerator, TraceDiffType};
 use crate::tests::TxPoolError::InvalidTransaction as TxPoolInvalidTransaction;
@@ -3463,7 +3463,7 @@ async fn stale_and_in_future_bundle_should_be_rejected() {
         );
         let (bundle_sender, _bundle_receiver) =
             sc_utils::mpsc::tracing_unbounded("domain_bundle_stream", 100);
-        DomainBundleProducer::new(
+        TestBundleProducer::new(
             EVM_DOMAIN_ID,
             ferdie.client.clone(),
             alice.client.clone(),
@@ -4634,7 +4634,7 @@ async fn test_bad_receipt_chain() {
         );
         let (bundle_sender, _bundle_receiver) =
             sc_utils::mpsc::tracing_unbounded("domain_bundle_stream", 100);
-        DomainBundleProducer::new(
+        TestBundleProducer::new(
             EVM_DOMAIN_ID,
             ferdie.client.clone(),
             alice.client.clone(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::domain_block_processor::{DomainBlockProcessor, PendingConsensusBlocks};
-use crate::domain_bundle_producer::DomainBundleProducer;
+use crate::domain_bundle_producer::{BundleProducer, DomainBundleProducer};
 use crate::domain_bundle_proposer::DomainBundleProposer;
 use crate::fraud_proof::{FraudProofGenerator, TraceDiffType};
 use crate::tests::TxPoolError::InvalidTransaction as TxPoolInvalidTransaction;


### PR DESCRIPTION
This PR splits the test-only code out of `DomainBundleProducer` into `TestBundleProducer`, and uses the test type where needed.

Close #3254.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
