### PR TITLE
Move timestamp into invalid extrinsics fraud proof storage

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -223,7 +223,7 @@ mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_support::traits::fungible::{Inspect, InspectHold, Mutate, MutateHold};
     use frame_support::traits::tokens::Preservation;
-    use frame_support::traits::Randomness as RandomnessT;
+    use frame_support::traits::{Randomness as RandomnessT, Time};
     use frame_support::weights::Weight;
     use frame_support::{Identity, PalletError};
     use frame_system::pallet_prelude::*;
@@ -248,7 +248,7 @@ mod pallet {
     use sp_std::fmt::Debug;
     use sp_subspace_mmr::MmrProofVerifier;
     use subspace_core_primitives::{Randomness, U256};
-    use subspace_runtime_primitives::{Moment, StorageFee};
+    use subspace_runtime_primitives::StorageFee;
 
     #[pallet::config]
     pub trait Config: frame_system::Config<Hash: Into<H256>> {
@@ -389,6 +389,9 @@ mod pallet {
 
         /// Storage fee interface used to deal with bundle storage fee
         type StorageFee: StorageFee<BalanceOf<Self>>;
+
+        /// The block timestamp
+        type BlockTimestamp: Time;
 
         /// The block slot
         type BlockSlot: BlockSlot<Self>;
@@ -1913,7 +1916,12 @@ mod pallet {
                     Into::<H256>::into(Self::extrinsics_shuffling_seed()).to_fixed_bytes(),
                 );
 
-                let timestamp = Moment::default();
+                // There is no actual conversion here, but the trait bounds required to prove that
+                // (and debug-print the error in expect()) are very verbose.
+                let timestamp = T::BlockTimestamp::now()
+                    .try_into()
+                    .map_err(|_| ())
+                    .expect("Moment is the same type in both pallets; qed");
 
                 let invalid_inherent_extrinsic_data = InvalidInherentExtrinsicData {
                     extrinsics_shuffling_seed,

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -248,7 +248,7 @@ mod pallet {
     use sp_std::fmt::Debug;
     use sp_subspace_mmr::MmrProofVerifier;
     use subspace_core_primitives::{Randomness, U256};
-    use subspace_runtime_primitives::StorageFee;
+    use subspace_runtime_primitives::{Moment, StorageFee};
 
     #[pallet::config]
     pub trait Config: frame_system::Config<Hash: Into<H256>> {
@@ -1913,8 +1913,11 @@ mod pallet {
                     Into::<H256>::into(Self::extrinsics_shuffling_seed()).to_fixed_bytes(),
                 );
 
+                let timestamp = Moment::default();
+
                 let invalid_inherent_extrinsic_data = InvalidInherentExtrinsicData {
                     extrinsics_shuffling_seed,
+                    timestamp,
                 };
 
                 BlockInvalidInherentExtrinsicData::<T>::set(Some(invalid_inherent_extrinsic_data));

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -263,6 +263,7 @@ impl pallet_domains::Config for Test {
     type Randomness = MockRandomness;
     type PalletId = DomainsPalletId;
     type StorageFee = DummyStorageFee;
+    type BlockTimestamp = pallet_timestamp::Pallet<Test>;
     type BlockSlot = DummyBlockSlot;
     type DomainsTransfersTracker = MockDomainsTransfersTracker;
     type MaxInitialDomainAccounts = MaxInitialDomainAccounts;

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -92,7 +92,7 @@ where
     let shuffling_seed = invalid_inherent_extrinsic_data.extrinsics_shuffling_seed;
 
     let domain_inherent_extrinsic_data = DomainInherentExtrinsicData {
-        timestamp: inherent_extrinsic_verified.timestamp,
+        timestamp: invalid_inherent_extrinsic_data.timestamp,
         maybe_domain_runtime_upgrade: inherent_extrinsic_verified.maybe_domain_runtime_upgrade,
         consensus_transaction_byte_fee: inherent_extrinsic_verified.consensus_transaction_byte_fee,
         domain_chain_allowlist: inherent_extrinsic_verified.domain_chain_allowlist,

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -836,6 +836,7 @@ impl pallet_domains::Config for Runtime {
     type Randomness = Subspace;
     type PalletId = DomainsPalletId;
     type StorageFee = TransactionFees;
+    type BlockTimestamp = pallet_timestamp::Pallet<Runtime>;
     type BlockSlot = BlockSlot;
     type BundleLongevity = BundleLongevity;
     type DomainsTransfersTracker = Transporter;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1041,9 +1041,6 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
                 pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
             }
-            FraudProofStorageKeyRequest::Timestamp => {
-                pallet_timestamp::Now::<Runtime>::hashed_key().to_vec()
-            }
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)
             }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -766,6 +766,7 @@ impl pallet_domains::Config for Runtime {
     type MinNominatorStake = MinNominatorStake;
     type PalletId = DomainsPalletId;
     type StorageFee = TransactionFees;
+    type BlockTimestamp = pallet_timestamp::Pallet<Runtime>;
     type BlockSlot = BlockSlot;
     type BundleLongevity = BundleLongevity;
     type DomainsTransfersTracker = Transporter;

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1118,9 +1118,6 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
                 pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
             }
-            FraudProofStorageKeyRequest::Timestamp => {
-                pallet_timestamp::Now::<Runtime>::hashed_key().to_vec()
-            }
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)
             }


### PR DESCRIPTION
This PR moves the block timestamp into the shared invalid extrinsics fraud proof data.

Part of #3281

Breaking changes:
- fraud proof data layout
- enum variants which are passed to runtime functions

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
