### PR TITLE
Add `--challenge-period` command-line parameter in dev networks

### DIFF
--- a/crates/pallet-domains/src/benchmarking.rs
+++ b/crates/pallet-domains/src/benchmarking.rs
@@ -47,7 +47,7 @@ mod benchmarks {
     /// - The bundle contains receipt that will prune the block tree
     #[benchmark]
     fn submit_bundle() {
-        let block_tree_pruning_depth = T::BlockTreePruningDepth::get().saturated_into::<u32>();
+        let block_tree_pruning_depth = BlockTreePruningDepth::<T>::get().saturated_into::<u32>();
         let domain_id = register_domain::<T>();
         let (_, operator_id) =
             register_helper_operator::<T>(domain_id, T::MinNominatorStake::get());
@@ -72,9 +72,7 @@ mod benchmarks {
                 let bundle = dummy_opaque_bundle(domain_id, operator_id, receipt);
                 assert_ok!(Domains::<T>::submit_bundle(RawOrigin::None.into(), bundle));
             } else {
-                // Since the challenge period is set to 1 day we don't want to fill up all the ERs
-                // (i.e. 14_400 number of ERs) which seems take forever to finish, thus we instead
-                // manually insert the last ER into the state.
+                // TODO: we manually insert the last ER into the state, but we could just fill up all 16 ERs instead
                 let receipt_block_number = domain_block_number - One::one();
                 let receipt = ExecutionReceipt::dummy::<DomainHashingFor<T>>(
                     consensus_block_number - One::one(),
@@ -516,7 +514,7 @@ mod benchmarks {
         _(RawOrigin::Root, runtime_id, genesis_storage.clone());
 
         let scheduled_at = frame_system::Pallet::<T>::current_block_number()
-            .checked_add(&T::DomainRuntimeUpgradeDelay::get())
+            .checked_add(&DomainRuntimeUpgradeDelay::<T>::get())
             .expect("must not overflow");
         let scheduled_upgrade = ScheduledRuntimeUpgrades::<T>::get(scheduled_at, runtime_id)
             .expect("scheduled upgrade must exist");
@@ -660,7 +658,7 @@ mod benchmarks {
         assert_eq!(
             *operator.status::<T>(operator_id),
             OperatorStatus::Deregistered(
-                (domain_id, 1u32, T::StakeWithdrawalLockingPeriod::get()).into()
+                (domain_id, 1u32, StakeWithdrawalLockingPeriod::<T>::get()).into()
             ),
         );
     }
@@ -761,7 +759,7 @@ mod benchmarks {
 
         // Update the `HeadDomainNumber` so unlock can success
         let next_head_domain_number = HeadDomainNumber::<T>::get(domain_id)
-            + T::StakeWithdrawalLockingPeriod::get()
+            + StakeWithdrawalLockingPeriod::<T>::get()
             + One::one();
         HeadDomainNumber::<T>::set(domain_id, next_head_domain_number);
 
@@ -795,7 +793,7 @@ mod benchmarks {
 
         // Update the `HeadDomainNumber` so unlock can success
         let next_head_domain_number = HeadDomainNumber::<T>::get(domain_id)
-            + T::StakeWithdrawalLockingPeriod::get()
+            + StakeWithdrawalLockingPeriod::<T>::get()
             + One::one();
         HeadDomainNumber::<T>::set(domain_id, next_head_domain_number);
 

--- a/crates/pallet-domains/src/lib.rs
+++ b/crates/pallet-domains/src/lib.rs
@@ -285,9 +285,9 @@ mod pallet {
         #[pallet::constant]
         type ConfirmationDepthK: Get<BlockNumberFor<Self>>;
 
-        /// Delay before a domain runtime is upgraded.
+        /// Default delay before a domain runtime is upgraded.
         #[pallet::constant]
-        type DomainRuntimeUpgradeDelay: Get<BlockNumberFor<Self>>;
+        type DefaultDomainRuntimeUpgradeDelay: Get<BlockNumberFor<Self>>;
 
         /// Currency type used by the domains for staking and other currency related stuff.
         type Currency: Inspect<Self::AccountId, Balance = Self::Balance>
@@ -311,9 +311,9 @@ mod pallet {
         /// A variation of the Identifier used for holding the funds used for staking and domains.
         type HoldIdentifier: HoldIdentifier<Self>;
 
-        /// The block tree pruning depth.
+        /// The default block tree pruning depth.
         #[pallet::constant]
-        type BlockTreePruningDepth: Get<DomainBlockNumberFor<Self>>;
+        type DefaultBlockTreePruningDepth: Get<DomainBlockNumberFor<Self>>;
 
         /// Consensus chain slot probability.
         #[pallet::constant]
@@ -354,9 +354,9 @@ mod pallet {
         #[pallet::constant]
         type MinNominatorStake: Get<BalanceOf<Self>>;
 
-        /// Minimum number of blocks after which any finalized withdrawals are released to nominators.
+        /// Default minimum number of blocks after which any finalized withdrawals are released to nominators.
         #[pallet::constant]
-        type StakeWithdrawalLockingPeriod: Get<DomainBlockNumberFor<Self>>;
+        type DefaultStakeWithdrawalLockingPeriod: Get<DomainBlockNumberFor<Self>>;
 
         /// Domain epoch transition interval
         #[pallet::constant]
@@ -594,6 +594,37 @@ mod pallet {
     #[pallet::storage]
     pub(super) type BlockTreeNodes<T: Config> =
         StorageMap<_, Identity, ReceiptHashFor<T>, BlockTreeNodeFor<T>, OptionQuery>;
+
+    /// The block tree pruning depth.
+    /// In dev and test environments, the default value can be overridden from the command-line,
+    /// by storing a different value in this storage item.
+    ///
+    /// If this type name is updated, consensus_block_tree_pruning_depth_storage_key() also needs to be updated.
+    #[pallet::storage]
+    pub(super) type BlockTreePruningDepth<T: Config> =
+        StorageValue<_, DomainBlockNumberFor<T>, ValueQuery, T::DefaultBlockTreePruningDepth>;
+
+    /// Minimum number of blocks after which any finalized withdrawals are released to nominators.
+    /// In dev and test environments, the default value can be overridden from the command-line,
+    /// by storing a different value in this storage item.
+    ///
+    /// If this type name is updated, consensus_stake_withdrawal_locking_period_storage_key() also needs to be updated.
+    #[pallet::storage]
+    pub(super) type StakeWithdrawalLockingPeriod<T: Config> = StorageValue<
+        _,
+        DomainBlockNumberFor<T>,
+        ValueQuery,
+        T::DefaultStakeWithdrawalLockingPeriod,
+    >;
+
+    /// Delay before a domain runtime is upgraded.
+    /// In dev and test environments, the default value can be overridden from the command-line,
+    /// by storing a different value in this storage item.
+    ///
+    /// If this type name is updated, consensus_domain_runtime_upgrade_delay_storage_key() also needs to be updated.
+    #[pallet::storage]
+    pub(super) type DomainRuntimeUpgradeDelay<T: Config> =
+        StorageValue<_, BlockNumberFor<T>, ValueQuery, T::DefaultDomainRuntimeUpgradeDelay>;
 
     /// The head receipt number of each domain
     #[pallet::storage]

--- a/crates/pallet-domains/src/staking_epoch.rs
+++ b/crates/pallet-domains/src/staking_epoch.rs
@@ -523,7 +523,7 @@ mod tests {
         do_finalize_domain_current_epoch, operator_take_reward_tax_and_stake,
     };
     use crate::tests::{new_test_ext, Test};
-    use crate::{BalanceOf, Config, HoldIdentifier, NominatorId};
+    use crate::{BalanceOf, Config, HoldIdentifier, NominatorId, StakeWithdrawalLockingPeriod};
     #[cfg(not(feature = "std"))]
     use alloc::vec;
     use frame_support::assert_ok;
@@ -611,7 +611,7 @@ mod tests {
             // Update `HeadDomainNumber` to ensure unlock success
             HeadDomainNumber::<Test>::set(
                 domain_id,
-                head_domain_number + <Test as crate::Config>::StakeWithdrawalLockingPeriod::get(),
+                head_domain_number + StakeWithdrawalLockingPeriod::<Test>::get(),
             );
 
             for (nominator_id, _) in nominators {

--- a/crates/sp-domains/src/lib.rs
+++ b/crates/sp-domains/src/lib.rs
@@ -1187,6 +1187,57 @@ pub fn self_domain_id_storage_key() -> StorageKey {
     )
 }
 
+/// The storage key of the `BlockTreePruningDepth` storage item in `pallet-domains`
+///
+/// Any change to the storage item name or `pallet-domains` name used in the `construct_runtime`
+/// macro must be reflected here.
+pub fn consensus_block_tree_pruning_depth_storage_key() -> StorageKey {
+    StorageKey(
+        frame_support::storage::storage_prefix(
+            // This is the name used for `pallet-domains` in the `construct_runtime` macro
+            // i.e. `Domains: pallet_domains = 12`
+            "Domains".as_bytes(),
+            // This is the storage item name used inside `pallet-domains`
+            "BlockTreePruningDepth".as_bytes(),
+        )
+        .to_vec(),
+    )
+}
+
+/// The storage key of the `StakeWithdrawalLockingPeriod` storage item in `pallet-domains`
+///
+/// Any change to the storage item name or `pallet-domains` name used in the `construct_runtime`
+/// macro must be reflected here.
+pub fn consensus_stake_withdrawal_locking_period_storage_key() -> StorageKey {
+    StorageKey(
+        frame_support::storage::storage_prefix(
+            // This is the name used for `pallet-domains` in the `construct_runtime` macro
+            // i.e. `Domains: pallet_domains = 12`
+            "Domains".as_bytes(),
+            // This is the storage item name used inside `pallet-domains`
+            "StakeWithdrawalLockingPeriod".as_bytes(),
+        )
+        .to_vec(),
+    )
+}
+
+/// The storage key of the `DomainRuntimeUpgradeDelay` storage item in `pallet-domains`
+///
+/// Any change to the storage item name or `pallet-domains` name used in the `construct_runtime`
+/// macro must be reflected here.
+pub fn consensus_domain_runtime_upgrade_delay_storage_key() -> StorageKey {
+    StorageKey(
+        frame_support::storage::storage_prefix(
+            // This is the name used for `pallet-domains` in the `construct_runtime` macro
+            // i.e. `Domains: pallet_domains = 12`
+            "Domains".as_bytes(),
+            // This is the storage item name used inside `pallet-domains`
+            "DomainRuntimeUpgradeDelay".as_bytes(),
+        )
+        .to_vec(),
+    )
+}
+
 /// `DomainInstanceData` is used to construct the genesis storage of domain instance chain
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
 pub struct DomainInstanceData {

--- a/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
+++ b/crates/subspace-malicious-operator/src/bin/subspace-malicious-operator.rs
@@ -81,6 +81,7 @@ fn main() -> Result<(), Error> {
     let cli = Cli::from_args();
 
     let sudo_account = cli.sudo_account();
+    let challenge_period = cli.challenge_period;
     let runner = cli.create_runner(&cli.run)?;
     set_default_ss58_version(&runner.config().chain_spec);
     runner.run_node_until_exit(|mut consensus_chain_config| async move {
@@ -323,7 +324,7 @@ fn main() -> Result<(), Error> {
                             }
                         };
 
-                        match domain_starter.start(bootstrap_result, sudo_account).await {
+                        match domain_starter.start(bootstrap_result, sudo_account, challenge_period).await {
                             Ok(domain_code_executor) => {
                                 let span = sc_tracing::tracing::info_span!(
                                     sc_tracing::logging::PREFIX_LOG_SPAN,

--- a/crates/subspace-malicious-operator/src/lib.rs
+++ b/crates/subspace-malicious-operator/src/lib.rs
@@ -19,7 +19,7 @@ use sp_core::crypto::{AccountId32, Ss58Codec};
 use sp_domains::storage::RawGenesis;
 use sp_domains::DomainId;
 use sp_runtime::BuildStorage;
-use subspace_runtime_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
+use subspace_runtime_primitives::DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH;
 
 /// Subspace Cli.
 #[derive(Debug, Parser)]
@@ -40,7 +40,7 @@ pub struct Cli {
 
     /// The blockchain challenge period.
     /// All valid nodes in the network have the same value for this parameter.
-    #[arg(long, default_value_t = DOMAINS_BLOCK_PRUNING_DEPTH)]
+    #[arg(long, default_value_t = DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH)]
     pub challenge_period: u32,
 
     /// Domain arguments

--- a/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
+++ b/crates/subspace-malicious-operator/src/malicious_domain_instance_starter.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::{AccountId, DOMAINS_BLOCK_PRUNING_DEPTH};
+use subspace_runtime_primitives::AccountId;
 use subspace_service::FullClient as CFullClient;
 
 /// `DomainInstanceStarter` used to start a domain instance node based on the given
@@ -54,6 +54,7 @@ impl DomainInstanceStarter {
         self,
         bootstrap_result: BootstrapResult<CBlock>,
         sudo_account: AccountId,
+        challenge_period: u32,
     ) -> Result<Arc<sc_domains::RuntimeExecutor>, Box<dyn std::error::Error>> {
         let BootstrapResult {
             domain_instance_data,
@@ -166,7 +167,7 @@ impl DomainInstanceStarter {
                     consensus_chain_sync_params: None::<
                         ConsensusChainSyncParams<_, Arc<dyn NetworkRequest + Sync + Send>>,
                     >,
-                    challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                    challenge_period,
                 };
 
                 let mut domain_node = domain_service::new_full::<
@@ -229,7 +230,7 @@ impl DomainInstanceStarter {
                     consensus_chain_sync_params: None::<
                         ConsensusChainSyncParams<_, Arc<dyn NetworkRequest + Sync + Send>>,
                     >,
-                    challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                    challenge_period,
                 };
 
                 let mut domain_node = domain_service::new_full::<

--- a/crates/subspace-node/src/commands/run/consensus.rs
+++ b/crates/subspace-node/src/commands/run/consensus.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 use subspace_core_primitives::BlockNumber;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_networking::libp2p::Multiaddr;
-use subspace_runtime_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
+use subspace_runtime_primitives::DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH;
 use subspace_service::config::{
     ChainSyncMode, SubspaceConfiguration, SubspaceNetworking, SubstrateConfiguration,
     SubstrateNetworkConfiguration, SubstrateRpcConfiguration,
@@ -435,7 +435,7 @@ pub(super) struct ConsensusChainOptions {
 
     /// The blockchain challenge period.
     /// All nodes in the network must have the same value for this parameter.
-    #[arg(long, default_value_t = DOMAINS_BLOCK_PRUNING_DEPTH)]
+    #[arg(long, default_value_t = DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH)]
     challenge_period: u32,
 
     /// Options for Substrate networking
@@ -577,9 +577,9 @@ pub(super) fn create_consensus_chain_configuration(
             }
         });
 
-        if challenge_period != DOMAINS_BLOCK_PRUNING_DEPTH && !dev {
+        if challenge_period != DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH && !dev {
             return Err(Error::Other(
-                "Challenge period must be set to {DOMAINS_BLOCK_PRUNING_DEPTH}, unless in dev mode"
+                "Challenge period must be set to {DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH}, unless in dev mode"
                     .to_string(),
             ));
         }
@@ -604,7 +604,7 @@ pub(super) fn create_consensus_chain_configuration(
     };
 
     // Set pallet-domains parameters, if needed
-    if challenge_period != DOMAINS_BLOCK_PRUNING_DEPTH {
+    if challenge_period != DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH {
         let mut raw_genesis = RawGenesis::from_storage(
             chain_spec
                 .build_storage()

--- a/crates/subspace-node/src/commands/run/domain.rs
+++ b/crates/subspace-node/src/commands/run/domain.rs
@@ -37,7 +37,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use subspace_runtime::RuntimeApi as CRuntimeApi;
 use subspace_runtime_primitives::opaque::Block as CBlock;
-use subspace_runtime_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
 use subspace_service::FullClient as CFullClient;
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -135,6 +134,7 @@ pub(super) struct DomainOptions {
 #[derive(Debug)]
 pub(super) struct DomainConfiguration {
     pub(super) domain_config: Configuration,
+    pub(super) challenge_period: u32,
     pub(super) domain_id: DomainId,
     pub(super) operator_id: Option<OperatorId>,
     pub(super) additional_args: Vec<String>,
@@ -143,6 +143,7 @@ pub(super) struct DomainConfiguration {
 pub(super) fn create_domain_configuration(
     consensus_chain_configuration: &Configuration,
     dev: bool,
+    challenge_period: u32,
     domain_options: DomainOptions,
 ) -> Result<DomainConfiguration, Error> {
     let DomainOptions {
@@ -156,7 +157,6 @@ pub(super) fn create_domain_configuration(
         keystore_options,
         pool_config,
         additional_args,
-        ..
     } = domain_options;
 
     let domain_id;
@@ -373,6 +373,7 @@ pub(super) fn create_domain_configuration(
 
     Ok(DomainConfiguration {
         domain_config: Configuration::from(domain_config),
+        challenge_period,
         domain_id,
         operator_id,
         additional_args,
@@ -414,6 +415,7 @@ where
 
     let DomainConfiguration {
         mut domain_config,
+        challenge_period,
         domain_id,
         operator_id,
         additional_args,
@@ -514,7 +516,7 @@ where
                 maybe_operator_id: operator_id,
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 consensus_chain_sync_params,
-                challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                challenge_period,
             };
 
             let mut domain_node = domain_service::new_full::<
@@ -555,7 +557,7 @@ where
                 maybe_operator_id: operator_id,
                 confirmation_depth_k: chain_constants.confirmation_depth_k(),
                 consensus_chain_sync_params,
-                challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+                challenge_period,
             };
 
             let mut domain_node = domain_service::new_full::<

--- a/crates/subspace-runtime-primitives/src/lib.rs
+++ b/crates/subspace-runtime-primitives/src/lib.rs
@@ -50,8 +50,10 @@ pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 /// Pruning depth multiplier for state and blocks pruning.
 pub const DOMAINS_PRUNING_DEPTH_MULTIPLIER: u32 = 2;
 
-/// Domains Block pruning depth.
-pub const DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 14_400;
+/// Default domains block pruning depth.
+/// This is also the default challenge period, staking withdrawal period, and runtime upgrade delay.
+/// (Runtime upgrades are delayed for 1 day at 6 sec block time.)
+pub const DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 14_400;
 
 /// We allow for 3.75 MiB for `Normal` extrinsic with 5 MiB maximum block length.
 pub fn maximum_normal_block_length() -> BlockLength {

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -106,8 +106,8 @@ use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilit
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash,
     HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate, BLOCK_WEIGHT_FOR_2_SEC,
-    MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY,
-    SSC,
+    DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR,
+    NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY, SSC,
 };
 
 sp_runtime::impl_opaque_keys! {
@@ -760,8 +760,8 @@ parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 128;
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
     pub const DomainTxRangeAdjustmentInterval: u64 = TX_RANGE_ADJUSTMENT_INTERVAL_BLOCKS;
-    /// Runtime upgrade is delayed for 1 day at 6 sec block time.
-    pub const DomainRuntimeUpgradeDelay: BlockNumber = 14_400;
+    /// This should match the default value in the command-line options.
+    pub const DefaultDomainRuntimeUpgradeDelay: BlockNumber = DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH;
     /// Minimum operator stake to become an operator.
     // TODO: this value should be properly updated before mainnet
     pub const MinOperatorStake: Balance = 100 * SSC;
@@ -774,8 +774,9 @@ parameter_types! {
     pub MaxDomainBlockWeight: Weight = maximum_domain_block_weight();
     pub const DomainInstantiationDeposit: Balance = 100 * SSC;
     pub const MaxDomainNameLength: u32 = 32;
-    pub const BlockTreePruningDepth: u32 = DOMAINS_BLOCK_PRUNING_DEPTH;
-    pub const StakeWithdrawalLockingPeriod: DomainNumber = 14_400;
+    /// These should also match the default values in the command-line options.
+    pub const DefaultBlockTreePruningDepth: u32 = DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH;
+    pub const DefaultStakeWithdrawalLockingPeriod: DomainNumber = DEFAULT_DOMAINS_BLOCK_PRUNING_DEPTH;
     // TODO: revisit these. For now epoch every 10 mins for a 6 second block and only 100 number of staking
     // operations allowed within each epoch.
     pub const StakeEpochDuration: DomainNumber = 100;
@@ -800,7 +801,7 @@ const_assert!(BlockHashCount::get() > BlockSlotCount::get());
 const_assert!(MinOperatorStake::get() >= MinNominatorStake::get());
 
 // Stake Withdrawal locking period must be >= Block tree pruning depth
-const_assert!(StakeWithdrawalLockingPeriod::get() >= BlockTreePruningDepth::get());
+const_assert!(DefaultStakeWithdrawalLockingPeriod::get() >= DefaultBlockTreePruningDepth::get());
 
 pub struct BlockSlot;
 
@@ -847,7 +848,7 @@ impl pallet_domains::Config for Runtime {
     type DomainHash = DomainHash;
     type DomainHeader = sp_runtime::generic::Header<DomainNumber, BlakeTwo256>;
     type ConfirmationDepthK = ConfirmationDepthK;
-    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
+    type DefaultDomainRuntimeUpgradeDelay = DefaultDomainRuntimeUpgradeDelay;
     type Currency = Balances;
     type HoldIdentifier = HoldIdentifierWrapper;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
@@ -860,9 +861,9 @@ impl pallet_domains::Config for Runtime {
     type DomainInstantiationDeposit = DomainInstantiationDeposit;
     type MaxDomainNameLength = MaxDomainNameLength;
     type Share = Balance;
-    type BlockTreePruningDepth = BlockTreePruningDepth;
+    type DefaultBlockTreePruningDepth = DefaultBlockTreePruningDepth;
     type ConsensusSlotProbability = SlotProbability;
-    type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
+    type DefaultStakeWithdrawalLockingPeriod = DefaultStakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;

--- a/crates/subspace-runtime/src/lib.rs
+++ b/crates/subspace-runtime/src/lib.rs
@@ -106,8 +106,8 @@ use subspace_runtime_primitives::utility::{DefaultNonceProvider, MaybeIntoUtilit
 use subspace_runtime_primitives::{
     maximum_normal_block_length, AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash,
     HoldIdentifier, Moment, Nonce, Signature, SlowAdjustingFeeUpdate, BLOCK_WEIGHT_FOR_2_SEC,
-    DOMAINS_BLOCK_PRUNING_DEPTH, MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO,
-    SHANNON, SLOT_PROBABILITY, SSC,
+    MAX_BLOCK_LENGTH, MIN_REPLICATION_FACTOR, NORMAL_DISPATCH_RATIO, SHANNON, SLOT_PROBABILITY,
+    SSC,
 };
 
 sp_runtime::impl_opaque_keys! {

--- a/domains/client/block-preprocessor/src/inherents.rs
+++ b/domains/client/block-preprocessor/src/inherents.rs
@@ -105,7 +105,7 @@ where
     Ok(is_upgraded)
 }
 
-/// Returns new upgraded runtime if upgraded did happen in the provided consensus block.
+/// Returns new upgraded runtime if upgrade happened in the provided consensus block.
 pub fn extract_domain_runtime_upgrade_code<CClient, CBlock, Block>(
     consensus_client: &Arc<CClient>,
     consensus_block_hash: CBlock::Hash,

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -75,6 +75,7 @@ use std::time::Duration;
 use subspace_core_primitives::pot::PotOutput;
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_runtime_primitives::{Balance, SSC};
+use subspace_test_primitives::TEST_DOMAINS_BLOCK_PRUNING_DEPTH;
 use subspace_test_service::{
     produce_block_with, produce_blocks, produce_blocks_until, MockConsensusNode,
 };
@@ -6337,9 +6338,11 @@ async fn test_skip_empty_bundle_production() {
     .build_evm_node(Role::Authority, Alice, &mut ferdie)
     .await;
 
-    // Wait for `BlockTreePruningDepth + 1` blocks which is 10 + 1 in test
+    // Wait for `BlockTreePruningDepth + 1` blocks
     // to enure the genesis ER is confirmed
-    produce_blocks!(ferdie, alice, 11).await.unwrap();
+    produce_blocks!(ferdie, alice, TEST_DOMAINS_BLOCK_PRUNING_DEPTH + 1)
+        .await
+        .unwrap();
     let consensus_block_number = ferdie.client.info().best_number;
     let domain_block_number = alice.client.info().best_number;
 

--- a/domains/client/domain-operator/src/tests.rs
+++ b/domains/client/domain-operator/src/tests.rs
@@ -252,6 +252,7 @@ async fn setup_evm_test_nodes(
         ferdie_key,
         BasePath::new(directory.path().join("ferdie")),
         None,
+        None,
         private_evm,
         evm_owner,
     );
@@ -6855,6 +6856,7 @@ async fn test_verify_mmr_proof_stateless() {
         BasePath::new(directory.path().join("ferdie")),
         // finalization depth
         Some(10),
+        None,
         false,
         None,
     );
@@ -6933,6 +6935,7 @@ async fn test_equivocated_bundle_check() {
         BasePath::new(directory.path().join("ferdie")),
         // finalization depth
         Some(10),
+        None,
         false,
         None,
     );

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -43,7 +43,7 @@ use std::future::Future;
 use std::sync::Arc;
 use subspace_runtime_primitives::opaque::Block as CBlock;
 use subspace_runtime_primitives::Nonce;
-use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
+use subspace_test_primitives::TEST_DOMAINS_BLOCK_PRUNING_DEPTH;
 use subspace_test_service::MockConsensusNode;
 use substrate_frame_rpc_system::AccountNonceApi;
 use substrate_test_client::{
@@ -220,7 +220,7 @@ where
             skip_out_of_order_slot: true,
             maybe_operator_id,
             confirmation_depth_k: chain_constants.confirmation_depth_k(),
-            challenge_period: maybe_challenge_period.unwrap_or(DOMAINS_BLOCK_PRUNING_DEPTH),
+            challenge_period: maybe_challenge_period.unwrap_or(TEST_DOMAINS_BLOCK_PRUNING_DEPTH),
             consensus_chain_sync_params: None::<
                 ConsensusChainSyncParams<_, Arc<dyn NetworkRequest + Sync + Send>>,
             >,

--- a/domains/test/service/src/domain.rs
+++ b/domains/test/service/src/domain.rs
@@ -140,6 +140,7 @@ where
         domain_nodes_exclusive: bool,
         skip_empty_bundle_production: bool,
         maybe_operator_id: Option<OperatorId>,
+        maybe_challenge_period: Option<u32>,
         role: Role,
         mock_consensus_node: &mut MockConsensusNode,
     ) -> Self {
@@ -219,7 +220,7 @@ where
             skip_out_of_order_slot: true,
             maybe_operator_id,
             confirmation_depth_k: chain_constants.confirmation_depth_k(),
-            challenge_period: DOMAINS_BLOCK_PRUNING_DEPTH,
+            challenge_period: maybe_challenge_period.unwrap_or(DOMAINS_BLOCK_PRUNING_DEPTH),
             consensus_chain_sync_params: None::<
                 ConsensusChainSyncParams<_, Arc<dyn NetworkRequest + Sync + Send>>,
             >,
@@ -499,6 +500,7 @@ pub struct DomainNodeBuilder {
     skip_empty_bundle_production: bool,
     base_path: BasePath,
     maybe_operator_id: Option<OperatorId>,
+    maybe_challenge_period: Option<u32>,
 }
 
 impl DomainNodeBuilder {
@@ -514,6 +516,7 @@ impl DomainNodeBuilder {
             skip_empty_bundle_production: false,
             base_path,
             maybe_operator_id: None,
+            maybe_challenge_period: None,
         }
     }
 
@@ -546,6 +549,12 @@ impl DomainNodeBuilder {
         self
     }
 
+    /// Set the challenge period
+    pub fn challenge_period(mut self, challenge_period: u32) -> Self {
+        self.maybe_challenge_period = Some(challenge_period);
+        self
+    }
+
     /// Build an EVM domain node
     pub async fn build_evm_node(
         self,
@@ -562,6 +571,7 @@ impl DomainNodeBuilder {
             self.domain_nodes_exclusive,
             self.skip_empty_bundle_production,
             self.maybe_operator_id,
+            self.maybe_challenge_period,
             role,
             mock_consensus_node,
         )
@@ -584,6 +594,7 @@ impl DomainNodeBuilder {
             self.domain_nodes_exclusive,
             self.skip_empty_bundle_production,
             self.maybe_operator_id,
+            self.maybe_challenge_period,
             role,
             mock_consensus_node,
         )

--- a/test/subspace-test-primitives/src/lib.rs
+++ b/test/subspace-test-primitives/src/lib.rs
@@ -7,8 +7,15 @@ use sp_messenger::messages::{ChainId, ChannelId};
 use sp_runtime::traits::NumberFor;
 use sp_subspace_mmr::{ConsensusChainMmrLeafProof, MmrLeaf};
 
-/// Domains Block pruning depth.
-pub const DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 10;
+/// Test domain runtime upgrade period for lower-level runtime tests.
+pub const TEST_DOMAIN_RUNTIME_UPGRADE_DELAY: u32 = 10;
+
+/// Test domains block pruning depth, also used as the test challenge period.
+/// In operator instance tests, also used as the staking withdrawal period and domain runtime upgrade delay.
+pub const TEST_DOMAINS_BLOCK_PRUNING_DEPTH: u32 = 16;
+
+/// Test staking withdrawal period for lower-level runtime tests.
+pub const TEST_STAKE_WITHDRAWAL_LOCKING_PERIOD: u32 = 20;
 
 sp_api::decl_runtime_apis! {
     /// Api for querying onchain state in the test

--- a/test/subspace-test-runtime/src/lib.rs
+++ b/test/subspace-test-runtime/src/lib.rs
@@ -115,7 +115,10 @@ use subspace_runtime_primitives::{
     AccountId, Balance, BlockNumber, FindBlockRewardAddress, Hash, HoldIdentifier, Moment, Nonce,
     Signature, MIN_REPLICATION_FACTOR, SHANNON, SSC,
 };
-use subspace_test_primitives::DOMAINS_BLOCK_PRUNING_DEPTH;
+use subspace_test_primitives::{
+    TEST_DOMAINS_BLOCK_PRUNING_DEPTH, TEST_DOMAIN_RUNTIME_UPGRADE_DELAY,
+    TEST_STAKE_WITHDRAWAL_LOCKING_PERIOD,
+};
 
 sp_runtime::impl_opaque_keys! {
     pub struct SessionKeys {
@@ -721,7 +724,7 @@ parameter_types! {
     pub const MaximumReceiptDrift: BlockNumber = 2;
     pub const InitialDomainTxRange: u64 = INITIAL_DOMAIN_TX_RANGE;
     pub const DomainTxRangeAdjustmentInterval: u64 = 100;
-    pub const DomainRuntimeUpgradeDelay: BlockNumber = 10;
+    pub const DefaultDomainRuntimeUpgradeDelay: BlockNumber = TEST_DOMAIN_RUNTIME_UPGRADE_DELAY;
     pub const MinOperatorStake: Balance = 100 * SSC;
     pub const MinNominatorStake: Balance = SSC;
     /// Use the consensus chain's `Normal` extrinsics block size limit as the domain block size limit
@@ -730,8 +733,8 @@ parameter_types! {
     pub MaxDomainBlockWeight: Weight = NORMAL_DISPATCH_RATIO * BLOCK_WEIGHT_FOR_2_SEC;
     pub const DomainInstantiationDeposit: Balance = 100 * SSC;
     pub const MaxDomainNameLength: u32 = 32;
-    pub const BlockTreePruningDepth: u32 = DOMAINS_BLOCK_PRUNING_DEPTH;
-    pub const StakeWithdrawalLockingPeriod: BlockNumber = 20;
+    pub const DefaultBlockTreePruningDepth: u32 = TEST_DOMAINS_BLOCK_PRUNING_DEPTH;
+    pub const DefaultStakeWithdrawalLockingPeriod: BlockNumber = TEST_STAKE_WITHDRAWAL_LOCKING_PERIOD;
     pub const StakeEpochDuration: DomainNumber = 5;
     pub TreasuryAccount: AccountId = PalletId(*b"treasury").into_account_truncating();
     pub const MaxPendingStakingOperation: u32 = 512;
@@ -752,6 +755,9 @@ const_assert!(BlockHashCount::get() > BlockSlotCount::get());
 
 // Minimum operator stake must be >= minimum nominator stake since operator is also a nominator.
 const_assert!(MinOperatorStake::get() >= MinNominatorStake::get());
+
+// Stake Withdrawal locking period must be >= Block tree pruning depth
+const_assert!(DefaultStakeWithdrawalLockingPeriod::get() >= DefaultBlockTreePruningDepth::get());
 
 pub struct BlockSlot;
 
@@ -798,7 +804,7 @@ impl pallet_domains::Config for Runtime {
     type DomainHash = DomainHash;
     type DomainHeader = DomainHeader;
     type ConfirmationDepthK = ConfirmationDepthK;
-    type DomainRuntimeUpgradeDelay = DomainRuntimeUpgradeDelay;
+    type DefaultDomainRuntimeUpgradeDelay = DefaultDomainRuntimeUpgradeDelay;
     type Currency = Balances;
     type HoldIdentifier = HoldIdentifierWrapper;
     type WeightInfo = pallet_domains::weights::SubstrateWeight<Runtime>;
@@ -810,9 +816,9 @@ impl pallet_domains::Config for Runtime {
     type DomainInstantiationDeposit = DomainInstantiationDeposit;
     type MaxDomainNameLength = MaxDomainNameLength;
     type Share = Balance;
-    type BlockTreePruningDepth = BlockTreePruningDepth;
+    type DefaultBlockTreePruningDepth = DefaultBlockTreePruningDepth;
     type ConsensusSlotProbability = SlotProbability;
-    type StakeWithdrawalLockingPeriod = StakeWithdrawalLockingPeriod;
+    type DefaultStakeWithdrawalLockingPeriod = DefaultStakeWithdrawalLockingPeriod;
     type StakeEpochDuration = StakeEpochDuration;
     type TreasuryAccount = TreasuryAccount;
     type MaxPendingStakingOperation = MaxPendingStakingOperation;


### PR DESCRIPTION
This PR makes local testing easier, by adding a `--challenge-period` parameter to the node command line. This parameter makes some common waiting periods faster. They are currently 1 day by default, which is a long time to wait and see if an upgrade or change worked.

This parameter is used in dev networks to set the:
- challenge period
- `BlockTreePruningDepth`
- `RuntimeUpgradeDelay`
- `StakeWithdrawalLockingPeriod`

In non-dev networks, the parameter is ignored.

We originally talked about using a genesis config instead, but I had trouble adapting the `pallet-domains` tests and benchmarks to work that way. Let me know if we want to do that instead, and I'll try to work out how to add genesis parameters to those test runtime instances.

Close #2822.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
