### PR TITLE
Update gateway HTTP server object mapping format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12592,6 +12592,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
+ "hex",
  "parity-scale-codec",
  "subspace-archiving",
  "subspace-core-primitives",

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -55,11 +55,11 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::hashes::Blake3Hash;
-use subspace_core_primitives::objects::GlobalObjectMapping;
+use subspace_core_primitives::objects::{GlobalObjectMapping, ObjectMappingResponse};
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex};
 use subspace_core_primitives::solutions::Solution;
-use subspace_core_primitives::{BlockHash, BlockNumber, PublicKey, SlotNumber};
+use subspace_core_primitives::{BlockHash, PublicKey, SlotNumber};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_kzg::Kzg;
@@ -221,19 +221,6 @@ impl CachedArchivedSegment {
             CachedArchivedSegment::Weak(weak_archived_segment) => weak_archived_segment.upgrade(),
         }
     }
-}
-
-/// Response to object mapping subscription, including a block height.
-/// Large responses are batched, so the block height can be repeated in different responses.
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ObjectMappingResponse {
-    /// The block number that the object mapping is from.
-    pub block_number: BlockNumber,
-
-    /// The object mappings.
-    #[serde(flatten)]
-    pub objects: GlobalObjectMapping,
 }
 
 /// Subspace RPC configuration

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -24,6 +24,7 @@ extern crate alloc;
 
 use crate::hashes::Blake3Hash;
 use crate::pieces::PieceIndex;
+use crate::BlockNumber;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::default::Default;
@@ -171,4 +172,18 @@ impl GlobalObjectMapping {
             Self::V0 { objects, .. } => objects,
         }
     }
+}
+
+/// Response to object mapping subscription, including a block height.
+/// Large responses are batched, so the block height can be repeated in different responses.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ObjectMappingResponse {
+    /// The block number that the object mapping is from.
+    pub block_number: BlockNumber,
+
+    /// The object mappings.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub objects: GlobalObjectMapping,
 }

--- a/crates/subspace-gateway-rpc/src/lib.rs
+++ b/crates/subspace-gateway-rpc/src/lib.rs
@@ -132,13 +132,8 @@ where
             return Err(Error::TooManyMappings { count });
         }
 
-        let mut objects = Vec::with_capacity(count);
-        // TODO: fetch concurrently
-        for mapping in mappings.objects() {
-            let data = self.object_fetcher.fetch_object(*mapping).await?;
-
-            objects.push(data.into());
-        }
+        let objects = self.object_fetcher.fetch_objects(mappings).await?;
+        let objects = objects.into_iter().map(HexData::from).collect();
 
         Ok(objects)
     }

--- a/crates/subspace-gateway/src/main.rs
+++ b/crates/subspace-gateway/src/main.rs
@@ -1,5 +1,7 @@
 //! Subspace gateway implementation.
 
+#![feature(iterator_try_collect)]
+
 mod commands;
 mod node_client;
 mod piece_getter;

--- a/shared/subspace-data-retrieval/Cargo.toml
+++ b/shared/subspace-data-retrieval/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 anyhow = "1.0.89"
 async-trait = "0.1.83"
 futures = "0.3.31"
+hex = "0.4.3"
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }
 subspace-archiving = { version = "0.1.0", path = "../../crates/subspace-archiving" }
 subspace-core-primitives = { version = "0.1.0", path = "../../crates/subspace-core-primitives" }

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -30,8 +30,9 @@ use tracing::{debug, trace, warn};
 
 /// The maximum amount of segment padding.
 ///
-/// This is the difference between the compact encoding of lengths 1 to 63, and the compact
-/// encoding of lengths 2^14 to 2^30 - 1.
+/// This is the difference between the lengths of the compact encodings of the minimum and maximum
+/// block sizes, in any domain. As of January 2025, the minimum block size is (potentially) 63 or
+/// less, and the maximum block size is in the range 2^14 to 2^30 - 1.
 /// <https://docs.substrate.io/reference/scale-codec/#fn-1>
 pub const MAX_SEGMENT_PADDING: usize = 3;
 

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -206,7 +206,7 @@ where
 
         // Validate parameters
         if !piece_index.is_source() {
-            tracing::debug!(
+            debug!(
                 ?mapping,
                 "Invalid piece index for object: must be a source piece",
             );
@@ -216,7 +216,7 @@ where
         }
 
         if offset >= RawRecord::SIZE as u32 {
-            tracing::debug!(
+            debug!(
                 ?mapping,
                 RawRecord_SIZE = RawRecord::SIZE,
                 "Invalid piece offset for object: must be less than the size of a raw record",
@@ -245,13 +245,13 @@ where
 
         let data_hash = blake3_hash(&data);
         if data_hash != hash {
-            tracing::debug!(
+            debug!(
                 ?data_hash,
                 data_size = %data.len(),
                 ?mapping,
                 "Retrieved data doesn't match requested mapping hash"
             );
-            tracing::trace!(data = %hex::encode(&data), "Retrieved data");
+            trace!(data = %hex::encode(&data), "Retrieved data");
 
             return Err(Error::InvalidDataHash {
                 data_hash,
@@ -423,7 +423,7 @@ where
         let offset_in_segment =
             piece_position_in_segment as usize * RawRecord::SIZE + offset as usize;
 
-        tracing::trace!(
+        trace!(
             %segment_index,
             offset_in_segment,
             piece_position_in_segment,
@@ -466,7 +466,7 @@ where
                     }
                 })?;
 
-            tracing::trace!(
+            trace!(
                 progress,
                 %segment_index,
                 offset_in_segment,
@@ -510,7 +510,7 @@ where
             }
         };
 
-        tracing::trace!(
+        trace!(
             %segment_index,
             offset_in_segment,
             piece_position_in_segment,

--- a/shared/subspace-data-retrieval/src/piece_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/piece_fetcher.rs
@@ -28,7 +28,7 @@ use tracing::{debug, trace};
 // This code was copied and modified from subspace_service::sync_from_dsn::download_and_reconstruct_blocks():
 // <https://github.com/autonomys/subspace/blob/d71ca47e45e1b53cd2e472413caa23472a91cd74/crates/subspace-service/src/sync_from_dsn/import_blocks.rs#L236-L322>
 pub async fn download_pieces<PG>(
-    piece_indexes: Vec<PieceIndex>,
+    piece_indexes: &Vec<PieceIndex>,
     piece_getter: &PG,
 ) -> anyhow::Result<Vec<Piece>>
 where


### PR DESCRIPTION
This PR makes the gateway use the same object mapping format as the RPC server subscription. This is a breaking change.

The format is documented here (it's the same as the `result` inside the subscription wrapper):
https://github.com/autonomys/subspace/tree/main/crates/subspace-gateway-rpc#using-the-gateway-rpcs

As part of this change, the gateway:
- retrieves batches of mappings via RPC and HTTP. HTTP uses a `+` separator if there is more than one mapping. (Preparation for #3316.)
- does the hash checks during object retrieval. (Preparation for #3318.)
- simplifies the RPC and HTTP code. (Preparation for #3317.)

I also made the logging inside the object fetcher more consistent.

Close #3323.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
