### PR TITLE
XDM limit max number of future nonces allowed and relayer header backend fix

### DIFF
--- a/domains/client/cross-domain-message-gossip/src/message_listener.rs
+++ b/domains/client/cross-domain-message-gossip/src/message_listener.rs
@@ -482,7 +482,7 @@ where
 pub fn can_allow_xdm_submission<Client, Block>(
     client: &Arc<Client>,
     xdm_id: XdmId,
-    submitted_block_id: BlockId<Block>,
+    maybe_submitted_block_id: Option<BlockId<Block>>,
     current_block_id: BlockId<Block>,
     maybe_channel_nonce: Option<ChannelNonce>,
 ) -> bool
@@ -518,20 +518,25 @@ where
         }
     }
 
-    match client.hash(submitted_block_id.number).ok().flatten() {
-        // there is no block at this number, allow xdm submission
-        None => return true,
-        Some(hash) => {
-            if hash != submitted_block_id.hash {
-                // client re-org'ed, allow xdm submission
-                return true;
+    match maybe_submitted_block_id {
+        None => true,
+        Some(submitted_block_id) => {
+            match client.hash(submitted_block_id.number).ok().flatten() {
+                // there is no block at this number, allow xdm submission
+                None => return true,
+                Some(hash) => {
+                    if hash != submitted_block_id.hash {
+                        // client re-org'ed, allow xdm submission
+                        return true;
+                    }
+                }
             }
+
+            let latest_block_number = current_block_id.number;
+            let block_limit: NumberFor<Block> = XDM_ACCEPT_BLOCK_LIMIT.saturated_into();
+            submitted_block_id.number < latest_block_number.saturating_sub(block_limit)
         }
     }
-
-    let latest_block_number = current_block_id.number;
-    let block_limit: NumberFor<Block> = XDM_ACCEPT_BLOCK_LIMIT.saturated_into();
-    submitted_block_id.number < latest_block_number.saturating_sub(block_limit)
 }
 
 async fn handle_xdm_message<TxPool, Client, CBlock>(
@@ -566,21 +571,22 @@ where
         let maybe_channel_nonce =
             runtime_api.channel_nonce(block_id.hash, src_chain_id, channel_id)?;
 
-        if let Some(submitted_block_id) =
-            get_xdm_processed_block_number::<_, BlockOf<TxPool>>(&**client, TX_POOL_PREFIX, xdm_id)?
-            && !can_allow_xdm_submission(
-                client,
-                xdm_id,
-                submitted_block_id.clone(),
-                block_id.clone(),
-                maybe_channel_nonce,
-            )
-        {
+        let maybe_submitted_xdm_block = get_xdm_processed_block_number::<_, BlockOf<TxPool>>(
+            &**client,
+            TX_POOL_PREFIX,
+            xdm_id,
+        )?;
+        if !can_allow_xdm_submission(
+            client,
+            xdm_id,
+            maybe_submitted_xdm_block,
+            block_id.clone(),
+            maybe_channel_nonce,
+        ) {
             tracing::debug!(
                 target: LOG_TARGET,
-                "Skipping XDM[{:?}] submission. At: {:?} and Now: {:?}",
+                "Skipping XDM[{:?}] submission. At: {:?}",
                 xdm_id,
-                submitted_block_id,
                 block_id
             );
             return Ok(true);

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -50,11 +50,17 @@ use sp_runtime::DispatchError;
 
 /// Maximum number of XDMs per domain/channel with future nonces that are allowed to be validated.
 /// Any XDM comes with a nonce above Maximum future nonce will be rejected.
-const MAX_FUTURE_ALLOWED_NONCES: u32 = 20;
+// TODO: We need to benchmark how many XDMs can fit in to a
+//  - Single consensus block
+//  - Single domain block(includes all bundles filled with XDMs)
+//  Once we have that info, we can make a better judgement on how many XDMs
+//  we want to include per block while allowing other extrinsics to be included as well.
+//  Note: Currently XDM takes priority over other extrinsics unless they come with priority fee
+const MAX_FUTURE_ALLOWED_NONCES: u32 = 256;
 
 /// Transaction validity for a given validated XDM extrinsic.
 /// If the extrinsic is not included in the bundle, extrinsic is removed from the TxPool.
-const XDM_TRANSACTION_LONGEVITY: u64 = 5;
+const XDM_TRANSACTION_LONGEVITY: u64 = 10;
 
 pub(crate) mod verification_errors {
     // When updating these error codes, check for clashes between:

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -48,6 +48,14 @@ use sp_messenger::messages::{
 use sp_runtime::traits::{Extrinsic, Hash};
 use sp_runtime::DispatchError;
 
+/// Maximum number of XDMs per domain/channel with future nonces that are allowed to be validated.
+/// Any XDM comes with a nonce above Maximum future nonce will be rejected.
+const MAX_FUTURE_ALLOWED_NONCES: u32 = 20;
+
+/// Transaction validity for a given validated XDM extrinsic.
+/// If the extrinsic is not included in the bundle, extrinsic is removed from the TxPool.
+const XDM_TRANSACTION_LONGEVITY: u64 = 5;
+
 pub(crate) mod verification_errors {
     // When updating these error codes, check for clashes between:
     // <https://github.com/autonomys/subspace/blob/main/domains/primitives/runtime/src/lib.rs#L85-L88>
@@ -56,6 +64,7 @@ pub(crate) mod verification_errors {
     pub(crate) const NONCE_OVERFLOW: u8 = 202;
     // This error code was previously 200, but that clashed with ERR_BALANCE_OVERFLOW.
     pub(crate) const INVALID_CHANNEL: u8 = 203;
+    pub(crate) const IN_FUTURE_NONCE: u8 = 204;
 }
 
 #[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo, Copy)]
@@ -118,7 +127,7 @@ mod pallet {
     use crate::{
         BalanceOf, ChainAllowlistUpdate, Channel, ChannelId, ChannelState, CloseChannelBy,
         FeeModel, HoldIdentifier, Nonce, OutboxMessageResult, StateRootOf, ValidatedRelayMessage,
-        STORAGE_VERSION, U256,
+        MAX_FUTURE_ALLOWED_NONCES, STORAGE_VERSION, U256, XDM_TRANSACTION_LONGEVITY,
     };
     #[cfg(not(feature = "std"))]
     use alloc::boxed::Box;
@@ -428,6 +437,15 @@ mod pallet {
                     let mut valid_tx_builder = ValidTransaction::with_tag_prefix("MessengerInbox");
                     // Only add the requires tag if the msg nonce is in future
                     if msg_nonce > next_nonce {
+                        let max_future_nonce =
+                            next_nonce.saturating_add(MAX_FUTURE_ALLOWED_NONCES.into());
+                        if msg_nonce > max_future_nonce {
+                            return Err(InvalidTransaction::Custom(
+                                crate::verification_errors::IN_FUTURE_NONCE,
+                            )
+                            .into());
+                        }
+
                         valid_tx_builder = valid_tx_builder.and_requires((
                             dst_chain_id,
                             channel_id,
@@ -438,7 +456,7 @@ mod pallet {
                         // XDM have a bit higher priority than normal extrinsic but must less than
                         // fraud proof
                         .priority(1)
-                        .longevity(TransactionLongevity::MAX)
+                        .longevity(XDM_TRANSACTION_LONGEVITY)
                         .and_provides((dst_chain_id, channel_id, msg_nonce))
                         .propagate(true)
                         .build()
@@ -461,6 +479,15 @@ mod pallet {
                         ValidTransaction::with_tag_prefix("MessengerOutboxResponse");
                     // Only add the requires tag if the msg nonce is in future
                     if msg_nonce > next_nonce {
+                        let max_future_nonce =
+                            next_nonce.saturating_add(MAX_FUTURE_ALLOWED_NONCES.into());
+                        if msg_nonce > max_future_nonce {
+                            return Err(InvalidTransaction::Custom(
+                                crate::verification_errors::IN_FUTURE_NONCE,
+                            )
+                            .into());
+                        }
+
                         valid_tx_builder = valid_tx_builder.and_requires((
                             dst_chain_id,
                             channel_id,
@@ -471,7 +498,7 @@ mod pallet {
                         // XDM have a bit higher priority than normal extrinsic but must less than
                         // fraud proof
                         .priority(1)
-                        .longevity(TransactionLongevity::MAX)
+                        .longevity(XDM_TRANSACTION_LONGEVITY)
                         .and_provides((dst_chain_id, channel_id, msg_nonce))
                         .propagate(true)
                         .build()


### PR DESCRIPTION
This PR brings following
- Add maximum future nonce allowed for a given XDM to 256. So at a time, txpool will include xdms with future nonces to 20 for given domain and channel.
		- Though I left a todo to benchmark and derive a sane number through that bechmarked data
- Adjust XDM Transaction logenvity to 10 blocks
- Fix relayer using consensus client as header backend while sending XDM from Domains. This was observed in taurus 
- Do some function parameters renaming for better readability

Note: Will handle https://github.com/autonomys/subspace/issues/3371 in a different PR

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
