### PR TITLE
Update the consensus and domain existential deposit

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -322,9 +322,9 @@ parameter_types! {
     // Price per byte = Min Number of validators * Storage duration (years) * Storage cost per year
     // Account data size (80 bytes)
     // Min Number of redundant validators (100) - For a stable and redundant blockchain we need at least a certain number of full nodes/collators.
-    // Storage duration (20 years) - It is theoretically unlimited, accounts will stay around while the chain is alive.
+    // Storage duration (1 year) - It is theoretically unlimited, accounts will stay around while the chain is alive.
     // Storage cost per year of (12 * 1e-9 * 0.1 ) - SSD storage on cloud hosting costs about 0.1 USD per Gb per month
-    pub const ExistentialDeposit: Balance = 200_000_000_000_000 * SHANNON;
+    pub const ExistentialDeposit: Balance = 10_000_000_000_000 * SHANNON;
 }
 
 #[derive(

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -93,8 +93,13 @@ pub fn maximum_block_length() -> BlockLength {
     BlockLength::max_with_normal_ratio(MAX_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO)
 }
 
-/// The existential deposit. Same with the one on primary chain.
-pub const EXISTENTIAL_DEPOSIT: Balance = 500 * SHANNON;
+/// Computed as ED = Account data size * Price per byte, where
+/// Price per byte = Min Number of validators * Storage duration (years) * Storage cost per year
+/// Account data size (80 bytes)
+/// Min Number of redundant validators (10) - For a stable and redundant blockchain we need at least a certain number of full nodes/collators.
+/// Storage duration (1 year) - It is theoretically unlimited, accounts will stay around while the chain is alive.
+/// Storage cost per year of (12 * 1e-9 * 0.1 ) - SSD storage on cloud hosting costs about 0.1 USD per Gb per month
+pub const EXISTENTIAL_DEPOSIT: Balance = 1_000_000_000_000 * SHANNON;
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -5,11 +5,10 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
-use subspace_runtime_primitives::{AccountId, Balance, Signature};
+use subspace_runtime_primitives::{AccountId, Balance, Signature, SSC};
 use subspace_test_runtime::{
     AllowAuthoringBy, BalancesConfig, DomainsConfig, EnableRewardsAt, HistorySeedingConfig,
-    RewardsConfig, RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, SSC,
-    WASM_BINARY,
+    RewardsConfig, RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
 
 /// Generate a crypto pair from seed.

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -100,7 +100,7 @@ use subspace_core_primitives::solutions::SolutionRange;
 use subspace_core_primitives::{hashes, PublicKey, Randomness, SlotNumber, U256};
 use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce,
-    Signature, MIN_REPLICATION_FACTOR,
+    Signature, MIN_REPLICATION_FACTOR, SHANNON, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -129,13 +129,6 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     transaction_version: 1,
     system_version: 2,
 };
-
-/// The smallest unit of the token is called Shannon.
-pub const SHANNON: Balance = 1;
-/// Subspace Credits have 18 decimal places.
-pub const DECIMAL_PLACES: u8 = 18;
-/// One Subspace Credit.
-pub const SSC: Balance = (10 * SHANNON).pow(DECIMAL_PLACES as u32);
 
 // TODO: Many of below constants should probably be updatable but currently they are not
 
@@ -364,8 +357,7 @@ impl pallet_balances::Config for Runtime {
     /// The ubiquitous event type.
     type RuntimeEvent = RuntimeEvent;
     type DustRemoval = ();
-    // TODO: Correct value
-    type ExistentialDeposit = ConstU128<{ 500 * SHANNON }>;
+    type ExistentialDeposit = ConstU128<{ 10_000_000_000_000 * SHANNON }>;
     type AccountStore = System;
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
     type FreezeIdentifier = ();


### PR DESCRIPTION
close #3289

This PR updates the consensus chain existential deposit to `10_000_000_000_000 * SHANNON` and the domain chain existential deposit to `1_000_000_000_000 * SHANNON` as discussed in #3289

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
