### PR TITLE
Remove legacy `RecordStore` support

### DIFF
--- a/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
+++ b/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared/network.rs
@@ -98,7 +98,7 @@ pub(in super::super) fn configure_network<FarmIndex, NC>(
     node_client: NC,
     farmer_caches: FarmerCaches,
     prometheus_metrics_registry: Option<&mut Registry>,
-) -> Result<(Node, NodeRunner<FarmerCaches>), anyhow::Error>
+) -> Result<(Node, NodeRunner), anyhow::Error>
 where
     FarmIndex: Hash + Eq + Copy + fmt::Debug + Send + Sync + 'static,
     usize: From<FarmIndex>,
@@ -116,12 +116,7 @@ where
     .map(Box::new)?;
 
     let maybe_weak_node = Arc::new(Mutex::new(None::<WeakNode>));
-    let default_config = Config::new(
-        protocol_prefix,
-        keypair,
-        farmer_caches.clone(),
-        prometheus_metrics_registry,
-    );
+    let default_config = Config::new(protocol_prefix, keypair, prometheus_metrics_registry);
     let config = Config {
         reserved_peers,
         listen_on,

--- a/crates/subspace-gateway/src/commands.rs
+++ b/crates/subspace-gateway/src/commands.rs
@@ -128,7 +128,7 @@ pub async fn initialize_object_fetcher(
     options: GatewayOptions,
 ) -> anyhow::Result<(
     ObjectFetcher<DsnPieceGetter<SegmentCommitmentPieceValidator<RpcNodeClient>>>,
-    NodeRunner<()>,
+    NodeRunner,
 )> {
     let GatewayOptions {
         dev,

--- a/crates/subspace-gateway/src/commands/network.rs
+++ b/crates/subspace-gateway/src/commands/network.rs
@@ -64,7 +64,7 @@ pub async fn configure_network(
         pending_out_connections,
         listen_on,
     }: NetworkArgs,
-) -> anyhow::Result<(Node, NodeRunner<()>, RpcNodeClient)> {
+) -> anyhow::Result<(Node, NodeRunner, RpcNodeClient)> {
     info!(url = %node_rpc_url, "Connecting to node RPC");
     let node_client = RpcNodeClient::new(&node_rpc_url)
         .await
@@ -89,12 +89,12 @@ pub async fn configure_network(
     debug!(?dsn_protocol_version, "Setting DSN protocol version...");
 
     // TODO:
-    // - use a fixed identity kepair
+    // - use a fixed identity keypair
     // - cache known peers on disk
     // - prometheus telemetry
     let keypair = identity::ed25519::Keypair::generate();
     let keypair = identity::Keypair::from(keypair);
-    let default_config = Config::new(dsn_protocol_version, keypair, (), None);
+    let default_config = Config::new(dsn_protocol_version, keypair, None);
 
     let config = Config {
         bootstrap_addresses: bootstrap_nodes,

--- a/crates/subspace-networking/examples/benchmark.rs
+++ b/crates/subspace-networking/examples/benchmark.rs
@@ -345,7 +345,7 @@ pub async fn configure_dsn(
 ) -> Node {
     let keypair = Keypair::generate_ed25519();
 
-    let default_config = Config::new(protocol_prefix, keypair, (), None);
+    let default_config = Config::new(protocol_prefix, keypair, None);
 
     let config = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],

--- a/crates/subspace-networking/examples/random-walker.rs
+++ b/crates/subspace-networking/examples/random-walker.rs
@@ -366,7 +366,7 @@ async fn configure_dsn(
 ) -> Node {
     let keypair = Keypair::generate_ed25519();
 
-    let default_config = Config::new(protocol_prefix, keypair, (), None);
+    let default_config = Config::new(protocol_prefix, keypair, None);
 
     let config = Config {
         listen_on: vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],

--- a/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
+++ b/crates/subspace-networking/src/bin/subspace-bootstrap-node/main.rs
@@ -162,12 +162,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 kademlia_mode: KademliaMode::Static(Mode::Server),
                 external_addresses,
 
-                ..Config::new(
-                    protocol_version.to_string(),
-                    keypair,
-                    (),
-                    dsn_metrics_registry,
-                )
+                ..Config::new(protocol_version.to_string(), keypair, dsn_metrics_registry)
             };
             let (node, mut node_runner) =
                 subspace_networking::construct(config).expect("Networking stack creation failed.");

--- a/crates/subspace-networking/src/constructor.rs
+++ b/crates/subspace-networking/src/constructor.rs
@@ -122,40 +122,48 @@ impl RecordStore for DummyRecordStore {
     where
         Self: 'a;
 
+    #[inline]
     fn get(&self, _key: &RecordKey) -> Option<Cow<'_, Record>> {
         // Not supported
         None
     }
 
+    #[inline]
     fn put(&mut self, _record: Record) -> store::Result<()> {
         // Not supported
         Ok(())
     }
 
+    #[inline]
     fn remove(&mut self, _key: &RecordKey) {
         // Not supported
     }
 
+    #[inline]
     fn records(&self) -> Self::RecordsIter<'_> {
         // Not supported
         iter::empty()
     }
 
+    #[inline]
     fn add_provider(&mut self, _record: ProviderRecord) -> store::Result<()> {
         // Not supported
         Ok(())
     }
 
+    #[inline]
     fn providers(&self, _key: &RecordKey) -> Vec<ProviderRecord> {
         // Not supported
         Vec::new()
     }
 
+    #[inline]
     fn provided(&self) -> Self::ProvidedIter<'_> {
         // Not supported
         iter::empty()
     }
 
+    #[inline]
     fn remove_provider(&mut self, _key: &RecordKey, _provider: &PeerId) {
         // Not supported
     }

--- a/crates/subspace-networking/src/lib.rs
+++ b/crates/subspace-networking/src/lib.rs
@@ -21,9 +21,7 @@ pub use crate::node::{
     GetClosestPeersError, Node, SendRequestError, SubscribeError, TopicSubscription, WeakNode,
 };
 pub use crate::node_runner::NodeRunner;
-pub use constructor::{
-    construct, peer_id, Config, CreationError, KademliaMode, LocalRecordProvider,
-};
+pub use constructor::{construct, peer_id, Config, CreationError, KademliaMode};
 pub use libp2p;
 pub use shared::PeerDiscovered;
 pub use utils::key_with_distance::KeyWithDistance;

--- a/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/crates/subspace-networking/src/utils/piece_provider.rs
@@ -1,5 +1,6 @@
 //! Provides methods to retrieve pieces from DSN.
 
+use crate::constructor::DummyRecordStore;
 use crate::protocols::request_response::handlers::cached_piece_by_index::{
     CachedPieceByIndexRequest, CachedPieceByIndexResponse, PieceResult,
 };
@@ -15,19 +16,16 @@ use futures::future::FusedFuture;
 use futures::stream::FuturesUnordered;
 use futures::task::noop_waker_ref;
 use futures::{stream, FutureExt, Stream, StreamExt};
-use libp2p::kad::store::RecordStore;
-use libp2p::kad::{store, Behaviour as Kademlia, KBucketKey, ProviderRecord, Record, RecordKey};
+use libp2p::kad::{Behaviour as Kademlia, KBucketKey, RecordKey};
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{Multiaddr, PeerId};
 use rand::prelude::*;
 use std::any::type_name;
-use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::iter::Empty;
+use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::{fmt, iter};
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use tokio_stream::StreamMap;
 use tracing::{debug, trace, warn, Instrument};
@@ -404,57 +402,6 @@ where
         }
 
         None
-    }
-}
-
-struct DummyRecordStore;
-
-impl RecordStore for DummyRecordStore {
-    type RecordsIter<'a>
-        = Empty<Cow<'a, Record>>
-    where
-        Self: 'a;
-    type ProvidedIter<'a>
-        = Empty<Cow<'a, ProviderRecord>>
-    where
-        Self: 'a;
-
-    fn get(&self, _key: &RecordKey) -> Option<Cow<'_, Record>> {
-        // Not supported
-        None
-    }
-
-    fn put(&mut self, _record: Record) -> store::Result<()> {
-        // Not supported
-        Ok(())
-    }
-
-    fn remove(&mut self, _key: &RecordKey) {
-        // Not supported
-    }
-
-    fn records(&self) -> Self::RecordsIter<'_> {
-        // Not supported
-        iter::empty()
-    }
-
-    fn add_provider(&mut self, _record: ProviderRecord) -> store::Result<()> {
-        // Not supported
-        Ok(())
-    }
-
-    fn providers(&self, _key: &RecordKey) -> Vec<ProviderRecord> {
-        // Not supported
-        Vec::new()
-    }
-
-    fn provided(&self) -> Self::ProvidedIter<'_> {
-        // Not supported
-        iter::empty()
-    }
-
-    fn remove_provider(&mut self, _key: &RecordKey, _provider: &PeerId) {
-        // Not supported
     }
 }
 

--- a/crates/subspace-service/src/dsn.rs
+++ b/crates/subspace-service/src/dsn.rs
@@ -70,7 +70,7 @@ pub(crate) fn create_dsn_instance(
     dsn_protocol_version: String,
     dsn_config: DsnConfig,
     prometheus_registry: Option<&mut Registry>,
-) -> Result<(Node, NodeRunner<()>), DsnConfigurationError> {
+) -> Result<(Node, NodeRunner), DsnConfigurationError> {
     trace!("Subspace networking starting.");
 
     let known_peers_registry = {
@@ -96,7 +96,7 @@ pub(crate) fn create_dsn_instance(
 
     let keypair = dsn_config.keypair.clone();
     let default_networking_config =
-        subspace_networking::Config::new(dsn_protocol_version, keypair, (), prometheus_registry);
+        subspace_networking::Config::new(dsn_protocol_version, keypair, prometheus_registry);
 
     let networking_config = subspace_networking::Config {
         keypair: dsn_config.keypair.clone(),


### PR DESCRIPTION
As you can see from usage locations, we've been using `()` implementation for quite some time, but farmer was still able to serve very old clients that relied on requests through Kademlia's DHT and its `RecordStore` implementation.

`RecordStore` has [synchronous API](https://github.com/libp2p/rust-libp2p/issues/3035) and doesn't allow us to do more advanced iterative lookups, which is why we have implemented custom logic and abandoned `RecordStore` usage.

This moves `DummyRecordStore` from `piece_provider` module to `constructor` and simply prunes record store configuration option with all generics that it involved.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
