### PR TITLE
Windows self hosted runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -15,6 +15,7 @@ runners:
     spot: capacity-optimized
     image: windowscustomimage
 
+# todo: replace with official image from maintainer https://github.com/runs-on/runner-images-for-aws/blob/main/releases/windows22/x64/images/windows/Windows2022-Readme.md
 images:
   windowscustomimage:
     platform: "windows"

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -15,7 +15,21 @@ runners:
     spot: capacity-optimized
     image: windowscustomimage
 
-# todo: replace with official image from maintainer https://github.com/runs-on/runner-images-for-aws/blob/main/releases/windows22/x64/images/windows/Windows2022-Readme.md
+# TODO: Replace with the official Windows runner image once all required packages are available.
+# Reference: https://github.com/runs-on/runner-images-for-aws/blob/main/releases/windows22/x64/images/windows/Windows2022-Readme.md
+#
+# Currently, this image is a minimal Windows base installation and lacks many essential packages listed in the official runner image readme.
+# The goal is to transition to an AWS-compatible image that maintains **1:1 compatibility** with the official GitHub-hosted Windows image.
+#
+# **Temporary Workaround:**
+# - We are using a **custom-built image** with the required dependencies pre-installed.
+# - This custom image (AMI) is derived from our **dedicated runners** image.
+# - More details: https://runs-on.com/configuration/custom-images/
+#
+# **Next Steps:**
+# - Replace the custom image with the official Windows runner image once it becomes available.
+# - Track progress here: https://github.com/runs-on/runs-on/issues/231
+
 images:
   windowscustomimage:
     platform: "windows"

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -6,3 +6,18 @@ runners:
     family: ["c7a", "c7i", "m7a", "m7i"]
     spot: capacity-optimized
     image: ubuntu22-full-x64
+
+  self-hosted-windows-server-2022-x86-64:
+    cpu: [16, 32, 64]
+    ram: [32, 64, 128]
+    disk: default
+    family: ["c7a", "c7i", "m7a", "m7i"]
+    spot: capacity-optimized
+    image: windowscustomimage
+
+images:
+  windowscustomimage:
+    platform: "windows"
+    arch: "x64"
+    owner: "227107093234"
+    ami: "ami-0108ce4fb0e0704da"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
             "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
-            ["self-hosted", "windows-server-2022-x86-64"],
+            "runs-on=${{ github.run_id }}/runner=self-hosted-windows-server-2022-x86-64",
             ["self-hosted", "macos-14-arm64"]
           ]' ||
           '["ubuntu-22.04", "windows-2022", "macos-14"]') }}
@@ -168,7 +168,7 @@ jobs:
         os: ${{ fromJson(github.repository_owner == 'autonomys' &&
           '[
             "runs-on=${{ github.run_id }}/runner=self-hosted-ubuntu-22.04-x86-64",
-            ["self-hosted", "windows-server-2022-x86-64"],
+            "runs-on=${{ github.run_id }}/runner=self-hosted-windows-server-2022-x86-64",
             ["self-hosted", "macos-14-arm64"]
           ]' ||
           '["ubuntu-22.04", "windows-2022", "macos-14"]') }}

--- a/.github/workflows/snapshot-build.yml
+++ b/.github/workflows/snapshot-build.yml
@@ -145,11 +145,11 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "macos-14-arm64"]' || '"macos-14"') }}
             target: aarch64-apple-darwin
             suffix: macos-aarch64-${{ github.ref_name }}
-          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "windows-server-2022-x86-64"]' || '"windows-2022"') }}
+          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '"runs-on=${{ github.run_id }}/runner=self-hosted-windows-server-2022-x86-64"' || '"windows-2022"') }}
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-skylake-${{ github.ref_name }}
             rustflags: "-C target-cpu=skylake"
-          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '["self-hosted", "windows-server-2022-x86-64"]' || '"windows-2022"') }}
+          - os: ${{ fromJson(github.repository_owner == 'autonomys' && '"runs-on=${{ github.run_id }}/runner=self-hosted-windows-server-2022-x86-64"' || '"windows-2022"') }}
             target: x86_64-pc-windows-msvc
             suffix: windows-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"


### PR DESCRIPTION
This PR builds upon [#3373](https://github.com/autonomys/subspace/pull/3373) by introducing Windows self-hosted runners utilizing spot instances.  

## TODO  
- Replace the current custom image with the **official Windows runner image** once all required packages are available:  
  [Windows2022-Readme.md](https://github.com/runs-on/runner-images-for-aws/blob/main/releases/windows22/x64/images/windows/Windows2022-Readme.md).  

## Current Status  
- The **current image** is a base Windows installation and is missing many essential packages listed in the official runner image readme.  
- The **goal** is to use AWS-compatible images that provide **1:1 compatibility** with the official GitHub-hosted Windows image.  

## Temporary Workaround  
- Until the full Windows image is published by the maintainer, we are using a **custom-built image** with the necessary dependencies pre-installed.  
- This custom image is derived from our **dedicated runners** image and is required for this configuration.  
- More details on custom images can be found here:  
  [Custom Image Configuration](https://runs-on.com/configuration/custom-images/).  

## Next Steps  
- Replace the custom image with the **official full Windows image** once it becomes available.  
- Track progress on the official full image here:  
  [Issue runs-on/runner-images-for-aws#19](https://github.com/runs-on/runner-images-for-aws/issues/19).  

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
