### PR TITLE
Fix comments and missing READMEs in Cargo.tomls

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -680,7 +680,7 @@ mod pallet {
     pub(super) type PermissionedActionAllowedBy<T: Config> =
         StorageValue<_, sp_domains::PermissionedActionAllowedBy<T::AccountId>, OptionQuery>;
 
-    /// Accumulate treasury funds temporarily until the funds are above Existential despoit.
+    /// Accumulate treasury funds temporarily until the funds are above Existential deposit.
     /// We do this to ensure minting small amounts into treasury would not fail.
     #[pallet::storage]
     pub(super) type AccumulatedTreasuryFunds<T> = StorageValue<_, BalanceOf<T>, ValueQuery>;
@@ -1140,11 +1140,11 @@ mod pallet {
             // consensus block, which also mean a domain block will be produced thus update `HeadDomainNumber`
             // to this domain block's block number.
             if SuccessfulBundles::<T>::get(domain_id).is_empty() {
-                // Domain runtime upgrade is forced happened even if there is no bundle submitted for a given domain
+                // Domain runtime upgrade is forced to happen, even if there is no bundle submitted for a given domain
                 // it will still derive a domain block for the upgrade, so we need to increase the `HeadDomainNumber`
-                // by the number of runtime upgrade happen since last block to account for these blocks.
+                // by the number of runtime upgrades that happened since the last block, to account for these blocks.
                 //
-                // NOTE: if a domain runtime upgrade happened in the current block it won't be accounted into
+                // NOTE: if a domain runtime upgrade happened in the current block it won't be accounted for in
                 // `missed_upgrade` because `DomainRuntimeUpgradeRecords` is updated in the next block's initialization.
                 let missed_upgrade =
                     Self::missed_domain_runtime_upgrade(domain_id).map_err(Error::<T>::from)?;
@@ -1155,7 +1155,7 @@ mod pallet {
                     .checked_add(&missed_upgrade.into())
                     .ok_or::<Error<T>>(BlockTreeError::MaxHeadDomainNumber.into())?;
 
-                // Trigger epoch transition if any at the first bundle in the block
+                // Trigger an epoch transition, if needed, at the first bundle in the block
                 #[cfg(not(feature = "runtime-benchmarks"))]
                 if next_number % T::StakeEpochDuration::get() == Zero::zero() {
                     let epoch_transition_res = do_finalize_domain_current_epoch::<T>(domain_id)
@@ -1173,7 +1173,7 @@ mod pallet {
                 HeadDomainNumber::<T>::set(domain_id, next_number);
             }
 
-            // Put the `extrinsics_root` to the inbox of the current under building domain block
+            // Put the `extrinsics_root` into the inbox of the current domain block being built
             let head_domain_number = HeadDomainNumber::<T>::get(domain_id);
             let consensus_block_number = frame_system::Pallet::<T>::current_block_number();
             ExecutionInbox::<T>::append(
@@ -1191,7 +1191,7 @@ mod pallet {
 
             OperatorBundleSlot::<T>::mutate(operator_id, |slot_set| slot_set.insert(slot_number));
 
-            // slash operator who are in pending slash
+            // slash operators who are in pending slash
             #[cfg(not(feature = "runtime-benchmarks"))]
             {
                 let slashed_nominator_count =
@@ -1288,8 +1288,8 @@ mod pallet {
             runtime_name: String,
             runtime_type: RuntimeType,
             // TODO: we can use `RawGenesis` as argument directly to avoid decoding but the in tool like
-            // `polkadot.js` it will required the user to provide each field of the struct type and not
-            // support upload file which will brings bad UX.
+            // `polkadot.js` it will require the user to provide each field of the struct type and not
+            // support uploading file, which is bad UX.
             raw_genesis_storage: Vec<u8>,
         ) -> DispatchResult {
             ensure_root(origin)?;
@@ -1436,7 +1436,7 @@ mod pallet {
         }
 
         /// Unlocks the first withdrawal given the unlocking period is complete.
-        /// Even if rest of the withdrawals are out of unlocking period, nominator
+        /// Even if the rest of the withdrawals are out of the unlocking period, the nominator
         /// should call this extrinsic to unlock each withdrawal
         #[pallet::call_index(10)]
         #[pallet::weight(T::WeightInfo::unlock_funds())]
@@ -1580,7 +1580,7 @@ mod pallet {
 
         /// Prunes a given execution receipt for given frozen domain.
         /// This call assumes the execution receipt to be bad and implicitly trusts Sudo
-        /// to do necessary validation of the ER before dispatching this call.
+        /// to do the necessary validation of the ER before dispatching this call.
         #[pallet::call_index(19)]
         #[pallet::weight(Pallet::<T>::max_prune_domain_execution_receipt())]
         pub fn prune_domain_execution_receipt(

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -5995,7 +5995,7 @@ async fn test_multiple_consensus_blocks_derive_similar_domain_block() {
     assert_ne!(domain_block_hash_fork_a, domain_block_hash_fork_b);
 
     // The domain block header should contain a digest that points to the consensus block, which
-    // devrives the domain block
+    // derives the domain block
     let get_header = |hash| alice.client.header(hash).unwrap().unwrap();
     let get_digest_consensus_block_hash = |header: &Header| -> <CBlock as BlockT>::Hash {
         header

--- a/domains/primitives/auto-id/Cargo.toml
+++ b/domains/primitives/auto-id/Cargo.toml
@@ -10,7 +10,6 @@ description = "Primitives for AutoId"
 include = [
     "/src",
     "/Cargo.toml",
-    "/README.md",
 ]
 
 [dependencies]

--- a/domains/primitives/digests/Cargo.toml
+++ b/domains/primitives/digests/Cargo.toml
@@ -10,7 +10,6 @@ description = "Primitives of domain related digests"
 include = [
     "/src",
     "/Cargo.toml",
-    "/README.md",
 ]
 
 [dependencies]

--- a/domains/primitives/domain-sudo/Cargo.toml
+++ b/domains/primitives/domain-sudo/Cargo.toml
@@ -10,7 +10,6 @@ description = "Primitives of pallet domain sudo"
 include = [
     "/src",
     "/Cargo.toml",
-    "/README.md",
 ]
 
 [dependencies]

--- a/domains/primitives/executive/Cargo.toml
+++ b/domains/primitives/executive/Cargo.toml
@@ -10,7 +10,6 @@ description = "Primitives of pallet executive"
 include = [
     "/src",
     "/Cargo.toml",
-    "/README.md",
 ]
 
 [dependencies]

--- a/domains/primitives/messenger-host-functions/Cargo.toml
+++ b/domains/primitives/messenger-host-functions/Cargo.toml
@@ -10,7 +10,6 @@ description = "Host functions for Messenger"
 include = [
     "/src",
     "/Cargo.toml",
-    "/README.md",
 ]
 
 [dependencies]

--- a/domains/primitives/messenger/Cargo.toml
+++ b/domains/primitives/messenger/Cargo.toml
@@ -10,7 +10,6 @@ description = "Primitives for Messenger"
 include = [
     "/src",
     "/Cargo.toml",
-    "/README.md",
 ]
 
 [dependencies]

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -529,7 +529,7 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns a valid Sudo call.
+/// Returns `true` if this is a valid Sudo call.
 /// Should extend this function to limit specific calls Sudo can make when needed.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
     UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -894,7 +894,7 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns a valid Sudo call.
+/// Returns `true` if this is a valid Sudo call.
 /// Should extend this function to limit specific calls Sudo can make when needed.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
     UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -523,7 +523,7 @@ fn is_xdm_mmr_proof_valid(ext: &<Block as BlockT>::Extrinsic) -> Option<bool> {
     }
 }
 
-/// Returns a valid Sudo call.
+/// Returns `true` if this is a valid Sudo call.
 /// Should extend this function to limit specific calls Sudo can make when needed.
 fn is_valid_sudo_call(encoded_ext: Vec<u8>) -> bool {
     UncheckedExtrinsic::decode(&mut encoded_ext.as_slice()).is_ok()


### PR DESCRIPTION
This PR is a low priority cleanup.

It fixes some confusing comments I noticed during #3381, and removes some `README.md`s that don't exist from `Cargo.toml` include lists.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
