### PR TITLE
Get some runtime API values from combined fraud proof storage

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -202,7 +202,7 @@ mod pallet {
     #[cfg(not(feature = "runtime-benchmarks"))]
     use crate::staking_epoch::do_slash_operator;
     use crate::staking_epoch::{do_finalize_domain_current_epoch, Error as StakingEpochError};
-    use crate::storage_proof::InvalidInherentExtrinsicData;
+    use crate::storage_proof::InherentExtrinsicData;
     use crate::weights::WeightInfo;
     #[cfg(not(feature = "runtime-benchmarks"))]
     use crate::DomainHashingFor;
@@ -1857,7 +1857,7 @@ mod pallet {
 
     /// Combined fraud proof data for the InvalidInherentExtrinsic fraud proof
     #[pallet::storage]
-    pub type BlockInvalidInherentExtrinsicData<T> = StorageValue<_, InvalidInherentExtrinsicData>;
+    pub type BlockInherentExtrinsicData<T> = StorageValue<_, InherentExtrinsicData>;
 
     #[pallet::hooks]
     // TODO: proper benchmark
@@ -1908,7 +1908,7 @@ mod pallet {
                 }
             }
 
-            BlockInvalidInherentExtrinsicData::<T>::kill();
+            BlockInherentExtrinsicData::<T>::kill();
 
             Weight::zero()
         }
@@ -1930,13 +1930,13 @@ mod pallet {
                 // The value returned by the consensus_chain_byte_fee() runtime API
                 let consensus_transaction_byte_fee = Self::consensus_transaction_byte_fee_value();
 
-                let invalid_inherent_extrinsic_data = InvalidInherentExtrinsicData {
+                let inherent_extrinsic_data = InherentExtrinsicData {
                     extrinsics_shuffling_seed,
                     timestamp,
                     consensus_transaction_byte_fee,
                 };
 
-                BlockInvalidInherentExtrinsicData::<T>::set(Some(invalid_inherent_extrinsic_data));
+                BlockInherentExtrinsicData::<T>::set(Some(inherent_extrinsic_data));
             }
 
             let _ = LastEpochStakingDistribution::<T>::clear(u32::MAX, None);
@@ -2764,16 +2764,16 @@ impl<T: Config> Pallet<T> {
     }
 
     /// The external function used to access the extrinsics shuffling seed stored in
-    /// `BlockInvalidInherentExtrinsicData`.
+    /// `BlockInherentExtrinsicData`.
     pub fn extrinsics_shuffling_seed() -> T::Hash {
         // Fall back to recalculating if it hasn't been stored yet.
-        BlockInvalidInherentExtrinsicData::<T>::get()
+        BlockInherentExtrinsicData::<T>::get()
             .map(|data| H256::from(*data.extrinsics_shuffling_seed).into())
             .unwrap_or_else(|| Self::extrinsics_shuffling_seed_value())
     }
 
     /// The internal function used to calculate the extrinsics shuffling seed for storage into
-    /// `BlockInvalidInherentExtrinsicData`.
+    /// `BlockInherentExtrinsicData`.
     fn extrinsics_shuffling_seed_value() -> T::Hash {
         let subject = DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT;
         let (randomness, _) = T::Randomness::random(subject);
@@ -2781,16 +2781,16 @@ impl<T: Config> Pallet<T> {
     }
 
     /// The external function used to access the timestamp stored in
-    /// `BlockInvalidInherentExtrinsicData`.
+    /// `BlockInherentExtrinsicData`.
     pub fn timestamp() -> Moment {
         // Fall back to recalculating if it hasn't been stored yet.
-        BlockInvalidInherentExtrinsicData::<T>::get()
+        BlockInherentExtrinsicData::<T>::get()
             .map(|data| data.timestamp)
             .unwrap_or_else(|| Self::timestamp_value())
     }
 
     /// The internal function used to access the timestamp for storage into
-    /// `BlockInvalidInherentExtrinsicData`.
+    /// `BlockInherentExtrinsicData`.
     fn timestamp_value() -> Moment {
         // There are no actual conversions here, but the trait bounds required to prove that
         // (and debug-print the error in expect()) are very verbose.
@@ -2801,17 +2801,17 @@ impl<T: Config> Pallet<T> {
     }
 
     /// The external function used to access the consensus transaction byte fee stored in
-    /// `BlockInvalidInherentExtrinsicData`.
+    /// `BlockInherentExtrinsicData`.
     /// This value is returned by the consensus_chain_byte_fee() runtime API
     pub fn consensus_transaction_byte_fee() -> Balance {
         // Fall back to recalculating if it hasn't been stored yet.
-        BlockInvalidInherentExtrinsicData::<T>::get()
+        BlockInherentExtrinsicData::<T>::get()
             .map(|data| data.consensus_transaction_byte_fee)
             .unwrap_or_else(|| Self::consensus_transaction_byte_fee_value())
     }
 
     /// The internal function used to calculate the consensus transaction byte fee for storage into
-    /// `BlockInvalidInherentExtrinsicData`.
+    /// `BlockInherentExtrinsicData`.
     fn consensus_transaction_byte_fee_value() -> Balance {
         // There are no actual conversions here, but the trait bounds required to prove that
         // (and debug-print the error in expect()) are very verbose.

--- a/crates/sp-domains-fraud-proof/src/storage_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/storage_proof.rs
@@ -369,7 +369,7 @@ impl MaybeDomainRuntimeUpgradedProof {
 }
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]
-pub struct InvalidInherentExtrinsicData {
+pub struct InherentExtrinsicData {
     /// Extrinsics shuffling seed, derived from block randomness
     pub extrinsics_shuffling_seed: Randomness,
 
@@ -380,7 +380,7 @@ pub struct InvalidInherentExtrinsicData {
     pub consensus_transaction_byte_fee: Balance,
 }
 
-impl PassBy for InvalidInherentExtrinsicData {
+impl PassBy for InherentExtrinsicData {
     type PassBy = pass_by::Codec<Self>;
 }
 
@@ -389,7 +389,7 @@ pub struct InvalidInherentExtrinsicDataProof(StorageProof);
 
 impl_storage_proof!(InvalidInherentExtrinsicDataProof);
 impl<Block: BlockT> BasicStorageProof<Block> for InvalidInherentExtrinsicDataProof {
-    type StorageValue = InvalidInherentExtrinsicData;
+    type StorageValue = InherentExtrinsicData;
     fn storage_key_request(_key: Self::Key) -> FraudProofStorageKeyRequest<NumberFor<Block>> {
         FraudProofStorageKeyRequest::InvalidInherentExtrinsicData
     }

--- a/crates/sp-domains/src/extrinsics.rs
+++ b/crates/sp-domains/src/extrinsics.rs
@@ -1,11 +1,9 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use domain_runtime_primitives::opaque::AccountId;
-use hash_db::Hasher;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -14,15 +12,6 @@ use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::vec_deque::VecDeque;
 use sp_std::fmt::Debug;
 use subspace_core_primitives::Randomness;
-
-pub fn extrinsics_shuffling_seed<Hashing>(block_randomness: Randomness) -> Hashing::Out
-where
-    Hashing: Hasher,
-{
-    let mut subject = DOMAIN_EXTRINSICS_SHUFFLING_SEED_SUBJECT.to_vec();
-    subject.extend_from_slice(block_randomness.as_ref());
-    Hashing::hash(&subject)
-}
 
 pub fn deduplicate_and_shuffle_extrinsics<Extrinsic>(
     mut extrinsics: Vec<(Option<AccountId>, Extrinsic)>,

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1470,8 +1470,9 @@ pub enum OperatorRewardSource<Number> {
 sp_api::decl_runtime_apis! {
     /// APIs used to access the domains pallet.
     // When updating this version, document new APIs with "Only present in API versions" comments.
-    // TODO: when removing this version, also remove "Only present in API versions" comments.
-    #[api_version(2)]
+    // TODO: when removing this version, also remove "Only present in API versions" comments and
+    // deprecated attributes.
+    #[api_version(3)]
     pub trait DomainsApi<DomainHeader: HeaderT> {
         /// Submits the transaction bundle via an unsigned extrinsic.
         fn submit_bundle_unsigned(opaque_bundle: OpaqueBundle<NumberFor<Block>, Block::Hash, DomainHeader, Balance>);
@@ -1502,7 +1503,22 @@ sp_api::decl_runtime_apis! {
         fn domain_instance_data(domain_id: DomainId) -> Option<(DomainInstanceData, NumberFor<Block>)>;
 
         /// Returns the current timestamp at the current height.
+        fn domain_timestamp() -> Moment;
+
+        /// Returns the current timestamp at the current height.
+        #[allow(clippy::deprecated_semver)]
+        #[deprecated(since = "3", note = "Use `domain_timestamp()` instead")]
         fn timestamp() -> Moment;
+
+        /// Returns the consensus transaction byte fee that will used to charge the domain
+        /// transaction for consensus chain storage fees.
+        fn consensus_transaction_byte_fee() -> Balance;
+
+        /// Returns the consensus chain byte fee that will used to charge the domain transaction
+        /// for consensus chain storage fees.
+        #[allow(clippy::deprecated_semver)]
+        #[deprecated(since = "3", note = "Use `consensus_transaction_byte_fee()` instead")]
+        fn consensus_chain_byte_fee() -> Balance;
 
         /// Returns the current Tx range for the given domain Id.
         fn domain_tx_range(domain_id: DomainId) -> U256;
@@ -1533,10 +1549,6 @@ sp_api::decl_runtime_apis! {
 
         /// Returns the execution receipt hash of the given domain and domain block number.
         fn receipt_hash(domain_id: DomainId, domain_number: HeaderNumberFor<DomainHeader>) -> Option<HeaderHashFor<DomainHeader>>;
-
-        /// Returns the consensus chain byte fee that will used to charge the domain transaction for consensus
-        /// chain storage fees.
-        fn consensus_chain_byte_fee() -> Balance;
 
         /// Returns the latest confirmed domain block number and hash.
         fn latest_confirmed_domain_block(domain_id: DomainId) -> Option<(HeaderNumberFor<DomainHeader>, HeaderHashFor<DomainHeader>)>;

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -218,7 +218,19 @@ sp_api::impl_runtime_apis! {
             unreachable!()
         }
 
-        fn timestamp() -> Moment{
+        fn domain_timestamp() -> Moment {
+            unreachable!()
+        }
+
+        fn timestamp() -> Moment {
+            unreachable!()
+        }
+
+        fn consensus_transaction_byte_fee() -> Balance {
+            unreachable!()
+        }
+
+        fn consensus_chain_byte_fee() -> Balance {
             unreachable!()
         }
 
@@ -259,10 +271,6 @@ sp_api::impl_runtime_apis! {
         }
 
         fn receipt_hash(_domain_id: DomainId, _domain_number: DomainNumber) -> Option<DomainHash> {
-            unreachable!()
-        }
-
-        fn consensus_chain_byte_fee() -> Balance {
             unreachable!()
         }
 

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1038,7 +1038,7 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
     fn storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8> {
         match req {
             FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
-                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
+                pallet_domains::BlockInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
             }
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1278,8 +1278,20 @@ impl_runtime_apis! {
             Domains::domain_instance_data(domain_id)
         }
 
-        fn timestamp() -> Moment{
+        fn domain_timestamp() -> Moment {
+            Domains::timestamp()
+        }
+
+        fn timestamp() -> Moment {
             Timestamp::now()
+        }
+
+        fn consensus_transaction_byte_fee() -> Balance {
+            Domains::consensus_transaction_byte_fee()
+        }
+
+        fn consensus_chain_byte_fee() -> Balance {
+            DOMAIN_STORAGE_FEE_MULTIPLIER * TransactionFees::transaction_byte_fee()
         }
 
         fn domain_tx_range(domain_id: DomainId) -> U256 {
@@ -1323,10 +1335,6 @@ impl_runtime_apis! {
 
         fn receipt_hash(domain_id: DomainId, domain_number: DomainNumber) -> Option<DomainHash> {
             Domains::receipt_hash(domain_id, domain_number)
-        }
-
-        fn consensus_chain_byte_fee() -> Balance {
-            DOMAIN_STORAGE_FEE_MULTIPLIER * TransactionFees::transaction_byte_fee()
         }
 
         fn latest_confirmed_domain_block(domain_id: DomainId) -> Option<(DomainNumber, DomainHash)>{

--- a/domains/client/domain-operator/src/domain_bundle_proposer.rs
+++ b/domains/client/domain-operator/src/domain_bundle_proposer.rs
@@ -154,6 +154,13 @@ where
 
         let (domain_bundle_limit, storage_fund_balance, transaction_byte_fee) = {
             let consensus_runtime_api = self.consensus_client.runtime_api();
+            // Some APIs are only present in API versions 3 and later. On earlier versions, we need to
+            // call legacy code.
+            // TODO: remove version check before next network
+            let domains_api_version = consensus_runtime_api
+                .api_version::<dyn DomainsApi<CBlock, CBlock::Header>>(consensus_best_hash)?
+                // It is safe to return a default version of 1, since there will always be version 1.
+                .unwrap_or(1);
 
             let domain_bundle_limit = consensus_runtime_api
                 .domain_bundle_limit(consensus_best_hash, self.domain_id)?
@@ -166,8 +173,12 @@ where
             let storage_fund_balance = consensus_runtime_api
                 .storage_fund_account_balance(consensus_best_hash, operator_id)?;
 
-            let transaction_byte_fee =
-                consensus_runtime_api.consensus_chain_byte_fee(consensus_best_hash)?;
+            let transaction_byte_fee = if domains_api_version >= 3 {
+                consensus_runtime_api.consensus_transaction_byte_fee(consensus_best_hash)?
+            } else {
+                #[allow(deprecated)]
+                consensus_runtime_api.consensus_chain_byte_fee(consensus_best_hash)?
+            };
 
             (
                 domain_bundle_limit,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -792,13 +792,13 @@ async fn test_executor_inherent_timestamp_is_set() {
     let consensus_timestamp = ferdie
         .client
         .runtime_api()
-        .timestamp(ferdie.client.info().best_hash)
+        .domain_timestamp(ferdie.client.info().best_hash)
         .unwrap();
 
     let domain_timestamp = bob
         .client
         .runtime_api()
-        .timestamp(bob.client.info().best_hash)
+        .domain_timestamp(bob.client.info().best_hash)
         .unwrap();
 
     assert_eq!(
@@ -4965,12 +4965,12 @@ async fn test_domain_chain_storage_price_should_be_aligned_with_the_consensus_ch
     let consensus_chain_byte_fee = ferdie
         .client
         .runtime_api()
-        .consensus_chain_byte_fee(ferdie.client.info().best_hash)
+        .consensus_transaction_byte_fee(ferdie.client.info().best_hash)
         .unwrap();
     let operator_consensus_chain_byte_fee = alice
         .client
         .runtime_api()
-        .consensus_chain_byte_fee(alice.client.info().best_hash)
+        .consensus_transaction_byte_fee(alice.client.info().best_hash)
         .unwrap();
     assert!(operator_consensus_chain_byte_fee.is_zero());
     assert!(!consensus_chain_byte_fee.is_zero());
@@ -4982,12 +4982,12 @@ async fn test_domain_chain_storage_price_should_be_aligned_with_the_consensus_ch
     let consensus_chain_byte_fee = ferdie
         .client
         .runtime_api()
-        .consensus_chain_byte_fee(ferdie.client.info().best_hash)
+        .consensus_transaction_byte_fee(ferdie.client.info().best_hash)
         .unwrap();
     let operator_consensus_chain_byte_fee = alice
         .client
         .runtime_api()
-        .consensus_chain_byte_fee(alice.client.info().best_hash)
+        .consensus_transaction_byte_fee(alice.client.info().best_hash)
         .unwrap();
     assert_eq!(consensus_chain_byte_fee, operator_consensus_chain_byte_fee);
 }

--- a/domains/test/primitives/src/lib.rs
+++ b/domains/test/primitives/src/lib.rs
@@ -9,7 +9,7 @@ sp_api::decl_runtime_apis! {
     /// Api that returns the timestamp
     pub trait TimestampApi {
         /// Api to construct inherent timestamp extrinsic from given time
-        fn timestamp() -> Moment;
+        fn domain_timestamp() -> Moment;
     }
 }
 
@@ -27,6 +27,6 @@ sp_api::decl_runtime_apis! {
         fn get_open_channel_for_chain(dst_chain_id: ChainId) -> Option<ChannelId>;
 
         /// Api to get the current domain transaction byte fee
-        fn consensus_chain_byte_fee() -> Balance;
+        fn consensus_transaction_byte_fee() -> Balance;
     }
 }

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -982,7 +982,7 @@ impl_runtime_apis! {
             Messenger::get_open_channel_for_chain(dst_chain_id).map(|(c, _)| c)
         }
 
-        fn consensus_chain_byte_fee() -> Balance {
+        fn consensus_transaction_byte_fee() -> Balance {
             BlockFees::consensus_chain_byte_fee()
         }
     }

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -1506,7 +1506,7 @@ impl_runtime_apis! {
     }
 
     impl domain_test_primitives::TimestampApi<Block> for Runtime {
-        fn timestamp() -> Moment {
+        fn domain_timestamp() -> Moment {
              Timestamp::now()
         }
     }
@@ -1520,7 +1520,7 @@ impl_runtime_apis! {
             Messenger::get_open_channel_for_chain(dst_chain_id).map(|(c, _)| c)
         }
 
-        fn consensus_chain_byte_fee() -> Balance {
+        fn consensus_transaction_byte_fee() -> Balance {
             BlockFees::consensus_chain_byte_fee()
         }
     }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1326,8 +1326,20 @@ impl_runtime_apis! {
             Domains::domain_instance_data(domain_id)
         }
 
-        fn timestamp() -> Moment{
+        fn domain_timestamp() -> Moment {
+            Domains::timestamp()
+        }
+
+        fn timestamp() -> Moment {
             Timestamp::now()
+        }
+
+        fn consensus_transaction_byte_fee() -> Balance {
+            Domains::consensus_transaction_byte_fee()
+        }
+
+        fn consensus_chain_byte_fee() -> Balance {
+            DOMAIN_STORAGE_FEE_MULTIPLIER * TransactionFees::transaction_byte_fee()
         }
 
         fn domain_tx_range(_: DomainId) -> U256 {
@@ -1371,10 +1383,6 @@ impl_runtime_apis! {
 
         fn receipt_hash(domain_id: DomainId, domain_number: DomainNumber) -> Option<DomainHash> {
             Domains::receipt_hash(domain_id, domain_number)
-        }
-
-        fn consensus_chain_byte_fee() -> Balance {
-            DOMAIN_STORAGE_FEE_MULTIPLIER * TransactionFees::transaction_byte_fee()
         }
 
         fn latest_confirmed_domain_block(domain_id: DomainId) -> Option<(DomainNumber, DomainHash)>{

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1109,7 +1109,7 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
     fn storage_key(req: FraudProofStorageKeyRequest<NumberFor<Block>>) -> Vec<u8> {
         match req {
             FraudProofStorageKeyRequest::InvalidInherentExtrinsicData => {
-                pallet_domains::BlockInvalidInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
+                pallet_domains::BlockInherentExtrinsicData::<Runtime>::hashed_key().to_vec()
             }
             FraudProofStorageKeyRequest::SuccessfulBundles(domain_id) => {
                 pallet_domains::SuccessfulBundles::<Runtime>::hashed_key_for(domain_id)


### PR DESCRIPTION
This PR adds new runtime APIs to get the timestamp and byte fees from the combined fraud proof storage, so they are always consistent. The old APIs are marked as deprecated, which will cause a compiler warning if they are accidentally used.

I also changed the existing runtime API to get the extrinsics shuffling seed from the combined storage. This doesn't need a new runtime API, because a pallet method to get that value already exists (so we can just change its implementation inside the runtime).

I also removed some related unused code, and updated the tests to use the new APIs method names. (The tests don't use the domains pallet, so they can't use the new implementations.)

Close #3281.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
