### PR TITLE
Log segment header when archiver instantiation fails

### DIFF
--- a/crates/sc-consensus-subspace/src/archiver.rs
+++ b/crates/sc-consensus-subspace/src/archiver.rs
@@ -687,16 +687,19 @@ where
 
             let last_archived_block_encoded = encode_block(last_archived_block);
 
-            let archiver = Archiver::with_initial_state(
+            Archiver::with_initial_state(
                 subspace_link.kzg().clone(),
                 subspace_link.erasure_coding().clone(),
                 last_segment_header,
                 &last_archived_block_encoded,
                 block_object_mappings,
             )
-            .expect("Incorrect parameters for archiver");
-
-            archiver
+            .map_err(|error| {
+                sp_blockchain::Error::Application(
+                    format!("Incorrect parameters for archiver: {error:?} {last_segment_header:?}")
+                        .into(),
+                )
+            })?
         } else {
             info!("Starting archiving from genesis");
 

--- a/crates/subspace-archiving/src/archiver.rs
+++ b/crates/subspace-archiving/src/archiver.rs
@@ -201,12 +201,13 @@ pub struct ArchiveBlockOutcome {
 /// Archiver instantiation error
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, thiserror::Error)]
 pub enum ArchiverInstantiationError {
-    /// Invalid last archived block, its size is the same as encoded block
-    #[error("Invalid last archived block, its size {0} bytes is the same as encoded block")]
-    InvalidLastArchivedBlock(BlockNumber),
-    /// Invalid block, its size is smaller than already archived number of bytes
+    /// Invalid last archived block, its size is the same as the encoded block
+    /// (so it should have been completely archived, not partially archived)
+    #[error("Invalid last archived block, its size {0} bytes is the same as the encoded block")]
+    InvalidLastArchivedBlock(u32),
+    /// Invalid block, its size is smaller than the already archived number of bytes
     #[error(
-        "Invalid block, its size {block_bytes} bytes is smaller than already archived \
+        "Invalid block, its size {block_bytes} bytes is smaller than the already archived block \
         {archived_block_bytes} bytes"
     )]
     InvalidBlockSmallSize {


### PR DESCRIPTION
We had a report of archiver errors on a timekeeper:
> I noticed a timekeeper in an endless restart loop and always throwing this panic
> archival-node-1  | 2025-02-07T17:05:49.143589Z  INFO Consensus: sc_consensus_subspace::archiver: Resuming archiver from last archived block last_archived_block_number=2358
> archival-node-1  | thread 'tokio-runtime-worker' panicked at /code/crates/sc-consensus-subspace/src/archiver.rs:713:14:
> archival-node-1  | Incorrect parameters for archiver: InvalidBlockSmallSize { block_bytes: 874, archived_block_bytes: 1751094 }
> archival-node-1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> 
> Things i did:
> - I switched cores for the timekeeper thread to run on (no luck),
> - I then removed the timekeeper flags and tried to start it but no luck. 
> - I then removed the timekeeper flags and wiped the node and it started.

Looking at the code, there's nowhere that changes the segment header (last archived block) or block data. So this seems like corruption in the segment or block stores due to overclocking. This PR prints the segment header on archiver instantiation errors, to help diagnose similar errors in future.

This PR also changes an incorrect (but harmless) `BlockNumber` type in archiver instantiation errors to `u32`.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
