### PR TITLE
Suppress RUSTSEC-2024-0421 advisory

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -20,5 +20,6 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 #v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Remove once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
-          ignore: RUSTSEC-2024-0336
+          # TODO: Remove first once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
+          # TODO: Remove second once Substrate upgrades libp2p and we no longer have old idna in our dependencies
+          ignore: RUSTSEC-2024-0336,RUSTSEC-2024-0421


### PR DESCRIPTION
We'll need https://github.com/hickory-dns/hickory-dns/issues/2661 to fix it for modern version of libp2p and other uses, but we'll not be able to get rid of the dependency completely until libp2p is [upgraded](https://github.com/paritytech/polkadot-sdk/issues/5996) in Substrate.

The issue itself should not be critical for our usage.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
