### PR TITLE
Add protocol to indexer endpoint CLI option

### DIFF
--- a/crates/subspace-gateway/src/commands/http.rs
+++ b/crates/subspace-gateway/src/commands/http.rs
@@ -15,7 +15,7 @@ pub(crate) struct HttpCommandOptions {
     #[clap(flatten)]
     gateway_options: GatewayOptions,
 
-    #[arg(long, default_value = "127.0.0.1:3000")]
+    #[arg(long, default_value = "http://127.0.0.1:3000")]
     indexer_endpoint: String,
 
     #[arg(long, default_value = "127.0.0.1:8080")]

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -44,7 +44,7 @@ where
 /// Requests an object mapping with `hash` from the indexer service.
 async fn request_object_mapping(endpoint: &str, hash: Blake3Hash) -> anyhow::Result<ObjectMapping> {
     let client = reqwest::Client::new();
-    let object_mappings_url = format!("http://{}/objects/{}", endpoint, hex::encode(hash));
+    let object_mappings_url = format!("{}/objects/{}", endpoint, hex::encode(hash));
 
     debug!(?hash, ?object_mappings_url, "Requesting object mapping...");
 


### PR DESCRIPTION
This PR refactor indexer endpoint - it receives protocol as part of the endpoint instead of <IP:port>. 
It follows this comment: https://github.com/autonomys/subspace/pull/3286#discussion_r1874534401

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
