### PR TITLE
Show panic backtraces in rust workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   # Build smaller artifacts to avoid running out of space in CI and make it a bit faster
   RUSTFLAGS: -C strip=symbols
+  RUST_BACKTRACE: full
 
 jobs:
   cargo-fmt:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -12,7 +12,9 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: full
 
 jobs:
   rustdoc:


### PR DESCRIPTION
It's annoying to have a panic in CI, but no details about where it was.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
