### PR TITLE
Improve cluster plotter performance

### DIFF
--- a/crates/subspace-farmer/src/plotter/gpu/gpu_encoders_manager.rs
+++ b/crates/subspace-farmer/src/plotter/gpu/gpu_encoders_manager.rs
@@ -96,12 +96,6 @@ where
             let listener = event.listen();
 
             if let Some(thread_pool_pair) = mutex.lock().pop() {
-                drop(listener);
-                // It is possible that we got here because there was the last free pair available
-                // and in the meantime listener received notification. Just in case that was the
-                // case, notify one more listener (if there is any) to make sure all available
-                // thread pools are utilized when there is demand for them.
-                event.notify(1);
                 break thread_pool_pair;
             }
 

--- a/crates/subspace-farmer/src/thread_pool_manager.rs
+++ b/crates/subspace-farmer/src/thread_pool_manager.rs
@@ -109,12 +109,6 @@ impl PlottingThreadPoolManager {
             let listener = event.listen();
 
             if let Some(thread_pool_pair) = mutex.lock().thread_pool_pairs.pop() {
-                drop(listener);
-                // It is possible that we got here because there was the last free pair available
-                // and in the meantime listener received notification. Just in case that was the
-                // case, notify one more listener (if there is any) to make sure all available
-                // thread pools are utilized when there is demand for them.
-                event.notify(1);
                 break thread_pool_pair;
             }
 


### PR DESCRIPTION
This should help with utilization of multiple GPUs. The theory here is that under certain conditions timeouts are preventing lower index sectors from making progress (order is not deterministic) and higher index sectors can't start because lower sector index are waiting for retry.

Notifying one of the pending sectors should allow to make progress faster and avoid leaving GPU idling. This may actually allow us to increase maximum time between retries now or even combine multiple concurrent retries into a single queue.

Waiting for community feedback on this before merging.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
