### PR TITLE
Fraud proof naming, test & comment cleanups

### DIFF
--- a/crates/sc-proof-of-time/src/source/gossip.rs
+++ b/crates/sc-proof-of-time/src/source/gossip.rs
@@ -16,7 +16,7 @@ use schnellru::{ByLength, LruMap};
 use sp_consensus::SyncOracle;
 use sp_consensus_slots::Slot;
 use sp_consensus_subspace::PotNextSlotInput;
-use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
+use sp_runtime::traits::{Block as BlockT, Hash as HashT, HashingFor};
 use std::cmp;
 use std::collections::{HashMap, VecDeque};
 use std::future::poll_fn;
@@ -143,7 +143,7 @@ where
         GossipSync: GossipSyncing<Block> + 'static,
         SO: SyncOracle + Send + Sync + 'static,
     {
-        let topic = <Block::Header as HeaderT>::Hashing::hash(b"proofs");
+        let topic = HashingFor::<Block>::hash(b"proofs");
 
         let validator = Arc::new(PotGossipValidator::new(
             Arc::clone(&state),

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -527,12 +527,16 @@ pub enum InvalidBundlesProofData<Number, Hash, MmrHash, DomainHeader: HeaderT> {
     },
 }
 
+/// A proof about a bundle that was marked invalid (but might or might not actually be invalid).
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct InvalidBundlesProof<Number, Hash, MmrHash, DomainHeader: HeaderT> {
     pub bundle_index: u32,
+    /// The invalid bundle type that the bundle was marked with.
     pub invalid_bundle_type: InvalidBundleType,
-    pub is_true_invalid_fraud_proof: bool,
-    /// Proof data of the invalid bundle
+    /// If `true`, the fraud proof must prove the bundle was correctly marked invalid.
+    /// If `false`, it must prove the bundle was marked invalid, but is actually valid.
+    pub is_good_invalid_fraud_proof: bool,
+    /// Proof data of the bundle which was marked invalid.
     pub proof_data: InvalidBundlesProofData<Number, Hash, MmrHash, DomainHeader>,
 }
 

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -23,7 +23,7 @@ use sp_core::H256;
 use sp_domains::{BundleProducerElectionApi, DomainsApi, ExtrinsicDigest};
 use sp_externalities::Extensions;
 use sp_messenger::MessengerApi;
-use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT, NumberFor};
+use sp_runtime::traits::{Block as BlockT, Hash as HashT, HashingFor, NumberFor};
 use sp_runtime::OpaqueExtrinsic;
 use sp_state_machine::{LayoutV1, OverlayedChanges, StateMachine, TrieBackend, TrieBackendBuilder};
 use sp_trie::{MemoryDB, StorageProof};
@@ -179,14 +179,12 @@ where
             .map(|(signer, tx)| {
                 (
                     signer,
-                    ExtrinsicDigest::new::<LayoutV1<<DomainBlock::Header as HeaderT>::Hashing>>(
-                        tx.encode(),
-                    ),
+                    ExtrinsicDigest::new::<LayoutV1<HashingFor<DomainBlock>>>(tx.encode()),
                 )
             })
             .collect();
 
-        Some(<DomainBlock::Header as HeaderT>::Hashing::hash_of(&ext_signers).into())
+        Some(HashingFor::<DomainBlock>::hash_of(&ext_signers).into())
     }
 
     fn execution_proof_check(
@@ -215,7 +213,7 @@ where
         )
         .extensions_for(domain_block_hash.into(), domain_block_number.into());
 
-        execution_proof_check::<<DomainBlock::Header as HeaderT>::Hashing, _>(
+        execution_proof_check::<HashingFor<DomainBlock>, _>(
             pre_state_root.into(),
             proof,
             &mut Default::default(),

--- a/crates/sp-domains-fraud-proof/src/tests.rs
+++ b/crates/sp-domains-fraud-proof/src/tests.rs
@@ -677,7 +677,7 @@ async fn test_evm_domain_block_fee() {
         .unwrap();
     let consensus_block_hash = ferdie.client.info().best_hash;
 
-    // Produce one more bundle, this bundle should contains the ER of the previous bundle
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
     let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
     let receipt = bundle.into_receipt();
     assert_eq!(receipt.consensus_block_hash, consensus_block_hash);

--- a/domains/client/block-preprocessor/src/lib.rs
+++ b/domains/client/block-preprocessor/src/lib.rs
@@ -41,8 +41,11 @@ use subspace_runtime_primitives::Balance;
 
 type DomainBlockElements<CBlock> = (Vec<<CBlock as BlockT>::Extrinsic>, Randomness);
 
+/// A wrapper indicating a valid bundle contents, or an invalid bundle reason.
 enum BundleValidity<Extrinsic> {
+    /// A valid bundle contents.
     Valid(Vec<Extrinsic>),
+    /// An invalid bundle reason.
     Invalid(InvalidBundleType),
 }
 

--- a/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
+++ b/domains/client/cross-domain-message-gossip/src/gossip_worker.rs
@@ -12,7 +12,7 @@ use sp_api::StorageProof;
 use sp_consensus::SyncOracle;
 use sp_core::twox_256;
 use sp_messenger::messages::{ChainId, ChannelId};
-use sp_runtime::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
+use sp_runtime::traits::{Block as BlockT, Hash as HashT, HashingFor};
 use std::collections::{BTreeMap, HashSet};
 use std::future::poll_fn;
 use std::pin::pin;
@@ -159,7 +159,7 @@ pub fn xdm_gossip_peers_set_config() -> (NonDefaultSetConfig, Box<dyn Notificati
 
 /// Cross chain message topic.
 fn topic<Block: BlockT>() -> Block::Hash {
-    <Block::Header as HeaderT>::Hashing::hash(b"cross-chain-messages")
+    HashingFor::<Block>::hash(b"cross-chain-messages")
 }
 
 impl<Block: BlockT, Network, SO: SyncOracle> GossipWorker<Block, Network, SO> {

--- a/domains/client/cross-domain-message-gossip/src/message_listener.rs
+++ b/domains/client/cross-domain-message-gossip/src/message_listener.rs
@@ -23,7 +23,7 @@ use sp_domains::{DomainId, DomainsApi, RuntimeType};
 use sp_messenger::messages::{ChainId, Channel, ChannelId};
 use sp_messenger::{ChannelNonce, MessengerApi, RelayerApi, XdmId};
 use sp_runtime::codec::Decode;
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Header, NumberFor};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, HashingFor, Header, NumberFor};
 use sp_runtime::{SaturatedConversion, Saturating};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -40,7 +40,6 @@ const XDM_ACCEPT_BLOCK_LIMIT: u32 = 5;
 type BlockOf<T> = <T as TransactionPool>::Block;
 type HeaderOf<T> = <<T as TransactionPool>::Block as BlockT>::Header;
 type ExtrinsicOf<T> = <<T as TransactionPool>::Block as BlockT>::Extrinsic;
-type HashingFor<B> = <<B as BlockT>::Header as Header>::Hashing;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/domains/client/domain-operator/src/aux_schema.rs
+++ b/domains/client/domain-operator/src/aux_schema.rs
@@ -217,15 +217,19 @@ where
     )
 }
 
+/// Different kinds of bundle mismatches.
 #[derive(Encode, Decode, Debug, PartialEq)]
 pub(super) enum BundleMismatchType {
-    // The invalid bundle is mismatch
-    // For `TrueInvalid`, the fraud proof need to prove the bundle is indeed invalid due to `InvalidBundleType`
-    // For `FalseInvalid`, the fraud proof need to prove the bundle is not invalid due to `InvalidBundleType`
-    TrueInvalid(InvalidBundleType),
-    FalseInvalid(InvalidBundleType),
-    // The valid bundle is mismatch
-    Valid,
+    /// The fraud proof needs to prove the bundle is invalid with `InvalidBundleType`,
+    /// because the bundle is actually an invalid bundle, but it is either marked as valid,
+    /// or as a lower priority invalid type.
+    GoodInvalid(InvalidBundleType),
+    /// The fraud proof needs to prove the `InvalidBundleType` is incorrect,
+    /// because the bundle type is either valid, or a lower priority invalid type.
+    BadInvalid(InvalidBundleType),
+    /// The fraud proof needs to prove the valid bundle contents are incorrect,
+    /// because the bundles are both valid, but their contents are different.
+    ValidBundleContents,
 }
 
 #[cfg(test)]

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -879,7 +879,6 @@ where
                         mismatch_type,
                         bundle_index,
                         bad_receipt_hash,
-                        false,
                     )
                     .map_err(|err| {
                         sp_blockchain::Error::Application(Box::from(format!(

--- a/domains/client/domain-operator/src/domain_block_processor.rs
+++ b/domains/client/domain-operator/src/domain_block_processor.rs
@@ -636,24 +636,26 @@ where
                 .checking_order()
                 .cmp(&external_invalid_type.checking_order())
             {
-                // The `external_invalid_type` claim a prior check is pass while the `local_invalid_type` think
-                // it is failed, so generate a fraud proof to prove that check is truely invalid
-                Ordering::Less => BundleMismatchType::TrueInvalid(local_invalid_type),
-                // The `external_invalid_type` claim a prior check is failed while the `local_invalid_type` think
-                // it is pass, so generate a fraud proof to prove that check is falsely invalid
-                Ordering::Greater => BundleMismatchType::FalseInvalid(external_invalid_type),
+                // The `external_invalid_type` claims a prior check passed, while the `local_invalid_type` thinks
+                // it failed, so generate a fraud proof to prove that prior check is truly invalid
+                Ordering::Less => BundleMismatchType::GoodInvalid(local_invalid_type),
+                // The `external_invalid_type` claims a prior check failed, while the `local_invalid_type` thinks
+                // it passed, so generate a fraud proof to prove that prior check was actually valid
+                Ordering::Greater => BundleMismatchType::BadInvalid(external_invalid_type),
                 Ordering::Equal => unreachable!(
                     "bundle validity must be different as the local/external bundle are checked to be different \
                     and they have the same `extrinsic_root`"
                 ),
             }
         }
-        (BundleValidity::Valid(_), BundleValidity::Valid(_)) => BundleMismatchType::Valid,
+        (BundleValidity::Valid(_), BundleValidity::Valid(_)) => {
+            BundleMismatchType::ValidBundleContents
+        }
         (BundleValidity::Valid(_), BundleValidity::Invalid(invalid_type)) => {
-            BundleMismatchType::FalseInvalid(invalid_type)
+            BundleMismatchType::BadInvalid(invalid_type)
         }
         (BundleValidity::Invalid(invalid_type), BundleValidity::Valid(_)) => {
-            BundleMismatchType::TrueInvalid(invalid_type)
+            BundleMismatchType::GoodInvalid(invalid_type)
         }
     };
 
@@ -856,7 +858,7 @@ where
         }) = find_inboxed_bundles_mismatch::<Block, CBlock>(&local_receipt, &bad_receipt)?
         {
             return match mismatch_type {
-                BundleMismatchType::Valid => self
+                BundleMismatchType::ValidBundleContents => self
                     .fraud_proof_generator
                     .generate_valid_bundle_proof(
                         self.domain_id,
@@ -1046,7 +1048,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::Valid,
+                mismatch_type: BundleMismatchType::ValidBundleContents,
                 bundle_index: 1,
             })
         );
@@ -1065,7 +1067,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::TrueInvalid(InvalidBundleType::UndecodableTx(1)),
+                mismatch_type: BundleMismatchType::GoodInvalid(InvalidBundleType::UndecodableTx(1)),
                 bundle_index: 1,
             })
         );
@@ -1082,9 +1084,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::FalseInvalid(InvalidBundleType::UndecodableTx(
-                    3
-                )),
+                mismatch_type: BundleMismatchType::BadInvalid(InvalidBundleType::UndecodableTx(3)),
                 bundle_index: 1,
             })
         );
@@ -1102,7 +1102,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::FalseInvalid(InvalidBundleType::IllegalTx(3)),
+                mismatch_type: BundleMismatchType::BadInvalid(InvalidBundleType::IllegalTx(3)),
                 bundle_index: 1,
             })
         );
@@ -1124,7 +1124,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::FalseInvalid(
+                mismatch_type: BundleMismatchType::BadInvalid(
                     InvalidBundleType::InherentExtrinsic(3)
                 ),
                 bundle_index: 1,
@@ -1147,7 +1147,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::TrueInvalid(
+                mismatch_type: BundleMismatchType::GoodInvalid(
                     InvalidBundleType::InherentExtrinsic(3)
                 ),
                 bundle_index: 1,
@@ -1171,7 +1171,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::Valid,
+                mismatch_type: BundleMismatchType::ValidBundleContents,
                 bundle_index: 0,
             })
         );
@@ -1190,7 +1190,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::FalseInvalid(InvalidBundleType::IllegalTx(3)),
+                mismatch_type: BundleMismatchType::BadInvalid(InvalidBundleType::IllegalTx(3)),
                 bundle_index: 0,
             })
         );
@@ -1209,7 +1209,7 @@ mod tests {
             )
             .unwrap(),
             Some(InboxedBundleMismatchInfo {
-                mismatch_type: BundleMismatchType::TrueInvalid(InvalidBundleType::IllegalTx(3)),
+                mismatch_type: BundleMismatchType::GoodInvalid(InvalidBundleType::IllegalTx(3)),
                 bundle_index: 0,
             })
         );

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -520,9 +520,13 @@ where
         bundle_index: u32,
         bad_receipt_hash: Block::Hash,
         // Whether allow generating an invalid proof against a valid ER,
-        // only used in tests
-        allow_invalid_proof: bool,
+        // only used in tests, ignored in production
+        mut allow_invalid_proof: bool,
     ) -> Result<FraudProofFor<CBlock, Block::Header>, FraudProofError> {
+        if cfg!(not(test)) {
+            allow_invalid_proof = false;
+        }
+
         let consensus_block_hash = local_receipt.consensus_block_hash;
         let consensus_block_number = local_receipt.consensus_block_number;
 

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -28,7 +28,7 @@ use sp_domains_fraud_proof::FraudProofApi;
 use sp_messenger::MessengerApi;
 use sp_mmr_primitives::MmrApi;
 use sp_runtime::generic::BlockId;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One};
+use sp_runtime::traits::{Block as BlockT, HashingFor, Header as HeaderT, NumberFor, One};
 use sp_runtime::{Digest, DigestItem};
 use sp_trie::LayoutV1;
 use std::marker::PhantomData;
@@ -921,7 +921,7 @@ where
                 }
 
                 let proof_of_inclusion = StorageProofProvider::<
-                    LayoutV1<<Block::Header as HeaderT>::Hashing>,
+                    LayoutV1<HashingFor<Block>>,
                 >::generate_enumerated_proof_of_inclusion(
                     encoded_extrinsics.as_slice(),
                     extrinsic_index as u32,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -5869,7 +5869,7 @@ async fn test_domain_transaction_fee_and_operator_reward() {
         .unwrap();
     let consensus_block_hash = ferdie.client.info().best_hash;
 
-    // Produce one more bundle, this bundle should contains the ER of the previous bundle
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
     let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
     let receipt = bundle.into_receipt();
     assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
@@ -5989,8 +5989,8 @@ async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
             .unwrap();
     assert_ne!(domain_block_hash_fork_a, domain_block_hash_fork_b);
 
-    // The domain block header should contains digest that point to the consensus block, which
-    // devrive the domain block
+    // The domain block header should contain a digest that points to the consensus block, which
+    // devrives the domain block
     let get_header = |hash| alice.client.header(hash).unwrap().unwrap();
     let get_digest_consensus_block_hash = |header: &Header| -> <CBlock as BlockT>::Hash {
         header

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1955,7 +1955,7 @@ async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
     // Produce all possible invalid fraud proof
     for bundle_index in 0..6 {
         for extrinsic_index in 0..4 {
-            for is_true_invalid in [true, false] {
+            for is_good_invalid_fraud_proof in [true, false] {
                 for invalid_type in 0..6 {
                     let invalid_bundle_type = match invalid_type {
                         0 => InvalidBundleType::UndecodableTx(extrinsic_index),
@@ -1970,10 +1970,10 @@ async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
                         5 if extrinsic_index == 0 => InvalidBundleType::InvalidBundleWeight,
                         _ => continue,
                     };
-                    let mismatch_type = if is_true_invalid {
-                        BundleMismatchType::TrueInvalid(invalid_bundle_type)
+                    let mismatch_type = if is_good_invalid_fraud_proof {
+                        BundleMismatchType::GoodInvalid(invalid_bundle_type)
                     } else {
-                        BundleMismatchType::FalseInvalid(invalid_bundle_type)
+                        BundleMismatchType::BadInvalid(invalid_bundle_type)
                     };
                     let res = fraud_proof_generator.generate_invalid_bundle_proof(
                         EVM_DOMAIN_ID,
@@ -2692,7 +2692,7 @@ async fn test_true_invalid_bundles_inherent_extrinsic_proof_creation_and_verific
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InherentExtrinsic(_) = proof.invalid_bundle_type {
-                assert!(proof.is_true_invalid_fraud_proof);
+                assert!(proof.is_good_invalid_fraud_proof);
                 return true;
             }
         }
@@ -2809,7 +2809,7 @@ async fn test_false_invalid_bundles_inherent_extrinsic_proof_creation_and_verifi
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InherentExtrinsic(_) = proof.invalid_bundle_type {
-                assert!(!proof.is_true_invalid_fraud_proof);
+                assert!(!proof.is_good_invalid_fraud_proof);
                 return true;
             }
         }
@@ -2955,7 +2955,7 @@ async fn test_true_invalid_bundles_undecodeable_tx_proof_creation_and_verificati
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::UndecodableTx(_) = proof.invalid_bundle_type {
-                assert!(proof.is_true_invalid_fraud_proof);
+                assert!(proof.is_good_invalid_fraud_proof);
                 return true;
             }
         }
@@ -3072,7 +3072,7 @@ async fn test_false_invalid_bundles_undecodeable_tx_proof_creation_and_verificat
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::UndecodableTx(_) = proof.invalid_bundle_type {
-                assert!(!proof.is_true_invalid_fraud_proof);
+                assert!(!proof.is_good_invalid_fraud_proof);
                 return true;
             }
         }
@@ -3229,7 +3229,7 @@ async fn test_true_invalid_bundles_illegal_xdm_proof_creation_and_verification()
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InvalidXDM(extrinsic_index) = proof.invalid_bundle_type {
-                assert!(proof.is_true_invalid_fraud_proof);
+                assert!(proof.is_good_invalid_fraud_proof);
                 assert_eq!(extrinsic_index, 0);
                 return true;
             }
@@ -3398,7 +3398,7 @@ async fn test_true_invalid_bundles_illegal_extrinsic_proof_creation_and_verifica
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::IllegalTx(extrinsic_index) = proof.invalid_bundle_type {
-                assert!(proof.is_true_invalid_fraud_proof);
+                assert!(proof.is_good_invalid_fraud_proof);
                 assert_eq!(extrinsic_index, 2);
                 return true;
             }
@@ -3535,7 +3535,7 @@ async fn test_false_invalid_bundles_illegal_extrinsic_proof_creation_and_verific
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::IllegalTx(extrinsic_index) = proof.invalid_bundle_type {
-                assert!(!proof.is_true_invalid_fraud_proof);
+                assert!(!proof.is_good_invalid_fraud_proof);
                 assert_eq!(extrinsic_index, 1);
                 return true;
             }
@@ -3660,7 +3660,7 @@ async fn test_true_invalid_bundle_weight_proof_creation_and_verification() {
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if InvalidBundleType::InvalidBundleWeight == proof.invalid_bundle_type {
-                assert!(proof.is_true_invalid_fraud_proof);
+                assert!(proof.is_good_invalid_fraud_proof);
                 return true;
             }
         }
@@ -3775,7 +3775,7 @@ async fn test_false_invalid_bundle_weight_proof_creation_and_verification() {
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if InvalidBundleType::InvalidBundleWeight == proof.invalid_bundle_type {
-                assert!(!proof.is_true_invalid_fraud_proof);
+                assert!(!proof.is_good_invalid_fraud_proof);
                 return true;
             }
         }
@@ -6968,7 +6968,7 @@ async fn test_xdm_false_invalid_fraud_proof() {
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InvalidXDM(extrinsic_index) = proof.invalid_bundle_type {
-                assert!(!proof.is_true_invalid_fraud_proof);
+                assert!(!proof.is_good_invalid_fraud_proof);
                 assert_eq!(extrinsic_index, 0);
                 return true;
             }
@@ -7216,7 +7216,7 @@ async fn test_stale_fork_xdm_true_invalid_fraud_proof() {
     let wait_for_fraud_proof_fut = ferdie.wait_for_fraud_proof(move |fp| {
         if let FraudProofVariant::InvalidBundles(proof) = &fp.proof {
             if let InvalidBundleType::InvalidXDM(extrinsic_index) = proof.invalid_bundle_type {
-                assert!(proof.is_true_invalid_fraud_proof);
+                assert!(proof.is_good_invalid_fraud_proof);
                 assert_eq!(extrinsic_index, 0);
                 return true;
             }

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1778,28 +1778,7 @@ async fn test_executor_inherent_timestamp_is_set() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
-    let directory = TempDir::new().expect("Must be able to create temporary directory");
-
-    let mut builder = sc_cli::LoggerBuilder::new("");
-    builder.with_colors(false);
-    let _ = builder.init();
-
-    let tokio_handle = tokio::runtime::Handle::current();
-
-    // Start Ferdie
-    let mut ferdie = MockConsensusNode::run(
-        tokio_handle.clone(),
-        Ferdie,
-        BasePath::new(directory.path().join("ferdie")),
-    );
-
-    // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
-        tokio_handle.clone(),
-        BasePath::new(directory.path().join("alice")),
-    )
-    .build_evm_node(Role::Authority, Alice, &mut ferdie)
-    .await;
+    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie).await;
 
     let fraud_proof_generator = FraudProofGenerator::new(
         alice.client.clone(),
@@ -2023,28 +2002,7 @@ async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_fraud_proof_is_rejected() {
-    let directory = TempDir::new().expect("Must be able to create temporary directory");
-
-    let mut builder = sc_cli::LoggerBuilder::new("");
-    builder.with_colors(false);
-    let _ = builder.init();
-
-    let tokio_handle = tokio::runtime::Handle::current();
-
-    // Start Ferdie
-    let mut ferdie = MockConsensusNode::run(
-        tokio_handle.clone(),
-        Ferdie,
-        BasePath::new(directory.path().join("ferdie")),
-    );
-
-    // Run Alice (a evm domain authority node)
-    let mut alice = domain_test_service::DomainNodeBuilder::new(
-        tokio_handle.clone(),
-        BasePath::new(directory.path().join("alice")),
-    )
-    .build_evm_node(Role::Authority, Alice, &mut ferdie)
-    .await;
+    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie).await;
 
     let fraud_proof_generator = FraudProofGenerator::new(
         alice.client.clone(),

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -1975,7 +1975,7 @@ async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
                     } else {
                         BundleMismatchType::BadInvalid(invalid_bundle_type)
                     };
-                    let res = fraud_proof_generator.generate_invalid_bundle_proof(
+                    let res = fraud_proof_generator.generate_invalid_bundle_proof_for_test(
                         EVM_DOMAIN_ID,
                         &valid_receipt,
                         mismatch_type,


### PR DESCRIPTION
#### How to review this PR

The real diff starts at aa63e5da6e0185d91981274a04c47df46bb778e0, the other commits are from the `main` branch. (They'll disappear once #3368 merges.)

#### What it does

This PR refactors some fraud proof code so it's easier to use and understand:
- Use `HashingFor` rather than complex trait type paths (some added in #3368)
- Rename `IsFalseInvalid` because double negatives are confusing, and make comments clearer
- Ignore test-only `ignore_invalid_proof` argument in production builds (added in #3368)
- Simplify some tests added in #3368 using test setup functions


### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
