### PR TITLE
Sync mainnet runtime versions with taurus versions

### DIFF
--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -121,6 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace"),
     impl_name: Cow::Borrowed("subspace"),
     authoring_version: 0,
+    // The spec version can be different on Taurus and Mainnet
     spec_version: 2,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,

--- a/domains/runtime/auto-id/src/lib.rs
+++ b/domains/runtime/auto-id/src/lib.rs
@@ -122,6 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace-auto-id-domain"),
     impl_name: Cow::Borrowed("subspace-auto-id-domain"),
     authoring_version: 0,
+    // The spec version can be different on Taurus and Mainnet
     spec_version: 0,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -283,6 +283,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("subspace-evm-domain"),
     impl_name: Cow::Borrowed("subspace-evm-domain"),
     authoring_version: 0,
+    // The spec version can be different on Taurus and Mainnet
     spec_version: 0,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,

--- a/domains/runtime/evm/src/lib.rs
+++ b/domains/runtime/evm/src/lib.rs
@@ -286,7 +286,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 0,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 0,
+    transaction_version: 1,
     system_version: 2,
 };
 


### PR DESCRIPTION
This PR makes the runtime versions the same in the mainnet and taurus branches, so we can use runtime migration version filters reliably.

See the full discussion here:
https://github.com/autonomys/subspace/pull/3360#issuecomment-2656226845

These changes are taken from:
- https://github.com/autonomys/subspace/compare/main...taurus-runtime-upgrade (currently no differences)
- https://github.com/autonomys/subspace/compare/main...taurus_evm_upgrade

The storage versions didn't need to be changed, because they are the same as those branches. We don't want to change the spec versions.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
