### PR TITLE
Give FraudProofVariant explicit codec indexes

### DIFF
--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -336,18 +336,23 @@ pub struct FraudProof<Number, Hash, DomainHeader: HeaderT, MmrHash> {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub enum FraudProofVariant<Number, Hash, MmrHash, DomainHeader: HeaderT> {
+    #[codec(index = 0)]
     InvalidStateTransition(InvalidStateTransitionProof),
+    #[codec(index = 1)]
     ValidBundle(ValidBundleProof<Number, Hash, DomainHeader>),
+    #[codec(index = 2)]
     InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof),
+    #[codec(index = 3)]
     InvalidBundles(InvalidBundlesProof<Number, Hash, MmrHash, DomainHeader>),
+    #[codec(index = 4)]
     InvalidDomainBlockHash(InvalidDomainBlockHashProof),
+    #[codec(index = 5)]
     InvalidBlockFees(InvalidBlockFeesProof),
+    #[codec(index = 6)]
     InvalidTransfers(InvalidTransfersProof),
-    // Dummy fraud proof only used in test and benchmark
-    //
-    // NOTE: the `Dummy` must be the last variant, because the `#[cfg(..)]` will apply to
-    // all the variants after it.
+    /// Dummy fraud proof only used in tests and benchmarks
     #[cfg(any(feature = "std", feature = "runtime-benchmarks"))]
+    #[codec(index = 100)]
     Dummy,
 }
 


### PR DESCRIPTION
A conditionally compiled variant changes enum variant numbering for everything after that variant, so giving the variants explicit indexes means that the order of the `Dummy` variant doesn't matter.

And in Rust, conditional compilation only applies to the item, variant, or block:
https://doc.rust-lang.org/reference/conditional-compilation.html#forms-of-conditional-compilation

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
