### PR TITLE
Ignore hickory-proto security issue until libp2p is upgraded

### DIFF
--- a/.github/workflows/rustsec-audit.yml
+++ b/.github/workflows/rustsec-audit.yml
@@ -22,4 +22,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # TODO: Remove first once Substrate upgrades litep2p and we no longer have rustls 0.20.9 in our dependencies
           # TODO: Remove second once Substrate upgrades libp2p and we no longer have old idna in our dependencies
-          ignore: RUSTSEC-2024-0336,RUSTSEC-2024-0421
+          # TODO: Remove third once Substrate upgrades libp2p and we no longer have old hickory-proto in our dependencies
+          ignore: RUSTSEC-2024-0336,RUSTSEC-2024-0421,RUSTSEC-2025-0006


### PR DESCRIPTION
We are waiting on an upstream `libp2p` upgrade to resolve this issue.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
