### PR TITLE
Create invalid extrinsics fraud proof storage, and move block randomness into it

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -2889,9 +2889,9 @@ impl<T: Config> Pallet<T> {
             parent_receipt.consensus_block_number
         };
 
-        let is_domain_runtime_updraded = current_runtime_obj.updated_at >= at;
+        let is_domain_runtime_upgraded = current_runtime_obj.updated_at >= at;
 
-        let mut runtime_obj = match (is_domain_runtime_updraded, maybe_domain_runtime_code_at) {
+        let mut runtime_obj = match (is_domain_runtime_upgraded, maybe_domain_runtime_code_at) {
             //  The domain runtime is upgraded since `at`, the domain runtime code in `at` is not available
             // so `domain_runtime_code_proof` must be provided
             (true, None) => return Err(FraudProofError::DomainRuntimeCodeProofNotFound),

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -2717,8 +2717,8 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn extrinsics_shuffling_seed() -> T::Hash {
-        let seed = DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT;
-        let (randomness, _) = T::Randomness::random(seed);
+        let subject = DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT;
+        let (randomness, _) = T::Randomness::random(subject);
         randomness
     }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -494,7 +494,11 @@ pub struct InvalidExtrinsicsRootProof {
     /// Valid Bundle digests
     pub valid_bundle_digests: Vec<ValidBundleDigest>,
 
-    /// The storage proof used during verification
+    /// The combined storage proofs used during verification
+    pub invalid_inherent_extrinsic_proofs: InvalidInherentExtrinsicDataProof,
+
+    /// The individual storage proofs used during verification
+    // TODO: combine these proofs into `InvalidInherentExtrinsicDataProof`
     pub invalid_inherent_extrinsic_proof: InvalidInherentExtrinsicProof,
 
     /// Optional sudo extrinsic call storage proof

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -262,8 +262,6 @@ where
         domain_inherent_extrinsic_data: DomainInherentExtrinsicData,
     ) -> Option<DomainInherentExtrinsic> {
         let DomainInherentExtrinsicData {
-            // Used by caller
-            extrinsics_shuffling_seed: _,
             timestamp,
             maybe_domain_runtime_upgrade,
             consensus_transaction_byte_fee,

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -263,7 +263,7 @@ where
     ) -> Option<DomainInherentExtrinsic> {
         let DomainInherentExtrinsicData {
             // Used by caller
-            block_randomness: _,
+            extrinsics_shuffling_seed: _,
             timestamp,
             maybe_domain_runtime_upgrade,
             consensus_transaction_byte_fee,

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -108,7 +108,7 @@ pub enum DomainChainAllowlistUpdateExtrinsic {
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct DomainInherentExtrinsicData {
-    pub block_randomness: Randomness,
+    pub extrinsics_shuffling_seed: Randomness,
     pub timestamp: Moment,
     pub maybe_domain_runtime_upgrade: Option<Vec<u8>>,
     pub consensus_transaction_byte_fee: Balance,

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -54,7 +54,7 @@ use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 use sp_runtime::OpaqueExtrinsic;
 use sp_runtime_interface::pass_by;
 use sp_runtime_interface::pass_by::PassBy;
-use subspace_core_primitives::{Randomness, U256};
+use subspace_core_primitives::U256;
 use subspace_runtime_primitives::{Balance, Moment};
 
 /// Custom invalid validity code for the extrinsics in pallet-domains.
@@ -108,7 +108,6 @@ pub enum DomainChainAllowlistUpdateExtrinsic {
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct DomainInherentExtrinsicData {
-    pub extrinsics_shuffling_seed: Randomness,
     pub timestamp: Moment,
     pub maybe_domain_runtime_upgrade: Option<Vec<u8>>,
     pub consensus_transaction_byte_fee: Balance,

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -92,7 +92,6 @@ where
     let shuffling_seed = invalid_inherent_extrinsic_data.extrinsics_shuffling_seed;
 
     let domain_inherent_extrinsic_data = DomainInherentExtrinsicData {
-        extrinsics_shuffling_seed: invalid_inherent_extrinsic_data.extrinsics_shuffling_seed,
         timestamp: inherent_extrinsic_verified.timestamp,
         maybe_domain_runtime_upgrade: inherent_extrinsic_verified.maybe_domain_runtime_upgrade,
         consensus_transaction_byte_fee: inherent_extrinsic_verified.consensus_transaction_byte_fee,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1038,8 +1038,8 @@ pub struct StorageKeyProvider;
 impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
     fn storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8> {
         match req {
-            FraudProofStorageKeyRequest::BlockRandomness => {
-                pallet_subspace::BlockRandomness::<Runtime>::hashed_key().to_vec()
+            FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
+                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
             }
             FraudProofStorageKeyRequest::Timestamp => {
                 pallet_timestamp::Now::<Runtime>::hashed_key().to_vec()

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -382,6 +382,13 @@ where
         let maybe_runtime_id =
             self.is_domain_runtime_upgraded_at(domain_id, consensus_block_hash)?;
 
+        let invalid_inherent_extrinsic_proofs = InvalidInherentExtrinsicDataProof::generate(
+            self.consensus_client.as_ref(),
+            consensus_block_hash,
+            (),
+            &self.storage_key_provider,
+        )?;
+
         let invalid_inherent_extrinsic_proof = InvalidInherentExtrinsicProof::generate(
             &self.storage_key_provider,
             self.consensus_client.as_ref(),
@@ -404,6 +411,7 @@ where
             maybe_domain_runtime_code_proof,
             proof: FraudProofVariant::InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof {
                 valid_bundle_digests,
+                invalid_inherent_extrinsic_proofs,
                 invalid_inherent_extrinsic_proof,
                 domain_sudo_call_proof,
             }),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1115,8 +1115,8 @@ pub struct StorageKeyProvider;
 impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
     fn storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8> {
         match req {
-            FraudProofStorageKeyRequest::BlockRandomness => {
-                pallet_subspace::BlockRandomness::<Runtime>::hashed_key().to_vec()
+            FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
+                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
             }
             FraudProofStorageKeyRequest::Timestamp => {
                 pallet_timestamp::Now::<Runtime>::hashed_key().to_vec()


### PR DESCRIPTION
This PR:
- creates a common `InvalidInherentExtrinsicData` fraud proof storage, and
- moves the `extrinsics_shuffling_seed` derived from `block_randomness` into it

It also fixes some typos, and simplifies some of the code.

Part of #3281.

Eventually, all of `InvalidInherentExtrinsicProof` and most of `DomainInherentExtrinsicData` (except the sudo call) will be moved into `InvalidInherentExtrinsicData`.

Breaking changes:
- fraud proof data layout and semantics
- enum variants which are passed to runtime functions

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
