### PR TITLE
Fix bug in fraud proof transaction fee value, and combine storage

### DIFF
--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -242,10 +242,6 @@ where
         }
     }
 
-    pub fn transaction_byte_fee_storage_key() -> Vec<u8> {
-        TransactionByteFee::<T>::hashed_key().to_vec()
-    }
-
     pub fn calculate_transaction_byte_fee() -> BalanceOf<T> {
         let credit_supply = T::CreditSupply::get();
 

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -160,7 +160,7 @@ sp_api::decl_runtime_apis! {
         /// Submit the fraud proof via an unsigned extrinsic.
         fn submit_fraud_proof_unsigned(fraud_proof: FraudProof<NumberFor<Block>, Block::Hash, DomainHeader, H256>);
 
-        /// Reture the storage key used in fraud proof
+        /// Return the storage key used in fraud proof
         fn fraud_proof_storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8>;
     }
 }

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -94,7 +94,8 @@ where
     let domain_inherent_extrinsic_data = DomainInherentExtrinsicData {
         timestamp: invalid_inherent_extrinsic_data.timestamp,
         maybe_domain_runtime_upgrade: inherent_extrinsic_verified.maybe_domain_runtime_upgrade,
-        consensus_transaction_byte_fee: inherent_extrinsic_verified.consensus_transaction_byte_fee,
+        consensus_transaction_byte_fee: invalid_inherent_extrinsic_data
+            .consensus_transaction_byte_fee,
         domain_chain_allowlist: inherent_extrinsic_verified.domain_chain_allowlist,
         maybe_sudo_runtime_call: domain_sudo_call.maybe_call,
     };

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1045,18 +1045,12 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)
             }
-            FraudProofStorageKeyRequest::TransactionByteFee => {
-                TransactionFees::transaction_byte_fee_storage_key()
-            }
             FraudProofStorageKeyRequest::DomainAllowlistUpdates(domain_id) => {
                 Messenger::domain_allow_list_update_storage_key(domain_id)
             }
             FraudProofStorageKeyRequest::BlockDigest => sp_domains::system_digest_final_key(),
             FraudProofStorageKeyRequest::RuntimeRegistry(runtime_id) => {
                 pallet_domains::RuntimeRegistry::<Runtime>::hashed_key_for(runtime_id)
-            }
-            FraudProofStorageKeyRequest::DynamicCostOfStorage => {
-                pallet_runtime_configs::EnableDynamicCostOfStorage::<Runtime>::hashed_key().to_vec()
             }
             FraudProofStorageKeyRequest::DomainSudoCall(domain_id) => {
                 pallet_domains::DomainSudoCalls::<Runtime>::hashed_key_for(domain_id)

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1122,18 +1122,12 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)
             }
-            FraudProofStorageKeyRequest::TransactionByteFee => {
-                TransactionFees::transaction_byte_fee_storage_key()
-            }
             FraudProofStorageKeyRequest::DomainAllowlistUpdates(domain_id) => {
                 Messenger::domain_allow_list_update_storage_key(domain_id)
             }
             FraudProofStorageKeyRequest::BlockDigest => sp_domains::system_digest_final_key(),
             FraudProofStorageKeyRequest::RuntimeRegistry(runtime_id) => {
                 pallet_domains::RuntimeRegistry::<Runtime>::hashed_key_for(runtime_id)
-            }
-            FraudProofStorageKeyRequest::DynamicCostOfStorage => {
-                pallet_runtime_configs::EnableDynamicCostOfStorage::<Runtime>::hashed_key().to_vec()
             }
             FraudProofStorageKeyRequest::DomainSudoCall(domain_id) => {
                 pallet_domains::DomainSudoCalls::<Runtime>::hashed_key_for(domain_id)


### PR DESCRIPTION
The fraud proof was calculating the consensus transaction byte fee as `1` when dynamic cost of storage was disabled. But the `consensus_chain_byte_fee()` runtime API returned `DOMAIN_STORAGE_FEE_MULTIPLIER` in that case. This PR makes the values consistent by fixing the fraud proof calculation.

It also:
- moves the fee into the combined fraud proof storage, which is a breaking change to the fraud proof data layout
- changes an enum which is passed to runtime functions, which is a breaking runtime change.

Part of ticket #3281.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
