### PR TITLE
Fix spelling error in `mock.rs`

### DIFF
--- a/domains/pallets/messenger/src/mock.rs
+++ b/domains/pallets/messenger/src/mock.rs
@@ -66,17 +66,17 @@ macro_rules! impl_runtime {
         #[derive(
             PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
         )]
-        pub enum MockHoldIdentifer {
+        pub enum MockHoldIdentifier {
             Messenger(HoldIdentifier)
         }
 
-        impl VariantCount for MockHoldIdentifer {
+        impl VariantCount for MockHoldIdentifier {
             const VARIANT_COUNT: u32 = mem::variant_count::<HoldIdentifier>() as u32;
         }
 
-        impl crate::HoldIdentifier<$runtime> for MockHoldIdentifer {
+        impl crate::HoldIdentifier<$runtime> for MockHoldIdentifier {
             fn messenger_channel() -> Self {
-                MockHoldIdentifer::Messenger(HoldIdentifier::MessengerChannel)
+                MockHoldIdentifier::Messenger(HoldIdentifier::MessengerChannel)
             }
         }
 
@@ -100,7 +100,7 @@ macro_rules! impl_runtime {
             type DomainOwner = ();
             type ChannelReserveFee = ChannelReserveFee;
             type ChannelInitReservePortion = ChannelInitReservePortion;
-            type HoldIdentifier = MockHoldIdentifer;
+            type HoldIdentifier = MockHoldIdentifier;
             type DomainRegistration = DomainRegistration;
             type ChannelFeeModel = ChannelFeeModel;
             type MaxOutgoingMessages = MaxOutgoingMessages;
@@ -138,7 +138,7 @@ macro_rules! impl_runtime {
             type Balance = Balance;
             type DustRemoval = ();
             type ExistentialDeposit = ExistentialDeposit;
-            type RuntimeHoldReason = MockHoldIdentifer;
+            type RuntimeHoldReason = MockHoldIdentifier;
         }
 
         parameter_types! {

--- a/domains/pallets/transporter/src/mock.rs
+++ b/domains/pallets/transporter/src/mock.rs
@@ -44,7 +44,7 @@ impl pallet_balances::Config for MockRuntime {
     type Balance = Balance;
     type DustRemoval = ();
     type ExistentialDeposit = ExistentialDeposit;
-    type RuntimeHoldReason = MockHoldIdentifer;
+    type RuntimeHoldReason = MockHoldIdentifier;
 }
 
 parameter_types! {
@@ -60,11 +60,11 @@ parameter_types! {
 #[derive(
     PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd, Copy, Debug,
 )]
-pub enum MockHoldIdentifer {
+pub enum MockHoldIdentifier {
     Messenger(HoldIdentifier),
 }
 
-impl VariantCount for MockHoldIdentifer {
+impl VariantCount for MockHoldIdentifier {
     const VARIANT_COUNT: u32 = 1u32;
 }
 
@@ -76,9 +76,9 @@ impl sp_messenger::DomainRegistration for DomainRegistration {
     }
 }
 
-impl pallet_messenger::HoldIdentifier<MockRuntime> for MockHoldIdentifer {
+impl pallet_messenger::HoldIdentifier<MockRuntime> for MockHoldIdentifier {
     fn messenger_channel() -> Self {
-        MockHoldIdentifer::Messenger(HoldIdentifier::MessengerChannel)
+        MockHoldIdentifier::Messenger(HoldIdentifier::MessengerChannel)
     }
 }
 
@@ -95,7 +95,7 @@ impl pallet_messenger::Config for MockRuntime {
     type DomainOwner = ();
     type ChannelReserveFee = ChannelReserveFee;
     type ChannelInitReservePortion = ChannelInitReservePortion;
-    type HoldIdentifier = MockHoldIdentifer;
+    type HoldIdentifier = MockHoldIdentifier;
     type DomainRegistration = DomainRegistration;
     type ChannelFeeModel = ChannelFeeModel;
     type MaxOutgoingMessages = MaxOutgoingMessages;


### PR DESCRIPTION
- Updated `MockHoldIdentifer` to `MockHoldIdentifier` in:
  - `domains/pallets/messenger/src/mock.rs`
  - `domains/pallets/transporter/src/mock.rs`
