### PR TITLE
Stop panicking when mapping with only genesis block

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -631,8 +631,9 @@ where
     }
 
     // If the user chooses an object mapping start block we don't have data or state for, we can't
-    // create mappings for it, so the node must exit with an error
-    if create_object_mappings.is_enabled() {
+    // create mappings for it, so the node must exit with an error. We ignore genesis here, because
+    // it doesn't have mappings.
+    if create_object_mappings.is_enabled() && best_block_to_archive >= 1 {
         let Some(best_block_to_archive_hash) = client.hash(best_block_to_archive.into())? else {
             let error = format!(
                 "Missing hash for mapping block {best_block_to_archive}, \

--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -618,7 +618,7 @@ where
     if let Some(block_number) = create_object_mappings.block() {
         // There aren't any mappings in the genesis block, so starting there is pointless.
         // (And causes errors on restart, because genesis block data is never stored during snap sync.)
-        best_block_to_archive = best_block_to_archive.min(block_number.max(1));
+        best_block_to_archive = best_block_to_archive.min(block_number);
     }
 
     if (best_block_to_archive..best_block_number)


### PR DESCRIPTION
This PR fixes an unexpected panic when trying to generate mappings when only the genesis block is available:
```sh
subspace-node run --dev --sync=full --create-object-mappings=yes
```

```
2024-12-03T15:36:10.816772Z  INFO Consensus: sc_consensus_subspace::archiver: Creating object mappings from the configured block onwards create_object_mappings=Block(1)
thread 'main' panicked at /web/subspace/subspace/crates/sc-consensus-subspace/src/archiver.rs:638:14:
just checked above; qed
```

> .max(1) above that caused block 1 to be selected while it is not created yet, there is just genesis block.

I also tested that these commands launch successfully:

Full sync with no mappings:
```sh
subspace-node run --dev --sync=full --create-object-mappings=no
```

Full sync with a restart, and a custom mapping start block:
```sh
subspace-node run --chain=taurus --base-path=/tmp/taurus-full --sync=full --create-object-mappings=yes
# wait a few minutes
subspace-node run --chain=taurus --base-path=/tmp/taurus-full --sync=full --create-object-mappings=yes
subspace-node run --chain=taurus --base-path=/tmp/taurus-full --sync=full --create-object-mappings=2
```


Snap sync with a restart:
```sh
subspace-node run --chain=taurus --base-path=/tmp/taurus-snap --sync=snap --create-object-mappings=yes
# wait a few minutes
subspace-node run --chain=taurus --base-path=/tmp/taurus-snap --sync=snap --create-object-mappings=yes 
subspace-node run --chain=taurus --base-path=/tmp/taurus-snap --sync=snap --create-object-mappings=2
```

Snap sync with no mappings:
```sh
subspace-node run --chain=taurus --base-path=/tmp/taurus-snap-no --sync=snap
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
