### PR TITLE
Storage proof: change BlockDigest to DomainRuntimeUpgrades

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -699,7 +699,7 @@ mod pallet {
     #[pallet::storage]
     pub(super) type AccumulatedTreasuryFunds<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
-    /// Storage used to keep track of which consensus block the domain runtime upgrade happen.
+    /// Storage used to keep track of which consensus block each domain runtime upgrade happens in.
     #[pallet::storage]
     pub(super) type DomainRuntimeUpgradeRecords<T: Config> = StorageMap<
         _,
@@ -709,8 +709,8 @@ mod pallet {
         ValueQuery,
     >;
 
-    /// Temporary storage keep track of domain runtime upgrade happen in the current block, cleared
-    /// in the next block initialization.
+    /// Temporary storage to keep track of domain runtime upgrades which happened in the parent
+    /// block. Cleared in the current block's initialization.
     #[pallet::storage]
     pub type DomainRuntimeUpgrades<T> = StorageValue<_, Vec<RuntimeId>, ValueQuery>;
 
@@ -1885,7 +1885,7 @@ mod pallet {
             }
             do_upgrade_runtimes::<T>(block_number);
 
-            // Store the hash of the parent consensus block for domain that have bundles submitted
+            // Store the hash of the parent consensus block for domains that have bundles submitted
             // in that consensus block
             for (domain_id, _) in SuccessfulBundles::<T>::drain() {
                 ConsensusBlockHash::<T>::insert(domain_id, parent_number, parent_hash);
@@ -1896,7 +1896,8 @@ mod pallet {
             }
 
             for (operator_id, slot_set) in OperatorBundleSlot::<T>::drain() {
-                // NOTE: `OperatorBundleSlot` use `BTreeSet` so `last` will return the maximum value in the set
+                // NOTE: `OperatorBundleSlot` uses `BTreeSet` so `last` will return the maximum
+                // value in the set
                 if let Some(highest_slot) = slot_set.last() {
                     OperatorHighestSlot::<T>::insert(operator_id, highest_slot);
                 }
@@ -1908,7 +1909,8 @@ mod pallet {
         }
 
         fn on_finalize(_: BlockNumberFor<T>) {
-            // If this consensus block will derive any domain block, gather the necessary storage for potential fraud proof usage
+            // If this consensus block will derive any domain block, gather the necessary storage
+            // for potential fraud proof usage
             if SuccessfulBundles::<T>::iter_keys().count() > 0
                 || DomainRuntimeUpgrades::<T>::exists()
             {
@@ -2910,7 +2912,7 @@ impl<T: Config> Pallet<T> {
     }
 
     // Get the domain runtime code that used to derive `receipt`, if the runtime code still present in
-    // the state then get it from the state otherwise from the `maybe_domain_runtime_code_at` prood.
+    // the state then get it from the state otherwise from the `maybe_domain_runtime_code_at` proof.
     pub fn get_domain_runtime_code_for_receipt(
         domain_id: DomainId,
         receipt: &ExecutionReceiptOf<T>,

--- a/crates/pallet-transaction-fees/src/lib.rs
+++ b/crates/pallet-transaction-fees/src/lib.rs
@@ -21,11 +21,6 @@
 
 pub mod weights;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 use codec::{Codec, Decode, Encode};
 use frame_support::sp_runtime::traits::Zero;
 use frame_support::sp_runtime::SaturatedConversion;

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -497,9 +497,11 @@ pub struct InvalidExtrinsicsRootProof {
     /// The combined storage proofs used during verification
     pub invalid_inherent_extrinsic_proofs: InvalidInherentExtrinsicDataProof,
 
-    /// The individual storage proofs used during verification
-    // TODO: combine these proofs into `InvalidInherentExtrinsicDataProof`
-    pub invalid_inherent_extrinsic_proof: InvalidInherentExtrinsicProof,
+    /// Domain runtime code upgraded (or "not upgraded") storage proof
+    pub domain_runtime_upgraded_proof: DomainRuntimeUpgradedProof,
+
+    /// Storage proof for a change to the chains that are allowed to open a channel with each domain
+    pub domain_chain_allowlist_proof: DomainChainsAllowlistUpdateStorageProof,
 
     /// Optional sudo extrinsic call storage proof
     pub domain_sudo_call_proof: DomainSudoCallStorageProof,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1394,9 +1394,9 @@ pub type ExecutionReceiptFor<DomainHeader, CBlock, Balance> = ExecutionReceipt<
 /// Domain chains allowlist updates.
 #[derive(Default, Debug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
 pub struct DomainAllowlistUpdates {
-    /// Chains that are allowed to open channel with this chain.
+    /// Chains that are allowed to open a channel with this chain.
     pub allow_chains: BTreeSet<ChainId>,
-    /// Chains that are not allowed to open channel with this chain.
+    /// Chains that are not allowed to open a channel with this chain.
     pub remove_chains: BTreeSet<ChainId>,
 }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1048,7 +1048,9 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::DomainAllowlistUpdates(domain_id) => {
                 Messenger::domain_allow_list_update_storage_key(domain_id)
             }
-            FraudProofStorageKeyRequest::BlockDigest => sp_domains::system_digest_final_key(),
+            FraudProofStorageKeyRequest::DomainRuntimeUpgrades => {
+                pallet_domains::DomainRuntimeUpgrades::<Runtime>::hashed_key().to_vec()
+            }
             FraudProofStorageKeyRequest::RuntimeRegistry(runtime_id) => {
                 pallet_domains::RuntimeRegistry::<Runtime>::hashed_key_for(runtime_id)
             }

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -389,12 +389,18 @@ where
             &self.storage_key_provider,
         )?;
 
-        let invalid_inherent_extrinsic_proof = InvalidInherentExtrinsicProof::generate(
+        let domain_runtime_upgraded_proof = DomainRuntimeUpgradedProof::generate(
             &self.storage_key_provider,
             self.consensus_client.as_ref(),
-            domain_id,
             consensus_block_hash,
             maybe_runtime_id,
+        )?;
+
+        let domain_chain_allowlist_proof = DomainChainsAllowlistUpdateStorageProof::generate(
+            self.consensus_client.as_ref(),
+            consensus_block_hash,
+            domain_id,
+            &self.storage_key_provider,
         )?;
 
         let domain_sudo_call_proof = DomainSudoCallStorageProof::generate(
@@ -412,7 +418,8 @@ where
             proof: FraudProofVariant::InvalidExtrinsicsRoot(InvalidExtrinsicsRootProof {
                 valid_bundle_digests,
                 invalid_inherent_extrinsic_proofs,
-                invalid_inherent_extrinsic_proof,
+                domain_runtime_upgraded_proof,
+                domain_chain_allowlist_proof,
                 domain_sudo_call_proof,
             }),
         };

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -57,6 +57,7 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use sp_weights::Weight;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
+use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_runtime_primitives::{Balance, SSC};
@@ -64,6 +65,9 @@ use subspace_test_service::{
     produce_block_with, produce_blocks, produce_blocks_until, MockConsensusNode,
 };
 use tempfile::TempDir;
+use tracing::error;
+
+const TIMEOUT: Duration = Duration::from_mins(2);
 
 fn number_of(consensus_node: &MockConsensusNode, block_hash: Hash) -> u32 {
     consensus_node
@@ -1231,7 +1235,9 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
 
     // When the system domain node process the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -1374,7 +1380,9 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -1486,7 +1494,9 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -1627,7 +1637,9 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -1739,7 +1751,9 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -1893,7 +1907,9 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2056,7 +2072,9 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2188,7 +2206,9 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2307,7 +2327,9 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2417,7 +2439,9 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2528,7 +2552,9 @@ async fn test_false_invalid_bundles_non_exist_extrinsic_proof_creation_and_verif
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2609,7 +2635,9 @@ async fn test_invalid_block_fees_proof_creation() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2710,7 +2738,9 @@ async fn test_invalid_transfers_fraud_proof() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2806,7 +2836,9 @@ async fn test_invalid_domain_block_hash_proof_creation() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -2902,7 +2934,9 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -4738,7 +4772,9 @@ async fn test_bad_receipt_chain() {
     }
 
     // The fraud proof should be submitted
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // The first bad ER should be pruned and its descendants are marked as pending to prune
     ferdie.produce_blocks(1).await.unwrap();
@@ -5457,7 +5493,9 @@ async fn test_xdm_false_invalid_fraud_proof() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
@@ -5703,7 +5741,9 @@ async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = wait_for_fraud_proof_fut.await;
+    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+        .await
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1235,14 +1235,17 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
 
     // When the system domain node process the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1380,14 +1383,17 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1494,14 +1500,17 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1637,14 +1646,17 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1751,14 +1763,17 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1907,14 +1922,17 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2072,14 +2090,17 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2206,14 +2227,17 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2327,14 +2351,17 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2439,14 +2466,17 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2552,14 +2582,17 @@ async fn test_false_invalid_bundles_non_exist_extrinsic_proof_creation_and_verif
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2635,14 +2668,17 @@ async fn test_invalid_block_fees_proof_creation() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2738,14 +2774,17 @@ async fn test_invalid_transfers_fraud_proof() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2836,14 +2875,17 @@ async fn test_invalid_domain_block_hash_proof_creation() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2934,14 +2976,17 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
 
     // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -4772,9 +4817,10 @@ async fn test_bad_receipt_chain() {
     }
 
     // The fraud proof should be submitted
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // The first bad ER should be pruned and its descendants are marked as pending to prune
     ferdie.produce_blocks(1).await.unwrap();
@@ -4885,6 +4931,8 @@ async fn test_bad_receipt_chain() {
     assert_eq!(bob_best_number, bob.client.info().best_number);
 
     produce_blocks!(ferdie, bob, 15).await.unwrap();
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -5493,14 +5541,17 @@ async fn test_xdm_false_invalid_fraud_proof() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }
 
 // TODO: this test is flaky and sometime hang forever in CI thus disable it temporary,
@@ -5741,12 +5792,15 @@ async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    let _ = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
+    let timed_out = tokio::time::timeout(TIMEOUT, wait_for_fraud_proof_fut)
         .await
-        .inspect_err(|_| error!("fraud proof was not created before the timeout"));
+        .inspect_err(|_| error!("fraud proof was not created before the timeout"))
+        .is_err();
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
     // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
+    // We check for timeouts last, because they are the least useful test failure message.
+    assert!(!timed_out);
 }

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1165,7 +1165,7 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidStateTransition(proof) = &fp.proof {
             match (trace_diff_type, mismatch_trace_index) {
@@ -1215,7 +1215,7 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
         }
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -1229,12 +1229,12 @@ async fn test_invalid_state_transition_proof_creation_and_verification(
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    // When the system domain node process the primary block that contains the `bad_submit_bundle_tx`,
+    // When the system domain node process the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -1318,7 +1318,7 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
         bundle_to_tx(opaque_bundle)
     };
 
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -1349,7 +1349,7 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InherentExtrinsic(_) = proof.invalid_bundle_type {
@@ -1360,7 +1360,7 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -1377,7 +1377,7 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -1461,7 +1461,7 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InherentExtrinsic(_) = proof.invalid_bundle_type {
@@ -1472,7 +1472,7 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -1489,7 +1489,7 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -1571,7 +1571,7 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
         bundle_to_tx(opaque_bundle)
     };
 
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -1602,7 +1602,7 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::UndecodableTx(_) = proof.invalid_bundle_type {
@@ -1613,7 +1613,7 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -1630,7 +1630,7 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -1714,7 +1714,7 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::UndecodableTx(_) = proof.invalid_bundle_type {
@@ -1725,7 +1725,7 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -1742,7 +1742,7 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -1835,7 +1835,7 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
         bundle_to_tx(opaque_bundle)
     };
 
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -1866,7 +1866,7 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InvalidXDM(extrinsic_index) = proof.invalid_bundle_type {
@@ -1878,9 +1878,9 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -1896,7 +1896,7 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -1999,7 +1999,7 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
         bundle_to_tx(opaque_bundle)
     };
 
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -2030,7 +2030,7 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::IllegalTx(extrinsic_index) = proof.invalid_bundle_type {
@@ -2042,7 +2042,7 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2059,7 +2059,7 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2162,7 +2162,7 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::IllegalTx(extrinsic_index) = proof.invalid_bundle_type {
@@ -2174,7 +2174,7 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2191,7 +2191,7 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2251,7 +2251,7 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
         bundle_to_tx(opaque_bundle)
     };
 
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -2282,7 +2282,7 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if InvalidBundleType::InvalidBundleWeight == proof.invalid_bundle_type {
@@ -2293,7 +2293,7 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2310,7 +2310,7 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2392,7 +2392,7 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if InvalidBundleType::InvalidBundleWeight == proof.invalid_bundle_type {
@@ -2403,7 +2403,7 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2420,7 +2420,7 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2503,7 +2503,7 @@ async fn test_false_invalid_bundles_non_exist_extrinsic_proof_creation_and_verif
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundlesProofData::Bundle(_) = proof.proof_data {
@@ -2514,7 +2514,7 @@ async fn test_false_invalid_bundles_non_exist_extrinsic_proof_creation_and_verif
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2531,7 +2531,7 @@ async fn test_false_invalid_bundles_non_exist_extrinsic_proof_creation_and_verif
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2585,7 +2585,7 @@ async fn test_invalid_block_fees_proof_creation() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         matches!(
             fp.proof,
@@ -2593,7 +2593,7 @@ async fn test_invalid_block_fees_proof_creation() {
         )
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2607,12 +2607,12 @@ async fn test_invalid_block_fees_proof_creation() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
+    // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2686,7 +2686,7 @@ async fn test_invalid_transfers_fraud_proof() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         matches!(
             fp.proof,
@@ -2694,7 +2694,7 @@ async fn test_invalid_transfers_fraud_proof() {
         )
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2708,12 +2708,12 @@ async fn test_invalid_transfers_fraud_proof() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
+    // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2782,7 +2782,7 @@ async fn test_invalid_domain_block_hash_proof_creation() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         matches!(
             fp.proof,
@@ -2790,7 +2790,7 @@ async fn test_invalid_domain_block_hash_proof_creation() {
         )
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2804,12 +2804,12 @@ async fn test_invalid_domain_block_hash_proof_creation() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
+    // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -2878,7 +2878,7 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         matches!(
             fp.proof,
@@ -2886,7 +2886,7 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
         )
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -2900,12 +2900,12 @@ async fn test_invalid_domain_extrinsics_root_proof_creation() {
     .unwrap();
     assert!(ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
-    // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
+    // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
-    let _ = wait_for_fraud_proof_fut.await;
+    wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -3177,7 +3177,7 @@ async fn test_valid_bundle_proof_generation_and_verification() {
         (bundle.receipt().clone(), bundle_to_tx(bundle))
     };
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     let mut import_tx_stream = ferdie.transaction_pool.import_notification_stream();
     produce_block_with!(
@@ -3194,7 +3194,7 @@ async fn test_valid_bundle_proof_generation_and_verification() {
         .does_receipt_exist(bad_receipt.hash::<BlakeTwo256>())
         .unwrap());
 
-    // When the domain node operator process the primary block that contains the `bad_submit_bundle_tx`,
+    // When the domain node operator processes the primary block that contains `bad_submit_bundle_tx`,
     // it will generate and submit a fraud proof
     while let Some(ready_tx_hash) = import_tx_stream.next().await {
         let ready_tx = ferdie
@@ -3239,7 +3239,7 @@ async fn test_valid_bundle_proof_generation_and_verification() {
     }
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie
         .does_receipt_exist(bad_receipt.hash::<BlakeTwo256>())
@@ -4664,7 +4664,7 @@ async fn test_bad_receipt_chain() {
         )
     };
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
@@ -5430,7 +5430,7 @@ async fn test_xdm_false_invalid_fraud_proof() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InvalidXDM(extrinsic_index) = proof.invalid_bundle_type {
@@ -5442,9 +5442,9 @@ async fn test_xdm_false_invalid_fraud_proof() {
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -5460,7 +5460,7 @@ async fn test_xdm_false_invalid_fraud_proof() {
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }
@@ -5676,7 +5676,7 @@ async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
         )
     };
 
-    // Wait for the fraud proof that target the bad ER
+    // Wait for the fraud proof that targets the bad ER
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InvalidXDM(extrinsic_index) = proof.invalid_bundle_type {
@@ -5688,9 +5688,9 @@ async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
         false
     });
 
-    // Produce a consensus block that contains the `bad_submit_bundle_tx` and the bad receipt should
+    // Produce a consensus block that contains `bad_submit_bundle_tx` and the bad receipt should
     // be added to the consensus chain block tree
-    // Produce a block that contains the `bad_submit_bundle_tx`
+    // Produce a block that contains `bad_submit_bundle_tx`
     produce_block_with!(
         ferdie.produce_block_with_slot_at(
             slot,
@@ -5706,7 +5706,7 @@ async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
     let _ = wait_for_fraud_proof_fut.await;
 
     // Produce a consensus block that contains the fraud proof, the fraud proof wil be verified
-    // and executed, thus pruned the bad receipt from the block tree
+    // and executed, and prune the bad receipt from the block tree
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 }

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -4768,7 +4768,7 @@ async fn test_bad_receipt_chain() {
         ) && fp.targeted_bad_receipt_hash() == bad_receipt_hash
     });
 
-    // Produce more bundle with bad ER that use previous bad ER as parent
+    // Produce more bundles with bad ERs that use the previous bad ER as an ancestor
     let mut parent_bad_receipt_hash = bad_receipt_hash;
     let mut bad_receipt_descendants = vec![];
     for _ in 0..7 {
@@ -4822,7 +4822,7 @@ async fn test_bad_receipt_chain() {
         .inspect_err(|_| error!("fraud proof was not created before the timeout"))
         .is_err();
 
-    // The first bad ER should be pruned and its descendants are marked as pending to prune
+    // The first bad ER should be pruned, and its descendants marked as pending to prune
     ferdie.produce_blocks(1).await.unwrap();
     assert!(!ferdie.does_receipt_exist(bad_receipt_hash).unwrap());
 
@@ -4848,7 +4848,7 @@ async fn test_bad_receipt_chain() {
         .head_receipt_number(ferdie_best_hash, EVM_DOMAIN_ID)
         .unwrap();
     assert_eq!(head_domain_number - head_receipt_number, 9);
-    // The previou bundle will be rejected as there is a receipt gap
+    // The previous bundle will be rejected as there is a receipt gap
     match ferdie
         .submit_transaction(bundle_to_tx(stale_bundle))
         .await
@@ -4903,7 +4903,7 @@ async fn test_bad_receipt_chain() {
     let bob_best_number = bob.client.info().best_number;
     assert_eq!(alice_best_number, bob_best_number);
 
-    // Bad receipt should be pruned as singletone receipt submitting
+    // The bad receipt and its descendants should be pruned immediately
     for receipt_hash in vec![bad_receipt_hash]
         .into_iter()
         .chain(bad_receipt_descendants)
@@ -4914,7 +4914,7 @@ async fn test_bad_receipt_chain() {
         assert!(!ferdie.does_receipt_exist(receipt_hash).unwrap());
     }
 
-    // The receipt gap should be fill up
+    // The receipt gap should be filled up
     let ferdie_best_hash = ferdie.client.info().best_hash;
     let head_domain_number = ferdie
         .client

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1125,7 +1125,9 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::DomainAllowlistUpdates(domain_id) => {
                 Messenger::domain_allow_list_update_storage_key(domain_id)
             }
-            FraudProofStorageKeyRequest::BlockDigest => sp_domains::system_digest_final_key(),
+            FraudProofStorageKeyRequest::DomainRuntimeUpgrades => {
+                pallet_domains::DomainRuntimeUpgrades::<Runtime>::hashed_key().to_vec()
+            }
             FraudProofStorageKeyRequest::RuntimeRegistry(runtime_id) => {
                 pallet_domains::RuntimeRegistry::<Runtime>::hashed_key_for(runtime_id)
             }

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -809,11 +809,11 @@ impl MockConsensusNode {
             .is_some())
     }
 
-    /// Return a future that only resolve if a fraud proof that the given `fraud_proof_predict`
+    /// Return a future that only resolve if a fraud proof that the given `fraud_proof_predicate`
     /// return true is submitted to the consensus tx pool
     pub fn wait_for_fraud_proof<FP>(
         &self,
-        fraud_proof_predict: FP,
+        fraud_proof_predicate: FP,
     ) -> Pin<Box<dyn Future<Output = ()> + Send>>
     where
         FP: Fn(&FraudProofFor<Block, DomainBlock>) -> bool + Send + 'static,
@@ -833,7 +833,7 @@ impl MockConsensusNode {
                     pallet_domains::Call::submit_fraud_proof { fraud_proof },
                 ) = ext.function
                 {
-                    if fraud_proof_predict(&fraud_proof) {
+                    if fraud_proof_predicate(&fraud_proof) {
                         break;
                     }
                 }


### PR DESCRIPTION
This PR replaces the block digest storage proof with the existing runtime upgrade records storage proof.

It also cleans up the fraud proof struct hierarchy, and fixes up some comments.

Breaking changes:
- moving structs and proofs around in the fraud proof data layout
- add/delete enum variants which are passed to runtime functions, which is a breaking runtime change.

Part of ticket #3281.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
