### PR TITLE
Fix cache group CLI option name

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -56,7 +56,7 @@ pub(super) struct ControllerArgs {
     ///
     /// It is strongly recommended to use alphanumeric values for cache group, the same cache group
     /// must be also specified on corresponding caches.
-    #[arg(long, default_value = "default")]
+    #[arg(long = "cache-group", default_value = "default")]
     cache_groups: Vec<String>,
     /// Number of service instances.
     ///


### PR DESCRIPTION
Forgot to keep the old name after adding support for multiple

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
