### PR TITLE
Move InvalidExtrinsicsRootProof storage so it is easier to combine later

### DIFF
--- a/crates/pallet-domains/src/block_tree.rs
+++ b/crates/pallet-domains/src/block_tree.rs
@@ -598,7 +598,7 @@ pub(crate) fn prune_receipt<T: Config>(
     // If the pruned ER is the operator's `latest_submitted_er` for this domain, it means either:
     //
     // - All the ER the operator submitted for this domain are confirmed and pruned, so the operator
-    //   can't be targetted by fraud proof later unless it submit other new ERs.
+    //   can't be targeted by fraud proof later unless it submit other new ERs.
     //
     // - All the bad ER the operator submitted for this domain are pruned and the operator is already
     //   slashed, so wwe don't need `LatestSubmittedER` to determine if the operator is pending slash.

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -777,7 +777,7 @@ fn test_basic_fraud_proof_processing() {
 
             for block_number in bad_receipt_at..=head_domain_number {
                 if block_number == bad_receipt_at {
-                    // The targetted ER should be removed from the block tree
+                    // The targeted ER should be removed from the block tree
                     assert!(BlockTree::<Test>::get(domain_id, block_number).is_none());
                 } else {
                     // All the bad ER's descendants should be marked as pending to prune and the submitter

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -320,13 +320,13 @@ pub struct FraudProof<Number, Hash, DomainHeader: HeaderT, MmrHash> {
     pub domain_id: DomainId,
     /// Hash of the bad receipt this fraud proof targeted
     pub bad_receipt_hash: HeaderHashFor<DomainHeader>,
-    /// The MMR proof for the consensus state root that used to verify the storage proof
+    /// The MMR proof for the consensus state root that is used to verify the storage proof
     ///
-    /// It is set `None` if the specific fraud proof variant doesn't contains storage proof
+    /// It is set `None` if the specific fraud proof variant doesn't contain a storage proof
     pub maybe_mmr_proof: Option<ConsensusChainMmrLeafProof<Number, Hash, MmrHash>>,
     /// The domain runtime code storage proof
     ///
-    /// It is set `None` if the specific fraud proof variant doesn't required domain runtime code
+    /// It is set `None` if the specific fraud proof variant doesn't require domain runtime code
     /// or the required domain runtime code is available from the current runtime state.
     pub maybe_domain_runtime_code_proof: Option<DomainRuntimeCodeAt<Number, Hash, MmrHash>>,
     /// The specific fraud proof variant
@@ -485,7 +485,7 @@ pub struct InvalidStateTransitionProof {
 /// Fraud proof for the valid bundles in `ExecutionReceipt::inboxed_bundles`
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
 pub struct ValidBundleProof<Number, Hash, DomainHeader: HeaderT> {
-    /// The targetted bundle with proof
+    /// The targeted bundle with proof
     pub bundle_with_proof: OpaqueBundleWithProof<Number, Hash, DomainHeader, Balance>,
 }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -493,10 +493,12 @@ pub struct ValidBundleProof<Number, Hash, DomainHeader: HeaderT> {
 pub struct InvalidExtrinsicsRootProof {
     /// Valid Bundle digests
     pub valid_bundle_digests: Vec<ValidBundleDigest>,
-    /// Block randomness storage proof
-    pub block_randomness_proof: BlockRandomnessProof,
+
     /// The storage proof used during verification
-    pub domain_inherent_extrinsic_data_proof: DomainInherentExtrinsicDataProof,
+    pub invalid_extrinsics_data_proof: InvalidExtrinsicsDataProof,
+
+    /// Optional sudo extrinsic call storage proof
+    pub domain_sudo_call_proof: DomainSudoCallStorageProof,
 }
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -262,6 +262,8 @@ where
         domain_inherent_extrinsic_data: DomainInherentExtrinsicData,
     ) -> Option<DomainInherentExtrinsic> {
         let DomainInherentExtrinsicData {
+            // Used by caller
+            block_randomness: _,
             timestamp,
             maybe_domain_runtime_upgrade,
             consensus_transaction_byte_fee,

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -54,7 +54,7 @@ use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 use sp_runtime::OpaqueExtrinsic;
 use sp_runtime_interface::pass_by;
 use sp_runtime_interface::pass_by::PassBy;
-use subspace_core_primitives::U256;
+use subspace_core_primitives::{Randomness, U256};
 use subspace_runtime_primitives::{Balance, Moment};
 
 /// Custom invalid validity code for the extrinsics in pallet-domains.
@@ -108,6 +108,7 @@ pub enum DomainChainAllowlistUpdateExtrinsic {
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct DomainInherentExtrinsicData {
+    pub block_randomness: Randomness,
     pub timestamp: Moment,
     pub maybe_domain_runtime_upgrade: Option<Vec<u8>>,
     pub consensus_transaction_byte_fee: Balance,

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -65,19 +65,24 @@ where
 {
     let InvalidExtrinsicsRootProof {
         valid_bundle_digests,
-        block_randomness_proof,
-        domain_inherent_extrinsic_data_proof,
-        ..
+        invalid_extrinsics_data_proof,
+        domain_sudo_call_proof,
     } = fraud_proof;
 
-    let domain_inherent_extrinsic_data = domain_inherent_extrinsic_data_proof
-        .verify::<CBlock, SKP>(domain_id, runtime_id, &state_root)?;
+    let mut domain_inherent_extrinsic_data =
+        invalid_extrinsics_data_proof.verify::<CBlock, SKP>(domain_id, runtime_id, &state_root)?;
 
-    let block_randomness = <BlockRandomnessProof as BasicStorageProof<CBlock>>::verify::<SKP>(
-        block_randomness_proof.clone(),
-        (),
+    let domain_sudo_call = <DomainSudoCallStorageProof as BasicStorageProof<CBlock>>::verify::<SKP>(
+        domain_sudo_call_proof.clone(),
+        domain_id,
         &state_root,
     )?;
+    domain_inherent_extrinsic_data.maybe_sudo_runtime_call = domain_sudo_call.maybe_call;
+
+    let shuffling_seed = H256::from_slice(
+        extrinsics_shuffling_seed::<Hashing>(domain_inherent_extrinsic_data.block_randomness)
+            .as_ref(),
+    );
 
     let DomainInherentExtrinsic {
         domain_timestamp_extrinsic,
@@ -109,9 +114,6 @@ where
 
         bundle_extrinsics_digests.extend(bundle_digest.bundle_digest.clone());
     }
-
-    let shuffling_seed =
-        H256::from_slice(extrinsics_shuffling_seed::<Hashing>(block_randomness).as_ref());
 
     let mut ordered_extrinsics = deduplicate_and_shuffle_extrinsics(
         bundle_extrinsics_digests,

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -379,22 +379,22 @@ where
         let maybe_domain_runtime_code_proof =
             self.maybe_generate_domain_runtime_code_proof_for_receipt(domain_id, local_receipt)?;
 
-        let block_randomness_proof = BlockRandomnessProof::generate(
-            self.consensus_client.as_ref(),
-            consensus_block_hash,
-            (),
-            &self.storage_key_provider,
-        )?;
-
         let maybe_runtime_id =
             self.is_domain_runtime_updraded_at(domain_id, consensus_block_hash)?;
 
-        let domain_inherent_extrinsic_data_proof = DomainInherentExtrinsicDataProof::generate(
+        let invalid_extrinsics_data_proof = InvalidExtrinsicsDataProof::generate(
             &self.storage_key_provider,
             self.consensus_client.as_ref(),
             domain_id,
             consensus_block_hash,
             maybe_runtime_id,
+        )?;
+
+        let domain_sudo_call_proof = DomainSudoCallStorageProof::generate(
+            self.consensus_client.as_ref(),
+            consensus_block_hash,
+            domain_id,
+            &self.storage_key_provider,
         )?;
 
         let invalid_domain_extrinsics_root_proof = FraudProof {
@@ -404,8 +404,8 @@ where
             maybe_domain_runtime_code_proof,
             proof: FraudProofVariant::InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof {
                 valid_bundle_digests,
-                block_randomness_proof,
-                domain_inherent_extrinsic_data_proof,
+                invalid_extrinsics_data_proof,
+                domain_sudo_call_proof,
             }),
         };
 


### PR DESCRIPTION
This PR is a refactor to prepare for combining storage in #3281. It moves all the storage that will be combined together, and moves out large storage that we won't combine.

In the next PR, I'll combine all the storage proofs in `InvalidExtrinsicsDataProof` into a single storage proof.

Breaking changes:
- fraud proof data layout
- a host function change, which was accidental and reverted in #3314


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
