### PR TITLE
Allow 3 bytes of segment padding in object fetcher

### DIFF
--- a/crates/subspace-gateway/src/commands.rs
+++ b/crates/subspace-gateway/src/commands.rs
@@ -161,7 +161,7 @@ pub async fn initialize_object_fetcher(
         )),
     );
     let piece_getter = DsnPieceGetter::new(piece_provider);
-    let object_fetcher = ObjectFetcher::new(piece_getter.into(), erasure_coding, Some(max_size));
+    let object_fetcher = ObjectFetcher::new(piece_getter.into(), erasure_coding, max_size);
 
     Ok((object_fetcher, dsn_node_runner))
 }


### PR DESCRIPTION
The old code for the object fetcher assumed the maximum segment padding was 2 bytes, but it is actually 3 bytes. (Assuming objects are limited to < 1 GB.)

This PR fixes that bug, and returns an error for objects larger than 1 GB. Currently the maximum object size is 5 MB, because object size is limited by domain block size.

If we need to support larger objects, we can update the code to allow more padding easily.

Close #3324.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
