### PR TITLE
Merge DomainAllowlistUpdates into common storage proof

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -2117,6 +2117,15 @@ impl<T: Config> Pallet<T> {
             .map(|domain_object| domain_object.domain_config.runtime_id)
     }
 
+    pub fn domain_id(runtime_id: RuntimeId) -> Option<DomainId> {
+        RuntimeRegistry::<T>::get(runtime_id).and_then(|runtime_object| {
+            runtime_object
+                .raw_genesis
+                .domain_id()
+                .expect("DomainId must be valid since domain is insantiated; qed")
+        })
+    }
+
     pub fn domain_instance_data(
         domain_id: DomainId,
     ) -> Option<(DomainInstanceData, BlockNumberFor<T>)> {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -5,10 +5,11 @@ use crate::runtime_registry::ScheduledRuntimeUpgrade;
 use crate::staking::Operator;
 use crate::{
     self as pallet_domains, BalanceOf, BlockSlot, BlockTree, BlockTreeNodes, BundleError, Config,
-    ConsensusBlockHash, DomainBlockNumberFor, DomainHashingFor, DomainRegistry,
-    DomainRuntimeUpgradeRecords, DomainRuntimeUpgrades, ExecutionInbox, ExecutionReceiptOf,
-    FraudProofError, FungibleHoldId, HeadDomainNumber, HeadReceiptNumber, NextDomainId, Operators,
-    RuntimeRegistry, ScheduledRuntimeUpgrades,
+    ConsensusBlockHash, DomainAllowlistUpdates, DomainAllowlistUpdatesProvider,
+    DomainBlockNumberFor, DomainHashingFor, DomainRegistry, DomainRuntimeUpgradeRecords,
+    DomainRuntimeUpgrades, ExecutionInbox, ExecutionReceiptOf, FraudProofError, FungibleHoldId,
+    HeadDomainNumber, HeadReceiptNumber, NextDomainId, Operators, RuntimeRegistry,
+    ScheduledRuntimeUpgrades,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::mem;
@@ -237,6 +238,12 @@ impl sp_domains::DomainsTransfersTracker<Balance> for MockDomainsTransfersTracke
     }
 }
 
+impl DomainAllowlistUpdatesProvider for () {
+    fn domain_allowlist_updates(_domain_id: DomainId) -> Option<DomainAllowlistUpdates> {
+        None
+    }
+}
+
 impl pallet_domains::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type DomainHash = sp_core::H256;
@@ -272,6 +279,7 @@ impl pallet_domains::Config for Test {
     type ConsensusSlotProbability = SlotProbability;
     type DomainBundleSubmitted = ();
     type OnDomainInstantiated = ();
+    type DomainAllowlistUpdates = ();
     type Balance = Balance;
     type MmrHash = H256;
     type MmrProofVerifier = ();

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -21,11 +21,6 @@
 
 pub mod weights;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use codec::{Codec, Decode, Encode};
 use frame_support::sp_runtime::traits::Zero;
 use frame_support::sp_runtime::SaturatedConversion;

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -497,10 +497,6 @@ pub struct InvalidExtrinsicsRootProof {
     /// The combined storage proofs used during verification
     pub invalid_inherent_extrinsic_proofs: InvalidInherentExtrinsicDataProof,
 
-    /// The individual storage proofs used during verification
-    // TODO: combine these proofs into `InvalidInherentExtrinsicDataProof`
-    pub invalid_inherent_extrinsic_proof: InvalidInherentExtrinsicProof,
-
     /// Optional domain runtime code upgrade storage proof
     pub maybe_domain_runtime_upgrade_proof: MaybeDomainRuntimeUpgradedProof,
 

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -66,7 +66,6 @@ where
     let InvalidExtrinsicsRootProof {
         valid_bundle_digests,
         invalid_inherent_extrinsic_proofs,
-        invalid_inherent_extrinsic_proof,
         maybe_domain_runtime_upgrade_proof,
         domain_sudo_call_proof,
     } = fraud_proof;
@@ -74,12 +73,9 @@ where
     let invalid_inherent_extrinsic_data =
         <InvalidInherentExtrinsicDataProof as BasicStorageProof<CBlock>>::verify::<SKP>(
             invalid_inherent_extrinsic_proofs.clone(),
-            (),
+            domain_id,
             &state_root,
         )?;
-
-    let inherent_extrinsic_verified =
-        invalid_inherent_extrinsic_proof.verify::<CBlock, SKP>(domain_id, &state_root)?;
 
     let maybe_domain_runtime_upgrade =
         maybe_domain_runtime_upgrade_proof.verify::<CBlock, SKP>(runtime_id, &state_root)?;
@@ -97,7 +93,7 @@ where
         maybe_domain_runtime_upgrade,
         consensus_transaction_byte_fee: invalid_inherent_extrinsic_data
             .consensus_transaction_byte_fee,
-        domain_chain_allowlist: inherent_extrinsic_verified.domain_chain_allowlist,
+        domain_chain_allowlist: invalid_inherent_extrinsic_data.domain_chain_allowlist,
         maybe_sudo_runtime_call: domain_sudo_call.maybe_call,
     };
 

--- a/crates/sp-domains/src/storage.rs
+++ b/crates/sp-domains/src/storage.rs
@@ -55,6 +55,13 @@ impl RawGenesis {
         );
     }
 
+    pub fn domain_id(&self) -> Result<Option<DomainId>, parity_scale_codec::Error> {
+        match self.top.get(&self_domain_id_storage_key()) {
+            Some(sd) => Ok(Some(DomainId::decode(&mut sd.0.as_slice())?)),
+            None => Ok(None),
+        }
+    }
+
     pub fn set_evm_chain_id(&mut self, chain_id: EVMChainId) {
         let _ = self
             .top

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -790,6 +790,14 @@ impl pallet_domains::BlockSlot<Runtime> for BlockSlot {
     }
 }
 
+pub struct DomainAllowlistUpdatesSource;
+
+impl pallet_domains::DomainAllowlistUpdatesProvider for DomainAllowlistUpdatesSource {
+    fn domain_allowlist_updates(domain_id: DomainId) -> Option<DomainAllowlistUpdates> {
+        Messenger::domain_chains_allowlist_update(domain_id)
+    }
+}
+
 pub struct OnChainRewards;
 
 impl sp_domains::OnChainRewards<Balance> for OnChainRewards {
@@ -844,6 +852,7 @@ impl pallet_domains::Config for Runtime {
     type MinInitialDomainAccountBalance = MinInitialDomainAccountBalance;
     type DomainBundleSubmitted = Messenger;
     type OnDomainInstantiated = Messenger;
+    type DomainAllowlistUpdates = DomainAllowlistUpdatesSource;
     type Balance = Balance;
     type MmrHash = mmr::Hash;
     type MmrProofVerifier = MmrProofVerifier;
@@ -1039,14 +1048,13 @@ pub struct StorageKeyProvider;
 impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
     fn storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8> {
         match req {
-            FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
-                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
+            FraudProofStorageKeyRequest::InvalidInherentExtrinsicData(domain_id) => {
+                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key_for(
+                    domain_id,
+                )
             }
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)
-            }
-            FraudProofStorageKeyRequest::DomainAllowlistUpdates(domain_id) => {
-                Messenger::domain_allow_list_update_storage_key(domain_id)
             }
             FraudProofStorageKeyRequest::DomainRuntimeUpgrades => {
                 pallet_domains::DomainRuntimeUpgrades::<Runtime>::hashed_key().to_vec()

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -385,15 +385,8 @@ where
         let invalid_inherent_extrinsic_proofs = InvalidInherentExtrinsicDataProof::generate(
             self.consensus_client.as_ref(),
             consensus_block_hash,
-            (),
-            &self.storage_key_provider,
-        )?;
-
-        let invalid_inherent_extrinsic_proof = InvalidInherentExtrinsicProof::generate(
-            &self.storage_key_provider,
-            self.consensus_client.as_ref(),
             domain_id,
-            consensus_block_hash,
+            &self.storage_key_provider,
         )?;
 
         let maybe_domain_runtime_upgrade_proof = MaybeDomainRuntimeUpgradedProof::generate(
@@ -418,7 +411,6 @@ where
             proof: FraudProofVariant::InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof {
                 valid_bundle_digests,
                 invalid_inherent_extrinsic_proofs,
-                invalid_inherent_extrinsic_proof,
                 maybe_domain_runtime_upgrade_proof,
                 domain_sudo_call_proof,
             }),

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -720,6 +720,14 @@ impl pallet_domains::BlockSlot<Runtime> for BlockSlot {
     }
 }
 
+pub struct DomainAllowlistUpdatesSource;
+
+impl pallet_domains::DomainAllowlistUpdatesProvider for DomainAllowlistUpdatesSource {
+    fn domain_allowlist_updates(_domain_id: DomainId) -> Option<DomainAllowlistUpdates> {
+        None
+    }
+}
+
 pub struct OnChainRewards;
 
 impl sp_domains::OnChainRewards<Balance> for OnChainRewards {
@@ -774,6 +782,7 @@ impl pallet_domains::Config for Runtime {
     type MinInitialDomainAccountBalance = MinInitialDomainAccountBalance;
     type DomainBundleSubmitted = Messenger;
     type OnDomainInstantiated = Messenger;
+    type DomainAllowlistUpdates = DomainAllowlistUpdatesSource;
     type Balance = Balance;
     type MmrHash = mmr::Hash;
     type MmrProofVerifier = MmrProofVerifier;
@@ -1116,14 +1125,13 @@ pub struct StorageKeyProvider;
 impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
     fn storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8> {
         match req {
-            FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
-                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
+            FraudProofStorageKeyRequest::InvalidInherentExtrinsicData(domain_id) => {
+                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key_for(
+                    domain_id,
+                )
             }
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)
-            }
-            FraudProofStorageKeyRequest::DomainAllowlistUpdates(domain_id) => {
-                Messenger::domain_allow_list_update_storage_key(domain_id)
             }
             FraudProofStorageKeyRequest::DomainRuntimeUpgrades => {
                 pallet_domains::DomainRuntimeUpgrades::<Runtime>::hashed_key().to_vec()


### PR DESCRIPTION
This PR merges the domain chains allow list storage proof into the common storage proof struct. (I split #3329 into a separate PR.)

It also re-arranges those structs so an old storage proofs struct is empty, and then removes that empty struct.

Part of ticket #3281.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
