### PR TITLE
Fix bug in cross-segment object retrieval

### DIFF
--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -514,13 +514,12 @@ where
                         }
                     }
 
-                    // Padding at the end of segments can be skipped, it's not part of the object data
-                    SegmentItem::Padding => {}
+                    // Padding at the end of segments, and segment headers can be skipped,
+                    // they're not part of the object data
+                    SegmentItem::Padding | SegmentItem::ParentSegmentHeader(_) => {}
 
                     // We should not see these items while collecting data for a single object
-                    SegmentItem::Block { .. }
-                    | SegmentItem::BlockStart { .. }
-                    | SegmentItem::ParentSegmentHeader(_) => {
+                    SegmentItem::Block { .. } | SegmentItem::BlockStart { .. } => {
                         debug!(
                             collected_data = ?data.len(),
                             %segment_index,


### PR DESCRIPTION
The parent segment header is always the first item in a segment, so retrieving objects that cross segments was always returning an error.

This PR ignores the header, allowing the object to be retrieved.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
