### PR TITLE
Simplify docs CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,32 +155,6 @@ jobs:
           cargo -Zgitoxide -Zgit clippy --locked --all-targets --features rocm -- -D warnings
         if: runner.os == 'Windows'
 
-  cargo-docs:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || '"ubuntu-22.04"') }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Check Documentation
-        run: cargo -Zgitoxide -Zgit doc --locked --all --no-deps --lib
-        env:
-          RUSTDOCFLAGS: "-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links"
-
   cargo-test:
     strategy:
       matrix:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
+  merge_group:
 
 concurrency:
   group: rustdoc-${{ github.workflow }}-${{ github.ref }}
@@ -48,9 +51,9 @@ jobs:
 
       # Build the rust crate docs
       - name: Build Documentation
-        run: cargo -Zgitoxide -Zgit doc --all --no-deps --lib --features cuda
+        run: cargo -Zgitoxide -Zgit doc --locked --all --no-deps --lib --features cuda
         env:
-          RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
+          RUSTDOCFLAGS: "-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links -Z unstable-options --enable-index-page"
 
       - name: Deploy Docs
         uses: JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29 # v4.6.8
@@ -58,3 +61,4 @@ jobs:
           branch: gh-pages
           single-commit: true
           folder: target/doc
+        if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
`cargo-docs` was mostly, but not exactly, duplicate of `rustdoc`.

This makes use of `rustdoc` by default, just skips deployment unless pushed into `main`, while `cargo-docs` is removed as no longer necessary.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
