### PR TITLE
XDM: Message submission checks to avoid validating duplicate XDM

### DIFF
--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -32,7 +32,7 @@ use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{ApplyExtrinsicResult, ExtrinsicInclusionMode};
@@ -364,6 +364,10 @@ sp_api::impl_runtime_apis! {
         }
 
         fn xdm_id(_ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            unreachable!()
+        }
+
+        fn channel_nonce(_chain_id: ChainId, _channel_id: ChannelId) -> Option<ChannelNonce> {
             unreachable!()
         }
     }

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -32,6 +32,7 @@ use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, MessageId, MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity};
 use sp_runtime::{ApplyExtrinsicResult, ExtrinsicInclusionMode};
@@ -359,6 +360,10 @@ sp_api::impl_runtime_apis! {
         }
 
         fn domain_chains_allowlist_update(_domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
+            unreachable!()
+        }
+
+        fn xdm_id(_ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
             unreachable!()
         }
     }

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -355,7 +355,6 @@ fn main() -> Result<(), Error> {
                                         _,
                                         _,
                                         _,
-                                        DomainBlock,
                                         _,
                                         _,
                                     >(

--- a/crates/subspace-node/src/commands/run.rs
+++ b/crates/subspace-node/src/commands/run.rs
@@ -212,7 +212,6 @@ pub async fn run(run_options: RunOptions) -> Result<(), Error> {
                                 _,
                                 _,
                                 _,
-                                DomainBlock,
                                 _,
                                 _,
                             >(

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -83,7 +83,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
@@ -1454,6 +1454,10 @@ impl_runtime_apis! {
                 }
                 _ => None,
             }
+        }
+
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Messenger::channel_nonce(chain_id, channel_id)
         }
     }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -83,6 +83,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
@@ -1441,6 +1442,18 @@ impl_runtime_apis! {
 
         fn domain_chains_allowlist_update(domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
             Messenger::domain_chains_allowlist_update(domain_id)
+        }
+
+        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            match &ext.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
+                    Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(XdmId::RelayResponseMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
+++ b/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
@@ -314,4 +314,8 @@ pub(crate) mod rep {
     /// Reputation change when a peer sends us a gossip message that can't be decoded.
     pub(crate) const GOSSIP_NOT_DECODABLE: ReputationChange =
         ReputationChange::new_fatal("Cross chain message: not decodable");
+
+    /// Reputation change when a peer sends us a non XDM message
+    pub(crate) const NOT_XDM: ReputationChange =
+        ReputationChange::new_fatal("Cross chain message: not XDM");
 }

--- a/domains/client/cross-domain-message-gossip/src/lib.rs
+++ b/domains/client/cross-domain-message-gossip/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 #![warn(rust_2018_idioms)]
 
 mod aux_schema;

--- a/domains/client/cross-domain-message-gossip/src/message_listener.rs
+++ b/domains/client/cross-domain-message-gossip/src/message_listener.rs
@@ -470,9 +470,12 @@ async fn handle_xdm_message<TxPool, Client>(
     Client: HeaderBackend<BlockOf<TxPool>>,
 {
     let at = client.info().best_hash;
+    let tx_hash = tx_pool.hash_of(&ext);
     tracing::debug!(
         target: LOG_TARGET,
-        "Submitting extrinsic to tx pool at block: {:?}",
+        "Submitting extrinsic {:?} to tx pool for chain {:?} at block: {:?}",
+        tx_hash,
+        chain_id,
         at
     );
 
@@ -487,5 +490,13 @@ async fn handle_xdm_message<TxPool, Client>(
             chain_id,
             err
         );
+    } else {
+        tracing::debug!(
+            target: LOG_TARGET,
+            "Submitted extrinsic {:?} to tx pool for chain {:?} at {:?}",
+            tx_hash,
+            chain_id,
+            at
+        )
     }
 }

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -139,7 +139,7 @@ mod pallet {
         MessageWeightTag, Payload, ProtocolMessageRequest, RequestResponse, VersionedPayload,
     };
     use sp_messenger::{
-        DomainRegistration, InherentError, InherentType, OnXDMRewards, StorageKeys,
+        ChannelNonce, DomainRegistration, InherentError, InherentType, OnXDMRewards, StorageKeys,
         INHERENT_IDENTIFIER,
     };
     use sp_runtime::traits::Zero;
@@ -1348,6 +1348,16 @@ mod pallet {
 
         pub fn updated_channels() -> BTreeSet<(ChainId, ChannelId)> {
             UpdatedChannels::<T>::get()
+        }
+
+        pub fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Channels::<T>::get(chain_id, channel_id).map(|channel| {
+                let last_inbox_nonce = channel.next_inbox_nonce.checked_sub(U256::one());
+                ChannelNonce {
+                    relay_msg_nonce: last_inbox_nonce,
+                    relay_response_msg_nonce: channel.latest_response_received_message_nonce,
+                }
+            })
         }
 
         pub fn pre_dispatch_with_trusted_mmr_proof(

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -33,6 +33,7 @@ use codec::{Decode, Encode};
 use frame_support::inherent::InherentData;
 use frame_support::inherent::{InherentIdentifier, IsFatalError};
 use messages::{BlockMessagesWithStorageKey, ChannelId, CrossDomainMessage, MessageId};
+use scale_info::TypeInfo;
 use sp_domains::{ChainId, DomainAllowlistUpdates, DomainId};
 use sp_subspace_mmr::ConsensusChainMmrLeafProof;
 #[cfg(feature = "std")]
@@ -159,6 +160,13 @@ impl sp_inherents::InherentDataProvider for InherentDataProvider {
     }
 }
 
+/// Represent a union of XDM types with their message ID
+#[derive(Debug, Encode, Decode, TypeInfo)]
+pub enum XdmId {
+    RelayMessage(MessageKey),
+    RelayResponseMessage(MessageKey),
+}
+
 sp_api::decl_runtime_apis! {
     /// Api useful for relayers to fetch messages and submit transactions.
     pub trait RelayerApi<BlockNumber, CNumber, CHash>
@@ -220,5 +228,8 @@ sp_api::decl_runtime_apis! {
 
         /// Returns any domain's chains allowlist updates on consensus chain.
         fn domain_chains_allowlist_update(domain_id: DomainId) -> Option<DomainAllowlistUpdates>;
+
+        /// Returns XDM message ID
+        fn xdm_id(ext: &Block::Extrinsic) -> Option<XdmId>;
     }
 }

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -167,6 +167,15 @@ pub enum XdmId {
     RelayResponseMessage(MessageKey),
 }
 
+impl XdmId {
+    pub fn get_chain_id_and_channel_id(&self) -> (ChainId, ChannelId) {
+        match self {
+            XdmId::RelayMessage(key) => (key.0, key.1),
+            XdmId::RelayResponseMessage(key) => (key.0, key.1),
+        }
+    }
+}
+
 #[derive(Debug, Encode, Decode, TypeInfo, Copy, Clone)]
 pub struct ChannelNonce {
     /// Last processed relay message nonce.

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -222,6 +222,7 @@ sp_api::decl_runtime_apis! {
     }
 
     /// Api to provide XDM extraction from Runtime Calls.
+    #[api_version(2)]
     pub trait MessengerApi<CNumber, CHash>
     where
         CNumber: Encode + Decode,

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -161,7 +161,7 @@ impl sp_inherents::InherentDataProvider for InherentDataProvider {
 }
 
 /// Represent a union of XDM types with their message ID
-#[derive(Debug, Encode, Decode, TypeInfo)]
+#[derive(Debug, Encode, Decode, TypeInfo, Copy, Clone)]
 pub enum XdmId {
     RelayMessage(MessageKey),
     RelayResponseMessage(MessageKey),

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -179,10 +179,10 @@ impl XdmId {
 #[derive(Debug, Encode, Decode, TypeInfo, Copy, Clone)]
 pub struct ChannelNonce {
     /// Last processed relay message nonce.
-    /// Could be nne if there is not relay message yet.
+    /// Could be None if there is no relay message yet.
     pub relay_msg_nonce: Option<Nonce>,
     /// Last processed relay response message nonce.
-    /// Could be None since there is no first response yet
+    /// Could be None if there is no first response yet
     pub relay_response_msg_nonce: Option<Nonce>,
 }
 

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -23,7 +23,7 @@ pub mod messages;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::messages::MessageKey;
+use crate::messages::{MessageKey, Nonce};
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeSet;
 #[cfg(not(feature = "std"))]
@@ -167,6 +167,16 @@ pub enum XdmId {
     RelayResponseMessage(MessageKey),
 }
 
+#[derive(Debug, Encode, Decode, TypeInfo, Copy, Clone)]
+pub struct ChannelNonce {
+    /// Last processed relay message nonce.
+    /// Could be nne if there is not relay message yet.
+    pub relay_msg_nonce: Option<Nonce>,
+    /// Last processed relay response message nonce.
+    /// Could be None since there is no first response yet
+    pub relay_response_msg_nonce: Option<Nonce>,
+}
+
 sp_api::decl_runtime_apis! {
     /// Api useful for relayers to fetch messages and submit transactions.
     pub trait RelayerApi<BlockNumber, CNumber, CHash>
@@ -231,5 +241,8 @@ sp_api::decl_runtime_apis! {
 
         /// Returns XDM message ID
         fn xdm_id(ext: &Block::Extrinsic) -> Option<XdmId>;
+
+        /// Get Channel nonce for given chain and channel id.
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce>;
     }
 }

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -45,6 +45,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -908,6 +909,18 @@ impl_runtime_apis! {
         fn domain_chains_allowlist_update(_domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
             // not valid call on domains
             None
+        }
+
+        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            match &ext.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
+                    Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(XdmId::RelayResponseMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -45,7 +45,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -921,6 +921,10 @@ impl_runtime_apis! {
                 }
                 _ => None,
             }
+        }
+
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Messenger::channel_nonce(chain_id, channel_id)
         }
     }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -58,7 +58,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -1332,6 +1332,10 @@ impl_runtime_apis! {
                 }
                 _ => None,
             }
+        }
+
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Messenger::channel_nonce(chain_id, channel_id)
         }
     }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -58,6 +58,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -1319,6 +1320,18 @@ impl_runtime_apis! {
         fn domain_chains_allowlist_update(_domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
             // not valid call on domains
             None
+        }
+
+        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            match &ext.0.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
+                    Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(XdmId::RelayResponseMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/domains/service/src/domain.rs
+++ b/domains/service/src/domain.rs
@@ -581,25 +581,17 @@ where
     }
 
     // Start cross domain message listener for domain
-    let domain_listener = cross_domain_message_gossip::start_cross_chain_message_listener::<
-        _,
-        _,
-        _,
-        _,
-        _,
-        Block,
-        _,
-        _,
-    >(
-        ChainId::Domain(domain_id),
-        consensus_client.clone(),
-        client.clone(),
-        params.transaction_pool.clone(),
-        consensus_network,
-        domain_message_receiver,
-        code_executor.clone(),
-        domain_sync_oracle,
-    );
+    let domain_listener =
+        cross_domain_message_gossip::start_cross_chain_message_listener::<_, _, _, _, _, _, _>(
+            ChainId::Domain(domain_id),
+            consensus_client.clone(),
+            client.clone(),
+            params.transaction_pool.clone(),
+            consensus_network,
+            domain_message_receiver,
+            code_executor.clone(),
+            domain_sync_oracle,
+        );
 
     spawn_essential.spawn_essential_blocking(
         "domain-message-listener",

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -45,7 +45,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -912,6 +912,10 @@ impl_runtime_apis! {
                 }
                 _ => None,
             }
+        }
+
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Messenger::channel_nonce(chain_id, channel_id)
         }
     }
 

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -45,6 +45,7 @@ use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, Endp
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -899,6 +900,18 @@ impl_runtime_apis! {
         fn domain_chains_allowlist_update(_domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
             // not valid call on domains
             None
+        }
+
+        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            match &ext.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
+                    Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(XdmId::RelayResponseMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -58,6 +58,7 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
     MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -1275,6 +1276,18 @@ impl_runtime_apis! {
         fn domain_chains_allowlist_update(_domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
             // not valid call on domains
             None
+        }
+
+        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            match &ext.0.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
+                    Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(XdmId::RelayResponseMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -58,7 +58,7 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
     MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::generic::Era;
@@ -1288,6 +1288,10 @@ impl_runtime_apis! {
                 }
                 _ => None,
             }
+        }
+
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Messenger::channel_nonce(chain_id, channel_id)
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -73,6 +73,7 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
     MessageKey,
 };
+use sp_messenger::XdmId;
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
@@ -1502,6 +1503,18 @@ impl_runtime_apis! {
 
         fn domain_chains_allowlist_update(domain_id: DomainId) -> Option<DomainAllowlistUpdates>{
             Messenger::domain_chains_allowlist_update(domain_id)
+        }
+
+        fn xdm_id(ext: &<Block as BlockT>::Extrinsic) -> Option<XdmId> {
+            match &ext.function {
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message { msg })=> {
+                    Some(XdmId::RelayMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                RuntimeCall::Messenger(pallet_messenger::Call::relay_message_response { msg }) => {
+                    Some(XdmId::RelayResponseMessage((msg.src_chain_id, msg.channel_id, msg.nonce)))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -73,7 +73,7 @@ use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, ChannelId, CrossDomainMessage, FeeModel, MessageId,
     MessageKey,
 };
-use sp_messenger::XdmId;
+use sp_messenger::{ChannelNonce, XdmId};
 use sp_messenger_host_functions::{get_storage_key, StorageKeyRequest};
 use sp_mmr_primitives::EncodableOpaqueLeaf;
 use sp_runtime::traits::{
@@ -1515,6 +1515,10 @@ impl_runtime_apis! {
                 }
                 _ => None,
             }
+        }
+
+        fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
+            Messenger::channel_nonce(chain_id, channel_id)
         }
     }
 

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -518,25 +518,17 @@ impl MockConsensusNode {
             tracing_unbounded("consensus_message_channel", 100);
 
         // Start cross domain message listener for Consensus chain to receive messages from domains in the network
-        let consensus_listener = cross_domain_message_gossip::start_cross_chain_message_listener::<
-            _,
-            _,
-            _,
-            _,
-            _,
-            DomainBlock,
-            _,
-            _,
-        >(
-            ChainId::Consensus,
-            client.clone(),
-            client.clone(),
-            transaction_pool.clone(),
-            network_service.clone(),
-            consensus_msg_receiver,
-            domain_executor,
-            sync_service.clone(),
-        );
+        let consensus_listener =
+            cross_domain_message_gossip::start_cross_chain_message_listener::<_, _, _, _, _, _, _>(
+                ChainId::Consensus,
+                client.clone(),
+                client.clone(),
+                transaction_pool.clone(),
+                network_service.clone(),
+                consensus_msg_receiver,
+                domain_executor,
+                sync_service.clone(),
+            );
 
         task_manager
             .spawn_essential_handle()


### PR DESCRIPTION
This PR aims to eliminate 
- validating the same XDM that is already validated and submitted to txpool
	- 	This will elimanate `tx_pool low priority` error since there is already an XDM in the txpool
-  validating of stale XDM.
	- This elimates the `InvalidTransaction(201)` but not trying to add the xdm to txpool since such XDM already executed in the canonical chain.


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
