### PR TITLE
Add fallback decoding for the pallet-domains v3 storage migration

### DIFF
--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -22,7 +22,8 @@ extern crate alloc;
 
 use crate::block_tree::{verify_execution_receipt, Error as BlockTreeError};
 use crate::bundle_storage_fund::{charge_bundle_storage_fee, storage_fund_account};
-use crate::domain_registry::{DomainConfig, Error as DomainRegistryError};
+use crate::domain_registry::{DomainConfig, DomainObject, Error as DomainRegistryError};
+use crate::migration_v2_to_v3::DomainRegistryV2;
 use crate::runtime_registry::into_complete_raw_genesis;
 #[cfg(feature = "runtime-benchmarks")]
 pub use crate::staking::do_register_operator;
@@ -2145,9 +2146,28 @@ impl<T: Config> Pallet<T> {
         Ok(HeadDomainNumber::<T>::get(domain_id) + missed_upgrade.into())
     }
 
+    /// Fallback decoding for the domain registry v2 to v3 migration.
+    /// Returns the domain registry entry for the supplied `domain_id`, if that domain exists.
+    /// Tries the v3 storage format first, then falls back to the v2 format.
+    ///
+    /// All reads that could possibly happen between the runtime upgrade and the storage migration
+    /// must go through this function. (Writes are ok, because any v3 writes will look "corrupt"
+    /// and get skipped by the migration.)
+    //
+    // TODO: remove this fallback in the next runtime upgrade after the v3 storage format,
+    // and just read DomainRegistry directly.
+    #[expect(clippy::type_complexity)]
+    pub fn domain_registry_fallback(
+        domain_id: DomainId,
+    ) -> Option<DomainObject<BlockNumberFor<T>, ReceiptHashFor<T>, T::AccountId, BalanceOf<T>>>
+    {
+        DomainRegistry::<T>::get(domain_id)
+            .or_else(|| DomainRegistryV2::<T>::get(domain_id).map(Into::into))
+    }
+
     /// Returns the runtime ID for the supplied `domain_id`, if that domain exists.
     pub fn runtime_id(domain_id: DomainId) -> Option<RuntimeId> {
-        DomainRegistry::<T>::get(domain_id)
+        Self::domain_registry_fallback(domain_id)
             .map(|domain_object| domain_object.domain_config.runtime_id)
     }
 
@@ -2159,7 +2179,7 @@ impl<T: Config> Pallet<T> {
     pub fn domain_instance_data(
         domain_id: DomainId,
     ) -> Option<(DomainInstanceData, BlockNumberFor<T>)> {
-        let domain_obj = DomainRegistry::<T>::get(domain_id)?;
+        let domain_obj = Self::domain_registry_fallback(domain_id)?;
         let runtime_object = RuntimeRegistry::<T>::get(domain_obj.domain_config.runtime_id)?;
         let runtime_type = runtime_object.runtime_type;
         let total_issuance = domain_obj.domain_config.total_issuance()?;
@@ -2198,7 +2218,7 @@ impl<T: Config> Pallet<T> {
         domain_id: DomainId,
     ) -> Option<BundleProducerElectionParams<BalanceOf<T>>> {
         match (
-            DomainRegistry::<T>::get(domain_id),
+            Self::domain_registry_fallback(domain_id),
             DomainStakingSummary::<T>::get(domain_id),
         ) {
             (Some(domain_object), Some(stake_summary)) => Some(BundleProducerElectionParams {
@@ -2392,17 +2412,17 @@ impl<T: Config> Pallet<T> {
             BundleError::UnexpectedReceiptGap,
         );
 
-        let domain_config = DomainRegistry::<T>::get(domain_id)
+        let domain_config = &Self::domain_registry_fallback(domain_id)
             .ok_or(BundleError::InvalidDomainId)?
             .domain_config;
 
-        Self::validate_bundle(opaque_bundle, &domain_config)?;
+        Self::validate_bundle(opaque_bundle, domain_config)?;
 
         Self::validate_eligibility(
             sealed_header.pre_hash().as_ref(),
             &sealed_header.signature,
             &sealed_header.header.proof_of_election,
-            &domain_config,
+            domain_config,
             pre_dispatch,
         )?;
 
@@ -2428,7 +2448,7 @@ impl<T: Config> Pallet<T> {
             BundleError::ExpectingReceiptGap,
         );
 
-        let domain_config = DomainRegistry::<T>::get(domain_id)
+        let domain_config = Self::domain_registry_fallback(domain_id)
             .ok_or(BundleError::InvalidDomainId)?
             .domain_config;
         Self::validate_eligibility(
@@ -2770,7 +2790,7 @@ impl<T: Config> Pallet<T> {
     pub fn domain_bundle_limit(
         domain_id: DomainId,
     ) -> Result<Option<DomainBundleLimit>, DomainRegistryError> {
-        let domain_config = match DomainRegistry::<T>::get(domain_id) {
+        let domain_config = match Self::domain_registry_fallback(domain_id) {
             None => return Ok(None),
             Some(domain_obj) => domain_obj.domain_config,
         };
@@ -3106,7 +3126,8 @@ impl<T: Config> Pallet<T> {
                 // If there is no `ExecutionInbox` exist for the `last_domain_block_number` it means
                 // there is no bundle submitted for the domain since it is instantiated, in this case,
                 // we use the `domain_obj.created_at` (which derive the genesis block).
-                .or(DomainRegistry::<T>::get(domain_id).map(|domain_obj| domain_obj.created_at))
+                .or(Self::domain_registry_fallback(domain_id)
+                    .map(|domain_obj| domain_obj.created_at))
                 .ok_or(BlockTreeError::LastBlockNotFound)?;
 
         Ok(DomainRuntimeUpgradeRecords::<T>::get(runtime_id)
@@ -3137,7 +3158,7 @@ impl<T: Config> Pallet<T> {
 
     /// Returns true if this is an EVM domain.
     pub fn is_evm_domain(domain_id: DomainId) -> bool {
-        if let Some(domain_obj) = DomainRegistry::<T>::get(domain_id) {
+        if let Some(domain_obj) = Self::domain_registry_fallback(domain_id) {
             domain_obj.domain_runtime_info.is_evm_domain()
         } else {
             false
@@ -3146,7 +3167,7 @@ impl<T: Config> Pallet<T> {
 
     /// Returns true if this is a private EVM domain.
     pub fn is_private_evm_domain(domain_id: DomainId) -> bool {
-        if let Some(domain_obj) = DomainRegistry::<T>::get(domain_id) {
+        if let Some(domain_obj) = Self::domain_registry_fallback(domain_id) {
             domain_obj.domain_runtime_info.is_private_evm_domain()
         } else {
             false
@@ -3163,7 +3184,7 @@ impl<T: Config> Pallet<T> {
 
 impl<T: Config> sp_domains::DomainOwner<T::AccountId> for Pallet<T> {
     fn is_domain_owner(domain_id: DomainId, acc: T::AccountId) -> bool {
-        if let Some(domain_obj) = DomainRegistry::<T>::get(domain_id) {
+        if let Some(domain_obj) = Self::domain_registry_fallback(domain_id) {
             domain_obj.owner_account_id == acc
         } else {
             false

--- a/crates/pallet-domains/src/migration_v2_to_v3.rs
+++ b/crates/pallet-domains/src/migration_v2_to_v3.rs
@@ -4,10 +4,27 @@
 //! If we add EVM or AutoId domains to Mainnet, also deploy it there.
 //! (If there are no EVM or AutoId domains, this migration does nothing, so it's safe to run.)
 
+// Types that have changed are imported or declared with a V2/V3 suffix.
+// Types that haven't changed are imported or declared without a suffix.
+pub(crate) use registry_v2::DomainRegistry as DomainRegistryV2;
+
+use crate::domain_registry::{DomainConfig, DomainObject as DomainObjectV3};
+use crate::pallet::DomainRegistry as DomainRegistryV3;
+use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
 use crate::{Config, Pallet};
+use codec::{Decode, Encode};
+use domain_runtime_primitives::EVMChainId;
 use frame_support::migrations::VersionedMigration;
+use frame_support::pallet_prelude::TypeInfo;
 use frame_support::traits::UncheckedOnRuntimeUpgrade;
 use frame_support::weights::Weight;
+use sp_domains::DomainId;
+use sp_domains::{
+    AutoIdDomainRuntimeConfig as AutoIdDomainRuntimeConfigV3,
+    // changed in V3, but we use Into to convert to it
+    // DomainRuntimeConfig as DomainRuntimeConfigV3,
+    EvmDomainRuntimeConfig as EvmDomainRuntimeConfigV3,
+};
 
 pub type VersionCheckedMigrateDomainsV2ToV3<T> = VersionedMigration<
     2,
@@ -24,52 +41,77 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV2ToV3<T> {
     }
 }
 
-mod domain_registry_structure_migration {
-    // Types that have changed are imported or declared with a V2/V3 suffix.
-    // Types that haven't changed are imported or declared without a suffix.
-    pub(super) use crate::domain_registry::{DomainConfig, DomainObject as DomainObjectV3};
-    pub(super) use crate::pallet::DomainRegistry as DomainRegistryV3;
-    pub(super) use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
-    use crate::{BalanceOf, BlockNumberFor, Config, Pallet, ReceiptHashFor};
-    use codec::{Decode, Encode};
-    use domain_runtime_primitives::EVMChainId;
-    use frame_support::pallet_prelude::{OptionQuery, TypeInfo, Weight};
+/// Domain runtime specific information to create domain raw genesis.
+#[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Copy)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum DomainRuntimeInfoV2 {
+    EVM { chain_id: EVMChainId },
+    AutoId,
+}
+
+#[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct DomainObjectV2<Number, ReceiptHash, AccountId: Ord, Balance> {
+    /// The address of the domain creator, used to validate updating the domain config.
+    pub owner_account_id: AccountId,
+    /// The consensus chain block number when the domain first instantiated.
+    pub created_at: Number,
+    /// The hash of the genesis execution receipt for this domain.
+    pub genesis_receipt_hash: ReceiptHash,
+    /// The domain config.
+    pub domain_config: DomainConfig<AccountId, Balance>,
+    /// Domain runtime specific information.
+    pub domain_runtime_info: DomainRuntimeInfoV2,
+    /// The amount of balance hold on the domain owner account
+    pub domain_instantiation_deposit: Balance,
+}
+
+impl<T, U, V: Ord, W> From<DomainObjectV2<T, U, V, W>> for DomainObjectV3<T, U, V, W> {
+    fn from(domain_object_v2: DomainObjectV2<T, U, V, W>) -> Self {
+        let DomainObjectV2 {
+            owner_account_id,
+            created_at,
+            genesis_receipt_hash,
+            domain_config,
+            domain_runtime_info: domain_runtime_info_v2,
+            domain_instantiation_deposit,
+        } = domain_object_v2;
+
+        DomainObjectV3 {
+            owner_account_id,
+            created_at,
+            genesis_receipt_hash,
+            domain_config,
+            domain_runtime_info: domain_runtime_info_v2.into(),
+            domain_instantiation_deposit,
+        }
+    }
+}
+
+impl From<DomainRuntimeInfoV2> for DomainRuntimeInfoV3 {
+    fn from(domain_runtime_info_v2: DomainRuntimeInfoV2) -> Self {
+        match domain_runtime_info_v2 {
+            DomainRuntimeInfoV2::EVM { chain_id } => DomainRuntimeInfoV3::Evm {
+                chain_id,
+                // Added in V3
+                domain_runtime_config: EvmDomainRuntimeConfigV3::default(),
+            },
+            DomainRuntimeInfoV2::AutoId => DomainRuntimeInfoV3::AutoId {
+                // Added in V3
+                domain_runtime_config: AutoIdDomainRuntimeConfigV3::default(),
+            },
+        }
+    }
+}
+
+mod registry_v2 {
+    use super::*;
+    use crate::{BalanceOf, Config, Pallet, ReceiptHashFor};
+    use frame_support::pallet_prelude::OptionQuery;
     use frame_support::{storage_alias, Identity};
-    use sp_core::Get;
-    pub(super) use sp_domains::{
-        AutoIdDomainRuntimeConfig as AutoIdDomainRuntimeConfigV3,
-        DomainId,
-        // changed in V3, but we use Into to convert to it
-        // DomainRuntimeConfig as DomainRuntimeConfigV3,
-        EvmDomainRuntimeConfig as EvmDomainRuntimeConfigV3,
-    };
-
-    /// Domain runtime specific information to create domain raw genesis.
-    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Copy)]
-    #[allow(clippy::upper_case_acronyms)]
-    pub enum DomainRuntimeInfoV2 {
-        EVM { chain_id: EVMChainId },
-        AutoId,
-    }
-
-    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
-    pub struct DomainObjectV2<Number, ReceiptHash, AccountId: Ord, Balance> {
-        /// The address of the domain creator, used to validate updating the domain config.
-        pub owner_account_id: AccountId,
-        /// The consensus chain block number when the domain first instantiated.
-        pub created_at: Number,
-        /// The hash of the genesis execution receipt for this domain.
-        pub genesis_receipt_hash: ReceiptHash,
-        /// The domain config.
-        pub domain_config: DomainConfig<AccountId, Balance>,
-        /// Domain runtime specific information.
-        pub domain_runtime_info: DomainRuntimeInfoV2,
-        /// The amount of balance hold on the domain owner account
-        pub domain_instantiation_deposit: Balance,
-    }
+    use frame_system::pallet_prelude::BlockNumberFor;
 
     #[storage_alias]
-    pub(super) type DomainRegistry<T: Config> = StorageMap<
+    pub(crate) type DomainRegistry<T: Config> = StorageMap<
         Pallet<T>,
         Identity,
         DomainId,
@@ -81,6 +123,13 @@ mod domain_registry_structure_migration {
         >,
         OptionQuery,
     >;
+}
+
+mod domain_registry_structure_migration {
+    use super::{DomainObjectV2, DomainObjectV3, DomainRegistryV3};
+    use crate::{BalanceOf, BlockNumberFor, Config, ReceiptHashFor};
+    use frame_support::pallet_prelude::Weight;
+    use sp_core::Get;
 
     pub(super) fn migrate_domain_registry_structure<T: Config>() -> Weight {
         let mut domain_count = 0;
@@ -91,31 +140,7 @@ mod domain_registry_structure_migration {
         >(|domain_object_v2| {
             domain_count += 1;
 
-            let domain_runtime_info_v3 = match domain_object_v2.domain_runtime_info {
-                DomainRuntimeInfoV2::EVM { chain_id } => {
-                    DomainRuntimeInfoV3::Evm {
-                        chain_id,
-                        // Added in V3
-                        domain_runtime_config: EvmDomainRuntimeConfigV3::default(),
-                    }
-                }
-                DomainRuntimeInfoV2::AutoId => {
-                    DomainRuntimeInfoV3::AutoId {
-                        // Added in V3
-                        domain_runtime_config: AutoIdDomainRuntimeConfigV3::default(),
-                    }
-                }
-            };
-
-            Some(DomainObjectV3 {
-                owner_account_id: domain_object_v2.owner_account_id,
-                created_at: domain_object_v2.created_at,
-                genesis_receipt_hash: domain_object_v2.genesis_receipt_hash,
-                domain_config: domain_object_v2.domain_config,
-                // Modified in V3
-                domain_runtime_info: domain_runtime_info_v3,
-                domain_instantiation_deposit: domain_object_v2.domain_instantiation_deposit,
-            })
+            Some(DomainObjectV3::from(domain_object_v2))
         });
 
         // 1 read and 1 write per domain
@@ -125,11 +150,8 @@ mod domain_registry_structure_migration {
 
 #[cfg(test)]
 mod tests {
-    use super::domain_registry_structure_migration::{
-        migrate_domain_registry_structure, AutoIdDomainRuntimeConfigV3, DomainConfig, DomainId,
-        DomainObjectV2, DomainObjectV3, DomainRegistry, DomainRegistryV3, DomainRuntimeInfoV2,
-        DomainRuntimeInfoV3, EvmDomainRuntimeConfigV3,
-    };
+    use super::domain_registry_structure_migration::*;
+    use super::*;
     use crate::tests::{new_test_ext, Test};
     use sp_domains::{EvmType as EvmTypeV3, OperatorAllowList};
 
@@ -155,33 +177,35 @@ mod tests {
             domain_runtime_info: DomainRuntimeInfoV2::EVM { chain_id },
             domain_instantiation_deposit: 9u32.into(),
         };
-
-        ext.execute_with(|| DomainRegistry::<Test>::set(domain_id, Some(domain.clone())));
-
-        ext.commit_all().unwrap();
+        let expected_migration = DomainObjectV3 {
+            owner_account_id: domain.owner_account_id,
+            created_at: domain.created_at,
+            genesis_receipt_hash: domain.genesis_receipt_hash,
+            domain_config: domain_config.clone(),
+            domain_runtime_info: DomainRuntimeInfoV3::Evm {
+                chain_id,
+                domain_runtime_config: EvmDomainRuntimeConfigV3 {
+                    // All current EVM domains are public EVMs
+                    evm_type: EvmTypeV3::Public,
+                },
+            },
+            domain_instantiation_deposit: domain.domain_instantiation_deposit,
+        };
 
         ext.execute_with(|| {
+            DomainRegistryV2::<Test>::set(domain_id, Some(domain.clone()));
+
+            let fallback_outcome = Pallet::<Test>::domain_registry_fallback(domain_id);
+            assert_eq!(fallback_outcome.unwrap(), expected_migration);
+
             let weights = migrate_domain_registry_structure::<Test>();
             assert_eq!(
                 weights,
                 <Test as frame_system::Config>::DbWeight::get().reads_writes(1, 1),
             );
             assert_eq!(
-                DomainRegistryV3::<Test>::get(domain_id),
-                Some(DomainObjectV3 {
-                    owner_account_id: domain.owner_account_id,
-                    created_at: domain.created_at,
-                    genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config,
-                    domain_runtime_info: DomainRuntimeInfoV3::Evm {
-                        chain_id,
-                        domain_runtime_config: EvmDomainRuntimeConfigV3 {
-                            // All current EVM domains are public EVMs
-                            evm_type: EvmTypeV3::Public
-                        },
-                    },
-                    domain_instantiation_deposit: domain.domain_instantiation_deposit,
-                })
+                DomainRegistryV3::<Test>::get(domain_id).unwrap(),
+                expected_migration,
             );
         });
     }
@@ -207,30 +231,32 @@ mod tests {
             domain_runtime_info: DomainRuntimeInfoV2::AutoId,
             domain_instantiation_deposit: 19u32.into(),
         };
-
-        ext.execute_with(|| DomainRegistry::<Test>::set(domain_id, Some(domain.clone())));
-
-        ext.commit_all().unwrap();
+        let expected_migration = DomainObjectV3 {
+            owner_account_id: domain.owner_account_id,
+            created_at: domain.created_at,
+            genesis_receipt_hash: domain.genesis_receipt_hash,
+            domain_config,
+            domain_runtime_info: DomainRuntimeInfoV3::AutoId {
+                // There are no AutoId-specific config fields at this time
+                domain_runtime_config: AutoIdDomainRuntimeConfigV3 {},
+            },
+            domain_instantiation_deposit: domain.domain_instantiation_deposit,
+        };
 
         ext.execute_with(|| {
+            DomainRegistryV2::<Test>::set(domain_id, Some(domain.clone()));
+
+            let fallback_outcome = Pallet::<Test>::domain_registry_fallback(domain_id);
+            assert_eq!(fallback_outcome.unwrap(), expected_migration);
+
             let weights = migrate_domain_registry_structure::<Test>();
             assert_eq!(
                 weights,
                 <Test as frame_system::Config>::DbWeight::get().reads_writes(1, 1),
             );
             assert_eq!(
-                DomainRegistryV3::<Test>::get(domain_id),
-                Some(DomainObjectV3 {
-                    owner_account_id: domain.owner_account_id,
-                    created_at: domain.created_at,
-                    genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config,
-                    domain_runtime_info: DomainRuntimeInfoV3::AutoId {
-                        // There are no AutoId-specific config fields at this time
-                        domain_runtime_config: AutoIdDomainRuntimeConfigV3 {}
-                    },
-                    domain_instantiation_deposit: domain.domain_instantiation_deposit,
-                })
+                DomainRegistryV3::<Test>::get(domain_id).unwrap(),
+                expected_migration,
             );
         });
     }

--- a/crates/pallet-domains/src/migration_v2_to_v3.rs
+++ b/crates/pallet-domains/src/migration_v2_to_v3.rs
@@ -25,45 +25,24 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateV2ToV3<T> {
 }
 
 mod domain_registry_structure_migration {
-    use crate::domain_registry::{DomainConfig as DomainConfigV3, DomainObject as DomainObjectV3};
-    use crate::pallet::DomainRegistry as DomainRegistryV3;
-    use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
+    // Types that have changed are imported or declared with a V2/V3 suffix.
+    // Types that haven't changed are imported or declared without a suffix.
+    pub(super) use crate::domain_registry::{DomainConfig, DomainObject as DomainObjectV3};
+    pub(super) use crate::pallet::DomainRegistry as DomainRegistryV3;
+    pub(super) use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
     use crate::{BalanceOf, BlockNumberFor, Config, Pallet, ReceiptHashFor};
     use codec::{Decode, Encode};
-    use domain_runtime_primitives::{EVMChainId, MultiAccountId};
+    use domain_runtime_primitives::EVMChainId;
     use frame_support::pallet_prelude::{OptionQuery, TypeInfo, Weight};
     use frame_support::{storage_alias, Identity};
-    use scale_info::prelude::string::String;
     use sp_core::Get;
-    use sp_domains::{
-        AutoIdDomainRuntimeConfig,
+    pub(super) use sp_domains::{
+        AutoIdDomainRuntimeConfig as AutoIdDomainRuntimeConfigV3,
         DomainId,
         // changed in V3, but we use Into to convert to it
         // DomainRuntimeConfig as DomainRuntimeConfigV3,
-        EvmDomainRuntimeConfig,
-        OperatorAllowList,
-        RuntimeId,
+        EvmDomainRuntimeConfig as EvmDomainRuntimeConfigV3,
     };
-    use sp_runtime::Vec;
-
-    #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq)]
-    pub struct DomainConfigV2<AccountId: Ord, Balance> {
-        /// A user defined name for this domain, should be a human-readable UTF-8 encoded string.
-        pub domain_name: String,
-        /// A pointer to the `RuntimeRegistry` entry for this domain.
-        pub runtime_id: RuntimeId,
-        /// The max bundle size for this domain, may not exceed the system-wide `MaxDomainBlockSize` limit.
-        pub max_bundle_size: u32,
-        /// The max bundle weight for this domain, may not exceed the system-wide `MaxDomainBlockWeight` limit.
-        pub max_bundle_weight: Weight,
-        /// The probability of successful bundle in a slot (active slots coefficient). This defines the
-        /// expected bundle production rate, must be `> 0` and `≤ 1`.
-        pub bundle_slot_probability: (u64, u64),
-        /// Allowed operators to operate for this domain.
-        pub operator_allow_list: OperatorAllowList<AccountId>,
-        // Initial balances for Domain.
-        pub initial_balances: Vec<(MultiAccountId, Balance)>,
-    }
 
     /// Domain runtime specific information to create domain raw genesis.
     #[derive(TypeInfo, Debug, Encode, Decode, Clone, PartialEq, Eq, Copy)]
@@ -82,7 +61,7 @@ mod domain_registry_structure_migration {
         /// The hash of the genesis execution receipt for this domain.
         pub genesis_receipt_hash: ReceiptHash,
         /// The domain config.
-        pub domain_config: DomainConfigV2<AccountId, Balance>,
+        pub domain_config: DomainConfig<AccountId, Balance>,
         /// Domain runtime specific information.
         pub domain_runtime_info: DomainRuntimeInfoV2,
         /// The amount of balance hold on the domain owner account
@@ -112,18 +91,18 @@ mod domain_registry_structure_migration {
         >(|domain_object_v2| {
             domain_count += 1;
 
-            let domain_runtime_info = match domain_object_v2.domain_runtime_info {
+            let domain_runtime_info_v3 = match domain_object_v2.domain_runtime_info {
                 DomainRuntimeInfoV2::EVM { chain_id } => {
                     DomainRuntimeInfoV3::Evm {
                         chain_id,
                         // Added in V3
-                        domain_runtime_config: EvmDomainRuntimeConfig::default(),
+                        domain_runtime_config: EvmDomainRuntimeConfigV3::default(),
                     }
                 }
                 DomainRuntimeInfoV2::AutoId => {
                     DomainRuntimeInfoV3::AutoId {
                         // Added in V3
-                        domain_runtime_config: AutoIdDomainRuntimeConfig::default(),
+                        domain_runtime_config: AutoIdDomainRuntimeConfigV3::default(),
                     }
                 }
             };
@@ -132,17 +111,9 @@ mod domain_registry_structure_migration {
                 owner_account_id: domain_object_v2.owner_account_id,
                 created_at: domain_object_v2.created_at,
                 genesis_receipt_hash: domain_object_v2.genesis_receipt_hash,
-                domain_config: DomainConfigV3 {
-                    domain_name: domain_object_v2.domain_config.domain_name,
-                    runtime_id: domain_object_v2.domain_config.runtime_id,
-                    max_bundle_size: domain_object_v2.domain_config.max_bundle_size,
-                    max_bundle_weight: domain_object_v2.domain_config.max_bundle_weight,
-                    bundle_slot_probability: domain_object_v2.domain_config.bundle_slot_probability,
-                    operator_allow_list: domain_object_v2.domain_config.operator_allow_list,
-                    initial_balances: domain_object_v2.domain_config.initial_balances,
-                },
+                domain_config: domain_object_v2.domain_config,
                 // Modified in V3
-                domain_runtime_info,
+                domain_runtime_info: domain_runtime_info_v3,
                 domain_instantiation_deposit: domain_object_v2.domain_instantiation_deposit,
             })
         });
@@ -155,35 +126,32 @@ mod domain_registry_structure_migration {
 #[cfg(test)]
 mod tests {
     use super::domain_registry_structure_migration::{
-        migrate_domain_registry_structure, DomainConfigV2, DomainObjectV2, DomainRegistry,
-        DomainRuntimeInfoV2,
+        migrate_domain_registry_structure, AutoIdDomainRuntimeConfigV3, DomainConfig, DomainId,
+        DomainObjectV2, DomainObjectV3, DomainRegistry, DomainRegistryV3, DomainRuntimeInfoV2,
+        DomainRuntimeInfoV3, EvmDomainRuntimeConfigV3,
     };
-    use crate::domain_registry::{DomainConfig as DomainConfigV3, DomainObject as DomainObjectV3};
-    use crate::pallet::DomainRegistry as DomainRegistryV3;
-    use crate::runtime_registry::DomainRuntimeInfo as DomainRuntimeInfoV3;
     use crate::tests::{new_test_ext, Test};
-    use sp_domains::{
-        AutoIdDomainRuntimeConfig, DomainId, EvmDomainRuntimeConfig, EvmType, OperatorAllowList,
-    };
+    use sp_domains::{EvmType as EvmTypeV3, OperatorAllowList};
 
     #[test]
     fn test_domain_registry_structure_migration_evm() {
         let mut ext = new_test_ext();
         let domain_id: DomainId = 0.into();
         let chain_id = 8u32.into();
+        let domain_config = DomainConfig {
+            domain_name: "test-evm-migrate".to_string(),
+            runtime_id: 3u32,
+            max_bundle_size: 4,
+            max_bundle_weight: 5.into(),
+            bundle_slot_probability: (6, 7),
+            operator_allow_list: OperatorAllowList::Anyone,
+            initial_balances: vec![],
+        };
         let domain = DomainObjectV2 {
             owner_account_id: 1u32.into(),
             created_at: 2u32.into(),
             genesis_receipt_hash: Default::default(),
-            domain_config: DomainConfigV2 {
-                domain_name: "test-evm-migrate".to_string(),
-                runtime_id: 3u32,
-                max_bundle_size: 4,
-                max_bundle_weight: 5.into(),
-                bundle_slot_probability: (6, 7),
-                operator_allow_list: OperatorAllowList::Anyone,
-                initial_balances: vec![],
-            },
+            domain_config: domain_config.clone(),
             domain_runtime_info: DomainRuntimeInfoV2::EVM { chain_id },
             domain_instantiation_deposit: 9u32.into(),
         };
@@ -204,20 +172,12 @@ mod tests {
                     owner_account_id: domain.owner_account_id,
                     created_at: domain.created_at,
                     genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config: DomainConfigV3 {
-                        domain_name: domain.domain_config.domain_name,
-                        runtime_id: domain.domain_config.runtime_id,
-                        max_bundle_size: domain.domain_config.max_bundle_size,
-                        max_bundle_weight: domain.domain_config.max_bundle_weight,
-                        bundle_slot_probability: domain.domain_config.bundle_slot_probability,
-                        operator_allow_list: domain.domain_config.operator_allow_list,
-                        initial_balances: domain.domain_config.initial_balances,
-                    },
+                    domain_config,
                     domain_runtime_info: DomainRuntimeInfoV3::Evm {
                         chain_id,
-                        domain_runtime_config: EvmDomainRuntimeConfig {
+                        domain_runtime_config: EvmDomainRuntimeConfigV3 {
                             // All current EVM domains are public EVMs
-                            evm_type: EvmType::Public
+                            evm_type: EvmTypeV3::Public
                         },
                     },
                     domain_instantiation_deposit: domain.domain_instantiation_deposit,
@@ -230,19 +190,20 @@ mod tests {
     fn test_domain_registry_structure_migration_auto_id() {
         let mut ext = new_test_ext();
         let domain_id: DomainId = 10.into();
+        let domain_config = DomainConfig {
+            domain_name: "test-auto-id-migrate".to_string(),
+            runtime_id: 13u32,
+            max_bundle_size: 14,
+            max_bundle_weight: 15.into(),
+            bundle_slot_probability: (16, 17),
+            operator_allow_list: OperatorAllowList::Anyone,
+            initial_balances: vec![],
+        };
         let domain = DomainObjectV2 {
             owner_account_id: 11u32.into(),
             created_at: 12u32.into(),
             genesis_receipt_hash: Default::default(),
-            domain_config: DomainConfigV2 {
-                domain_name: "test-auto-id-migrate".to_string(),
-                runtime_id: 13u32,
-                max_bundle_size: 14,
-                max_bundle_weight: 15.into(),
-                bundle_slot_probability: (16, 17),
-                operator_allow_list: OperatorAllowList::Anyone,
-                initial_balances: vec![],
-            },
+            domain_config: domain_config.clone(),
             domain_runtime_info: DomainRuntimeInfoV2::AutoId,
             domain_instantiation_deposit: 19u32.into(),
         };
@@ -263,18 +224,10 @@ mod tests {
                     owner_account_id: domain.owner_account_id,
                     created_at: domain.created_at,
                     genesis_receipt_hash: domain.genesis_receipt_hash,
-                    domain_config: DomainConfigV3 {
-                        domain_name: domain.domain_config.domain_name,
-                        runtime_id: domain.domain_config.runtime_id,
-                        max_bundle_size: domain.domain_config.max_bundle_size,
-                        max_bundle_weight: domain.domain_config.max_bundle_weight,
-                        bundle_slot_probability: domain.domain_config.bundle_slot_probability,
-                        operator_allow_list: domain.domain_config.operator_allow_list,
-                        initial_balances: domain.domain_config.initial_balances,
-                    },
+                    domain_config,
                     domain_runtime_info: DomainRuntimeInfoV3::AutoId {
                         // There are no AutoId-specific config fields at this time
-                        domain_runtime_config: AutoIdDomainRuntimeConfig {}
+                        domain_runtime_config: AutoIdDomainRuntimeConfigV3 {}
                     },
                     domain_instantiation_deposit: domain.domain_instantiation_deposit,
                 })

--- a/crates/pallet-domains/src/staking.rs
+++ b/crates/pallet-domains/src/staking.rs
@@ -5,9 +5,8 @@ extern crate alloc;
 
 use crate::bundle_storage_fund::{self, deposit_reserve_for_storage_fund};
 use crate::pallet::{
-    Deposits, DomainRegistry, DomainStakingSummary, HeadDomainNumber, NextOperatorId,
-    NominatorCount, OperatorIdOwner, Operators, PendingSlashes, PendingStakingOperationCount,
-    Withdrawals,
+    Deposits, DomainStakingSummary, HeadDomainNumber, NextOperatorId, NominatorCount,
+    OperatorIdOwner, Operators, PendingSlashes, PendingStakingOperationCount, Withdrawals,
 };
 use crate::staking_epoch::{mint_funds, mint_into_treasury};
 use crate::{
@@ -326,7 +325,8 @@ pub fn do_register_operator<T: Config>(
             Error::MinimumNominatorStake
         );
 
-        let domain_obj = DomainRegistry::<T>::get(domain_id).ok_or(Error::DomainNotInitialized)?;
+        let domain_obj =
+            Pallet::<T>::domain_registry_fallback(domain_id).ok_or(Error::DomainNotInitialized)?;
         ensure!(
             domain_obj
                 .domain_config


### PR DESCRIPTION
This PR makes all production reads of the domain registry go through a new `domain_registry_fallback()` method. This method first tries decoding as the v3 storage format, then tries v2 if that doesn't work.

This is required so that code which queries the domain registry between runtime activation and storage migration still works.

Early writes to the storage using the v3 format are fine: they will be skipped as "corrupted" by the migration (which reads as v2), and be read as v3 correctly by the fallback decoder:
https://docs.rs/frame-support/latest/frame_support/storage/types/struct.StorageMap.html#method.translate_values

During local `dev` testing, the upgrade block logs some spurious corrupted state warnings, then the next block imports without any warnings:
```
2025-02-27T04:57:24.626389Z  INFO Consensus: substrate: 🏆 Imported #40 (0xf06c…371c → 0xe0d6…e46a)    
2025-02-27T04:57:25.962553Z ERROR Domain: runtime::storage: Corrupted state at `0x0b41d0c7f7b4485bd7be1d66066b00ad32214eaa0b8523eaebb7f83e73660c1b00000000`: Error    
2025-02-27T04:57:25.962925Z  WARN Domain: domain_client_operator::bundle_processor: Slow consensus block preprocessing, took 1336ms consensus_block_info=(0xe0d6391593445327fd3773219914a535407ad725ae647d8f91ca353558e5e46a, 40)
2025-02-27T04:57:26.089486Z ERROR Domain: runtime::storage: Corrupted state at `0x0b41d0c7f7b4485bd7be1d66066b00ad32214eaa0b8523eaebb7f83e73660c1b00000000`: Error    
2025-02-27T04:57:26.089795Z ERROR Domain: runtime::storage: Corrupted state at `0x0b41d0c7f7b4485bd7be1d66066b00ad32214eaa0b8523eaebb7f83e73660c1b00000000`: Error    
2025-02-27T04:57:26.090665Z ERROR Domain: runtime::storage: Corrupted state at `0x0b41d0c7f7b4485bd7be1d66066b00ad32214eaa0b8523eaebb7f83e73660c1b00000000`: Error    
...
2025-02-27T04:57:26.092961Z  INFO Consensus: sc_basic_authorship::basic_authorship: 🙌 Starting consensus session on top of parent 0xe0d6391593445327fd3773219914a535407ad725ae647d8f91ca353558e5e46a (#40)    
2025-02-27T04:57:26.093188Z ERROR Domain: runtime::storage: Corrupted state at `0x0b41d0c7f7b4485bd7be1d66066b00ad32214eaa0b8523eaebb7f83e73660c1b00000000`: Error    
2025-02-27T04:57:26.094389Z  INFO Consensus: runtime::frame-support: 🐥 New pallet "Multisig" detected in the runtime. Initializing the on-chain storage version to match the storage version defined in the pallet: StorageVersion(1)    
2025-02-27T04:57:26.094524Z  WARN Consensus: frame_support::migrations: 🚚 Pallet "Messenger" VersionedMigration migration 0->1 can be removed; on-chain is already at StorageVersion(1).    
2025-02-27T04:57:26.094592Z  INFO Consensus: frame_support::migrations: 🚚 Pallet "Domains" VersionedMigration migrating storage version from 2 to 3.
...
2025-02-27T04:57:26.101735Z  INFO Consensus: substrate: 🏆 Imported #41 (0xe0d6…e46a → 0x7063…f2be)    
2025-02-27T04:57:27.603282Z  INFO Domain: substrate: 💤 Idle (0 peers), best: #21 (0xed9f…85de), finalized #0 (0x4e8c…00f8), ⬇ 0 ⬆ 0    
2025-02-27T04:57:27.603282Z  INFO Consensus: substrate: 💤 Idle (0 peers), best: #41 (0x7063…f2be), finalized #0 (0x44cc…3a30), ⬇ 0 ⬆ 0  
...
2025-02-27T04:57:29.480017Z  INFO Consensus: sc_basic_authorship::basic_authorship: 🙌 Starting consensus session on top of parent 0x70634939d6d28c7c02409d020d276fe28901914357663e7f5141de157f68f2be (#41
```

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
