### PR TITLE
change to self-hosted ephemeral linux runners all workflows

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,7 +1,7 @@
 runners:
-  self-hosted-linux:
-    cpu: [8, 16]
-    ram: [16, 32, 64]
+  self-hosted-ubuntu22-full-x64:
+    cpu: [16, 32, 64]
+    ram: [32, 64, 128]
     disk: default
     family: ["c7a", "c7i", "m7a", "m7i"]
     spot: capacity-optimized

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,5 +1,5 @@
 runners:
-  self-hosted-ubuntu22-full-x64:
+  self-hosted-ubuntu-22.04-x86-64:
     cpu: [16, 32, 64]
     ram: [32, 64, 128]
     disk: default

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,8 @@
+runners:
+  self-hosted-linux:
+    cpu: [8, 16]
+    ram: [16, 32, 64]
+    disk: default
+    family: ["c7a", "c7i", "m7a", "m7i"]
+    spot: capacity-optimized
+    image: ubuntu22-full-x64

--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   chains-spec:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -13,7 +13,9 @@ on:
 
 jobs:
   chains-spec:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || 'ubuntu-22.04') }}
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -14,8 +14,7 @@ on:
 jobs:
   chains-spec:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
-      '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/chain-spec-snapshot-build.yml
+++ b/.github/workflows/chain-spec-snapshot-build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   chains-spec:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -13,8 +13,7 @@ on:
 jobs:
   domain-genesis-storage:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
-      '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   domain-genesis-storage:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -12,7 +12,9 @@ on:
 
 jobs:
   domain-genesis-storage:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || 'ubuntu-22.04') }}
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/domain-genesis-storage-snapshot-build.yml
+++ b/.github/workflows/domain-genesis-storage-snapshot-build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   domain-genesis-storage:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   runtime:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' ||
-      '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   runtime:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   runtime:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || 'ubuntu-22.04') }}
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/runtime-snapshot-build.yml
+++ b/.github/workflows/runtime-snapshot-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   runtime:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' ||
       '"ubuntu-22.04"') }}
     permissions:
       contents: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   cargo-fmt:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout
@@ -52,11 +52,11 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
-          '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
+          '["ubuntu-22.04", "windows-2022", "macos-14"]') }}
 
     runs-on: ${{ matrix.os }}
 
@@ -167,11 +167,11 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
-          '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
+          '["ubuntu-22.04", "windows-2022", "macos-14"]') }}
     runs-on: ${{ matrix.os }}
     # Don't use the full 6 hours if a test hangs
     timeout-minutes: 120

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   cargo-fmt:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' ||
       '"ubuntu-22.04"') }}
 
     steps:
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-linux",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
@@ -168,7 +168,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-linux",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,7 @@ env:
 jobs:
   cargo-fmt:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' ||
-      '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout
@@ -53,7 +52,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-linux",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||
@@ -168,7 +167,7 @@ jobs:
       matrix:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
-            "runs-on=${{ github.run_id }}/runner=self-hosted-linux",
+            "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64",
             ["self-hosted", "windows-server-2022-x86-64"],
             ["self-hosted", "macos-14-arm64"]
           ]' ||

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,9 @@ env:
 
 jobs:
   cargo-fmt:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || '"ubuntu-22.04"') }}
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"ubuntu-22.04"') }}
 
     steps:
       - name: Checkout
@@ -49,7 +51,13 @@ jobs:
   cargo-clippy:
     strategy:
       matrix:
-        os: ${{ fromJson(github.repository_owner == 'autonomys' && '[["self-hosted", "ubuntu-22.04-x86-64"], ["self-hosted", "macos-14-arm64"], ["self-hosted", "windows-server-2022-x86-64"]]' || '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
+        os: ${{ fromJson(github.repository_owner == 'autonomys' &&
+          '[
+            "runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64",
+            ["self-hosted", "windows-server-2022-x86-64"],
+            ["self-hosted", "macos-14-arm64"]
+          ]' ||
+          '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
 
     runs-on: ${{ matrix.os }}
 
@@ -158,8 +166,13 @@ jobs:
   cargo-test:
     strategy:
       matrix:
-        os: ${{ fromJson(github.repository_owner == 'autonomys' && '[["self-hosted", "ubuntu-22.04-x86-64"], ["self-hosted", "macos-14-arm64"], ["self-hosted", "windows-server-2022-x86-64"]]' || '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
-
+        os: ${{ fromJson(github.repository_owner == 'autonomys' &&
+          '[
+            "runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64",
+            ["self-hosted", "windows-server-2022-x86-64"],
+            ["self-hosted", "macos-14-arm64"]
+          ]' ||
+          '["ubuntu-22.04", "macos-14", "windows-2022"]') }}
     runs-on: ${{ matrix.os }}
     # Don't use the full 6 hours if a test hangs
     timeout-minutes: 120

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,7 +21,7 @@ jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' ||
       '"ubuntu-22.04"') }}
     permissions:
       contents: write

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,8 +21,7 @@ jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-linux"' ||
-      '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -21,7 +21,7 @@ jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
     runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
-      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu22-full-x64"' || '"ubuntu-22.04"') }}
+      '"runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64"' || '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -20,7 +20,9 @@ env:
 jobs:
   # This will build container images and then extract executables out of them
   ubuntu:
-    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "ubuntu-22.04-x86-64"]' || '"ubuntu-22.04"') }}
+    runs-on: ${{ fromJson(github.repository_owner == 'autonomys' &&
+      '"runs-on=${{ github.run_id }}/cpu=8+16/ram=32+64/family=m7a+m7i-flex/image=ubuntu22-full-x64"' ||
+      '"ubuntu-22.04"') }}
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
This PR changes our CI workflows to use Linux ephemeral self hosted runners on AWS spot instances, instead of dedicated runners. A follow up PR will be done to switch windows over once the base image is ready.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
