### PR TITLE
increase linux runner resources baseline

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,7 +1,7 @@
 runners:
   self-hosted-ubuntu-22.04-x86-64:
     cpu: [16, 32, 64]
-    ram: [32, 64, 128]
+    ram: [64, 128]
     disk: default
     family: ["c7a", "c7i", "m7a", "m7i"]
     spot: capacity-optimized


### PR DESCRIPTION
Our linux self hosted ephemerals are running into OOM and killing our snapshot docker build CI jobs. I'm increasing the baseline resources for spot runners to use machines with more memory resources.

### Code contributor checklist:
* [X] I have read, understood and followed [contributing guide](https://github.com/autonomys/subspace/blob/main/CONTRIBUTING.md)
