### PR TITLE
Simplify gateway HTTP server code using typed parameters

### DIFF
--- a/crates/subspace-gateway/src/commands/http.rs
+++ b/crates/subspace-gateway/src/commands/http.rs
@@ -22,7 +22,7 @@ pub(crate) struct HttpCommandOptions {
     http_listen_on: String,
 }
 
-/// Runs an HTTP server
+/// Runs an HTTP server which fetches DSN objects based on object hashes.
 pub async fn run(run_options: HttpCommandOptions) -> anyhow::Result<()> {
     let signal = shutdown_signal();
 

--- a/crates/subspace-gateway/src/commands/http.rs
+++ b/crates/subspace-gateway/src/commands/http.rs
@@ -1,5 +1,5 @@
 //! Gateway http command.
-//! This command start an HTTP server to serve object requests.
+//! This command starts an HTTP server to serve object requests.
 
 pub(crate) mod server;
 

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -108,6 +108,7 @@ where
                     ?hash,
                     "Retrieved data doesn't match requested mapping hash"
                 );
+                trace!(data = %hex::encode(object), "Retrieved data");
                 return HttpResponse::ServiceUnavailable().finish();
             }
 

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -1,3 +1,5 @@
+//! HTTP server which fetches objects from the DSN based on a hash, using a mapping indexer service.
+
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::default::Default;
@@ -9,6 +11,7 @@ use subspace_data_retrieval::object_fetcher::ObjectFetcher;
 use subspace_data_retrieval::piece_getter::PieceGetter;
 use tracing::{debug, error, trace};
 
+/// Parameters for the DSN object HTTP server.
 pub(crate) struct ServerParameters<PG>
 where
     PG: PieceGetter + Send + Sync + 'static,
@@ -18,6 +21,7 @@ where
     pub(crate) http_endpoint: String,
 }
 
+/// Object mapping format from the indexer service.
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 struct ObjectMapping {
@@ -28,6 +32,7 @@ struct ObjectMapping {
     block_number: BlockNumber,
 }
 
+/// Utility function to deserialize a JSON string into a u32.
 fn string_to_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
 where
     D: Deserializer<'de>,
@@ -118,6 +123,7 @@ where
         .body(object)
 }
 
+/// Starts the DSN object HTTP server.
 pub async fn start_server<PG>(server_params: ServerParameters<PG>) -> std::io::Result<()>
 where
     PG: PieceGetter + Send + Sync + 'static,

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -98,12 +98,13 @@ where
 
     let object = match object_fetcher_result {
         Ok(object) => {
-            trace!(?hash, size=%object.len(), "Object fetched successfully");
+            trace!(?hash, size = %object.len(), "Object fetched successfully");
 
             let data_hash = blake3_hash(&object);
             if data_hash != hash {
                 error!(
                     ?data_hash,
+                    data_size = %object.len(),
                     ?hash,
                     "Retrieved data doesn't match requested mapping hash"
                 );

--- a/crates/subspace-gateway/src/commands/rpc.rs
+++ b/crates/subspace-gateway/src/commands/rpc.rs
@@ -1,5 +1,5 @@
 //! Gateway rpc command.
-//! This command start an RPC server to serve object requests.
+//! This command starts an RPC server to serve object requests from the DSN.
 pub(crate) mod server;
 
 use crate::commands::rpc::server::{launch_rpc_server, RpcOptions, RPC_DEFAULT_PORT};
@@ -21,7 +21,7 @@ pub(crate) struct RpcCommandOptions {
     rpc_options: RpcOptions<RPC_DEFAULT_PORT>,
 }
 
-/// Runs an RPC server
+/// Runs an RPC server which fetches DSN objects based on mappings.
 pub async fn run(run_options: RpcCommandOptions) -> anyhow::Result<()> {
     let signal = shutdown_signal();
 


### PR DESCRIPTION
This PR uses `Blake3Hash` rather than `String` to simplify some of the gateway HTTP server code.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
