### PR TITLE
opt: improve farms maintenance performance via parallelization

### DIFF
--- a/crates/subspace-farmer/src/cluster/controller/farms.rs
+++ b/crates/subspace-farmer/src/cluster/controller/farms.rs
@@ -44,7 +44,6 @@ type AddRemoveStream<'a, R> = Pin<Box<dyn Stream<Item = R> + Unpin + 'a>>;
 struct FarmsAddRemoveStreamMap<'a, R> {
     in_progress: StreamMap<FarmIndex, AddRemoveStream<'a, R>>,
     farms_to_add_remove: HashMap<FarmIndex, VecDeque<AddRemoveFuture<'a, R>>>,
-    is_terminated: bool,
 }
 
 impl<R> Default for FarmsAddRemoveStreamMap<'_, R> {
@@ -52,7 +51,6 @@ impl<R> Default for FarmsAddRemoveStreamMap<'_, R> {
         Self {
             in_progress: StreamMap::default(),
             farms_to_add_remove: HashMap::default(),
-            is_terminated: true,
         }
     }
 }
@@ -62,9 +60,6 @@ impl<'a, R: 'a> FarmsAddRemoveStreamMap<'a, R> {
     ///   - If there is, the task is added to `farms_to_add_remove`.
     ///   - If not, the task is directly added to `in_progress`.
     fn push(&mut self, farm_index: FarmIndex, fut: AddRemoveFuture<'a, R>) {
-        // Reset termination flag since there are new task to execute
-        self.is_terminated = false;
-
         if self.in_progress.contains_key(&farm_index) {
             let queue = self.farms_to_add_remove.entry(farm_index).or_default();
             queue.push_back(fut);
@@ -78,45 +73,30 @@ impl<'a, R: 'a> FarmsAddRemoveStreamMap<'a, R> {
     /// If there are no more tasks to execute, returns `None`.
     fn poll_next_entry(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
         if let Some((farm_index, res)) = std::task::ready!(self.in_progress.poll_next_unpin(cx)) {
-            // Current task completed, remove from in_progress queue, check if there are more tasks to execute
+            // Current task completed, remove from in_progress queue and check for more tasks
             self.in_progress.remove(&farm_index);
-            if self.farms_to_add_remove.is_empty() && self.in_progress.is_empty() {
-                // No more tasks to execute
-                self.is_terminated = true;
-                return Poll::Ready(Some(res));
-            }
+            self.process_farm_queue(farm_index);
+            Poll::Ready(Some(res))
+        } else {
+            // No more tasks to execute
+            assert!(self.farms_to_add_remove.is_empty());
+            Poll::Ready(None)
+        }
+    }
 
-            let Some(mut next_entry) = self.farms_to_add_remove.remove(&farm_index) else {
-                // Current index no more tasks to execute
-                return Poll::Ready(Some(res));
-            };
-            if let Some(fut) = next_entry.pop_front() {
+    /// Process the next task from the farm queue for the given `farm_index`
+    fn process_farm_queue(&mut self, farm_index: FarmIndex) {
+        if let Entry::Occupied(mut next_entry) = self.farms_to_add_remove.entry(farm_index) {
+            let task_queue = next_entry.get_mut();
+            if let Some(fut) = task_queue.pop_front() {
                 self.in_progress
                     .insert(farm_index, Box::pin(fut.into_stream()) as _);
             }
 
-            // Re-insert back into farms_to_add_remove if there are more tasks to execute
-            if !next_entry.is_empty() {
-                self.farms_to_add_remove.insert(farm_index, next_entry);
+            // Remove the farm index from the map if there are no more tasks
+            if task_queue.is_empty() {
+                next_entry.remove();
             }
-
-            Poll::Ready(Some(res))
-        } else {
-            // All tasks completed
-            if self.farms_to_add_remove.is_empty() {
-                // No more tasks to execute
-                self.is_terminated = true;
-                return Poll::Ready(None);
-            }
-
-            // Push tasks into in_progress queue
-            for (farm_index, futs) in self.farms_to_add_remove.iter_mut() {
-                if let Some(fut) = futs.pop_front() {
-                    self.in_progress
-                        .insert(*farm_index, Box::pin(fut.into_stream()) as _);
-                }
-            }
-            Poll::Pending
         }
     }
 }
@@ -132,7 +112,7 @@ impl<'a, R: 'a> Stream for FarmsAddRemoveStreamMap<'a, R> {
 
 impl<'a, R: 'a> FusedStream for FarmsAddRemoveStreamMap<'a, R> {
     fn is_terminated(&self) -> bool {
-        self.is_terminated
+        self.in_progress.is_empty() && self.farms_to_add_remove.is_empty()
     }
 }
 

--- a/crates/subspace-farmer/src/cluster/controller/farms/tests.rs
+++ b/crates/subspace-farmer/src/cluster/controller/farms/tests.rs
@@ -1,0 +1,138 @@
+use crate::cluster::controller::farms::FarmsAddRemoveStreamMap;
+use futures::StreamExt;
+use std::task::Context;
+use std::time::Duration;
+use tokio::time::{sleep, timeout};
+
+fn assert_is_terminated<'a, R: 'a>(stream_map: &FarmsAddRemoveStreamMap<'a, R>) {
+    assert!(stream_map.in_progress.is_empty());
+    assert!(stream_map.farms_to_add_remove.is_empty());
+    assert!(stream_map.is_terminated);
+}
+
+#[test]
+fn test_stream_map_default() {
+    let stream_map = FarmsAddRemoveStreamMap::<()>::default();
+    assert_is_terminated(&stream_map);
+}
+
+#[test]
+fn test_stream_map_push() {
+    let mut stream_map = FarmsAddRemoveStreamMap::default();
+
+    let farm_index = 1;
+    let fut = Box::pin(async { () });
+    stream_map.push(farm_index, fut);
+    assert!(stream_map.farms_to_add_remove.is_empty());
+    assert!(stream_map.in_progress.contains_key(&farm_index));
+    assert!(!stream_map.is_terminated);
+}
+
+#[test]
+fn test_stream_map_poll_next_entry() {
+    let mut stream_map = FarmsAddRemoveStreamMap::default();
+
+    let fut = Box::pin(async { () });
+    stream_map.push(0, fut);
+
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+    let poll_result = stream_map.poll_next_entry(&mut cx);
+    assert!(poll_result.is_ready());
+    assert_is_terminated(&stream_map);
+}
+
+#[tokio::test]
+async fn test_stream_map_stream() {
+    let mut stream_map = FarmsAddRemoveStreamMap::default();
+
+    let fut00 = Box::pin(async {
+        sleep(Duration::from_millis(1)).await;
+        0x00
+    });
+    stream_map.push(0, fut00);
+
+    let next_item = timeout(Duration::from_millis(3), stream_map.next()).await;
+    assert_eq!(next_item.unwrap(), Some(0x00));
+    assert_is_terminated(&stream_map);
+
+    let fut11 = Box::pin(async {
+        sleep(Duration::from_millis(1)).await;
+        0x11
+    });
+    let fut12 = Box::pin(async {
+        sleep(Duration::from_millis(1)).await;
+        0x12
+    });
+    let fut13 = Box::pin(async {
+        sleep(Duration::from_millis(1)).await;
+        0x13
+    });
+    let fut21 = Box::pin(async {
+        sleep(Duration::from_millis(10)).await;
+        0x21
+    });
+    let fut22 = Box::pin(async {
+        sleep(Duration::from_millis(1)).await;
+        0x22
+    });
+    stream_map.push(1, fut11);
+    stream_map.push(1, fut12);
+    assert!(!stream_map.is_terminated);
+    assert_eq!(stream_map.in_progress.len(), 1);
+    assert!(stream_map.in_progress.contains_key(&1));
+    assert_eq!(stream_map.farms_to_add_remove.len(), 1);
+
+    stream_map.push(2, fut21);
+    assert_eq!(stream_map.in_progress.len(), 2);
+    assert!(stream_map.in_progress.contains_key(&2));
+    assert_eq!(stream_map.farms_to_add_remove.len(), 1);
+
+    stream_map.push(2, fut22);
+    assert_eq!(stream_map.in_progress.len(), 2);
+    assert_eq!(stream_map.farms_to_add_remove.len(), 2);
+    assert_eq!(stream_map.farms_to_add_remove[&2].len(), 1);
+
+    stream_map.push(1, fut13);
+    assert!(!stream_map.is_terminated);
+    assert!(stream_map.in_progress.contains_key(&1));
+    assert_eq!(stream_map.in_progress.len(), 2);
+    assert_eq!(stream_map.farms_to_add_remove[&1].len(), 2);
+
+    let next_item = stream_map.next().await;
+    assert!(!stream_map.is_terminated);
+    assert_eq!(next_item.unwrap(), 0x11);
+    assert!(stream_map.in_progress.contains_key(&1));
+    assert!(stream_map.in_progress.contains_key(&2));
+    assert_eq!(stream_map.in_progress.len(), 2);
+    assert_eq!(stream_map.farms_to_add_remove[&1].len(), 1);
+
+    let next_item = stream_map.next().await;
+    assert!(!stream_map.is_terminated);
+    assert_eq!(next_item.unwrap(), 0x12);
+    assert_eq!(stream_map.in_progress.len(), 2);
+    assert!(stream_map.in_progress.contains_key(&1));
+    assert!(stream_map.in_progress.contains_key(&2));
+    assert!(stream_map.farms_to_add_remove.get(&1).is_none());
+
+    let next_item = stream_map.next().await;
+    assert!(!stream_map.is_terminated);
+    assert_eq!(next_item.unwrap(), 0x13);
+    assert_eq!(stream_map.in_progress.len(), 1);
+    assert!(!stream_map.in_progress.contains_key(&1));
+    assert!(stream_map.in_progress.contains_key(&2));
+    assert!(stream_map.farms_to_add_remove.get(&1).is_none());
+    assert_eq!(stream_map.farms_to_add_remove[&2].len(), 1);
+
+    let next_item = stream_map.next().await;
+    assert!(!stream_map.is_terminated);
+    assert_eq!(next_item.unwrap(), 0x21);
+    assert_eq!(stream_map.in_progress.len(), 1);
+    assert!(!stream_map.in_progress.contains_key(&1));
+    assert!(stream_map.in_progress.contains_key(&2));
+    assert!(stream_map.farms_to_add_remove.get(&1).is_none());
+    assert!(stream_map.farms_to_add_remove.get(&2).is_none());
+
+    let next_item = timeout(Duration::from_millis(3), stream_map.next()).await;
+    assert_eq!(next_item.unwrap(), Some(0x22));
+    assert_is_terminated(&stream_map);
+}

--- a/crates/subspace-farmer/src/cluster/controller/farms/tests.rs
+++ b/crates/subspace-farmer/src/cluster/controller/farms/tests.rs
@@ -22,7 +22,7 @@ fn test_stream_map_push() {
     let mut stream_map = FarmsAddRemoveStreamMap::default();
 
     let farm_index = 1;
-    let fut = Box::pin(async { () });
+    let fut = Box::pin(async {});
     stream_map.push(farm_index, fut);
     assert!(stream_map.farms_to_add_remove.is_empty());
     assert!(stream_map.in_progress.contains_key(&farm_index));
@@ -33,7 +33,7 @@ fn test_stream_map_push() {
 fn test_stream_map_poll_next_entry() {
     let mut stream_map = FarmsAddRemoveStreamMap::default();
 
-    let fut = Box::pin(async { () });
+    let fut = Box::pin(async {});
     stream_map.push(0, fut);
 
     let mut cx = Context::from_waker(futures::task::noop_waker_ref());
@@ -129,7 +129,7 @@ async fn test_stream_map_stream() {
     assert_eq!(stream_map.in_progress.len(), 2);
     assert!(stream_map.in_progress.contains_key(&1));
     assert!(stream_map.in_progress.contains_key(&2));
-    assert!(stream_map.farms_to_add_remove.get(&1).is_none());
+    assert!(!stream_map.farms_to_add_remove.contains_key(&1));
 
     // Poll the next item in the stream, fut13 should be polled next.
     // For now, all futures in farm index 1 have been polled, so farm index 1 should be removed
@@ -140,7 +140,7 @@ async fn test_stream_map_stream() {
     assert_eq!(stream_map.in_progress.len(), 1);
     assert!(!stream_map.in_progress.contains_key(&1));
     assert!(stream_map.in_progress.contains_key(&2));
-    assert!(stream_map.farms_to_add_remove.get(&1).is_none());
+    assert!(!stream_map.farms_to_add_remove.contains_key(&1));
     assert_eq!(stream_map.farms_to_add_remove[&2].len(), 1);
 
     // We hope futures with the same index are polled in the order they are pushed,
@@ -154,8 +154,8 @@ async fn test_stream_map_stream() {
     assert_eq!(stream_map.in_progress.len(), 1);
     assert!(!stream_map.in_progress.contains_key(&1));
     assert!(stream_map.in_progress.contains_key(&2));
-    assert!(stream_map.farms_to_add_remove.get(&1).is_none());
-    assert!(stream_map.farms_to_add_remove.get(&2).is_none());
+    assert!(!stream_map.farms_to_add_remove.contains_key(&1));
+    assert!(!stream_map.farms_to_add_remove.contains_key(&2));
 
     // Poll the next item in the stream, fut22 should be polled next.
     // For now, all futures in farm index 2 have been polled, so farm index 2 should be removed

--- a/crates/subspace-farmer/src/cluster/controller/farms/tests.rs
+++ b/crates/subspace-farmer/src/cluster/controller/farms/tests.rs
@@ -1,4 +1,5 @@
 use crate::cluster::controller::farms::FarmsAddRemoveStreamMap;
+use futures::stream::FusedStream;
 use futures::StreamExt;
 use std::task::Context;
 use std::time::Duration;
@@ -7,7 +8,7 @@ use tokio::time::{sleep, timeout};
 fn assert_is_terminated<'a, R: 'a>(stream_map: &FarmsAddRemoveStreamMap<'a, R>) {
     assert!(stream_map.in_progress.is_empty());
     assert!(stream_map.farms_to_add_remove.is_empty());
-    assert!(stream_map.is_terminated);
+    assert!(stream_map.is_terminated());
 }
 
 #[test]
@@ -25,7 +26,7 @@ fn test_stream_map_push() {
     stream_map.push(farm_index, fut);
     assert!(stream_map.farms_to_add_remove.is_empty());
     assert!(stream_map.in_progress.contains_key(&farm_index));
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
 }
 
 #[test]
@@ -45,16 +46,19 @@ fn test_stream_map_poll_next_entry() {
 async fn test_stream_map_stream() {
     let mut stream_map = FarmsAddRemoveStreamMap::default();
 
+    // Push a future that sleeps for 1 millisecond and returns 0x00
     let fut00 = Box::pin(async {
         sleep(Duration::from_millis(1)).await;
         0x00
     });
     stream_map.push(0, fut00);
 
+    // Wait for the next item in the stream with a timeout of 3 milliseconds
     let next_item = timeout(Duration::from_millis(3), stream_map.next()).await;
     assert_eq!(next_item.unwrap(), Some(0x00));
     assert_is_terminated(&stream_map);
 
+    // Push multiple futures with different sleep durations and return values
     let fut11 = Box::pin(async {
         sleep(Duration::from_millis(1)).await;
         0x11
@@ -75,47 +79,63 @@ async fn test_stream_map_stream() {
         sleep(Duration::from_millis(1)).await;
         0x22
     });
+
+    // Push 2 futs into the same farm index 1, expect fut11 to be polled first,
+    // fut12 should push into the in_progress queue and wait for fut11 to finish
     stream_map.push(1, fut11);
     stream_map.push(1, fut12);
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
     assert_eq!(stream_map.in_progress.len(), 1);
     assert!(stream_map.in_progress.contains_key(&1));
     assert_eq!(stream_map.farms_to_add_remove.len(), 1);
 
+    // Push fut22 into farm index 2, we have 2 in progress futures now
     stream_map.push(2, fut21);
     assert_eq!(stream_map.in_progress.len(), 2);
     assert!(stream_map.in_progress.contains_key(&2));
     assert_eq!(stream_map.farms_to_add_remove.len(), 1);
 
+    // Push fut22 into farm index 2, in-progress queue length should not change,
+    // but the farms_to_add_remove should have 2 entries now
     stream_map.push(2, fut22);
     assert_eq!(stream_map.in_progress.len(), 2);
     assert_eq!(stream_map.farms_to_add_remove.len(), 2);
     assert_eq!(stream_map.farms_to_add_remove[&2].len(), 1);
 
+    // Push fut13 into farm index 1, fut13 should be polled after fut11 and fut12
     stream_map.push(1, fut13);
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
     assert!(stream_map.in_progress.contains_key(&1));
     assert_eq!(stream_map.in_progress.len(), 2);
     assert_eq!(stream_map.farms_to_add_remove[&1].len(), 2);
 
+    // Poll the next item in the stream, fut11 should be polled first,
+    // fut12 should be pushed into the in-progress queue
     let next_item = stream_map.next().await;
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
     assert_eq!(next_item.unwrap(), 0x11);
     assert!(stream_map.in_progress.contains_key(&1));
     assert!(stream_map.in_progress.contains_key(&2));
     assert_eq!(stream_map.in_progress.len(), 2);
     assert_eq!(stream_map.farms_to_add_remove[&1].len(), 1);
 
+    // Here, fut12 and fut 13 should be polled before fut21 because fut21 has a longer sleep duration
+    // fut13 should be pushed into the in_progress queue.
+    // There are no more futures waiting to be polled in farm index 1, so the farm index 1
+    // should be removed from the farms_to_add_remove map.
     let next_item = stream_map.next().await;
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
     assert_eq!(next_item.unwrap(), 0x12);
     assert_eq!(stream_map.in_progress.len(), 2);
     assert!(stream_map.in_progress.contains_key(&1));
     assert!(stream_map.in_progress.contains_key(&2));
     assert!(stream_map.farms_to_add_remove.get(&1).is_none());
 
+    // Poll the next item in the stream, fut13 should be polled next.
+    // For now, all futures in farm index 1 have been polled, so farm index 1 should be removed
+    // from the in-progress queue.
     let next_item = stream_map.next().await;
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
     assert_eq!(next_item.unwrap(), 0x13);
     assert_eq!(stream_map.in_progress.len(), 1);
     assert!(!stream_map.in_progress.contains_key(&1));
@@ -123,8 +143,13 @@ async fn test_stream_map_stream() {
     assert!(stream_map.farms_to_add_remove.get(&1).is_none());
     assert_eq!(stream_map.farms_to_add_remove[&2].len(), 1);
 
+    // We hope futures with the same index are polled in the order they are pushed,
+    // so fut21 should be polled next, even though fut22 has a shorter sleep duration.
+    // fut22 should be pushed into the in-progress queue.
+    // There are no more futures waiting to be polled in farm index 2, so the farm index 2
+    // should be removed from the farms_to_add_remove map.
     let next_item = stream_map.next().await;
-    assert!(!stream_map.is_terminated);
+    assert!(!stream_map.is_terminated());
     assert_eq!(next_item.unwrap(), 0x21);
     assert_eq!(stream_map.in_progress.len(), 1);
     assert!(!stream_map.in_progress.contains_key(&1));
@@ -132,6 +157,10 @@ async fn test_stream_map_stream() {
     assert!(stream_map.farms_to_add_remove.get(&1).is_none());
     assert!(stream_map.farms_to_add_remove.get(&2).is_none());
 
+    // Poll the next item in the stream, fut22 should be polled next.
+    // For now, all futures in farm index 2 have been polled, so farm index 2 should be removed
+    // from the in-progress queue.
+    // Finally, the stream should be terminated.
     let next_item = timeout(Duration::from_millis(3), stream_map.next()).await;
     assert_eq!(next_item.unwrap(), Some(0x22));
     assert_is_terminated(&stream_map);


### PR DESCRIPTION
There's no need for sequential execution here; parallelizing it will improve performance.

It's even simpler than I imagined—just placing the tasks in a FuturesUnordered for background execution, with no changes to the other logic.

in #3309 , I believe what’s needed is another background task queue to collect the stream reques, which doesn’t conflict with this PR, so I’ve submitted it directly.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
