### PR TITLE
Take reward of correct offending voter

### DIFF
--- a/crates/pallet-subspace/src/lib.rs
+++ b/crates/pallet-subspace/src/lib.rs
@@ -1678,7 +1678,7 @@ fn check_vote<T: Config>(
                     (reward_address, _signature),
                 ) in current_reward_receivers.iter_mut()
                 {
-                    if public_key != &offender {
+                    if public_key == &offender {
                         // Revoke reward if assigned in current block.
                         reward_address.take();
                     }


### PR DESCRIPTION
Typo from https://github.com/autonomys/subspace/pull/3072 that was not only reward of the equivocating voter, but every other voter too (except other rewards of the same voter if there were any in the same block).

Added regression test that fails before this PR and succeeds after.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
