### PR TITLE
Fix second segment offset in object retrieval, other minor cleanups

### DIFF
--- a/crates/pallet-domains/src/runtime_registry.rs
+++ b/crates/pallet-domains/src/runtime_registry.rs
@@ -21,8 +21,8 @@ use sp_core::crypto::AccountId32;
 use sp_core::Hasher;
 use sp_domains::storage::{RawGenesis, StorageData, StorageKey};
 use sp_domains::{
-    AutoIdDomainRuntimeConfig, DomainId, DomainsDigestItem, EvmDomainRuntimeConfig, RuntimeId,
-    RuntimeObject, RuntimeType,
+    AutoIdDomainRuntimeConfig, DomainId, DomainRuntimeConfig, DomainsDigestItem,
+    EvmDomainRuntimeConfig, RuntimeId, RuntimeObject, RuntimeType,
 };
 use sp_runtime::traits::{CheckedAdd, Get, Zero};
 use sp_runtime::DigestItem;
@@ -65,6 +65,38 @@ impl Default for DomainRuntimeInfo {
             chain_id: 0,
             domain_runtime_config: EvmDomainRuntimeConfig::default(),
         }
+    }
+}
+
+impl DomainRuntimeInfo {
+    /// Returns the inner config as a `DomainRuntimeConfig`.
+    pub fn domain_runtime_config(&self) -> DomainRuntimeConfig {
+        match self {
+            Self::Evm {
+                domain_runtime_config,
+                ..
+            } => DomainRuntimeConfig::Evm(domain_runtime_config.clone()),
+            Self::AutoId {
+                domain_runtime_config,
+                ..
+            } => DomainRuntimeConfig::AutoId(domain_runtime_config.clone()),
+        }
+    }
+
+    /// If this is an EVM runtime, returns the chain id.
+    pub fn evm_chain_id(&self) -> Option<EVMChainId> {
+        match self {
+            Self::Evm { chain_id, .. } => Some(*chain_id),
+            _ => None,
+        }
+    }
+
+    pub fn is_evm(&self) -> bool {
+        matches!(self, Self::Evm { .. })
+    }
+
+    pub fn is_auto_id(&self) -> bool {
+        matches!(self, Self::AutoId { .. })
     }
 }
 

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -1454,7 +1454,6 @@ pub(crate) mod tests {
                 bundle_slot_probability: (0, 0),
                 operator_allow_list: OperatorAllowList::Anyone,
                 initial_balances: Default::default(),
-                domain_runtime_config: Default::default(),
             };
 
             let domain_obj = DomainObject {
@@ -1818,7 +1817,6 @@ pub(crate) mod tests {
                 bundle_slot_probability: (0, 0),
                 operator_allow_list: OperatorAllowList::Anyone,
                 initial_balances: Default::default(),
-                domain_runtime_config: Default::default(),
             };
 
             let domain_obj = DomainObject {

--- a/crates/pallet-domains/src/tests.rs
+++ b/crates/pallet-domains/src/tests.rs
@@ -634,7 +634,6 @@ fn test_bundle_format_verification() {
             bundle_slot_probability: (1, 1),
             operator_allow_list: OperatorAllowList::Anyone,
             initial_balances: Default::default(),
-            domain_runtime_config: Default::default(),
         };
         let domain_obj = DomainObject {
             owner_account_id: Default::default(),

--- a/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -38,7 +38,7 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 use subspace_archiving::archiver::NewArchivedSegment;
 use subspace_core_primitives::hashes::Blake3Hash;
-use subspace_core_primitives::objects::{GlobalObjectMapping, ObjectMappingResponse};
+use subspace_core_primitives::objects::GlobalObjectMapping;
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex};
 use subspace_core_primitives::solutions::Solution;
@@ -48,8 +48,8 @@ use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_kzg::Kzg;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_rpc_primitives::{
-    FarmerAppInfo, RewardSignatureResponse, RewardSigningInfo, SlotInfo, SolutionResponse,
-    MAX_SEGMENT_HEADERS_PER_REQUEST,
+    FarmerAppInfo, ObjectMappingResponse, RewardSignatureResponse, RewardSigningInfo, SlotInfo,
+    SolutionResponse, MAX_SEGMENT_HEADERS_PER_REQUEST,
 };
 use tracing::{debug, error, warn};
 

--- a/crates/sc-consensus-subspace/src/lib.rs
+++ b/crates/sc-consensus-subspace/src/lib.rs
@@ -6,8 +6,7 @@
 //!
 //! All of the modules here are crucial for consensus, open each module for specific details.
 
-#![feature(let_chains, try_blocks)]
-#![feature(duration_constructors)]
+#![feature(let_chains, try_blocks, duration_constructors)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -4,8 +4,7 @@
 #![allow(incomplete_features)]
 // TODO: This feature is not actually used in this crate, but is added as a workaround for
 //  https://github.com/rust-lang/rust/issues/133199
-#![feature(generic_const_exprs)]
-#![feature(associated_type_defaults)]
+#![feature(generic_const_exprs, associated_type_defaults)]
 
 #[cfg(feature = "std")]
 pub mod execution_prover;

--- a/crates/subspace-core-primitives/src/objects.rs
+++ b/crates/subspace-core-primitives/src/objects.rs
@@ -9,7 +9,6 @@ extern crate alloc;
 
 use crate::hashes::Blake3Hash;
 use crate::pieces::PieceIndex;
-use crate::BlockNumber;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::default::Default;
@@ -157,18 +156,4 @@ impl GlobalObjectMapping {
             Self::V0 { objects, .. } => objects,
         }
     }
-}
-
-/// Response to object mapping subscription, including a block height.
-/// Large responses are batched, so the block height can be repeated in different responses.
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct ObjectMappingResponse {
-    /// The block number that the object mapping is from.
-    pub block_number: BlockNumber,
-
-    /// The object mappings.
-    #[cfg_attr(feature = "serde", serde(flatten))]
-    pub objects: GlobalObjectMapping,
 }

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -22,7 +22,7 @@ where
 /// Multiple hashes are separated by `+`.
 async fn request_object_mapping(
     endpoint: &str,
-    hashes: &Vec<Blake3Hash>,
+    hashes: &[Blake3Hash],
 ) -> anyhow::Result<ObjectMappingResponse> {
     let client = reqwest::Client::new();
     let hash_list = hashes.iter().map(hex::encode).collect::<Vec<_>>();

--- a/crates/subspace-gateway/src/commands/http/server.rs
+++ b/crates/subspace-gateway/src/commands/http/server.rs
@@ -3,9 +3,9 @@
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 use std::sync::Arc;
 use subspace_core_primitives::hashes::Blake3Hash;
-use subspace_core_primitives::objects::ObjectMappingResponse;
 use subspace_data_retrieval::object_fetcher::ObjectFetcher;
 use subspace_data_retrieval::piece_getter::PieceGetter;
+use subspace_rpc_primitives::ObjectMappingResponse;
 use tracing::{debug, error, trace};
 
 /// Parameters for the DSN object HTTP server.

--- a/crates/subspace-rpc-primitives/src/lib.rs
+++ b/crates/subspace-rpc-primitives/src/lib.rs
@@ -4,8 +4,9 @@ use parity_scale_codec::{Decode, Encode, EncodeLike, Input, Output};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use subspace_core_primitives::hashes::Blake3Hash;
+use subspace_core_primitives::objects::GlobalObjectMapping;
 use subspace_core_primitives::solutions::{RewardSignature, Solution, SolutionRange};
-use subspace_core_primitives::{PublicKey, SlotNumber};
+use subspace_core_primitives::{BlockNumber, PublicKey, SlotNumber};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_networking::libp2p::Multiaddr;
 
@@ -138,4 +139,17 @@ pub struct RewardSignatureResponse {
     pub hash: [u8; 32],
     /// Pre-header or vote hash signature.
     pub signature: Option<RewardSignature>,
+}
+
+/// Response to object mapping subscription, including a block height.
+/// Large responses are batched, so the block height can be repeated in different responses.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectMappingResponse {
+    /// The block number that the object mapping is from.
+    pub block_number: BlockNumber,
+
+    /// The object mappings.
+    #[serde(flatten)]
+    pub objects: GlobalObjectMapping,
 }

--- a/domains/client/domain-operator/src/domain_worker.rs
+++ b/domains/client/domain-operator/src/domain_worker.rs
@@ -200,6 +200,7 @@ pub(super) async fn start_worker<
                         );
                     }
                 }
+                else => { break }
             }
         }
     } else {

--- a/domains/client/domain-operator/src/lib.rs
+++ b/domains/client/domain-operator/src/lib.rs
@@ -58,11 +58,13 @@
 //! [`BlockBuilder`]: ../domain_block_builder/struct.BlockBuilder.html
 //! [`FraudProof`]: ../sp_domains/struct.FraudProof.html
 
-#![feature(array_windows)]
-#![feature(box_into_inner)]
-#![feature(duration_constructors)]
-#![feature(extract_if)]
-#![feature(assert_matches)]
+#![feature(
+    array_windows,
+    box_into_inner,
+    duration_constructors,
+    extract_if,
+    assert_matches
+)]
 
 mod aux_schema;
 mod bundle_processor;

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -18,10 +18,9 @@ use domain_test_service::evm_domain_test_runtime::{
 use domain_test_service::EcdsaKeyring::{Alice, Bob, Charlie, Dave, Eve};
 use domain_test_service::Sr25519Keyring::{self, Alice as Sr25519Alice, Ferdie};
 use domain_test_service::{
-    construct_extrinsic_generic, DomainNode, AUTO_ID_DOMAIN_ID, EVM_DOMAIN_ID,
+    construct_extrinsic_generic, EvmDomainNode, AUTO_ID_DOMAIN_ID, EVM_DOMAIN_ID,
 };
 use ethereum::TransactionV2 as EthereumTransaction;
-use evm_domain_test_runtime::{Runtime as EvmRuntime, RuntimeApi as EvmRuntimeApi};
 use fp_rpc::EthereumRuntimeRPCApi;
 use futures::StreamExt;
 use hex_literal::hex;
@@ -228,11 +227,7 @@ pub fn generate_evm_account_list(
 
 async fn setup_evm_test_nodes(
     ferdie_key: Sr25519Keyring,
-) -> (
-    TempDir,
-    MockConsensusNode,
-    DomainNode<EvmRuntime, EvmRuntimeApi>,
-) {
+) -> (TempDir, MockConsensusNode, EvmDomainNode) {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
     let mut builder = sc_cli::LoggerBuilder::new("");
@@ -261,12 +256,7 @@ async fn setup_evm_test_nodes(
 
 async fn setup_evm_test_accounts(
     ferdie_key: Sr25519Keyring,
-) -> (
-    TempDir,
-    MockConsensusNode,
-    DomainNode<EvmRuntime, EvmRuntimeApi>,
-    Vec<AccountInfo>,
-) {
+) -> (TempDir, MockConsensusNode, EvmDomainNode, Vec<AccountInfo>) {
     let (directory, mut ferdie, mut alice) = setup_evm_test_nodes(ferdie_key).await;
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1629,7 +1629,12 @@ async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
 
     async {
         while alice.sync_service.is_major_syncing() || bob.sync_service.is_major_syncing() {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            // TODO: Unfortunately, this test contains a race condition where Alice sometimes bans
+            // Bob for making multiple requests for the same block. And in response to that ban's
+            // reject message, Bob bans Alice.
+            alice.unban_peer(bob.addr.clone());
+            bob.unban_peer(alice.addr.clone());
         }
     }
     .timeout()

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -72,6 +72,7 @@ use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use sp_weights::Weight;
 use std::assert_matches::assert_matches;
 use std::collections::{BTreeMap, VecDeque};
+use std::future::IntoFuture;
 use std::sync::Arc;
 use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
@@ -83,7 +84,22 @@ use subspace_test_service::{
 use tempfile::TempDir;
 use tracing::error;
 
+/// The general timeout for test operations that could hang.
 const TIMEOUT: Duration = Duration::from_mins(2);
+
+/// A trait that makes it easier to add a timeout to any future: `future.timeout().await?`.
+trait TestTimeout: IntoFuture {
+    fn timeout(self) -> tokio::time::Timeout<Self::IntoFuture>;
+}
+
+impl<F> TestTimeout for F
+where
+    F: IntoFuture,
+{
+    fn timeout(self) -> tokio::time::Timeout<Self::IntoFuture> {
+        tokio::time::timeout(TIMEOUT, self)
+    }
+}
 
 fn number_of(consensus_node: &MockConsensusNode, block_hash: Hash) -> u32 {
     consensus_node
@@ -1600,44 +1616,34 @@ async fn collected_receipts_should_be_on_the_same_branch_with_current_best_block
     );
 }
 
+// This test hangs occasionally, but we don't know which step hangs.
+// TODO: when the test is fixed, decide if we want to remove the timeouts.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_domain_tx_propagate() {
-    let directory = TempDir::new().expect("Must be able to create temporary directory");
-
-    let mut builder = sc_cli::LoggerBuilder::new("");
-    builder.with_colors(false);
-    let _ = builder.init();
-
-    let tokio_handle = tokio::runtime::Handle::current();
-
-    // Start Ferdie
-    let mut ferdie = MockConsensusNode::run(
-        tokio_handle.clone(),
-        Ferdie,
-        BasePath::new(directory.path().join("ferdie")),
-    );
-
-    // Run Alice (a evm domain authority node)
-    let alice = domain_test_service::DomainNodeBuilder::new(
-        tokio_handle.clone(),
-        BasePath::new(directory.path().join("alice")),
-    )
-    .build_evm_node(Role::Authority, Alice, &mut ferdie)
-    .await;
+async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
+    let (directory, mut ferdie, alice) = setup_evm_test_nodes(Ferdie).timeout().await?;
 
     // Run Bob (a evm domain full node)
     let mut bob = domain_test_service::DomainNodeBuilder::new(
-        tokio_handle,
+        tokio::runtime::Handle::current(),
         BasePath::new(directory.path().join("bob")),
     )
     .connect_to_domain_node(alice.addr.clone())
     .build_evm_node(Role::Full, Bob, &mut ferdie)
-    .await;
+    .timeout()
+    .await?;
 
-    produce_blocks!(ferdie, alice, 5, bob).await.unwrap();
-    while alice.sync_service.is_major_syncing() || bob.sync_service.is_major_syncing() {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    produce_blocks!(ferdie, alice, 5, bob)
+        .timeout()
+        .await?
+        .unwrap();
+
+    async {
+        while alice.sync_service.is_major_syncing() || bob.sync_service.is_major_syncing() {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
     }
+    .timeout()
+    .await?;
 
     let pre_bob_free_balance = alice.free_balance(bob.key.to_account_id());
     // Construct and send an extrinsic to bob, as bob is not a authority node, the extrinsic has
@@ -1646,7 +1652,8 @@ async fn test_domain_tx_propagate() {
         dest: Alice.to_account_id(),
         value: 123,
     })
-    .await
+    .timeout()
+    .await?
     .expect("Failed to send extrinsic");
 
     produce_blocks_until!(
@@ -1659,8 +1666,11 @@ async fn test_domain_tx_propagate() {
         },
         bob
     )
-    .await
+    .timeout()
+    .await?
     .unwrap();
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -85,7 +85,7 @@ use tempfile::TempDir;
 use tracing::error;
 
 /// The general timeout for test operations that could hang.
-const TIMEOUT: Duration = Duration::from_mins(2);
+const TIMEOUT: Duration = Duration::from_mins(10);
 
 /// A trait that makes it easier to add a timeout to any future: `future.timeout().await?`.
 trait TestTimeout: IntoFuture {

--- a/domains/pallets/evm-tracker/src/lib.rs
+++ b/domains/pallets/evm-tracker/src/lib.rs
@@ -90,7 +90,7 @@ mod pallet {
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_finalize(_now: BlockNumberFor<T>) {
-            // clear the storage since we would start with updated nonce
+            // clear the nonce storage, since we would start with updated nonce
             // during the pre_dispatch in next block
             let _ = AccountNonce::<T>::clear(u32::MAX, None);
         }
@@ -108,12 +108,12 @@ impl<T: Config> Pallet<T> {
         AccountNonce::<T>::set(account, Some(nonce))
     }
 
-    /// Returns true if the account is allowed to create contracts.
+    /// Returns true if the supplied account is allowed to create contracts.
     pub fn is_allowed_to_create_contracts(signer: &T::AccountId) -> bool {
         ContractCreationAllowedBy::<T>::get().is_allowed(signer)
     }
 
-    /// Returns true if the account is allowed to create contracts.
+    /// Returns true if any account is allowed to create contracts.
     pub fn is_allowed_to_create_unsigned_contracts() -> bool {
         ContractCreationAllowedBy::<T>::get().is_anyone_allowed()
     }

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -20,7 +20,7 @@ use pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi;
 use sc_client_api::HeaderBackend;
 use sc_domains::RuntimeExecutor;
 use sc_network::service::traits::NetworkService;
-use sc_network::{NetworkRequest, NetworkStateInfo};
+use sc_network::{NetworkRequest, NetworkStateInfo, ReputationChange};
 use sc_network_sync::SyncingService;
 use sc_service::config::MultiaddrWithPeerId;
 use sc_service::{BasePath, Role, RpcHandlers, TFullBackend, TaskManager};
@@ -405,6 +405,35 @@ where
     {
         let function = function.into();
         UncheckedExtrinsicFor::<Runtime>::new_unsigned(function)
+    }
+
+    /// Give the peer at `addr` the minimum reputation, which will ban it.
+    // TODO: also ban/unban in the DSN
+    pub fn ban_peer(&self, addr: MultiaddrWithPeerId) {
+        // If unban_peer() has been called on the peer, we need to bump it twice
+        // to give it the minimal reputation.
+        self.network_service.report_peer(
+            addr.peer_id,
+            ReputationChange::new_fatal("Peer banned by test (1)"),
+        );
+        self.network_service.report_peer(
+            addr.peer_id,
+            ReputationChange::new_fatal("Peer banned by test (2)"),
+        );
+    }
+
+    /// Give the peer at `addr` a high reputation, which guarantees it is un-banned it.
+    pub fn unban_peer(&self, addr: MultiaddrWithPeerId) {
+        // If ReputationChange::new_fatal() has been called on the peer, we need to bump it twice
+        // to give it a positive reputation.
+        self.network_service.report_peer(
+            addr.peer_id,
+            ReputationChange::new(i32::MAX, "Peer unbanned by test (1)"),
+        );
+        self.network_service.report_peer(
+            addr.peer_id,
+            ReputationChange::new(i32::MAX, "Peer unbanned by test (2)"),
+        );
     }
 }
 

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -98,10 +98,10 @@ pub enum Error {
     },
 
     /// Hash doesn't match data
-    #[error("Incorrect data hash {data_hash:?} for {data_size} byte object: {mapping:?}")]
+    #[error("Incorrect data hash {data_hash:?} for {data_length} byte object: {mapping:?}")]
     InvalidDataHash {
         data_hash: Blake3Hash,
-        data_size: usize,
+        data_length: usize,
         mapping: GlobalObject,
     },
 
@@ -240,7 +240,7 @@ where
             if data_hash != hash {
                 debug!(
                     ?data_hash,
-                    data_size = %data.len(),
+                    data_length = %data.len(),
                     ?mapping,
                     "Retrieved data doesn't match requested mapping hash"
                 );
@@ -248,7 +248,7 @@ where
 
                 return Err(Error::InvalidDataHash {
                     data_hash,
-                    data_size: data.len(),
+                    data_length: data.len(),
                     mapping,
                 });
             }

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -447,8 +447,9 @@ where
                 .await?
                 .into_items();
             // Go through the segment until we reach the offset.
-            // Unconditional progress is enum variant + compact encoding of number of elements
-            let mut progress = 1 + Compact::compact_len(&(items.len() as u64));
+            // Unconditional progress is enum variant, always 1 byte in SCALE encoding.
+            // (Segments do not have an item count, to make incremental writing easier.)
+            let mut progress = 1;
             let segment_item = items
                 .into_iter()
                 .find(|item| {

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -16,14 +16,14 @@ use tracing::{debug, trace, warn};
 /// The maximum amount of segment padding.
 ///
 /// This is the difference between the lengths of the compact encodings of the minimum and maximum
-/// block sizes, in any domain. As of January 2025, the minimum block size is (potentially) 63 or
-/// less, and the maximum block size is in the range 2^14 to 2^30 - 1.
+/// block sizes in the consensus chain. As of January 2025, the minimum block size is (potentially)
+/// 63 or less, and the maximum block size is in the range 2^14 to 2^30 - 1.
 /// <https://docs.substrate.io/reference/scale-codec/#fn-1>
 pub const MAX_SEGMENT_PADDING: usize = 3;
 
 /// The maximum object length this module can handle.
 ///
-/// Currently objects are limited by the largest block size in any domain, which is 5 MB.
+/// Currently objects are limited by the largest block size on the consensus chain, which is 5 MB.
 /// But this implementation supports the maximum length of the 4 byte scale encoding.
 pub const MAX_SUPPORTED_OBJECT_LENGTH: usize = 1024 * 1024 * 1024 - 1;
 

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -395,8 +395,8 @@ where
             let remaining_piece_indexes = (next_source_piece_index..)
                 .filter(|i| i.is_source())
                 .take(remaining_piece_count)
-                .collect::<Vec<_>>();
-            self.read_pieces(&remaining_piece_indexes, mapping)
+                .collect();
+            self.read_pieces(remaining_piece_indexes, mapping)
                 .await?
                 .into_iter()
                 .for_each(|piece| {
@@ -611,10 +611,10 @@ where
     /// The mapping is only used for error reporting.
     async fn read_pieces(
         &self,
-        piece_indexes: &Vec<PieceIndex>,
+        piece_indexes: Arc<[PieceIndex]>,
         mapping: GlobalObject,
     ) -> Result<Vec<Piece>, Error> {
-        download_pieces(piece_indexes, &self.piece_getter)
+        download_pieces(piece_indexes.clone(), &self.piece_getter)
             .await
             .map_err(|source| {
                 debug!(
@@ -636,7 +636,7 @@ where
         piece_index: PieceIndex,
         mapping: GlobalObject,
     ) -> Result<Piece, Error> {
-        download_pieces(&vec![piece_index], &self.piece_getter)
+        download_pieces(vec![piece_index].into(), &self.piece_getter)
             .await
             .map(|pieces| {
                 pieces

--- a/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -42,7 +42,10 @@ pub enum Error {
     PieceOffsetTooLarge { mapping: GlobalObject },
 
     /// No item in segment at offset
-    #[error("Offset {offset_in_segment} in segment {segment_index} is not an item, current progress: {progress}, object: {mapping:?}")]
+    #[error(
+        "Offset {offset_in_segment} in segment {segment_index} is not an item, \
+         current progress: {progress}, object: {mapping:?}"
+    )]
     NoSegmentItem {
         progress: usize,
         offset_in_segment: usize,
@@ -51,7 +54,10 @@ pub enum Error {
     },
 
     /// Unexpected item in first segment at offset
-    #[error("Offset {offset_in_segment} in first segment {segment_index} has unexpected item, current progress: {segment_progress}, object: {mapping:?}, item: {segment_item:?}")]
+    #[error(
+        "Offset {offset_in_segment} in first segment {segment_index} has unexpected item, \
+         current progress: {segment_progress}, object: {mapping:?}, item: {segment_item:?}"
+    )]
     UnexpectedFirstSegmentItem {
         segment_progress: usize,
         offset_in_segment: usize,
@@ -61,7 +67,10 @@ pub enum Error {
     },
 
     /// Unexpected item in continuing segment at offset
-    #[error("Continuing segment {segment_index} has unexpected item, collected data: {collected_data}, object: {mapping:?}, item: {segment_item:?}")]
+    #[error(
+        "Continuing segment {segment_index} has unexpected item, \
+         collected data: {collected_data}, object: {mapping:?}, item: {segment_item:?}"
+    )]
     UnexpectedContinuingSegmentItem {
         collected_data: usize,
         segment_index: SegmentIndex,
@@ -70,7 +79,10 @@ pub enum Error {
     },
 
     /// Object not found after downloading expected number of segments
-    #[error("Object segment range {first_segment_index}..={last_segment_index} did not contain full object, object: {mapping:?}")]
+    #[error(
+        "Object segment range {first_segment_index}..={last_segment_index} did not contain \
+         full object, object: {mapping:?}"
+    )]
     TooManySegments {
         first_segment_index: SegmentIndex,
         last_segment_index: SegmentIndex,
@@ -79,7 +91,8 @@ pub enum Error {
 
     /// Object is too large error
     #[error(
-        "Data length {data_length} exceeds maximum object size {max_object_len} for object: {mapping:?}"
+        "Data length {data_length} exceeds maximum object size {max_object_len} \
+         for object: {mapping:?}"
     )]
     ObjectTooLarge {
         data_length: usize,
@@ -89,7 +102,8 @@ pub enum Error {
 
     /// Length prefix is too large error
     #[error(
-        "Length prefix length {length_prefix_len} exceeds maximum object size {max_object_len} for object: {mapping:?}"
+        "Length prefix length {length_prefix_len} exceeds maximum object size {max_object_len} \
+         for object: {mapping:?}"
     )]
     LengthPrefixTooLarge {
         length_prefix_len: usize,

--- a/shared/subspace-data-retrieval/src/piece_fetcher.rs
+++ b/shared/subspace-data-retrieval/src/piece_fetcher.rs
@@ -3,6 +3,7 @@
 use crate::object_fetcher::Error;
 use crate::piece_getter::PieceGetter;
 use futures::StreamExt;
+use std::sync::Arc;
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use tracing::{debug, trace};
 
@@ -13,7 +14,7 @@ use tracing::{debug, trace};
 // This code was copied and modified from subspace_service::sync_from_dsn::download_and_reconstruct_blocks():
 // <https://github.com/autonomys/subspace/blob/d71ca47e45e1b53cd2e472413caa23472a91cd74/crates/subspace-service/src/sync_from_dsn/import_blocks.rs#L236-L322>
 pub async fn download_pieces<PG>(
-    piece_indexes: &Vec<PieceIndex>,
+    piece_indexes: Arc<[PieceIndex]>,
     piece_getter: &PG,
 ) -> anyhow::Result<Vec<Piece>>
 where
@@ -28,8 +29,8 @@ where
     // TODO:
     // - if we're close to the number of pieces in a segment, or we can't find a piece, use segment downloading and piece
     //   reconstruction instead
-    // Currently most objects are limited to 4 pieces, so this isn't needed yet.
-    let mut received_pieces = piece_getter.get_pieces(piece_indexes.clone()).await?;
+    // Currently most objects are limited to 4-6 pieces, so this isn't needed yet.
+    let mut received_pieces = piece_getter.get_pieces(piece_indexes.to_vec()).await?;
 
     let mut pieces = Vec::new();
     pieces.resize(piece_indexes.len(), Piece::default());


### PR DESCRIPTION
This PR fixes a bug in the offset of the second segment downloaded during object reconstruction (commit 30b816755ec3df5e5759df0b9a883d6780167cec). This bug has been in the code since we added incremental segment creation, and removed the segment item count.

It also fixes a test hang in test_domain_tx_propagate.

This PR also contains multiple small cleanups based on these reviews:
- domain config duplication: https://github.com/autonomys/subspace/pull/3350#discussion_r1939987013
- feature formatting: https://github.com/autonomys/subspace/pull/3350#discussion_r1940667856

And the reviewed cleanups from PR #3362, with changes from these reviews:
- Vec clone vs slice reference: https://github.com/autonomys/subspace/pull/3362#discussion_r1936805987
- incorrect comments about domain block size: https://github.com/autonomys/subspace/pull/3362#discussion_r1936811677

Close #3370.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
