### PR TITLE
XDM: ensure relayer is only submitting XDMs that are within max nonce limit

### DIFF
--- a/crates/subspace-fake-runtime-api/src/lib.rs
+++ b/crates/subspace-fake-runtime-api/src/lib.rs
@@ -396,6 +396,10 @@ sp_api::impl_runtime_apis! {
         fn channel_storage_key(_chain_id: ChainId, _channel_id: ChannelId) -> Vec<u8> {
             unreachable!()
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            unreachable!()
+        }
     }
 
     impl sp_domains_fraud_proof::FraudProofApi<Block, DomainHeader> for Runtime {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -1494,6 +1494,10 @@ impl_runtime_apis! {
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
             Messenger::channel_storage_key(chain_id, channel_id)
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::open_channels()
+        }
     }
 
     impl sp_domains_fraud_proof::FraudProofApi<Block, DomainHeader> for Runtime {

--- a/domains/client/relayer/src/lib.rs
+++ b/domains/client/relayer/src/lib.rs
@@ -311,9 +311,9 @@ where
             .ok()
             .flatten()
     {
-        // if this message should relay,
-        // check if the dst_chain inbox nonce is more than message nonce,
-        // if so, skip relaying since message is already executed on dst_chain
+        // if the dst_chain inbox nonce is more than message nonce, skip relaying since message is
+        // already executed on dst_chain.
+        // if the message nonce is more than the max allowed nonce on dst_chain, skip relaying message.
         let max_messages_nonce_allowed = dst_channel_state
             .next_inbox_nonce
             .saturating_add(MAX_FUTURE_ALLOWED_NONCES.into());

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -1389,6 +1389,19 @@ mod pallet {
             UpdatedChannels::<T>::get()
         }
 
+        pub fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Channels::<T>::iter().fold(
+                BTreeSet::new(),
+                |mut acc, (dst_chain_id, channel_id, channel)| {
+                    if channel.state != ChannelState::Closed {
+                        acc.insert((dst_chain_id, channel_id));
+                    }
+
+                    acc
+                },
+            )
+        }
+
         pub fn channel_nonce(chain_id: ChainId, channel_id: ChannelId) -> Option<ChannelNonce> {
             Channels::<T>::get(chain_id, channel_id).map(|channel| {
                 let last_inbox_nonce = channel.next_inbox_nonce.checked_sub(U256::one());

--- a/domains/pallets/messenger/src/lib.rs
+++ b/domains/pallets/messenger/src/lib.rs
@@ -48,16 +48,6 @@ use sp_messenger::messages::{
 use sp_runtime::traits::{Extrinsic, Hash};
 use sp_runtime::DispatchError;
 
-/// Maximum number of XDMs per domain/channel with future nonces that are allowed to be validated.
-/// Any XDM comes with a nonce above Maximum future nonce will be rejected.
-// TODO: We need to benchmark how many XDMs can fit in to a
-//  - Single consensus block
-//  - Single domain block(includes all bundles filled with XDMs)
-//  Once we have that info, we can make a better judgement on how many XDMs
-//  we want to include per block while allowing other extrinsics to be included as well.
-//  Note: Currently XDM takes priority over other extrinsics unless they come with priority fee
-const MAX_FUTURE_ALLOWED_NONCES: u32 = 256;
-
 /// Transaction validity for a given validated XDM extrinsic.
 /// If the extrinsic is not included in the bundle, extrinsic is removed from the TxPool.
 const XDM_TRANSACTION_LONGEVITY: u64 = 10;
@@ -133,7 +123,7 @@ mod pallet {
     use crate::{
         BalanceOf, ChainAllowlistUpdate, Channel, ChannelId, ChannelState, CloseChannelBy,
         FeeModel, HoldIdentifier, Nonce, OutboxMessageResult, StateRootOf, ValidatedRelayMessage,
-        MAX_FUTURE_ALLOWED_NONCES, STORAGE_VERSION, U256, XDM_TRANSACTION_LONGEVITY,
+        STORAGE_VERSION, U256, XDM_TRANSACTION_LONGEVITY,
     };
     #[cfg(not(feature = "std"))]
     use alloc::boxed::Box;
@@ -158,7 +148,7 @@ mod pallet {
     };
     use sp_messenger::{
         ChannelNonce, DomainRegistration, InherentError, InherentType, OnXDMRewards, StorageKeys,
-        INHERENT_IDENTIFIER,
+        INHERENT_IDENTIFIER, MAX_FUTURE_ALLOWED_NONCES,
     };
     use sp_runtime::traits::Zero;
     use sp_runtime::{ArithmeticError, Perbill, Saturating};

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -198,6 +198,7 @@ pub struct ChannelNonce {
 
 sp_api::decl_runtime_apis! {
     /// Api useful for relayers to fetch messages and submit transactions.
+    #[api_version(2)]
     pub trait RelayerApi<BlockNumber, CNumber, CHash>
     where
         BlockNumber: Encode + Decode,
@@ -229,6 +230,9 @@ sp_api::decl_runtime_apis! {
 
         /// Returns storage key for channels for given chain and channel id.
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8>;
+
+        /// Returns all the open channels to other chains.
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)>;
     }
 
     /// Api to provide XDM extraction from Runtime Calls.

--- a/domains/primitives/messenger/src/lib.rs
+++ b/domains/primitives/messenger/src/lib.rs
@@ -42,6 +42,16 @@ use std::collections::BTreeSet;
 /// Messenger inherent identifier.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"messengr";
 
+/// Maximum number of XDMs per domain/channel with future nonces that are allowed to be validated.
+/// Any XDM comes with a nonce above Maximum future nonce will be rejected.
+// TODO: We need to benchmark how many XDMs can fit in to a
+//  - Single consensus block
+//  - Single domain block(includes all bundles filled with XDMs)
+//  Once we have that info, we can make a better judgement on how many XDMs
+//  we want to include per block while allowing other extrinsics to be included as well.
+//  Note: Currently XDM takes priority over other extrinsics unless they come with priority fee
+pub const MAX_FUTURE_ALLOWED_NONCES: u32 = 256;
+
 /// Trait to handle XDM rewards.
 pub trait OnXDMRewards<Balance> {
     fn on_xdm_rewards(rewards: Balance);

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -960,6 +960,10 @@ impl_runtime_apis! {
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
             Messenger::channel_storage_key(chain_id, channel_id)
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::open_channels()
+        }
     }
 
     impl sp_domain_sudo::DomainSudoApi<Block> for Runtime {

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -1418,6 +1418,10 @@ impl_runtime_apis! {
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
             Messenger::channel_storage_key(chain_id, channel_id)
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::open_channels()
+        }
     }
 
     impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {

--- a/domains/test/runtime/auto-id/src/lib.rs
+++ b/domains/test/runtime/auto-id/src/lib.rs
@@ -954,6 +954,10 @@ impl_runtime_apis! {
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
             Messenger::channel_storage_key(chain_id, channel_id)
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::open_channels()
+        }
     }
 
     impl sp_domain_sudo::DomainSudoApi<Block> for Runtime {

--- a/domains/test/runtime/evm/src/lib.rs
+++ b/domains/test/runtime/evm/src/lib.rs
@@ -1440,6 +1440,10 @@ impl_runtime_apis! {
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
             Messenger::channel_storage_key(chain_id, channel_id)
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::open_channels()
+        }
     }
 
     impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -1547,6 +1547,10 @@ impl_runtime_apis! {
         fn channel_storage_key(chain_id: ChainId, channel_id: ChannelId) -> Vec<u8> {
             Messenger::channel_storage_key(chain_id, channel_id)
         }
+
+        fn open_channels() -> BTreeSet<(ChainId, ChannelId)> {
+            Messenger::open_channels()
+        }
     }
 
     impl sp_domains_fraud_proof::FraudProofApi<Block, DomainHeader> for Runtime {


### PR DESCRIPTION
We [recently](https://github.com/autonomys/subspace/pull/3380) introduced changes to Messenger disallowing future XDMs beyond the defined nonce limit. But relayer still tries to broadcast all the XDMs that are confirmed only to be rejected the `dst_chain's tx_pool` if the future nonce limit is reached. This PR updates the relayer to broadcast XDMs that will be accepted by the `dst_chain's tx_pool`.

Relayer will filter the XDM messages using the channel state available in its Aux store. Channel state is broadcasted every time there is an update to channel. This should be sufficient most of the time. But there are cases where an operator recently joined the network and has been no XDM in the recent past. In this case, relayer of the new operator will not have channel state in their Aux store. To handle this scenario, for every 300 blocks, we broadcast all the channel's state.

**Other considered approaches:**
- Relayer either keeping track of last broadcasted nonce and then submitting next set of XDMs based on the previous nonce. While this works, relayer do not have access to `tx_pool` of the `dst_chain` and might end up submitting next set only to be rejected by the `dst_chain's tx_pool`.
- Relayer filtering the messages from ready to submit XDM after initial filtering of previously submitted XDMs and this has the same problem as above.

Overall, I prefer the currently implemented version since relayer can reliably predict the max nonce allowed based on the channel state which gets published as soon as there is update.
Only caveat I see could be the delay in channel state broadcast due to network 

Closes: #3371 

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
