### PR TITLE
Small Dockerfile refactoring

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,7 +1,6 @@
 *
 !/crates
 !/domains
-!/orml
 !/shared
 !/test
 !/Cargo.lock

--- a/docker/bootstrap-node.Dockerfile
+++ b/docker/bootstrap-node.Dockerfile
@@ -55,16 +55,9 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY Cargo.lock /code/Cargo.lock
-COPY Cargo.toml /code/Cargo.toml
-COPY rust-toolchain.toml /code/rust-toolchain.toml
-
-COPY crates /code/crates
-COPY domains /code/domains
-COPY shared /code/shared
-COPY test /code/test
-
 # Up until this line all Rust images in this repo should be the same to share the same layers
+
+COPY . /code
 
 ARG TARGETVARIANT
 

--- a/docker/farmer.Dockerfile
+++ b/docker/farmer.Dockerfile
@@ -55,15 +55,6 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY Cargo.lock /code/Cargo.lock
-COPY Cargo.toml /code/Cargo.toml
-COPY rust-toolchain.toml /code/rust-toolchain.toml
-
-COPY crates /code/crates
-COPY domains /code/domains
-COPY shared /code/shared
-COPY test /code/test
-
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 # CUDA toolchain, including support for cross-compilation from x86-64 to aarch64, but NOT from aarch64 to x86-64
@@ -103,6 +94,8 @@ RUN \
       echo "/opt/rocm/lib" > /etc/ld.so.conf.d/rocm.conf && \
       ldconfig \
     ; fi
+
+COPY . /code
 
 ARG TARGETVARIANT
 

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -55,16 +55,9 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY Cargo.lock /code/Cargo.lock
-COPY Cargo.toml /code/Cargo.toml
-COPY rust-toolchain.toml /code/rust-toolchain.toml
-
-COPY crates /code/crates
-COPY domains /code/domains
-COPY shared /code/shared
-COPY test /code/test
-
 # Up until this line all Rust images in this repo should be the same to share the same layers
+
+COPY . /code
 
 ARG TARGETVARIANT
 

--- a/docker/node.Dockerfile
+++ b/docker/node.Dockerfile
@@ -55,16 +55,9 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY Cargo.lock /code/Cargo.lock
-COPY Cargo.toml /code/Cargo.toml
-COPY rust-toolchain.toml /code/rust-toolchain.toml
-
-COPY crates /code/crates
-COPY domains /code/domains
-COPY shared /code/shared
-COPY test /code/test
-
 # Up until this line all Rust images in this repo should be the same to share the same layers
+
+COPY . /code
 
 ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
 ARG TARGETVARIANT

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -55,16 +55,9 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
     /root/.cargo/bin/rustup target add wasm32-unknown-unknown
 
-COPY Cargo.lock /code/Cargo.lock
-COPY Cargo.toml /code/Cargo.toml
-COPY rust-toolchain.toml /code/rust-toolchain.toml
-
-COPY crates /code/crates
-COPY domains /code/domains
-COPY shared /code/shared
-COPY test /code/test
-
 # Up until this line all Rust images in this repo should be the same to share the same layers
+
+COPY . /code
 
 ARG TARGETVARIANT
 


### PR DESCRIPTION
While I generally don't like `COPY .`, in this case it is fine because we have the same exact list of files to include specified in `.dockerignore` file.

The benefit of this change is that CUDA and ROCm dependencies in farmer container do not need to be reinstalled when only source code changes, which helps with cache reuse.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
