### PR TITLE
Fix inconsistency of bundle digest generation and add invalid fraud proof integration test

### DIFF
--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -20,12 +20,12 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::traits::{CallContext, CodeExecutor, FetchRuntimeCode, RuntimeCode};
 use sp_core::H256;
-use sp_domains::{BundleProducerElectionApi, DomainsApi};
+use sp_domains::{BundleProducerElectionApi, DomainsApi, ExtrinsicDigest};
 use sp_externalities::Extensions;
 use sp_messenger::MessengerApi;
 use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT, NumberFor};
 use sp_runtime::OpaqueExtrinsic;
-use sp_state_machine::{OverlayedChanges, StateMachine, TrieBackend, TrieBackendBuilder};
+use sp_state_machine::{LayoutV1, OverlayedChanges, StateMachine, TrieBackend, TrieBackendBuilder};
 use sp_trie::{MemoryDB, StorageProof};
 use sp_weights::Weight;
 use std::borrow::Cow;
@@ -179,7 +179,9 @@ where
             .map(|(signer, tx)| {
                 (
                     signer,
-                    <DomainBlock::Header as HeaderT>::Hashing::hash_of(&tx),
+                    ExtrinsicDigest::new::<LayoutV1<<DomainBlock::Header as HeaderT>::Hashing>>(
+                        tx.encode(),
+                    ),
                 )
             })
             .collect();

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -877,6 +877,7 @@ where
                         mismatch_type,
                         bundle_index,
                         bad_receipt_hash,
+                        false,
                     )
                     .map_err(|err| {
                         sp_blockchain::Error::Application(Box::from(format!(

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -518,6 +518,9 @@ where
         mismatch_type: BundleMismatchType,
         bundle_index: u32,
         bad_receipt_hash: Block::Hash,
+        // Whether allow generate invalid proof against valid ER,
+        // only used in test
+        allow_invalid_proof: bool,
     ) -> Result<FraudProofFor<CBlock, Block::Header>, FraudProofError> {
         let consensus_block_hash = local_receipt.consensus_block_hash;
         let consensus_block_number = local_receipt.consensus_block_number;
@@ -641,11 +644,12 @@ where
                     // If the proof is false invalid then validation response should not be Err.
                     // OR
                     // If it is true invalid and expected extrinsic index does not match
-                    if (is_true_invalid == validation_response.is_ok())
-                        || (is_true_invalid
-                            && validation_response
-                                .as_ref()
-                                .is_err_and(|e| e.extrinsic_index != expected_extrinsic_index))
+                    if !allow_invalid_proof
+                        && ((is_true_invalid == validation_response.is_ok())
+                            || (is_true_invalid
+                                && validation_response
+                                    .as_ref()
+                                    .is_err_and(|e| e.extrinsic_index != expected_extrinsic_index)))
                     {
                         return Err(FraudProofError::InvalidIllegalTxFraudProofExtrinsicIndex {
                             index: expected_extrinsic_index as usize,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1,3 +1,4 @@
+use crate::aux_schema::BundleMismatchType;
 use crate::domain_block_processor::{DomainBlockProcessor, PendingConsensusBlocks};
 use crate::domain_bundle_producer::{BundleProducer, TestBundleProducer};
 use crate::domain_bundle_proposer::DomainBundleProposer;
@@ -809,6 +810,367 @@ async fn test_executor_inherent_timestamp_is_set() {
         consensus_timestamp, domain_timestamp,
         "Timestamp should be preset on domain and must match Consensus runtime timestamp"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
+
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Ferdie,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+
+    // Run Alice (a evm domain authority node)
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
+    .await;
+
+    let fraud_proof_generator = FraudProofGenerator::new(
+        alice.client.clone(),
+        ferdie.client.clone(),
+        alice.backend.clone(),
+        alice.code_executor.clone(),
+    );
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    let mut bundles = vec![];
+    let alice_nonce = alice.account_nonce();
+    for (i, acc) in [Bob, Charlie, Dave].into_iter().enumerate() {
+        let tx = alice.construct_extrinsic(
+            alice_nonce + i as u32,
+            pallet_balances::Call::transfer_allow_death {
+                dest: acc.to_account_id(),
+                value: 12334567890987654321,
+            },
+        );
+        alice
+            .send_extrinsic(tx)
+            .await
+            .expect("Failed to send extrinsic");
+    }
+    let (_, valid_bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(valid_bundle.extrinsics.len(), 3);
+    bundles.push(valid_bundle.clone());
+
+    // UndecodableTx
+    bundles.push({
+        let (_, mut b) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+        let undecodable_tx =
+            OpaqueExtrinsic::from_bytes(&rand::random::<[u8; 5]>().to_vec().encode())
+                .expect("raw byte encoding and decoding never fails; qed");
+        b.extrinsics.push(undecodable_tx);
+        b.extrinsics.extend_from_slice(&valid_bundle.extrinsics);
+        b
+    });
+
+    // IllegalTx
+    bundles.push({
+        let (_, mut b) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+        let illegal_tx = alice
+            .construct_extrinsic(
+                alice_nonce, // stale nonce
+                pallet_balances::Call::transfer_allow_death {
+                    dest: Eve.to_account_id(),
+                    value: 12334567890987654321,
+                },
+            )
+            .into();
+        b.extrinsics.extend_from_slice(&valid_bundle.extrinsics);
+        b.extrinsics.push(illegal_tx);
+        b
+    });
+
+    // InvalidXDM
+    bundles.push({
+        let (_, mut b) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+        let invalid_xdm = evm_domain_test_runtime::UncheckedExtrinsic::new_unsigned(
+            pallet_messenger::Call::relay_message {
+                msg: CrossDomainMessage {
+                    src_chain_id: ChainId::Consensus,
+                    dst_chain_id: ChainId::Domain(EVM_DOMAIN_ID),
+                    channel_id: Default::default(),
+                    nonce: Default::default(),
+                    proof: Proof::Domain {
+                        consensus_chain_mmr_proof: ConsensusChainMmrLeafProof {
+                            consensus_block_number: 1,
+                            consensus_block_hash: Default::default(),
+                            opaque_mmr_leaf: EncodableOpaqueLeaf(vec![0, 1, 2]),
+                            proof: MmrProof {
+                                leaf_indices: vec![],
+                                leaf_count: 0,
+                                items: vec![],
+                            },
+                        },
+                        domain_proof: StorageProof::empty(),
+                        message_proof: StorageProof::empty(),
+                    },
+                    weight_tag: Default::default(),
+                },
+            }
+            .into(),
+        )
+        .into();
+        b.extrinsics.push(invalid_xdm);
+        b
+    });
+
+    // InherentTx
+    bundles.push({
+        let (_, mut b) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+        let inherent_tx = subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
+            pallet_timestamp::Call::set { now: 12345 }.into(),
+        )
+        .into();
+        b.extrinsics.extend_from_slice(&valid_bundle.extrinsics);
+        b.extrinsics[1] = inherent_tx;
+        b
+    });
+
+    // InvalidBundleWeight
+    bundles.push({
+        let (_, mut b) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+        b.sealed_header.header.estimated_bundle_weight = Weight::from_all(123456);
+        b
+    });
+
+    let submit_bundle_txs: Vec<_> = bundles
+        .into_iter()
+        .map(|mut opaque_bundle| {
+            let extrinsics = opaque_bundle
+                .extrinsics
+                .iter()
+                .map(|ext| ext.encode())
+                .collect();
+            opaque_bundle.sealed_header.header.bundle_extrinsics_root =
+                BlakeTwo256::ordered_trie_root(extrinsics, StateVersion::V1);
+            opaque_bundle.sealed_header.signature = Sr25519Keyring::Alice
+                .pair()
+                .sign(opaque_bundle.sealed_header.pre_hash().as_ref())
+                .into();
+            subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
+                pallet_domains::Call::submit_bundle { opaque_bundle }.into(),
+            )
+            .into()
+        })
+        .collect();
+
+    assert_eq!(submit_bundle_txs.len(), 6);
+
+    // Produce a block that contains all the bundle
+    produce_block_with!(
+        ferdie.produce_block_with_extrinsics(submit_bundle_txs),
+        alice
+    )
+    .await
+    .unwrap();
+
+    // Get the receipt of that domain block and produce another bundle to submit the receipt
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+
+    let valid_receipt = bundle.into_receipt();
+    let valid_receipt_hash = valid_receipt.hash::<BlakeTwo256>();
+    assert_eq!(valid_receipt.execution_trace.len(), 7);
+    assert_eq!(valid_receipt.inboxed_bundles.len(), 6);
+
+    // Produce all possible invalid fraud proof
+    for bundle_index in 0..6 {
+        for extrinsic_index in 0..4 {
+            for is_true_invalid in [true, false] {
+                for invalid_type in 0..6 {
+                    let invalid_bundle_type = match invalid_type {
+                        0 => InvalidBundleType::UndecodableTx(extrinsic_index),
+                        // TODO: We use `U256::MAX` as the tx range in the test to ensure all
+                        // extrinsic will be included by the bundle but in production the fraud
+                        // proof verification use `U256::MAX/3` thus the invalid OutOfRangeTx
+                        // frauf proof may be accepted, need to workaround to add this test case
+                        // 1 => InvalidBundleType::OutOfRangeTx(extrinsic_index),
+                        2 => InvalidBundleType::IllegalTx(extrinsic_index),
+                        3 => InvalidBundleType::InvalidXDM(extrinsic_index),
+                        4 => InvalidBundleType::InherentExtrinsic(extrinsic_index),
+                        5 if extrinsic_index == 0 => InvalidBundleType::InvalidBundleWeight,
+                        _ => continue,
+                    };
+                    let mismatch_type = if is_true_invalid {
+                        BundleMismatchType::TrueInvalid(invalid_bundle_type)
+                    } else {
+                        BundleMismatchType::FalseInvalid(invalid_bundle_type)
+                    };
+                    let res = fraud_proof_generator.generate_invalid_bundle_proof(
+                        EVM_DOMAIN_ID,
+                        &valid_receipt,
+                        mismatch_type,
+                        bundle_index,
+                        valid_receipt_hash,
+                        true,
+                    );
+
+                    let fp = match res {
+                        Ok(fp) => fp,
+                        Err(_) => {
+                            // There are some invalid fraud proofs are impossible to construct
+                            // e.g. the execution proof can't construct for the undecodable tx
+                            continue;
+                        }
+                    };
+
+                    let submit_fraud_proof_extrinsic =
+                        subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
+                            pallet_domains::Call::submit_fraud_proof {
+                                fraud_proof: Box::new(fp),
+                            }
+                            .into(),
+                        )
+                        .into();
+
+                    let res = ferdie
+                        .submit_transaction(submit_fraud_proof_extrinsic)
+                        .await;
+
+                    assert!(matches!(
+                        res,
+                        Err(PoolError::Pool(TxPoolInvalidTransaction(
+                            InvalidTransaction::Custom(tx_code)
+                        ))) if tx_code == InvalidTransactionCode::FraudProof as u8
+                    ));
+                }
+            }
+        }
+    }
+
+    ferdie.produce_blocks(1).await.unwrap();
+    assert!(ferdie.does_receipt_exist(valid_receipt_hash).unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_bad_fraud_proof_is_rejected() {
+    let directory = TempDir::new().expect("Must be able to create temporary directory");
+
+    let mut builder = sc_cli::LoggerBuilder::new("");
+    builder.with_colors(false);
+    let _ = builder.init();
+
+    let tokio_handle = tokio::runtime::Handle::current();
+
+    // Start Ferdie
+    let mut ferdie = MockConsensusNode::run(
+        tokio_handle.clone(),
+        Ferdie,
+        BasePath::new(directory.path().join("ferdie")),
+    );
+
+    // Run Alice (a evm domain authority node)
+    let mut alice = domain_test_service::DomainNodeBuilder::new(
+        tokio_handle.clone(),
+        BasePath::new(directory.path().join("alice")),
+    )
+    .build_evm_node(Role::Authority, Alice, &mut ferdie)
+    .await;
+
+    let fraud_proof_generator = FraudProofGenerator::new(
+        alice.client.clone(),
+        ferdie.client.clone(),
+        alice.backend.clone(),
+        alice.code_executor.clone(),
+    );
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    alice
+        .construct_and_send_extrinsic(pallet_balances::Call::transfer_allow_death {
+            dest: Bob.to_account_id(),
+            value: 12334567890987654321,
+        })
+        .await
+        .expect("Failed to send extrinsic");
+
+    // Produce a domain block that contains the previously sent extrinsic
+    produce_blocks!(ferdie, alice, 1).await.unwrap();
+
+    // Get the receipt of that domain block and produce another bundle to submit the receipt
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+
+    let valid_receipt = bundle.into_receipt();
+    let valid_receipt_hash = valid_receipt.hash::<BlakeTwo256>();
+    assert_eq!(valid_receipt.execution_trace.len(), 5);
+
+    let mut fraud_proofs = vec![fraud_proof_generator
+        .generate_valid_bundle_proof(EVM_DOMAIN_ID, &valid_receipt, 0, valid_receipt_hash)
+        .unwrap()];
+
+    fraud_proofs.push(
+        fraud_proof_generator
+            .generate_invalid_domain_extrinsics_root_proof(
+                EVM_DOMAIN_ID,
+                &valid_receipt,
+                valid_receipt_hash,
+            )
+            .unwrap(),
+    );
+
+    fraud_proofs.push(
+        fraud_proof_generator
+            .generate_invalid_block_fees_proof(EVM_DOMAIN_ID, &valid_receipt, valid_receipt_hash)
+            .unwrap(),
+    );
+
+    fraud_proofs.push(
+        fraud_proof_generator
+            .generate_invalid_transfers_proof(EVM_DOMAIN_ID, &valid_receipt, valid_receipt_hash)
+            .unwrap(),
+    );
+
+    fraud_proofs.push(
+        fraud_proof_generator
+            .generate_invalid_domain_block_hash_proof(
+                EVM_DOMAIN_ID,
+                &valid_receipt,
+                valid_receipt_hash,
+            )
+            .unwrap(),
+    );
+
+    for fp in fraud_proofs {
+        let submit_fraud_proof_extrinsic = subspace_test_runtime::UncheckedExtrinsic::new_unsigned(
+            pallet_domains::Call::submit_fraud_proof {
+                fraud_proof: Box::new(fp),
+            }
+            .into(),
+        )
+        .into();
+
+        let res = ferdie
+            .submit_transaction(submit_fraud_proof_extrinsic)
+            .await;
+
+        assert!(matches!(
+            res,
+            Err(PoolError::Pool(TxPoolInvalidTransaction(
+                InvalidTransaction::Custom(tx_code)
+            ))) if tx_code == InvalidTransactionCode::FraudProof as u8
+        ));
+    }
+
+    ferdie.produce_blocks(1).await.unwrap();
+    assert!(ferdie.does_receipt_exist(valid_receipt_hash).unwrap());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
The first commit fixes a bug of the valid bundle fraud proof where the bundle digest generation in the fraud proof verification is different from the ER:
https://github.com/autonomys/subspace/blob/f5e8b43d13eb2d2e1072e3c3ac7d7a0f238d6ef4/crates/sp-domains-fraud-proof/src/host_functions.rs#L181-L182
https://github.com/autonomys/subspace/blob/f5e8b43d13eb2d2e1072e3c3ac7d7a0f238d6ef4/domains/client/block-preprocessor/src/lib.rs#L258-L260

This can cause valid ER produced by honest operators to be slashed by invalid fraud proof produced by malicious actors. NOTE: this does not affect mainnet since the domain is not enabled there.

The second commit adds integration tests to ensure any invalid fraud proof that targets a valid ER will be rejected by the tx pool, note this PR didn't add test case for the invalid state transition fraud proof because it is already covered by the test `test_bad_invalid_state_transition_proof_is_rejected`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
