### PR TITLE
Fix panic when searching for archived block data

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -452,9 +452,10 @@ where
             continue;
         };
 
-        let last_archived_block = client
-            .block(last_archived_block_hash)?
-            .expect("Last archived block must always be retrievable; qed");
+        let Some(last_archived_block) = client.block(last_archived_block_hash)? else {
+            // This block data was already pruned (but the headers weren't)
+            continue;
+        };
 
         // If we're starting mapping creation at this block, return its mappings.
         let block_object_mappings = if create_object_mappings {


### PR DESCRIPTION
We expected a block’s data would always be available if its hash was, but this isn’t always the case.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
