### PR TITLE
add rust-src component for docker builds

### DIFF
--- a/docker/bootstrap-node.Dockerfile
+++ b/docker/bootstrap-node.Dockerfile
@@ -53,7 +53,8 @@ RUN \
 
 RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
-    /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+    /root/.cargo/bin/rustup target add wasm32-unknown-unknown && \
+    /root/.cargo/bin/rustup component add rust-src --toolchain $RUSTC_VERSION
 
 # Up until this line all Rust images in this repo should be the same to share the same layers
 

--- a/docker/farmer.Dockerfile
+++ b/docker/farmer.Dockerfile
@@ -53,7 +53,8 @@ RUN \
 
 RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
-    /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+    /root/.cargo/bin/rustup target add wasm32-unknown-unknown && \
+    /root/.cargo/bin/rustup component add rust-src --toolchain $RUSTC_VERSION
 
 # Up until this line all Rust images in this repo should be the same to share the same layers
 

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -53,7 +53,8 @@ RUN \
 
 RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
-    /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+    /root/.cargo/bin/rustup target add wasm32-unknown-unknown && \
+    /root/.cargo/bin/rustup component add rust-src --toolchain $RUSTC_VERSION
 
 # Up until this line all Rust images in this repo should be the same to share the same layers
 

--- a/docker/node.Dockerfile
+++ b/docker/node.Dockerfile
@@ -53,8 +53,8 @@ RUN \
 
 RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
-    /root/.cargo/bin/rustup target add wasm32-unknown-unknown
-
+    /root/.cargo/bin/rustup target add wasm32-unknown-unknown && \
+    /root/.cargo/bin/rustup component add rust-src --toolchain $RUSTC_VERSION
 # Up until this line all Rust images in this repo should be the same to share the same layers
 
 COPY . /code

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -53,7 +53,8 @@ RUN \
 
 RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION && \
-    /root/.cargo/bin/rustup target add wasm32-unknown-unknown
+    /root/.cargo/bin/rustup target add wasm32-unknown-unknown && \
+    /root/.cargo/bin/rustup component add rust-src --toolchain $RUSTC_VERSION
 
 # Up until this line all Rust images in this repo should be the same to share the same layers
 


### PR DESCRIPTION
Recent pre-release docker builds failed with rust-src component missing. 
Adding the component during the build itself.

If you are aware of other alternatives let me know.

### Code contributor checklist:
* [x] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
