### PR TITLE
Add debugging fields to archiver errors

### DIFF
--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -247,6 +247,21 @@ pub struct Archiver {
     last_archived_block: LastArchivedBlock,
 }
 
+// Equality, mainly for use in integration tests
+impl PartialEq for Archiver {
+    fn eq(&self, other: &Self) -> bool {
+        // We ignore incremental record commitments, because they depend on the order of method calls.
+        // Subspace uses fixed Kzg parameters, so they don't need to be checked either.
+        self.buffer == other.buffer
+            && self.erasure_coding == other.erasure_coding
+            && self.segment_index == other.segment_index
+            && self.prev_segment_header_hash == other.prev_segment_header_hash
+            && self.last_archived_block == other.last_archived_block
+    }
+}
+
+impl Eq for Archiver {}
+
 impl Archiver {
     /// Create a new instance
     pub fn new(kzg: Kzg, erasure_coding: ErasureCoding) -> Self {

--- a/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/crates/subspace-archiving/tests/integration/archiver.rs
@@ -2,7 +2,6 @@ use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
 use rand::{thread_rng, Rng};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::assert_matches::assert_matches;
 use std::io::Write;
 use std::iter;
 use std::num::NonZeroUsize;
@@ -437,14 +436,14 @@ fn invalid_usage() {
             BlockObjectMapping::default(),
         );
 
-        assert_matches!(
+        assert_eq!(
             result,
-            Err(ArchiverInstantiationError::InvalidLastArchivedBlock(_)),
+            Err(ArchiverInstantiationError::InvalidLastArchivedBlock {
+                block_bytes: 10,
+                prev_segment_index: SegmentIndex::ZERO,
+                prev_segment_header_hash: Blake3Hash::default()
+            }),
         );
-
-        if let Err(ArchiverInstantiationError::InvalidLastArchivedBlock(size)) = result {
-            assert_eq!(size, 10);
-        }
     }
 
     {
@@ -464,19 +463,15 @@ fn invalid_usage() {
             BlockObjectMapping::default(),
         );
 
-        assert_matches!(
+        assert_eq!(
             result,
-            Err(ArchiverInstantiationError::InvalidBlockSmallSize { .. }),
+            Err(ArchiverInstantiationError::InvalidBlockSmallSize {
+                block_bytes: 6,
+                archived_block_bytes: 10,
+                prev_segment_index: SegmentIndex::ZERO,
+                prev_segment_header_hash: Blake3Hash::default()
+            }),
         );
-
-        if let Err(ArchiverInstantiationError::InvalidBlockSmallSize {
-            block_bytes,
-            archived_block_bytes,
-        }) = result
-        {
-            assert_eq!(block_bytes, 6);
-            assert_eq!(archived_block_bytes, 10);
-        }
     }
 }
 

--- a/crates/subspace-erasure-coding/src/lib.rs
+++ b/crates/subspace-erasure-coding/src/lib.rs
@@ -25,6 +25,15 @@ pub struct ErasureCoding {
     fft_settings: Arc<FsFFTSettings>,
 }
 
+impl PartialEq for ErasureCoding {
+    fn eq(&self, other: &Self) -> bool {
+        // The max_width is 1 << scale, so it is enough to compare just this one field
+        self.fft_settings.max_width == other.fft_settings.max_width
+    }
+}
+
+impl Eq for ErasureCoding {}
+
 impl ErasureCoding {
     /// Create new erasure coding instance.
     ///


### PR DESCRIPTION
We had a report of archiver errors on a timekeeper:

> I noticed a timekeeper in an endless restart loop and always throwing this panic
> archival-node-1  | 2025-02-07T17:05:49.143589Z  INFO Consensus: sc_consensus_subspace::archiver: Resuming archiver from last archived block last_archived_block_number=2358
> archival-node-1  | thread 'tokio-runtime-worker' panicked at /code/crates/sc-consensus-subspace/src/archiver.rs:713:14:
> archival-node-1  | Incorrect parameters for archiver: InvalidBlockSmallSize { block_bytes: 874, archived_block_bytes: 1751094 }
> archival-node-1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> 
> Things i did:
> - I switched cores for the timekeeper thread to run on (no luck),
> - I then removed the timekeeper flags and tried to start it but no luck. 
> - I then removed the timekeeper flags and wiped the node and it started.

Looking at the code, there's nowhere that changes the segment header (last archived block) or block data. So this seems like corruption in the segment or block stores due to overclocking. This PR adds debugging fields to archiver instantiation errors, to help diagnose similar errors in future.

It also adds a `PartialEq` implementation for `Archiver`, which simplifies existing tests. I plan to use it in future archiver object mapping or retrieval tests. (Unfortunately this impl can't be `cfg(test)`, because it's used in integration tests.)

Finally, this PR changes an incorrect (but harmless) `BlockNumber` type in that error to `u32`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
