### PR TITLE
Allow domain owner to change Private EVM contract creation allow list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ dependencies = [
  "sp-core",
  "sp-domain-sudo",
  "sp-domains",
+ "sp-evm-tracker",
  "sp-executive",
  "sp-externalities",
  "sp-inherents",
@@ -3288,6 +3289,7 @@ dependencies = [
  "sp-core",
  "sp-domain-sudo",
  "sp-domains",
+ "sp-evm-tracker",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-messenger",
@@ -3346,6 +3348,7 @@ dependencies = [
  "sp-core",
  "sp-domain-sudo",
  "sp-domains",
+ "sp-evm-tracker",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -7830,6 +7833,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-domains",
+ "sp-evm-tracker",
  "sp-runtime",
  "subspace-runtime-primitives",
 ]
@@ -11909,6 +11913,18 @@ dependencies = [
  "thiserror 2.0.0",
  "tokio",
  "trie-db",
+]
+
+[[package]]
+name = "sp-evm-tracker"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "domain-runtime-primitives",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-domains",
+ "sp-inherents",
 ]
 
 [[package]]

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -34,6 +34,7 @@ use alloc::collections::btree_map::BTreeMap;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
+use domain_runtime_primitives::EthereumAccountId;
 use frame_support::ensure;
 use frame_support::pallet_prelude::StorageVersion;
 use frame_support::traits::fungible::{Inspect, InspectHold};
@@ -205,7 +206,7 @@ mod pallet {
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
     use codec::FullCodec;
-    use domain_runtime_primitives::EVMChainId;
+    use domain_runtime_primitives::{EVMChainId, EthereumAccountId};
     use frame_support::pallet_prelude::*;
     use frame_support::traits::fungible::{Inspect, InspectHold, Mutate, MutateHold};
     use frame_support::traits::tokens::Preservation;
@@ -216,9 +217,10 @@ mod pallet {
     use sp_core::H256;
     use sp_domains::bundle_producer_election::ProofOfElectionError;
     use sp_domains::{
-        BundleDigest, DomainBundleSubmitted, DomainId, DomainSudoCall, DomainsTransfersTracker,
-        EpochIndex, GenesisDomain, OnChainRewards, OnDomainInstantiated, OperatorAllowList,
-        OperatorId, OperatorRewardSource, RuntimeId, RuntimeObject, RuntimeType,
+        BundleDigest, DomainBundleSubmitted, DomainId, DomainOwner, DomainSudoCall,
+        DomainsTransfersTracker, EpochIndex, EvmDomainContractCreationAllowedByCall, GenesisDomain,
+        OnChainRewards, OnDomainInstantiated, OperatorAllowList, OperatorId, OperatorRewardSource,
+        RuntimeId, RuntimeObject, RuntimeType,
     };
     use sp_domains_fraud_proof::fraud_proof_runtime_interface::domain_runtime_call;
     use sp_domains_fraud_proof::storage_proof::{self, FraudProofStorageKeyProvider};
@@ -700,7 +702,7 @@ mod pallet {
     #[pallet::storage]
     pub type DomainRuntimeUpgrades<T> = StorageValue<_, Vec<RuntimeId>, ValueQuery>;
 
-    /// Temporary storage to hold the sudo calls meant for the Domains.
+    /// Temporary storage to hold the sudo calls meant for domains.
     ///
     /// Storage is cleared when there are any successful bundles in the next block.
     /// Only one sudo call is allowed per domain per consensus block.
@@ -713,6 +715,14 @@ mod pallet {
     /// A frozen domain does not accept the bundles but does accept a fraud proof.
     #[pallet::storage]
     pub type FrozenDomains<T> = StorageValue<_, BTreeSet<DomainId>, ValueQuery>;
+
+    /// Temporary storage to hold the "set contract creation allowed by" calls meant for EVM Domains.
+    ///
+    /// Storage is cleared when there are any successful bundles in the next block.
+    /// Only one of these calls is allowed per domain per consensus block.
+    #[pallet::storage]
+    pub type EvmDomainContractCreationAllowedByCalls<T: Config> =
+        StorageMap<_, Identity, DomainId, EvmDomainContractCreationAllowedByCall, ValueQuery>;
 
     #[derive(TypeInfo, Encode, Decode, PalletError, Debug, PartialEq)]
     pub enum BundleError {
@@ -881,12 +891,18 @@ mod pallet {
         BundleStorageFund(BundleStorageFundError),
         /// Permissioned action is not allowed by the caller.
         PermissionedActionNotAllowed,
-        /// Domain Sudo already exists.
+        /// Domain Sudo call already exists.
         DomainSudoCallExists,
         /// Invalid Domain sudo call.
         InvalidDomainSudoCall,
         /// Domain must be frozen before execution receipt can be pruned.
         DomainNotFrozen,
+        /// Domain is not an EVM domain.
+        NotEvmDomain,
+        /// Account is not a Domain owner.
+        NotDomainOwner,
+        /// EVM Domain "set contract creation allowed by" call already exists.
+        EvmDomainContractCreationAllowedByCallExists,
     }
 
     /// Reason for slashing an operator
@@ -1761,6 +1777,43 @@ mod pallet {
             // Ensure the returned weight not exceed the maximum weight in the `pallet::weight`
             Ok(Some(actual_weight.min(Self::max_submit_receipt_weight())).into())
         }
+
+        /// Submit an EVM domain "set contract creation allowed by" call.
+        #[pallet::call_index(22)]
+        #[pallet::weight(<T as frame_system::Config>::DbWeight::get().reads_writes(3, 1))]
+        pub fn send_evm_domain_set_contract_creation_allowed_by_call(
+            origin: OriginFor<T>,
+            domain_id: DomainId,
+            contract_creation_allowed_by: sp_domains::PermissionedActionAllowedBy<
+                EthereumAccountId,
+            >,
+        ) -> DispatchResult {
+            let signer = ensure_signed(origin)?;
+
+            ensure!(
+                Pallet::<T>::is_evm_domain(domain_id),
+                Error::<T>::NotEvmDomain,
+            );
+            ensure!(
+                Pallet::<T>::is_domain_owner(domain_id, signer),
+                Error::<T>::NotDomainOwner,
+            );
+            ensure!(
+                EvmDomainContractCreationAllowedByCalls::<T>::get(domain_id)
+                    .maybe_call
+                    .is_none(),
+                Error::<T>::EvmDomainContractCreationAllowedByCallExists,
+            );
+
+            EvmDomainContractCreationAllowedByCalls::<T>::set(
+                domain_id,
+                EvmDomainContractCreationAllowedByCall {
+                    maybe_call: Some(contract_creation_allowed_by),
+                },
+            );
+
+            Ok(())
+        }
     }
 
     #[pallet::genesis_config]
@@ -1881,9 +1934,17 @@ mod pallet {
             for (domain_id, _) in SuccessfulBundles::<T>::drain() {
                 ConsensusBlockHash::<T>::insert(domain_id, parent_number, parent_hash);
                 T::DomainBundleSubmitted::domain_bundle_submitted(domain_id);
+
+                // And clear the domain inherents which have been submitted.
                 DomainSudoCalls::<T>::mutate(domain_id, |sudo_call| {
                     sudo_call.clear();
                 });
+                EvmDomainContractCreationAllowedByCalls::<T>::mutate(
+                    domain_id,
+                    |evm_contract_call| {
+                        evm_contract_call.clear();
+                    },
+                );
             }
 
             for (operator_id, slot_set) in OperatorBundleSlot::<T>::drain() {
@@ -3057,7 +3118,7 @@ impl<T: Config> Pallet<T> {
         DomainStakingSummary::<T>::contains_key(domain_id)
     }
 
-    /// Returns domain's sudo call if any.
+    /// Returns domain's sudo call, if any.
     pub fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>> {
         DomainSudoCalls::<T>::get(domain_id).maybe_call
     }
@@ -3069,6 +3130,22 @@ impl<T: Config> Pallet<T> {
         let head_receipt_number = HeadReceiptNumber::<T>::get(domain_id);
 
         Ok(domain_best_number.saturating_sub(head_receipt_number))
+    }
+
+    /// Returns true if this is an EVM domain.
+    fn is_evm_domain(domain_id: DomainId) -> bool {
+        if let Some(domain_obj) = DomainRegistry::<T>::get(domain_id) {
+            domain_obj.domain_runtime_info.is_evm()
+        } else {
+            false
+        }
+    }
+
+    /// Returns EVM domain's "set contract creation allowed by" call, if any.
+    pub fn evm_domain_contract_creation_allowed_by_call(
+        domain_id: DomainId,
+    ) -> Option<sp_domains::PermissionedActionAllowedBy<EthereumAccountId>> {
+        EvmDomainContractCreationAllowedByCalls::<T>::get(domain_id).maybe_call
     }
 }
 

--- a/crates/sp-domains-fraud-proof/src/fraud_proof.rs
+++ b/crates/sp-domains-fraud-proof/src/fraud_proof.rs
@@ -505,6 +505,10 @@ pub struct InvalidExtrinsicsRootProof {
 
     /// Optional sudo extrinsic call storage proof
     pub domain_sudo_call_proof: DomainSudoCallStorageProof,
+
+    /// Optional EVM domain "set contract creation allowed by" extrinsic call storage proof
+    pub evm_domain_contract_creation_allowed_by_call_proof:
+        EvmDomainContractCreationAllowedByCallStorageProof,
 }
 
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, TypeInfo)]

--- a/crates/sp-domains-fraud-proof/src/host_functions.rs
+++ b/crates/sp-domains-fraud-proof/src/host_functions.rs
@@ -267,6 +267,7 @@ where
             consensus_transaction_byte_fee,
             domain_chain_allowlist,
             maybe_sudo_runtime_call,
+            maybe_evm_domain_contract_creation_allowed_by_call,
         } = domain_inherent_extrinsic_data;
 
         let domain_stateless_runtime = StatelessRuntime::<Block, DomainBlock, _>::new(
@@ -315,12 +316,24 @@ where
             ),
         };
 
+        let maybe_evm_domain_contract_creation_allowed_by_call_extrinsic =
+            match maybe_evm_domain_contract_creation_allowed_by_call {
+                None => None,
+                Some(call) => Some(
+                    domain_stateless_runtime
+                        .construct_evm_contract_creation_allowed_by_extrinsic(call)
+                        .ok()
+                        .map(|call| call.encode())?,
+                ),
+            };
+
         Some(DomainInherentExtrinsic {
             domain_timestamp_extrinsic,
             maybe_domain_chain_allowlist_extrinsic,
             consensus_chain_byte_fee_extrinsic,
             maybe_domain_set_code_extrinsic,
             maybe_domain_sudo_call_extrinsic,
+            maybe_evm_domain_contract_creation_allowed_by_call_extrinsic,
         })
     }
 

--- a/crates/sp-domains-fraud-proof/src/lib.rs
+++ b/crates/sp-domains-fraud-proof/src/lib.rs
@@ -25,6 +25,7 @@ use crate::storage_proof::FraudProofStorageKeyRequest;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
+use domain_runtime_primitives::EthereumAccountId;
 #[cfg(feature = "std")]
 pub use host_functions::{
     FraudProofExtension, FraudProofHostFunctions, FraudProofHostFunctionsImpl,
@@ -34,7 +35,7 @@ pub use runtime_interface::fraud_proof_runtime_interface;
 pub use runtime_interface::fraud_proof_runtime_interface::HostFunctions;
 use scale_info::TypeInfo;
 use sp_core::H256;
-use sp_domains::DomainAllowlistUpdates;
+use sp_domains::{DomainAllowlistUpdates, PermissionedActionAllowedBy};
 use sp_runtime::traits::{Header as HeaderT, NumberFor};
 use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity};
 use sp_runtime::OpaqueExtrinsic;
@@ -102,6 +103,8 @@ pub struct DomainInherentExtrinsicData {
     pub consensus_transaction_byte_fee: Balance,
     pub domain_chain_allowlist: DomainAllowlistUpdates,
     pub maybe_sudo_runtime_call: Option<Vec<u8>>,
+    pub maybe_evm_domain_contract_creation_allowed_by_call:
+        Option<PermissionedActionAllowedBy<EthereumAccountId>>,
 }
 
 impl PassBy for DomainInherentExtrinsicData {
@@ -115,6 +118,7 @@ pub struct DomainInherentExtrinsic {
     consensus_chain_byte_fee_extrinsic: Vec<u8>,
     maybe_domain_set_code_extrinsic: Option<Vec<u8>>,
     maybe_domain_sudo_call_extrinsic: Option<Vec<u8>>,
+    maybe_evm_domain_contract_creation_allowed_by_call_extrinsic: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]

--- a/crates/sp-domains-fraud-proof/src/verification.rs
+++ b/crates/sp-domains-fraud-proof/src/verification.rs
@@ -69,6 +69,7 @@ where
         maybe_domain_runtime_upgraded_proof,
         domain_chain_allowlist_proof,
         domain_sudo_call_proof,
+        evm_domain_contract_creation_allowed_by_call_proof,
     } = fraud_proof;
 
     let invalid_inherent_extrinsic_data =
@@ -93,6 +94,15 @@ where
         &state_root,
     )?;
 
+    let evm_domain_contract_creation_allowed_by_call =
+        <EvmDomainContractCreationAllowedByCallStorageProof as BasicStorageProof<CBlock>>::verify::<
+            SKP,
+        >(
+            evm_domain_contract_creation_allowed_by_call_proof.clone(),
+            domain_id,
+            &state_root,
+        )?;
+
     let shuffling_seed = invalid_inherent_extrinsic_data.extrinsics_shuffling_seed;
 
     let domain_inherent_extrinsic_data = DomainInherentExtrinsicData {
@@ -102,6 +112,8 @@ where
             .consensus_transaction_byte_fee,
         domain_chain_allowlist,
         maybe_sudo_runtime_call: domain_sudo_call.maybe_call,
+        maybe_evm_domain_contract_creation_allowed_by_call:
+            evm_domain_contract_creation_allowed_by_call.maybe_call,
     };
 
     let DomainInherentExtrinsic {
@@ -110,6 +122,7 @@ where
         consensus_chain_byte_fee_extrinsic,
         maybe_domain_set_code_extrinsic,
         maybe_domain_sudo_call_extrinsic,
+        maybe_evm_domain_contract_creation_allowed_by_call_extrinsic,
     } = fraud_proof_runtime_interface::construct_domain_inherent_extrinsic(
         domain_runtime_code,
         domain_inherent_extrinsic_data,
@@ -138,18 +151,19 @@ where
     let mut ordered_extrinsics =
         deduplicate_and_shuffle_extrinsics(bundle_extrinsics_digests, shuffling_seed);
 
-    // NOTE: the order of the inherent extrinsic MUST aligned with the
-    // pallets order defined in `construct_runtime` macro for domains.
-    // currently this is the following order
+    // NOTE: the order of the inherent extrinsics MUST be the same as the pallet order defined in
+    // the `construct_runtime` macro for domains.
+    // Currently this is the following order:
     // - timestamp extrinsic
     // - executive set_code extrinsic
     // - messenger update_domain_allowlist extrinsic
+    // - evm_tracker contract_creation_allowed_by extrinsic
     // - block_fees transaction_byte_fee_extrinsic
     // - domain_sudo extrinsic
-    // since we use `push_front` the extrinsic should be pushed in reversed order
+    // Since we use `push_front`, the extrinsics should be pushed in reverse order.
     // TODO: this will not be valid once we have a different runtime. To achive consistency across
-    //  domains, we should define a runtime api for each domain that should order the extrinsics
-    //  like inherent are derived while domain block is being built
+    // domains, we should define a runtime api for each domain, which orders the extrinsics the
+    // same way the inherents are derived while the domain block is being built.
 
     if let Some(domain_sudo_call_extrinsic) = maybe_domain_sudo_call_extrinsic {
         let domain_sudo_call_extrinsic = ExtrinsicDigest::new::<
@@ -162,6 +176,16 @@ where
         LayoutV1<HeaderHashingFor<DomainHeader>>,
     >(consensus_chain_byte_fee_extrinsic);
     ordered_extrinsics.push_front(transaction_byte_fee_extrinsic);
+
+    if let Some(evm_domain_contract_creation_allowed_by_call_extrinsic) =
+        maybe_evm_domain_contract_creation_allowed_by_call_extrinsic
+    {
+        let evm_domain_contract_creation_allowed_by_call_extrinsic =
+            ExtrinsicDigest::new::<LayoutV1<HeaderHashingFor<DomainHeader>>>(
+                evm_domain_contract_creation_allowed_by_call_extrinsic,
+            );
+        ordered_extrinsics.push_front(evm_domain_contract_creation_allowed_by_call_extrinsic);
+    }
 
     if let Some(domain_chain_allowlist_extrinsic) = maybe_domain_chain_allowlist_extrinsic {
         let domain_chain_allowlist_extrinsic = ExtrinsicDigest::new::<

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1529,6 +1529,22 @@ impl DomainSudoCall {
     }
 }
 
+/// EVM Domain "update contract creation allowed by" runtime call.
+///
+/// This structure exists because we need to generate a storage proof for FP
+/// and Storage shouldn't be None. So each domain must always hold this value even if
+/// there is an empty runtime call inside
+#[derive(Default, Debug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
+pub struct EvmDomainContractCreationAllowedByCall {
+    pub maybe_call: Option<PermissionedActionAllowedBy<EthereumAccountId>>,
+}
+
+impl EvmDomainContractCreationAllowedByCall {
+    pub fn clear(&mut self) {
+        self.maybe_call.take();
+    }
+}
+
 #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct RuntimeObject<Number, Hash> {
     pub runtime_name: String,
@@ -1574,7 +1590,7 @@ sp_api::decl_runtime_apis! {
     // When updating this version, document new APIs with "Only present in API versions" comments.
     // TODO: when removing this version, also remove "Only present in API versions" comments and
     // deprecated attributes.
-    #[api_version(3)]
+    #[api_version(4)]
     pub trait DomainsApi<DomainHeader: HeaderT> {
         /// Submits the transaction bundle via an unsigned extrinsic.
         fn submit_bundle_unsigned(opaque_bundle: OpaqueBundle<NumberFor<Block>, Block::Hash, DomainHeader, Balance>);
@@ -1664,8 +1680,12 @@ sp_api::decl_runtime_apis! {
         /// Returns true if the given domain's runtime code has been upgraded since `at`.
         fn is_domain_runtime_upgraded_since(domain_id: DomainId, at: NumberFor<Block>) -> Option<bool>;
 
-        /// Returns the domain sudo calls for the given domain, if any.
+        /// Returns the domain sudo call for the given domain, if any.
         fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>>;
+
+        /// Returns the "set contract creation allowed by" call for the given EVM domain, if any.
+        /// Only present in API versions 4 and later.
+        fn evm_domain_contract_creation_allowed_by_call(domain_id: DomainId) -> Option<PermissionedActionAllowedBy<EthereumAccountId>>;
 
         /// Returns the last confirmed domain block execution receipt.
         fn last_confirmed_domain_block_receipt(domain_id: DomainId) ->Option<ExecutionReceiptFor<DomainHeader, Block, Balance>>;

--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -1,7 +1,9 @@
 //! Provides "fake" runtime API implementation as a workaround for compile-time checks.
 
 use domain_runtime_primitives::opaque::Header as DomainHeader;
-use domain_runtime_primitives::{BlockNumber as DomainNumber, Hash as DomainHash};
+use domain_runtime_primitives::{
+    BlockNumber as DomainNumber, EthereumAccountId, Hash as DomainHash,
+};
 use frame_support::weights::Weight;
 use sp_consensus_subspace::{ChainConstants, PotParameters, SignedVote, SolutionRanges};
 use sp_core::crypto::KeyTypeId;
@@ -9,7 +11,7 @@ use sp_core::{OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainAllowlistUpdates, DomainId, DomainInstanceData, ExecutionReceiptFor, OperatorId,
-    OperatorPublicKey,
+    OperatorPublicKey, PermissionedActionAllowedBy,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::FraudProofStorageKeyRequest;
@@ -275,6 +277,10 @@ sp_api::impl_runtime_apis! {
         }
 
         fn domain_sudo_call(_domain_id: DomainId) -> Option<Vec<u8>> {
+            unreachable!()
+        }
+
+        fn evm_domain_contract_creation_allowed_by_call(_domain_id: DomainId) -> Option<PermissionedActionAllowedBy<EthereumAccountId>>{
             unreachable!()
         }
 

--- a/crates/subspace-node/src/chain_spec.rs
+++ b/crates/subspace-node/src/chain_spec.rs
@@ -10,7 +10,7 @@ use sc_subspace_chain_specs::{DEVNET_CHAIN_SPEC, MAINNET_CHAIN_SPEC, TAURUS_CHAI
 use sc_telemetry::TelemetryEndpoints;
 use serde::Deserialize;
 use sp_core::crypto::Ss58Codec;
-use sp_domains::PermissionedActionAllowedBy;
+use sp_domains::{EvmType, PermissionedActionAllowedBy};
 use sp_runtime::{BoundedVec, Percent};
 use std::marker::PhantomData;
 use std::num::{NonZeroU128, NonZeroU32};
@@ -359,6 +359,11 @@ pub fn dev_config() -> Result<GenericChainSpec, String> {
                     genesis_domains: vec![evm_chain_spec::get_genesis_domain(
                         SpecId::Dev,
                         sudo_account,
+                        // TODO: in production configs, set this to Public, unless we specifically want a private EVM
+                        EvmType::Private {
+                            initial_contract_creation_allow_list:
+                                PermissionedActionAllowedBy::Anyone,
+                        },
                     )?],
                 },
                 CouncilDemocracyConfigParams::<BlockNumber>::fast_params(),

--- a/crates/subspace-node/src/domain/evm_chain_spec.rs
+++ b/crates/subspace-node/src/domain/evm_chain_spec.rs
@@ -13,7 +13,9 @@ use sc_chain_spec::GenericChainSpec;
 use sc_service::ChainType;
 use sp_core::crypto::UncheckedFrom;
 use sp_domains::storage::RawGenesis;
-use sp_domains::{EvmDomainRuntimeConfig, OperatorAllowList, OperatorPublicKey, RuntimeType};
+use sp_domains::{
+    EvmDomainRuntimeConfig, EvmType, OperatorAllowList, OperatorPublicKey, RuntimeType,
+};
 use sp_runtime::traits::Convert;
 use sp_runtime::BuildStorage;
 use std::collections::BTreeSet;
@@ -182,6 +184,7 @@ fn get_operator_params(
 pub fn get_genesis_domain(
     spec_id: SpecId,
     sudo_account: subspace_runtime_primitives::AccountId,
+    evm_type: EvmType,
 ) -> Result<GenesisDomain, String> {
     let chain_spec = match spec_id {
         SpecId::Dev => development_config(get_testnet_genesis_by_spec_id(spec_id))?,
@@ -207,11 +210,6 @@ pub fn get_genesis_domain(
         initial_balances: get_testnet_endowed_accounts_by_spec_id(spec_id),
         operator_allow_list,
         operator_signing_key,
-        domain_runtime_config: EvmDomainRuntimeConfig {
-            // TODO: for the private EVM instance, set this to the accounts that are initially
-            // allowed to create contracts (for example, the domain owner)
-            initial_contract_creation_allow_list: sp_domains::PermissionedActionAllowedBy::Anyone,
-        }
-        .into(),
+        domain_runtime_config: EvmDomainRuntimeConfig { evm_type }.into(),
     })
 }

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -61,6 +61,9 @@ pub type Signature = MultiSignature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
+//
+// Note: sometimes this type alias causes complex trait ambiguity / conflicting implementation errors.
+// As a workaround, `use sp_runtime::AccountId32 as AccountId` instead.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 /// Balance of an account.

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -34,7 +34,7 @@ use core::num::NonZeroU64;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::{
     maximum_domain_block_weight, AccountIdConverter, BlockNumber as DomainNumber,
-    Hash as DomainHash, MAX_OUTGOING_MESSAGES,
+    EthereumAccountId, Hash as DomainHash, MAX_OUTGOING_MESSAGES,
 };
 use frame_support::genesis_builder_helper::{build_state, get_preset};
 use frame_support::inherent::ProvideInherent;
@@ -61,8 +61,8 @@ use sp_core::{ConstBool, OpaqueMetadata, H256};
 use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     ChannelId, DomainAllowlistUpdates, DomainId, DomainInstanceData, ExecutionReceiptFor,
-    OperatorId, OperatorPublicKey, OperatorRewardSource, DOMAIN_STORAGE_FEE_MULTIPLIER,
-    INITIAL_DOMAIN_TX_RANGE,
+    OperatorId, OperatorPublicKey, OperatorRewardSource, PermissionedActionAllowedBy,
+    DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::{
@@ -1057,6 +1057,11 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::DomainSudoCall(domain_id) => {
                 pallet_domains::DomainSudoCalls::<Runtime>::hashed_key_for(domain_id)
             }
+            FraudProofStorageKeyRequest::EvmDomainContractCreationAllowedByCall(domain_id) => {
+                pallet_domains::EvmDomainContractCreationAllowedByCalls::<Runtime>::hashed_key_for(
+                    domain_id,
+                )
+            }
             FraudProofStorageKeyRequest::MmrRoot(block_number) => {
                 pallet_subspace_mmr::MmrRootHashes::<Runtime>::hashed_key_for(block_number)
             }
@@ -1361,6 +1366,11 @@ impl_runtime_apis! {
         fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>> {
             Domains::domain_sudo_call(domain_id)
         }
+
+        fn evm_domain_contract_creation_allowed_by_call(domain_id: DomainId) -> Option<PermissionedActionAllowedBy<EthereumAccountId>> {
+            Domains::evm_domain_contract_creation_allowed_by_call(domain_id)
+        }
+
 
         fn last_confirmed_domain_block_receipt(domain_id: DomainId) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>>{
             Domains::latest_confirmed_domain_execution_receipt(domain_id)

--- a/domains/client/block-preprocessor/Cargo.toml
+++ b/domains/client/block-preprocessor/Cargo.toml
@@ -24,6 +24,7 @@ sp-block-fees = { version = "0.1.0", path = "../../primitives/block-fees" }
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains" }
 sp-domain-sudo = { version = "0.1.0", path = "../../primitives/domain-sudo" }
+sp-evm-tracker = { version = "0.1.0", path = "../../primitives/evm-tracker" }
 sp-executive = { version = "0.1.0", path = "../../primitives/executive" }
 sp-externalities = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-inherents = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -180,6 +180,7 @@ where
         sp_executive::InherentDataProvider,
         sp_messenger::InherentDataProvider,
         sp_domain_sudo::InherentDataProvider,
+        sp_evm_tracker::InherentDataProvider,
     );
 
     async fn create_inherent_data_providers(
@@ -243,12 +244,26 @@ where
         let domain_sudo_call_inherent_provider =
             sp_domain_sudo::InherentDataProvider::new(maybe_domain_sudo_call);
 
+        let maybe_evm_domain_contract_creation_allowed_by_call = if domains_api_version >= 4 {
+            runtime_api.evm_domain_contract_creation_allowed_by_call(
+                consensus_block_hash,
+                self.domain_id,
+            )?
+        } else {
+            None
+        };
+        let evm_domain_contract_creation_allowed_by_call_inherent_provider =
+            sp_evm_tracker::InherentDataProvider::new(
+                maybe_evm_domain_contract_creation_allowed_by_call,
+            );
+
         Ok((
             timestamp_provider,
             storage_price_provider,
             runtime_upgrade_provider,
             messenger_inherent_provider,
             domain_sudo_call_inherent_provider,
+            evm_domain_contract_creation_allowed_by_call_inherent_provider,
         ))
     }
 }

--- a/domains/client/block-preprocessor/src/stateless_runtime.rs
+++ b/domains/client/block-preprocessor/src/stateless_runtime.rs
@@ -1,6 +1,8 @@
 use codec::{Codec, Encode};
 use domain_runtime_primitives::opaque::AccountId;
-use domain_runtime_primitives::{Balance, CheckExtrinsicsValidityError, DecodeExtrinsicError};
+use domain_runtime_primitives::{
+    Balance, CheckExtrinsicsValidityError, DecodeExtrinsicError, EthereumAccountId,
+};
 use sc_client_api::execution_extensions::ExtensionsFactory;
 use sc_executor::RuntimeVersionOf;
 use sp_api::{ApiError, Core};
@@ -8,7 +10,8 @@ use sp_core::traits::{CallContext, CodeExecutor, FetchRuntimeCode, RuntimeCode};
 use sp_core::Hasher;
 use sp_domain_sudo::DomainSudoApi;
 use sp_domains::core_api::DomainCoreApi;
-use sp_domains::{ChainId, ChannelId, DomainAllowlistUpdates};
+use sp_domains::{ChainId, ChannelId, DomainAllowlistUpdates, PermissionedActionAllowedBy};
+use sp_evm_tracker::EvmTrackerApi;
 use sp_messenger::messages::MessageKey;
 use sp_messenger::{MessengerApi, RelayerApi};
 use sp_runtime::traits::{Block as BlockT, NumberFor};
@@ -107,6 +110,23 @@ where
 }
 
 impl<CBlock, Block, Executor> DomainSudoApi<Block> for StatelessRuntime<CBlock, Block, Executor>
+where
+    CBlock: BlockT,
+    Block: BlockT,
+    NumberFor<Block>: Codec,
+    Executor: CodeExecutor + RuntimeVersionOf,
+{
+    fn __runtime_api_internal_call_api_at(
+        &self,
+        _at: Block::Hash,
+        params: Vec<u8>,
+        fn_name: &dyn Fn(RuntimeVersion) -> &'static str,
+    ) -> Result<Vec<u8>, ApiError> {
+        self.dispatch_call(fn_name, params)
+    }
+}
+
+impl<CBlock, Block, Executor> EvmTrackerApi<Block> for StatelessRuntime<CBlock, Block, Executor>
 where
     CBlock: BlockT,
     Block: BlockT,
@@ -373,6 +393,17 @@ where
         inner_call: Vec<u8>,
     ) -> Result<Block::Extrinsic, ApiError> {
         <Self as DomainSudoApi<Block>>::construct_domain_sudo_extrinsic(
+            self,
+            Default::default(),
+            inner_call,
+        )
+    }
+
+    pub fn construct_evm_contract_creation_allowed_by_extrinsic(
+        &self,
+        inner_call: PermissionedActionAllowedBy<EthereumAccountId>,
+    ) -> Result<Block::Extrinsic, ApiError> {
+        <Self as EvmTrackerApi<Block>>::construct_evm_contract_creation_allowed_by_extrinsic(
             self,
             Default::default(),
             inner_call,

--- a/domains/client/block-preprocessor/src/stateless_runtime.rs
+++ b/domains/client/block-preprocessor/src/stateless_runtime.rs
@@ -356,7 +356,7 @@ where
         )
     }
 
-    /// This is stateful runtime api call and require setting of storage keys.
+    /// This is a stateful runtime api call and requires setting storage keys.
     pub fn check_extrinsics_and_do_pre_dispatch(
         &self,
         uxts: Vec<Block::Extrinsic>,

--- a/domains/client/domain-operator/src/fraud_proof.rs
+++ b/domains/client/domain-operator/src/fraud_proof.rs
@@ -411,6 +411,14 @@ where
             &self.storage_key_provider,
         )?;
 
+        let evm_domain_contract_creation_allowed_by_call_proof =
+            EvmDomainContractCreationAllowedByCallStorageProof::generate(
+                self.consensus_client.as_ref(),
+                consensus_block_hash,
+                domain_id,
+                &self.storage_key_provider,
+            )?;
+
         let invalid_domain_extrinsics_root_proof = FraudProof {
             domain_id,
             bad_receipt_hash,
@@ -422,6 +430,7 @@ where
                 maybe_domain_runtime_upgraded_proof,
                 domain_chain_allowlist_proof,
                 domain_sudo_call_proof,
+                evm_domain_contract_creation_allowed_by_call_proof,
             }),
         };
 

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -5329,8 +5329,8 @@ async fn test_domain_sudo_calls() {
     .unwrap()
     .unwrap();
 
-    // produce 150 more blocks to ensure nothing went wrong
-    produce_blocks!(ferdie, alice, 150).await.unwrap();
+    // produce 30 more blocks to ensure nothing went wrong
+    produce_blocks!(ferdie, alice, 30).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -5423,8 +5423,8 @@ async fn test_domain_owner_calls() {
     .await
     .unwrap();
 
-    // produce 150 more blocks to ensure nothing went wrong
-    produce_blocks!(ferdie, alice, 150).await.unwrap();
+    // produce 30 more blocks to ensure nothing went wrong
+    produce_blocks!(ferdie, alice, 30).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -5517,8 +5517,8 @@ async fn test_public_evm_rejects_allow_list_domain_sudo_calls() {
     let receipt = bundle.into_receipt();
     assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
 
-    // produce 150 more blocks to ensure nothing went wrong
-    produce_blocks!(ferdie, alice, 150).await.unwrap();
+    // produce 30 more blocks to ensure nothing went wrong
+    produce_blocks!(ferdie, alice, 30).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -5595,8 +5595,8 @@ async fn test_public_evm_rejects_allow_list_domain_owner_calls() {
     let receipt = bundle.into_receipt();
     assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
 
-    // produce 150 more blocks to ensure nothing went wrong
-    produce_blocks!(ferdie, alice, 150).await.unwrap();
+    // produce 30 more blocks to ensure nothing went wrong
+    produce_blocks!(ferdie, alice, 30).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -2026,7 +2026,17 @@ async fn test_bad_fraud_proof_is_rejected() {
         .await
         .expect("Failed to send extrinsic");
 
-    // Produce a domain block that contains the previously sent extrinsic
+    ferdie
+        .construct_and_send_extrinsic_with(
+            pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+                domain_id: EVM_DOMAIN_ID,
+                contract_creation_allowed_by: PermissionedActionAllowedBy::Anyone,
+            },
+        )
+        .await
+        .expect("Failed to send extrinsic");
+
+    // Produce a domain block that contains the previously sent extrinsics
     produce_blocks!(ferdie, alice, 1).await.unwrap();
 
     // Get the receipt of that domain block and produce another bundle to submit the receipt

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -228,6 +228,7 @@ pub fn generate_evm_account_list(
 
 async fn setup_evm_test_nodes(
     ferdie_key: Sr25519Keyring,
+    private_evm: bool,
 ) -> (TempDir, MockConsensusNode, EvmDomainNode) {
     let directory = TempDir::new().expect("Must be able to create temporary directory");
 
@@ -238,10 +239,12 @@ async fn setup_evm_test_nodes(
     let tokio_handle = tokio::runtime::Handle::current();
 
     // Start Ferdie with Alice Key since that is the sudo key
-    let mut ferdie = MockConsensusNode::run(
+    let mut ferdie = MockConsensusNode::run_with_finalization_depth(
         tokio_handle.clone(),
         ferdie_key,
         BasePath::new(directory.path().join("ferdie")),
+        None,
+        private_evm,
     );
 
     // Run Alice (an evm domain)
@@ -257,8 +260,9 @@ async fn setup_evm_test_nodes(
 
 async fn setup_evm_test_accounts(
     ferdie_key: Sr25519Keyring,
+    private_evm: bool,
 ) -> (TempDir, MockConsensusNode, EvmDomainNode, Vec<AccountInfo>) {
-    let (directory, mut ferdie, mut alice) = setup_evm_test_nodes(ferdie_key).await;
+    let (directory, mut ferdie, mut alice) = setup_evm_test_nodes(ferdie_key, private_evm).await;
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
 
@@ -288,9 +292,9 @@ async fn setup_evm_test_accounts(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_evm_domain_create_contracts_with_allow_list_default() {
+async fn test_private_evm_domain_create_contracts_with_allow_list_default() {
     let (_directory, mut ferdie, mut alice, account_infos) =
-        setup_evm_test_accounts(Sr25519Alice).await;
+        setup_evm_test_accounts(Sr25519Alice, true).await;
 
     let gas_price = alice
         .client
@@ -405,9 +409,126 @@ async fn test_evm_domain_create_contracts_with_allow_list_default() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_public_evm_domain_create_contracts() {
+    let (_directory, mut ferdie, mut alice, account_infos) =
+        setup_evm_test_accounts(Sr25519Alice, false).await;
+
+    let gas_price = alice
+        .client
+        .runtime_api()
+        .gas_price(alice.client.info().best_hash)
+        .unwrap();
+
+    // Any account should be able to create contracts in a public EVM domain
+    let mut eth_nonce = U256::zero();
+    let eth_tx = generate_eth_domain_extrinsic(
+        account_infos[0].clone(),
+        ethereum::TransactionAction::Create,
+        eth_nonce,
+        gas_price,
+    );
+    eth_nonce += U256::one();
+
+    let result = alice.send_extrinsic(eth_tx).await;
+    assert_matches!(
+        result,
+        Ok(_),
+        "Unexpectedly failed to send self-contained extrinsic"
+    );
+
+    let mut evm_nonce = U256::zero();
+    let mut evm_tx = generate_evm_domain_call(
+        account_infos[1].clone(),
+        ethereum::TransactionAction::Create,
+        0,
+        evm_nonce,
+        gas_price,
+    );
+    evm_nonce += U256::one();
+
+    let result = alice.construct_and_send_extrinsic(evm_tx).await;
+    assert_matches!(
+        result,
+        Ok(_),
+        "Unexpectedly failed to send signed extrinsic"
+    );
+
+    // Produce a bundle that contains just the sent extrinsics
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 2);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    let gas_price = alice
+        .client
+        .runtime_api()
+        .gas_price(alice.client.info().best_hash)
+        .unwrap();
+
+    // Nested should behave exactly the same
+    evm_tx = generate_evm_domain_call(
+        account_infos[1].clone(),
+        ethereum::TransactionAction::Create,
+        1,
+        evm_nonce,
+        gas_price,
+    );
+    evm_nonce += U256::one();
+
+    let result = alice.construct_and_send_extrinsic(evm_tx).await;
+    assert_matches!(
+        result,
+        Ok(_),
+        "Unexpectedly failed to send nested signed extrinsic"
+    );
+
+    evm_tx = generate_evm_domain_call(
+        account_infos[2].clone(),
+        ethereum::TransactionAction::Create,
+        0,
+        evm_nonce,
+        gas_price,
+    );
+    evm_nonce += U256::one();
+
+    let evm_ex = alice.construct_unsigned_extrinsic(evm_tx);
+    let result = alice.send_extrinsic(evm_ex).await;
+    // TODO: fix NoUnsignedValidator error
+    assert_matches!(
+        result,
+        Err(_),
+        "Test should fail until the test runtime is given an unsigned validator"
+    );
+
+    // Produce a bundle that contains just the sent extrinsics
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 1);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_create_contracts_with_allow_list_reject_all() {
     let (_directory, mut ferdie, mut alice, account_infos) =
-        setup_evm_test_accounts(Sr25519Alice).await;
+        setup_evm_test_accounts(Sr25519Alice, true).await;
 
     let gas_price = alice
         .client
@@ -451,30 +572,20 @@ async fn test_evm_domain_create_contracts_with_allow_list_reject_all() {
     // Sudo on consensus chain will send a sudo call to domain
     // once the call is executed in the domain, list will be updated.
     let allow_list = generate_evm_account_list(&account_infos, EvmAccountList::NoOne);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
         alice.evm_contract_creation_allowed_by() == allow_list
     })
+    .timeout()
     .await
+    .unwrap()
     .unwrap();
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
@@ -639,7 +750,7 @@ async fn test_evm_domain_create_contracts_with_allow_list_reject_all() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_create_contracts_with_allow_list_single() {
     let (_directory, mut ferdie, mut alice, account_infos) =
-        setup_evm_test_accounts(Sr25519Alice).await;
+        setup_evm_test_accounts(Sr25519Alice, true).await;
 
     let gas_price = alice
         .client
@@ -679,30 +790,20 @@ async fn test_evm_domain_create_contracts_with_allow_list_single() {
 
     // 1 account in the allow list
     let allow_list = generate_evm_account_list(&account_infos, EvmAccountList::One);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
         alice.evm_contract_creation_allowed_by() == allow_list
     })
+    .timeout()
     .await
+    .unwrap()
     .unwrap();
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
@@ -871,34 +972,24 @@ async fn test_evm_domain_create_contracts_with_allow_list_single() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_evm_domain_create_contracts_with_allow_list_multiple() {
     let (_directory, mut ferdie, mut alice, account_infos) =
-        setup_evm_test_accounts(Sr25519Alice).await;
+        setup_evm_test_accounts(Sr25519Alice, true, Ferdie).await;
 
     // Multiple accounts in the allow list
     let allow_list = generate_evm_account_list(&account_infos, EvmAccountList::Multiple);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
         alice.evm_contract_creation_allowed_by() == allow_list
     })
+    .timeout()
     .await
+    .unwrap()
     .unwrap();
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
@@ -1611,7 +1702,7 @@ async fn collected_receipts_should_be_on_the_same_branch_with_current_best_block
 // TODO: when the test is fixed, decide if we want to remove the timeouts.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_domain_tx_propagate() -> Result<(), tokio::time::error::Elapsed> {
-    let (directory, mut ferdie, alice) = setup_evm_test_nodes(Ferdie).timeout().await?;
+    let (directory, mut ferdie, alice) = setup_evm_test_nodes(Ferdie, false).timeout().await?;
 
     // Run Bob (a evm domain full node)
     let mut bob = domain_test_service::DomainNodeBuilder::new(
@@ -1783,7 +1874,7 @@ async fn test_executor_inherent_timestamp_is_set() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
-    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie).await;
+    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie, false).await;
 
     let fraud_proof_generator = FraudProofGenerator::new(
         alice.client.clone(),
@@ -2007,7 +2098,7 @@ async fn test_bad_invalid_bundle_fraud_proof_is_rejected() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_fraud_proof_is_rejected() {
-    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie).await;
+    let (_directory, mut ferdie, mut alice) = setup_evm_test_nodes(Ferdie, true).await;
 
     let fraud_proof_generator = FraudProofGenerator::new(
         alice.client.clone(),
@@ -5026,7 +5117,7 @@ async fn existing_bundle_can_be_resubmitted_to_new_fork() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_domain_sudo_calls() {
     let (_directory, mut ferdie, mut alice, account_infos) =
-        setup_evm_test_accounts(Sr25519Alice).await;
+        setup_evm_test_accounts(Sr25519Alice, true).await;
 
     // Run the cross domain gossip message worker
     ferdie.start_cross_domain_gossip_message_worker();
@@ -5096,84 +5187,52 @@ async fn test_domain_sudo_calls() {
 
     // Start with a redundant set to make sure the test framework works.
     let mut allow_list = generate_evm_account_list(&account_infos, EvmAccountList::Anyone);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
         alice.evm_contract_creation_allowed_by() == allow_list
     })
+    .timeout()
     .await
+    .unwrap()
     .unwrap();
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
 
     // Then use actual settings
     allow_list = generate_evm_account_list(&account_infos, EvmAccountList::NoOne);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
         alice.evm_contract_creation_allowed_by() == allow_list
     })
+    .timeout()
     .await
+    .unwrap()
     .unwrap();
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
 
     // 1 account in the allow list
     allow_list = generate_evm_account_list(&account_infos, EvmAccountList::One);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
@@ -5186,24 +5245,12 @@ async fn test_domain_sudo_calls() {
 
     // Multiple accounts in the allow list
     allow_list = generate_evm_account_list(&account_infos, EvmAccountList::Multiple);
-    let sudo_unsigned_extrinsic = alice
-        .construct_unsigned_extrinsic(evm_domain_test_runtime::RuntimeCall::EVMNoncetracker(
-            pallet_evm_tracker::Call::set_contract_creation_allowed_by {
-                contract_creation_allowed_by: allow_list.clone(),
-            },
-        ))
-        .encode();
-    ferdie
-        .construct_and_send_extrinsic_with(pallet_sudo::Call::sudo {
-            call: Box::new(subspace_test_runtime::RuntimeCall::Domains(
-                pallet_domains::Call::send_domain_sudo_call {
-                    domain_id: EVM_DOMAIN_ID,
-                    call: sudo_unsigned_extrinsic,
-                },
-            )),
-        })
-        .await
-        .expect("Failed to construct and send consensus chain to update EVM contract allow list");
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
 
     // Wait until list is updated
     produce_blocks_until!(ferdie, alice, {
@@ -5258,7 +5305,7 @@ async fn test_domain_sudo_calls() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_domain_owner_calls() {
     let (_directory, mut ferdie, alice, account_infos) =
-        setup_evm_test_accounts(Sr25519Alice).await;
+        setup_evm_test_accounts(Sr25519Alice, true).await;
 
     produce_blocks!(ferdie, alice, 3).await.unwrap();
 
@@ -5344,6 +5391,175 @@ async fn test_domain_owner_calls() {
     })
     .await
     .unwrap();
+
+    // produce 150 more blocks to ensure nothing went wrong
+    produce_blocks!(ferdie, alice, 150).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_public_evm_rejects_allow_list_domain_sudo_calls() {
+    let (_directory, mut ferdie, alice, account_infos) =
+        setup_evm_test_accounts(Sr25519Alice, false).await;
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    // check initial contract allow list
+    assert_eq!(
+        alice.evm_contract_creation_allowed_by(),
+        PermissionedActionAllowedBy::Anyone,
+        "initial contract allow list should be anyone"
+    );
+
+    // try to set EVM contract allow list on Domain using domain sudo.
+    // pallet-domains should reject these calls on a public EVM instance.
+
+    // A redundant set should still fail
+    let mut allow_list = generate_evm_account_list(&account_infos, EvmAccountList::Anyone);
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
+
+    // Produce a bundle that contains just the sent extrinsics (and not the failed ones)
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 0);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    // Then use actual settings
+    allow_list = generate_evm_account_list(&account_infos, EvmAccountList::NoOne);
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
+
+    // Produce a bundle that contains just the sent extrinsics (and not the failed ones)
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 0);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    // Multiple accounts in the allow list
+    allow_list = generate_evm_account_list(&account_infos, EvmAccountList::Multiple);
+    ferdie.construct_and_send_extrinsic_with(pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+        domain_id: EVM_DOMAIN_ID,
+        contract_creation_allowed_by: allow_list.clone(),
+    })
+    .await
+    .expect("Failed to construct and send consensus chain sudo call to update EVM contract allow list");
+
+    // Produce a bundle that contains just the sent extrinsics (and not the failed ones)
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 0);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
+
+    // produce 150 more blocks to ensure nothing went wrong
+    produce_blocks!(ferdie, alice, 150).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_public_evm_rejects_allow_list_domain_owner_calls() {
+    let (_directory, mut ferdie, alice, account_infos) =
+        setup_evm_test_accounts(Sr25519Alice, false).await;
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    // check initial contract allow list
+    assert_eq!(
+        alice.evm_contract_creation_allowed_by(),
+        PermissionedActionAllowedBy::Anyone,
+        "initial contract allow list should be anyone"
+    );
+
+    // Try to set EVM contract allow list on Domain using domain owner.
+    // pallet-domains should reject these calls on a public EVM instance.
+
+    // A redundant set should still fail.
+    let mut allow_list = generate_evm_account_list(&account_infos, EvmAccountList::Anyone);
+    ferdie
+        .construct_and_send_extrinsic_with(
+            pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+                domain_id: EVM_DOMAIN_ID,
+                contract_creation_allowed_by: allow_list.clone(),
+            },
+        )
+        .await
+        .expect(
+            "Owner update to public EVM contract allow list shouldn't have failed at this stage",
+        );
+
+    // Produce a bundle that contains just the sent extrinsics (and not the failed ones)
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 0);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
+
+    produce_blocks!(ferdie, alice, 3).await.unwrap();
+
+    // Then use actual settings
+    // 1 account in the allow list
+    allow_list = generate_evm_account_list(&account_infos, EvmAccountList::One);
+    ferdie
+        .construct_and_send_extrinsic_with(
+            pallet_domains::Call::send_evm_domain_set_contract_creation_allowed_by_call {
+                domain_id: EVM_DOMAIN_ID,
+                contract_creation_allowed_by: allow_list.clone(),
+            },
+        )
+        .await
+        .expect(
+            "Owner update to public EVM contract allow list shouldn't have failed at this stage",
+        );
+
+    // Produce a bundle that contains just the sent extrinsics (and not the failed ones)
+    let (slot, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    assert_eq!(bundle.extrinsics.len(), 0);
+    produce_block_with!(ferdie.produce_block_with_slot(slot), alice)
+        .await
+        .unwrap();
+    let consensus_block_hash = ferdie.client.info().best_hash;
+
+    // Produce one more bundle, this bundle should contain the ER of the previous bundle
+    let (_, bundle) = ferdie.produce_slot_and_wait_for_bundle_submission().await;
+    let receipt = bundle.into_receipt();
+    assert_eq!(receipt.consensus_block_hash, consensus_block_hash);
 
     // produce 150 more blocks to ensure nothing went wrong
     produce_blocks!(ferdie, alice, 150).await.unwrap();
@@ -6662,6 +6878,7 @@ async fn test_verify_mmr_proof_stateless() {
         BasePath::new(directory.path().join("ferdie")),
         // finalization depth
         Some(10),
+        false,
     );
 
     // Run Alice (an evm domain)
@@ -6738,6 +6955,7 @@ async fn test_equivocated_bundle_check() {
         BasePath::new(directory.path().join("ferdie")),
         // finalization depth
         Some(10),
+        false,
     );
 
     // Run Alice (an evm domain)

--- a/domains/pallets/evm-tracker/Cargo.toml
+++ b/domains/pallets/evm-tracker/Cargo.toml
@@ -23,6 +23,7 @@ pallet-utility = { default-features = false, git = "https://github.com/subspace/
 scale-info = { version = "2.11.2", default-features = false, features = ["derive"] }
 sp-core = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
+sp-evm-tracker = { version = "0.1.0", default-features = false, path = "../../primitives/evm-tracker" }
 sp-runtime = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 subspace-runtime-primitives = { version = "0.1.0", path = "../../../crates/subspace-runtime-primitives", default-features = false }
 
@@ -39,6 +40,7 @@ std = [
     "scale-info/std",
     "sp-core/std",
     "sp-domains/std",
+    "sp-evm-tracker/std",
     "sp-runtime/std",
     "subspace-runtime-primitives/std",
 ]

--- a/domains/pallets/evm-tracker/src/lib.rs
+++ b/domains/pallets/evm-tracker/src/lib.rs
@@ -89,7 +89,7 @@ mod pallet {
         ) -> DispatchResult {
             ensure_none(origin)?;
 
-            // is_private_evm_domain() was already checked by pallet-domains.
+            // signer and is_private_evm_domain() were already checked by pallet-domains.
 
             ContractCreationAllowedBy::<T>::put(contract_creation_allowed_by);
 

--- a/domains/pallets/evm-tracker/src/lib.rs
+++ b/domains/pallets/evm-tracker/src/lib.rs
@@ -83,7 +83,7 @@ mod pallet {
         /// An inherent call to set ContractCreationAllowedBy.
         #[pallet::call_index(0)]
         #[pallet::weight((T::DbWeight::get().reads_writes(0, 1), DispatchClass::Mandatory))]
-        pub fn inherent_set_contract_creation_allowed_by(
+        pub fn set_contract_creation_allowed_by(
             origin: OriginFor<T>,
             contract_creation_allowed_by: PermissionedActionAllowedBy<EthereumAccountId>,
         ) -> DispatchResult {
@@ -111,11 +111,11 @@ mod pallet {
 
             inherent_data
                 .maybe_call
-                .map(|contract_creation_allowed_by| {
-                    Call::inherent_set_contract_creation_allowed_by {
+                .map(
+                    |contract_creation_allowed_by| Call::set_contract_creation_allowed_by {
                         contract_creation_allowed_by,
-                    }
-                })
+                    },
+                )
         }
 
         fn is_inherent_required(data: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
@@ -144,7 +144,7 @@ mod pallet {
         }
 
         fn is_inherent(call: &Self::Call) -> bool {
-            matches!(call, Call::inherent_set_contract_creation_allowed_by { .. })
+            matches!(call, Call::set_contract_creation_allowed_by { .. })
         }
     }
 

--- a/domains/pallets/evm-tracker/src/lib.rs
+++ b/domains/pallets/evm-tracker/src/lib.rs
@@ -80,27 +80,19 @@ mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        /// Replace ContractCreationAllowedBy setting in storage, as a domain sudo call.
-        #[pallet::call_index(0)]
-        #[pallet::weight(<T as frame_system::Config>::DbWeight::get().reads_writes(0, 1))]
-        pub fn set_contract_creation_allowed_by(
-            origin: OriginFor<T>,
-            contract_creation_allowed_by: PermissionedActionAllowedBy<EthereumAccountId>,
-        ) -> DispatchResult {
-            ensure_root(origin)?;
-            ContractCreationAllowedBy::<T>::put(contract_creation_allowed_by);
-            Ok(())
-        }
-
         /// An inherent call to set ContractCreationAllowedBy.
-        #[pallet::call_index(1)]
-        #[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Mandatory))]
+        #[pallet::call_index(0)]
+        #[pallet::weight((T::DbWeight::get().reads_writes(0, 1), DispatchClass::Mandatory))]
         pub fn inherent_set_contract_creation_allowed_by(
             origin: OriginFor<T>,
             contract_creation_allowed_by: PermissionedActionAllowedBy<EthereumAccountId>,
         ) -> DispatchResult {
             ensure_none(origin)?;
+
+            // is_private_evm_domain() was already checked by pallet-domains.
+
             ContractCreationAllowedBy::<T>::put(contract_creation_allowed_by);
+
             Ok(())
         }
     }

--- a/domains/primitives/evm-tracker/Cargo.toml
+++ b/domains/primitives/evm-tracker/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "sp-evm-tracker"
+version = "0.1.0"
+authors = ["Teor <teor@riseup.net>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://subspace.network"
+repository = "https://github.com/autonomys/subspace"
+description = "Primitives of pallet evm tracker"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+async-trait = { version = "0.1.83", optional = true }
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+domain-runtime-primitives = { version = "0.1.0", default-features = false, path = "../runtime" }
+sp-api = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
+sp-domains = { version = "0.1.0", default-features = false, path = "../../../crates/sp-domains" }
+sp-inherents = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
+
+[features]
+default = ["std"]
+std = [
+    "async-trait",
+    "codec/std",
+    "domain-runtime-primitives/std",
+    "sp-api/std",
+    "sp-domains/std",
+    "sp-inherents/std",
+]

--- a/domains/primitives/evm-tracker/src/lib.rs
+++ b/domains/primitives/evm-tracker/src/lib.rs
@@ -1,0 +1,84 @@
+//! Inherents for EVM tracker
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+use domain_runtime_primitives::EthereumAccountId;
+use sp_domains::PermissionedActionAllowedBy;
+#[cfg(feature = "std")]
+use sp_inherents::{Error, InherentData};
+use sp_inherents::{InherentIdentifier, IsFatalError};
+
+/// Executive inherent identifier.
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"dmnevmtr";
+
+#[derive(Debug, Encode)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub enum InherentError {
+    MissingRuntimeCall,
+    InvalidRuntimeCall,
+    IncorrectRuntimeCall,
+}
+
+impl IsFatalError for InherentError {
+    fn is_fatal_error(&self) -> bool {
+        true
+    }
+}
+
+/// The type of the Subspace inherent data.
+#[derive(Debug, Encode, Decode)]
+pub struct InherentType {
+    /// EVM tracker "set contract creation allowed by" call
+    pub maybe_call: Option<PermissionedActionAllowedBy<EthereumAccountId>>,
+}
+
+/// Provides the set code inherent data.
+#[cfg(feature = "std")]
+pub struct InherentDataProvider {
+    data: InherentType,
+}
+
+#[cfg(feature = "std")]
+impl InherentDataProvider {
+    /// Create new inherent data provider from the given `data`.
+    pub fn new(maybe_call: Option<PermissionedActionAllowedBy<EthereumAccountId>>) -> Self {
+        Self {
+            data: InherentType { maybe_call },
+        }
+    }
+
+    /// Returns the `data` of this inherent data provider.
+    pub fn data(&self) -> &InherentType {
+        &self.data
+    }
+}
+
+#[cfg(feature = "std")]
+#[async_trait::async_trait]
+impl sp_inherents::InherentDataProvider for InherentDataProvider {
+    async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
+        inherent_data.put_data(INHERENT_IDENTIFIER, &self.data)
+    }
+
+    async fn try_handle_error(
+        &self,
+        identifier: &InherentIdentifier,
+        error: &[u8],
+    ) -> Option<Result<(), Error>> {
+        if *identifier != INHERENT_IDENTIFIER {
+            return None;
+        }
+
+        let error = InherentError::decode(&mut &*error).ok()?;
+
+        Some(Err(Error::Application(Box::from(format!("{error:?}")))))
+    }
+}
+
+sp_api::decl_runtime_apis! {
+    /// Api to check and verify the evm-tracker extrinsic calls
+    pub trait EvmTrackerApi {
+        /// Returns an encoded extrinsic for domain "set contract creation allowed by" call.
+        fn construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument: PermissionedActionAllowedBy<EthereumAccountId>) -> Block::Extrinsic;
+    }
+}

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -45,6 +45,9 @@ pub type Signature = MultiSignature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
+//
+// Note: sometimes this type alias causes complex trait ambiguity / conflicting implementation errors.
+// As a workaround, `use sp_runtime::AccountId32 as AccountId` instead.
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 /// Balance of an account.
@@ -73,6 +76,9 @@ pub type EthereumSignature = EVMSignature;
 
 /// Some way of identifying an account on the EVM chain. We intentionally make it equivalent
 /// to the public key of the EVM transaction signing scheme.
+//
+// Note: sometimes this type alias causes complex trait ambiguity / conflicting implementation errors.
+// As a workaround, `use fp_account::AccountId20 as EthereumAccountId` instead.
 pub type EthereumAccountId = <<EthereumSignature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 /// Dispatch ratio for domains

--- a/domains/primitives/runtime/src/lib.rs
+++ b/domains/primitives/runtime/src/lib.rs
@@ -243,7 +243,7 @@ pub struct CheckExtrinsicsValidityError {
 #[derive(Debug, Decode, Encode, TypeInfo, PartialEq, Eq, Clone)]
 pub struct DecodeExtrinsicError(pub String);
 
-/// fullu qualified method name of check_extrinsics_and_do_pre_dispatch runtime api.
+/// Fully qualified method name of check_extrinsics_and_do_pre_dispatch runtime api.
 /// Used to call state machine.
 /// Change it when the runtime api's name is changed in the interface.
 pub const CHECK_EXTRINSICS_AND_DO_PRE_DISPATCH_METHOD_NAME: &str =

--- a/domains/runtime/evm/Cargo.toml
+++ b/domains/runtime/evm/Cargo.toml
@@ -52,6 +52,7 @@ sp-block-builder = { default-features = false, git = "https://github.com/subspac
 sp-core = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-domains = { version = "0.1.0", path = "../../../crates/sp-domains", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "../../primitives/domain-sudo", default-features = false }
+sp-evm-tracker = { version = "0.1.0", path = "../../primitives/evm-tracker", default-features = false }
 sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
 sp-inherents = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../primitives/messenger" }
@@ -114,6 +115,7 @@ std = [
     "sp-core/std",
     "sp-domains/std",
     "sp-domain-sudo/std",
+    "sp-evm-tracker/std",
     "sp-genesis-builder/std",
     "sp-inherents/std",
     "sp-messenger/std",

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -55,7 +55,9 @@ use pallet_transporter::EndpointHandler;
 use sp_api::impl_runtime_apis;
 use sp_core::crypto::KeyTypeId;
 use sp_core::{Get, OpaqueMetadata, H160, H256, U256};
-use sp_domains::{ChannelId, DomainAllowlistUpdates, DomainId, Transfers};
+use sp_domains::{
+    ChannelId, DomainAllowlistUpdates, DomainId, PermissionedActionAllowedBy, Transfers,
+};
 use sp_messenger::endpoint::{Endpoint, EndpointHandler as EndpointHandlerT, EndpointId};
 use sp_messenger::messages::{
     BlockMessagesWithStorageKey, ChainId, CrossDomainMessage, FeeModel, MessageId, MessageKey,
@@ -900,12 +902,25 @@ fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
     UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()
 }
 
+/// Constructs a domain-sudo call extrinsic from the given encoded extrinsic.
 fn construct_sudo_call_extrinsic(encoded_ext: Vec<u8>) -> <Block as BlockT>::Extrinsic {
     let ext = UncheckedExtrinsic::decode(&mut encoded_ext.as_slice())
         .expect("must always be an valid extrinsic due to the check above; qed");
     UncheckedExtrinsic::new_unsigned(
         pallet_domain_sudo::Call::sudo {
             call: Box::new(ext.0.function),
+        }
+        .into(),
+    )
+}
+
+/// Constructs an evm-tracker call extrinsic from the given extrinsic.
+fn construct_evm_contract_creation_allowed_by_extrinsic(
+    decoded_argument: PermissionedActionAllowedBy<AccountId>,
+) -> <Block as BlockT>::Extrinsic {
+    UncheckedExtrinsic::new_unsigned(
+        pallet_evm_tracker::Call::inherent_set_contract_creation_allowed_by {
+            contract_creation_allowed_by: decoded_argument,
         }
         .into(),
     )
@@ -1254,6 +1269,7 @@ impl_runtime_apis! {
                 RuntimeCall::ExecutivePallet(call) => ExecutivePallet::is_inherent(call),
                 RuntimeCall::Messenger(call) => Messenger::is_inherent(call),
                 RuntimeCall::Sudo(call) => Sudo::is_inherent(call),
+                RuntimeCall::EVMNoncetracker(call) => EVMNoncetracker::is_inherent(call),
                 _ => false,
             }
         }
@@ -1623,6 +1639,12 @@ impl_runtime_apis! {
 
         fn construct_domain_sudo_extrinsic(inner: Vec<u8>) -> <Block as BlockT>::Extrinsic {
             construct_sudo_call_extrinsic(inner)
+        }
+    }
+
+    impl sp_evm_tracker::EvmTrackerApi<Block> for Runtime {
+        fn construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument: PermissionedActionAllowedBy<AccountId>) -> <Block as BlockT>::Extrinsic {
+            construct_evm_contract_creation_allowed_by_extrinsic(decoded_argument)
         }
     }
 

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -919,7 +919,7 @@ fn construct_evm_contract_creation_allowed_by_extrinsic(
     decoded_argument: PermissionedActionAllowedBy<AccountId>,
 ) -> <Block as BlockT>::Extrinsic {
     UncheckedExtrinsic::new_unsigned(
-        pallet_evm_tracker::Call::inherent_set_contract_creation_allowed_by {
+        pallet_evm_tracker::Call::set_contract_creation_allowed_by {
             contract_creation_allowed_by: decoded_argument,
         }
         .into(),

--- a/domains/test/runtime/evm/Cargo.toml
+++ b/domains/test/runtime/evm/Cargo.toml
@@ -52,6 +52,7 @@ sp-block-builder = { default-features = false, git = "https://github.com/subspac
 sp-core = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-domains = { version = "0.1.0", path = "../../../../crates/sp-domains", default-features = false }
 sp-domain-sudo = { version = "0.1.0", path = "../../../primitives/domain-sudo", default-features = false }
+sp-evm-tracker = { version = "0.1.0", path = "../../../primitives/evm-tracker", default-features = false }
 sp-genesis-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305", default-features = false }
 sp-inherents = { default-features = false, git = "https://github.com/subspace/polkadot-sdk", rev = "94a1a8143a89bbe9f938c1939ff68abc1519a305" }
 sp-messenger = { version = "0.1.0", default-features = false, path = "../../../primitives/messenger" }
@@ -112,6 +113,7 @@ std = [
     "sp-core/std",
     "sp-domains/std",
     "sp-domain-sudo/std",
+    "sp-evm-tracker/std",
     "sp-genesis-builder/std",
     "sp-inherents/std",
     "sp-messenger/std",

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -956,7 +956,7 @@ fn construct_evm_contract_creation_allowed_by_extrinsic(
     decoded_argument: PermissionedActionAllowedBy<AccountId>,
 ) -> <Block as BlockT>::Extrinsic {
     UncheckedExtrinsic::new_unsigned(
-        pallet_evm_tracker::Call::inherent_set_contract_creation_allowed_by {
+        pallet_evm_tracker::Call::set_contract_creation_allowed_by {
             contract_creation_allowed_by: decoded_argument,
         }
         .into(),

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -298,7 +298,7 @@ where
             .expect("Fail to get account nonce")
     }
 
-    /// Sends an system.remark extrinsic to the pool.
+    /// Sends a signed system.remark extrinsic to the pool containing the current account nonce.
     pub async fn send_system_remark(&mut self) {
         let nonce = self.account_nonce();
         let _ = self
@@ -309,7 +309,7 @@ where
             .map(|_| ());
     }
 
-    /// Construct an extrinsic with the current nonce of the node account and send it to this node.
+    /// Construct a signed extrinsic with the current nonce of the node account and send it to this node.
     pub async fn construct_and_send_extrinsic(
         &mut self,
         function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
@@ -318,7 +318,7 @@ where
             .await
     }
 
-    /// Construct an extrinsic with the given nonce and tip for the node account and send it to this node.
+    /// Construct a signed extrinsic with the given nonce and tip for the node account and send it to this node.
     pub async fn construct_and_send_extrinsic_with(
         &self,
         nonce: u32,
@@ -336,7 +336,7 @@ where
         self.rpc_handlers.send_transaction(extrinsic.into()).await
     }
 
-    /// Construct an extrinsic.
+    /// Construct a signed extrinsic.
     pub fn construct_extrinsic(
         &mut self,
         nonce: u32,
@@ -352,7 +352,7 @@ where
         )
     }
 
-    /// Construct an extrinsic with the given transaction tip.
+    /// Construct a signed extrinsic with the given transaction tip.
     pub fn construct_extrinsic_with_tip(
         &mut self,
         nonce: u32,
@@ -407,6 +407,15 @@ where
     {
         let function = function.into();
         UncheckedExtrinsicFor::<Runtime>::new_unsigned(function)
+    }
+
+    /// Construct an unsigned extrinsic and send it to this node.
+    pub async fn construct_and_send_unsigned_extrinsic(
+        &mut self,
+        function: impl Into<<Runtime as frame_system::Config>::RuntimeCall>,
+    ) -> Result<RpcTransactionOutput, RpcTransactionError> {
+        let extrinsic = self.construct_unsigned_extrinsic(function);
+        self.rpc_handlers.send_transaction(extrinsic.into()).await
     }
 
     /// Give the peer at `addr` the minimum reputation, which will ban it.

--- a/test/subspace-test-client/src/chain_spec.rs
+++ b/test/subspace-test-client/src/chain_spec.rs
@@ -30,7 +30,12 @@ pub fn get_account_id_from_seed(seed: &str) -> AccountId {
 ///
 /// If `private_evm` is `true`, contract creation will have an allow list, which is set to `Anyone` by default.
 /// Otherwise, any account can create contracts, and the allow list can't be changed.
-pub fn subspace_local_testnet_config(private_evm: bool) -> Result<GenericChainSpec, String> {
+///
+/// If the EVM owner account isn't specified, `sudo_account` will be used.
+pub fn subspace_local_testnet_config(
+    private_evm: bool,
+    evm_owner_account: Option<AccountId>,
+) -> Result<GenericChainSpec, String> {
     let evm_type = if private_evm {
         EvmType::Private {
             initial_contract_creation_allow_list: PermissionedActionAllowedBy::Anyone,
@@ -38,6 +43,35 @@ pub fn subspace_local_testnet_config(private_evm: bool) -> Result<GenericChainSp
     } else {
         EvmType::Public
     };
+
+    let sudo_account = get_account_id_from_seed("Alice");
+    let evm_owner_account = evm_owner_account.unwrap_or_else(|| sudo_account.clone());
+
+    // Pre-funded accounts
+    // Alice and the EVM owner get more funds that are used during domain instantiation
+    let mut balances = vec![
+        (get_account_id_from_seed("Alice"), 1_000_000_000 * SSC),
+        (get_account_id_from_seed("Bob"), 1_000 * SSC),
+        (get_account_id_from_seed("Charlie"), 1_000 * SSC),
+        (get_account_id_from_seed("Dave"), 1_000 * SSC),
+        (get_account_id_from_seed("Eve"), 1_000 * SSC),
+        (get_account_id_from_seed("Ferdie"), 1_000 * SSC),
+        (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
+        (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
+        (get_account_id_from_seed("Charlie//stash"), 1_000 * SSC),
+        (get_account_id_from_seed("Dave//stash"), 1_000 * SSC),
+        (get_account_id_from_seed("Eve//stash"), 1_000 * SSC),
+        (get_account_id_from_seed("Ferdie//stash"), 1_000 * SSC),
+    ];
+
+    if let Some((_existing_account, balance)) = balances
+        .iter_mut()
+        .find(|(account_id, _balance)| account_id == &evm_owner_account)
+    {
+        *balance = 1_000_000_000 * SSC;
+    } else {
+        balances.push((evm_owner_account.clone(), 1_000_000_000 * SSC));
+    }
 
     Ok(GenericChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
@@ -49,24 +83,10 @@ pub fn subspace_local_testnet_config(private_evm: bool) -> Result<GenericChainSp
     .with_genesis_config(
         serde_json::to_value(create_genesis_config(
             // Sudo account
-            get_account_id_from_seed("Alice"),
-            // Pre-funded accounts
-            // Alice also get more funds that are used during the domain instantiation
-            vec![
-                (get_account_id_from_seed("Alice"), 1_000_000_000 * SSC),
-                (get_account_id_from_seed("Bob"), 1_000 * SSC),
-                (get_account_id_from_seed("Charlie"), 1_000 * SSC),
-                (get_account_id_from_seed("Dave"), 1_000 * SSC),
-                (get_account_id_from_seed("Eve"), 1_000 * SSC),
-                (get_account_id_from_seed("Ferdie"), 1_000 * SSC),
-                (get_account_id_from_seed("Alice//stash"), 1_000 * SSC),
-                (get_account_id_from_seed("Bob//stash"), 1_000 * SSC),
-                (get_account_id_from_seed("Charlie//stash"), 1_000 * SSC),
-                (get_account_id_from_seed("Dave//stash"), 1_000 * SSC),
-                (get_account_id_from_seed("Eve//stash"), 1_000 * SSC),
-                (get_account_id_from_seed("Ferdie//stash"), 1_000 * SSC),
-            ],
+            sudo_account,
+            balances,
             evm_type,
+            evm_owner_account,
         )?)
         .map_err(|error| format!("Failed to serialize genesis config: {error}"))?,
     )
@@ -79,6 +99,7 @@ fn create_genesis_config(
     sudo_account: AccountId,
     balances: Vec<(AccountId, Balance)>,
     evm_type: EvmType,
+    evm_owner_account: AccountId,
 ) -> Result<RuntimeGenesisConfig, String> {
     Ok(RuntimeGenesisConfig {
         system: SystemConfig::default(),
@@ -102,9 +123,9 @@ fn create_genesis_config(
         domains: DomainsConfig {
             permissioned_action_allowed_by: Some(sp_domains::PermissionedActionAllowedBy::Anyone),
             genesis_domains: vec![
-                crate::evm_domain_chain_spec::get_genesis_domain(sudo_account.clone(), evm_type)
+                crate::evm_domain_chain_spec::get_genesis_domain(evm_owner_account, evm_type)
                     .expect("hard-coded values are valid; qed"),
-                crate::auto_id_domain_chain_spec::get_genesis_domain(sudo_account.clone())
+                crate::auto_id_domain_chain_spec::get_genesis_domain(sudo_account)
                     .expect("hard-coded values are valid; qed"),
             ],
         },

--- a/test/subspace-test-client/src/evm_domain_chain_spec.rs
+++ b/test/subspace-test-client/src/evm_domain_chain_spec.rs
@@ -10,7 +10,8 @@ use sc_chain_spec::{ChainType, GenericChainSpec, NoExtension};
 use sp_core::{ecdsa, Pair, Public};
 use sp_domains::storage::RawGenesis;
 use sp_domains::{
-    DomainId, DomainRuntimeConfig, GenesisDomain, OperatorAllowList, OperatorPublicKey, RuntimeType,
+    DomainId, EvmDomainRuntimeConfig, EvmType, GenesisDomain, OperatorAllowList, OperatorPublicKey,
+    RuntimeType,
 };
 use sp_runtime::traits::{Convert, IdentifyAccount, Verify};
 use sp_runtime::{BuildStorage, Percent};
@@ -94,6 +95,7 @@ pub fn testnet_evm_genesis() -> RuntimeGenesisConfig {
 
 pub fn get_genesis_domain(
     sudo_account: subspace_runtime_primitives::AccountId,
+    evm_type: EvmType,
 ) -> Result<GenesisDomain<AccountId, Balance>, String> {
     let raw_genesis_storage = {
         let domain_chain_spec = GenericChainSpec::<NoExtension, ()>::builder(
@@ -135,6 +137,6 @@ pub fn get_genesis_domain(
             .map(|k| (AccountId20Converter::convert(k), 2_000_000 * SSC))
             .collect(),
 
-        domain_runtime_config: DomainRuntimeConfig::default_evm(),
+        domain_runtime_config: EvmDomainRuntimeConfig { evm_type }.into(),
     })
 }

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -41,7 +41,8 @@ use core::mem;
 use core::num::NonZeroU64;
 use domain_runtime_primitives::opaque::Header as DomainHeader;
 use domain_runtime_primitives::{
-    AccountIdConverter, BlockNumber as DomainNumber, Hash as DomainHash, MAX_OUTGOING_MESSAGES,
+    AccountIdConverter, BlockNumber as DomainNumber, EthereumAccountId, Hash as DomainHash,
+    MAX_OUTGOING_MESSAGES,
 };
 use frame_support::genesis_builder_helper::{build_state, get_preset};
 use frame_support::inherent::ProvideInherent;
@@ -67,7 +68,7 @@ use sp_domains::bundle_producer_election::BundleProducerElectionParams;
 use sp_domains::{
     DomainAllowlistUpdates, DomainId, DomainInstanceData, ExecutionReceiptFor, OpaqueBundle,
     OpaqueBundles, OperatorId, OperatorPublicKey, OperatorRewardSource,
-    DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
+    PermissionedActionAllowedBy, DOMAIN_STORAGE_FEE_MULTIPLIER, INITIAL_DOMAIN_TX_RANGE,
 };
 use sp_domains_fraud_proof::fraud_proof::FraudProof;
 use sp_domains_fraud_proof::storage_proof::{
@@ -1133,6 +1134,11 @@ impl FraudProofStorageKeyProvider<NumberFor<Block>> for StorageKeyProvider {
             FraudProofStorageKeyRequest::DomainSudoCall(domain_id) => {
                 pallet_domains::DomainSudoCalls::<Runtime>::hashed_key_for(domain_id)
             }
+            FraudProofStorageKeyRequest::EvmDomainContractCreationAllowedByCall(domain_id) => {
+                pallet_domains::EvmDomainContractCreationAllowedByCalls::<Runtime>::hashed_key_for(
+                    domain_id,
+                )
+            }
             FraudProofStorageKeyRequest::MmrRoot(block_number) => {
                 pallet_subspace_mmr::MmrRootHashes::<Runtime>::hashed_key_for(block_number)
             }
@@ -1413,6 +1419,10 @@ impl_runtime_apis! {
 
         fn domain_sudo_call(domain_id: DomainId) -> Option<Vec<u8>> {
             Domains::domain_sudo_call(domain_id)
+        }
+
+        fn evm_domain_contract_creation_allowed_by_call(domain_id: DomainId) -> Option<PermissionedActionAllowedBy<EthereumAccountId>> {
+            Domains::evm_domain_contract_creation_allowed_by_call(domain_id)
         }
 
         fn last_confirmed_domain_block_receipt(domain_id: DomainId) -> Option<ExecutionReceiptFor<DomainHeader, Block, Balance>>{

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -109,6 +109,7 @@ const MAX_PRODUCE_BUNDLE_TRY: usize = 10;
 ///
 /// By default an in-memory socket will be used, therefore you need to provide boot
 /// nodes if you want the future node to be connected to other nodes.
+#[expect(clippy::too_many_arguments)]
 pub fn node_config(
     tokio_handle: tokio::runtime::Handle,
     key: Sr25519Keyring,
@@ -116,6 +117,7 @@ pub fn node_config(
     run_farmer: bool,
     force_authoring: bool,
     force_synced: bool,
+    private_evm: bool,
     base_path: BasePath,
 ) -> Configuration {
     let root = base_path.path();
@@ -125,7 +127,7 @@ pub fn node_config(
         Role::Full
     };
     let key_seed = key.to_seed();
-    let spec = chain_spec::subspace_local_testnet_config().unwrap();
+    let spec = chain_spec::subspace_local_testnet_config(private_evm).unwrap();
 
     let mut network_config = NetworkConfiguration::new(
         key_seed.to_string(),
@@ -388,7 +390,16 @@ impl MockConsensusNode {
         key: Sr25519Keyring,
         base_path: BasePath,
     ) -> MockConsensusNode {
-        Self::run_with_finalization_depth(tokio_handle, key, base_path, None)
+        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, false)
+    }
+
+    /// Run a mock consensus node with a private EVM domain
+    pub fn run_with_private_evm(
+        tokio_handle: tokio::runtime::Handle,
+        key: Sr25519Keyring,
+        base_path: BasePath,
+    ) -> MockConsensusNode {
+        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, true)
     }
 
     /// Run a mock consensus node with finalization depth
@@ -397,10 +408,20 @@ impl MockConsensusNode {
         key: Sr25519Keyring,
         base_path: BasePath,
         finalize_block_depth: Option<NumberFor<Block>>,
+        private_evm: bool,
     ) -> MockConsensusNode {
         let log_prefix = key.into();
 
-        let mut config = node_config(tokio_handle, key, vec![], false, false, false, base_path);
+        let mut config = node_config(
+            tokio_handle,
+            key,
+            vec![],
+            false,
+            false,
+            false,
+            private_evm,
+            base_path,
+        );
 
         // Set `transaction_pool.ban_time` to 0 such that duplicated tx will not immediately rejected
         // by `TemporarilyBanned`

--- a/test/subspace-test-service/src/lib.rs
+++ b/test/subspace-test-service/src/lib.rs
@@ -118,6 +118,7 @@ pub fn node_config(
     force_authoring: bool,
     force_synced: bool,
     private_evm: bool,
+    evm_owner_account: Option<AccountId>,
     base_path: BasePath,
 ) -> Configuration {
     let root = base_path.path();
@@ -127,7 +128,7 @@ pub fn node_config(
         Role::Full
     };
     let key_seed = key.to_seed();
-    let spec = chain_spec::subspace_local_testnet_config(private_evm).unwrap();
+    let spec = chain_spec::subspace_local_testnet_config(private_evm, evm_owner_account).unwrap();
 
     let mut network_config = NetworkConfiguration::new(
         key_seed.to_string(),
@@ -390,16 +391,17 @@ impl MockConsensusNode {
         key: Sr25519Keyring,
         base_path: BasePath,
     ) -> MockConsensusNode {
-        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, false)
+        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, false, None)
     }
 
     /// Run a mock consensus node with a private EVM domain
     pub fn run_with_private_evm(
         tokio_handle: tokio::runtime::Handle,
         key: Sr25519Keyring,
+        evm_owner: Option<Sr25519Keyring>,
         base_path: BasePath,
     ) -> MockConsensusNode {
-        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, true)
+        Self::run_with_finalization_depth(tokio_handle, key, base_path, None, true, evm_owner)
     }
 
     /// Run a mock consensus node with finalization depth
@@ -409,6 +411,7 @@ impl MockConsensusNode {
         base_path: BasePath,
         finalize_block_depth: Option<NumberFor<Block>>,
         private_evm: bool,
+        evm_owner: Option<Sr25519Keyring>,
     ) -> MockConsensusNode {
         let log_prefix = key.into();
 
@@ -420,6 +423,7 @@ impl MockConsensusNode {
             false,
             false,
             private_evm,
+            evm_owner.map(|key| key.to_account_id()),
             base_path,
         );
 


### PR DESCRIPTION
#### TODOs

- [ ] devnet testing of domain upgrade, see https://github.com/autonomys/subspace/pull/3381#discussion_r1954480386
- [x] upgrade types in migration PR
- [x] update spec for "public EVM" setting

#### Why are we doing this?

We want to allow the domain owner to change the EVM contract creation allow list. So we need to add a call to the subspace runtime, which gets turned into an inherent for the EVM domain runtime.

#### What it does

This PR makes the following changes:
- use the `EthereumAccountId` type in all code that deals with contract creation filters (called `AccountId` in EVM runtime code)
- add a call to `pallet-domains`, and turn it into an inherent in `pallet-evm-tracker`
- add a fraud proof for the new inherent
- optional: improve UX by changing the `pallet-domains` call to take a list of accounts, rather than an encoded call

This is similar to `pallet-domain-sudo`, except that we're sending just one kind of call (earlier in the PR), or just the call argument (at the end of the PR).

#### Breaking Changes

This PR has some (potentially) breaking changes:
- a new runtime API version
- adding new fields to structs passed to and from host functions
- adding new variants to enums passed to the stateless runtime, and new API impls on the stateless runtime
- new fraud proof fields, storage key request variants, and other enum variants

### Focus of Initial Reviews

The next step is testing on Devnet. I don’t think we need to merge it to do that, but we should have any major changes done.

So here’s what I’d like to focus on in the review:
- is the code good enough to deploy to Devnet?
- are there any API changes needed? (ideally they should happen before Rust or Devnet tests)
- are there any migrations needed for Taurus?

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
