### PR TITLE
Fix cluster piece getter

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -205,7 +205,7 @@ pub(super) async fn controller(
             );
 
             let fut = farmer_cache_worker
-                .run(piece_getter.downgrade())
+                .run(piece_getter)
                 .instrument(info_span!("", %cache_group));
 
             async move {

--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -487,6 +487,9 @@ where
 
     let farmer_cache_worker_fut = run_future_in_dedicated_thread(
         {
+            // Piece cache worker uses piece getter, while piece getter uses piece cache, which
+            // piece cache worker depends on. Use weak reference to break the cycle and allow worker
+            // to exit when last piece cache instance is dropped.
             let future = farmer_cache_worker.run(piece_getter.downgrade());
 
             move || future


### PR DESCRIPTION
Weak reference was created and original was dropped immediately :sob: 

This effectively broke piece getter for piece cache sync purposes.

Since in cluster setup cluster cache worker only depends on other workers' caches, but not on its own (since https://github.com/autonomys/subspace/pull/3290, which introduced this regression), we do not need a weak reference here (also added useful comment in another place where it is in fact needed).

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
